### PR TITLE
Use TypeScript unions for message types; convert compose_fade_helper, compose_fade_users to TypeScript

### DIFF
--- a/web/src/compose_fade_helper.ts
+++ b/web/src/compose_fade_helper.ts
@@ -1,27 +1,27 @@
+import assert from "minimalistic-assert";
+
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
+import type {Message} from "./types";
+import type {Recipient} from "./util";
 import * as util from "./util";
 
-let focused_recipient;
+let focused_recipient: Recipient | undefined;
 
-export function should_fade_message(message) {
+export function should_fade_message(message: Message): boolean {
     return !util.same_recipient(focused_recipient, message);
 }
 
-export function clear_focused_recipient() {
+export function clear_focused_recipient(): void {
     focused_recipient = undefined;
 }
 
-export function set_focused_recipient(recipient) {
+export function set_focused_recipient(recipient?: Recipient): void {
     focused_recipient = recipient;
 }
 
-function is_pm_recipient(user_id) {
-    const recipients = focused_recipient.to_user_ids.split(",");
-    return recipients.includes(user_id.toString());
-}
-
-export function would_receive_message(user_id) {
+export function would_receive_message(user_id: number): boolean | undefined {
+    assert(focused_recipient !== undefined);
     if (focused_recipient.type === "stream") {
         const sub = sub_store.get(focused_recipient.stream_id);
         if (!sub) {
@@ -35,10 +35,12 @@ export function would_receive_message(user_id) {
     }
 
     // Direct message, so check if the given email is in the recipients list.
-    return is_pm_recipient(user_id);
+    assert(focused_recipient.to_user_ids !== undefined);
+    const recipients = focused_recipient.to_user_ids.split(",");
+    return recipients.includes(user_id.toString());
 }
 
-export function want_normal_display() {
+export function want_normal_display(): boolean {
     // If we're not composing show a normal display.
     if (focused_recipient === undefined) {
         return true;

--- a/web/src/compose_fade_users.js
+++ b/web/src/compose_fade_users.js
@@ -1,26 +1,26 @@
 import * as compose_fade_helper from "./compose_fade_helper";
 import * as people from "./people";
 
-function update_user_row_when_fading(li, conf) {
-    const user_id = conf.get_user_id(li);
+function update_user_row_when_fading($li, conf) {
+    const user_id = conf.get_user_id($li);
     const would_receive = compose_fade_helper.would_receive_message(user_id);
 
     if (would_receive || people.is_my_user_id(user_id)) {
-        conf.unfade(li);
+        conf.unfade($li);
     } else {
-        conf.fade(li);
+        conf.fade($li);
     }
 }
 
 export function fade_users(items, conf) {
-    for (const li of items) {
-        update_user_row_when_fading(li, conf);
+    for (const $li of items) {
+        update_user_row_when_fading($li, conf);
     }
 }
 
 export function display_users_normally(items, conf) {
-    for (const li of items) {
-        conf.unfade(li);
+    for (const $li of items) {
+        conf.unfade($li);
     }
 }
 

--- a/web/src/compose_fade_users.ts
+++ b/web/src/compose_fade_users.ts
@@ -1,7 +1,13 @@
 import * as compose_fade_helper from "./compose_fade_helper";
 import * as people from "./people";
 
-function update_user_row_when_fading($li, conf) {
+export type UserFadeConfig = {
+    get_user_id($li: JQuery): number;
+    fade($li: JQuery): void;
+    unfade($li: JQuery): void;
+};
+
+function update_user_row_when_fading($li: JQuery, conf: UserFadeConfig): void {
     const user_id = conf.get_user_id($li);
     const would_receive = compose_fade_helper.would_receive_message(user_id);
 
@@ -12,19 +18,19 @@ function update_user_row_when_fading($li, conf) {
     }
 }
 
-export function fade_users(items, conf) {
+export function fade_users(items: JQuery[], conf: UserFadeConfig): void {
     for (const $li of items) {
         update_user_row_when_fading($li, conf);
     }
 }
 
-export function display_users_normally(items, conf) {
+export function display_users_normally(items: JQuery[], conf: UserFadeConfig): void {
     for (const $li of items) {
         conf.unfade($li);
     }
 }
 
-export function update_user_info(items, conf) {
+export function update_user_info(items: JQuery[], conf: UserFadeConfig): void {
     if (compose_fade_helper.want_normal_display()) {
         display_users_normally(items, conf);
     } else {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -160,7 +160,7 @@ export function by_conversation_and_time_url(message: Message): string {
     const suffix = "/near/" + internal_url.encodeHashComponent(message.id.toString());
 
     if (message.type === "stream") {
-        return absolute_url + by_stream_topic_url(message.stream_id!, message.topic) + suffix;
+        return absolute_url + by_stream_topic_url(message.stream_id, message.topic) + suffix;
     }
 
     return absolute_url + people.pm_perma_link(message) + suffix;

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -23,5 +23,5 @@ export function get_key_from_message(msg: Message): string | undefined {
     }
 
     // For messages with type = "stream".
-    return get_topic_key(msg.stream_id!, msg.topic);
+    return get_topic_key(msg.stream_id, msg.topic);
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -5,7 +5,6 @@ export type MatchedMessage = {
 };
 
 // TODO/typescript: Move this to message_store
-export type MessageType = "private" | "stream";
 export type MessageReactionType = "unicode_emoji" | "realm_emoji" | "zulip_extra_emoji";
 
 // TODO/typescript: Move these types to message_store
@@ -71,17 +70,27 @@ export type RawMessage = {
     sender_full_name: string;
     sender_id: number;
     sender_realm_str: string;
-    stream_id?: number;
-    subject: string;
     submessages: Submessage[];
     timestamp: number;
-    topic_links: TopicLink[];
-    type: MessageType;
     flags: string[];
-} & MatchedMessage;
+} & (
+    | {
+          type: "private";
+      }
+    | {
+          type: "stream";
+          stream_id: number;
+          subject: string;
+          topic_links: TopicLink[];
+      }
+) &
+    MatchedMessage;
 
 // We add these boolean properties to Raw message in `message_store.set_message_booleans` method.
-export type MessageWithBooleans = Omit<RawMessage, "flags"> & {
+export type MessageWithBooleans = (
+    | Omit<RawMessage & {type: "private"}, "flags">
+    | Omit<RawMessage & {type: "stream"}, "flags">
+) & {
     unread: boolean;
     historical: boolean;
     starred: boolean;
@@ -108,26 +117,38 @@ export type MessageCleanReaction = {
 };
 
 // TODO/typescript: Move this to message_store
-export type Message = Omit<MessageWithBooleans, "reactions"> & {
+export type Message = (
+    | Omit<MessageWithBooleans & {type: "private"}, "reactions">
+    | Omit<MessageWithBooleans & {type: "stream"}, "reactions">
+) & {
     // Added in `reactions.set_clean_reactions`.
     clean_reactions: Map<string, MessageCleanReaction>;
 
     // Added in `message_helper.process_new_message`.
     sent_by_me: boolean;
-    is_private?: boolean;
-    is_stream?: boolean;
-    stream?: string;
     reply_to: string;
     display_reply_to?: string;
-    pm_with_url?: string;
-    to_user_ids?: string;
-    topic: string;
 
     // These properties are used in `message_list_view.js`.
     starred_status: string;
     message_reactions: MessageCleanReaction[];
     url: string;
-};
+} & (
+        | {
+              type: "private";
+              is_private: true;
+              is_stream: false;
+              pm_with_url: string;
+              to_user_ids: string;
+          }
+        | {
+              type: "stream";
+              is_private: false;
+              is_stream: true;
+              stream: string;
+              topic: string;
+          }
+    );
 
 // TODO/typescript: Move this to server_events_dispatch
 export type UserGroupUpdateEvent = {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -71,7 +71,9 @@ export function extract_pm_recipients(recipients: string): string[] {
 
 // When the type is "private", properties from to_user_ids might be undefined.
 // See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
-type Recipient = {to_user_ids?: string; type: "private"} | (StreamTopic & {type: "stream"});
+export type Recipient =
+    | {type: "private"; to_user_ids?: string; reply_to: string}
+    | ({type: "stream"} & StreamTopic);
 
 export const same_recipient = function util_same_recipient(a?: Recipient, b?: Recipient): boolean {
     if (a === undefined || b === undefined) {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -253,7 +253,7 @@ export function is_topic_synonym(operator: string): boolean {
 }
 
 export function convert_message_topic(message: Message): void {
-    if (message.topic === undefined) {
+    if (message.type === "stream" && message.topic === undefined) {
         message.topic = message.subject;
     }
 }


### PR DESCRIPTION
[Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/typescript.3A.20message.20type/near/1640680).

This replaces part of #26505, but in a way that allows `compose_fade_helpers.should_fade_message` to correctly accept `Message`.

Cc @jychen630 @Lalit3716 @shameondev.