### PR TITLE
compose: Refactor drafts restoration code to reduce duplication

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -152,15 +152,11 @@ export function abort_video_callbacks(edit_message_id = "") {
     }
 }
 
-export function empty_topic_placeholder() {
-    return $t({defaultMessage: "(no topic)"});
-}
-
 export function create_message_object() {
     // Topics are optional, and we provide a placeholder if one isn't given.
     let topic = compose_state.topic();
     if (topic === "") {
-        topic = empty_topic_placeholder();
+        topic = compose_state.empty_topic_placeholder();
     }
 
     // Changes here must also be kept in sync with echo.try_deliver_locally

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -253,14 +253,14 @@ export function start(msg_type, opts) {
         compose_state.message_content(opts.content);
     }
 
-    if (opts.draft_id) {
-        $("#compose-textarea").data("draft-id", opts.draft_id);
-    }
-
     compose_state.set_message_type(msg_type);
 
     // Show either stream/topic fields or "You and" field.
     show_compose_box(msg_type, opts);
+
+    if (opts.draft_id) {
+        $("#compose-textarea").data("draft-id", opts.draft_id);
+    }
 
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -222,8 +222,9 @@ export function start(msg_type, opts) {
         opts.stream_id = subbed_streams[0].stream_id;
     }
 
-    if (compose_state.composing() && !same_recipient_as_before(msg_type, opts)) {
-        // Clear the compose box if the existing message is to a different recipient
+    if (compose_state.composing() && !same_recipient_as_before(msg_type, opts) && !opts.draft_id) {
+        // Clear the compose box if the existing message is to a different recipient or the new
+        // content is a draft.
         clear_box();
     }
 
@@ -260,6 +261,13 @@ export function start(msg_type, opts) {
 
     if (opts.draft_id) {
         $("#compose-textarea").data("draft-id", opts.draft_id);
+    }
+
+    if (opts.content !== undefined) {
+        // If we were provided with message content, we might need to
+        // resize the compose box, or display that it's too long.
+        compose_ui.autosize_textarea($("#compose-textarea"));
+        compose_validate.check_overflow_text();
     }
 
     // Show a warning if topic is resolved

--- a/web/src/compose_state.js
+++ b/web/src/compose_state.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
+import {$t} from "./i18n";
 import * as sub_store from "./sub_store";
 
 let message_type = false; // 'stream', 'private', or false-y
@@ -99,6 +100,10 @@ export function set_compose_recipient_id(recipient_id) {
 
 // TODO: Break out setter and getter into their own functions.
 export const topic = get_or_set("stream_message_recipient_topic");
+
+export function empty_topic_placeholder() {
+    return $t({defaultMessage: "(no topic)"});
+}
 
 // We can't trim leading whitespace in `compose_textarea` because
 // of the indented syntax for multi-line code blocks.

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -284,7 +284,7 @@ export function restore_draft(draft_id) {
         return;
     }
 
-    const compose_args = restore_message(draft);
+    const compose_args = {...restore_message(draft), draft_id};
 
     if (compose_args.type === "stream") {
         if (draft.stream_id !== "" && draft.topic !== "") {
@@ -309,7 +309,6 @@ export function restore_draft(draft_id) {
     compose.clear_preview_area();
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
-    $("#compose-textarea").data("draft-id", draft_id);
     compose_validate.check_overflow_text();
 }
 

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -11,10 +11,7 @@ import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
-import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
-import * as compose_ui from "./compose_ui";
-import * as compose_validate from "./compose_validate";
 import * as confirm_dialog from "./confirm_dialog";
 import {$t, $t_html} from "./i18n";
 import {localstorage} from "./localstorage";
@@ -305,11 +302,7 @@ export function restore_draft(draft_id) {
     }
 
     overlays.close_overlay("drafts");
-    compose_fade.clear_compose();
-    compose.clear_preview_area();
     compose_actions.start(compose_args.type, compose_args);
-    compose_ui.autosize_textarea($("#compose-textarea"));
-    compose_validate.check_overflow_text();
 }
 
 const DRAFT_LIFETIME = 30;

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -9,7 +9,6 @@ import render_draft_table_body from "../templates/draft_table_body.hbs";
 
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
-import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
 import * as confirm_dialog from "./confirm_dialog";
@@ -347,7 +346,7 @@ export function format_draft(draft) {
             invite_only = sub.invite_only;
             is_web_public = sub.is_web_public;
         }
-        const draft_topic = draft.topic || compose.empty_topic_placeholder();
+        const draft_topic = draft.topic || compose_state.empty_topic_placeholder();
         const draft_stream_color = stream_data.get_color(draft.stream_id);
 
         formatted = {

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -13,6 +13,7 @@ import * as channel from "./channel";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_banner from "./compose_banner";
+import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";
 import * as composebox_typeahead from "./composebox_typeahead";
@@ -756,7 +757,7 @@ export function start_inline_topic_edit($recipient_row) {
     const msg_id = rows.id_for_recipient_row($recipient_row);
     const message = message_lists.current.get(msg_id);
     let topic = message.topic;
-    if (topic === compose.empty_topic_placeholder()) {
+    if (topic === compose_state.empty_topic_placeholder()) {
         topic = "";
     }
     const $inline_topic_edit_input = $form.find(".inline_topic_edit");

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -11,8 +11,8 @@ import render_single_message from "../templates/single_message.hbs";
 
 import * as activity from "./activity";
 import * as blueslip from "./blueslip";
-import * as compose from "./compose";
 import * as compose_fade from "./compose_fade";
+import * as compose_state from "./compose_state";
 import * as condense from "./condense";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
@@ -176,7 +176,7 @@ function set_topic_edit_properties(group, message) {
 
     // Messages with no topics should always have an edit icon visible
     // to encourage updating them. Admins can also edit any topic.
-    if (message.topic === compose.empty_topic_placeholder()) {
+    if (message.topic === compose_state.empty_topic_placeholder()) {
         group.always_visible_topic_edit = true;
     } else {
         group.on_hover_topic_edit = true;

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -11,7 +11,7 @@ const {MessageList} = zrequire("message_list");
 const message_lists = zrequire("message_lists");
 const popover_menus_data = zrequire("popover_menus_data");
 const people = zrequire("people");
-const compose = zrequire("compose");
+const compose_state = zrequire("compose_state");
 
 const noop = function () {};
 
@@ -242,7 +242,7 @@ test("not_my_message_view_source_and_move", () => {
             type: "stream",
             unread: false,
             collapsed: false,
-            topic: compose.empty_topic_placeholder(),
+            topic: compose_state.empty_topic_placeholder(),
             edit_history: [
                 {
                     prev_content: "Previous content",


### PR DESCRIPTION
This PR is a fixed and updated version of #24680 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
