### PR TITLE
support: Add basic support endpoint for remote servers.

### DIFF
--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -18,7 +18,7 @@ from analytics.views.stats import (
     stats_for_remote_installation,
     stats_for_remote_realm,
 )
-from analytics.views.support import support
+from analytics.views.support import remote_servers_support, support
 from analytics.views.user_activity import get_user_activity
 from zerver.lib.rest import rest_path
 
@@ -26,6 +26,7 @@ i18n_urlpatterns: List[Union[URLPattern, URLResolver]] = [
     # Server admin (user_profile.is_staff) visible stats pages
     path("activity", get_installation_activity),
     path("activity/support", support, name="support"),
+    path("activity/remote/support", remote_servers_support, name="remote_servers_support"),
     path("realm_activity/<realm_str>/", get_realm_activity),
     path("user_activity/<user_profile_id>/", get_user_activity),
     path("stats/realm/<realm_str>/", stats_for_realm),

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -1,0 +1,33 @@
+{% extends "zerver/base.html" %}
+{% set entrypoint = "support" %}
+
+{# Remote servers. #}
+
+{% block title %}
+<title>Remote servers</title>
+{% endblock %}
+
+
+{% block content %}
+<div class="container">
+    <br />
+    <form>
+        <center>
+            <input type="text" name="q" class="input-xxlarge search-query" placeholder="hostname or contact email" value="{{ request.GET.get('q', '') }}" autofocus />
+            <button type="submit" class="btn btn-default support-search-button">Search</button>
+        </center>
+    </form>
+
+    <div id="remote-server-query-results">
+        {% for remote_server in remote_servers %}
+        <div class="support-query-result">
+            <span class="label">remote server</span>
+            <h3>{{ remote_server.hostname }}</h3>
+            <b>Contact email</b>: {{ remote_server.contact_email }}<br />
+            <b>Last updated</b>: {{ remote_server.last_updated|timesince }} ago<br />
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+{% endblock %}

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -545,6 +545,7 @@ html_rules: List["Rule"] = [
         },
         "exclude": {
             "templates/analytics/support.html",
+            "templates/analytics/remote_server_support.html",
             # We have URL template and Pygments language name as placeholders
             # in the below template which we don't want to be translatable.
             "web/templates/settings/playground_settings_admin.hbs",


### PR DESCRIPTION
No automated tests yet.

I figured that if in the default view we want to be able to just browse remote servers, it should be displayed in a table:
![image](https://github.com/zulip/zulip/assets/45007152/d8560ba6-5286-468d-b4fc-1e93fd38440c)

And you can search by hostname or contact email in the top bar, similar to regular `/activity/support`.

How to test this:
- Set up test data in `manage.py shell`:
```
n = 20
from zilencer.models import RemoteZulipServer
import uuid

for i in range(0, 20):
    hostname = f"zulip-{i}.example.com"
    RemoteZulipServer.objects.create(hostname=hostname, contact_email=f"admin@{hostname}", plan_type=1, uuid=uuid.uuid4())
```

- Log in as `Iago` (this user has `.is_staff` enabled) and go to http://localhost:9991/activity/remote/support