### PR TITLE
margined unsubscribed button

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -73,6 +73,10 @@
     margin-right: 10px;
 }
 
+#remove_subscriber_stream {
+    margin-right: 20px;
+}
+
 .create_user_group_plus_button,
 .create_stream_plus_button {
     font-size: 24px;

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -12,7 +12,7 @@
     <td class="unsubscribe">
         <div class="subscriber_list_remove">
             <form class="remove-subscriber-form">
-                <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded btn-danger">
+                <button type="submit" name="unsubscribe" id="remove_subscriber_stream" class="remove-subscriber-button button small rounded btn-danger">
                     {{t 'Unsubscribe' }}
                 </button>
             </form>


### PR DESCRIPTION
Fixes: [26835](https://github.com/zulip/zulip/pull/26834)

I reviewed this [PR](https://github.com/zulip/zulip/pull/26834) which mentioned that the Unsubscribe Button: Not Margined Correctly which kind of solved this issue also but having conflicts with claimed changes.

As far as I digged, the conflict was just because of some unwanted changes through out files, which I think was to be done in order to make code more readable which I don't think was needed.
