### PR TITLE
typing_indicator: Update APIs for stream typing notifications.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -26,6 +26,9 @@ format used by the Zulip server that they are interacting with.
   with `direct` in the `message_type` field for the `typing` events
   sent when a user starts or stops typing a message.
 
+* [`POST /typing`](/api/set-typing-status): Stopped supporting `private`
+  as a valid value for the `type` parameter.
+
 **Feature level 214**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 215**
+
+* [`GET /events`](/api/get-events): Replaced the value `private`
+  with `direct` in the `message_type` field for the `typing` events
+  sent when a user starts or stops typing a message.
+
 **Feature level 214**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -29,6 +29,14 @@ format used by the Zulip server that they are interacting with.
 * [`POST /typing`](/api/set-typing-status): Stopped supporting `private`
   as a valid value for the `type` parameter.
 
+* [`POST /typing`](/api/set-typing-status): When the `type` of the message
+  being composed is `"stream"`, changed the `to` parameter to accept the
+  ID of the stream in which the message is being typed. Previously, it
+  accepted a single-element list containing the ID of the stream.
+
+* Note that stream typing notifications were not enabled in any Zulip client
+  prior to feature level 215.
+
 **Feature level 214**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 214
+API_FEATURE_LEVEL = 215
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -756,7 +756,7 @@ exports.fixtures = {
     typing__start: {
         type: "typing",
         op: "start",
-        message_type: "private",
+        message_type: "direct",
         sender: typing_person1,
         recipients: [typing_person2],
     },
@@ -764,7 +764,7 @@ exports.fixtures = {
     typing__stop: {
         type: "typing",
         op: "stop",
-        message_type: "private",
+        message_type: "direct",
         sender: typing_person1,
         recipients: [typing_person2],
     },

--- a/zerver/actions/typing.py
+++ b/zerver/actions/typing.py
@@ -19,7 +19,7 @@ def do_send_typing_notification(
     ]
     event = dict(
         type="typing",
-        message_type="private",
+        message_type="direct",
         op=operator,
         sender=sender_dict,
         recipients=recipient_dicts,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1443,9 +1443,9 @@ typing_person_type = DictType(
     ]
 )
 
-equals_private_or_stream = EnumType(
+equals_direct_or_stream = EnumType(
     [
-        "private",
+        "direct",
         "stream",
     ]
 )
@@ -1454,7 +1454,7 @@ typing_start_event = event_dict_type(
     required_keys=[
         ("type", Equals("typing")),
         ("op", Equals("start")),
-        ("message_type", equals_private_or_stream),
+        ("message_type", equals_direct_or_stream),
         ("sender", typing_person_type),
     ],
     optional_keys=[
@@ -1469,7 +1469,7 @@ typing_stop_event = event_dict_type(
     required_keys=[
         ("type", Equals("typing")),
         ("op", Equals("stop")),
-        ("message_type", equals_private_or_stream),
+        ("message_type", equals_direct_or_stream),
         ("sender", typing_person_type),
     ],
     optional_keys=[

--- a/zerver/lib/recipient_parsing.py
+++ b/zerver/lib/recipient_parsing.py
@@ -1,0 +1,31 @@
+from typing import List
+
+import orjson
+from django.utils.translation import gettext as _
+
+from zerver.lib.exceptions import JsonableError
+
+
+def extract_stream_id(req_to: str) -> int:
+    # Recipient should only be a single stream ID.
+    try:
+        stream_id = int(req_to)
+    except ValueError:
+        raise JsonableError(_("Invalid data type for stream ID"))
+    return stream_id
+
+
+def extract_direct_message_recipient_ids(req_to: str) -> List[int]:
+    try:
+        user_ids = orjson.loads(req_to)
+    except orjson.JSONDecodeError:
+        user_ids = req_to
+
+    if not isinstance(user_ids, list):
+        raise JsonableError(_("Invalid data type for recipients"))
+
+    for user_id in user_ids:
+        if not isinstance(user_id, int):
+            raise JsonableError(_("Recipient list may only contain user IDs"))
+
+    return list(set(user_ids))

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1351,7 +1351,7 @@ def set_typing_status(client: Client) -> None:
     request = {
         "type": "stream",
         "op": "start",
-        "to": [stream_id],
+        "to": stream_id,
         "topic": topic,
     }
     result = client.set_typing_status(request)
@@ -1369,7 +1369,7 @@ def set_typing_status(client: Client) -> None:
     request = {
         "type": "stream",
         "op": "stop",
-        "to": [stream_id],
+        "to": stream_id,
         "topic": topic,
     }
     result = client.set_typing_status(request)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16630,7 +16630,11 @@ paths:
         See the subsystems documentation on [typing indicators][typing-protocol-docs]
         for additional design details on Zulip's typing notifications protocol.
 
-        **Changes**: Support for displaying stream typing notifications was new
+        **Changes**: Clients shouldn't care about the APIs prior to Zulip 8.0 (feature level 215)
+        for stream typing notifications, as no client actually implemented
+        the previous API for those.
+
+        Support for displaying stream typing notifications was new
         in Zulip 4.0 (feature level 58). Clients should indicate they support
         processing stream typing notifications via the `stream_typing_notifications`
         value in the `client_capabilities` parameter of the
@@ -16689,10 +16693,15 @@ paths:
             being typed. Send a JSON-encoded list of user IDs. (Use a list even if
             there is only one recipient.)
 
-            For `"stream"` type it is a single element list containing ID of stream in
-            which the message is being typed.
+            For `"stream"` type it is the ID of the stream in which the message is
+            being typed.
 
-            **Changes**: Support for typing notifications for stream messages
+            **Changes**: In Zulip 8.0 (feature level 215), for the `"stream"` `type`,
+            changed this parameter to accept the ID of the stream in which the message
+            is being typed. Previously, it accepted a single-element list containing
+            the ID of the stream.
+
+            Support for typing notifications for stream messages
             is new in Zulip 4.0 (feature level 58). Previously, typing
             notifications were only for direct messages.
 
@@ -16702,9 +16711,12 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: integer
+                oneOf:
+                  - type: integer
+                  - type: array
+                    items:
+                      type: integer
+                    minLength: 1
               example: [9, 10]
           required: true
         - name: topic

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16654,7 +16654,10 @@ paths:
           description: |
             Type of the message being composed.
 
-            **Changes**: In Zulip 7.0 (feature level 174), `"direct"` was added
+            **Changes**: In Zulip 8.0 (feature level 215), stopped supporting
+            `"private"` as a valid value for this parameter.
+
+            In Zulip 7.0 (feature level 174), `"direct"` was added
             as the preferred way to indicate a direct message is being composed,
             becoming the default value for this parameter and deprecating the
             original `"private"`.
@@ -16666,7 +16669,6 @@ paths:
             enum:
               - direct
               - stream
-              - private
             default: direct
           example: direct
         - name: op

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2523,12 +2523,15 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be `"stream"` or `"private"`.
+                                    Type of message being composed. Must be `"stream"` or `"direct"`.
 
-                                    **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly direct messages.
+                                    **Changes**: In Zulip 8.0 (feature level 215), replaced the
+                                    value `"private"` with `"direct"`.
+
+                                    New in Zulip 4.0 (feature level 58). Previously, all typing
+                                    notifications were implicitly direct messages.
                                   enum:
-                                    - private
+                                    - direct
                                     - stream
                                 sender:
                                   additionalProperties: false
@@ -2547,7 +2550,7 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present if `message_type` is `"private"`.
+                                    Only present if `message_type` is `"direct"`.
 
                                     Array of dictionaries describing the set of users who would be
                                     recipients of the message being typed. Each dictionary contains
@@ -2589,7 +2592,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "start",
-                                  "message_type": "private",
+                                  "message_type": "direct",
                                   "sender":
                                     {
                                       "user_id": 10,
@@ -2641,12 +2644,15 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be `"stream"` or `"private"`.
+                                    Type of message being composed. Must be `"stream"` or `"direct"`.
 
-                                    **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly direct messages.
+                                    **Changes**: In Zulip 8.0 (feature level 215), replaced the
+                                    value `"private"` with `"direct"`.
+
+                                    New in Zulip 4.0 (feature level 58). Previously all typing
+                                    notifications were implicitly direct messages.
                                   enum:
-                                    - private
+                                    - direct
                                     - stream
                                 sender:
                                   additionalProperties: false
@@ -2665,7 +2671,7 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present if `message_type` is `"private"`.
+                                    Only present if `message_type` is `"direct"`.
 
                                     Array of dictionaries describing the set of users who would be
                                     recipients of the message that was previously being typed. Each
@@ -2707,7 +2713,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "stop",
-                                  "message_type": "private",
+                                  "message_type": "direct",
                                   "sender":
                                     {
                                       "user_id": 10,

--- a/zerver/tests/test_recipient_parsing.py
+++ b/zerver/tests/test_recipient_parsing.py
@@ -1,0 +1,46 @@
+import orjson
+
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.recipient_parsing import extract_direct_message_recipient_ids, extract_stream_id
+from zerver.lib.test_classes import ZulipTestCase
+
+
+class TestRecipientParsing(ZulipTestCase):
+    def test_extract_stream_id(self) -> None:
+        # stream message recipient = single stream ID.
+        stream_id = extract_stream_id("1")
+        self.assertEqual(stream_id, 1)
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("1,2")
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("[1]")
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("general")
+
+    def test_extract_recipient_ids(self) -> None:
+        # direct message recipients = user IDs.
+        user_ids = "[3,2,1]"
+        result = sorted(extract_direct_message_recipient_ids(user_ids))
+        self.assertEqual(result, [1, 2, 3])
+
+        # JSON list w/duplicates
+        user_ids = orjson.dumps([3, 3, 12]).decode()
+        result = sorted(extract_direct_message_recipient_ids(user_ids))
+        self.assertEqual(result, [3, 12])
+
+        # Invalid data
+        user_ids = "1, 12"
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
+            extract_direct_message_recipient_ids(user_ids)
+
+        user_ids = orjson.dumps(dict(recipient=12)).decode()
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
+            extract_direct_message_recipient_ids(user_ids)
+
+        # Heterogeneous lists are not supported
+        user_ids = orjson.dumps([3, 4, "eeshan@example.com"]).decode()
+        with self.assertRaisesRegex(JsonableError, "Recipient list may only contain user IDs"):
+            extract_direct_message_recipient_ids(user_ids)

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -11,12 +11,9 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.scheduled_messages import (
     SCHEDULED_MESSAGE_LATE_CUTOFF_MINUTES,
-    extract_direct_message_recipient_ids,
-    extract_stream_id,
     try_deliver_one_scheduled_message,
 )
 from zerver.actions.users import change_user_is_active
-from zerver.lib.exceptions import JsonableError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message
 from zerver.lib.timestamp import timestamp_to_datetime
@@ -717,42 +714,3 @@ class ScheduledMessageTest(ZulipTestCase):
             [scheduled_message.id],
         )
         self.assertEqual(scheduled_message.has_attachment, True)
-
-    def test_extract_stream_id(self) -> None:
-        # Scheduled stream message recipient = single stream ID.
-        stream_id = extract_stream_id("1")
-        self.assertEqual(stream_id, [1])
-
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
-            extract_stream_id("1,2")
-
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
-            extract_stream_id("[1]")
-
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
-            extract_stream_id("general")
-
-    def test_extract_recipient_ids(self) -> None:
-        # Scheduled direct message recipients = user IDs.
-        user_ids = "[3,2,1]"
-        result = sorted(extract_direct_message_recipient_ids(user_ids))
-        self.assertEqual(result, [1, 2, 3])
-
-        # JSON list w/duplicates
-        user_ids = orjson.dumps([3, 3, 12]).decode()
-        result = sorted(extract_direct_message_recipient_ids(user_ids))
-        self.assertEqual(result, [3, 12])
-
-        # Invalid data
-        user_ids = "1, 12"
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
-            extract_direct_message_recipient_ids(user_ids)
-
-        user_ids = orjson.dumps(dict(recipient=12)).decode()
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
-            extract_direct_message_recipient_ids(user_ids)
-
-        # Heterogeneous lists are not supported
-        user_ids = orjson.dumps([3, 4, "eeshan@example.com"]).decode()
-        with self.assertRaisesRegex(JsonableError, "Recipient list may only contain user IDs"):
-            extract_direct_message_recipient_ids(user_ids)

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -16,7 +16,7 @@ class TypingValidateOperatorTest(ZulipTestCase):
         result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_error(result, "Missing 'op' argument")
 
-    def test_invalid_parameter_pm(self) -> None:
+    def test_invalid_parameter_direct_message(self) -> None:
         """
         Sending typing notification with invalid value for op parameter fails
         """
@@ -50,9 +50,9 @@ class TypingMessagetypeTest(ZulipTestCase):
 
 
 class TypingValidateToArgumentsTest(ZulipTestCase):
-    def test_empty_to_array_pms(self) -> None:
+    def test_empty_to_array_direct_messages(self) -> None:
         """
-        Sending pms typing notification without recipient fails
+        Sending dms typing notification without recipient fails
         """
         sender = self.example_user("hamlet")
         result = self.api_post(sender, "/api/v1/typing", {"op": "start", "to": "[]"})
@@ -131,7 +131,7 @@ class TypingValidateToArgumentsTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid stream ID")
 
 
-class TypingHappyPathTestPMs(ZulipTestCase):
+class TypingHappyPathTestDirectMessages(ZulipTestCase):
     def test_valid_type_and_op_parameters(self) -> None:
         operator_type = ["start", "stop"]
         sender = self.example_user("hamlet")

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -133,21 +133,19 @@ class TypingValidateToArgumentsTest(ZulipTestCase):
 
 class TypingHappyPathTestPMs(ZulipTestCase):
     def test_valid_type_and_op_parameters(self) -> None:
-        recipient_type_name = ["direct", "private"]
         operator_type = ["start", "stop"]
         sender = self.example_user("hamlet")
         recipient_user = self.example_user("othello")
 
-        for type in recipient_type_name:
-            for operator in operator_type:
-                params = dict(
-                    to=orjson.dumps([recipient_user.id]).decode(),
-                    op=operator,
-                    type=type,
-                )
+        for operator in operator_type:
+            params = dict(
+                to=orjson.dumps([recipient_user.id]).decode(),
+                op=operator,
+                type="direct",
+            )
 
-                result = self.api_post(sender, "/api/v1/typing", params)
-                self.assert_json_success(result)
+            result = self.api_post(sender, "/api/v1/typing", params)
+            self.assert_json_success(result)
 
     def test_start_to_single_recipient(self) -> None:
         sender = self.example_user("hamlet")

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -8,10 +8,9 @@ from zerver.actions.scheduled_messages import (
     check_schedule_message,
     delete_scheduled_message,
     edit_scheduled_message,
-    extract_direct_message_recipient_ids,
-    extract_stream_id,
 )
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.recipient_parsing import extract_direct_message_recipient_ids, extract_stream_id
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.scheduled_messages import get_undelivered_scheduled_messages
@@ -133,7 +132,8 @@ def create_scheduled_message_backend(
     assert client is not None
 
     if recipient_type_name == "stream":
-        message_to = extract_stream_id(req_to)
+        stream_id = extract_stream_id(req_to)
+        message_to = [stream_id]
     else:
         message_to = extract_direct_message_recipient_ids(req_to)
 

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -1,14 +1,15 @@
-from typing import List, Optional
+from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
 from zerver.actions.typing import check_send_typing_notification, do_send_stream_typing_notification
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.recipient_parsing import extract_direct_message_recipient_ids, extract_stream_id
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_for_send_message
-from zerver.lib.validator import check_int, check_list, check_string_in
+from zerver.lib.validator import check_string_in
 from zerver.models import UserProfile
 
 VALID_OPERATOR_TYPES = ["start", "stop"]
@@ -23,36 +24,32 @@ def send_notification_backend(
         "type", str_validator=check_string_in(VALID_RECIPIENT_TYPES), default="direct"
     ),
     operator: str = REQ("op", str_validator=check_string_in(VALID_OPERATOR_TYPES)),
-    notification_to: List[int] = REQ("to", json_validator=check_list(check_int)),
+    notification_to: str = REQ("to"),
     topic: Optional[str] = REQ("topic", default=None),
 ) -> HttpResponse:
-    to_length = len(notification_to)
-
-    if to_length == 0:
-        raise JsonableError(_("Empty 'to' list"))
-
     recipient_type_name = req_type
     if recipient_type_name == "stream":
-        if to_length > 1:
-            raise JsonableError(_("Cannot send to multiple streams"))
-
+        stream_id = extract_stream_id(notification_to)
         if topic is None:
             raise JsonableError(_("Missing topic"))
 
         if not user_profile.send_stream_typing_notifications:
             raise JsonableError(_("User has disabled typing notifications for stream messages"))
 
-        stream_id = notification_to[0]
         # Verify that the user has access to the stream and has
         # permission to send messages to it.
         stream = access_stream_by_id(user_profile, stream_id)[0]
         access_stream_for_send_message(user_profile, stream, forwarder_user_profile=None)
         do_send_stream_typing_notification(user_profile, operator, stream, topic)
     else:
+        user_ids = extract_direct_message_recipient_ids(notification_to)
+        to_length = len(user_ids)
+        if to_length == 0:
+            raise JsonableError(_("Empty 'to' list"))
+
         if not user_profile.send_private_typing_notifications:
             raise JsonableError(_("User has disabled typing notifications for direct messages"))
 
-        user_ids = notification_to
         check_send_typing_notification(user_profile, user_ids, operator)
 
     return json_success(request)

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -9,9 +9,10 @@ from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_for_send_message
 from zerver.lib.validator import check_int, check_list, check_string_in
-from zerver.models import Message, UserProfile
+from zerver.models import UserProfile
 
 VALID_OPERATOR_TYPES = ["start", "stop"]
+VALID_RECIPIENT_TYPES = ["direct", "stream"]
 
 
 @has_request_variables
@@ -19,7 +20,7 @@ def send_notification_backend(
     request: HttpRequest,
     user_profile: UserProfile,
     req_type: str = REQ(
-        "type", str_validator=check_string_in(Message.API_RECIPIENT_TYPES), default="direct"
+        "type", str_validator=check_string_in(VALID_RECIPIENT_TYPES), default="direct"
     ),
     operator: str = REQ("op", str_validator=check_string_in(VALID_OPERATOR_TYPES)),
     notification_to: List[int] = REQ("to", json_validator=check_list(check_int)),
@@ -31,9 +32,6 @@ def send_notification_backend(
         raise JsonableError(_("Empty 'to' list"))
 
     recipient_type_name = req_type
-    if recipient_type_name == "private":
-        recipient_type_name = "direct"
-
     if recipient_type_name == "stream":
         if to_length > 1:
             raise JsonableError(_("Cannot send to multiple streams"))

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -32,7 +32,6 @@ def send_notification_backend(
 
     recipient_type_name = req_type
     if recipient_type_name == "private":
-        # TODO: Use "direct" in typing notification events.
         recipient_type_name = "direct"
 
     if recipient_type_name == "stream":


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/stream.20typing.20indicator/near/1649887)

> For https://zulip.com/api/get-events#typing-start, I think we should change the value "private" to "direct" --

> We could also remove the "private" compatibility support in [/api/set-typing-status](https://chat.zulip.org/api/set-typing-status) -- assuming we confirm that the mobile and terminal clients don't actually send the value "private"


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

<details><summary>set-typing-status</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/c22b129d-e535-4cc3-a7f4-cc1a80b52f8c">
</img>
</details> 

<details><summary>get-events#typing-start</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/f70adf97-1a73-4c59-adc6-5cc66f866903">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
