### PR TITLE
realm-deactivation: Send email to owners when deactivating organization.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -4319,7 +4319,10 @@ class StripeTest(StripeTestCase):
         self.assertEqual(last_ledger_entry.licenses_at_next_renewal, 20)
 
         do_deactivate_realm(
-            get_realm("zulip"), acting_user=None, deactivation_reason="owner_request"
+            get_realm("zulip"),
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
 
         plan.refresh_from_db()
@@ -4355,7 +4358,10 @@ class StripeTest(StripeTestCase):
             )
 
         do_deactivate_realm(
-            get_realm("zulip"), acting_user=None, deactivation_reason="owner_request"
+            get_realm("zulip"),
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         self.assertTrue(get_realm("zulip").deactivated)
         do_reactivate_realm(get_realm("zulip"))

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -1426,6 +1426,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 lear_realm,
                 acting_user=self.example_user("iago"),
                 deactivation_reason="owner_request",
+                email_owners=True,
             )
             self.assert_in_success_response(["lear deactivated"], result)
 

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -444,7 +444,10 @@ def support(
                 # TODO: Add support for deactivation reason in the support UI that'll be passed
                 # here.
                 do_deactivate_realm(
-                    realm, acting_user=acting_user, deactivation_reason="owner_request"
+                    realm,
+                    acting_user=acting_user,
+                    deactivation_reason="owner_request",
+                    email_owners=True,
                 )
                 context["success_message"] = f"{realm.string_id} deactivated."
         elif scrub_realm:

--- a/templates/zerver/emails/realm_deactivated.html
+++ b/templates/zerver/emails/realm_deactivated.html
@@ -1,0 +1,21 @@
+{% extends "zerver/emails/email_base_default.html" %}
+{% set localized_date = event_date|localize %}
+
+{% block illustration %}
+<img src="{{ email_images_base_url }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+<p>
+    {% if acting_user and initiated_deactivation %}
+        {% trans %}You have deactivated your Zulip organization, {{ realm_name }}, on {{ localized_date }}.{% endtrans %}
+    {% elif acting_user %}
+        {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated by {{ deactivating_owner }} on {{ localized_date }}.{% endtrans %}
+    {% else %}
+        {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated on {{ localized_date }}.{% endtrans %}
+    {% endif %}
+</p>
+<p>
+    {% trans %}If you have any questions or concerns, please reply to this email as soon as possible.{% endtrans %}
+</p>
+{% endblock %}

--- a/templates/zerver/emails/realm_deactivated.subject.txt
+++ b/templates/zerver/emails/realm_deactivated.subject.txt
@@ -1,0 +1,1 @@
+{% trans %}Your Zulip organization {{ realm_name }} has been deactivated{% endtrans %}

--- a/templates/zerver/emails/realm_deactivated.txt
+++ b/templates/zerver/emails/realm_deactivated.txt
@@ -1,0 +1,10 @@
+{% set localized_date = event_date|localize %}
+{% if acting_user and initiated_deactivation %}
+    {% trans %}You have deactivated your Zulip organization, {{ realm_name }}, on {{ localized_date }}.{% endtrans %}
+{% elif acting_user %}
+    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated by {{ deactivating_owner }} on {{ localized_date }}.{% endtrans %}
+{% else %}
+    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated on {{ localized_date }}.{% endtrans %}
+{% endif %}
+
+{% trans%}If you have any questions or concerns, please reply to this email as soon as possible.{% endtrans %}

--- a/tools/test-api
+++ b/tools/test-api
@@ -116,7 +116,9 @@ with test_server_running(
     do_reactivate_user(guest_user, acting_user=None)
 
     # Test realm deactivated error
-    do_deactivate_realm(guest_user.realm, acting_user=None, deactivation_reason="owner_request")
+    do_deactivate_realm(
+        guest_user.realm, acting_user=None, deactivation_reason="owner_request", email_owners=False
+    )
 
     client = Client(
         email=email,

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -98,7 +98,10 @@ def do_change_realm_subdomain(
     if add_deactivated_redirect:
         placeholder_realm = do_create_realm(old_subdomain, realm.name)
         do_deactivate_realm(
-            placeholder_realm, acting_user=None, deactivation_reason="subdomain_change"
+            placeholder_realm,
+            acting_user=None,
+            deactivation_reason="subdomain_change",
+            email_owners=False,
         )
         do_add_deactivated_redirect(placeholder_realm, realm.url)
 

--- a/zerver/management/commands/deactivate_realm.py
+++ b/zerver/management/commands/deactivate_realm.py
@@ -21,10 +21,15 @@ class Command(ZulipBaseCommand):
             help="Reason for deactivation",
             required=True,
         )
+        parser.add_argument(
+            "--email_owners",
+            action="store_true",
+            help="Whether to email organization owners about realm deactivation",
+        )
         self.add_realm_args(parser, required=True)
 
     @override
-    def handle(self, *args: Any, **options: str) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         deactivation_reason = options["deactivation_reason"]
 
@@ -38,8 +43,12 @@ class Command(ZulipBaseCommand):
             print("The realm", options["realm_id"], "is already deactivated.")
             return
 
+        send_realm_deactivation_email = options["email_owners"]
         print("Deactivating", options["realm_id"])
         do_deactivate_realm(
-            realm, acting_user=None, deactivation_reason=cast(Any, deactivation_reason)
+            realm,
+            acting_user=None,
+            deactivation_reason=cast(Any, deactivation_reason),
+            email_owners=send_realm_deactivation_email,
         )
         print("Done!")

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -203,7 +203,10 @@ class Command(ZulipBaseCommand):
         if options["deactivate_realm"]:
             print(f"\033[94mDeactivating realm\033[0m: {realm.string_id}")
             do_deactivate_realm(
-                realm, acting_user=None, deactivation_reason="self_hosting_migration"
+                realm,
+                acting_user=None,
+                deactivation_reason="self_hosting_migration",
+                email_owners=False,
             )
 
         def percent_callback(bytes_transferred: Any) -> None:

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -420,7 +420,9 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_realm_activation(self) -> None:
         realm = get_realm("zulip")
         user = self.example_user("desdemona")
-        do_deactivate_realm(realm, acting_user=user, deactivation_reason="owner_request")
+        do_deactivate_realm(
+            realm, acting_user=user, deactivation_reason="owner_request", email_owners=False
+        )
         log_entry = RealmAuditLog.objects.get(
             realm=realm, event_type=RealmAuditLog.REALM_DEACTIVATED, acting_user=user
         )

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -215,7 +215,10 @@ class AuthBackendTest(ZulipTestCase):
 
         # Verify auth fails with a deactivated realm
         do_deactivate_realm(
-            user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         result = backend.authenticate(**good_kwargs)
 
@@ -4992,7 +4995,10 @@ class FetchAPIKeyTest(ZulipTestCase):
 
     def test_deactivated_realm(self) -> None:
         do_deactivate_realm(
-            self.user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            self.user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         result = self.client_post(
             "/api/v1/fetch_api_key",
@@ -5056,7 +5062,10 @@ class DevFetchAPIKeyTest(ZulipTestCase):
 
     def test_deactivated_realm(self) -> None:
         do_deactivate_realm(
-            self.user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            self.user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         result = self.client_post("/api/v1/dev_fetch_api_key", dict(username=self.email))
         self.assert_json_error_contains(result, "This organization has been deactivated", 401)
@@ -6350,7 +6359,10 @@ class TestLDAP(ZulipLDAPTestCase):
             backend = self.backend
             email = "nonexisting@zulip.com"
             do_deactivate_realm(
-                backend._realm, acting_user=None, deactivation_reason="owner_request"
+                backend._realm,
+                acting_user=None,
+                deactivation_reason="owner_request",
+                email_owners=False,
             )
             with self.assertRaisesRegex(Exception, "Realm has been deactivated"):
                 backend.get_or_build_user(email, _LDAPUser())
@@ -7473,7 +7485,10 @@ class JWTFetchAPIKeyTest(ZulipTestCase):
     def test_inactive_realm_failure(self) -> None:
         payload = {"email": self.email}
         do_deactivate_realm(
-            self.user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            self.user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
             key = settings.JWT_AUTH_KEYS["zulip"]["key"]

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -583,7 +583,10 @@ class DeactivatedRealmTest(ZulipTestCase):
         """
         realm = get_realm("zulip")
         do_deactivate_realm(
-            get_realm("zulip"), acting_user=None, deactivation_reason="owner_request"
+            get_realm("zulip"),
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
 
         result = self.client_post(
@@ -652,7 +655,10 @@ class DeactivatedRealmTest(ZulipTestCase):
 
         """
         do_deactivate_realm(
-            get_realm("zulip"), acting_user=None, deactivation_reason="owner_request"
+            get_realm("zulip"),
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         user_profile = self.example_user("hamlet")
         api_key = get_api_key(user_profile)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -161,7 +161,10 @@ class EmailChangeTestCase(ZulipTestCase):
         activation_url = self.generate_email_change_link(new_email)
 
         do_deactivate_realm(
-            user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
 
         response = self.client_get(activation_url)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1283,7 +1283,10 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         mm_address = create_missed_message_address(user_profile, message)
 
         do_deactivate_realm(
-            user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
 
         incoming_valid_message = EmailMessage()

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3007,7 +3007,9 @@ class NormalActionsTest(BaseAction):
         # correct because were one to somehow compute page_params (as
         # this test does), but that's not actually possible.
         with self.verify_action(state_change_expected=False) as events:
-            do_deactivate_realm(realm, acting_user=None, deactivation_reason="owner_request")
+            do_deactivate_realm(
+                realm, acting_user=None, deactivation_reason="owner_request", email_owners=False
+            )
         check_realm_deactivated("events[0]", events[0])
 
     def test_do_mark_onboarding_step_as_read(self) -> None:

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1670,7 +1670,9 @@ class AnalyticsBouncerTest(BouncerTestCase):
         do_set_realm_authentication_methods(zephyr_realm, new_auth_method_dict, acting_user=user)
 
         # Deactivation is synced.
-        do_deactivate_realm(zephyr_realm, acting_user=None, deactivation_reason="owner_request")
+        do_deactivate_realm(
+            zephyr_realm, acting_user=None, deactivation_reason="owner_request", email_owners=False
+        )
 
         send_server_data_to_push_bouncer()
         check_counts(5, 5, 1, 1, 7)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -557,7 +557,10 @@ class PasswordResetTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
         do_deactivate_realm(
-            user_profile.realm, acting_user=None, deactivation_reason="owner_request"
+            user_profile.realm,
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
 
         # start the password reset process by supplying an email address
@@ -4353,7 +4356,10 @@ class TestFindMyTeam(ZulipTestCase):
 
     def test_find_team_deactivated_realm(self) -> None:
         do_deactivate_realm(
-            get_realm("zulip"), acting_user=None, deactivation_reason="owner_request"
+            get_realm("zulip"),
+            acting_user=None,
+            deactivation_reason="owner_request",
+            email_owners=False,
         )
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -494,7 +494,9 @@ def update_realm(
 @has_request_variables
 def deactivate_realm(request: HttpRequest, user: UserProfile) -> HttpResponse:
     realm = user.realm
-    do_deactivate_realm(realm, acting_user=user, deactivation_reason="owner_request")
+    do_deactivate_realm(
+        realm, acting_user=user, deactivation_reason="owner_request", email_owners=True
+    )
     return json_success(request)
 
 

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -5,6 +5,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template.defaultfilters import pluralize, slugify
 from django.urls import reverse
 from django.utils import translation
+from django.utils.formats import localize
 from django.utils.timesince import timesince
 from jinja2 import Environment
 from two_factor.plugins.phonenumber.templatetags.phonenumber import device_action
@@ -39,6 +40,7 @@ def environment(**options: Any) -> Environment:
     env.filters["display_list"] = display_list
     env.filters["device_action"] = device_action
     env.filters["timesince"] = timesince
+    env.filters["localize"] = localize
 
     env.policies["json.dumps_function"] = json_dumps
     env.policies["json.dumps_kwargs"] = {}


### PR DESCRIPTION
Creates a new `realm_deactivated` email that can be sent as part of the realm deactivation process.

Fixes #24685.

**Notes**:
- Adds a new boolean flag, `email_owners`, to `do_deactivate_realm`. This flag is set to `False` when `do_deactivate_realm` is used for realm exports or changing a realm's subdomain, so that the active organization owners are not emailed in those cases.

- This flag is optional for the `deactivate_realm` management command, but as there is no active user passed in that case, then the email is sent without a reference to who deactivated the realm.

- It is passed as `True` for the support analytics view, but the email that is generated does not include information about the support user who completed the request for organization deactivation.

- When an active organization owner deactivates the organization, then the flag is `True` and an email is sent to them as well as any other active organization owners, with a slight variation in the email text for those two cases.

- Adds specific tests for when `email_owners` is passed as `True`. All existing tests for other functionality of `do_deactivate_user` pass the flag as `False`.

**Questions**:
- The date format in the email is currently `year-month-day` and isn't adjusted for the realm's default langauge. We could reorder the date parts (e.g. `day-month-year`) or create a text based string, like we do for login notification emails. But we should probably think about internationalization here. While the date string for the login notification emails is good for English, it's a bit odd in other languages (see screenshot below with aaron's language set to Japanese)
- The issue has the Zulip Cloud footer linking to the help center article **Contact Support** and I just wanted to confirm that's the correct and we don't want to link directly to the support email address directly in the email.

<details>
<summary>Login notification email in Japanese</summary>

![Screenshot from 2023-09-26 15-31-02](https://github.com/zulip/zulip/assets/63245456/d4a105ce-9154-4dc3-b3af-9ab81a37ef2c)
</details>

---

**Screenshots and screen captures:**

<details>
<summary>Support deactivated realm - with Zulip Cloud footer</summary>

## Text version
![Screenshot from 2023-09-26 15-23-45](https://github.com/zulip/zulip/assets/63245456/ef504f30-df6a-43fe-80d0-1e664db1ee47)

## HTML version
![Screenshot from 2023-09-26 15-23-36](https://github.com/zulip/zulip/assets/63245456/8e5c19a4-737f-4027-b82f-cfd89a8c9cf5)
</details>
<details>
<summary>Active owner deactivated realm - with self-hosted footer</summary>

## Text version
*1st email is to the other active owner, 2nd email is to the owner who deactivated the organization.*
![Screenshot from 2023-09-26 14-39-33](https://github.com/zulip/zulip/assets/63245456/7e6ed8dc-e2ad-4c5d-8fce-cc410a86795d)

## HTML version
*1st email is to the other active owner, 2nd email is to the owner who deactivated the organization.*
![Screenshot from 2023-09-26 14-39-20](https://github.com/zulip/zulip/assets/63245456/717f1783-3f94-4104-9f6e-91e0e7464235)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
