### PR TITLE
Revert "markdown: Fix 3+ digit marker lists retaining alignment for 2 digits."

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -23,43 +23,15 @@
         margin-left: 0;
     }
 
+    /* Ensure ordered lists are nicely centered in 1-line messages */
     & ol {
-        margin: 2px 0 5px;
-
-        /* Ensure ordered lists are nicely centered in 1-line messages for up to 2
-           digit markers, else the markers take up as much space as needed without
-           being cut off at the beginning */
-        > li {
-            display: grid;
-            grid-template-columns:
-                [marker-start] minmax(20px, max-content)
-                [marker-end list-item-content-start] minmax(0, 1fr)
-                [list-item-content-end];
-
-            &::before {
-                content: counter(list-item) ". ";
-                counter-increment: list-item;
-                grid-column: marker;
-                text-align: right;
-                margin-right: 3px;
-            }
-
-            > * {
-                grid-column: list-item-content;
-            }
-
-            > p {
-                margin-top: 0;
-            }
-        }
+        margin: 2px 0 5px 20px;
     }
 
-    /* Invert direction of text alignment and margin of markers in ordered lists
-       for proper centering in Right-To-Left languages */
-    &.rtl ol > li::before {
-        text-align: left;
-        margin-left: 3px;
-        margin-right: unset;
+    /* Swap the left and right margins of ordered list for Right-To-Left languages */
+    &.rtl ol {
+        margin-right: 8px;
+        margin-left: 0;
     }
 
     /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */


### PR DESCRIPTION
This reverts commit d899c03da62988ab96753154f028fc80171f2489 (#25094, cc @N-Shar-ma). It broke the display of list items with inline formatting.

[Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/numbered.20list.20rendering.20broken/near/1645728).