### PR TITLE
help: Document Inbox view.

### DIFF
--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -16,7 +16,9 @@ preference settings, including the following:
     * [Displaying availability to other users](/help/status-and-availability)
     * [Allowing others to see when the user has read messages](/help/read-receipts)
 * Preferences, including:
-    * Default view ([Recent conversations](/help/recent-conversations) vs.
+    * [Default view](/help/configure-default-view)
+      ([Inbox](/help/inbox) vs.
+      [Recent conversations](/help/recent-conversations) vs.
       [All messages](/help/reading-strategies#all-messages))
     * [Light theme vs. dark theme](/help/dark-theme)
     * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)

--- a/help/configure-default-view.md
+++ b/help/configure-default-view.md
@@ -5,7 +5,8 @@ to the Zulip web app. You can also navigate to the default view via
 keyboard shortcuts.
 
 The default views available in Zulip are
-[Recent conversations](/help/recent-conversations) and
+[**Inbox**](/help/inbox),
+[Recent conversations](/help/recent-conversations), and
 [All messages](/help/all-messages). See
 [Reading strategies](/help/reading-strategies) for recommendations
 on how to use these views.
@@ -17,12 +18,15 @@ shortcut.
 
 ## Change default view
 
-Organization administrators can [set the default view for their
+Organization administrators can [configure the default view for their
 organization](/help/configure-default-new-user-settings) to
-[**Recent conversations**](/help/recent-conversations) or
+[**Inbox**](/help/inbox),
+[**Recent conversations**](/help/recent-conversations), or
 [**All messages**](/help/all-messages).
-**Recent conversations** is especially recommended for high-traffic
-organizations, and is configured by default.
+The **Inbox** view works best if you regularly clear all unread messages
+in most streams you follow. Otherwise, **Recent conversations**
+works well in high-traffic organizations. **All messages** is convenient for
+low-traffic organizations, or for skimming messages as they come in.
 
 You can customize your personal default view regardless of
 organization settings:
@@ -38,11 +42,9 @@ organization settings:
    shortcut twice to exit the settings and navigate to your default view
    (<kbd>Ctrl</kbd> + <kbd>[</kbd> or <kbd>Esc</kbd> if enabled).
 
-[configure-esc]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
-
 {end_tabs}
 
-## Set whether <kbd>Esc</kbd> navigates to the default view
+## Configure whether <kbd>Esc</kbd> navigates to the default view
 
 Zulip has a number of [keyboard shortcuts](/help/keyboard-shortcuts)
 designed to enhance the user experience in the app.

--- a/help/finding-a-topic-to-read.md
+++ b/help/finding-a-topic-to-read.md
@@ -2,6 +2,10 @@
 
 Like your email inbox, Zulip works best if you read it topic-by-topic.
 
+## From the Inbox view
+
+{!inbox.md!}
+
 ## From Recent conversations
 
 {!recent-conversations.md!}

--- a/help/getting-started-with-zulip.md
+++ b/help/getting-started-with-zulip.md
@@ -22,6 +22,10 @@ Like your email inbox, Zulip works best if you read it topic-by-topic.
 
 ### Finding a topic to read
 
+#### From the Inbox view
+
+{!inbox.md!}
+
 #### From Recent conversations
 
 {!recent-conversations.md!}

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -1,48 +1,6 @@
 # Inbox
 
-The **Inbox** is the default view in the Zulip mobile app. It's a great way to
-get an overview of all the unmuted [conversations](/help/recent-conversations)
-where you have unread messages, excluding [inactive
-streams](/help/manage-inactive-streams).
-
-The **Inbox** view shows your unread direct message conversations, followed by
-all topics with unread messages, grouped by stream. The list of streams is
-sorted alphabetically, with [pinned streams](/help/pin-a-stream) at the top.
-
-{start_tabs}
-
-{tab|desktop-web}
-
-{relative|message|inbox}
-
-1. The filters at the top help you quickly find relevant conversations.
-   You can filter by stream or conversation.
-
-!!! tip ""
-
-    You can collapse or expand the list of topics in a stream by clicking the
-    **collapse**
-    (<i class="zulip-icon zulip-icon-arrow-down"></i>)
-    or **expand**
-    (<i class="zulip-icon zulip-icon-arrow-down icon-collapsed-state"></i>)
-    icon to the left of a stream name.
-
-{tab|mobile}
-
-1. Tap the **Inbox**
-   (<img src="/static/images/help/mobile-inbox-icon.svg" alt="inbox" class="mobile-icon"/>)
-   tab in the bottom left corner of the app.
-
-!!! tip ""
-
-    You can collapse or expand the list of topics in a stream by tapping the
-    **collapse**
-    (<img src="/static/images/help/mobile-expand-less-icon.svg" alt="inbox" class="mobile-icon"/>)
-    or **expand**
-    (<img src="/static/images/help/mobile-expand-more-icon.svg" alt="inbox" class="mobile-icon"/>)
-    icon to the left of a stream name.
-
-{end_tabs}
+{!inbox.md!}
 
 !!! keyboard_tip ""
 

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -11,13 +11,27 @@ sorted alphabetically, with [pinned streams](/help/pin-a-stream) at the top.
 
 {start_tabs}
 
+{tab|desktop-web}
+
+{relative|message|inbox}
+
+1. The filters at the top help you quickly find relevant conversations.
+   You can filter by stream or conversation.
+
+!!! tip ""
+
+    You can collapse or expand the list of topics in a stream by clicking the
+    **collapse**
+    (<i class="zulip-icon zulip-icon-arrow-down"></i>)
+    or **expand**
+    (<i class="zulip-icon zulip-icon-arrow-down icon-collapsed-state"></i>)
+    icon to the left of a stream name.
+
 {tab|mobile}
 
 1. Tap the **Inbox**
    (<img src="/static/images/help/mobile-inbox-icon.svg" alt="inbox" class="mobile-icon"/>)
    tab in the bottom left corner of the app.
-
-{end_tabs}
 
 !!! tip ""
 
@@ -27,6 +41,13 @@ sorted alphabetically, with [pinned streams](/help/pin-a-stream) at the top.
     or **expand**
     (<img src="/static/images/help/mobile-expand-more-icon.svg" alt="inbox" class="mobile-icon"/>)
     icon to the left of a stream name.
+
+{end_tabs}
+
+!!! keyboard_tip ""
+
+    The arrow keys and vim navigation keys (<kbd>J</kbd>, <kbd>K</kbd>,
+    <kbd>L</kbd>, <kbd>H</kbd>) can be used to move between elements.
 
 ## Related articles
 

--- a/help/include/inbox.md
+++ b/help/include/inbox.md
@@ -1,0 +1,43 @@
+The **Inbox** is the default view in the Zulip mobile app. It's a great way to
+get an overview of all the unmuted [conversations](/help/recent-conversations)
+where you have unread messages, excluding [inactive
+streams](/help/manage-inactive-streams).
+
+The **Inbox** view shows your unread direct message conversations, followed by
+all topics with unread messages, grouped by stream. The list of streams is
+sorted alphabetically, with [pinned streams](/help/pin-a-stream) at the top.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|message|inbox}
+
+1. The filters at the top help you quickly find relevant conversations.
+   You can filter by stream or conversation.
+
+!!! tip ""
+
+    You can collapse or expand the list of topics in a stream by clicking the
+    **collapse**
+    (<i class="zulip-icon zulip-icon-arrow-down"></i>)
+    or **expand**
+    (<i class="zulip-icon zulip-icon-arrow-down icon-collapsed-state"></i>)
+    icon to the left of a stream name.
+
+{tab|mobile}
+
+1. Tap the **Inbox**
+   (<img src="/static/images/help/mobile-inbox-icon.svg" alt="inbox" class="mobile-icon"/>)
+   tab in the bottom left corner of the app.
+
+!!! tip ""
+
+    You can collapse or expand the list of topics in a stream by tapping the
+    **collapse**
+    (<img src="/static/images/help/mobile-expand-less-icon.svg" alt="inbox" class="mobile-icon"/>)
+    or **expand**
+    (<img src="/static/images/help/mobile-expand-more-icon.svg" alt="inbox" class="mobile-icon"/>)
+    icon to the left of a stream name.
+
+{end_tabs}

--- a/help/include/reading-topics.md
+++ b/help/include/reading-topics.md
@@ -1,5 +1,23 @@
 {start_tabs}
 
+{tab|via-inbox-view}
+
+{relative|message|inbox}
+
+1. Click on the name of a topic.
+
+1. Read the topic, scrolling down with the mouse or by pressing
+   <kbd>PgDn</kbd>.
+
+1. If the topic is not of interest, you can
+   [mark all messages as read](/help/marking-messages-as-read) by
+   jumping to the bottom with the **Scroll to bottom**
+   (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
+
+1. You can then click on another topic in the left sidebar, use the
+   <kbd>N</kbd> key to go to the next unread topic, or go back to the
+   **Inbox** view.
+
 {tab|via-recent-conversations}
 
 {relative|message|recent}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -93,9 +93,9 @@
 
 ## Reading messages
 * [Reading strategies](/help/reading-strategies)
+* [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
 * [All messages](/help/all-messages)
-* [Inbox](/help/inbox)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -48,7 +48,7 @@ in the Zulip app to add more to your repertoire as needed.
   <kbd>Esc</kbd>, [if enabled][disable-escape])
   until you are in the [default view](/help/configure-default-view).
 
-[disable-escape]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
+[disable-escape]: /help/configure-default-view#configure-whether-esc-navigates-to-the-default-view
 ## Navigation
 
 * **Search messages**: <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -71,6 +71,16 @@ stream or topic as read**.
     jumping to the bottom with the **Scroll to bottom**
     (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
 
+{tab|via-inbox-view}
+
+{relative|message|inbox}
+
+1. Hover over a stream or topic in the left sidebar.
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
+
+1. Click **Mark all messages as read**.
+
 {tab|via-recent-conversations}
 
 {relative|message|recent}

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -14,8 +14,9 @@
 
 !!! tip ""
 
-    You can also click the **mute** (<i class="zulip-icon zulip-icon-mute"></i>) icon
-    in the message recipient bar or in **Recent conversations**.
+    You can also click the **mute** (<i class="zulip-icon zulip-icon-mute-new"></i>)
+    icon in the message recipient bar, in the **Inbox view**, or in
+    **Recent conversations**.
 
 {tab|mobile}
 
@@ -39,8 +40,9 @@
 
 !!! tip ""
 
-    You can also click the **unmute** (<i class="zulip-icon zulip-icon-unmute"></i>) icon
-    in the message recipient bar or in **Recent conversations**.
+    You can also click the **unmute** (<i class="zulip-icon zulip-icon-unmute-new"></i>)
+    icon in the message recipient bar, in the **Inbox view**, or in
+    **Recent conversations**.
 
 {tab|mobile}
 

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -15,6 +15,10 @@ topic-by-topic.
 
 ### Finding a topic to read
 
+#### From the Inbox view
+
+{!inbox.md!}
+
 #### From Recent conversations
 
 {!recent-conversations.md!}

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -208,6 +208,10 @@
             vertical-align: middle;
         }
 
+        & i.icon-collapsed-state {
+            transform: rotate(270deg);
+        }
+
         @media (width <= 500px) {
             padding: 10px;
         }

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -108,6 +108,11 @@ direct_instructions = """
    keyboard shortcut.
 """
 
+inbox_instructions = """
+1. Click on <i class="zulip-icon zulip-icon-inbox"></i> **Inbox** in the left
+   sidebar.
+"""
+
 message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
@@ -115,6 +120,7 @@ message_info = {
     "all": ["All messages", "/#all_messages", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
     "direct": ["All direct messages", "/#narrow/is/dm", direct_instructions],
+    "inbox": ["Inbox", "/#inbox", inbox_instructions],
 }
 
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -72,6 +72,7 @@ TAB_SECTION_LABELS = {
     "stream": "From a stream view",
     "not-stream": "From other views",
     "via-recent-conversations": "Via recent conversations",
+    "via-inbox-view": "Via inbox view",
     "via-left-sidebar": "Via left sidebar",
     "instructions-for-all-platforms": "Instructions for all platforms",
     "public-streams": "Public streams",


### PR DESCRIPTION
- Adds desktop/web instructions for the Inbox view, including #inbox relative link for logged-in users.
- Moves Inbox article content to Markdown include, and adds new **From the Inbox view** section to "Finding a topic to read", "Getting started with Zulip", and "Reading strategies".
- Updates "Configure default view", adding Inbox as a new option for the default web app view, removing unused Markdown link in, tweaking a subheading ("Set" > "Configure") to better match help center patterns, and adding Inbox option in "Configure default settings for new users".
- Adds new tabbed section and instructions for marking messages as as read and reading topics via the Inbox view, and documents alternative way to mute a topic via the Inbox view.

Fixes #26903.

**Screenshots and screen captures:**

- https://zulip.com/help/inbox
![image](https://github.com/zulip/zulip/assets/2343554/d80f1b0a-4d15-46bb-a46d-61a8784aeded)

- http://zulip.com/help/getting-started-with-zulip
![image](https://github.com/zulip/zulip/assets/2343554/ca6a3a6f-94aa-4326-a0f4-0d56a0b14818)

- https://zulip.com/help/configure-default-view
![image](https://github.com/zulip/zulip/assets/2343554/ebe5600a-3535-4ba6-95f3-0a9a179189fe)
- http://zulip.com/help/configure-default-new-user-settings
![image](https://github.com/zulip/zulip/assets/2343554/9d92ed85-4174-4ca9-bddb-149698d8f9e6)

- https://zulip.com/help/marking-messages-as-read
![image](https://github.com/zulip/zulip/assets/2343554/2d4fef96-8b32-4159-b3d2-0a8600e16381)

- https://zulip.com/help/reading-topics
![image](https://github.com/zulip/zulip/assets/2343554/656836e8-0da2-41b5-a2a1-e0289164f258)

- http://zulip.com/help/mute-a-topic
![image](https://github.com/zulip/zulip/assets/2343554/dd6eb126-ad55-41e8-99ea-b8710bead7cd)
![image](https://github.com/zulip/zulip/assets/2343554/438565ea-5a2e-4b9e-8c11-2370819c8793)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>