### PR TITLE
middleware: Send got_request_exception signal for JSON 500 errors

### DIFF
--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -373,9 +373,6 @@ def validate_against_openapi_schema(
     # This first set of checks are primarily training wheels that we
     # hope to eliminate over time as we improve our API documentation.
 
-    # No 500 responses have been documented, so skip them
-    if status_code.startswith("5"):
-        return False
     if path not in openapi_spec.openapi()["paths"]:
         endpoint = find_openapi_endpoint(path)
         # If it doesn't match it hasn't been documented yet.

--- a/zerver/tests/test_health.py
+++ b/zerver/tests/test_health.py
@@ -16,9 +16,10 @@ class HealthTest(ZulipTestCase):
         with mock.patch(
             "zerver.views.health.check_database",
             side_effect=ServerNotReadyError("Cannot query postgresql"),
-        ), self.assertLogs(level="ERROR") as logs:
-            result = self.client_get("/health")
-        self.assert_json_error(result, "Cannot query postgresql", status_code=500)
+        ), self.assertLogs(level="ERROR") as logs, self.assertRaisesRegex(
+            ServerNotReadyError, r"^Cannot query postgresql$"
+        ):
+            self.client_get("/health")
         self.assertIn(
             "zerver.lib.exceptions.ServerNotReadyError: Cannot query postgresql", logs.output[0]
         )

--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -120,7 +120,7 @@ def check_send_webhook_fixture_message(
     if response.status_code == 200:
         responses = [{"status_code": response.status_code, "message": response.content.decode()}]
         return json_success(request, data={"responses": responses})
-    else:
+    else:  # nocoverage
         return response
 
 


### PR DESCRIPTION
This is ordinarily emitted by Django at https://github.com/django/django/blob/4.2.6/django/core/handlers/exception.py#L139 and received by Sentry at https://github.com/getsentry/sentry-python/blob/1.31.0/sentry_sdk/integrations/django/__init__.py#L166.