### PR TITLE
recipient-row: Remove logic for floating recipient bar.

### DIFF
--- a/web/src/rows.js
+++ b/web/src/rows.js
@@ -163,14 +163,6 @@ export function recipient_from_group(message_group) {
 }
 
 export function id_for_recipient_row($recipient_row) {
-    // A recipient row can be either a normal recipient row, or
-    // the FRB, which is a fake recipient row. If it's a FRB, it has
-    // a 'zid' property that stores the message id it is directly over
     const $msg_row = first_message_in_group($recipient_row);
-    if ($msg_row.length === 0) {
-        // If we're narrowing from the FRB, take the msg id
-        // directly from it
-        return id($recipient_row);
-    }
     return id($msg_row);
 }


### PR DESCRIPTION
In #23900, the floating recipient bar was replaced with a sticky recipient bar. The logic in `id_for_recipient_row` was not updated for that change, so we update that function to just get the first message in the group and return that message ID.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
