### PR TITLE
Refactoring Provisioning Logic for Improved Activation

### DIFF
--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -93,8 +93,16 @@ def setup_shell_profile(shell_profile: str) -> None:
             with open(shell_profile_path, "w") as shell_profile_file:
                 shell_profile_file.writelines(command + "\n")
 
-    source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
-    write_command(source_activate_command)
+    # Check if the environment is one of the dedicated containers: Vagrant, Docker, Droplet or WSL2
+    WSL = os.path.exists("/proc/sys/fs/binfmt_misc/WSLInterop")
+    vagrant = os.path.exists("/vagrant")
+    docker = os.path.exists("/var/run/docker.sock")
+    droplet = os.path.exists("/etc/digitalocean")
+    # If the environment matches one of the containers, write the activation command to the user's bash profile
+    if WSL or vagrant or docker or droplet:
+        source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
+        write_command(source_activate_command)
+
     if os.path.exists("/srv/zulip"):
         write_command("cd /srv/zulip")
 


### PR DESCRIPTION
Refactor tools/lib/provision_inner to conditionally write activation commands to the user's bash profile based on the machine type. Activation commands are now skipped for non-Vagrant/Droplet/Docker setups. 
<!-- Describe your pull request here.-->
This pull request refactors the `tools/lib/provision_inner` script to enhance machine type detection. Activation commands for the Zulip environment are now conditionally written to the user's bash profile, specifically targeting Vagrant, Droplet, and Docker setups. This change ensures that the activation script is only added for dedicated Zulip environments.
Fixes: <!-- Issue link, or clear description.--> #15029

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ x] Corner cases, error conditions, and easily imagined bugs.
</details>
