### PR TITLE
compose: Delete obsolete comment

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -46,14 +46,6 @@ import * as zcommand from "./zcommand";
 
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
 
-/* Track the state of the @all warning. The user must acknowledge that they are spamming the entire
-   stream before the warning will go away. If they try to send before explicitly dismissing the
-   warning, they will get an error message too.
-
-   undefined: no @all/@everyone in message;
-   false: user typed @all/@everyone;
-   true: user clicked YES */
-
 let uppy;
 
 export function get_compose_upload_object() {


### PR DESCRIPTION
Commit 57340a888c4aed129be004f155e7aed02a05007f (#19003) separated it from the variable it was commenting, and commit
8ced075643c96fedaf73661210b810fd87017258 (#22754) changed that to a different variable, so I infer that nobody thought this documentation was important.