### PR TITLE
unread_msgs: Fix all unreads in muted stream being treated as muted.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 213**
+
+* [`POST /register`](/api/register-queue): Fixed incorrect handling of
+  unmuted and followed topics in calculating the `mentions` and
+  `count` fields of the `unread_msgs` object.
+
 **Feature level 212**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 212
+API_FEATURE_LEVEL = 213
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -109,6 +109,21 @@ def set_topic_visibility_policy(
         )
 
 
+def get_topic_visibility_policy(
+    user_profile: UserProfile,
+    stream_id: int,
+    topic_name: str,
+) -> int:
+    try:
+        user_topic = UserTopic.objects.get(
+            user_profile=user_profile, stream_id=stream_id, topic_name__iexact=topic_name
+        )
+        visibility_policy = user_topic.visibility_policy
+    except UserTopic.DoesNotExist:
+        visibility_policy = UserTopic.VisibilityPolicy.INHERIT
+    return visibility_policy
+
+
 @transaction.atomic(savepoint=False)
 def bulk_set_user_topic_visibility_policy_in_database(
     user_profiles: List[UserProfile],

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11851,9 +11851,11 @@ paths:
                           count:
                             type: integer
                             description: |
-                              The total number of unread messages to display; this includes one-on-one
-                              and group direct messages, as well as all messages to unmuted topics
-                              on unmuted streams.
+                              The total number of unread messages to display. This includes one-on-one and group
+                              direct messages, as well as stream messages that are not [muted](/help/mute-a-topic).
+
+                              **Changes**: Before Zulip 8.0 (feature level 213), the unmute and follow
+                              topic features were not handled correctly in calculating this field.
                           pms:
                             type: array
                             description: |
@@ -11897,8 +11899,9 @@ paths:
                           streams:
                             type: array
                             description: |
-                              An array of objects where each object contains details of unread
-                              messages of a single subscribed stream, including muted streams.
+                              An array of dictionaries where each dictionary contains details of all
+                              unread messages of a single subscribed stream. This includes muted streams
+                              and muted topics, even though those messages are excluded from count.
 
                               **Changes**: Prior to Zulip 5.0 (feature level 90), these objects
                               included a `sender_ids` property, which listed the set of IDs of
@@ -11947,9 +11950,12 @@ paths:
                           mentions:
                             type: array
                             description: |
-                              Array containing the IDs of all unread messages in which the user has been
-                              mentioned. For muted streams, wildcard mentions will not be considered for
-                              this array.
+                              Array containing the IDs of all unread messages in which the user was
+                              mentioned directly, and unread [non-muted](/help/mute-a-topic) messages
+                              in which the user was mentioned through a wildcard.
+
+                              **Changes**: Before Zulip 8.0 (feature level 213), the unmute and follow
+                              topic features were not handled correctly in calculating this field.
                             items:
                               type: integer
                           old_unreads_missing:

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1611,7 +1611,7 @@ class MarkUnreadTest(ZulipTestCase):
             stream_dict={},
             huddle_dict={},
             mentions=set(),
-            muted_stream_ids=[],
+            muted_stream_ids=set(),
             unmuted_stream_msgs=set(),
             old_unreads_missing=False,
         )
@@ -1633,7 +1633,7 @@ class MarkUnreadTest(ZulipTestCase):
             stream_dict={},
             huddle_dict={},
             mentions=set(),
-            muted_stream_ids=[],
+            muted_stream_ids=set(),
             unmuted_stream_msgs=set(),
             old_unreads_missing=False,
         )

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -990,8 +990,8 @@ class GetUnreadMsgsTest(ZulipTestCase):
         result = get_unread_data()
 
         # The count here reflects the count of unread messages that we will
-        # report to users in the bankruptcy dialog, and for now it excludes unread messages
-        # from muted streams, but it doesn't exclude unread messages from muted topics yet.
+        # report to users in the bankruptcy dialog, and it excludes unread messages
+        # from muted streams and muted topics.
         self.assertEqual(result["count"], 4)
         self.assertFalse(result["old_unreads_missing"])
 


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20.60unread_msgs.2Ementions.60/near/1645170)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>Before</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/c8d553c2-d654-4c65-9088-143f2c1ba92e">
</img>
</details> 

<details><summary>After</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/1c1b3e07-5d6d-49ff-b7eb-1ce748dfe9b1">
</img>
</details> 

The count is still not correct as we don't use `unread_msgs.count` directly;  PR to show count correctly: #26849

**Updated Docs**

<details><summary>Count</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/df91a579-837c-46f7-bd55-b1f5480400a7">
</img>
</details> 

<details><summary>Streams</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/35702ecc-36d5-47bd-87ff-b522dbffd246">
</img>
</details> 

<details><summary>mentions</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/2c764e1e-8e1d-4790-8ff0-88862f876357">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
