### PR TITLE
poopover_menus: Set correct instance as undefined.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -556,7 +556,7 @@ export function initialize() {
             // Destroy instance so that event handlers
             // are destroyed too.
             instance.destroy();
-            popover_instances.compose_control_button = undefined;
+            popover_instances.compose_mobile_button = undefined;
         },
     });
 


### PR DESCRIPTION
This caused a bug where input keys were not working since `compose_mobile_button` was always set.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/j.2C.20k.2C.20and.20Esc.20broken.20again