### PR TITLE
help: Document "image viewer" mobile feature.

### DIFF
--- a/help/allow-image-link-previews.md
+++ b/help/allow-image-link-previews.md
@@ -22,3 +22,9 @@ prevent images from being used to track Zulip users.
 {!save-changes.md!}
 
 {end_tabs}
+
+## Related articles
+
+* [Manage your uploaded files](/help/manage-your-uploaded-files)
+* [Share and upload files](/help/share-and-upload-files)
+* [View images and videos](/help/view-images-and-videos)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -104,7 +104,7 @@
 * [Emoji reactions](/help/emoji-reactions)
 * [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)
-* [View images and videos](/help/view-and-browse-images)
+* [View images and videos](/help/view-images-and-videos)
 * [View messages sent by a user](/help/view-messages-sent-by-a-user)
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
 * [Searching for messages](/help/search-for-messages)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -104,7 +104,7 @@
 * [Emoji reactions](/help/emoji-reactions)
 * [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)
-* [View and browse images](/help/view-and-browse-images)
+* [View images and videos](/help/view-and-browse-images)
 * [View messages sent by a user](/help/view-messages-sent-by-a-user)
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
 * [Searching for messages](/help/search-for-messages)

--- a/help/manage-your-uploaded-files.md
+++ b/help/manage-your-uploaded-files.md
@@ -63,4 +63,4 @@ You can sort your uploaded files by name, upload date, message ID, and size.
 ## Related articles
 
 * [Share and upload files](/help/share-and-upload-files)
-* [View and browse images](/help/view-and-browse-images)
+* [View images and videos](/help/view-and-browse-images)

--- a/help/manage-your-uploaded-files.md
+++ b/help/manage-your-uploaded-files.md
@@ -63,4 +63,5 @@ You can sort your uploaded files by name, upload date, message ID, and size.
 ## Related articles
 
 * [Share and upload files](/help/share-and-upload-files)
-* [View images and videos](/help/view-and-browse-images)
+* [View images and videos](/help/view-images-and-videos)
+* [Block image and link previews](/help/allow-image-link-previews)

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -82,7 +82,7 @@ Zulip offers the following filters based on the location of the message.
 !!! tip ""
 
     You can also [view](/help/manage-your-uploaded-files) all the files you
-    have uploaded or [browse](/help/view-and-browse-images) all the images and
+    have uploaded or [browse](/help/view-images-and-videos) all the images and
     videos in the current view.
 
 ### Search your important messages

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -77,12 +77,13 @@ Zulip offers the following filters based on the location of the message.
 * `has:link`: Search messages that contain URLs.
 * `has:attachment`: Search messages that contain an [uploaded
   file](/help/share-and-upload-files).
-* `has:image`: Search messages that contain an uploaded image or link to an image.
+* `has:image`: Search messages that contain uploaded or linked images or videos.
 
 !!! tip ""
 
-    You can also [view](/help/manage-your-uploaded-files) all the files you have uploaded
-    or [browse](/help/view-and-browse-images) all the images in the current view.
+    You can also [view](/help/manage-your-uploaded-files) all the files you
+    have uploaded or [browse](/help/view-and-browse-images) all the images and
+    videos in the current view.
 
 ### Search your important messages
 

--- a/help/share-and-upload-files.md
+++ b/help/share-and-upload-files.md
@@ -4,9 +4,9 @@ Zulip supports attaching multiple files to messages, including images,
 documents, sound, and video. You can edit the names of the files others see
 after you upload them.
 
-Zulip will automatically generate a **thumbnail** for each file when you send
-the message, if it can. Image thumbnails will be shown directly in the message,
-and you can click on a thumbnail to [view the full image](/help/view-and-browse-images).
+For images and videos, a small preview will be shown directly in the message.
+People reading the message can click on the preview to
+[view the full-size image or video](/help/view-and-browse-images).
 
 ## Uploading files
 
@@ -125,5 +125,5 @@ This limit can be changed by the server administrator.
 ## Related articles
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
-* [View and browse images](/help/view-and-browse-images)
+* [View images and videos](/help/view-and-browse-images)
 * [Animated GIFs](/help/animated-gifs-from-giphy)

--- a/help/share-and-upload-files.md
+++ b/help/share-and-upload-files.md
@@ -6,7 +6,7 @@ after you upload them.
 
 For images and videos, a small preview will be shown directly in the message.
 People reading the message can click on the preview to
-[view the full-size image or video](/help/view-and-browse-images).
+[view the full-size image or video](/help/view-images-and-videos).
 
 ## Uploading files
 
@@ -125,5 +125,6 @@ This limit can be changed by the server administrator.
 ## Related articles
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
-* [View images and videos](/help/view-and-browse-images)
+* [View images and videos](/help/view-images-and-videos)
+* [Block image and link previews](/help/allow-image-link-previews)
 * [Animated GIFs](/help/animated-gifs-from-giphy)

--- a/help/view-and-browse-images.md
+++ b/help/view-and-browse-images.md
@@ -1,26 +1,37 @@
-# View and browse images
+# View images and videos
 
-When someone pastes or attaches an image to a message, Zulip shows a small
-preview. Click on the image preview to open the **image viewer**.
+Zulip shows previews of attached images and videos, unless previews are
+[disabled](/help/allow-image-link-previews) in your organization. You
+can click on a preview to view an image in more detail, or to play a
+video. Zulip also makes it convenient to browse all images and videos
+attached to messages in your current view.
 
-In the image viewer, you can:
+## Using the image viewer
 
-* Zoom in and out of the image
+{start_tabs}
 
-* Click and drag the image
+{tab|desktop-web}
 
-* **Reset zoom** so that the image is recentered and its original size
+1. Click an image preview to open the **image viewer**.
 
-* **Open** the image in a new browser tab
+1. You can interact with the image.
 
-* **Download** the image
+    * Zoom in and out of the image
 
-* Browse other images in the current view. For example, if you're in a
-  stream view, the image browser will show all the images from that stream. If
-  you do a [search](/help/search-for-messages), the image browser will show
-  all images in messages that matched that search.
+    * Click and drag the image
 
-Exit the image viewer by clicking anywhere outside the image.
+    * **Reset zoom** so that the image is recentered and back to its original size
+
+    * **Open** the image in a new browser tab if you are using the Zulip web app
+
+    * **Download** the image
+
+1. Click anywhere outside the image to close the image viewer once you are done.
+
+!!! tip ""
+
+    You can click on the file name to download an image rather than viewing it
+    in the Zulip app.
 
 !!! keyboard_tip ""
 
@@ -28,9 +39,30 @@ Exit the image viewer by clicking anywhere outside the image.
     <kbd>Z</kbd> and <kbd>Z</kbd> to zoom in and out of the image. Use
     <kbd>V</kbd> or <kbd>Esc</kbd> to **close** the image viewer.
 
-## Troubleshooting
+{end_tabs}
 
-To open the image viewer, you must click on the image preview, not the file name.
+## Using the image browser
+
+In the Zulip desktop or web app, you can browse the images in the current view.
+For example, if you're in a conversation view, the image browser will show all
+the images from that stream. If you do a [search](/help/search-for-messages),
+the image browser will show all images in messages that matched that search.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click an image preview or use <kbd>V</kbd> to open the **image viewer**.
+
+1. You can click an image or use the left and right buttons at the bottom of
+   the viewer to browse images.
+
+!!! keyboard_tip ""
+
+    Use <kbd class="arrow-key">←</kbd> and <kbd class="arrow-key">→</kbd>
+    to scroll through the images.
+
+{end_tabs}
 
 ## Related articles
 

--- a/help/view-images-and-videos.md
+++ b/help/view-images-and-videos.md
@@ -68,3 +68,4 @@ the image browser will show all images in messages that matched that search.
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 * [Share and upload files](/help/share-and-upload-files)
+* [Block image and link previews](/help/allow-image-link-previews)

--- a/help/view-images-and-videos.md
+++ b/help/view-images-and-videos.md
@@ -22,7 +22,7 @@ attached to messages in your current view.
 
     * **Reset zoom** so that the image is recentered and back to its original size
 
-    * **Open** the image in a new browser tab if you are using the Zulip web app
+    * **Open** the image in a new browser tab
 
     * **Download** the image
 
@@ -74,7 +74,7 @@ attached to messages in your current view.
 
     * Watch in **full screen** mode
 
-    * **Open** the video in a new browser tab if you are using the Zulip web app
+    * **Open** the video in a new browser tab
 
     * **Download** the video if it was uploaded to Zulip
 
@@ -95,6 +95,13 @@ attached to messages in your current view.
     Use <kbd class="arrow-key">↑</kbd> and <kbd class="arrow-key">↓</kbd>
     to increase or decrease the volume.
     Use <kbd>V</kbd> or <kbd>Esc</kbd> to **close** the video player.
+
+{tab|mobile}
+
+1. Tap a video thumbnail, link, or file name to open the video in your device's
+   default browser.
+
+1. You can switch back to the Zulip app once you are done.
 
 {end_tabs}
 

--- a/help/view-images-and-videos.md
+++ b/help/view-images-and-videos.md
@@ -6,7 +6,7 @@ can click on a preview to view an image in more detail, or to play a
 video. Zulip also makes it convenient to browse all images and videos
 attached to messages in your current view.
 
-## Using the image viewer
+## Use the image viewer
 
 {start_tabs}
 
@@ -41,26 +41,69 @@ attached to messages in your current view.
 
 {end_tabs}
 
-## Using the image browser
-
-In the Zulip desktop or web app, you can browse the images in the current view.
-For example, if you're in a conversation view, the image browser will show all
-the images from that stream. If you do a [search](/help/search-for-messages),
-the image browser will show all images in messages that matched that search.
+## Use the video player
 
 {start_tabs}
 
 {tab|desktop-web}
 
-1. Click an image preview or use <kbd>V</kbd> to open the **image viewer**.
+1. Click a video thumbnail to open the **video player**.
 
-1. You can click an image or use the left and right buttons at the bottom of
-   the viewer to browse images.
+1. You can interact with the video.
+
+    * **Play** the video
+
+    * Adjust the **volume**
+
+    * Watch in **full screen** mode
+
+    * **Open** the video in a new browser tab if you are using the Zulip web app
+
+    * **Download** the video if it was uploaded to Zulip
+
+    * Adjust **playback speed**
+
+    * Turn on **picture-in-picture**
+
+1. Click anywhere outside the video to close the video player once you are done.
+
+!!! tip ""
+
+    You can click on the file name to open the video in a new browser tab
+    rather than viewing it in the Zulip app.
 
 !!! keyboard_tip ""
 
-    Use <kbd class="arrow-key">←</kbd> and <kbd class="arrow-key">→</kbd>
-    to scroll through the images.
+    Use <kbd>V</kbd> to **open** the video player.
+    Use <kbd class="arrow-key">↑</kbd> and <kbd class="arrow-key">↓</kbd>
+    to increase or decrease the volume.
+    Use <kbd>V</kbd> or <kbd>Esc</kbd> to **close** the video player.
+
+{end_tabs}
+
+## Browse images and videos
+
+In the Zulip desktop or web app, you can browse the images and videos in
+the current view. For example, if you're in a stream view, you'll be able
+to browse through all the images and videos in that stream. If you do a
+[search](/help/search-for-messages), the **viewer** will display all the
+images and videos in messages matching that search.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click an image preview or video thumbnail to open the viewer.
+
+1. Browse by using the left and right arrow buttons at the bottom of the viewer.
+
+1. Click any image or video to display it.
+
+!!! keyboard_tip ""
+
+    Use <kbd>V</kbd> to **open** the viewer. Use
+    <kbd class="arrow-key">←</kbd> and <kbd class="arrow-key">→</kbd>
+    to scroll through the collection of images and videos.
 
 {end_tabs}
 

--- a/help/view-images-and-videos.md
+++ b/help/view-images-and-videos.md
@@ -39,6 +39,23 @@ attached to messages in your current view.
     <kbd>Z</kbd> and <kbd>Z</kbd> to zoom in and out of the image. Use
     <kbd>V</kbd> or <kbd>Esc</kbd> to **close** the image viewer.
 
+{tab|mobile}
+
+1. Tap an image preview or file name to open the **image viewer**.
+
+1. You can interact with the image.
+
+    * Zoom in and out of the image
+
+    * Pan the image if you are zoomed in
+
+    * Tap the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical-spread"></i>)
+      in the bottom right corner of the app to download the image, share it to
+      other apps, or share a link to the image
+
+1. Tap the **X** in the upper right corner of the app to close the image viewer
+   once you are done.
+
 {end_tabs}
 
 ## Use the video player

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -80,6 +80,7 @@ HELP_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
     URLRedirect("/help/configure-default-view", "/help/configure-home-view"),
     URLRedirect("/help/reading-topics", "/help/reading-conversations"),
     URLRedirect("/help/finding-a-topic-to-read", "/help/finding-a-conversation-to-read"),
+    URLRedirect("/help/view-and-browse-images", "/help/view-images-and-videos"),
 ]
 
 LANDING_PAGE_REDIRECTS = [


### PR DESCRIPTION
- Updates [View and browse images](https://zulip.com/help/view-and-browse-images), adding desktop/web app instructions and tweaking the intro paragraph.
- Renames page to **View images and videos**.
- Clarifies viewer support for browsing both images and videos, and tweaks documentation on other pages.
- Adds a new section to describing the video player features.
- Splits out browsing other images and videos in the view into its own section.
- Adds mobile app instructions.

Fixes #27801.

**Screenshots and screen captures:**
- https://zulip.com/help/view-and-browse-images
![image](https://github.com/zulip/zulip/assets/2343554/25cb8fda-9e07-42ad-909d-add8d42c5751)
![image](https://github.com/zulip/zulip/assets/2343554/9c47ac6b-ef64-497b-aa5c-24544036f42b)
![image](https://github.com/zulip/zulip/assets/2343554/16fb53b8-6c63-4b34-8efb-80e35372bfbf)

- https://zulip.com/help/search-for-messages#search-for-attachments-or-links
![image](https://github.com/zulip/zulip/assets/2343554/ffca2519-d9bd-472e-b785-85805ee0f9f9)

- https://zulip.com/help/share-and-upload-files
![image](https://github.com/zulip/zulip/assets/2343554/c5ca7ef0-4223-4752-aef9-0728b2223dd3)
