### PR TITLE
api-docs: Correct error documentation for api/deactivate-own-user.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8085,7 +8085,7 @@ paths:
       summary: Deactivate own user
       tags: ["users"]
       description: |
-        Deactivates the user's account. See also the administrative endpoint for
+        Deactivates the current user's account. See also the administrative endpoint for
         [deactivating another user](/api/deactivate-user).
 
         This endpoint is primarily useful to Zulip clients providing a user settings UI.
@@ -8098,16 +8098,45 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/CodedError"
-                  - example:
+                  - $ref: "#/components/schemas/CodedErrorBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      code: {}
+                      entity:
+                        type: string
+                        description: |
+                          An internationalized string that notes if the current user is the only
+                          organization owner or the only user in the organization.
+                      is_last_owner:
+                        type: boolean
+                        description: |
+                          Whether the current user is the only organization owner (meaning there
+                          are other active users in the organization) or the only active user in the
+                          organzation.
+                    required:
+                      - entity
+                      - is_last_owner
+                    example:
                       {
-                        "code": "BAD_REQUEST",
+                        "code": "CANNOT_DEACTIVATE_LAST_USER",
                         "msg": "Cannot deactivate the only organization owner",
                         "result": "error",
+                        "entity": "organization owner",
+                        "is_last_owner": true,
                       }
                     description: |
-                      An example JSON error response when attempting to deactivate the only
-                      organization owner in an organization:
+                      If the current user is the only organization owner or only user in the
+                      organization, their account cannot be deactivated and an error response
+                      will be returned. The `is_last_owner` field in the error response
+                      indicates whether the user is the only owner (`true`) or the only user
+                      (`false`). The `entity` field in the error response is a internationalized
+                      string that notes if the current user is the only organization owner or
+                      the only user.
+
+                      An example JSON error response when the current user is the only
+                      organization owner in the organization:
   /users/me/alert_words:
     get:
       operationId: get-alert-words


### PR DESCRIPTION
In commit 3e369bcf9, the `code` field for [api/deactivate-own-user](https://zulip.com/api/deactivate-own-user) was incorrectly documented as `"BAD_REQUEST"`, which is the code for the similar error returned by [api/deactivate-user](https://zulip.com/api/deactivate-user).

Corrects the error code to be `"CANNOT_DEACTIVATE_LAST_USER"` and adds documentation for the two other fields returned by this error response: `is_last_owner` and `entity`.

Note that the descriptions for the fields are added in the error response schema will not be rendered in our current documentation. They are rendered in other third-party tools and are therefore good to have in our OpenAPI documentation. The description that will be rendered in our documentation is the general error response schema description and that is also updated for details about the extra fields in this error response.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/error.20docs/near/1309006).

**Screenshots and screen captures:**

<details>
<summary>Deactivate own user - main description</summary>

[Current documentation](https://zulip.com/api/deactivate-own-user)
![Screenshot from 2023-09-22 16-52-55](https://github.com/zulip/zulip/assets/63245456/93aa8ae6-af75-4d63-b894-85143a2d6de0)

</details>
<details>
<summary>Deactivate own user - response section</summary>

[Current documentation](https://zulip.com/api/deactivate-own-user#response)
![Screenshot from 2023-09-22 16-53-12](https://github.com/zulip/zulip/assets/63245456/99101772-b1a5-4167-b756-9e7881f0f264)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
