### PR TITLE
recent_view_table: Add a tooltip to unread sort header.

### DIFF
--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -16,7 +16,7 @@
             <tr>
                 <th data-sort="stream_sort">{{t 'Stream' }}</th>
                 <th data-sort="topic_sort">{{t 'Topic' }}</th>
-                <th data-sort="unread_sort" class="unread_sort">
+                <th data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="unread_sort tippy-zulip-delayed-tooltip">
                     <i class="zulip-icon zulip-icon-unread"></i>
                 </th>
                 <th class='participants_header'>{{t 'Participants' }}</th>


### PR DESCRIPTION
<img width="326" alt="Screenshot 2023-09-28 at 2 24 14 PM" src="https://github.com/zulip/zulip/assets/25124304/f5a527d4-c808-41fe-bbd7-ab143c5fc257">
