### PR TITLE
tools: Add missing event schema checks.

### DIFF
--- a/tools/check-schemas
+++ b/tools/check-schemas
@@ -74,7 +74,6 @@ EXEMPT_OPENAPI_NAMES = [
     "message_event",
     # tuple handling
     "muted_topics_event",
-    "realm_filters_event",
     # bots, delivery_email, profile_data
     "realm_user_add_event",
     # OpenAPI is incomplete
@@ -82,6 +81,12 @@ EXEMPT_OPENAPI_NAMES = [
     # is_mirror_dummy
     "reaction_add_event",
     "reaction_remove_event",
+]
+
+# This is a list of events still documented in the OpenAPI that
+# are deprecated and no longer checked in event_schema.py.
+DEPRECATED_EVENTS = [
+    "realm_filters_event",
 ]
 
 
@@ -192,7 +197,8 @@ def validate_openapi_against_event_schema() -> None:
         name += "_event"
 
         if not hasattr(event_schema, name):
-            print("WARNING - NEED SCHEMA to match OpenAPI", name)
+            if name not in DEPRECATED_EVENTS:
+                print("WARNING - NEED SCHEMA to match OpenAPI", name)
             continue
 
         openapi_type = from_openapi(sub_node)

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -625,6 +625,7 @@ exports.fixtures = {
                 content: "Hello there!",
                 rendered_content: "<p>Hello there!</p>",
                 scheduled_delivery_timestamp: 1681662420,
+                failed: false,
             },
         ],
     },
@@ -645,6 +646,7 @@ exports.fixtures = {
             content: "Hello there!",
             rendered_content: "<p>Hello there!</p>",
             scheduled_delivery_timestamp: 1681662420,
+            failed: false,
         },
     },
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -259,6 +259,47 @@ def check_delete_message(
     assert set(event.keys()) == keys
 
 
+draft_fields = DictType(
+    required_keys=[
+        ("id", int),
+        ("type", EnumType(["", "stream", "private"])),
+        ("to", ListType(int)),
+        ("topic", str),
+        ("content", str),
+    ],
+    optional_keys=[
+        ("timestamp", int),
+    ],
+)
+
+drafts_add_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("drafts")),
+        ("op", Equals("add")),
+        ("drafts", ListType(draft_fields)),
+    ]
+)
+check_draft_add = make_checker(drafts_add_event)
+
+drafts_update_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("drafts")),
+        ("op", Equals("update")),
+        ("draft", draft_fields),
+    ]
+)
+check_draft_update = make_checker(drafts_update_event)
+
+drafts_remove_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("drafts")),
+        ("op", Equals("remove")),
+        ("draft_id", int),
+    ]
+)
+check_draft_remove = make_checker(drafts_remove_event)
+
+
 has_zoom_token_event = event_dict_type(
     required_keys=[
         ("type", Equals("has_zoom_token")),

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1188,6 +1188,48 @@ restart_event = event_dict_type(
 )
 check_restart_event = make_checker(restart_event)
 
+scheduled_message_fields = DictType(
+    required_keys=[
+        ("scheduled_message_id", int),
+        ("type", EnumType(["stream", "private"])),
+        ("to", UnionType([ListType(int), int])),
+        ("content", str),
+        ("rendered_content", str),
+        ("scheduled_delivery_timestamp", int),
+        ("failed", bool),
+    ],
+    optional_keys=[
+        ("topic", str),
+    ],
+)
+
+scheduled_messages_add_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("scheduled_messages")),
+        ("op", Equals("add")),
+        ("scheduled_messages", ListType(scheduled_message_fields)),
+    ]
+)
+check_scheduled_message_add = make_checker(scheduled_messages_add_event)
+
+scheduled_messages_update_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("scheduled_messages")),
+        ("op", Equals("update")),
+        ("scheduled_message", scheduled_message_fields),
+    ]
+)
+check_scheduled_message_update = make_checker(scheduled_messages_update_event)
+
+scheduled_messages_remove_event = event_dict_type(
+    required_keys=[
+        ("type", Equals("scheduled_messages")),
+        ("op", Equals("remove")),
+        ("scheduled_message_id", int),
+    ]
+)
+check_scheduled_message_remove = make_checker(scheduled_messages_remove_event)
+
 stream_create_event = event_dict_type(
     required_keys=[
         ("type", Equals("stream")),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5081,7 +5081,7 @@ paths:
                               "to": [3],
                               "topic": "sync drafts",
                               "content": "Let's add backend support for syncing drafts.",
-                              "timestamp": 1595479019.43915,
+                              "timestamp": 1595479019,
                             },
                             {
                               "id": 2,
@@ -5089,7 +5089,7 @@ paths:
                               "to": [4],
                               "topic": "",
                               "content": "What if we made it possible to sync drafts in Zulip?",
-                              "timestamp": 1595479020.43916,
+                              "timestamp": 1595479019,
                             },
                             {
                               "id": 3,
@@ -5097,7 +5097,7 @@ paths:
                               "to": [4, 10],
                               "topic": "",
                               "content": "What if we made it possible to sync drafts in Zulip?",
-                              "timestamp": 1595479021.43916,
+                              "timestamp": 1595479019,
                             },
                           ],
                       }
@@ -18773,7 +18773,7 @@ components:
           description: |
             The body of the draft. Should not contain null bytes.
         timestamp:
-          type: number
+          type: integer
           description: |
             A Unix timestamp (seconds only) representing when the draft was
             last edited. When creating a draft, this key need not be present

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -137,6 +137,9 @@ from zerver.lib.event_schema import (
     check_default_stream_groups,
     check_default_streams,
     check_delete_message,
+    check_draft_add,
+    check_draft_remove,
+    check_draft_update,
     check_has_zoom_token,
     check_heartbeat,
     check_hotspots,
@@ -3583,7 +3586,8 @@ class DraftActionTest(BaseAction):
             timestamp=1596820995,
         )
         action = lambda: do_create_drafts([dummy_draft], self.user_profile)
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_draft_add("events[0]", events[0])
 
     def test_draft_edit_event(self) -> None:
         self.do_enable_drafts_synchronization(self.user_profile)
@@ -3597,7 +3601,8 @@ class DraftActionTest(BaseAction):
         draft_id = do_create_drafts([dummy_draft], self.user_profile)[0].id
         dummy_draft.content = "Some more sample draft content"
         action = lambda: do_edit_draft(draft_id, dummy_draft, self.user_profile)
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_draft_update("events[0]", events[0])
 
     def test_draft_delete_event(self) -> None:
         self.do_enable_drafts_synchronization(self.user_profile)
@@ -3610,7 +3615,8 @@ class DraftActionTest(BaseAction):
         )
         draft_id = do_create_drafts([dummy_draft], self.user_profile)[0].id
         action = lambda: do_delete_draft(draft_id, self.user_profile)
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_draft_remove("events[0]", events[0])
 
 
 class ScheduledMessagesEventsTest(BaseAction):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -165,6 +165,9 @@ from zerver.lib.event_schema import (
     check_realm_user_add,
     check_realm_user_remove,
     check_realm_user_update,
+    check_scheduled_message_add,
+    check_scheduled_message_remove,
+    check_scheduled_message_update,
     check_stream_create,
     check_stream_delete,
     check_stream_update,
@@ -3623,7 +3626,8 @@ class ScheduledMessagesEventsTest(BaseAction):
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_scheduled_message_add("events[0]", events[0])
 
     def test_create_event_with_existing_scheduled_messages(self) -> None:
         # Create stream scheduled message
@@ -3649,7 +3653,8 @@ class ScheduledMessagesEventsTest(BaseAction):
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_scheduled_message_add("events[0]", events[0])
 
     def test_private_scheduled_message_create_event(self) -> None:
         # Create direct scheduled message
@@ -3663,7 +3668,8 @@ class ScheduledMessagesEventsTest(BaseAction):
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_scheduled_message_add("events[0]", events[0])
 
     def test_scheduled_message_edit_event(self) -> None:
         scheduled_message_id = check_schedule_message(
@@ -3687,7 +3693,8 @@ class ScheduledMessagesEventsTest(BaseAction):
             convert_to_UTC(dateparser("2023-04-20 18:24:56")),
             self.user_profile.realm,
         )
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_scheduled_message_update("events[0]", events[0])
 
     def test_scheduled_message_delete_event(self) -> None:
         scheduled_message_id = check_schedule_message(
@@ -3701,4 +3708,5 @@ class ScheduledMessagesEventsTest(BaseAction):
             self.user_profile.realm,
         )
         action = lambda: delete_scheduled_message(self.user_profile, scheduled_message_id)
-        self.verify_action(action)
+        events = self.verify_action(action)
+        check_scheduled_message_remove("events[0]", events[0])


### PR DESCRIPTION
On current main, `tools/check-schemas` has the following output:

```console
$ tools/check-schemas
WARNING - NEED SCHEMA: scheduled_messages__add
WARNING - NEED SCHEMA: scheduled_messages__remove
WARNING - NEED SCHEMA: scheduled_messages__update
WARNING - NEED SCHEMA to match OpenAPI realm_filters_event
WARNING - NEED SCHEMA to match OpenAPI drafts_add_event
WARNING - NEED SCHEMA to match OpenAPI drafts_update_event
WARNING - NEED SCHEMA to match OpenAPI drafts_remove_event
WARNING - NEED SCHEMA to match OpenAPI scheduled_messages_add_event
WARNING - NEED SCHEMA to match OpenAPI scheduled_messages_update_event
WARNING - NEED SCHEMA to match OpenAPI scheduled_messages_remove_event
Successful check. All tests passed.
```

Adds/corrects the following missing events schema:
- Adds schemas for scheduled message and draft events to `zerver/lib/event_schema.py`
- Corrects scheduled message event in `web/tests/lib/events.js` for missing 'failed' field
- Corrects draft timestamp field type in API documentation; see commit e60925b3e84c7414612e74a2287c03ed51b716a1.
- Adds event checks to scheduled message and drafts tests in `zerver/tests/test_events.py`
- Adds a list to track deprecated events in the OpenAPI documentation that no longer have an event schema that's checked in `zerver/lib/event_schema.py`, of which there is currently only the `realm_filters` event.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
