### PR TITLE
stream_settings_ui: Remove set_muted wrapper

### DIFF
--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -14,7 +14,6 @@ import * as settings_ui from "./settings_ui";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as stream_settings_data from "./stream_settings_data";
-import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_util from "./ui_util";
 import * as unread_ui from "./unread_ui";
@@ -326,8 +325,9 @@ export function initialize() {
         const stream_id = Number.parseInt($row.attr("data-stream-id"), 10);
         const sub = sub_store.get(stream_id);
 
-        stream_settings_ui.set_muted(
+        stream_edit.set_stream_property(
             sub,
+            "is_muted",
             !sub.is_muted,
             $row.closest(".subsection-parent").find(".alert-notification"),
         );

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -310,8 +310,9 @@ function stream_is_muted_changed(e) {
         return;
     }
 
-    stream_settings_ui.set_muted(
+    set_stream_property(
         sub,
+        "is_muted",
         e.target.checked,
         `#stream_change_property_status${CSS.escape(sub.stream_id)}`,
     );

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -20,6 +20,7 @@ import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
+import * as stream_edit from "./stream_edit";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
@@ -152,7 +153,7 @@ function build_stream_popover(opts) {
             $popper.on("click", ".toggle_stream_muted", (e) => {
                 const sub = stream_popover_sub(e);
                 hide_stream_popover();
-                stream_settings_ui.set_muted(sub, !sub.is_muted);
+                stream_edit.set_stream_property(sub, "is_muted", !sub.is_muted);
                 e.stopPropagation();
             });
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -38,7 +38,6 @@ import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as stream_edit_subscribers from "./stream_edit_subscribers";
 import * as stream_list from "./stream_list";
-import * as stream_muting from "./stream_muting";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
@@ -149,11 +148,6 @@ function selectText(element) {
 
 function should_list_all_streams() {
     return !page_params.realm_is_zephyr_mirror_realm;
-}
-
-export function set_muted(sub, is_muted, status_element) {
-    stream_muting.update_is_muted(sub, is_muted);
-    stream_edit.set_stream_property(sub, "is_muted", sub.is_muted, status_element);
 }
 
 export function toggle_pin_to_top_stream(sub) {


### PR DESCRIPTION
`stream_muting.update_is_muted` will be called when the event comes back from the server.

(79, 37) → (78, 35). [Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/simple.20import.20cycles/near/1653379).