### PR TITLE
compose: Remove redundant code from scheduled_messages_ui.js.

### DIFF
--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -2,10 +2,8 @@ import $ from "jquery";
 
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 
-import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_banner from "./compose_banner";
-import * as compose_ui from "./compose_ui";
 import {$t} from "./i18n";
 import * as narrow from "./narrow";
 import * as people from "./people";
@@ -62,10 +60,7 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
         narrow_via_edit_scheduled_message(compose_args);
     }
 
-    compose.clear_compose_box();
-    compose_banner.clear_message_sent_banners(false);
     compose_actions.start(compose_args.type, compose_args);
-    compose_ui.autosize_textarea($("#compose-textarea"));
     scheduled_messages.set_selected_schedule_timestamp(scheduled_msg.scheduled_delivery_timestamp);
 }
 


### PR DESCRIPTION
We remove redundant code when editing a scheduled message in the compose box, for resetting the compose box, as it anyway gets reset on calling `compose_actions.start()`.

Besides ending `scheduled_messages_ui.js`'s dependency on `compose.js` and `compose_ui.js`, this also fixes the bug where on editing a scheduled message when there was content in the compose box, it would be irretrievably lost. The old content is now drafted.

Fixes: [Issue described here](https://github.com/zulip/zulip/pull/26991#issuecomment-1745673474)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
