### PR TITLE
delete_old_unclaimed_attachments: Update docs on default max age.

### DIFF
--- a/zerver/management/commands/delete_old_unclaimed_attachments.py
+++ b/zerver/management/commands/delete_old_unclaimed_attachments.py
@@ -13,7 +13,7 @@ from zerver.models import ArchivedAttachment, Attachment, get_old_unclaimed_atta
 class Command(BaseCommand):
     help = """Remove unclaimed attachments from storage older than a supplied
               numerical value indicating the limit of how old the attachment can be.
-              One week is taken as the default value."""
+              The default is five weeks."""
 
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             dest="delta_weeks",
             default=5,
             type=int,
-            help="Limiting value of how old the file can be.",
+            help="How long unattached attachments are preserved; defaults to 5 weeks.",
         )
 
         parser.add_argument(


### PR DESCRIPTION
42f1cb3444e1 updated the default up, from 1 week to 5 weeks, but did not adjust the documentation.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
