### PR TITLE
popovers: Replace hide_all with tippy's hideAll method.

### DIFF
--- a/web/src/activity.js
+++ b/web/src/activity.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import {hideAll} from "tippy.js";
 
 import * as blueslip from "./blueslip";
 import * as buddy_data from "./buddy_data";
@@ -11,7 +12,6 @@ import * as narrow from "./narrow";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as presence from "./presence";
 import * as ui_util from "./ui_util";
 import {UserSearch} from "./user_search";
@@ -127,7 +127,7 @@ export function build_user_sidebar() {
 function do_update_users_for_search() {
     // Hide all the popovers but not userlist sidebar
     // when the user is searching.
-    popovers.hide_all_except_sidebars();
+    hideAll();
     build_user_sidebar();
     user_cursor.reset();
 }
@@ -289,7 +289,7 @@ function keydown_enter_key() {
     }
 
     narrow_for_user_id({user_id});
-    popovers.hide_all();
+    hideAll();
 }
 
 export function set_cursor_and_filter() {

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -489,28 +489,6 @@ export function initialize() {
         window.location.href = hash_util.build_login_link();
     });
 
-    $("#userlist-toggle-button").on("click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const sidebarHidden = !$(".app-main .column-right").hasClass("expanded");
-        popovers.hide_all();
-        if (sidebarHidden) {
-            right_sidebar_ui.show_userlist_sidebar();
-        }
-    });
-
-    $("#streamlist-toggle-button").on("click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const sidebarHidden = !$(".app-main .column-left").hasClass("expanded");
-        popovers.hide_all();
-        if (sidebarHidden) {
-            stream_popover.show_streamlist_sidebar();
-        }
-    });
-
     $("#user_presences")
         .expectOne()
         .on("click", ".selectable_sidebar_block", (e) => {
@@ -671,6 +649,7 @@ export function initialize() {
 
     user_profile.register_click_handlers();
     stream_popover.register_click_handlers();
+    right_sidebar_ui.register_click_handlers();
 
     $("body").on("click", ".logout_button", () => {
         $("#logout_form").trigger("submit");

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -27,7 +27,6 @@ import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_view_ui from "./recent_view_ui";
 import * as right_sidebar_ui from "./right_sidebar_ui";
@@ -206,7 +205,6 @@ export function initialize() {
         }
         compose_actions.respond_to_message({trigger: "message click"});
         e.stopPropagation();
-        popovers.hide_all();
     };
 
     // if on normal non-mobile experience, a `click` event should run the message
@@ -233,7 +231,6 @@ export function initialize() {
 
     $("#main_div").on("click", ".star_container", function (e) {
         e.stopPropagation();
-        popovers.hide_all();
 
         if (page_params.is_spectator) {
             spectators.login_to_access();
@@ -293,7 +290,6 @@ export function initialize() {
         message_lists.current.select_id(rows.id($row));
         message_edit.start($row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".move_message_button", function (e) {
         const $row = message_lists.current.get_row(rows.id($(this).closest(".message_row")));
@@ -307,43 +303,36 @@ export function initialize() {
             message,
         );
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".always_visible_topic_edit,.on_hover_topic_edit", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.start_inline_topic_edit($recipient_row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".topic_edit_save", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.save_inline_topic_edit($recipient_row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".topic_edit_cancel", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.end_inline_topic_edit($recipient_row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".message_edit_save", function (e) {
         const $row = $(this).closest(".message_row");
         message_edit.save_message_row_edit($row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".message_edit_cancel", function (e) {
         const $row = $(this).closest(".message_row");
         message_edit.end_message_row_edit($row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", ".message_edit_close", function (e) {
         const $row = $(this).closest(".message_row");
         message_edit.end_message_row_edit($row);
         e.stopPropagation();
-        popovers.hide_all();
     });
     $("body").on("click", "a", function () {
         if (document.activeElement === this) {
@@ -498,7 +487,6 @@ export function initialize() {
 
             e.preventDefault();
             e.stopPropagation();
-            popovers.hide_all();
             $(".tooltip").remove();
         });
 
@@ -713,9 +701,6 @@ export function initialize() {
             e.preventDefault();
             return;
         }
-
-        // Still hide the popovers, however
-        popovers.hide_all();
     }
 
     $("body").on("click", "#compose-content", handle_compose_click);
@@ -882,21 +867,6 @@ export function initialize() {
             // the child nodes, so the #compose stopPropagation doesn't get a
             // chance to capture right clicks.
             return;
-        }
-
-        // Dismiss popovers if the user has clicked outside them
-        if (
-            $(
-                '.popover-inner, #user-profile-modal, .emoji-picker-popover, .app-main [class^="column-"].expanded',
-            ).has(e.target).length === 0
-        ) {
-            // Since tippy instance can handle outside clicks on their own,
-            // we don't need to trigger them from here.
-            // This fixes the bug of `hideAll` being called
-            // after a tippy popover has been triggered which hides
-            // the popover without being displayed.
-            const not_hide_tippy_instances = true;
-            popovers.hide_all(not_hide_tippy_instances);
         }
 
         if (compose_state.composing() && !$(e.target).parents("#compose").length) {

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -696,8 +696,6 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
-        $(e.target).toggleClass("has_popover");
-
         let $target_textarea;
         let edit_message_id;
         const compose_click_target = compose_ui.get_compose_click_target(e);
@@ -708,7 +706,7 @@ export function initialize() {
             $target_textarea = $(compose_click_target).closest("form").find("textarea");
         }
 
-        if ($(e.target).hasClass("has_popover")) {
+        if (!flatpickr.is_flatpickr_open) {
             const on_timestamp_selection = (val) => {
                 const timestr = `<time:${val}> `;
                 compose_ui.insert_syntax_and_focus(timestr, $target_textarea);
@@ -721,8 +719,15 @@ export function initialize() {
                 {
                     // place the time picker wherever there is space and center it horizontally
                     position: "auto center",
+                    onOpen: () => flatpickr.set_flatpickr_open(true),
+                    onClose: () => flatpickr.set_flatpickr_open(false),
+                    // Since we want to handle close of flatpickr manually, we don't want
+                    // flatpickr to hide automatically on clicking its trigger element.
+                    ignoredFocusElements: [e.currentTarget],
                 },
             );
+        } else {
+            flatpickr.current_flatpickr_instance.close();
         }
     });
 

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -15,7 +15,6 @@ import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as recent_view_data from "./recent_view_data";
 import * as rows from "./rows";
 import * as sent_messages from "./sent_messages";
@@ -479,7 +478,6 @@ export function initialize({on_send_message_success}) {
     function on_failed_action(selector, callback) {
         $("#main_div").on("click", selector, function (e) {
             e.stopPropagation();
-            popovers.hide_all();
             const $row = $(this).closest(".message_row");
             const local_id = rows.local_echo_id($row);
             // Message should be waiting for ack and only have a local id,

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -7,6 +7,13 @@ import assert from "minimalistic-assert";
 import {$t} from "./i18n";
 import {user_settings} from "./user_settings";
 
+export let is_flatpickr_open: boolean = false;
+export let current_flatpickr_instance: flatpickr.Instance;
+
+export function set_flatpickr_open(value: boolean): void {
+    is_flatpickr_open = value;
+}
+
 function is_numeric_key(key: string): boolean {
     return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
 }
@@ -19,7 +26,7 @@ export function show_flatpickr(
 ): flatpickr.Instance {
     const $flatpickr_input = $<HTMLInputElement>("<input>").attr("id", "#timestamp_flatpickr");
 
-    const instance = flatpickr($flatpickr_input[0], {
+    current_flatpickr_instance = flatpickr($flatpickr_input[0], {
         mode: "single",
         enableTime: true,
         clickOpens: false,
@@ -77,7 +84,7 @@ export function show_flatpickr(
         ...options,
     });
 
-    const $container = $(instance.calendarContainer);
+    const $container = $(current_flatpickr_instance.calendarContainer);
 
     $container.on("keydown", (e) => {
         // Main keyboard UI implementation.
@@ -97,14 +104,12 @@ export function show_flatpickr(
                 // use flatpickr's built-in behavior to choose the selected day.
                 return true;
             }
-            $(element).toggleClass("has_popover");
             $container.find(".flatpickr-confirm").trigger("click");
         }
 
         if (e.key === "Escape") {
-            $(element).toggleClass("has_popover");
-            instance.close();
-            instance.destroy();
+            current_flatpickr_instance.close();
+            current_flatpickr_instance.destroy();
         }
 
         if (e.key === "Tab") {
@@ -127,14 +132,14 @@ export function show_flatpickr(
         const time = $flatpickr_input.val();
         assert(typeof time === "string");
         callback(time);
-        instance.close();
-        instance.destroy();
+        current_flatpickr_instance.close();
+        current_flatpickr_instance.destroy();
     });
-    instance.open();
-    assert(instance.selectedDateElem !== undefined);
-    instance.selectedDateElem.focus();
+    current_flatpickr_instance.open();
+    assert(current_flatpickr_instance.selectedDateElem !== undefined);
+    current_flatpickr_instance.selectedDateElem.focus();
 
-    return instance;
+    return current_flatpickr_instance;
 }
 
 export function close_all(): void {

--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -8,7 +8,6 @@ import * as compose_ui from "./compose_ui";
 import {media_breakpoints_num} from "./css_variables";
 import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
-import * as popovers from "./popovers";
 import * as rows from "./rows";
 import * as ui_util from "./ui_util";
 
@@ -195,7 +194,6 @@ function toggle_giphy_popover(target) {
                 giphy_popover_instance = instance;
                 const $popper = $(giphy_popover_instance.popper).trigger("focus");
                 gifs_grid = await renderGIPHYGrid($popper.find(".giphy-content")[0]);
-                popovers.hide_all(true);
 
                 const $click_target = $(instance.reference);
                 if ($click_target.parents(".message_edit_form").length === 1) {

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -18,7 +18,6 @@ import * as narrow from "./narrow";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
-import * as popovers from "./popovers";
 import * as recent_view_ui from "./recent_view_ui";
 import * as recent_view_util from "./recent_view_util";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
@@ -473,7 +472,6 @@ function hashchanged(from_reload, e) {
 
     // We are changing to a "main screen" view.
     overlays.close_for_hash_change();
-    popovers.hide_all();
     browser_history.state.changing_hash = true;
     const ret = do_hashchange_normal(from_reload);
     browser_history.state.changing_hash = false;

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import * as activity from "./activity";
 import * as browser_history from "./browser_history";
@@ -40,6 +41,7 @@ import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_view_ui from "./recent_view_ui";
 import * as recent_view_util from "./recent_view_util";
+import * as right_sidebar_ui from "./right_sidebar_ui";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
 import * as search from "./search";
 import * as settings_data from "./settings_data";
@@ -271,7 +273,9 @@ export function process_escape_key(e) {
             $("#user_card_popover .user-card-popover-manage-menu-btn").trigger("focus");
             return true;
         }
-        popovers.hide_all();
+        right_sidebar_ui.hide_userlist_sidebar();
+        stream_popover.hide_streamlist_sidebar();
+        hideAll();
         return true;
     }
 

--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -7,7 +7,6 @@ import * as blueslip from "./blueslip";
 import * as message_store from "./message_store";
 import * as overlays from "./overlays";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as rows from "./rows";
 
 let is_open = false;
@@ -326,7 +325,6 @@ export function build_open_image_function(on_close) {
             on_close,
         });
 
-        popovers.hide_all();
         is_open = true;
     };
 }

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -10,7 +10,6 @@ import {$t, $t_html} from "./i18n";
 import * as message_lists from "./message_lists";
 import {page_params} from "./page_params";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
 import * as spectators from "./spectators";
@@ -178,7 +177,6 @@ export function initialize() {
     $("body").on("click", ".message_edit_notice", (e) => {
         e.stopPropagation();
         e.preventDefault();
-        popovers.hide_all();
 
         const message_id = rows.id($(e.currentTarget).closest(".message_row"));
         const $row = message_lists.current.get_row(message_id);

--- a/web/src/muted_users_ui.js
+++ b/web/src/muted_users_ui.js
@@ -1,3 +1,5 @@
+import {hideAll} from "tippy.js";
+
 import render_confirm_mute_user from "../templates/confirm_dialog/confirm_mute_user.hbs";
 
 import * as activity from "./activity";
@@ -9,7 +11,6 @@ import * as muted_users from "./muted_users";
 import * as overlays from "./overlays";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as recent_view_ui from "./recent_view_ui";
 import * as settings_muted_users from "./settings_muted_users";
 
@@ -65,7 +66,7 @@ export function rerender_for_muted_user() {
 }
 
 export function handle_user_updates(muted_user_ids) {
-    popovers.hide_all();
+    hideAll();
     muted_users.set_muted_users(muted_user_ids);
     rerender_for_muted_user();
 }

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Micromodal from "micromodal";
+import {hideAll} from "tippy.js";
 
 import * as blueslip from "./blueslip";
 
@@ -148,6 +149,7 @@ export function open_overlay(opts: OverlayOptions): void {
         },
     };
 
+    hideAll();
     disable_scrolling();
     opts.$overlay.addClass("show");
     opts.$overlay.attr("aria-hidden", "false");
@@ -208,6 +210,7 @@ export function open_modal(
     }
 
     blueslip.debug("open modal: " + modal_id);
+    hideAll();
 
     // Micromodal gets elements using the getElementById DOM function
     // which doesn't require the hash. We add it manually here.

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -868,7 +868,7 @@ export function initialize() {
             message_lists.current.select_id(message_id);
             const args = popover_menus_data.get_actions_popover_content_context(message_id);
             instance.setContent(parse_html(render_actions_popover_content(args)));
-            $row.addClass("has_popover has_actions_popover");
+            $row.addClass("has_actions_popover");
         },
         onMount(instance) {
             if (message_actions_popover_keyboard_toggle) {
@@ -994,7 +994,7 @@ export function initialize() {
         },
         onHidden(instance) {
             const $row = $(instance.reference).closest(".message_row");
-            $row.removeClass("has_popover has_actions_popover");
+            $row.removeClass("has_actions_popover");
             instance.destroy();
             popover_instances.message_actions = undefined;
             message_actions_popover_keyboard_toggle = false;

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -4,7 +4,7 @@
 
 import ClipboardJS from "clipboard";
 import $ from "jquery";
-import tippy, {delegate} from "tippy.js";
+import tippy, {delegate, hideAll} from "tippy.js";
 
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
 import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
@@ -41,7 +41,6 @@ import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as popover_menus_data from "./popover_menus_data";
-import * as popovers from "./popovers";
 import * as read_receipts from "./read_receipts";
 import * as rows from "./rows";
 import * as scheduled_messages from "./scheduled_messages";
@@ -242,7 +241,6 @@ function on_show_prep(instance) {
         e.stopPropagation();
         instance.hide();
     });
-    popovers.hide_all_except_sidebars();
 }
 
 function get_props_for_popover_centering(popover_props) {
@@ -584,7 +582,6 @@ export function initialize() {
                 ),
             );
             popover_instances.compose_control_buttons = instance;
-            popovers.hide_all_except_sidebars();
         },
         onHidden(instance) {
             instance.destroy();
@@ -1025,7 +1022,6 @@ export function initialize() {
             });
         },
         onShow(instance) {
-            popovers.hide_all_except_sidebars();
             const show_unstar_all_button = starred_messages.get_count() > 0;
 
             instance.setContent(
@@ -1057,8 +1053,6 @@ export function initialize() {
             });
         },
         onShow(instance) {
-            popovers.hide_all_except_sidebars();
-
             instance.setContent(parse_html(render_drafts_sidebar_actions({})));
         },
         onHidden(instance) {
@@ -1081,7 +1075,6 @@ export function initialize() {
             });
         },
         onShow(instance) {
-            popovers.hide_all_except_sidebars();
             instance.setContent(parse_html(render_all_messages_sidebar_actions()));
         },
         onHidden(instance) {
@@ -1098,7 +1091,6 @@ export function initialize() {
             $("#compose-textarea").trigger("focus");
         },
         onShow(instance) {
-            popovers.hide_all_except_sidebars(instance);
             const formatted_send_later_time = get_formatted_selected_send_later_time();
             instance.setContent(
                 parse_html(
@@ -1124,10 +1116,6 @@ export function initialize() {
         },
     });
 
-    /* Configure popovers to hide when toggling overlays. */
-    overlays.register_pre_open_hook(popovers.hide_all);
-    overlays.register_pre_close_hook(popovers.hide_all);
-
     let last_scroll = 0;
 
     $(document).on("scroll", () => {
@@ -1138,14 +1126,14 @@ export function initialize() {
 
         const date = Date.now();
 
-        // only run `popovers.hide_all()` if the last scroll was more
+        // only run `hideAll()` if the last scroll was more
         // than 250ms ago.
         if (date - last_scroll > 250) {
-            popovers.hide_all();
+            hideAll();
         }
 
         // update the scroll time on every event to make sure it doesn't
-        // retrigger `hide_all` while still scrolling.
+        // retrigger `hideAll()` while still scrolling.
         last_scroll = date;
     });
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1,48 +1,11 @@
 import $ from "jquery";
-import {hideAll} from "tippy.js";
-
-import * as emoji_picker from "./emoji_picker";
-import * as playground_links_popover from "./playground_links_popover";
-import * as popover_menus from "./popover_menus";
-import * as stream_popover from "./stream_popover";
-import * as user_card_popover from "./user_card_popover";
-import * as user_group_popover from "./user_group_popover";
 
 export function any_active() {
-    // True if any popover (that this module manages) is currently shown.
-    // Expanded sidebars on mobile view count as popovers as well.
-    return (
-        popover_menus.any_active() ||
-        stream_popover.is_open() ||
-        user_group_popover.is_open() ||
-        user_card_popover.user_sidebar.is_open() ||
-        user_card_popover.message_user_card.is_open() ||
-        user_card_popover.user_card.is_open() ||
-        emoji_picker.is_open() ||
-        playground_links_popover.is_open() ||
-        $("[class^='column-'].expanded").length
-    );
-}
-
-// This function will hide all true popovers (the streamlist and
-// userlist sidebars use the popover infrastructure, but doesn't work
-// like a popover structurally).
-export function hide_all_except_sidebars(opts) {
-    if (!opts || !opts.not_hide_tippy_instances) {
-        // hideAll hides all tippy instances (tooltips and popovers).
-        hideAll();
-    }
-    emoji_picker.hide_emoji_popover();
-    stream_popover.hide_stream_popover();
-    user_group_popover.hide();
-    user_card_popover.hide_all_user_card_popovers();
-    playground_links_popover.hide();
-}
-
-// This function will hide all the popovers, including the mobile web
-// or narrow window sidebars.
-export function hide_all(not_hide_tippy_instances) {
-    hide_all_except_sidebars({
-        not_hide_tippy_instances,
-    });
+    const $tippy_instances = $("[data-tippy-root]");
+    // tippy instances without `interactive: true` have `pointer-events: none`.
+    const any_interactive_instances = $tippy_instances.filter(
+        (_i, elt) => elt.style.pointerEvents === "",
+    ).length;
+    const is_sidebar_expanded = $("[class^='column-'].expanded").length;
+    return Boolean(any_interactive_instances || is_sidebar_expanded);
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -4,7 +4,6 @@ import {hideAll} from "tippy.js";
 import * as emoji_picker from "./emoji_picker";
 import * as playground_links_popover from "./playground_links_popover";
 import * as popover_menus from "./popover_menus";
-import * as right_sidebar_ui from "./right_sidebar_ui";
 import * as stream_popover from "./stream_popover";
 import * as user_card_popover from "./user_card_popover";
 import * as user_group_popover from "./user_group_popover";
@@ -44,8 +43,6 @@ export function hide_all_except_sidebars(opts) {
 // This function will hide all the popovers, including the mobile web
 // or narrow window sidebars.
 export function hide_all(not_hide_tippy_instances) {
-    right_sidebar_ui.hide_userlist_sidebar();
-    stream_popover.hide_streamlist_sidebar();
     hide_all_except_sidebars({
         not_hide_tippy_instances,
     });

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -28,7 +28,6 @@ export function any_active() {
 // userlist sidebars use the popover infrastructure, but doesn't work
 // like a popover structurally).
 export function hide_all_except_sidebars(opts) {
-    $(".has_popover").removeClass("has_popover has_actions_popover has_emoji_popover");
     if (!opts || !opts.not_hide_tippy_instances) {
         // hideAll hides all tippy instances (tooltips and popovers).
         hideAll();

--- a/web/src/read_receipts.js
+++ b/web/src/read_receipts.js
@@ -10,7 +10,6 @@ import * as loading from "./loading";
 import * as message_store from "./message_store";
 import * as overlays from "./overlays";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as ui_report from "./ui_report";
 
 export function show_user_list(message_id) {
@@ -78,10 +77,6 @@ export function show_user_list(message_id) {
                     },
                 });
             }
-        },
-        on_hide() {
-            // Ensure any user info popovers are closed
-            popovers.hide_all();
         },
     });
 }

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import {hideAll} from "tippy.js";
 
 import render_recent_view_filters from "../templates/recent_view_filters.hbs";
 import render_recent_view_row from "../templates/recent_view_row.hbs";
@@ -898,7 +899,7 @@ export function complete_rerender() {
         is_scroll_position_for_render,
         post_scroll__pre_render_callback() {
             // Hide popovers on scroll in recent conversations.
-            popovers.hide_all();
+            hideAll();
 
             // Update the focused element for keyboard navigation if needed.
             recenter_focus_if_off_screen();

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -1,5 +1,6 @@
 import autosize from "autosize";
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import * as blueslip from "./blueslip";
 import * as compose_state from "./compose_state";
@@ -10,7 +11,6 @@ import * as message_viewport from "./message_viewport";
 import * as navbar_alerts from "./navbar_alerts";
 import * as navigate from "./navigate";
 import * as popover_menus from "./popover_menus";
-import * as popovers from "./popovers";
 import * as util from "./util";
 
 function get_bottom_whitespace_height() {
@@ -167,7 +167,7 @@ export function handler() {
     // popping up when the user opened that very popover.
     const mobile = util.is_mobile();
     if (!mobile || new_width !== _old_width) {
-        popovers.hide_all();
+        hideAll();
     }
 
     if (new_width !== _old_width) {

--- a/web/src/right_sidebar_ui.js
+++ b/web/src/right_sidebar_ui.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import * as popovers from "./popovers";
 import * as resize from "./resize";
 
 export function hide_userlist_sidebar() {
@@ -9,4 +10,17 @@ export function hide_userlist_sidebar() {
 export function show_userlist_sidebar() {
     $(".app-main .column-right").addClass("expanded");
     resize.resize_page_components();
+}
+
+export function register_click_handlers() {
+    $("#userlist-toggle-button").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const sidebarHidden = !$(".app-main .column-right").hasClass("expanded");
+        popovers.hide_all();
+        if (sidebarHidden) {
+            show_userlist_sidebar();
+        }
+    });
 }

--- a/web/src/right_sidebar_ui.js
+++ b/web/src/right_sidebar_ui.js
@@ -1,6 +1,5 @@
 import $ from "jquery";
 
-import * as popovers from "./popovers";
 import * as resize from "./resize";
 
 export function hide_userlist_sidebar() {
@@ -13,14 +12,22 @@ export function show_userlist_sidebar() {
 }
 
 export function register_click_handlers() {
-    $("#userlist-toggle-button").on("click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
+    document.addEventListener(
+        "click",
+        (e) => {
+            const $right_column = $(".app-main .column-right");
+            const sidebarHidden = !$right_column.hasClass("expanded");
+            const $elt = $(e.target);
+            const toggle_button_clicked = Boolean($elt.closest("#userlist-toggle-button").length);
+            const click_outside_right_sidebar = !$elt.closest($right_column).length;
+            if (!sidebarHidden && (click_outside_right_sidebar || toggle_button_clicked)) {
+                hide_userlist_sidebar();
+            }
 
-        const sidebarHidden = !$(".app-main .column-right").hasClass("expanded");
-        popovers.hide_all();
-        if (sidebarHidden) {
-            show_userlist_sidebar();
-        }
-    });
+            if (sidebarHidden && toggle_button_clicked) {
+                show_userlist_sidebar();
+            }
+        },
+        {capture: true},
+    );
 }

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -1,11 +1,11 @@
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import render_search_list_item from "../templates/search_list_item.hbs";
 
 import {Filter} from "./filter";
 import * as keydown_util from "./keydown_util";
 import * as narrow_state from "./narrow_state";
-import * as popovers from "./popovers";
 import * as search_suggestion from "./search_suggestion";
 
 // Exported for unit testing
@@ -149,7 +149,6 @@ export function initialize({on_narrow_search}) {
 
     // register searchbar click handler
     $("#search_exit").on("click", (e) => {
-        popovers.hide_all();
         exit_search();
         e.preventDefault();
         e.stopPropagation();
@@ -166,7 +165,7 @@ export function initialize({on_narrow_search}) {
     // This prevents a bug where tab shows a visual change before the blur handler kicks in
     $("#search_exit").on("keydown", (e) => {
         if (e.key === "tab") {
-            popovers.hide_all();
+            hideAll();
             exit_search();
             e.preventDefault();
             e.stopPropagation();

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -1,8 +1,8 @@
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import * as browser_history from "./browser_history";
 import * as keydown_util from "./keydown_util";
-import * as popovers from "./popovers";
 import * as scroll_util from "./scroll_util";
 import * as settings from "./settings";
 import * as settings_sections from "./settings_sections";
@@ -100,7 +100,7 @@ export class SettingsPanelMenu {
     }
 
     activate_section_or_default(section) {
-        popovers.hide_all();
+        hideAll();
         if (!section) {
             // No section is given so we display the default.
 

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -14,7 +14,6 @@ import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as presence from "./presence";
 import * as scroll_util from "./scroll_util";
 import * as settings_bots from "./settings_bots";
@@ -449,7 +448,6 @@ function handle_deactivation($tbody) {
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
         e.stopPropagation();
-        popovers.hide_all();
 
         const $row = $(e.target).closest(".user_row");
         const user_id = $row.data("user-id");
@@ -474,7 +472,6 @@ function handle_bot_deactivation($tbody) {
     $tbody.on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        popovers.hide_all();
 
         const $button_elem = $(e.target);
         const $row = $button_elem.closest(".user_row");
@@ -521,7 +518,6 @@ function handle_reactivation($tbody) {
     $tbody.on("click", ".reactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        popovers.hide_all();
 
         // Go up the tree until we find the user row, then grab the email element
         const $button_elem = $(e.target);
@@ -547,7 +543,6 @@ function handle_edit_form($tbody) {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
-        popovers.hide_all();
 
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         if (people.is_my_user_id(user_id)) {

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
+import {hideAll} from "tippy.js";
 
 import render_filter_topics from "../templates/filter_topics.hbs";
 import render_stream_privacy from "../templates/stream_privacy.hbs";
@@ -14,7 +15,6 @@ import * as keydown_util from "./keydown_util";
 import {ListCursor} from "./list_cursor";
 import * as narrow_state from "./narrow_state";
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
 import * as settings_data from "./settings_data";
@@ -719,7 +719,6 @@ export function set_event_handlers({on_stream_click}) {
             return;
         }
         const stream_id = stream_id_for_elt($(e.target).parents("li"));
-        popovers.hide_all();
         on_stream_click(stream_id, "sidebar");
 
         clear_and_hide_search();
@@ -847,7 +846,7 @@ export function initiate_search() {
         $("#streamlist-toggle").is(":visible") &&
         !$(".app-main .column-left").hasClass("expanded")
     ) {
-        popovers.hide_all();
+        hideAll();
         stream_popover.show_streamlist_sidebar();
     }
     $filter.trigger("focus");

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -514,4 +514,15 @@ export function register_click_handlers() {
 
         e.stopPropagation();
     });
+
+    $("#streamlist-toggle-button").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const sidebarHidden = !$(".app-main .column-left").hasClass("expanded");
+        popovers.hide_all();
+        if (sidebarHidden) {
+            show_streamlist_sidebar();
+        }
+    });
 }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -515,14 +515,22 @@ export function register_click_handlers() {
         e.stopPropagation();
     });
 
-    $("#streamlist-toggle-button").on("click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
+    document.addEventListener(
+        "click",
+        (e) => {
+            const $left_column = $(".app-main .column-left");
+            const sidebarHidden = !$left_column.hasClass("expanded");
+            const $elt = $(e.target);
+            const toggle_button_clicked = Boolean($elt.closest("#streamlist-toggle-button").length);
+            const click_outside_left_sidebar = !$elt.closest($left_column).length;
+            if (!sidebarHidden && (click_outside_left_sidebar || toggle_button_clicked)) {
+                hide_streamlist_sidebar();
+            }
 
-        const sidebarHidden = !$(".app-main .column-left").hasClass("expanded");
-        popovers.hide_all();
-        if (sidebarHidden) {
-            show_streamlist_sidebar();
-        }
-    });
+            if (sidebarHidden && toggle_button_clicked) {
+                show_streamlist_sidebar();
+            }
+        },
+        {capture: true},
+    );
 }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -16,7 +16,6 @@ import {$t, $t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as popover_menus from "./popover_menus";
 import {left_sidebar_tippy_options} from "./popover_menus";
-import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
@@ -114,7 +113,6 @@ function build_stream_popover(opts) {
         return;
     }
 
-    popovers.hide_all_except_sidebars();
     const content = render_stream_sidebar_actions({
         stream: sub_store.get(stream_id),
     });

--- a/web/src/topic_zoom.js
+++ b/web/src/topic_zoom.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import * as pm_list from "./pm_list";
-import * as popovers from "./popovers";
 import * as stream_list from "./stream_list";
 import * as topic_list from "./topic_list";
 
@@ -15,7 +15,7 @@ export function is_zoomed_in() {
 function zoom_in() {
     const stream_id = topic_list.active_stream_id();
 
-    popovers.hide_all_except_sidebars();
+    hideAll();
     pm_list.close();
     topic_list.zoom_in();
     stream_list.zoom_in_topics({
@@ -35,7 +35,7 @@ export function zoom_out() {
     }
     const $stream_li = topic_list.get_stream_li();
 
-    popovers.hide_all_except_sidebars();
+    hideAll();
     topic_list.zoom_out();
     stream_list.zoom_out_topics();
 

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -1,7 +1,7 @@
 import ClipboardJS from "clipboard";
 import {parseISO} from "date-fns";
 import $ from "jquery";
-import tippy from "tippy.js";
+import tippy, {hideAll} from "tippy.js";
 
 import render_user_card_popover_content from "../templates/user_card_popover_content.hbs";
 import render_user_card_popover_manage_menu from "../templates/user_card_popover_manage_menu.hbs";
@@ -24,7 +24,6 @@ import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
-import {hide_all, hide_all_except_sidebars} from "./popovers";
 import * as right_sidebar_ui from "./right_sidebar_ui";
 import * as rows from "./rows";
 import * as settings_config from "./settings_config";
@@ -580,7 +579,7 @@ function toggle_sidebar_user_card_popover($target) {
 
     // Hide popovers, but we don't want to hide the sidebars on
     // smaller browser windows.
-    hide_all_except_sidebars();
+    hideAll();
 
     if (previous_user_sidebar_id === user_id) {
         // If the popover is already shown, clicking again should toggle it.
@@ -638,7 +637,6 @@ function register_click_handlers() {
     $("body").on("click", ".user-card-popover-actions .narrow_to_private_messages", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;
-        hide_all();
         if (overlays.is_active()) {
             overlays.close_active();
         }
@@ -650,7 +648,6 @@ function register_click_handlers() {
     $("body").on("click", ".user-card-popover-actions .narrow_to_messages_sent", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;
-        hide_all();
         if (overlays.is_active()) {
             overlays.close_active();
         }
@@ -675,7 +672,6 @@ function register_click_handlers() {
 
     $("body").on("click", ".user-card-popover-actions .sidebar-popover-reactivate-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
-        hide_all();
         e.stopPropagation();
         e.preventDefault();
         function handle_confirm() {
@@ -741,22 +737,18 @@ function register_click_handlers() {
      * but we do want to close the modal when you click them. */
 
     $("body").on("click", ".invisible_mode_turn_on", (e) => {
-        hide_all();
         user_status.server_invisible_mode_on();
         e.stopPropagation();
         e.preventDefault();
     });
 
     $("body").on("click", ".invisible_mode_turn_off", (e) => {
-        hide_all();
         user_status.server_invisible_mode_off();
         e.stopPropagation();
         e.preventDefault();
     });
 
     function open_user_status_modal(e) {
-        hide_all();
-
         user_status_ui.open_user_status_modal();
 
         e.stopPropagation();
@@ -802,7 +794,6 @@ function register_click_handlers() {
             trigger: "popover send private",
             private_message_recipient: email,
         });
-        hide_all();
         if (overlays.is_active()) {
             overlays.close_active();
         }
@@ -811,13 +802,11 @@ function register_click_handlers() {
     });
 
     $("body").on("click", ".copy_mention_syntax", (e) => {
-        hide_all();
         e.stopPropagation();
         e.preventDefault();
     });
 
     $("body").on("click", ".sidebar-popover-manage-user", (e) => {
-        hide_all();
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const user = people.get_by_user_id(user_id);
         user_profile.show_user_profile(user, "manage-profile-tab");

--- a/web/src/user_group_popover.js
+++ b/web/src/user_group_popover.js
@@ -8,7 +8,6 @@ import {media_breakpoints_num} from "./css_variables";
 import * as message_lists from "./message_lists";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
-import * as popovers from "./popovers";
 import * as rows from "./rows";
 import * as ui_util from "./ui_util";
 import * as user_groups from "./user_groups";
@@ -82,7 +81,6 @@ export function toggle_user_group_info_popover(element, message_id) {
                 ],
             },
             onCreate(instance) {
-                popovers.hide_all_except_sidebars();
                 if (message_id) {
                     message_lists.current.select_id(message_id);
                 }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -1,5 +1,6 @@
 import {parseISO} from "date-fns";
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
 import render_admin_human_form from "../templates/settings/admin_human_form.hbs";
 import render_edit_bot_form from "../templates/settings/edit_bot_form.hbs";
@@ -26,7 +27,6 @@ import * as ListWidget from "./list_widget";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
@@ -298,8 +298,7 @@ function initialize_user_type_fields(user) {
 }
 
 export function show_user_profile(user, default_tab_key = "profile-tab") {
-    popovers.hide_all();
-
+    hideAll();
     const field_types = page_params.custom_profile_field_types;
     const profile_data = page_params.custom_profile_fields
         .map((f) => get_custom_profile_field_data(user, f, field_types))

--- a/web/src/user_search.js
+++ b/web/src/user_search.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
+import {hideAll} from "tippy.js";
 
-import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as right_sidebar_ui from "./right_sidebar_ui";
 import * as stream_popover from "./stream_popover";
@@ -70,7 +70,7 @@ export class UserSearch {
     show_widget() {
         // Hide all the popovers but not userlist sidebar
         // when the user wants to search.
-        popovers.hide_all_except_sidebars();
+        hideAll();
         this.$widget.removeClass("notdisplayed");
         resize.resize_sidebars();
     }
@@ -96,7 +96,7 @@ export class UserSearch {
     expand_column() {
         const $column = this.$input.closest(".app-main [class^='column-']");
         if (!$column.hasClass("expanded")) {
-            popovers.hide_all();
+            hideAll();
             if ($column.hasClass("column-left")) {
                 stream_popover.show_streamlist_sidebar();
             } else if ($column.hasClass("column-right")) {

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -23,7 +23,6 @@ const compose_state = mock_esm("../src/compose_state");
 const narrow = mock_esm("../src/narrow");
 const padded_widget = mock_esm("../src/padded_widget");
 const pm_list = mock_esm("../src/pm_list");
-const popovers = mock_esm("../src/popovers");
 const resize = mock_esm("../src/resize");
 const right_sidebar_ui = mock_esm("../src/right_sidebar_ui");
 const scroll_util = mock_esm("../src/scroll_util");
@@ -279,8 +278,6 @@ test("handlers", ({override, mock_template}) => {
     });
     override(scroll_util, "scroll_element_into_container", () => {});
     override(padded_widget, "update_padding", () => {});
-    override(popovers, "hide_all", () => {});
-    override(popovers, "hide_all_except_sidebars", () => {});
     override(right_sidebar_ui, "show_userlist_sidebar", () => {});
     override(resize, "resize_sidebars", () => {});
 

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -20,7 +20,6 @@ const info_overlay = mock_esm("../src/info_overlay");
 const message_viewport = mock_esm("../src/message_viewport");
 const narrow = mock_esm("../src/narrow");
 const overlays = mock_esm("../src/overlays");
-const popovers = mock_esm("../src/popovers");
 const recent_view_ui = mock_esm("../src/recent_view_ui");
 const settings = mock_esm("../src/settings");
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
@@ -177,28 +176,21 @@ run_test("hash_interactions", ({override}) => {
     override(recent_view_ui, "show", () => {
         recent_view_ui_shown = true;
     });
-    let hide_all_called = false;
-    override(popovers, "hide_all", () => {
-        hide_all_called = true;
-    });
     window.location.hash = "#unknown_hash";
 
     browser_history.clear_for_testing();
     hashchange.initialize();
     // If it's an unknown hash it should show the default view.
     assert.equal(recent_view_ui_shown, true);
-    assert.equal(hide_all_called, true);
     helper.assert_events([
         [overlays, "close_for_hash_change"],
         [message_viewport, "stop_auto_scrolling"],
     ]);
 
     window.location.hash = "#all_messages";
-    hide_all_called = false;
 
     helper.clear_events();
     $window_stub.trigger("hashchange");
-    assert.equal(hide_all_called, true);
     helper.assert_events([
         [overlays, "close_for_hash_change"],
         [message_viewport, "stop_auto_scrolling"],

--- a/web/tests/lightbox.test.js
+++ b/web/tests/lightbox.test.js
@@ -13,9 +13,6 @@ mock_esm("../src/overlays", {
     close_active() {},
     open_overlay() {},
 });
-mock_esm("../src/popovers", {
-    hide_all() {},
-});
 const rows = mock_esm("../src/rows");
 
 const message_store = mock_esm("../src/message_store");

--- a/web/tests/stream_search.test.js
+++ b/web/tests/stream_search.test.js
@@ -17,7 +17,6 @@ mock_esm("../src/resize", {
     resize_stream_filters_container: noop,
 });
 
-const popovers = mock_esm("../src/popovers");
 const stream_popover = mock_esm("../src/stream_popover");
 
 const stream_list = zrequire("stream_list");
@@ -178,9 +177,6 @@ run_test("expanding_sidebar", () => {
     $(".app-main .column-left").removeClass("expanded");
 
     const events = [];
-    popovers.hide_all = () => {
-        events.push("popovers.hide_all");
-    };
     stream_popover.show_streamlist_sidebar = () => {
         events.push("stream_popover.show_streamlist_sidebar");
     };
@@ -188,5 +184,5 @@ run_test("expanding_sidebar", () => {
 
     stream_list.initiate_search();
 
-    assert.deepEqual(events, ["popovers.hide_all", "stream_popover.show_streamlist_sidebar"]);
+    assert.deepEqual(events, ["stream_popover.show_streamlist_sidebar"]);
 });

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -25,7 +25,6 @@ mock_esm("../src/buddy_list", {
     buddy_list: fake_buddy_list,
 });
 
-const popovers = mock_esm("../src/popovers");
 const presence = mock_esm("../src/presence");
 const stream_popover = mock_esm("../src/stream_popover");
 const resize = mock_esm("../src/resize");
@@ -97,7 +96,6 @@ test("escape_search", ({override}) => {
     page_params.realm_presence_disabled = true;
 
     override(resize, "resize_sidebars", () => {});
-    override(popovers, "hide_all_except_sidebars", () => {});
 
     $(".user-list-filter").val("somevalue");
     activity.escape_search();
@@ -108,8 +106,6 @@ test("escape_search", ({override}) => {
 
 test("blur search right", ({override}) => {
     override(right_sidebar_ui, "show_userlist_sidebar", () => {});
-    override(popovers, "hide_all", () => {});
-    override(popovers, "hide_all_except_sidebars", () => {});
     override(resize, "resize_sidebars", () => {});
 
     $(".user-list-filter").closest = (selector) => {
@@ -125,8 +121,6 @@ test("blur search right", ({override}) => {
 
 test("blur search left", ({override}) => {
     override(stream_popover, "show_streamlist_sidebar", () => {});
-    override(popovers, "hide_all", () => {});
-    override(popovers, "hide_all_except_sidebars", () => {});
     override(resize, "resize_sidebars", () => {});
 
     $(".user-list-filter").closest = (selector) => {
@@ -197,8 +191,6 @@ test("filter_user_ids", ({override}) => {
 test("click on user header to toggle display", ({override}) => {
     const $user_filter = $(".user-list-filter");
 
-    override(popovers, "hide_all", () => {});
-    override(popovers, "hide_all_except_sidebars", () => {});
     override(right_sidebar_ui, "show_userlist_sidebar", () => {});
     override(resize, "resize_sidebars", () => {});
 


### PR DESCRIPTION
Since tippy popovers hide on click outside them anyway, we don't
need to call hideAll everywhere. We only need to make sure
events that happen independent of clicks like keydown and scroll
call hideAll.