### PR TITLE
portico: Update quotes on /for/open-source.

### DIFF
--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -313,20 +313,18 @@
                 </ul>
                 <div class="quote">
                     <blockquote>
-                        I highly recommend Zulip to other communities. We’re
-                        coming from Freenode as our only real-time
-                        communication so the difference is night and day. Slack
-                        is a no-go for many due to not being FLOSS, and I’m
-                        concerned about vendor lock-in if they were to stop
-                        being so generous. Slack’s threading model is much
-                        worse than Zulip’s IMO. The streams/topics flow is an
-                        incredibly intuitive way to keep track of everything
-                        that is going on.
+                        The Lean community switched from Gitter to Zulip in early 2018,
+                        and never looked back. Zulip’s stream/topic model has been
+                        essential for organising research work and simultaneously
+                        onboarding newcomers as our community scaled. My experience with
+                        both the app and the website is extremely positive!
                     </blockquote>
                     <div class="author">
-                        &mdash; RJ Ryan, <a href="https://mixxx.org/">Mixxx</a>
-                        Developer
+                        &mdash; <a href="https://www.imperial.ac.uk/people/k.buzzard">Kevin Buzzard</a>, Professor of Pure Mathematics at <a href="https://www.imperial.ac.uk/">Imperial College London</a>
                     </div>
+                    <a class="case-study-link" href="/case-studies/lean/"
+                      target="_blank">How the Lean prover
+                    community uses Zulip ↗</a>
                 </div>
             </div>
         </div>
@@ -638,18 +636,17 @@
             <div class="feature-image">
                 <div class="quote">
                     <blockquote>
-                        The Lean community switched from Gitter to Zulip in early 2018,
-                        and never looked back. Zulip’s stream/topic model has been
-                        essential for organising research work and simultaneously
-                        onboarding newcomers as our community scaled. My experience with
-                        both the app and the website is extremely positive!
+                        The Zulip threading model is <i>fantastic</i> and
+                        <i>game-changing</i>, and you are doing your community a
+                        disservice if you choose Slack or Discord over Zulip.
                     </blockquote>
                     <div class="author">
-                        &mdash; <a href="https://www.imperial.ac.uk/people/k.buzzard">Kevin Buzzard</a>, Professor of Pure Mathematics at <a href="https://www.imperial.ac.uk/">Imperial College London</a>
+                        &mdash; <a href="https://github.com/jni">Juan
+                        Nunez-Iglesias</a>, <a href="https://napari.org/">napari
+                        project</a> co-founder and
+                        <a href="https://scikit-image.org/">scikit-image</a>
+                        core developer
                     </div>
-                    <a class="case-study-link" href="/case-studies/lean/"
-                      target="_blank">How the Lean prover
-                    community uses Zulip ↗</a>
                 </div>
             </div>
         </div>
@@ -704,18 +701,17 @@
             <div class="feature-image">
                 <div class="quote">
                     <blockquote>
-                        The Lean community switched from Gitter to Zulip in early 2018,
-                        and never looked back. Zulip’s stream/topic model has been
-                        essential for organising research work and simultaneously
-                        onboarding newcomers as our community scaled. My experience with
-                        both the app and the website is extremely positive!
+                        The Zulip threading model is <i>fantastic</i> and
+                        <i>game-changing</i>, and you are doing your community a
+                        disservice if you choose Slack or Discord over Zulip.
                     </blockquote>
                     <div class="author">
-                        &mdash; <a href="https://www.imperial.ac.uk/people/k.buzzard">Kevin Buzzard</a>, Professor of Pure Mathematics at <a href="https://www.imperial.ac.uk/">Imperial College London</a>
+                        &mdash; <a href="https://github.com/jni">Juan
+                        Nunez-Iglesias</a>, <a href="https://napari.org/">napari
+                        project</a> co-founder and
+                        <a href="https://scikit-image.org/">scikit-image</a>
+                        core developer
                     </div>
-                    <a class="case-study-link" href="/case-studies/lean/"
-                      target="_blank">How the Lean prover
-                    community uses Zulip ↗</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Notes

- Visually, the new bottom quote is shorter, but I think it's OK.
- The Lean quote doesn't really match the theme of the section it's under (MIXX was a better fit). I think it's OK?

## Screenshots

<details>
<summary>
New quote
</summary>
<img width="1076" alt="Screenshot 2023-09-29 at 12 11 40 PM" src="https://github.com/zulip/zulip/assets/2090066/ed55cd1c-c2ca-4b5f-9b33-bbc9a677f10c">



</details>

<details>
<summary>
New quote (mobile width)
</summary>
<img width="571" alt="Screenshot 2023-09-29 at 12 30 49 PM" src="https://github.com/zulip/zulip/assets/2090066/3dd0f735-09a2-4c59-82cc-3d40fd288424">



</details>

<details>
<summary>
Lean quote (moved)
</summary>

![Screenshot 2023-09-28 at 1 43 21 PM](https://github.com/zulip/zulip/assets/2090066/5c2bfc56-9739-4a6f-99f5-df32c0498306)

</details>

