### PR TITLE
edit history: Open the modal after fetching data.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1091,7 +1091,7 @@ export function process_hotkey(e, hotkey) {
         }
         case "view_edit_history": {
             if (page_params.realm_allow_edit_history) {
-                message_edit_history.show_history(msg);
+                message_edit_history.fetch_and_render_message_history(msg);
                 $("#message-history-cancel").trigger("focus");
                 return true;
             }

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1092,7 +1092,6 @@ export function process_hotkey(e, hotkey) {
         case "view_edit_history": {
             if (page_params.realm_allow_edit_history) {
                 message_edit_history.fetch_and_render_message_history(msg);
-                $("#message-history-cancel").trigger("focus");
                 return true;
             }
             return false;

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -191,7 +191,6 @@ export function initialize() {
 
         if (page_params.realm_allow_edit_history) {
             fetch_and_render_message_history(message);
-            $("#message-history-cancel").trigger("focus");
         }
     });
 }

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -120,6 +120,7 @@ export function fetch_and_render_message_history(message) {
             if (prev_stream_item !== null) {
                 prev_stream_item.new_stream = sub_store.maybe_get_stream_name(message.stream_id);
             }
+            show_history();
             $("#message-history").attr("data-message-id", message.id);
             $("#message-history").html(
                 render_message_edit_history({
@@ -144,22 +145,21 @@ export function fetch_and_render_message_history(message) {
     });
 }
 
-export function show_history(message) {
-    const rendered_message_history = render_message_history_modal();
+export function show_history() {
+    if (!$("#message-history").length) {
+        const rendered_message_history = render_message_history_modal();
 
-    dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Message edit history"}),
-        html_body: rendered_message_history,
-        html_submit_button: $t_html({defaultMessage: "Close"}),
-        id: "message-edit-history",
-        on_click() {},
-        close_on_submit: true,
-        focus_submit_on_open: true,
-        single_footer_button: true,
-        post_render() {
-            fetch_and_render_message_history(message);
-        },
-    });
+        dialog_widget.launch({
+            html_heading: $t_html({defaultMessage: "Message edit history"}),
+            html_body: rendered_message_history,
+            html_submit_button: $t_html({defaultMessage: "Close"}),
+            id: "message-edit-history",
+            on_click() {},
+            close_on_submit: true,
+            focus_submit_on_open: true,
+            single_footer_button: true,
+        });
+    }
 }
 
 export function initialize() {
@@ -190,7 +190,7 @@ export function initialize() {
         }
 
         if (page_params.realm_allow_edit_history) {
-            show_history(message);
+            fetch_and_render_message_history(message);
             $("#message-history-cancel").trigger("focus");
         }
     });

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -136,6 +136,7 @@ export function fetch_and_render_message_history(message) {
                 });
         },
         error(xhr) {
+            show_history();
             ui_report.error(
                 $t_html({defaultMessage: "Error fetching message edit history"}),
                 xhr,


### PR DESCRIPTION
The opening of the message edit history modal was moved to `fetch_and_render_message_history`, preventing the dialog to [flicker](https://github.com/zulip/zulip/issues/26582) with an empty entry. For completion the fetching function was moved to `initialize`.

<!-- Describe your pull request here.-->

In this PR the function `show_history` was moved to be called inside the `fetch_and_render_message_history`, in order to guarantee that the dialog only opens after the message history was completely fetched. `show_history` was also changed to open the edit message history dialog only if such dialog is not yet opened, keeping the dynamic elements.

Fixes: Solves issue [26582](https://github.com/zulip/zulip/issues/26582)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
