### PR TITLE
help: Update /help/mute-a-topic and document following topics.

### DIFF
--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -25,7 +25,7 @@ preference settings, including the following:
     * [What types of messages trigger notifications][default-notifications]
     * [Configurations for email notifications](/help/email-notifications)
 
-[default-notifications]: /help/stream-notifications#set-default-notifications-for-all-streams
+[default-notifications]: /help/stream-notifications#configure-default-notifications-for-all-streams
 
 ## How to configure default settings for new users
 

--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -1,0 +1,53 @@
+# Follow a topic
+
+Zulip lets you follow topics you are interested in. You can configure how you get notified about new messages for topics you follow.
+
+In muted streams, topics you follow are automatically treated as
+[unmuted](/help/mute-a-topic).
+
+## Follow or unfollow a topic
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!topic-actions.md!}
+
+1. Configure topic notifications using the row of icons at the top of the menu.
+
+!!! tip ""
+
+    You can also configure notifications by clicking the topic notifications status
+    icon in the message recipient bar or in **Recent conversations**.
+
+{end_tabs}
+
+## Configure notifications for followed topics
+
+{start_tabs}
+
+{settings_tab|notifications}
+
+1. In the **Notification triggers** table,
+   toggle the settings for **Followed topics**.
+
+{end_tabs}
+
+## Manage configured topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|topics}
+
+1. Configure notifications for each topic by selecting the desired option from
+   the dropdown in the **Status** column.
+
+{end_tabs}
+
+## Related articles
+
+* [Stream notifications](/help/stream-notifications)
+* [Mute or unmute a topic](/help/mute-a-topic)
+* [Mute or unmute a stream](/help/mute-a-stream)

--- a/help/include/configure-topic-notifications.md
+++ b/help/include/configure-topic-notifications.md
@@ -1,0 +1,22 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{!topic-actions.md!}
+
+1. Configure topic notifications using the row of icons at the top of the menu.
+
+!!! tip ""
+
+    You can also configure notifications by clicking the topic notifications status
+    icon in the message recipient bar or in **Recent conversations**.
+
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Mute topic** or **Unmute topic**.
+
+{!topic-long-press-menu-tip.md!}
+
+{end_tabs}

--- a/help/include/manage-configured-topics.md
+++ b/help/include/manage-configured-topics.md
@@ -1,0 +1,30 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|topics}
+
+1. Configure notifications for each topic by selecting the desired option from
+   the dropdown in the **Status** column.
+
+{tab|mobile}
+
+1. Tap the **Streams**
+   (<img src="/static/images/help/mobile-hash-icon.svg" alt="hash" class="mobile-icon"/>)
+   tab at the bottom of the app.
+
+1. Select a stream containing topics you want to configure.
+
+1. Tap the **Topics list**
+   (<img src="/static/images/help/mobile-list-icon.svg" alt="list" class="mobile-icon"/>)
+   icon in the upper right corner of the app.
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Mute topic** or **Unmute topic**.
+
+!!! tip ""
+
+    Muted topics are grayed out in the topics list.
+
+{end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -138,6 +138,7 @@
 
 ## Notifications
 * [Stream notifications](/help/stream-notifications)
+* [Follow a topic](/help/follow-a-topic)
 * [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
 * [Mute or unmute a stream](/help/mute-a-stream)
 * [Mute or unmute a topic](/help/mute-a-topic)

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -4,61 +4,11 @@
 
 ## Mute or unmute a topic
 
-{start_tabs}
-
-{tab|desktop-web}
-
-{!topic-actions.md!}
-
-1. Configure topic notifications using the row of icons at the top of the menu.
-
-!!! tip ""
-
-    You can also configure notifications by clicking the topic notifications status
-    icon in the message recipient bar or in **Recent conversations**.
-
-{tab|mobile}
-
-{!topic-long-press-menu.md!}
-
-1. Tap **Mute topic** or **Unmute topic**.
-
-{!topic-long-press-menu-tip.md!}
-
-{end_tabs}
+{!configure-topic-notifications.md!}
 
 ## Manage configured topics
 
-{start_tabs}
-
-{tab|desktop-web}
-
-{settings_tab|topics}
-
-1. Configure notifications for each topic by selecting the desired option from
-   the dropdown in the **Status** column.
-
-{tab|mobile}
-
-1. Tap the **Streams**
-   (<img src="/static/images/help/mobile-hash-icon.svg" alt="hash" class="mobile-icon"/>)
-   tab at the bottom of the app.
-
-1. Select a stream containing topics you want to configure.
-
-1. Tap the **Topics list**
-   (<img src="/static/images/help/mobile-list-icon.svg" alt="list" class="mobile-icon"/>)
-   icon in the upper right corner of the app.
-
-{!topic-long-press-menu.md!}
-
-1. Tap **Mute topic** or **Unmute topic**.
-
-!!! tip ""
-
-    Muted topics are grayed out in the topics list.
-
-{end_tabs}
+{!manage-configured-topics.md!}
 
 ## Related articles
 

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -2,7 +2,7 @@
 
 {!mute-unmute-intro.md!}
 
-## Configure topic notifications in unmuted streams
+## Mute or unmute a topic
 
 {start_tabs}
 
@@ -10,53 +10,18 @@
 
 {!topic-actions.md!}
 
-1. Select **Mute topic** or **Unmute topic**.
+1. Configure topic notifications using the row of icons at the top of the menu.
 
 !!! tip ""
 
-    You can also click the **mute** (<i class="zulip-icon zulip-icon-mute"></i>) icon
-    in the message recipient bar or in **Recent conversations**.
+    You can also configure notifications by clicking the topic notifications status
+    icon in the message recipient bar or in **Recent conversations**.
 
 {tab|mobile}
 
 {!topic-long-press-menu.md!}
 
 1. Tap **Mute topic** or **Unmute topic**.
-
-{!topic-long-press-menu-tip.md!}
-
-{end_tabs}
-
-## Configure topic notifications in muted streams
-
-{start_tabs}
-
-{tab|desktop-web}
-
-{!topic-actions.md!}
-
-1. Select **Unmute topic** or **Mute topic**.
-
-!!! tip ""
-
-    You can also click the **unmute** (<i class="zulip-icon zulip-icon-unmute"></i>) icon
-    in the message recipient bar or in **Recent conversations**.
-
-{tab|mobile}
-
-1. Tap the **Streams**
-   (<img src="/static/images/help/mobile-hash-icon.svg" alt="hash" class="mobile-icon"/>)
-   tab at the bottom of the app.
-
-1. Select a grayed-out (muted) stream from the streams list.
-
-1. Tap the **Topics list**
-   (<img src="/static/images/help/mobile-list-icon.svg" alt="list" class="mobile-icon"/>)
-   icon in the upper right corner of the app.
-
-{!topic-long-press-menu.md!}
-
-1. Tap **Unmute topic** or **Mute topic**.
 
 {!topic-long-press-menu-tip.md!}
 

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -13,4 +13,5 @@
 ## Related articles
 
 * [Mute or unmute a stream](/help/mute-a-stream)
+* [Follow a topic](/help/follow-a-topic)
 * [Mute a user](/help/mute-a-user)

--- a/help/stream-notifications.md
+++ b/help/stream-notifications.md
@@ -3,7 +3,7 @@
 You can configure desktop, mobile, and email notifications on a stream by
 stream basis.
 
-## Set notifications for a single stream
+## Configure notifications for a single stream
 
 These settings will override any default stream notification settings.
 
@@ -32,7 +32,7 @@ These settings will override any default stream notification settings.
 
 {end_tabs}
 
-## Set default notifications for all streams
+## Configure default notifications for all streams
 
 These settings only apply to streams where you have not
 explicitly set a notification preference.


### PR DESCRIPTION
## Mute a topic

Current: https://zulip.com/help/mute-a-topic


<details>
<summary>
Combining instructions for muted and unmuted streams:
</summary>
<img width="683" alt="Screenshot 2023-09-27 at 9 04 21 AM" src="https://github.com/zulip/zulip/assets/2090066/a8895bf9-337f-4b93-bd14-abb83d0646d5">
</details>

<details>
<summary>
Just using the unmuted stream instructions for mobile:
</summary>
<img width="739" alt="Screenshot 2023-09-27 at 9 11 27 AM" src="https://github.com/zulip/zulip/assets/2090066/910b2fa0-b42d-45ff-985b-9abaee00ae4b">


</details>




## Follow a topic

- No mobile UI yet. Can use the same instructions as /help/mute-a-topic once there is one.
- We'll add the setting for automatically following topics once it's merged in `main`.
- Sections ordered in terms of how useful I think they are.

<details>
<summary>
Screenshot
</summary>
<img width="611" alt="Screenshot 2023-09-27 at 9 04 05 AM" src="https://github.com/zulip/zulip/assets/2090066/aa63ea23-3e8b-48b8-a446-988d521fdb0a">

</details>

## Sidebar
<img width="261" alt="Screenshot 2023-09-26 at 4 28 35 PM" src="https://github.com/zulip/zulip/assets/2090066/10f19755-3202-43d0-8802-a2083fdeaa88">
