### PR TITLE
tooltips: Add hotkey hints and modify edit history tooltip.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -83,13 +83,6 @@
     opacity: 1;
 }
 
-.narrow_to_compose_recipient_current_view_help {
-    margin: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .compose_table {
     height: 100%;
     display: flex;

--- a/web/templates/buddy_list_tooltip_content.hbs
+++ b/web/templates/buddy_list_tooltip_content.hbs
@@ -1,14 +1,14 @@
 <div class="buddy_list_tooltip_content">
-    <span>
+    <div>
         {{first_line}}
         {{#if show_you}}
         <span class="my_user_status">{{t "(you)" }}</span>
         {{/if}}
-    </span>
+    </div>
     {{#if second_line}}
-    <br /><span class="tooltip-inner-content">{{second_line}}</span>
+        <div class="tooltip-inner-content">{{second_line}}</div>
     {{/if}}
     {{#if third_line}}
-    <br /><span class="tooltip-inner-content">{{third_line}}</span>
+        <div class="tooltip-inner-content">{{third_line}}</div>
     {{/if}}
 </div>

--- a/web/templates/change_visibility_policy_button_tooltip.hbs
+++ b/web/templates/change_visibility_policy_button_tooltip.hbs
@@ -1,5 +1,4 @@
 <div id="change_visibility_policy_button_tooltip">
     <strong>{{current_visibility_policy_str}}</strong>
-    <br/>
-    <span class="tooltip-inner-content italic">{{t 'Click to change notifications for this topic.' }}</span>
+    <div class="tooltip-inner-content italic">{{t 'Click to change notifications for this topic.' }}</div>
 </div>

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,6 +1,7 @@
 <div>
-    <div>{{edited_notice_str}}</div>
+    <div>{{t "View edit history"}}</div>
     {{#if realm_allow_edit_history}}
-        <div class="tooltip-inner-content italic">{{t 'Click to view edit history.' }}</div>
+        <div class="tooltip-inner-content italic">{{edited_notice_str}}</div>
     {{/if}}
 </div>
+{{tooltip_hotkey_hints "Shift" "H"}}

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,6 +1,6 @@
 <div>
     <div>{{edited_notice_str}}</div>
     {{#if realm_allow_edit_history}}
-        <i>{{t 'Click to view edit history.' }}</i>
+        <div class="tooltip-inner-content italic">{{t 'Click to view edit history.' }}</div>
     {{/if}}
 </div>

--- a/web/templates/message_inline_image_tooltip.hbs
+++ b/web/templates/message_inline_image_tooltip.hbs
@@ -1,5 +1,4 @@
 <div id="message_inline_image_tooltip">
     <strong>{{ title }}</strong>
-    <br/>
-    <span class="tooltip-inner-content italic">{{t 'Click to view or download.'}}</span>
+    <div class="tooltip-inner-content italic">{{t 'Click to view or download.'}}</div>
 </div>

--- a/web/templates/narrow_to_compose_recipients_tooltip.hbs
+++ b/web/templates/narrow_to_compose_recipients_tooltip.hbs
@@ -1,7 +1,7 @@
 <div>
-    <span>{{t 'Go to conversation' }}</span>
+    <div>{{t "Go to conversation"}}</div>
     {{#if display_current_view}}
-    <p class="narrow_to_compose_recipient_current_view_help tooltip-inner-content italic">{{display_current_view}}</p>
+        <div class="tooltip-inner-content italic">{{display_current_view}}</div>
     {{/if}}
 </div>
 {{tooltip_hotkey_hints "Ctrl" "."}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -55,8 +55,8 @@
 </template>
 <template id="add-global-time-tooltip">
     <div>
-        <span>{{t "Add global time" }}</span><br/>
-        <span class="tooltip-inner-content italic">{{t "Everyone sees global times in their own time zone." }}</span>
+        <div>{{t "Add global time" }}</div>
+        <div class="tooltip-inner-content italic">{{t "Everyone sees global times in their own time zone." }}</div>
     </div>
 </template>
 <template id="delete-draft-tooltip-template">
@@ -124,11 +124,11 @@
     {{tooltip_hotkey_hints "I"}}
 </template>
 <template id="star-message-tooltip-template">
-    <span class="starred-status">{{t "Star this message" }}</span>
+    <div class="starred-status">{{t "Star this message" }}</div>
     {{tooltip_hotkey_hints "Ctrl" "S"}}
 </template>
 <template id="unstar-message-tooltip-template">
-    <span class="starred-status">{{t "Unstar this message" }}</span>
+    <div class="starred-status">{{t "Unstar this message" }}</div>
     {{tooltip_hotkey_hints "Ctrl" "S"}}
 </template>
 <template id="search-query-tooltip-template">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR consists of the following changes:
- Replace `<span>` tags with `<p>` tags inside the tooltip's inner content to remove the redundancy of having to use break tags to separate the tooltip's title and its content.
- Add the hotkey hints in the tooltip of the view edit history option, the shortcut (Shift + H) for which was added in PR #26245 
- Swap "Click to view edit history." and the edit status string (EDITED/MOVED/SAVING) to make the tooltip consistent with other tooltips across the web app.
- Rename "Click to view edit history." to "View edit history", since the "Click to view" part is evident from the icon as well as the the keyboard shortcut hints.

Fixes: #26581

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![edit-history-tooltip](https://github.com/zulip/zulip/assets/82862779/fdf0aaf6-7e54-4f39-a7e5-4b63cabf9947)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
