### PR TITLE
Rename some references to display settings -> preferences

### DIFF
--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -27,7 +27,7 @@ INTRO_HOTSPOTS: Dict[str, Dict[str, StrPromise]] = {
     "intro_gear": {
         "title": gettext_lazy("Settings"),
         "description": gettext_lazy(
-            "Go to Settings to configure your notifications and display settings."
+            "Go to Settings to configure your notifications and preferences."
         ),
     },
     "intro_compose": {

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1496,7 +1496,7 @@ class UserBaseSettings(models.Model):
     ### Generic UI settings
     enter_sends = models.BooleanField(default=False)
 
-    ### Display settings. ###
+    ### Preferences. ###
     # left_side_userlist was removed from the UI in Zulip 6.0; the
     # database model is being temporarily preserved in case we want to
     # restore a version of the setting, preserving who had it enabled.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes part of #26874 

Finished renaming 'display settings' -> 'preferences' in the following files to finish out the work started in https://github.com/zulip/zulip/issues/25945

zerver/lib/hotspots.py
zerver/models.py
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


