### PR TITLE
typeahead: Improve tests for multi word match's highlighting.

### DIFF
--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -650,8 +650,7 @@ test("test compare directly for direct message", () => {
 
 test("highlight_with_escaping", () => {
     function highlight(query, item) {
-        const regex = th.build_highlight_regex(query);
-        return th.highlight_with_escaping_and_regex(regex, item);
+        return th.make_query_highlighter(query)(item);
     }
 
     let item = "Denmark";


### PR DESCRIPTION
We refactor the tests to check if a multi word query's result is correctly highlighted (multi word highlighting fixed in e2c23b656ecac7cd78ab2584dd462d7ed309b3e1).

The test case was already present, but the setup was not correct, and has been corrected now to safeguard against regression in the future.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
