### PR TITLE
navbar: Avoid collisions with title content and search elements.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -69,7 +69,7 @@
         }
 
         #searchbox-input-container {
-            width: 150px;
+            width: var(--search-box-width);
         }
 
         .search-input {
@@ -95,12 +95,6 @@
         }
 
         @media (width < $md_min) {
-            #searchbox-input-container {
-                /* On small screens, the input container/button becomes just
-                   an icon. Width is to match the width of nearby buttons. */
-                width: 40px;
-            }
-
             .search-input {
                 opacity: 0;
             }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -63,9 +63,14 @@ body {
     the height of its parent (i.e. the header height).
     */
     --search-box-height: 28px;
+    --search-box-width: 150px;
 
     @media (width < $sm_min) {
         --search-box-height: var(--header-height);
+    }
+
+    @media (width < $md_min) {
+        --search-box-width: 40px;
     }
 
     /*

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -81,6 +81,8 @@ body {
     --navbar-fixed-height: calc(
         var(--header-height) + var(--navbar-alerts-wrapper-height)
     );
+    /* Keep content from colliding with the search box. */
+    --navbar-content-righthand-offset: 5px;
 
     /*
     We have a 10px gutter below the header,
@@ -2090,6 +2092,8 @@ div.focused-message-list {
         text-decoration: none;
         /* The first ~3px of padding here overlaps with the left padding from sub_count for some reason. */
         padding-right: calc(3px + 10px);
+        /* Don't yield any space needed for the stream name. */
+        flex-shrink: 0;
 
         .zulip-icon {
             font-size: 14px;
@@ -2164,10 +2168,6 @@ div.focused-message-list {
         white-space: nowrap;
         padding: 12px 0;
         padding-left: 10px;
-        /* We are adding right margin so the text can truncate
-        and it doesn't overflow through search section. We make it
-        5px more than the size of the search box. */
-        margin: 0 155px 0 0;
 
         @media (width < $sm_min) {
             padding: 7px 0;
@@ -2176,10 +2176,6 @@ div.focused-message-list {
 
         & > a {
             padding: 12px 0;
-        }
-
-        @media (width < $md_min) {
-            margin-right: 30px;
         }
     }
 
@@ -2190,6 +2186,12 @@ div.focused-message-list {
     .navbar_title,
     .narrow_description {
         flex-grow: 1;
+        margin: 0;
+        /* Calculate right margin so that text can truncate
+           and not collide with the search section. */
+        margin-right: calc(
+            var(--search-box-width) + var(--navbar-content-righthand-offset)
+        );
     }
 }
 


### PR DESCRIPTION
This corrects an issue where long DM conversations collided or were overlapped by the collapsed search inputs.

Additionally, it expresses the fixes along with existing styles, previously applied only to stream descriptions, as calculations around CSS variables. Values were derived from the existing design.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/availability.20and.20status.20emoji.20in.20DM.20views/near/1648122)

**Screenshots and screen captures:**

| Group DMs, Before | Group DMs, After |
| --- | --- |
| ![group-dms-before](https://github.com/zulip/zulip/assets/170719/83ea8693-9424-4e2a-baac-4b722c990ec3) | ![group-dms-after](https://github.com/zulip/zulip/assets/170719/2e911b53-3830-40bc-b2ab-1867815e2f31) |

| Stream Descriptions, Before | Stream Descriptions, After (virtually no change) |
| --- | --- |
| ![long-stream-before](https://github.com/zulip/zulip/assets/170719/d43e1ef7-59cb-4dd7-b038-0dc3a522d5f4) | ![long-stream-after](https://github.com/zulip/zulip/assets/170719/0fe6715d-41fc-4e7b-8981-9b1ce98c5dbb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>