### PR TITLE
help: Tweak wording in help/add-a-custom-linkifier.

### DIFF
--- a/help/add-a-custom-linkifier.md
+++ b/help/add-a-custom-linkifier.md
@@ -14,7 +14,7 @@ topic in the message recipient bar that links to the appropriate URL.
 If you have any trouble creating the linkifiers you want, please [contact Zulip
 support](/help/contact-support) with details on what you're trying to do.
 
-### Add a custom linkifier
+## Add a custom linkifier
 
 {start_tabs}
 
@@ -27,20 +27,19 @@ support](/help/contact-support) with details on what you're trying to do.
 
 {end_tabs}
 
-### Reorder linkifiers
+## Reorder linkifiers
 
 Linkifiers are processed in order, and will not apply to text that
-already is linkified. One can thus configure multiple linkifiers with
-overlapping syntax, and only the first one whose regular expression
-matches a given part of a message will take effect. See the
+is already linkified. You can therefore choose which linkifiers to prioritize
+when more than one linkifier applies. See the
 [overlapping patterns section](#overlapping-patterns) for examples.
 
 {start_tabs}
 
 {settings_tab|linkifier-settings}
 
-1. Under **Linkifiers**, click and drag existing linkifiers into
-   the desired order.
+1. Under **Linkifiers**, click and drag the vertical dots to reorder the list of
+   linkifiers.
 
 {end_tabs}
 


### PR DESCRIPTION
Current: https://zulip.com/help/add-a-custom-linkifier#reorder-linkifiers

Updated section: 

<img width="772" alt="Screenshot 2023-09-27 at 10 56 35 AM" src="https://github.com/zulip/zulip/assets/2090066/34e3627f-3710-4a0d-80d5-3f88f5aef451">

Note that the wording in the instruction is designed to match custom profile fields:

<img width="817" alt="Screenshot 2023-09-27 at 10 56 57 AM" src="https://github.com/zulip/zulip/assets/2090066/38c7f8c6-7ac3-4517-b48e-28bf2665421a">
