### PR TITLE
search: Always select search bar text when initiating search.

### DIFF
--- a/web/src/search.js
+++ b/web/src/search.js
@@ -183,13 +183,7 @@ export function initiate_search() {
     // Open the typeahead after opening the search bar, so that we don't
     // get a weird visual jump where the typeahead results are narrow
     // before the search bar expands and then wider it expands.
-    if (!$("#searchbox .dropdown-menu").is(":visible")) {
-        $("#search_query").typeahead("lookup");
-    }
-
-    if (!search_bar_already_open) {
-        $("#search_query").typeahead("lookup").trigger("select");
-    }
+    $("#search_query").typeahead("lookup").trigger("select");
 }
 
 export function clear_search_form() {


### PR DESCRIPTION
Fixes issue reported here: https://chat.zulip.org/#narrow/stream/9-issues/topic/search.20keyboard.20UI.20regression/near/1646401

I wish I could remember why these if statements were here, but I don't think we need them (or at least not anymore?).