### PR TITLE
Change the API endpoint of "custom_profile_fields" to ask users which parameters they needed from server 

### DIFF
--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -40,7 +40,8 @@ def list_realm_custom_profile_fields(
     request: HttpRequest, user_profile: UserProfile
 ) -> HttpResponse:
     fields = custom_profile_fields_for_realm(user_profile.realm_id)
-    return json_success(request, data={"custom_fields": [f.as_dict() for f in fields]})
+    custom_fields = [f.as_dict() for f in fields] # TODO: Update logic to see what fields I can show to the user
+    return json_success(request, data={"custom_fields": custom_fields})
 
 
 hint_validator = check_capped_string(CustomProfileField.HINT_MAX_LENGTH)


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Currently, I am drafting this PR and will update the description of the PR later.
I have added a TODO currently to cross-check whether I am going in the right way or not.  

The current API of `getting_custom_profile_fields` is fetching data of the `CustomProfileField` model and converting it to a dictionary using `as_dict` method of that [class](https://github.com/zulip/zulip/blob/main/zerver/models.py#L4883C29). Later it is converted to JSON before sending it as a response. So, what I am trying to do here is to make a variable that holds the data that has to be sent as a response. So, Can I change the API parameters that should be providing us the attributes they need and I will send only those keys as a response? 

Fixes: #23022 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
