### PR TITLE
compose: Update recipient placeholder when topic input changes.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -790,6 +790,10 @@ export function initialize() {
         compose_recipient.update_placeholder_text();
     });
 
+    $("#stream_message_recipient_topic").on("input", () => {
+        compose_recipient.update_placeholder_text();
+    });
+
     $("body").on("click", ".formatting_button", (e) => {
         const $compose_click_target = $(compose_ui.get_compose_click_target(e));
         const $textarea = $compose_click_target.closest("form").find("textarea");


### PR DESCRIPTION
Builds off of #21848, from this [CZO Topic](https://chat.zulip.org/#narrow/stream/101-design/topic/topic.20box.20width)

I chose "input" over a keyboard event. At first I tried "keydown", since I want the placeholder to always match the input, but that was being caught in an event handler somewhere (I'm guessing?) when I selected the input and cleared it. Input worked more reliably.