### PR TITLE
Improvements to integration URL modal.

### DIFF
--- a/web/src/integration_url_modal.js
+++ b/web/src/integration_url_modal.js
@@ -80,6 +80,10 @@ export function show_generate_integration_url_modal(api_key) {
             const base_url = `${realm_url}/api/v1/external/`;
             $integration_url.text(`${base_url}${selected_integration}?${params}`);
             $dialog_submit_button.prop("disabled", false);
+
+            if ($override_topic.prop("checked") && topic_name === "") {
+                $dialog_submit_button.prop("disabled", true);
+            }
         }
 
         integration_input_dropdown_widget = new dropdown_widget.DropdownWidget({

--- a/web/src/integration_url_modal.js
+++ b/web/src/integration_url_modal.js
@@ -99,7 +99,7 @@ export function show_generate_integration_url_modal(api_key) {
         stream_input_dropdown_widget = new dropdown_widget.DropdownWidget({
             widget_name: "integration-url-stream",
             get_options: get_options_for_stream_dropdown_widget,
-            item_click_callback,
+            item_click_callback: stream_item_click_callback,
             $events_container: $("#generate-integration-url-modal"),
             tippy_props: {
                 placement: "bottom-start",
@@ -121,7 +121,7 @@ export function show_generate_integration_url_modal(api_key) {
             return options;
         }
 
-        function item_click_callback(event, dropdown) {
+        function stream_item_click_callback(event, dropdown) {
             stream_input_dropdown_widget.render();
             $(".integration-url-stream-wrapper").trigger("input");
             const user_selected_option = stream_input_dropdown_widget.value();

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2084,6 +2084,11 @@ $option_title_width: 180px;
         word-break: break-all;
     }
 
+    .integration-url-name-wrapper .dropdown-widget-button {
+        width: 50%;
+    }
+
+    .integration-url-name-wrapper .dropdown_widget_value,
     .integration-url-stream-wrapper .dropdown_widget_value {
         white-space: nowrap;
         overflow: hidden;

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -1,7 +1,10 @@
 <div class="new-style">
     <div class="input-group">
-        <label for="integration-input">{{t "Integration"}}</label>
-        <input type="text" id="integration-input" class="modal_text_input integration-url-parameter" autocomplete="off"/>
+        <div class="integration-url-name-wrapper integration-url-parameter">
+            {{> ../dropdown_widget_with_label
+              widget_name="integration-name"
+              label=(t "Integration")}}
+        </div>
     </div>
     <div class="input-group">
         <div class="integration-url-stream-wrapper integration-url-parameter">

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -512,8 +512,10 @@ def fetch_initial_state_data(
             for bot in EMBEDDED_BOTS
         ]
 
-    # This does not have an apply_events counterpart either since
-    # this data is mostly static.
+    # This does not have an apply_events counterpart either since this
+    # data is mostly static. This excludes the legacy webhook
+    # integrations as those do not follow the same URL construction
+    # patterns as other integrations.
     if want("realm_incoming_webhook_bots"):
         state["realm_incoming_webhook_bots"] = [
             {
@@ -523,6 +525,7 @@ def fetch_initial_state_data(
                 "config": {c[1]: c[0] for c in integration.config_options},
             }
             for integration in WEBHOOK_INTEGRATIONS
+            if integration.legacy is False
         ]
 
     if want("recent_private_conversations"):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11713,7 +11713,7 @@ paths:
                         description: |
                           Present if `realm_incoming_webhook_bots` is present in `fetch_event_types`.
 
-                          An array of dictionaries where each dictionary describes an type of incoming webhook
+                          An array of dictionaries where each dictionary describes a type of incoming webhook
                           integration that is available to be configured on this Zulip server.
 
                           Clients only need these data if they contain UI for creating or administering bots.


### PR DESCRIPTION
This PR makes the following improvements to the integration URL modal:

- Migrates the integration input from typeahead to a dropdown widget.
- Disables the `Copy URL` button when the topic input is empty

Fixes: #26797

<hr>


**Screenshots and screen captures:**

<details> 


<summary>Integration input </summary>


| Before | After |
|--------|--------|
| ![typeahead](https://github.com/sbansal1999/zulip/assets/35286603/28655e9d-51b6-4965-a8eb-7740a9062654) | ![dropdown widget](https://github.com/sbansal1999/zulip/assets/35286603/154de25b-8bdc-48d1-8dc2-32892ef6e2b8) | 


</details>

<details>

<summary> "Copy URL" button when topic input is empty </summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/sbansal1999/zulip/assets/35286603/db202417-0401-4784-b111-6ff51a046224)  | ![image](https://github.com/sbansal1999/zulip/assets/35286603/b56e1f02-5d8d-4432-a895-28a66df166ba)  | 

</details>

<details>

<summary> Mobile view </summary>

![image](https://github.com/zulip/zulip/assets/35286603/05958a9f-aeec-46e9-b582-b97356b8f2ce)

</details>

<hr>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
