### PR TITLE
compose_banners: Explicitly target banner content, child p.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -301,7 +301,8 @@
         flex-wrap: wrap;
     }
 
-    & p {
+    & .banner_content,
+    & > p {
         margin: 0; /* override bootstrap */
         /* 5px right padding + 10px left-margin of the neighbouring button will match the left padding */
         padding: 8px 5px 8px 15px;


### PR DESCRIPTION
This ensures uniform display and flexing of different bits of banner content, including:

* Banners like Sent! Scroll down to view...) that have only a classless `<p>` marking their content
* Banners like the unscheduled message allert, which puts a .banner_content class right on the paragraph
* Banners like the Your message was sent to a stream you have muted", which tuck a `<p>` into a div with the .banner_content class

This carries forward the intrinsic design from #26730, but takes care of other banner structures that that PR neglected.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22Unmute.20topic.22.20button.20placement/near/1649325)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![banners-before](https://github.com/zulip/zulip/assets/170719/818a370b-3bcb-424a-aa71-d89015e91b1b) | ![banners-after](https://github.com/zulip/zulip/assets/170719/6c4602b4-c91e-4479-b54d-0566f2b9e694) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>