### PR TITLE
hotkey: Add shortcut toggle between preview and compose box

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -135,6 +135,9 @@ in the Zulip app to add more to your repertoire as needed.
 * **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
   <kbd>[</kbd> — Close the compose box and save the unsent message as a draft.
 
+* **Toggle Preview**: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> — Toggle
+  between a preview of the message and the compose box.
+
 ## Message actions
 
 * **Edit last message**: <kbd class="arrow-key">←</kbd> — Open the last

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -121,6 +121,21 @@ export function clear_private_stream_alert() {
     $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.private_stream_warning)}`).remove();
 }
 
+export function show_preview_area() {
+    const content = $("#compose-textarea").val();
+    $("#compose-textarea").hide();
+    $("#compose .markdown_preview").hide();
+    $("#compose .undo_markdown_preview").show();
+    $("#compose .undo_markdown_preview").trigger("focus");
+    $("#compose .preview_message_area").show();
+
+    render_and_show_preview(
+        $("#compose .markdown_preview_spinner"),
+        $("#compose .preview_content"),
+        content,
+    );
+}
+
 export function clear_preview_area() {
     $("#compose-textarea").show();
     $("#compose-textarea").trigger("focus");
@@ -735,18 +750,7 @@ export function initialize() {
         $("#compose").addClass("preview_mode");
         $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
-        const content = $("#compose-textarea").val();
-        $("#compose-textarea").hide();
-        $("#compose .markdown_preview").hide();
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .undo_markdown_preview").trigger("focus");
-        $("#compose .preview_message_area").show();
-
-        render_and_show_preview(
-            $("#compose .markdown_preview_spinner"),
-            $("#compose .preview_content"),
-            content,
-        );
+        show_preview_area();
     });
 
     $("#compose").on("click", ".undo_markdown_preview", (e) => {

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -122,6 +122,11 @@ export function clear_private_stream_alert() {
 }
 
 export function show_preview_area() {
+    // Disable unneeded compose_control_buttons as we don't
+    // need them in preview mode.
+    $("#compose").addClass("preview_mode");
+    $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
+
     const content = $("#compose-textarea").val();
     $("#compose-textarea").hide();
     $("#compose .markdown_preview").hide();
@@ -744,11 +749,6 @@ export function initialize() {
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
         e.stopPropagation();
-
-        // Disable unneeded compose_control_buttons as we don't
-        // need them in preview mode.
-        $("#compose").addClass("preview_mode");
-        $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
         show_preview_area();
     });

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -113,6 +113,10 @@ const keydown_cmd_or_ctrl_mappings = {
     190: {name: "narrow_to_compose_target", message_view_only: true}, // '.'
 };
 
+const keydown_cmd_or_ctrl_with_shift_mappings = {
+    80: {name: "toggle_compose_preview", message_view_only: true}, // 'P'
+};
+
 const keydown_either_mappings = {
     // these can be triggered by key or Shift + key
     // Note that codes for letters are still case sensitive!
@@ -199,6 +203,10 @@ export function get_keydown_hotkey(e) {
         }
         return undefined;
     } else if (e.metaKey || e.ctrlKey) {
+        hotkey = keydown_cmd_or_ctrl_with_shift_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
         return undefined;
     }
 
@@ -786,6 +794,16 @@ export function process_hotkey(e, hotkey) {
     if (event_name === "narrow_to_compose_target") {
         narrow.to_compose_target();
         return true;
+    }
+
+    if (event_name === "toggle_compose_preview" && compose_state.composing()) {
+        e.preventDefault();
+
+        if ($("#compose .markdown_preview").is(":visible")) {
+            compose.show_preview_area();
+        } else {
+            compose.clear_preview_area();
+        }
     }
 
     // Process hotkeys specially when in an input, select, textarea, or send button


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This adds the keyboard shortcut Ctrl + Shift + P to toggle between a preview of the message you are composing and the compose box.

A refactoring commit creates a function show_preview_area to perform the tasks that the show preview button does, which is used also used by the keyboard shortcut.

Please note that this PR borrows very heavily from #18938 by @Signior-X. I'm just trying to help move it along!

- Fixes: #18471

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

There really isn't a UI change but below are screenshots of using the keyboard shortcut Ctrl + Shift + P to toggle between compose and preview. Look, Ma! No mouse! ∅🖱️ 

<img width="408" alt="Screenshot 2023-09-23 at 5 34 30 PM" src="https://github.com/zulip/zulip/assets/21006/b45413f9-61fe-4796-abe4-db7e678d73d0">

<img width="408" alt="Screenshot 2023-09-23 at 5 34 37 PM" src="https://github.com/zulip/zulip/assets/21006/e38599d6-fbc9-4667-8372-d5cd0640cf30">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
