### PR TITLE
popover_menus: Fix enter keypress not working on some popovers.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -89,6 +89,11 @@ export function popover_items_handle_keyboard(key, $items) {
 
     let index = $items.index($items.filter(":focus"));
 
+    if (key === "enter" && index >= 0 && index < $items.length) {
+        $items.eq(index).trigger("click");
+        return;
+    }
+
     if (index === -1) {
         index = 0;
     } else if ((key === "down_arrow" || key === "vim_down") && index < $items.length - 1) {


### PR DESCRIPTION
I checked for stream, topic and message action popovers.


I don't recall how we used to do it earlier or what we changed, but this seems to work well.