### PR TITLE
copied_tooltip: Remove incorrect $ prefix from non-jQuery variable; convert module to TypeScript

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -74,7 +74,7 @@ EXEMPT_FILES = make_set(
         "web/src/composebox_typeahead.js",
         "web/src/condense.js",
         "web/src/confirm_dialog.ts",
-        "web/src/copied_tooltip.js",
+        "web/src/copied_tooltip.ts",
         "web/src/copy_and_paste.js",
         "web/src/csrf.ts",
         "web/src/css_variables.js",

--- a/web/src/copied_tooltip.js
+++ b/web/src/copied_tooltip.js
@@ -2,9 +2,9 @@ import tippy from "tippy.js";
 
 import {$t} from "./i18n";
 
-export function show_copied_confirmation($copy_button, on_hide_callback, timeout_in_ms = 1000) {
+export function show_copied_confirmation(copy_button, on_hide_callback, timeout_in_ms = 1000) {
     // Display a tooltip to notify the user the message or code was copied.
-    const instance = tippy($copy_button, {
+    const instance = tippy(copy_button, {
         placement: "top",
         appendTo: () => document.body,
         onUntrigger() {

--- a/web/src/copied_tooltip.ts
+++ b/web/src/copied_tooltip.ts
@@ -2,7 +2,11 @@ import tippy from "tippy.js";
 
 import {$t} from "./i18n";
 
-export function show_copied_confirmation(copy_button, on_hide_callback, timeout_in_ms = 1000) {
+export function show_copied_confirmation(
+    copy_button: HTMLElement,
+    on_hide_callback: () => void,
+    timeout_in_ms = 1000,
+): void {
     // Display a tooltip to notify the user the message or code was copied.
     const instance = tippy(copy_button, {
         placement: "top",
@@ -18,7 +22,7 @@ export function show_copied_confirmation(copy_button, on_hide_callback, timeout_
     });
     instance.setContent($t({defaultMessage: "Copied!"}));
     instance.show();
-    function remove_instance() {
+    function remove_instance(): void {
         if (!instance.state.isDestroyed) {
             instance.destroy();
         }


### PR DESCRIPTION
Cc @amanagr
