### PR TITLE
Deactivated Profile indicator in the profile view

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -328,6 +328,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         user_avatar: people.medium_avatar_url_for_person(user),
         is_me: people.is_current_user(user.email),
         is_bot: user.is_bot,
+        profile_is_deactivated: !people.is_person_active(user.user_id),
         date_joined: timerender.get_localized_date_or_time_for_format(
             parseISO(user.date_joined),
             "dayofyear_year",

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -25,7 +25,7 @@
                     <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
                 </div>
                 <div class="modal__status">
-                    {{#if user_is_deactivated}}
+                    {{#if profile_is_deactivated}}
                         <i class="user_profile_status">Deactivated Profile</i>
                     {{/if}}
                 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -1,27 +1,34 @@
 <div class="micromodal" id="user-profile-modal" data-user-id="{{user_id}}" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1">
         <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
-            <div class="modal__header">
-                {{#unless is_bot}}
-                <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
-                    <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
+            <div class="modal__header_main center">
+                <div class="modal__header">
+                    {{#unless is_bot}}
+                    <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
+                        <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
+                    </div>
+                    {{/unless}}
+                    <h1 class="modal__title user_profile_name_heading" id="name">
+                        {{#if is_bot}}
+                            <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                        {{/if}}
+                        <span class="user_profile_name">{{full_name}}</span>
+                        {{#if is_me}}
+                            <a href="/#settings/profile">
+                                <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_own_edit_button" data-tippy-content="{{t 'Edit profile' }}" aria-hidden="true"></i>
+                            </a>
+                        {{/if}}
+                        {{#if can_manage_profile}}
+                            <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_others_edit_button" data-tippy-content="{{t 'Manage user' }}" aria-hidden="true"></i>
+                        {{/if}}
+                    </h1>
+                    <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
                 </div>
-                {{/unless}}
-                <h1 class="modal__title user_profile_name_heading" id="name">
-                    {{#if is_bot}}
-                        <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                <div class="modal__status">
+                    {{#if user_is_deactivated}}
+                        <i class="user_profile_status">Deactivated Profile</i>
                     {{/if}}
-                    <span class="user_profile_name">{{full_name}}</span>
-                    {{#if is_me}}
-                        <a href="/#settings/profile">
-                            <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_own_edit_button" data-tippy-content="{{t 'Edit profile' }}" aria-hidden="true"></i>
-                        </a>
-                    {{/if}}
-                    {{#if can_manage_profile}}
-                        <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_others_edit_button" data-tippy-content="{{t 'Manage user' }}" aria-hidden="true"></i>
-                    {{/if}}
-                </h1>
-                <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
+                </div>
             </div>
             <div id="tab-toggle" class="center"></div>
             <main class="modal__body" id="body" data-simplebar data-simplebar-auto-hide="false">


### PR DESCRIPTION
This PR addresses issue 2 of #26861
Added a "Deactivated Profile" sub header in the profile view to indicate deactivated users/bots


![image](https://github.com/zulip/zulip/assets/51041290/129b661e-f362-4102-83ff-d9877afa4a7b)

