### PR TITLE
Deactivated user indicator in profile view

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -3,9 +3,13 @@
         <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <div class="modal__header">
                 {{#unless is_bot}}
-                <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
-                    <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
-                </div>
+                    {{#if is_active}}
+                    <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
+                        <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
+                    </div>
+                    {{else}}
+                    <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="User is deactivated"></i>
+                    {{/if}}
                 {{/unless}}
                 <h1 class="modal__title user_profile_name_heading" id="name">
                     {{#if is_bot}}


### PR DESCRIPTION
Added a deactivated user indicator icon in the user profile view

Addresses box 2 of #26861:
Deactivated user icon is rendered in front of user fullname instead of circle presence icon (which indicates active users) for deactivated users

![screenshot](https://github.com/zulip/zulip/assets/51041290/7e0d26e8-76a2-4c7e-8971-502ef845e837)


<details>
 
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
