### PR TITLE
message_header: Remove the widget to change the visibility policy.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -209,6 +209,7 @@ function populate_group_from_message_container(group, message_container) {
             group.stream_id = sub.stream_id;
             group.stream_muted = sub.is_muted;
         }
+        group.is_subscribed = stream_data.is_subscribed(group.stream_id);
         group.topic_is_resolved = resolved_topic.is_resolved(group.topic);
         group.topic_muted = user_topics.is_topic_muted(group.stream_id, group.topic);
         group.topic_unmuted = user_topics.is_topic_unmuted(group.stream_id, group.topic);

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -58,32 +58,33 @@
                 <div class="toggle_resolve_topic_spinner" style="display: none"></div>
             {{/if}}
 
-            {{#if development}}
-                <span class="change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
-                    {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
-                        <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
-                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
-                    {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
-                        <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic'}}"
-                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic' }}"></i>
-                    {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
-                        <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
-                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
-                    {{else}}
-                        <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic'}}"
-                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
-                    {{/if}}
-                </span>
-            {{else}}
-                {{#if stream_muted}}
-                    <i class="zulip-icon zulip-icon-unmute stream_muted {{#if topic_unmuted}} on_hover_topic_mute {{else}} on_hover_topic_unmute {{/if}} recipient_bar_icon hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" role="button" tabindex="0"
-                      {{#if topic_unmuted}} data-tooltip-template-id="topic-mute-tooltip-template" aria-label="{{t 'Mute topic' }}" {{else}} data-tooltip-template-id="topic-unmute-tooltip-template" aria-label="{{t 'Unmute topic' }}" {{/if}}></i>
+            {{#if is_subscribed}}
+                {{#if development}}
+                    <span class="change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
+                        {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
+                            <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
+                              role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
+                        {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
+                            <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic'}}"
+                              role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic' }}"></i>
+                        {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
+                            <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
+                              role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
+                        {{else}}
+                            <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic'}}"
+                              role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
+                        {{/if}}
+                    </span>
                 {{else}}
-                    <i class="zulip-icon zulip-icon-mute stream_unmuted{{#if topic_muted}} on_hover_topic_unmute {{else}} on_hover_topic_mute {{/if}} recipient_bar_icon hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" role="button" tabindex="0"
-                      {{#if topic_muted}} data-tooltip-template-id="topic-unmute-tooltip-template" aria-label="{{t 'Unmute topic' }}" {{else}} data-tooltip-template-id="topic-mute-tooltip-template" aria-label="{{t 'Mute topic' }}" {{/if}}></i>
+                    {{#if stream_muted}}
+                        <i class="zulip-icon zulip-icon-unmute stream_muted {{#if topic_unmuted}} on_hover_topic_mute {{else}} on_hover_topic_unmute {{/if}} recipient_bar_icon hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" role="button" tabindex="0"
+                          {{#if topic_unmuted}} data-tooltip-template-id="topic-mute-tooltip-template" aria-label="{{t 'Mute topic' }}" {{else}} data-tooltip-template-id="topic-unmute-tooltip-template" aria-label="{{t 'Unmute topic' }}" {{/if}}></i>
+                    {{else}}
+                        <i class="zulip-icon zulip-icon-mute stream_unmuted{{#if topic_muted}} on_hover_topic_unmute {{else}} on_hover_topic_mute {{/if}} recipient_bar_icon hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" role="button" tabindex="0"
+                          {{#if topic_muted}} data-tooltip-template-id="topic-unmute-tooltip-template" aria-label="{{t 'Unmute topic' }}" {{else}} data-tooltip-template-id="topic-mute-tooltip-template" aria-label="{{t 'Mute topic' }}" {{/if}}></i>
+                    {{/if}}
                 {{/if}}
             {{/if}}
-
         </span>
         <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
     </div>


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/follow.20topic.20in.20unsubscribed.20stream/near/1635049)

> currently the UI for following topics in the message header bar of the web app appears if I look at a public stream that I'm not subscribed to.

> Select a public stream Iago isn't subscribed to and view the stream (Shift V). Iago can now follow a topic in the stream view via a message header bar without suscribing to the stream.

> I feel like we should probably not have that option displayed until the user subscribes to the stream

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>Dummy ImageNot subscribed</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/206c9798-90f6-4c25-8dec-ed61d3601721">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
