### PR TITLE
unread_msgs: Fix the unread count in muted streams.

### DIFF
--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -360,7 +360,7 @@ class UnreadTopicCounter {
         for (const [topic, msgs] of per_stream_bucketer) {
             const topic_count = msgs.size;
 
-            if (user_topics.is_topic_unmuted(stream_id, topic)) {
+            if (user_topics.is_topic_unmuted_or_followed(stream_id, topic)) {
                 unmuted_count += topic_count;
             } else if (user_topics.is_topic_muted(stream_id, topic)) {
                 muted_count += topic_count;
@@ -464,7 +464,7 @@ class UnreadTopicCounter {
             const topic = stream_bucketer.reverse_lookup.get(message_id);
             const stream_is_muted = sub_store.get(stream_id)?.is_muted;
             if (stream_is_muted) {
-                if (user_topics.is_topic_unmuted(stream_id, topic)) {
+                if (user_topics.is_topic_unmuted_or_followed(stream_id, topic)) {
                     streams_with_unmuted_mentions.add(stream_id);
                 }
             } else {


### PR DESCRIPTION
In the muted stream, the unreads from followed topics were not adding up to the total unread count of the stream if both unmuted and followed topics had unreads.

<details><summary>Before</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/696bbf64-7d9f-44e9-adf6-176400ad44ad">
</img>
</details> 

<details><summary>After</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/4099f807-1fc4-450a-b21f-814ba323001e">
</img>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

---

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
