### PR TITLE
navbar_alerts: Improve info for users having at least 50K unreads.

### DIFF
--- a/web/src/navbar_alerts.js
+++ b/web/src/navbar_alerts.js
@@ -172,11 +172,15 @@ export function initialize() {
             rendered_alert_content_html: render_desktop_notifications_alert_content(),
         });
     } else if (unread_ui.should_display_bankruptcy_banner()) {
+        const old_unreads_missing = unread.old_unreads_missing;
         const unread_msgs_count = unread.get_unread_message_count();
         open({
             data_process: "bankruptcy",
             custom_class: "bankruptcy",
-            rendered_alert_content_html: render_bankruptcy_alert_content({unread_msgs_count}),
+            rendered_alert_content_html: render_bankruptcy_alert_content({
+                old_unreads_missing,
+                unread_msgs_count,
+            }),
         });
     } else if (check_profile_incomplete()) {
         open({

--- a/web/templates/navbar_alerts/bankruptcy.hbs
+++ b/web/templates/navbar_alerts/bankruptcy.hbs
@@ -1,9 +1,17 @@
 <div data-step="1">
-    {{#tr}}
-        Welcome back!  You have <z-link>{unread_msgs_count}</z-link> unread messages.
-        Do you want to mark them all as read?
-        {{#*inline "z-link"}}<span class="bankruptcy_unread_count">{{> @partial-block}}</span>{{/inline}}
-    {{/tr}}
+    {{t "Welcome back!" }}
+    {{#if old_unreads_missing}}
+        {{#tr}}
+            You have <z-link>at least {unread_msgs_count}</z-link> unread messages.
+            {{#*inline "z-link"}}<a href="/help/marking-messages-as-read" class="alert-link bankruptcy_unread_count" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{#tr}}
+            You have <z-link>{unread_msgs_count}</z-link> unread messages.
+            {{#*inline "z-link"}}<span class="bankruptcy_unread_count">{{> @partial-block}}</span>{{/inline}}
+        {{/tr}}
+    {{/if}}
+    {{t "Do you want to mark them all as read?" }}
     <span class="buttons">
         <a class="alert-link accept-bankruptcy" role="button" tabindex=0>{{t "Yes, please!" }}</a>
         &bull;


### PR DESCRIPTION
Improves the alert message to clearly state that "You have at least 50,000 unread messages."

**TODO:** Write a help center doc - **/help/marking-messages-as-read#bankruptcy**

Fixes #17469.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
---

**Screenshots and screen captures:**

<details><summary>At least 50K</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/5e441487-9234-4a93-81a3-e96f55b91dd5">
</img>
</details> 

<details><summary>500 < unreads < 50K and more than 2 days of inactivity</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/dfeb8f28-9a39-486c-8b36-c215cb86ccbc">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
