### PR TITLE
Migrate to tippy-content

### DIFF
--- a/web/templates/user_group_info_popover.hbs
+++ b/web/templates/user_group_info_popover.hbs
@@ -1,6 +1,6 @@
 <div class="group-info-popover">
     <div class="popover-inner">
-        <div class="popover-content">
+        <div class="tippy-content">
             <div class="group-info">
                 <div class="group-name"> {{group_name}} </div>
                 <div class="group-description">


### PR DESCRIPTION
Migrates to tippy-content from bootstrap css based on Issue #26821 for user-group-info-popover
Fixes: https://github.com/zulip/zulip/issues/26821 (The user-group-info-popover part)

If this is the desired output, will modify the rest.

<img width="647" alt="image" src="https://github.com/zulip/zulip/assets/57587313/15d6ffce-b31f-4ca9-b1fa-4b89994f075c">


<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
