### PR TITLE
i18n: Fix default language for users created via API/LDAP.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -406,7 +406,7 @@ def do_create_user(
     tos_version: Optional[str] = None,
     timezone: str = "",
     avatar_source: str = UserProfile.AVATAR_FROM_GRAVATAR,
-    default_language: str = "en",
+    default_language: Optional[str] = None,
     default_sending_stream: Optional[Stream] = None,
     default_events_register_stream: Optional[Stream] = None,
     default_all_public_streams: Optional[bool] = None,

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -58,6 +58,7 @@ def bulk_create_users(
             False,
             tos_version,
             timezone,
+            default_language=realm.default_language,
             tutorial_status=UserProfile.TUTORIAL_FINISHED,
             email_address_visibility=email_address_visibility,
         )

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -85,7 +85,13 @@ def get_browser_language_code(request: HttpRequest) -> Optional[str]:
     return None
 
 
-def get_default_language_for_new_user(realm: Realm, *, request: HttpRequest) -> str:
+def get_default_language_for_new_user(realm: Realm, *, request: Optional[HttpRequest]) -> str:
+    if request is None:
+        # Users created via the API or LDAP will not have a
+        # browser/request associated with them, and should just use
+        # the realm's default language.
+        return realm.default_language
+
     browser_language_code = get_browser_language_code(request)
     if browser_language_code is not None:
         return browser_language_code

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -85,7 +85,7 @@ def get_browser_language_code(request: HttpRequest) -> Optional[str]:
     return None
 
 
-def get_default_language_for_new_user(request: HttpRequest, realm: Realm) -> str:
+def get_default_language_for_new_user(realm: Realm, *, request: HttpRequest) -> str:
     browser_language_code = get_browser_language_code(request)
     if browser_language_code is not None:
         return browser_language_code

--- a/zerver/tests/test_mirror_users.py
+++ b/zerver/tests/test_mirror_users.py
@@ -173,6 +173,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
             kwargs["bot_owner"] = None
             kwargs["tos_version"] = None
             kwargs["timezone"] = timezone_now()
+            kwargs["default_language"] = "en"
             kwargs["email_address_visibility"] = UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
             create_user_profile(**kwargs).save()
             raise IntegrityError

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3996,6 +3996,9 @@ class UserSignUpTest(ZulipTestCase):
         req.META["HTTP_ACCEPT_LANGUAGE"] = ""
         self.assertEqual(get_default_language_for_new_user(realm, request=req), "hi")
 
+        # Test code path for users created via the API or LDAP
+        self.assertEqual(get_default_language_for_new_user(realm, request=None), "hi")
+
 
 class DeactivateUserTest(ZulipTestCase):
     def test_deactivate_user(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3984,17 +3984,17 @@ class UserSignUpTest(ZulipTestCase):
         realm = get_realm("zulip")
         req = HostRequestMock()
         req.META["HTTP_ACCEPT_LANGUAGE"] = "de,en"
-        self.assertEqual(get_default_language_for_new_user(req, realm), "de")
+        self.assertEqual(get_default_language_for_new_user(realm, request=req), "de")
 
         do_set_realm_property(realm, "default_language", "hi", acting_user=None)
         realm.refresh_from_db()
         req = HostRequestMock()
         req.META["HTTP_ACCEPT_LANGUAGE"] = "de,en"
-        self.assertEqual(get_default_language_for_new_user(req, realm), "de")
+        self.assertEqual(get_default_language_for_new_user(realm, request=req), "de")
 
         req = HostRequestMock()
         req.META["HTTP_ACCEPT_LANGUAGE"] = ""
-        self.assertEqual(get_default_language_for_new_user(req, realm), "hi")
+        self.assertEqual(get_default_language_for_new_user(realm, request=req), "hi")
 
 
 class DeactivateUserTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -938,6 +938,7 @@ class AdminCreateUserTest(ZulipTestCase):
         realm = admin.realm
         self.login_user(admin)
         do_change_user_role(admin, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        do_set_realm_property(realm, "default_language", "ja", acting_user=None)
         valid_params = dict(
             email="romeo@zulip.net",
             password="xxxx",
@@ -1026,6 +1027,8 @@ class AdminCreateUserTest(ZulipTestCase):
         self.assertEqual(new_user.full_name, "Romeo Montague")
         self.assertEqual(new_user.id, result["user_id"])
         self.assertEqual(new_user.tos_version, UserProfile.TOS_VERSION_BEFORE_FIRST_LOGIN)
+        # Make sure the new user got the realm's default language
+        self.assertEqual(new_user.default_language, "ja")
 
         # Make sure the recipient field is set correctly.
         self.assertEqual(

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -566,7 +566,7 @@ def registration_helper(
             do_change_user_setting(
                 user_profile,
                 "default_language",
-                get_default_language_for_new_user(request, realm),
+                get_default_language_for_new_user(realm, request=request),
                 acting_user=None,
             )
             # TODO: When we clean up the `do_activate_mirror_dummy_user` code path,
@@ -583,7 +583,7 @@ def registration_helper(
                 role=role,
                 tos_version=settings.TERMS_OF_SERVICE_VERSION,
                 timezone=timezone,
-                default_language=get_default_language_for_new_user(request, realm),
+                default_language=get_default_language_for_new_user(realm, request=request),
                 default_stream_groups=default_stream_groups,
                 source_profile=source_profile,
                 realm_creation=realm_creation,


### PR DESCRIPTION
This fixes a regression introduced in
9954db4b59f5b3565a998e0f8e03013669e7fb8a, where the realm's default
language would be ignored for users created via API/LDAP/SAML,
resulting in all such users having English as their default language.

The API/LDAP/SAML account creation code paths don't have a request,
and thus cannot pull default language from the user's browser.

We have the `realm.default_language` field intended for this use case,
but it was not being passed through the system.

Rather than pass `realm.default_language` through from each caller, we
make the low-level user creation code set this field, as that seems
more robust to the creation of future callers.

See https://chat.zulip.org/#narrow/stream/31-production-help/topic/default.20language.20for.20new.20users/near/1648829 for the original report.