### PR TITLE
recent_view_util: Fix return type of get_key_from_message.

### DIFF
--- a/web/src/recent_view_data.ts
+++ b/web/src/recent_view_data.ts
@@ -7,7 +7,7 @@ export type TopicData = {
     participated: boolean;
     type: "private" | "stream";
 };
-export const topics = new Map<string | undefined, TopicData>();
+export const topics = new Map<string, TopicData>();
 // For stream messages, key is stream-id:topic.
 // For pms, key is the user IDs to whom the message is being sent.
 

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -14,7 +14,7 @@ export function get_topic_key(stream_id: number, topic: string): string {
     return stream_id + ":" + topic.toLowerCase();
 }
 
-export function get_key_from_message(msg: Message): string | undefined {
+export function get_key_from_message(msg: Message): string {
     if (msg.type === "private") {
         // The to_user_ids field on a direct message object is a
         // string containing the user IDs involved in the message in


### PR DESCRIPTION
Since `msg.to_user_ids` is always defined when `msg.type === "private"`, return type is just string.

discussion: https://github.com/zulip/zulip/pull/26813#discussion_r1334598844