### PR TITLE
Remove popovers.hide_all calls after a click event.

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -27,6 +27,9 @@ export type ModalConfig = {
 let active_overlay: Overlay | undefined;
 let open_overlay_name: string | undefined;
 
+// Used for both overlays and modals.
+// We could split these hooks so that they are separate for
+// overlays and modals if we need to.
 const pre_open_hooks: Hook[] = [];
 const pre_close_hooks: Hook[] = [];
 
@@ -261,6 +264,7 @@ export function open_modal(
             conf.on_show();
         }
         disable_scrolling();
+        call_hooks(pre_open_hooks);
     }
 
     function on_close_callback(): void {
@@ -268,6 +272,7 @@ export function open_modal(
             conf.on_hide();
         }
         enable_scrolling();
+        call_hooks(pre_close_hooks);
     }
 
     Micromodal.show(modal_id, {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -150,7 +150,6 @@ export function on_show_prep(instance) {
         e.stopPropagation();
         instance.hide();
     });
-    popovers.hide_all();
 }
 
 function get_props_for_popover_centering(popover_props) {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -27,7 +27,6 @@ import * as loading from "./loading";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
-import * as popovers from "./popovers";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
@@ -317,8 +316,6 @@ function initialize_user_type_fields(user) {
 }
 
 export function show_user_profile(user, default_tab_key = "profile-tab") {
-    popovers.hide_all();
-
     const field_types = page_params.custom_profile_field_types;
     const profile_data = page_params.custom_profile_fields
         .map((f) => get_custom_profile_field_data(user, f, field_types))


### PR DESCRIPTION
Since tippy popovers hide on click outside themselves, we don't
need call `popovers.hide_all` separately for them.