### PR TITLE
webhooks: Logger and exception cleanups.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -33,7 +33,6 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django_otp import user_has_device
-from sentry_sdk import capture_exception
 from two_factor.utils import default_device
 from typing_extensions import Concatenate, ParamSpec
 
@@ -369,8 +368,6 @@ def webhook_view(
                 else:
                     if isinstance(err, WebhookError):
                         err.webhook_name = webhook_client_name
-                    if isinstance(err, UnsupportedWebhookEventTypeError):
-                        capture_exception(err)
                     log_exception_to_webhook_logger(request, err)
                 raise err
 
@@ -780,8 +777,6 @@ def authenticated_rest_api_view(
 
                 if isinstance(err, WebhookError):
                     err.webhook_name = webhook_client_name
-                if isinstance(err, UnsupportedWebhookEventTypeError):
-                    capture_exception(err)
                 log_exception_to_webhook_logger(request, err)
                 raise err
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -312,10 +312,13 @@ def log_unsupported_webhook_event(request: HttpRequest, summary: str) -> None:
 
 def log_exception_to_webhook_logger(request: HttpRequest, err: Exception) -> None:
     extra = {"request": request}
+    # We intentionally omit the stack_info for these events, where
+    # they are intentionally raised, and the stack_info between that
+    # point and this one is not interesting.
     if isinstance(err, AnomalousWebhookPayloadError):
-        webhook_anomalous_payloads_logger.exception(err, stack_info=True, extra=extra)
+        webhook_anomalous_payloads_logger.exception(err, extra=extra)
     elif isinstance(err, UnsupportedWebhookEventTypeError):
-        webhook_unsupported_events_logger.exception(err, stack_info=True, extra=extra)
+        webhook_unsupported_events_logger.exception(err, extra=extra)
     else:
         webhook_logger.exception(err, stack_info=True, extra=extra)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -362,7 +362,8 @@ def webhook_view(
                     log_exception_to_webhook_logger(request, err)
                 elif isinstance(err, WebhookError):
                     # Anything explicitly a webhook error deserves to
-                    # go to the webhook logs
+                    # go to the webhook logs.  The error middleware
+                    # skips logging these exceptions a second time.
                     err.webhook_name = webhook_client_name
                     log_exception_to_webhook_logger(request, err)
                 elif isinstance(err, InvalidJSONError) and notify_bot_owner_on_invalid_json:
@@ -777,7 +778,8 @@ def authenticated_rest_api_view(
                     log_exception_to_webhook_logger(request, err)
                 elif isinstance(err, WebhookError):
                     # Anything explicitly a webhook error deserves to
-                    # go to the webhook logs
+                    # go to the webhook logs.  The error middleware
+                    # skips logging these exceptions a second time.
                     err.webhook_name = webhook_client_name
                     log_exception_to_webhook_logger(request, err)
 

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -60,6 +60,7 @@ from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.users import is_2fa_verified
 from zerver.lib.utils import has_api_key_format
+from zerver.lib.webhooks.common import notify_bot_owner_about_invalid_json
 from zerver.models import UserProfile, get_client, get_user_profile_by_api_key
 
 if TYPE_CHECKING:
@@ -367,12 +368,6 @@ def webhook_view(
                 elif isinstance(err, InvalidJSONError) and notify_bot_owner_on_invalid_json:
                     # Invalid JSON is not notable for the logs -- it's
                     # the sender's fault, so tell the owner
-
-                    # NOTE: importing this at the top of file leads to a
-                    # cyclic import; correct fix is probably to move
-                    # notify_bot_owner_about_invalid_json to a smaller file.
-                    from zerver.lib.webhooks.common import notify_bot_owner_about_invalid_json
-
                     notify_bot_owner_about_invalid_json(user_profile, webhook_client_name)
 
                 raise err

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -313,11 +313,11 @@ def log_unsupported_webhook_event(request: HttpRequest, summary: str) -> None:
 def log_exception_to_webhook_logger(request: HttpRequest, err: Exception) -> None:
     extra = {"request": request}
     if isinstance(err, AnomalousWebhookPayloadError):
-        webhook_anomalous_payloads_logger.exception(str(err), stack_info=True, extra=extra)
+        webhook_anomalous_payloads_logger.exception(err, stack_info=True, extra=extra)
     elif isinstance(err, UnsupportedWebhookEventTypeError):
-        webhook_unsupported_events_logger.exception(str(err), stack_info=True, extra=extra)
+        webhook_unsupported_events_logger.exception(err, stack_info=True, extra=extra)
     else:
-        webhook_logger.exception(str(err), stack_info=True, extra=extra)
+        webhook_logger.exception(err, stack_info=True, extra=extra)
 
 
 def full_webhook_client_name(raw_client_name: Optional[str] = None) -> Optional[str]:

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -166,12 +166,12 @@ def standardize_headers(input_headers: Union[None, Dict[str, Any]]) -> Dict[str,
 
 
 def validate_extract_webhook_http_header(
-    request: HttpRequest, header: str, integration_name: str, fatal: bool = True
-) -> Optional[str]:
+    request: HttpRequest, header: str, integration_name: str
+) -> str:
     assert request.user.is_authenticated
 
     extracted_header = request.headers.get(header)
-    if extracted_header is None and fatal:
+    if extracted_header is None:
         message_body = MISSING_EVENT_HEADER_MESSAGE.format(
             bot_name=request.user.full_name,
             request_path=request.path,

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -15,7 +15,12 @@ from zerver.actions.message_send import (
     check_send_stream_message_by_id,
     send_rate_limited_pm_notification_to_bot_owner,
 )
-from zerver.lib.exceptions import ErrorCode, JsonableError, StreamDoesNotExistError
+from zerver.lib.exceptions import (
+    AnomalousWebhookPayloadError,
+    ErrorCode,
+    JsonableError,
+    StreamDoesNotExistError,
+)
 from zerver.lib.request import RequestNotes
 from zerver.lib.send_email import FromAddress
 from zerver.lib.timestamp import timestamp_to_datetime
@@ -61,7 +66,7 @@ def notify_bot_owner_about_invalid_json(
     )
 
 
-class MissingHTTPEventHeaderError(JsonableError):
+class MissingHTTPEventHeaderError(AnomalousWebhookPayloadError):
     code = ErrorCode.MISSING_HTTP_EVENT_HEADER
     data_fields = ["header"]
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -414,8 +414,12 @@ class DecoratorLoggingTestCase(ZulipTestCase):
             with self.assertRaisesRegex(UnsupportedWebhookEventTypeError, exception_msg):
                 my_webhook_raises_exception(request)
 
-        mock_exception.assert_called_with(
-            exception_msg, stack_info=True, extra={"request": request}
+        mock_exception.assert_called_once()
+        self.assertIsInstance(mock_exception.call_args.args[0], UnsupportedWebhookEventTypeError)
+        self.assertEqual(mock_exception.call_args.args[0].event_type, "test_event")
+        self.assertEqual(mock_exception.call_args.args[0].msg, exception_msg)
+        self.assertEqual(
+            mock_exception.call_args.kwargs, {"stack_info": True, "extra": {"request": request}}
         )
 
     def test_authenticated_rest_api_view_with_non_webhook_view(self) -> None:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -418,9 +418,7 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         self.assertIsInstance(mock_exception.call_args.args[0], UnsupportedWebhookEventTypeError)
         self.assertEqual(mock_exception.call_args.args[0].event_type, "test_event")
         self.assertEqual(mock_exception.call_args.args[0].msg, exception_msg)
-        self.assertEqual(
-            mock_exception.call_args.kwargs, {"stack_info": True, "extra": {"request": request}}
-        )
+        self.assertEqual(mock_exception.call_args.kwargs, {"extra": {"request": request}})
 
     def test_authenticated_rest_api_view_with_non_webhook_view(self) -> None:
         @authenticated_rest_api_view()

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -185,11 +185,13 @@ class MissingEventHeaderTestCase(WebhookTestCase):
     # an actual webhook, instead of just making a mock
     def test_missing_event_header(self) -> None:
         self.subscribe(self.test_user, self.STREAM_NAME)
-        result = self.client_post(
-            self.url,
-            self.get_body("ticket_state_changed"),
-            content_type="application/x-www-form-urlencoded",
-        )
+        with self.assertLogs("zulip.zerver.webhooks.anomalous", level="INFO") as webhook_logs:
+            result = self.client_post(
+                self.url,
+                self.get_body("ticket_state_changed"),
+                content_type="application/x-www-form-urlencoded",
+            )
+        self.assertTrue("Missing the HTTP event header 'X-Groove-Event'" in webhook_logs.output[0])
         self.assert_json_error(result, "Missing the HTTP event header 'X-Groove-Event'")
 
         realm = get_realm("zulip")

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -187,7 +187,6 @@ def get_type(request: HttpRequest, payload: WildValue) -> str:
         # Note that we only need the HTTP header to determine pullrequest events.
         # We rely on the payload itself to determine the other ones.
         event_key = validate_extract_webhook_http_header(request, "X-Event-Key", "BitBucket")
-        assert event_key is not None
         action = re.match("pullrequest:(?P<action>.*)$", event_key)
         if action:
             action_group = action.group("action")

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -436,10 +436,7 @@ def api_bitbucket3_webhook(
     if "eventKey" in payload:
         eventkey = payload["eventKey"].tame(check_string)
     else:
-        eventkey = validate_extract_webhook_http_header(
-            request, "X-Event-Key", "BitBucket", fatal=True
-        )
-        assert eventkey is not None
+        eventkey = validate_extract_webhook_http_header(request, "X-Event-Key", "BitBucket")
     handler = EVENT_HANDLER_MAP.get(eventkey)
     if handler is None:
         raise UnsupportedWebhookEventTypeError(eventkey)

--- a/zerver/webhooks/freshping/view.py
+++ b/zerver/webhooks/freshping/view.py
@@ -28,11 +28,11 @@ def api_freshping_webhook(
     *,
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
-    body = get_body_for_http_request(payload)
-    topic = get_topic_for_http_request(payload)
     check_state_name = payload["webhook_event_data"]["check_state_name"].tame(check_string)
     if check_state_name not in CHECK_STATE_NAME_TO_EVENT_TYPE:
         raise UnsupportedWebhookEventTypeError(check_state_name)
+    body = get_body_for_http_request(payload)
+    topic = get_topic_for_http_request(payload)
 
     check_send_webhook_message(
         request,

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -806,8 +806,6 @@ def api_github_webhook(
     refine it based on the payload.
     """
     header_event = validate_extract_webhook_http_header(request, "X-GitHub-Event", "GitHub")
-    if header_event is None:
-        raise UnsupportedWebhookEventTypeError("no header provided")
 
     event = get_zulip_event_name(header_event, payload, branches)
     if event is None:

--- a/zerver/webhooks/groove/view.py
+++ b/zerver/webhooks/groove/view.py
@@ -110,7 +110,6 @@ def api_groove_webhook(
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
     event = validate_extract_webhook_http_header(request, "X-Groove-Event", "Groove")
-    assert event is not None
     handler = EVENTS_FUNCTION_MAPPER.get(event)
     if handler is None:
         raise UnsupportedWebhookEventTypeError(event)

--- a/zerver/webhooks/harbor/view.py
+++ b/zerver/webhooks/harbor/view.py
@@ -65,7 +65,7 @@ def handle_scanning_completed_event(
     scan_results = ""
     scan_overview = payload["event_data"]["resources"][0]["scan_overview"]
     if "application/vnd.security.vulnerability.report; version=1.1" not in scan_overview:
-        raise UnsupportedWebhookEventTypeError("Unsupported harbor scanning webhook payload")
+        raise UnsupportedWebhookEventTypeError(str(list(scan_overview.keys())))
     scan_summaries = scan_overview["application/vnd.security.vulnerability.report; version=1.1"][
         "summary"
     ]["summary"]

--- a/zerver/webhooks/linear/view.py
+++ b/zerver/webhooks/linear/view.py
@@ -146,7 +146,7 @@ def get_topic(user_specified_topic: Optional[str], event: str, payload: WildValu
         issue_id = payload["data"]["id"].tame(check_string)
         return issue_id
 
-    raise UnsupportedWebhookEventTypeError("unknown event type")
+    raise UnsupportedWebhookEventTypeError(event)
 
 
 def get_event_type(payload: WildValue) -> Optional[str]:

--- a/zerver/webhooks/reviewboard/view.py
+++ b/zerver/webhooks/reviewboard/view.py
@@ -187,7 +187,6 @@ def api_reviewboard_webhook(
     event_type = validate_extract_webhook_http_header(
         request, "X-ReviewBoard-Event", "Review Board"
     )
-    assert event_type is not None
 
     body_function = RB_MESSAGE_FUNCTIONS.get(event_type)
     if body_function is not None:

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -228,7 +228,7 @@ def handle_issue_payload(
         body = ISSUE_IGNORED_MESSAGE_TEMPLATE.format(**context)
 
     else:
-        raise UnsupportedWebhookEventTypeError("unknown-issue-action type")
+        raise UnsupportedWebhookEventTypeError(f"{action} action")
 
     return (topic, body)
 

--- a/zerver/webhooks/statuspage/tests.py
+++ b/zerver/webhooks/statuspage/tests.py
@@ -43,3 +43,13 @@ class StatuspageHookTests(WebhookTestCase):
             expected_message,
             content_type="application/x-www-form-urlencoded",
         )
+
+    def test_statuspage_anomalous_payload(self) -> None:
+        result = self.client_post(
+            self.url,
+            {},
+            content_type="application/json",
+        )
+        self.assert_json_error(
+            result, "Unable to parse request: Did Statuspage generate this event?", 400
+        )

--- a/zerver/webhooks/statuspage/view.py
+++ b/zerver/webhooks/statuspage/view.py
@@ -2,7 +2,7 @@
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
-from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
+from zerver.lib.exceptions import AnomalousWebhookPayloadError
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.validator import WildValue, check_string
@@ -69,7 +69,7 @@ def api_statuspage_webhook(
         topic = get_component_topic(payload)
         body = get_components_update_body(payload)
     else:
-        raise UnsupportedWebhookEventTypeError("unknown-event")
+        raise AnomalousWebhookPayloadError
 
     check_send_webhook_message(request, user_profile, topic, body, event)
     return json_success(request)

--- a/zerver/webhooks/transifex/tests.py
+++ b/zerver/webhooks/transifex/tests.py
@@ -6,8 +6,6 @@ from zerver.lib.test_classes import WebhookTestCase
 class TransifexHookTests(WebhookTestCase):
     STREAM_NAME = "transifex"
     URL_TEMPLATE = "/api/v1/external/transifex?stream={stream}&api_key={api_key}"
-    URL_REVIEWED_METHOD_TEMPLATE = "reviewed=100"
-    URL_TRANSLATED_METHOD_TEMPLATE = "translated=100"
     WEBHOOK_DIR_NAME = "transifex"
 
     PROJECT = "project-title"
@@ -18,7 +16,8 @@ class TransifexHookTests(WebhookTestCase):
         expected_topic = f"{self.PROJECT} in {self.LANGUAGE}"
         expected_message = f"Resource {self.RESOURCE} fully reviewed."
         self.url = self.build_webhook_url(
-            self.URL_REVIEWED_METHOD_TEMPLATE,
+            event="review_completed",
+            reviewed="100",
             project=self.PROJECT,
             language=self.LANGUAGE,
             resource=self.RESOURCE,
@@ -29,7 +28,8 @@ class TransifexHookTests(WebhookTestCase):
         expected_topic = f"{self.PROJECT} in {self.LANGUAGE}"
         expected_message = f"Resource {self.RESOURCE} fully translated."
         self.url = self.build_webhook_url(
-            self.URL_TRANSLATED_METHOD_TEMPLATE,
+            event="translation_completed",
+            translated="100",
             project=self.PROJECT,
             language=self.LANGUAGE,
             resource=self.RESOURCE,

--- a/zerver/webhooks/transifex/view.py
+++ b/zerver/webhooks/transifex/view.py
@@ -23,17 +23,18 @@ def api_transifex_webhook(
     project: str,
     resource: str,
     language: str,
+    event: str,
     translated: Optional[Json[int]] = None,
     reviewed: Optional[Json[int]] = None,
 ) -> HttpResponse:
     topic = f"{project} in {language}"
-    if translated:
+    if event == "translation_completed":
         event = "translated"
         body = f"Resource {resource} fully translated."
-    elif reviewed:
+    elif event == "review_completed":
         event = "review"
         body = f"Resource {resource} fully reviewed."
     else:
-        raise UnsupportedWebhookEventTypeError("Unknown Event Type")
+        raise UnsupportedWebhookEventTypeError(event)
     check_send_webhook_message(request, user_profile, topic, body, event)
     return json_success(request)


### PR DESCRIPTION
It is not clear why 84723654c884 added these lines, are they are not related to status codes.

Using an explicit `capture_exception` causes the exception in Sentry to not have a `logger` field, which is quite useful for filtering.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
