### PR TITLE
compose: Show pronouns in compose typeaheads.

### DIFF
--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -10,6 +10,15 @@ export const page_params: {
         allowed: boolean;
     }[];
     corporate_enabled: boolean;
+    custom_profile_fields: {
+        display_in_profile_summary?: boolean;
+        field_data: string;
+        hint: string;
+        id: number;
+        name: string;
+        order: number;
+        type: number;
+    }[];
     delivery_email: string;
     development_environment: boolean;
     is_admin: boolean;

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1636,6 +1636,24 @@ export function get_custom_profile_data(user_id: number, field_id: number): Prof
     return profile_data[field_id];
 }
 
+export function get_custom_fields_by_type(
+    user_id: number,
+    field_type: number,
+): ProfileData[] | null {
+    const person = get_by_user_id(user_id);
+    const profile_data = person.profile_data;
+    if (profile_data === undefined) {
+        return null;
+    }
+    const filteredProfileData: ProfileData[] = [];
+    for (const field of page_params.custom_profile_fields) {
+        if (field.type === field_type) {
+            filteredProfileData.push(profile_data[field.id]);
+        }
+    }
+    return filteredProfileData;
+}
+
 export function is_my_user_id(user_id: number | string): boolean {
     if (!user_id) {
         return false;

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -7,6 +7,7 @@ import render_typeahead_list_item from "../templates/typeahead_list_item.hbs";
 
 import * as buddy_data from "./buddy_data";
 import * as compose_state from "./compose_state";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
 import * as recent_senders from "./recent_senders";
@@ -70,6 +71,7 @@ export function render_typeahead_item(args) {
     args.has_image = args.img_src !== undefined;
     args.has_status = args.status_emoji_info !== undefined;
     args.has_secondary = args.secondary !== undefined;
+    args.has_pronouns = args.pronouns !== undefined;
     return render_typeahead_list_item(args);
 }
 
@@ -86,6 +88,11 @@ export function render_person(person) {
 
     const status_emoji_info = user_status.get_status_emoji(person.user_id);
 
+    const PRONOUNS_ID = page_params.custom_profile_field_types.PRONOUNS.id;
+    const pronouns_list = people.get_custom_fields_by_type(person.user_id, PRONOUNS_ID);
+
+    const pronouns = pronouns_list?.[0]?.value;
+
     const typeahead_arguments = {
         primary: person.full_name,
         img_src: avatar_url,
@@ -93,6 +100,7 @@ export function render_person(person) {
         is_person: true,
         status_emoji_info,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(person.user_id),
+        pronouns,
     };
 
     typeahead_arguments.secondary = person.delivery_email;

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -24,6 +24,9 @@
         {{~ primary ~}}
     {{/if}}
 </strong>
+{{~#if has_pronouns}}
+    <span class="pronouns">({{pronouns}})</span>
+{{~/if}}
 {{~#if should_add_guest_user_indicator}}
     <i>({{t 'guest'}})</i>
 {{~/if}}

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -723,6 +723,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     });
 
     let expected_value;
+    page_params.custom_profile_field_types = {
+        PRONOUNS: {id: 8, name: "Pronouns"},
+    };
 
     mock_template("typeahead_list_item.hbs", true, (data, html) => {
         assert.equal(typeof data.primary, "string");

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -241,6 +241,17 @@ const all2 = {
     full_name: "all",
 };
 
+const stewie = {
+    email: "stewie@example.com",
+    user_id: 1204,
+    full_name: "Stewart Gilligan",
+    profile_data: {
+        1: "(888) 888-8888",
+        2: "(555) 555-5555",
+        3: "he/him",
+    },
+};
+
 // This is for error checking--never actually
 // tell people.js about this user.
 const invalid_user = {
@@ -523,6 +534,45 @@ test_people("my_custom_profile_data", () => {
     person.profile_data = {3: "My address", 4: "My phone number"};
     assert.equal(people.my_custom_profile_data(3), "My address");
     assert.equal(people.my_custom_profile_data(4), "My phone number");
+});
+
+test_people("get_custom_fields_by_type", () => {
+    people.add_active_user(stewie);
+    const person = people.get_by_user_id(stewie.user_id);
+    page_params.custom_profile_field_types = {
+        SHORT_TEXT: {
+            id: 1,
+            name: "Short text",
+        },
+        PRONOUNS: {
+            id: 8,
+            name: "Pronouns",
+        },
+    };
+    page_params.custom_profile_fields = [
+        {
+            id: 1,
+            name: "Phone number (mobile)",
+            type: 1,
+        },
+        {
+            id: 2,
+            name: "Phone number (office)",
+            type: 1,
+        },
+        {
+            id: 3,
+            name: "Pronouns",
+            type: 8,
+        },
+    ];
+    const SHORT_TEXT_ID = 1;
+    assert.deepEqual(people.get_custom_fields_by_type(person.user_id, SHORT_TEXT_ID), [
+        "(888) 888-8888",
+        "(555) 555-5555",
+    ]);
+    assert.deepEqual(people.get_custom_fields_by_type(person.user_id, 8), ["he/him"]);
+    assert.deepEqual(people.get_custom_fields_by_type(person.user_id, 100), []);
 });
 
 test_people("bot_custom_profile_data", () => {

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -680,6 +680,9 @@ test("highlight_with_escaping", () => {
 
 test("render_person when emails hidden", ({mock_template}) => {
     // Test render_person with regular person, under hidden email visibility case
+    page_params.custom_profile_field_types = {
+        PRONOUNS: {id: 8, name: "Pronouns"},
+    };
     let rendered = false;
     mock_template("typeahead_list_item.hbs", false, (args) => {
         assert.equal(args.primary, b_user_1.full_name);
@@ -694,6 +697,9 @@ test("render_person when emails hidden", ({mock_template}) => {
 test("render_person", ({mock_template}) => {
     // Test render_person with regular person
     a_user.delivery_email = "a_user_delivery@zulip.org";
+    page_params.custom_profile_field_types = {
+        PRONOUNS: {id: 8, name: "Pronouns"},
+    };
     let rendered = false;
     mock_template("typeahead_list_item.hbs", false, (args) => {
         assert.equal(args.primary, a_user.full_name);
@@ -774,6 +780,7 @@ test("render_emoji", ({mock_template}) => {
         emoji_code: "1f44d",
         is_emoji: true,
         has_image: false,
+        has_pronouns: false,
         has_secondary: false,
         has_status: false,
     };
@@ -800,6 +807,7 @@ test("render_emoji", ({mock_template}) => {
         img_src: "TBD",
         is_emoji: true,
         has_image: true,
+        has_pronouns: false,
         has_secondary: false,
         has_status: false,
     };


### PR DESCRIPTION
This PR adds the pronouns custom profile field to the typeaheads in the composebox along with the necessary node tests.

Details of the implementation:
- Added logic to display pronouns in ( ) after status emoji but before the user's email (if present) when the user has a non-empty pronoun-type custom profile field.
- If multiple pronoun fields exist in the organization, the implementation selects the one earlier in the list of custom profile fields.
- No pronouns are displayed if the selected pronoun field is empty.

Fixes: #26924

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/feature.20request.3A.20.60.40name.60.20shows.20pronouns/near/1591147)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Normal
![Normal](https://github.com/zulip/zulip/assets/82862779/171cedbb-b40d-4c8a-bb5c-0aa0d84c1046)
- When the pronouns field is empty
![image](https://github.com/zulip/zulip/assets/82862779/96274dc3-99be-44cb-9549-e55979058d47)
![image](https://github.com/zulip/zulip/assets/82862779/156cbddb-f3a5-4a50-8b93-763062ce93d1)
- When multiple pronouns exist and the order is changed.
![image](https://github.com/zulip/zulip/assets/82862779/9a32e0d6-38f4-4b5e-80bb-db530c50534b)
![image](https://github.com/zulip/zulip/assets/82862779/a4096e3f-f97a-41a1-b363-fbbfd81ecd76)
![image](https://github.com/zulip/zulip/assets/82862779/ab31d2ba-7116-45a0-addf-1fe9072d5c3d)
![image](https://github.com/zulip/zulip/assets/82862779/94295ee5-f9c6-4079-8c28-a2e72d2b595e)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
