### PR TITLE
typing_indicators: Add typing indicators for streams.

### DIFF
--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -133,7 +133,7 @@ like the following:
 - `add_typist`
 - `remove_typist`
 - `get_group_typists`
-- `get_all_typists`
+- `get_all_direct_message_typists`
 
 One subtle thing that the client has to do here is to maintain
 timers for typing notifications. The value of

--- a/web/shared/src/typing_status.js.flow
+++ b/web/shared/src/typing_status.js.flow
@@ -5,14 +5,15 @@
 "use strict";
 
 type RecipientUserIds<UserId: number> = $ReadOnlyArray<UserId>;
+type StreamTopicObject = {|stream_id: number, topic: string|};
 
 type Worker<UserId> = {|
     get_current_time: () => number, // as ms since epoch
-    notify_server_start: (RecipientUserIds<UserId>) => void,
-    notify_server_stop: (RecipientUserIds<UserId>) => void,
+    notify_server_start: (RecipientUserIds<UserId> | StreamTopicObject) => void,
+    notify_server_stop: (RecipientUserIds<UserId> | StreamTopicObject) => void,
 |};
 
 declare export function update<UserId>(
     worker: Worker<UserId>,
-    new_recipient: RecipientUserIds<UserId> | null,
+    new_recipient: RecipientUserIds<UserId> | StreamTopicObject | null,
 ): void;

--- a/web/src/narrow_state.js
+++ b/web/src/narrow_state.js
@@ -143,6 +143,14 @@ export function stream_sub() {
     return sub;
 }
 
+export function stream_id() {
+    const sub = stream_sub();
+    if (sub === undefined) {
+        return undefined;
+    }
+    return sub.stream_id;
+}
+
 export function topic() {
     if (current_filter === undefined) {
         return undefined;

--- a/web/src/typing.js
+++ b/web/src/typing.js
@@ -8,6 +8,7 @@ import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as stream_data from "./stream_data";
 import {user_settings} from "./user_settings";
 
 // This module handles the outbound side of typing indicators.
@@ -22,13 +23,10 @@ const typing_started_wait_period = page_params.server_typing_started_wait_period
 // do we send a 'stop' notification.
 const typing_stopped_wait_period = page_params.server_typing_stopped_wait_period_milliseconds;
 
-function send_typing_notification_ajax(user_ids_array, operation) {
+function send_typing_notification_ajax(data) {
     channel.post({
         url: "/json/typing",
-        data: {
-            to: JSON.stringify(user_ids_array),
-            op: operation,
-        },
+        data,
         success() {},
         error(xhr) {
             if (xhr.readyState !== 0) {
@@ -36,6 +34,33 @@ function send_typing_notification_ajax(user_ids_array, operation) {
             }
         },
     });
+}
+
+function send_direct_message_typing_notification(user_ids_array, operation) {
+    const data = {
+        to: JSON.stringify(user_ids_array),
+        op: operation,
+    };
+    send_typing_notification_ajax(data);
+}
+
+function send_stream_typing_notification(stream_id, topic, operation) {
+    const data = {
+        type: "stream",
+        to: JSON.stringify(stream_id),
+        topic,
+        op: operation,
+    };
+    send_typing_notification_ajax(data);
+}
+
+function send_typing_notification_based_on_message_type(to, operation) {
+    const message_type = to.stream_id ? "stream" : "direct";
+    if (message_type === "direct" && user_settings.send_private_typing_notifications) {
+        send_direct_message_typing_notification(to, operation);
+    } else if (message_type === "stream" && user_settings.send_stream_typing_notifications) {
+        send_stream_typing_notification(to.stream_id, to.topic, operation);
+    }
 }
 
 function get_user_ids_array() {
@@ -60,19 +85,27 @@ function get_current_time() {
     return Date.now();
 }
 
-function notify_server_start(user_ids_array) {
-    if (user_settings.send_private_typing_notifications) {
-        send_typing_notification_ajax(user_ids_array, "start");
-    }
+function notify_server_start(to) {
+    send_typing_notification_based_on_message_type(to, "start");
 }
 
-function notify_server_stop(user_ids_array) {
-    if (user_settings.send_private_typing_notifications) {
-        send_typing_notification_ajax(user_ids_array, "stop");
-    }
+function notify_server_stop(to) {
+    send_typing_notification_based_on_message_type(to, "stop");
 }
 
-export const get_recipient = get_user_ids_array;
+export function get_recipient() {
+    const message_type = compose_state.get_message_type();
+    if (message_type === "private") {
+        return get_user_ids_array();
+    }
+    if (message_type === "stream") {
+        const stream_name = compose_state.stream_name();
+        const stream_id = stream_data.get_stream_id(stream_name);
+        const topic = compose_state.topic();
+        return {stream_id, topic};
+    }
+    return null;
+}
 
 export function initialize() {
     const worker = {

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -11,13 +11,12 @@ export function clear_for_testing(): void {
     inbound_timer_dict.clear();
 }
 
-function get_key(group: number[]): string {
+export function get_direct_message_conversation_key(group: number[]): string {
     const ids = util.sorted_ids(group);
     return ids.join(",");
 }
 
-export function add_typist(group: number[], typist: number): void {
-    const key = get_key(group);
+export function add_typist(key: string, typist: number): void {
     const current = typist_dct.get(key) ?? [];
     if (!current.includes(typist)) {
         current.push(typist);
@@ -25,8 +24,7 @@ export function add_typist(group: number[], typist: number): void {
     typist_dct.set(key, util.sorted_ids(current));
 }
 
-export function remove_typist(group: number[], typist: number): boolean {
-    const key = get_key(group);
+export function remove_typist(key: string, typist: number): boolean {
     let current = typist_dct.get(key) ?? [];
 
     if (!current.includes(typist)) {
@@ -40,7 +38,7 @@ export function remove_typist(group: number[], typist: number): boolean {
 }
 
 export function get_group_typists(group: number[]): number[] {
-    const key = get_key(group);
+    const key = get_direct_message_conversation_key(group);
     const user_ids = typist_dct.get(key) ?? [];
     return muted_users.filter_muted_user_ids(user_ids);
 }
@@ -53,8 +51,7 @@ export function get_all_direct_message_typists(): number[] {
 
 // The next functions aren't pure data, but it is easy
 // enough to mock the setTimeout/clearTimeout functions.
-export function clear_inbound_timer(group: number[]): void {
-    const key = get_key(group);
+export function clear_inbound_timer(key: string): void {
     const timer = inbound_timer_dict.get(key);
     if (timer) {
         clearTimeout(timer);
@@ -62,13 +59,8 @@ export function clear_inbound_timer(group: number[]): void {
     }
 }
 
-export function kickstart_inbound_timer(
-    group: number[],
-    delay: number,
-    callback: () => void,
-): void {
-    const key = get_key(group);
-    clear_inbound_timer(group);
+export function kickstart_inbound_timer(key: string, delay: number, callback: () => void): void {
+    clear_inbound_timer(key);
     const timer = setTimeout(callback, delay);
     inbound_timer_dict.set(key, timer);
 }

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -45,7 +45,7 @@ export function get_group_typists(group: number[]): number[] {
     return muted_users.filter_muted_user_ids(user_ids);
 }
 
-export function get_all_typists(): number[] {
+export function get_all_direct_message_typists(): number[] {
     let typists = [...typist_dct.values()].flat();
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -3,11 +3,11 @@ import * as util from "./util";
 
 // See docs/subsystems/typing-indicators.md for details on typing indicators.
 
-const typist_dct = new Map<string, number[]>();
+const typists_dict = new Map<string, number[]>();
 const inbound_timer_dict = new Map<string, ReturnType<typeof setInterval> | undefined>();
 
 export function clear_for_testing(): void {
-    typist_dct.clear();
+    typists_dict.clear();
     inbound_timer_dict.clear();
 }
 
@@ -17,15 +17,15 @@ export function get_direct_message_conversation_key(group: number[]): string {
 }
 
 export function add_typist(key: string, typist: number): void {
-    const current = typist_dct.get(key) ?? [];
+    const current = typists_dict.get(key) ?? [];
     if (!current.includes(typist)) {
         current.push(typist);
     }
-    typist_dct.set(key, util.sorted_ids(current));
+    typists_dict.set(key, util.sorted_ids(current));
 }
 
 export function remove_typist(key: string, typist: number): boolean {
-    let current = typist_dct.get(key) ?? [];
+    let current = typists_dict.get(key) ?? [];
 
     if (!current.includes(typist)) {
         return false;
@@ -33,18 +33,18 @@ export function remove_typist(key: string, typist: number): boolean {
 
     current = current.filter((user_id) => user_id !== typist);
 
-    typist_dct.set(key, current);
+    typists_dict.set(key, current);
     return true;
 }
 
 export function get_group_typists(group: number[]): number[] {
     const key = get_direct_message_conversation_key(group);
-    const user_ids = typist_dct.get(key) ?? [];
+    const user_ids = typists_dict.get(key) ?? [];
     return muted_users.filter_muted_user_ids(user_ids);
 }
 
 export function get_all_direct_message_typists(): number[] {
-    let typists = [...typist_dct.values()].flat();
+    let typists = [...typists_dict.values()].flat();
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);
 }

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -60,7 +60,8 @@ export function get_all_direct_message_typists(): number[] {
 }
 
 export function get_topic_typists(stream_id: number, topic: string): number[] {
-    return typists_dict.get(get_topic_key(stream_id, topic)) ?? [];
+    const typists = typists_dict.get(get_topic_key(stream_id, topic)) ?? [];
+    return muted_users.filter_muted_user_ids(typists);
 }
 
 // The next functions aren't pure data, but it is easy

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -13,7 +13,12 @@ export function clear_for_testing(): void {
 
 export function get_direct_message_conversation_key(group: number[]): string {
     const ids = util.sorted_ids(group);
-    return ids.join(",");
+    return "direct:" + ids.join(",");
+}
+
+export function get_topic_key(stream_id: number, topic: string): string {
+    topic = topic.toLowerCase(); // Topics are case-insensitive
+    return "topic:" + JSON.stringify({stream_id, topic});
 }
 
 export function add_typist(key: string, typist: number): void {
@@ -44,9 +49,18 @@ export function get_group_typists(group: number[]): number[] {
 }
 
 export function get_all_direct_message_typists(): number[] {
-    let typists = [...typists_dict.values()].flat();
+    let typists: number[] = [];
+    for (const [key, value] of typists_dict) {
+        if (key.startsWith("direct:")) {
+            typists.push(...value);
+        }
+    }
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);
+}
+
+export function get_topic_typists(stream_id: number, topic: string): number[] {
+    return typists_dict.get(get_topic_key(stream_id, topic)) ?? [];
 }
 
 // The next functions aren't pure data, but it is easy

--- a/web/src/typing_events.js
+++ b/web/src/typing_events.js
@@ -73,9 +73,10 @@ export function hide_notification(event) {
     const recipients = event.recipients.map((user) => user.user_id);
     recipients.sort();
 
-    typing_data.clear_inbound_timer(recipients);
+    const conversation_key = typing_data.get_direct_message_conversation_key(recipients);
+    typing_data.clear_inbound_timer(conversation_key);
 
-    const removed = typing_data.remove_typist(recipients, event.sender.user_id);
+    const removed = typing_data.remove_typist(conversation_key, event.sender.user_id);
 
     if (removed) {
         render_notifications_for_narrow();
@@ -89,11 +90,12 @@ export function display_notification(event) {
     const sender_id = event.sender.user_id;
     event.sender.name = people.get_by_user_id(sender_id).full_name;
 
-    typing_data.add_typist(recipients, sender_id);
+    const conversation_key = typing_data.get_direct_message_conversation_key(recipients);
+    typing_data.add_typist(conversation_key, sender_id);
 
     render_notifications_for_narrow();
 
-    typing_data.kickstart_inbound_timer(recipients, typing_started_expiry_period, () => {
+    typing_data.kickstart_inbound_timer(conversation_key, typing_started_expiry_period, () => {
         hide_notification(event);
     });
 }

--- a/web/src/typing_events.js
+++ b/web/src/typing_events.js
@@ -47,8 +47,8 @@ function get_users_typing_for_narrow() {
         const group = [...narrow_user_ids, page_params.user_id];
         return typing_data.get_group_typists(group);
     }
-    // Get all users typing (in all private conversations with current user)
-    return typing_data.get_all_typists();
+    // Get all users typing (in all direct message conversations with current user)
+    return typing_data.get_all_direct_message_typists();
 }
 
 export function render_notifications_for_narrow() {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -819,6 +819,37 @@ run_test("typing", ({override}) => {
     page_params.user_id = typing_person1.user_id;
     event = event_fixtures.typing__start;
     dispatch(event);
+    page_params.user_id = undefined; // above change shouldn't effect stream_typing tests below
+});
+
+run_test("stream_typing", ({override}) => {
+    const stream_typing_in_id = events.stream_typing_in_id;
+    const topic_typing_in = events.topic_typing_in;
+    let event = event_fixtures.stream_typing__start;
+    {
+        const stub = make_stub();
+        override(typing_events, "display_notification", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("event");
+        assert_same(args.event.sender.user_id, typing_person1.user_id);
+        assert_same(args.event.message_type, "stream");
+        assert_same(args.event.stream_id, stream_typing_in_id);
+        assert_same(args.event.topic, topic_typing_in);
+    }
+
+    event = event_fixtures.stream_typing__stop;
+    {
+        const stub = make_stub();
+        override(typing_events, "hide_notification", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("event");
+        assert_same(args.event.sender.user_id, typing_person1.user_id);
+        assert_same(args.event.message_type, "stream");
+        assert_same(args.event.stream_id, stream_typing_in_id);
+        assert_same(args.event.topic, topic_typing_in);
+    }
 });
 
 run_test("user_settings", ({override}) => {

--- a/web/tests/example8.test.js
+++ b/web/tests/example8.test.js
@@ -76,6 +76,7 @@ run_test("typing_events.render_notifications_for_narrow", ({override, mock_templ
     // Narrow to a group direct message with four users.
     override(page_params, "user_id", anna.user_id);
     const group = [anna.user_id, vronsky.user_id, levin.user_id, kitty.user_id];
+    const conversation_key = typing_data.get_direct_message_conversation_key(group);
     const group_emails = `${anna.email},${vronsky.email},${levin.email},${kitty.email}`;
     narrow_state.set_current_filter(new Filter([{operator: "dm", operand: group_emails}]));
 
@@ -84,8 +85,8 @@ run_test("typing_events.render_notifications_for_narrow", ({override, mock_templ
     // MAX_USERS_TO_DISPLAY_NAME) or 'Several people are typing…'
 
     // For now, set two of the users as being typists.
-    typing_data.add_typist(group, anna.user_id);
-    typing_data.add_typist(group, vronsky.user_id);
+    typing_data.add_typist(conversation_key, anna.user_id);
+    typing_data.add_typist(conversation_key, vronsky.user_id);
 
     const two_typing_users_rendered_html = "Two typing users rendered html stub";
 
@@ -131,8 +132,8 @@ run_test("typing_events.render_notifications_for_narrow", ({override, mock_templ
 
     // Change to having four typists and verify the rendered html has
     // 'Several people are typing…' but not the list of users.
-    typing_data.add_typist(group, levin.user_id);
-    typing_data.add_typist(group, kitty.user_id);
+    typing_data.add_typist(conversation_key, levin.user_id);
+    typing_data.add_typist(conversation_key, kitty.user_id);
 
     typing_events.render_notifications_for_narrow();
     assert.ok($typing_notifications.html().includes("Several people are typing…"));

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -32,6 +32,8 @@ const typing_person2 = {
 
 exports.typing_person1 = typing_person1;
 exports.typing_person2 = typing_person2;
+exports.stream_typing_in_id = 1;
+exports.topic_typing_in = "Typing topic";
 
 const fake_then = 1596710000;
 const fake_now = 1596713966;
@@ -687,6 +689,24 @@ exports.fixtures = {
         stream_id: 99,
         property: "color",
         value: "blue",
+    },
+
+    stream_typing__start: {
+        type: "typing",
+        op: "start",
+        message_type: "stream",
+        sender: typing_person1,
+        stream_id: this.stream_typing_in_id,
+        topic: this.topic_typing_in,
+    },
+
+    stream_typing__stop: {
+        type: "typing",
+        op: "stop",
+        message_type: "stream",
+        sender: typing_person1,
+        stream_id: this.stream_typing_in_id,
+        topic: this.topic_typing_in,
     },
 
     submessage: {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -29,6 +29,7 @@ function test(label, f) {
 test("stream", () => {
     assert.equal(narrow_state.public_operators(), undefined);
     assert.ok(!narrow_state.active());
+    assert.equal(narrow_state.stream_id(), undefined);
 
     const test_stream = {name: "Test", stream_id: 15};
     stream_data.add_sub(test_stream);
@@ -43,6 +44,7 @@ test("stream", () => {
     assert.ok(narrow_state.active());
 
     assert.equal(narrow_state.stream_name(), "Test");
+    assert.equal(narrow_state.stream_id(), 15);
     assert.equal(narrow_state.stream_sub().stream_id, test_stream.stream_id);
     assert.equal(narrow_state.topic(), "Bar");
     assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -34,8 +34,8 @@ test("basics", () => {
     typing_data.add_typist([7, 15], 7);
     typing_data.add_typist([7, 15], 15);
 
-    // test get_all_typists
-    assert.deepEqual(typing_data.get_all_typists(), [7, 10, 15]);
+    // test get_all_direct_message_typists
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [7, 10, 15]);
 
     // test basic removal
     assert.ok(typing_data.remove_typist([15, 7], 7));
@@ -44,16 +44,16 @@ test("basics", () => {
     // test removing an id that is not there
     assert.ok(!typing_data.remove_typist([15, 7], 7));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
-    assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
     assert.ok(typing_data.remove_typist([15, 7], 15));
-    assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [10, 15]);
 
     // now remove from the other group
     assert.ok(typing_data.remove_typist([5, 15, 10], 15));
-    assert.deepEqual(typing_data.get_all_typists(), [10]);
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [10]);
 
     // test duplicate ids in a groups
     typing_data.add_typist([20, 40, 20], 20);
@@ -66,12 +66,12 @@ test("muted_typists_excluded", () => {
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
-    assert.deepEqual(typing_data.get_all_typists(), [5, 10]);
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [5, 10]);
 
     // Mute a user, and test that the get_* functions exclude that user.
     muted_users.add_muted_user(10);
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5]);
-    assert.deepEqual(typing_data.get_all_typists(), [5]);
+    assert.deepEqual(typing_data.get_all_direct_message_typists(), [5]);
 });
 
 test("timers", () => {

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -85,17 +85,26 @@ test("basics", () => {
 });
 
 test("muted_typists_excluded", () => {
+    const stream_id = 1;
+    const topic = "typing notifications";
+    const topic_typing_key = typing_data.get_topic_key(stream_id, topic);
+
     typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 5);
     typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 10);
+    typing_data.add_typist(topic_typing_key, 7);
+    typing_data.add_typist(topic_typing_key, 12);
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [5, 10]);
+    assert.deepEqual(typing_data.get_topic_typists(stream_id, topic), [7, 12]);
 
     // Mute a user, and test that the get_* functions exclude that user.
     muted_users.add_muted_user(10);
+    muted_users.add_muted_user(7);
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5]);
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [5]);
+    assert.deepEqual(typing_data.get_topic_typists(stream_id, topic), [12]);
 });
 
 test("timers", () => {

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -20,49 +20,57 @@ test("basics", () => {
     // The typing_data needs to be robust with lists of
     // user ids being in arbitrary sorting order. So all
     // the apparent randomness in these tests has a purpose.
-    typing_data.add_typist([5, 10, 15], 15);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 15);
     assert.deepEqual(typing_data.get_group_typists([15, 10, 5]), [15]);
 
     // test that you can add twice
-    typing_data.add_typist([5, 10, 15], 15);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 15);
 
     // add another id to our first group
-    typing_data.add_typist([5, 10, 15], 10);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 10);
     assert.deepEqual(typing_data.get_group_typists([10, 15, 5]), [10, 15]);
 
     // start adding to a new group
-    typing_data.add_typist([7, 15], 7);
-    typing_data.add_typist([7, 15], 15);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([7, 15]), 7);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([7, 15]), 15);
 
     // test get_all_direct_message_typists
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [7, 10, 15]);
 
     // test basic removal
-    assert.ok(typing_data.remove_typist([15, 7], 7));
+    assert.ok(
+        typing_data.remove_typist(typing_data.get_direct_message_conversation_key([15, 7]), 7),
+    );
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
 
     // test removing an id that is not there
-    assert.ok(!typing_data.remove_typist([15, 7], 7));
+    assert.ok(
+        !typing_data.remove_typist(typing_data.get_direct_message_conversation_key([15, 7]), 7),
+    );
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [10, 15]);
 
     // remove user from one group, but "15" will still be among
     // "all typists"
-    assert.ok(typing_data.remove_typist([15, 7], 15));
+    assert.ok(
+        typing_data.remove_typist(typing_data.get_direct_message_conversation_key([15, 7]), 15),
+    );
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [10, 15]);
 
     // now remove from the other group
-    assert.ok(typing_data.remove_typist([5, 15, 10], 15));
+    assert.ok(
+        typing_data.remove_typist(typing_data.get_direct_message_conversation_key([5, 15, 10]), 15),
+    );
     assert.deepEqual(typing_data.get_all_direct_message_typists(), [10]);
 
     // test duplicate ids in a groups
-    typing_data.add_typist([20, 40, 20], 20);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([20, 40, 20]), 20);
     assert.deepEqual(typing_data.get_group_typists([20, 40]), [20]);
 });
 
 test("muted_typists_excluded", () => {
-    typing_data.add_typist([5, 10, 15], 5);
-    typing_data.add_typist([5, 10, 15], 10);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 5);
+    typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 10);
 
     // Nobody is muted.
     assert.deepEqual(typing_data.get_group_typists([5, 10, 15]), [5, 10]);
@@ -102,12 +110,18 @@ test("timers", () => {
 
     function kickstart() {
         reset_events();
-        typing_data.kickstart_inbound_timer(stub_group, stub_delay, stub_f);
+        typing_data.kickstart_inbound_timer(
+            typing_data.get_direct_message_conversation_key(stub_group),
+            stub_delay,
+            stub_f,
+        );
     }
 
     function clear() {
         reset_events();
-        typing_data.clear_inbound_timer(stub_group);
+        typing_data.clear_inbound_timer(
+            typing_data.get_direct_message_conversation_key(stub_group),
+        );
     }
 
     set_global("setTimeout", set_timeout);

--- a/web/tests/typing_events.test.js
+++ b/web/tests/typing_events.test.js
@@ -45,6 +45,7 @@ people.add_active_user(kitty);
 run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     override(page_params, "user_id", anna.user_id);
     const group = [anna.user_id, vronsky.user_id, levin.user_id, kitty.user_id];
+    const conversation_key = typing_data.get_direct_message_conversation_key(group);
     const group_emails = `${anna.email},${vronsky.email},${levin.email},${kitty.email}`;
     narrow_state.set_current_filter(new Filter([{operator: "dm", operand: group_emails}]));
 
@@ -54,8 +55,8 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
 
     // Having only two(<MAX_USERS_TO_DISPLAY_NAME) typists, both of them
     // should be rendered but not 'Several people are typing…'
-    typing_data.add_typist(group, anna.user_id);
-    typing_data.add_typist(group, vronsky.user_id);
+    typing_data.add_typist(conversation_key, anna.user_id);
+    typing_data.add_typist(conversation_key, vronsky.user_id);
     typing_events.render_notifications_for_narrow();
     assert.ok($typing_notifications.visible());
     assert.ok($typing_notifications.html().includes(`${anna.full_name} is typing…`));
@@ -63,7 +64,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!$typing_notifications.html().includes("Several people are typing…"));
 
     // Having 3(=MAX_USERS_TO_DISPLAY_NAME) typists should also display only names
-    typing_data.add_typist(group, levin.user_id);
+    typing_data.add_typist(conversation_key, levin.user_id);
     typing_events.render_notifications_for_narrow();
     assert.ok($typing_notifications.visible());
     assert.ok($typing_notifications.html().includes(`${anna.full_name} is typing…`));
@@ -72,7 +73,7 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!$typing_notifications.html().includes("Several people are typing…"));
 
     // Having 4(>MAX_USERS_TO_DISPLAY_NAME) typists should display "Several people are typing…"
-    typing_data.add_typist(group, kitty.user_id);
+    typing_data.add_typist(conversation_key, kitty.user_id);
     typing_events.render_notifications_for_narrow();
     assert.ok($typing_notifications.visible());
     assert.ok($typing_notifications.html().includes("Several people are typing…"));
@@ -82,10 +83,10 @@ run_test("render_notifications_for_narrow", ({override, mock_template}) => {
     assert.ok(!$typing_notifications.html().includes(`${kitty.full_name} is typing…`));
 
     // #typing_notifications should be hidden when there are no typists.
-    typing_data.remove_typist(group, anna.user_id);
-    typing_data.remove_typist(group, vronsky.user_id);
-    typing_data.remove_typist(group, levin.user_id);
-    typing_data.remove_typist(group, kitty.user_id);
+    typing_data.remove_typist(conversation_key, anna.user_id);
+    typing_data.remove_typist(conversation_key, vronsky.user_id);
+    typing_data.remove_typist(conversation_key, levin.user_id);
+    typing_data.remove_typist(conversation_key, kitty.user_id);
     typing_events.render_notifications_for_narrow();
     assert.ok(!$typing_notifications.visible());
 });

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -137,7 +137,7 @@ def build_page_params_for_home_page_load(
         "notification_settings_null": True,
         "bulk_message_deletion": True,
         "user_avatar_url_field_optional": True,
-        "stream_typing_notifications": False,  # Set this to True when frontend support is implemented.
+        "stream_typing_notifications": True,
         "user_settings_object": True,
         "linkifier_url_template": True,
     }


### PR DESCRIPTION
Rebased #17040 and minor changes.


[typing.webm](https://github.com/zulip/zulip/assets/56781761/b6e4867a-0ac1-4ff6-951b-b066961389aa)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
