### PR TITLE
docs: Add a note about "good first issue" label to contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ repository](https://github.com/zulip/zulip/issues?q=is%3Aopen+is%3Aissue+label%3
 
 - We especially recommend browsing recently opened issues, as there are more
   likely to be easy ones for you to find.
+- Take a look at issues with the ["good first issue"
+  label](https://github.com/zulip/zulip/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22),
+  as they are especially accessible to new contributors. However, you will
+  likely find issues without this label that are accessible as well.
 - All issues are partitioned into areas like
   admin, compose, emoji, hotkeys, i18n, onboarding, search, etc. Look
   through our [list of labels](https://github.com/zulip/zulip/labels), and


### PR DESCRIPTION
<img width="757" alt="Screenshot 2023-10-01 at 10 53 27 PM" src="https://github.com/zulip/zulip/assets/2090066/3ff9dd62-3c88-42b7-b652-e13dadeed838">

Implements https://github.com/zulip/zulip/pull/23718#discussion_r1036829056.

I tested the link.