### PR TITLE
stream_edit: Move set_stream_property to new stream_settings_api module

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -211,6 +211,7 @@ EXEMPT_FILES = make_set(
         "web/src/stream_list.js",
         "web/src/stream_muting.js",
         "web/src/stream_popover.js",
+        "web/src/stream_settings_api.js",
         "web/src/stream_settings_containers.ts",
         "web/src/stream_settings_ui.js",
         "web/src/stream_ui_updates.js",

--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -13,6 +13,7 @@ import * as settings_org from "./settings_org";
 import * as settings_ui from "./settings_ui";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
+import * as set_stream_property from "./stream_settings_api";
 import * as stream_settings_data from "./stream_settings_data";
 import * as sub_store from "./sub_store";
 import * as ui_util from "./ui_util";
@@ -325,7 +326,7 @@ export function initialize() {
         const stream_id = Number.parseInt($row.attr("data-stream-id"), 10);
         const sub = sub_store.get(stream_id);
 
-        stream_edit.set_stream_property(
+        set_stream_property.set_stream_property(
             sub,
             "is_muted",
             !sub.is_muted,

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -24,10 +24,10 @@ import {page_params} from "./page_params";
 import * as scroll_util from "./scroll_util";
 import * as settings_config from "./settings_config";
 import * as settings_org from "./settings_org";
-import * as settings_ui from "./settings_ui";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_edit_subscribers from "./stream_edit_subscribers";
+import * as stream_settings_api from "./stream_settings_api";
 import * as stream_settings_containers from "./stream_settings_containers";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_settings_ui from "./stream_settings_ui";
@@ -310,7 +310,7 @@ function stream_is_muted_changed(e) {
         return;
     }
 
-    set_stream_property(
+    stream_settings_api.set_stream_property(
         sub,
         "is_muted",
         e.target.checked,
@@ -336,27 +336,7 @@ export function stream_setting_changed(e, from_notification_settings) {
         sub[setting] =
             user_settings[settings_config.generalize_stream_notification_setting[setting]];
     }
-    set_stream_property(sub, setting, e.target.checked, status_element);
-}
-
-export function bulk_set_stream_property(sub_data, status_element) {
-    const url = "/json/users/me/subscriptions/properties";
-    const data = {subscription_data: JSON.stringify(sub_data)};
-    if (!status_element) {
-        return channel.post({
-            url,
-            data,
-            timeout: 10 * 1000,
-        });
-    }
-
-    settings_ui.do_settings_change(channel.post, url, data, status_element);
-    return undefined;
-}
-
-export function set_stream_property(sub, property, value, status_element) {
-    const sub_data = {stream_id: sub.stream_id, property, value};
-    bulk_set_stream_property([sub_data], status_element);
+    stream_settings_api.set_stream_property(sub, setting, e.target.checked, status_element);
 }
 
 export function get_request_data_for_stream_privacy(selected_val) {

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -20,7 +20,7 @@ import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
-import * as stream_edit from "./stream_edit";
+import * as stream_settings_api from "./stream_settings_api";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
@@ -153,7 +153,7 @@ function build_stream_popover(opts) {
             $popper.on("click", ".toggle_stream_muted", (e) => {
                 const sub = stream_popover_sub(e);
                 hide_stream_popover();
-                stream_edit.set_stream_property(sub, "is_muted", !sub.is_muted);
+                stream_settings_api.set_stream_property(sub, "is_muted", !sub.is_muted);
                 e.stopPropagation();
             });
 

--- a/web/src/stream_settings_api.js
+++ b/web/src/stream_settings_api.js
@@ -1,0 +1,22 @@
+import * as channel from "./channel";
+import * as settings_ui from "./settings_ui";
+
+export function bulk_set_stream_property(sub_data, status_element) {
+    const url = "/json/users/me/subscriptions/properties";
+    const data = {subscription_data: JSON.stringify(sub_data)};
+    if (!status_element) {
+        return channel.post({
+            url,
+            data,
+            timeout: 10 * 1000,
+        });
+    }
+
+    settings_ui.do_settings_change(channel.post, url, data, status_element);
+    return undefined;
+}
+
+export function set_stream_property(sub, property, value, status_element) {
+    const sub_data = {stream_id: sub.stream_id, property, value};
+    bulk_set_stream_property([sub_data], status_element);
+}

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -38,6 +38,7 @@ import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as stream_edit_subscribers from "./stream_edit_subscribers";
 import * as stream_list from "./stream_list";
+import * as stream_settings_api from "./stream_settings_api";
 import * as stream_settings_data from "./stream_settings_data";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
@@ -151,7 +152,7 @@ function should_list_all_streams() {
 }
 
 export function toggle_pin_to_top_stream(sub) {
-    stream_edit.set_stream_property(sub, "pin_to_top", !sub.pin_to_top);
+    stream_settings_api.set_stream_property(sub, "pin_to_top", !sub.pin_to_top);
 }
 
 let subscribed_only = true;
@@ -255,7 +256,7 @@ export function update_is_default_stream() {
 
 export function set_color(stream_id, color) {
     const sub = sub_store.get(stream_id);
-    stream_edit.set_stream_property(sub, "color", color);
+    stream_settings_api.set_stream_property(sub, "color", color);
 }
 
 export function update_subscribers_ui(sub) {


### PR DESCRIPTION
(78, 35) → (77, 36). [Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/simple.20import.20cycles/near/1653379).