### PR TITLE
help: Restore scroll target styling

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -258,13 +258,13 @@ html {
     }
     /* Highlight the headings as well as the first child
       of any targeted div, as in the API documentation. */
-    & h1.scroll-target,
-    & h2.scroll-target,
-    & h3.scroll-target,
-    & h4.scroll-target,
-    & h5.scroll-target,
-    & h6.scroll-target,
-    & div.scroll-target > :first-child {
+    & h1:target,
+    & h2:target,
+    & h3:target,
+    & h4:target,
+    & h5:target,
+    & h6:target,
+    & div:target > :first-child {
         /* Increase the highlighted space around the text... */
         padding: 6px 8px;
         border-radius: 7px 7px 0 0;


### PR DESCRIPTION
This restores the styling previously added by commit ceec61ba109b87d5de8c2c7aa05fd45028e28e3c (#25573). The .scroll-target class of commit b852da6eedc5776a94ba65a8e69543f1698bf494 (#25573) was removed by commit 8dba4cbba6ccd17810a27edbb26fa8a4738a8a40 (#15713, merged later) and is unnecessary.

NB I never liked the way this looks and especially the way the extra border causes the header height to change on click, but I’m restoring it as-is since its removal was unintended.