### PR TITLE
users: Prevent mirror dummy users from being "reactivated."

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -19,6 +19,7 @@ from zerver.lib.avatar import avatar_url
 from zerver.lib.create_user import create_user
 from zerver.lib.default_streams import get_slim_realm_default_streams
 from zerver.lib.email_notifications import enqueue_welcome_emails, send_account_registered_email
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.send_email import clear_scheduled_invitation_emails
 from zerver.lib.stream_subscription import bulk_get_subscriber_peer_info
@@ -591,6 +592,10 @@ def do_activate_mirror_dummy_user(
 @transaction.atomic(savepoint=False)
 def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserProfile]) -> None:
     """Reactivate a user that had previously been deactivated"""
+    if user_profile.is_mirror_dummy:
+        raise JsonableError(
+            _("Cannot activate a placeholder account; ask the user to sign up, instead.")
+        )
     change_user_is_active(user_profile, True)
 
     event_time = timezone_now()

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1567,6 +1567,20 @@ class ActivateTest(ZulipTestCase):
         result = self.client_post(f"/json/users/{invalid_user_id}/reactivate")
         self.assert_json_error(result, "No such user")
 
+    def test_api_with_mirrordummy_user(self) -> None:
+        self.login("iago")
+        desdemona = self.example_user("desdemona")
+        change_user_is_active(desdemona, False)
+
+        desdemona.is_mirror_dummy = True
+        desdemona.save(update_fields=["is_mirror_dummy"])
+
+        # Cannot deactivate a user which is marked as "mirror dummy" from importing
+        result = self.client_post(f"/json/users/{desdemona.id}/reactivate")
+        self.assert_json_error(
+            result, "Cannot activate a placeholder account; ask the user to sign up, instead."
+        )
+
     def test_api_with_insufficient_permissions(self) -> None:
         non_admin = self.example_user("othello")
         do_change_user_role(non_admin, UserProfile.ROLE_MEMBER, acting_user=None)


### PR DESCRIPTION
These do not represent users who were ever active, so they should not be able to be reactivated.

See also #26703.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
