### PR TITLE
tests: Eliminate instances of time_machine.travel without tick=False.

### DIFF
--- a/tools/semgrep-py.yml
+++ b/tools/semgrep-py.yml
@@ -17,6 +17,15 @@ rules:
       include:
         - zerver/views/
 
+  - id: time-machine-travel-specify-tick
+    patterns:
+      - pattern: time_machine.travel(...)
+      - pattern-not: time_machine.travel(..., tick=..., ...)
+    message: |
+      Specify tick kwarg value for time_machine.travel(). Most cases will want to use False.
+    languages: [python]
+    severity: ERROR
+
   - id: limit-message-filter
     patterns:
       - pattern: Message.objects.filter(...)

--- a/zerver/tests/test_delete_unclaimed_attachments.py
+++ b/zerver/tests/test_delete_unclaimed_attachments.py
@@ -26,7 +26,7 @@ class UnclaimedAttachmentTest(UploadSerializeMixin, ZulipTestCase):
             uploader = self.example_user("hamlet")
         self.login_user(uploader)
 
-        with time_machine.travel(when):
+        with time_machine.travel(when, tick=False):
             file_obj = StringIO("zulip!")
             file_obj.name = filename
             response = self.assert_json_success(

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -335,7 +335,7 @@ class InviteUserTest(InviteUserBase):
 
         # We've sent 40 invites "today".  Fast-forward 48 hours
         # and ensure that we can invite more people
-        with time_machine.travel(timezone_now() + datetime.timedelta(hours=48)):
+        with time_machine.travel(timezone_now() + datetime.timedelta(hours=48), tick=False):
             result = try_invite(5, default_realm_max=30, new_realm_max=20, realm_max=10)
             self.assert_json_success(result)
             self.check_sent_emails([f"zulip-{i:02}@zulip.com" for i in range(5)], clear=True)


### PR DESCRIPTION
The default is `tick=True` (https://github.com/adamchainz/time-machine#traveldestination--ticktrue), which I think we generally don't want as it introduces unpredictability. So the first commit fixes existing instances where we didn't set `tick`, and the second proposes a semgrep rule to avoid this pattern of forgetting to set the kwarg.