### PR TITLE
left_sidebar: Gridded stream and topic rows.

### DIFF
--- a/web/src/topic_list.js
+++ b/web/src/topic_list.js
@@ -305,21 +305,25 @@ export function get_topic_search_term() {
 }
 
 export function initialize({on_topic_click}) {
-    $("#stream_filters").on("click", ".topic-box", (e) => {
-        if (e.metaKey || e.ctrlKey) {
-            return;
-        }
-        if ($(e.target).closest(".show-more-topics").length > 0) {
-            return;
-        }
+    $("#stream_filters").on(
+        "click",
+        ".sidebar-topic-check, .topic-name, .topic-markers-and-controls",
+        (e) => {
+            if (e.metaKey || e.ctrlKey) {
+                return;
+            }
+            if ($(e.target).closest(".show-more-topics").length > 0) {
+                return;
+            }
 
-        const $stream_row = $(e.target).parents(".narrow-filter");
-        const stream_id = Number.parseInt($stream_row.attr("data-stream-id"), 10);
-        const topic = $(e.target).parents("li").attr("data-topic-name");
-        on_topic_click(stream_id, topic);
+            const $stream_row = $(e.target).parents(".narrow-filter");
+            const stream_id = Number.parseInt($stream_row.attr("data-stream-id"), 10);
+            const topic = $(e.target).parents("li").attr("data-topic-name");
+            on_topic_click(stream_id, topic);
 
-        e.preventDefault();
-    });
+            e.preventDefault();
+        },
+    );
 
     $("body").on("input", "#filter-topic-input", () => {
         active_widgets.get(active_stream_id()).build();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -27,25 +27,24 @@ $before_unread_count_padding: 3px;
 }
 
 .stream-privacy {
-    font-size: 15px;
+    height: 16px;
     font-weight: 700;
-    min-width: $left_col_size;
     text-align: center;
 
     .zulip-icon.zulip-icon-globe {
         font-size: 12px;
-        position: relative;
-        top: 1px;
     }
 
     .zulip-icon.zulip-icon-hashtag {
         font-size: 13px;
-        position: relative;
-        top: 1.5px;
     }
 
     .zulip-icon.zulip-icon-lock {
         font-size: 13px;
+        /* Slight vertical adjustment so the lock
+           doesn't sit too high, relative to the
+           other stream icons. */
+        padding-top: 2px;
     }
 }
 
@@ -53,11 +52,6 @@ $before_unread_count_padding: 3px;
 .topic-name,
 .topic-markers-and-controls {
     cursor: pointer;
-}
-
-#stream_filters .zulip-icon-lock {
-    position: relative;
-    top: 2px;
 }
 
 #global_filters .filter-icon i {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -76,7 +76,6 @@ $before_unread_count_padding: 3px;
 li.show-more-topics {
     & a {
         font-size: 12px;
-        margin-left: $topic_resolve_width;
     }
 }
 
@@ -136,7 +135,7 @@ li.show-more-topics {
             margin-left: 0;
 
             &.topic-list li {
-                padding: 2px 0 2px calc($topic_indent - $topic_resolve_width);
+                padding: 2px 0;
 
                 &.filter-topics {
                     padding-bottom: 0;
@@ -600,21 +599,72 @@ li.top_left_scheduled_messages {
     font-size: 13px;
 }
 
+/* New .topic-box grid definitions here. */
 .topic-box {
-    padding-left: 5px;
-    margin-right: 30px;
+    /* Padding from original .topic-box definition. */
+    padding-top: 1px;
+    display: grid;
+    align-items: center;
+    /* This general pattern of elements applies to every single row in the left
+       sidebar, to some degree or another. Eventually, these template areas
+       could be applied to all rows, with different `grid-template-column`
+       values applied as needed (and shared as needed). For example, an element
+       with no "starting-offset" sets that area to `0`; so too with other non-
+       existent elements.
+
+       The offsets themselves are meant to greedily assign all of the available
+       horizontal space to the content area of the row. That space can then be
+       modified or reassigned as needed, without running up against `padding`
+       (which alters the box size) or `margin` (which notoriously bleeds outside
+       of the element it's defined on). */
+    grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
+    grid-template-columns:
+        25px $topic_resolve_width minmax(0, 1fr) minmax(0, max-content)
+        30px 0;
+}
+
+.topic-box .zero_count {
+    display: none;
 }
 
 .sidebar-topic-check {
-    display: flex;
-    align-items: center;
-    min-width: $topic_resolve_width;
+    grid-area: starting-anchor-element;
     font-size: 15px;
     height: 20px;
 }
 
+.topic-name {
+    grid-area: row-content;
+    padding: 1px 0;
+
+    /* TODO: We should figure out how to remove this without changing the spacing */
+    line-height: 1.1;
+
+    /* TODO: Consolidate these styles with conversation partners and stream name
+       once grid rewrite is complete on all sidebar rows.
+
+       Also: note that these styles will be moot for topic names once we allow
+       for multiline topics. If we hold multiline topics to a certain number
+       of lines, we'll likely need a JavaScript-based solution like Clamp.js
+       to display an ellipsis on the final visible line. */
+    white-space: nowrap;
+    /* Both `hidden` and `clip` are shown for the sake
+       of older browsers that do not support `clip`. */
+    overflow-x: hidden;
+    overflow-x: clip;
+    text-overflow: ellipsis;
+}
+
+.topic-markers-and-controls {
+    grid-area: markers-and-controls;
+}
+
+.bottom_left_row .topic-box .sidebar-menu-icon {
+    position: static;
+    grid-area: ending-anchor-element;
+}
+
 .conversation-partners-list,
-.topic-name,
 .stream-name {
     flex: auto;
     min-width: 0;
@@ -629,11 +679,6 @@ li.top_left_scheduled_messages {
     /* Don't allow growth, so that status emoji
        remain adjacent the username. */
     flex: 0 1 auto;
-}
-
-.topic-name {
-    /* TODO: We should figure out how to remove this without changing the spacing */
-    line-height: 1.1;
 }
 
 .left_sidebar_menu_icon_visible {
@@ -716,11 +761,11 @@ li.top_left_scheduled_messages {
     which also affects it positioning.
 */
 .bottom_left_row .topic-sidebar-menu-icon {
-    top: 2px;
-    right: 0;
     font-size: 0.9em;
-    text-align: center;
-    padding: 1px 6px 0;
+    /* Strip the line height back to the font size,
+       so that vertical positioning is handled by
+       grid exclusively. */
+    line-height: 1;
 }
 
 ul.topic-list {
@@ -733,14 +778,9 @@ li.topic-list-item {
     padding-right: 5px;
 }
 
-.pm-box,
-.topic-box {
+.pm-box {
     display: flex;
     padding-top: 1px;
-    align-items: center;
-}
-
-.pm-box {
     margin-right: 16px;
     align-items: baseline; /* Sets .user_circle alignment relative to text; standard icons do not participate in flex. */
 
@@ -760,8 +800,7 @@ li.topic-list-item {
     }
 }
 
-.zero-pm-unreads .pm-box,
-.zero-topic-unreads .topic-box {
+.zero-pm-unreads .pm-box {
     margin-right: 15px;
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -657,6 +657,22 @@ li.top_left_scheduled_messages {
 
 .topic-markers-and-controls {
     grid-area: markers-and-controls;
+    display: flex;
+    /* Present a uniform space between icons */
+    gap: 5px;
+    align-items: center;
+
+    .unread_mention_info {
+        /* Unset margin in favor of flex gap. */
+        margin: 0;
+    }
+
+    .unread_count {
+        /* Height is set here by the flexbox; this
+           decouples .unread_count from the app-wide
+           definition. */
+        height: auto;
+    }
 }
 
 .bottom_left_row .topic-box .sidebar-menu-icon {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -49,6 +49,12 @@ $before_unread_count_padding: 3px;
     }
 }
 
+.sidebar-topic-check,
+.topic-name,
+.topic-markers-and-controls {
+    cursor: pointer;
+}
+
 #left-sidebar .filter-icon i {
     padding-right: 3px;
 
@@ -731,7 +737,6 @@ li.topic-list-item {
 .topic-box {
     display: flex;
     padding-top: 1px;
-    cursor: pointer;
     align-items: center;
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -55,16 +55,13 @@ $before_unread_count_padding: 3px;
     cursor: pointer;
 }
 
-#left-sidebar .filter-icon i {
-    padding-right: 3px;
-
-    &.zulip-icon-lock {
-        position: relative;
-        top: 2px;
-    }
+#stream_filters .zulip-icon-lock {
+    position: relative;
+    top: 2px;
 }
 
 #global_filters .filter-icon i {
+    padding-right: 3px;
     color: var(--color-global-filter-icon);
 }
 
@@ -147,33 +144,16 @@ li.show-more-topics {
         }
     }
 
-    .subscription_block {
-        margin-right: 25px;
-        margin-left: $far_left_gutter_size;
-        display: flex;
-        align-items: center;
-        white-space: nowrap;
-
-        & .unread_count {
-            margin-right: 15px;
-        }
-
-        & .masked_unread_count {
-            /* TODO: In theory this should be 19, to make it center aligned with
-               unread_count span which has a padding of 4px
-               horizontally in addition to 15px margin. But 18px looks
-               better centered. */
-            margin-right: 18px;
-        }
-
-        &.stream-with-count {
-            margin-right: 15px;
-        }
-    }
-
     .stream-with-count.hide_unread_counts {
         .masked_unread_count {
-            display: inline;
+            display: block;
+            /* Shift masked dot to align with
+               the least-significant digit on
+               unreads in other rows.
+               We have to do this with margin,
+               because width or padding will
+               distort the CSS-created dot. */
+            margin-right: 3px;
         }
 
         .unread_count {
@@ -600,9 +580,8 @@ li.top_left_scheduled_messages {
 }
 
 /* New .topic-box grid definitions here. */
+.subscription_block,
 .topic-box {
-    /* Padding from original .topic-box definition. */
-    padding-top: 1px;
     display: grid;
     align-items: center;
     /* This general pattern of elements applies to every single row in the left
@@ -618,6 +597,26 @@ li.top_left_scheduled_messages {
        (which alters the box size) or `margin` (which notoriously bleeds outside
        of the element it's defined on). */
     grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
+}
+
+.subscription_block {
+    grid-template-columns:
+        7px 22px minmax(0, 1fr) minmax(0, max-content)
+        30px 0;
+    white-space: nowrap;
+
+    .stream-privacy {
+        grid-area: starting-anchor-element;
+    }
+
+    .stream-name {
+        grid-area: row-content;
+    }
+}
+
+.topic-box {
+    /* Padding from original .topic-box definition. */
+    padding-top: 1px;
     grid-template-columns:
         25px $topic_resolve_width minmax(0, 1fr) minmax(0, max-content)
         30px 0;
@@ -655,6 +654,7 @@ li.top_left_scheduled_messages {
     text-overflow: ellipsis;
 }
 
+.stream-markers-and-controls,
 .topic-markers-and-controls {
     grid-area: markers-and-controls;
     display: flex;
@@ -675,6 +675,7 @@ li.top_left_scheduled_messages {
     }
 }
 
+.bottom_left_row .subscription_block .sidebar-menu-icon,
 .bottom_left_row .topic-box .sidebar-menu-icon {
     position: static;
     grid-area: ending-anchor-element;

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -3,13 +3,15 @@
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
         <a class="topic-name" tabindex="0">{{t "more topics" }}</a>
-        {{#if more_topics_have_unread_mention_messages}}
-            <span class="unread_mention_info">
-                @
+        <div class="topic-markers-and-controls">
+            {{#if more_topics_have_unread_mention_messages}}
+                <span class="unread_mention_info">
+                    @
+                </span>
+            {{/if}}
+            <span class="unread_count {{#unless more_topics_unreads}}zero_count{{/unless}}">
+                {{more_topics_unreads}}
             </span>
-        {{/if}}
-        <span class="unread_count {{#unless more_topics_unreads}}zero_count{{/unless}}">
-            {{more_topics_unreads}}
-        </span>
+        </div>
     </div>
 </li>

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -1,7 +1,7 @@
 <li class="topic-list-item show-more-topics bottom_left_row
   {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
-    <span class='topic-box'>
+    <div class="topic-box">
         <a class="topic-name" tabindex="0">{{t "more topics" }}</a>
         {{#if more_topics_have_unread_mention_messages}}
             <span class="unread_mention_info">
@@ -11,5 +11,5 @@
         <span class="unread_count {{#unless more_topics_unreads}}zero_count{{/unless}}">
             {{more_topics_unreads}}
         </span>
-    </span>
+    </div>
 </li>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -10,10 +10,13 @@
 
             <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
 
-            <span class="unread_mention_info"></span>
-            <span class="unread_count"></span>
-            <span class="masked_unread_count"></span>
+            <div class="stream-markers-and-controls">
+                <span class="unread_mention_info"></span>
+                <span class="unread_count"></span>
+                <span class="masked_unread_count"></span>
+            </div>
+
+            <span class="sidebar-menu-icon stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
         </div>
-        <span class="sidebar-menu-icon stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -3,20 +3,22 @@
         <span class="sidebar-topic-check">
             {{topic_resolved_prefix}}
         </span>
-        <a href='{{url}}' class="topic-name" title="{{topic_name}}">
+        <a href="{{url}}" class="topic-name" title="{{topic_name}}">
             {{topic_display_name}}
         </a>
-        {{#if contains_unread_mention}}
-            <span class="unread_mention_info">
-                @
+        <div class="topic-markers-and-controls">
+            {{#if contains_unread_mention}}
+                <span class="unread_mention_info">
+                    @
+                </span>
+            {{else if is_followed}}
+                <i class="zulip-icon zulip-icon-follow" aria-hidden="true"> </i>
+                &nbsp;
+            {{/if}}
+            <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
+                {{unread}}
             </span>
-        {{else if is_followed}}
-            <i class="zulip-icon zulip-icon-follow" aria-hidden="true"> </i>
-            &nbsp;
-        {{/if}}
-        <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
-            {{unread}}
-        </span>
+        </div>
         <span class="sidebar-menu-icon topic-sidebar-menu-icon">
             <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
         </span>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -1,5 +1,5 @@
-<li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} {{#if is_unmuted_or_followed}}unmuted_or_followed_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
-    <span class='topic-box'>
+<li class="bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} {{#if is_unmuted_or_followed}}unmuted_or_followed_topic{{/if}} topic-list-item" data-topic-name="{{topic_name}}">
+    <div class="topic-box">
         <span class="sidebar-topic-check">
             {{topic_resolved_prefix}}
         </span>
@@ -17,7 +17,7 @@
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}
         </span>
-    </span>
+    </div>
     <span class="sidebar-menu-icon topic-sidebar-menu-icon">
         <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
     </span>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -17,8 +17,8 @@
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}
         </span>
+        <span class="sidebar-menu-icon topic-sidebar-menu-icon">
+            <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
+        </span>
     </div>
-    <span class="sidebar-menu-icon topic-sidebar-menu-icon">
-        <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
-    </span>
 </li>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -12,8 +12,7 @@
                     @
                 </span>
             {{else if is_followed}}
-                <i class="zulip-icon zulip-icon-follow" aria-hidden="true"> </i>
-                &nbsp;
+                <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
             {{/if}}
             <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
                 {{unread}}


### PR DESCRIPTION
This PR is the first of a few closely-related planned PRs to introduce grid-based layout to all the different rows in the left sidebar. I'm beginning with topics because they're the innermost rows, and getting them right will make it easier to move up the tree to headings and DM rows (which will increase in number in [the redesigned left-sidebar](https://zulip-sidebar.vladkorobov.repl.co/) and [collapsing views PR](https://github.com/zulip/zulip/pull/26035)).

CZO discussions:
* [UI design: left sidebar](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20left.20sidebar/near/1644570)
* [Left sidebar rows as grids](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Left.20sidebar.20rows.20as.20grids/near/1645034)

<details>
<summary><b>Explanation and theory behind these changes:</b></summary>
The goal of this rewrite is to make it so that adding, removing, and repositioning icons, markers, and other elements do not disturb other parts of the existing layout--while also making sure that those placed elements behave predictably.

To that end, the grid defined here is meant to ultimately apply to all the other rows in the left sidebar--just with different dimensions.

Breaking things down, all rows in the left sidebar can be expressed as some variation of this:

| Left offset space  | Anchor element (chevron control, stream icon, checkmark) | Text content (heading, stream/topic name, conversation partners) | Markers and controls (@s, bells, unreads) |  Anchor element (vdots, heading icons) | Right offset space |
| - | - | - | - | - | - |

Some rows, of course, do not have offset space; and that's fine, as the actual `grid-template-column` for that particular left-sidebar row can just specify `0` as the offset space; likewise for any other column element that doesn't exist in a given row.

But when things like offset space is needed, it can be declared at the grid level--instead of as margin or padding on an inner element or the grid container itself.

And that use of grid to manipulate negative space comes with some important benefits:

1. Things like offset space or empty interstitial columns get occupied by other elements in the row
2. Adding new elements to occupy that space means just adjusting the grid definition, _rather than_ playing around with padding or (worse) margin that would be otherwise set to occupy the negative space--or keep elements out of it
3. Positioning rows within the left sidebar is a matter of positioning solid blocks: there's no margin hanging around to bleed through and make life messy and unpredictable when tweaking the design
4. Elements like zero-unreads can either be safely removed from the DOM, or given `display: none` (the zero-unreads are currently obscured from view with `visibility: hidden`, as are the resolved checkmarks on topics); that means no mystery clickable elements, or keeping a hidden element around for the sake of preventing the layout from collapsing

Other, positive space in the grid can be used as expected. The WIP grid here also uses `max-content` as the width for the grouped markers and controls area. That area itself can probably best be presented as a flexbox, but its overall relationship to other elements in the row is all handled by grid.
</details>

**Screenshots and screen captures (updated 2023-09-26):**

_Only the stream and topic rows are changed; the screenshots include the entire left sidebar to demonstrate no ill side-effects on the filters, DM rows, or headings._

| Before | After |
| --- | --- |
| <img width="300" alt="stream-and-topics-before" src="https://github.com/zulip/zulip/assets/170719/1ef1af85-7fa2-44a0-9776-4a1af7e78515"> | <img width="300" alt="streams-and-topics-after" src="https://github.com/zulip/zulip/assets/170719/e3892b86-72e8-49a2-9738-d66abe8dcdcb"> |

**TODOs & known issues**
- [x] Clickable areas on topics; this PR moves the handler from `.topic-box` as the click handler to the three specific elements that should handle clicks: `.sidebar-topic-check`, `.topic-name`, `.topic-markers-and-controls`; that seems to be more the spirit of the current design on `main`, but can now be more easily adjusted further as needed
- [x] (Update: this will almost certainly be properly resolved when the other unread-containing rows are themselves expressed as grids.) Horizontal alignment of the right side of the unread count is off by a sub-pixel value compared to the unread count in the stream header (e.g, the `#devel` stream in the screenshots below); that is likely owing to some calculated and eyeballed values for the stream heaading's placement of icons--but it could be bleedthrough from some as-yet unremoved styles on unreads and adjacent elements that are no longer needed in a grid setting
- [x] Vertical alignment is off on the resolved-topic checkbox and vdots icons, largely owing to old positioning- and float-based styles that I still need to clean up on icons and their containers
- [x] (Update: to do this right, we'll need to arrive at a specific line-height value. So let's keep multiline topics to their own PR.) Styles for presenting multiline topics (part of full redesign, so possibly not part of this PR--although having those styles ready to go and just pulled into a separate branch is a goal)
- [x] (Update: mostly cleaned up, but still more to come in subsequent PRs). The codebase still includes whole bunch of overridden and unreachable selectors, styles, etc. that are no longer necessary; and honestly a separate PR should take a hard look at `left_sidebar.css` and reorganize it. That should probably happen after the gridded row work is complete, as that will remove things and introduce others

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
