### PR TITLE
provision: added a checker function to write activation command in user's bash profile only for dedicated containers

### DIFF
--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -2,6 +2,7 @@
 import argparse
 import glob
 import os
+import pwd
 import shutil
 import sys
 from typing import List
@@ -79,6 +80,16 @@ def configure_rabbitmq_paths() -> List[str]:
     return paths
 
 
+def check_environment() -> bool:
+    user_id = os.getuid()
+    user_name = pwd.getpwuid(user_id).pw_name
+    wsl_path = "/proc/sys/fs/binfmt_misc/WSLInterop"
+    if os.path.exists(wsl_path) or user_name == "vagrant":
+        return True
+    else:
+        return False
+
+
 def setup_shell_profile(shell_profile: str) -> None:
     shell_profile_path = os.path.expanduser(shell_profile)
 
@@ -93,8 +104,13 @@ def setup_shell_profile(shell_profile: str) -> None:
             with open(shell_profile_path, "w") as shell_profile_file:
                 shell_profile_file.writelines(command + "\n")
 
-    source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
-    write_command(source_activate_command)
+    # check the environment, to be eligible for automatic activation
+    dedicated_container = check_environment()
+    # If the environment is a dedicated container, write the activation command to the user's bash profile
+    if dedicated_container:
+        source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
+        write_command(source_activate_command)
+
     if os.path.exists("/srv/zulip"):
         write_command("cd /srv/zulip")
 


### PR DESCRIPTION

Refactor tools/lib/provision_inner to conditionally write activation commands to user's bash profile based on the host machine type. Automatic activation now skipped for native linux containers. Fixes #15029

<!-- Describe your pull request here.-->
This pull request attempts to write Zulip's venv activation command `source /srv/zulip-py3-venv/bin/activate` to the user's bash profile based on the type of machine they used to install Zulip's development server.

As mentioned in the issue linked below, automatic activation of `zulip-py3-venv` at the launch of the shell will now be avoided for native Linux containers.

Fixes: <!-- Issue link, or clear description.-->#15029

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
