### PR TITLE
realm: Differentiate reserved realms from in-use realms.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -599,21 +599,29 @@ class TestSupportEndpoint(ZulipTestCase):
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "new-name"}
         )
         self.assert_in_success_response(
-            ["Subdomain unavailable. Please choose a different one."], result
+            ["Subdomain already in use. Please choose a different one."], result
         )
 
         result = self.client_post(
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "zulip"}
         )
         self.assert_in_success_response(
-            ["Subdomain unavailable. Please choose a different one."], result
+            ["Subdomain already in use. Please choose a different one."], result
         )
 
         result = self.client_post(
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "lear"}
         )
         self.assert_in_success_response(
-            ["Subdomain unavailable. Please choose a different one."], result
+            ["Subdomain already in use. Please choose a different one."], result
+        )
+
+        # Test renaming to a "reserved" subdomain
+        result = self.client_post(
+            "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "your-org"}
+        )
+        self.assert_in_success_response(
+            ["Subdomain reserved. Please choose a different one."], result
         )
 
     def test_downgrade_realm(self) -> None:

--- a/zerver/management/commands/import.py
+++ b/zerver/management/commands/import.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
-from zerver.forms import check_subdomain_available
+from zerver.forms import OverridableValidationError, check_subdomain_available
 from zerver.lib.import_realm import do_import_realm
 
 
@@ -79,11 +79,13 @@ import a database dump from one or more JSON files."""
 
         try:
             check_subdomain_available(subdomain, allow_reserved_subdomain)
-        except ValidationError as e:
+        except OverridableValidationError as e:
             raise CommandError(
                 e.messages[0]
                 + "\nPass --allow-reserved-subdomain to override subdomain restrictions."
             )
+        except ValidationError as e:
+            raise CommandError(e.messages[0])
 
         paths = []
         for path in options["export_paths"]:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -223,7 +223,7 @@ class RealmTest(ZulipTestCase):
         )
         realm.save()
         result = self.client_patch("/json/realm", data)
-        self.assert_json_error(result, "Subdomain unavailable. Please choose a different one.")
+        self.assert_json_error(result, "Subdomain already in use. Please choose a different one.")
 
         # Now try to change the string_id to something available.
         data = dict(string_id="coolrealm")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1845,11 +1845,11 @@ class RealmCreationTest(ZulipTestCase):
             "-id": "cannot start or end with a",
             "string-ID": "lowercase letters",
             "string_id": "lowercase letters",
-            "stream": "unavailable",
-            "streams": "unavailable",
-            "about": "unavailable",
-            "abouts": "unavailable",
-            "zephyr": "unavailable",
+            "stream": "reserved",
+            "streams": "reserved",
+            "about": "reserved",
+            "abouts": "reserved",
+            "zephyr": "already in use",
         }
         for string_id, error_msg in errors.items():
             result = self.submit_realm_creation_form(
@@ -1881,7 +1881,7 @@ class RealmCreationTest(ZulipTestCase):
         email = "user1@test.com"
 
         result = self.submit_realm_creation_form(email, realm_subdomain="test", realm_name="Test")
-        self.assert_in_response("Subdomain unavailable. Please choose a different one.", result)
+        self.assert_in_response("Subdomain reserved. Please choose a different one.", result)
 
     @override_settings(OPEN_REALM_CREATION=True)
     def test_subdomain_restrictions_root_domain(self) -> None:
@@ -1894,7 +1894,7 @@ class RealmCreationTest(ZulipTestCase):
             result = self.submit_realm_creation_form(
                 email, realm_subdomain="", realm_name=realm_name
             )
-            self.assert_in_response("unavailable", result)
+            self.assert_in_response("already in use", result)
 
         # test valid use of root domain
         result = self.submit_realm_creation_form(email, realm_subdomain="", realm_name=realm_name)
@@ -1921,7 +1921,7 @@ class RealmCreationTest(ZulipTestCase):
             result = self.submit_realm_creation_form(
                 email, realm_subdomain="abcdef", realm_name=realm_name, realm_in_root_domain="true"
             )
-            self.assert_in_response("unavailable", result)
+            self.assert_in_response("already in use", result)
 
         # test valid use of root domain
         result = self.submit_realm_creation_form(
@@ -1956,7 +1956,7 @@ class RealmCreationTest(ZulipTestCase):
     def test_subdomain_check_api(self) -> None:
         result = self.client_get("/json/realm/subdomain/zulip")
         self.assert_in_success_response(
-            ["Subdomain unavailable. Please choose a different one."], result
+            ["Subdomain already in use. Please choose a different one."], result
         )
 
         result = self.client_get("/json/realm/subdomain/zu_lip")
@@ -1967,12 +1967,13 @@ class RealmCreationTest(ZulipTestCase):
         with self.settings(SOCIAL_AUTH_SUBDOMAIN="zulipauth"):
             result = self.client_get("/json/realm/subdomain/zulipauth")
             self.assert_in_success_response(
-                ["Subdomain unavailable. Please choose a different one."], result
+                ["Subdomain reserved. Please choose a different one."], result
             )
 
         result = self.client_get("/json/realm/subdomain/hufflepuff")
         self.assert_in_success_response(["available"], result)
-        self.assert_not_in_success_response(["unavailable"], result)
+        self.assert_not_in_success_response(["already in use"], result)
+        self.assert_not_in_success_response(["reserved"], result)
 
     def test_subdomain_check_management_command(self) -> None:
         # Short names should not work, even with the flag
@@ -2719,7 +2720,7 @@ class UserSignUpTest(ZulipTestCase):
         )
         self.assert_in_success_response(
             [
-                "Subdomain unavailable. Please choose a different one.",
+                "Subdomain already in use. Please choose a different one.",
                 'value="Test"',
                 'name="realm_name"',
             ],


### PR DESCRIPTION
Fixes: #23896.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
