### PR TITLE
Fix registration pages for small widths.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -14,7 +14,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
 
 {% block portico_content %}
 <div class="register-account flex full-page">
-    <div class="center-block new-style" style="padding: 20px 0px" id="create-account">
+    <div class="center-block new-style" id="create-account">
 
         <div class="pitch">
             {% if creating_new_realm %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -14,7 +14,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
 
 {% block portico_content %}
 <div class="register-account flex full-page">
-    <div class="center-block new-style" style="padding: 20px 0px">
+    <div class="center-block new-style" style="padding: 20px 0px" id="create-account">
 
         <div class="pitch">
             {% if creating_new_realm %}

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1340,9 +1340,18 @@ button#register_auth_button_gitlab {
         min-height: calc(100vh - 505px);
     }
 
+    #create-account,
     #new-realm-creation {
         margin: 0 -30px;
         transform: scale(0.9);
+    }
+
+    #create-account {
+        margin: -70px;
+
+        #registration {
+            padding: 0;
+        }
     }
 }
 
@@ -1351,16 +1360,26 @@ button#register_auth_button_gitlab {
         min-height: calc(100vh - 560px);
     }
 
+    #create-account,
     #new-realm-creation {
         margin: -10px -40px;
         transform: scale(0.8);
     }
+
+    #create-account {
+        margin: -100px;
+    }
 }
 
 @media (width <= 340px) {
+    #create-account,
     #new-realm-creation {
         margin: -40px -60px;
         transform: scale(0.7);
+    }
+
+    #create-account {
+        margin: -150px;
     }
 }
 

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1339,11 +1339,28 @@ button#register_auth_button_gitlab {
         /* the header becomes smaller, so comp for that. */
         min-height: calc(100vh - 505px);
     }
+
+    #new-realm-creation {
+        margin: 0 -30px;
+        transform: scale(0.9);
+    }
 }
 
 @media (width <= 400px) {
     .flex {
         min-height: calc(100vh - 560px);
+    }
+
+    #new-realm-creation {
+        margin: -10px -40px;
+        transform: scale(0.8);
+    }
+}
+
+@media (width <= 340px) {
+    #new-realm-creation {
+        margin: -40px -60px;
+        transform: scale(0.7);
     }
 }
 

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -52,6 +52,10 @@ html {
     }
 }
 
+#create-account {
+    padding: 20px 0;
+}
+
 .bottom-text-large {
     text-align: center;
     margin-top: 20px;


### PR DESCRIPTION

<img width="529" alt="Screenshot 2023-10-03 at 2 46 00 PM" src="https://github.com/zulip/zulip/assets/25124304/185f4f9b-a269-4728-9758-78686452ae7e">
<img width="529" alt="Screenshot 2023-10-03 at 2 39 15 PM" src="https://github.com/zulip/zulip/assets/25124304/1626457a-649d-4300-bab2-a3cae254def1">
<img width="529" alt="Screenshot 2023-10-03 at 2 24 35 PM" src="https://github.com/zulip/zulip/assets/25124304/b1fec101-b56e-4934-9d50-c04b509cba56">
<img width="529" alt="Screenshot 2023-10-03 at 2 24 24 PM" src="https://github.com/zulip/zulip/assets/25124304/5585425a-a8f1-499c-b57b-9f2931c2434b">
<img width="529" alt="Screenshot 2023-10-03 at 2 24 17 PM" src="https://github.com/zulip/zulip/assets/25124304/e48315d1-3d5b-45f7-ba8b-1f8e82de2555">

This is just a temporary fix. We probably need redesign these pages for mobile widths.