### PR TITLE
Issue #26914 remove warning banner duplication

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -10,6 +10,7 @@ import * as browser_history from "./browser_history";
 import * as buddy_data from "./buddy_data";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_reply from "./compose_reply";
 import * as compose_state from "./compose_state";
 import {media_breakpoints_num} from "./css_variables";
@@ -700,6 +701,7 @@ export function initialize() {
 
     $("body").on("click", "#compose_close", () => {
         compose_actions.cancel();
+        compose_banner.visible_banners.clear();
     });
 
     // LEFT SIDEBAR
@@ -842,6 +844,7 @@ export function initialize() {
                 // Check if the click is within the body to prevent extensions from
                 // interfering with the compose box.
                 compose_actions.cancel();
+                compose_banner.visible_banners.clear();
             }
         }
     });

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -374,7 +374,16 @@ function schedule_message_to_custom_date() {
             deliver_at,
         });
         compose_banner.clear_message_sent_banners();
-        compose_banner.append_compose_banner_to_banner_list(new_row, $banner_container);
+
+        const banner_data = JSON.stringify({
+            scheduled_message_id: data.scheduled_message_id,
+            deliver_at,
+            message_type,
+        });
+        if (!compose_banner.in_visible_banners(banner_data)) {
+            compose_banner.append_visible_banners(banner_data);
+            compose_banner.append_compose_banner_to_banner_list(new_row, $banner_container);
+        }
     };
 
     const error = function (xhr) {

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -328,6 +328,7 @@ export function cancel() {
     compose_state.set_message_type(false);
     compose_pm_pill.clear();
     $(document).trigger("compose_canceled.zulip");
+    compose_banner.visible_banners.clear();
 }
 
 export function on_topic_narrow() {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -54,6 +54,16 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
+export const visible_banners = new Set();
+
+export function append_visible_banners(banner_data: string): void {
+    visible_banners.add(banner_data);
+}
+
+export function in_visible_banners(banner_data: string): boolean {
+    return visible_banners.has(banner_data);
+}
+
 export function get_compose_banner_container($textarea: JQuery): JQuery {
     return $textarea.attr("id") === "compose-textarea"
         ? $("#compose_banners")
@@ -86,6 +96,12 @@ export function update_or_append_banner(
 export function clear_message_sent_banners(include_unmute_banner = true): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
         $(`#compose_banners .${CSS.escape(classname)}`).remove();
+        for (const banner_data_string of visible_banners) {
+            const banner_string = banner_data_string as string;
+            if (banner_string.includes(classname)) {
+                visible_banners.delete(banner_string);
+            }
+        }
     }
     if (include_unmute_banner) {
         clear_unmute_topic_notifications();
@@ -123,6 +139,7 @@ export function clear_unmute_topic_notifications(): void {
 
 export function clear_all(): void {
     scroll_util.get_content_element($(`#compose_banners`)).empty();
+    visible_banners.clear();
 }
 
 export function show_error_message(

--- a/web/src/compose_notifications.js
+++ b/web/src/compose_notifications.js
@@ -51,7 +51,11 @@ export function notify_above_composebox(
     // We pass in include_unmute_banner as false because we don't want to
     // clear any unmute_banner associated with this same message.
     compose_banner.clear_message_sent_banners(false);
-    compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
+    const banner_data = JSON.stringify({classname, link_msg_id});
+    if (!compose_banner.in_visible_banners(banner_data)) {
+        compose_banner.append_visible_banners(banner_data);
+        compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
+    }
 }
 
 export function notify_automatic_new_visibility_policy(message, data) {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -245,6 +245,11 @@ export function initialize() {
         $("body").on("click", `${classname_selector} .main-view-banner-close-button`, (event) => {
             event.preventDefault();
             $(event.target).parents(classname_selector).remove();
+            for (const banner_data of compose_banner.visible_banners) {
+                if (banner_data.includes(classname_selector.slice(1))) {
+                    compose_banner.visible_banners.delete(JSON.stringify(banner_data));
+                }
+            }
         });
     }
 

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1118,6 +1118,7 @@ export function edit_last_sent_message() {
 
     // Finally do the real work!
     compose_actions.cancel();
+    compose_banner.visible_banners.clear();
     start($msg_row, () => {
         $(".message_edit_content").trigger("focus");
     });


### PR DESCRIPTION
compose_banners: Add `visible_banners` set to prevent duplicate warning banners.
2 utility functions added for better readability,  `append_visible_banners` to append strings into visible_banners and `in_visible_banners` to check if a particular data string already exists in the set.

Introduces a "visible_banners" set in compose_banners to store strings containing details of currently rendered banners. This set is cleared in instances where `compose_actions.cancel()` is triggered, ensuring smooth functionality with hotkeys and the close button. The implementation checks for existing banners to prevent duplicate warning banners from being displayed when mentioning private streams. Duplicate warning banners are not created for the same stream while warnings for other streams still get rendered.


Fixes: https://github.com/zulip/zulip/issues/26914



![image](https://github.com/zulip/zulip/assets/29460617/5f2d68a9-8b4b-4283-9e1d-ed31be680d73)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
