### PR TITLE
view_labels: Change 'Direct messages' to 'All direct messages'.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -185,7 +185,7 @@ through the following views for Cordelia (and have Hamlet send new
 messages after each narrow):
 
 - Go to All messages view.
-- Go to Direct messages view.
+- Go to All direct messages view.
 - Go to Direct messages w/Hamlet.
 - Go to Direct messages w/Hamlet and Othello.
 - Go to Verona view.
@@ -217,9 +217,9 @@ populated and where the focus is placed.
 - Buttons
 
   - Narrow to a stream and click on "New topic"
-  - Narrow "Direct messages" and click on "New topic"
+  - Narrow "All direct messages" and click on "New topic"
   - Narrow to a stream and click on "New direct message"
-  - Narrow "Direct messages" and click on "New direct message"
+  - Narrow "All direct messages" and click on "New direct message"
 
 - Topics
 

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -277,7 +277,7 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
         "New stream message",
     );
-    assert.strictEqual(await page.title(), "Direct messages - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "All direct messages - Zulip Dev - Zulip");
 }
 
 async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {

--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -747,7 +747,7 @@ export class Filter {
                 case "is-mentioned":
                     return $t({defaultMessage: "Mentions"});
                 case "is-dm":
-                    return $t({defaultMessage: "Direct messages"});
+                    return $t({defaultMessage: "All direct messages"});
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
                 // These cases return false for is_common_narrow, and therefore are not

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1596,7 +1596,7 @@ test("navbar_helpers", () => {
             operator: is_dm,
             is_common_narrow: true,
             icon: "envelope",
-            title: "translated: Direct messages",
+            title: "translated: All direct messages",
             redirect_url_with_search: "/#narrow/is/dm",
         },
         {


### PR DESCRIPTION
This PR changes the top-navbar title from "Direct messages" to "All direct messages."

Developer documentation (apparently the only docs that mention this view by name) has also been updated to reflect this change.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/availability.20and.20status.20emoji.20in.20DM.20views/near/1647277)

**Screenshots and screen captures:**

| All DMs view, before | All DMs view, after |
| --- | --- |
| ![all-dms-before](https://github.com/zulip/zulip/assets/170719/9bf69ede-0c45-4b05-a97b-6b5ddc7ca2b2) | ![all-dms-after](https://github.com/zulip/zulip/assets/170719/0ea4272a-9a63-41ad-956a-858fbc662072) | 

| [Dev docs, before](https://zulip.readthedocs.io/en/latest/testing/manual-testing.html) | [Dev docs, after](https://zulip--26896.org.readthedocs.build/en/26896/testing/manual-testing.html) |
| --- | --- |
| ![docs-before-1](https://github.com/zulip/zulip/assets/170719/83a030a8-75e9-4d69-9afb-3e83449b26b1) | ![docs-after-1](https://github.com/zulip/zulip/assets/170719/9c2798b1-deed-45e5-8500-d869b274e0ec) |
| ![docs-before-2](https://github.com/zulip/zulip/assets/170719/b1bae5ff-447b-4b84-b41f-63a2004a3c84) | ![docs-after-2](https://github.com/zulip/zulip/assets/170719/e5330f54-1796-4c6e-9f67-7f86efd1fa93) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
