### PR TITLE
compose: Only save as draft when the compose state is about to change.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -187,10 +187,6 @@ export function start(msg_type, opts) {
         return;
     }
 
-    // We may be able to clear it to change the recipient, so save any
-    // existing content as a draft.
-    drafts.update_draft();
-
     autosize_message_content();
 
     if (reload_state.is_in_progress()) {
@@ -222,9 +218,13 @@ export function start(msg_type, opts) {
         opts.stream_id = subbed_streams[0].stream_id;
     }
 
-    if (compose_state.composing() && !same_recipient_as_before(msg_type, opts) && !opts.draft_id) {
-        // Clear the compose box if the existing message is to a different recipient or the new
-        // content is a draft.
+    // If we go to a different narrow or there is new message content to populate the compose box
+    // with (like from a draft), save any existing content as a draft, and clear the compose box.
+    if (
+        compose_state.composing() &&
+        (!same_recipient_as_before(msg_type, opts) || opts.content !== undefined)
+    ) {
+        drafts.update_draft();
         clear_box();
     }
 


### PR DESCRIPTION
Up until now, we unconditionally saved any message content as a draft whenever the composebox was `start`ed. This led to a lot of unnecessary saving of drafts even when the composebox stayed undisturbed.

To fix this, now we only save the draft when the compose state is about to be overidden, which is by either changing the recipient narrow or by restoring another draft.

Fixes: #26976.

**Screenshots and screen captures:**
[can add a video by tomorrow]

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
