### PR TITLE
push_notifications: Clear push notifications on message deletion.

### DIFF
--- a/zerver/actions/message_delete.py
+++ b/zerver/actions/message_delete.py
@@ -1,5 +1,6 @@
 from typing import Iterable, List, TypedDict
 
+from zerver.actions.message_flags import do_clear_mobile_push_notifications_for_ids
 from zerver.lib import retention
 from zerver.lib.retention import move_messages_to_archive
 from zerver.lib.stream_subscription import get_active_subscriptions_for_stream_id
@@ -55,6 +56,7 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
 
     event["message_type"] = message_type
     send_event_on_commit(realm, event, users_to_notify)
+    do_clear_mobile_push_notifications_for_ids(users_to_notify, message_ids)
 
 
 def do_delete_messages_by_sender(user: UserProfile) -> None:

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -219,10 +219,6 @@ def do_clear_mobile_push_notifications_for_ids(
     if len(message_ids) == 0:
         return
 
-    # This function supports clearing notifications for several users
-    # only for the message-edit use case where we'll have a single message_id.
-    assert len(user_profile_ids) == 1 or len(message_ids) == 1
-
     messages_by_user = defaultdict(list)
     notifications_to_update = (
         UserMessage.objects.filter(

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -11,6 +11,7 @@ from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.actions.scheduled_messages import check_schedule_message, delete_scheduled_message
 from zerver.actions.submessage import do_add_submessage
+from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.retention import (
     archive_messages,
     clean_archived_data,
@@ -36,6 +37,7 @@ from zerver.models import (
     Stream,
     SubMessage,
     UserMessage,
+    UserProfile,
     get_client,
     get_realm,
     get_stream,
@@ -1137,7 +1139,7 @@ class TestDoDeleteMessages(ZulipTestCase):
         message_ids = [self.send_stream_message(cordelia, "Verona", str(i)) for i in range(10)]
         messages = Message.objects.filter(id__in=message_ids)
 
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(21):
             do_delete_messages(realm, messages)
         self.assertFalse(Message.objects.filter(id__in=message_ids).exists())
 
@@ -1169,3 +1171,40 @@ class TestDoDeleteMessages(ZulipTestCase):
         # We only send the event to see no exception is thrown - as it would be if the block
         # in process_notification to handle this old format of "users to notify" wasn't correct.
         send_event(realm, event, [{"id": cordelia.id}, {"id": hamlet.id}])
+
+    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    def test_clear_push_notifications_on_message_deletion(
+        self, mock_push_notifications: mock.MagicMock
+    ) -> None:
+        realm = get_realm("zulip")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        do_change_user_setting(cordelia, "enable_stream_push_notifications", True, acting_user=None)
+
+        def get_mobile_push_notification_ids(user_profile: UserProfile) -> List[int]:
+            return list(
+                UserMessage.objects.filter(
+                    user_profile=user_profile,
+                )
+                .extra(
+                    where=[UserMessage.where_active_push_notification()],
+                )
+                .order_by("message_id")
+                .values_list("message_id", flat=True)
+            )
+
+        self.assertEqual(get_mobile_push_notification_ids(cordelia), [])
+
+        message_ids = [self.send_stream_message(hamlet, "Verona", str(i)) for i in range(10)]
+        self.assertEqual(
+            get_mobile_push_notification_ids(cordelia),
+            message_ids,
+        )
+
+        messages = Message.objects.filter(id__in=message_ids)
+        do_delete_messages(realm, messages)
+        self.assertEqual(
+            get_mobile_push_notification_ids(cordelia),
+            [],
+        )
+        mock_push_notifications.assert_called()


### PR DESCRIPTION
Mobile push notifications for messages on deletion are revoked.

Fixes part of #26584.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
