### PR TITLE
activity: Add separate page for remote server information/table.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -31,8 +31,12 @@ class ActivityTest(ZulipTestCase):
         user_profile.is_staff = True
         user_profile.save(update_fields=["is_staff"])
 
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(17):
             result = self.client_get("/activity")
+            self.assertEqual(result.status_code, 200)
+
+        with self.assert_database_query_count(4):
+            result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 
         with self.assert_database_query_count(8):

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -4,7 +4,10 @@ from django.conf.urls import include
 from django.urls import path
 from django.urls.resolvers import URLPattern, URLResolver
 
-from analytics.views.installation_activity import get_installation_activity
+from analytics.views.installation_activity import (
+    get_installation_activity,
+    get_remote_server_activity,
+)
 from analytics.views.realm_activity import get_realm_activity
 from analytics.views.stats import (
     get_chart_data,
@@ -25,6 +28,7 @@ from zerver.lib.rest import rest_path
 i18n_urlpatterns: List[Union[URLPattern, URLResolver]] = [
     # Server admin (user_profile.is_staff) visible stats pages
     path("activity", get_installation_activity),
+    path("activity/remote", get_remote_server_activity),
     path("activity/support", support, name="support"),
     path("realm_activity/<realm_str>/", get_realm_activity),
     path("user_activity/<user_profile_id>/", get_user_activity),

--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -95,7 +95,7 @@ def remote_installation_stats_link(server_id: int, hostname: str) -> Markup:
     from analytics.views.stats import stats_for_remote_installation
 
     url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
-    return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i>{hostname}</a>').format(
+    return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a> {hostname}').format(
         url=url, hostname=hostname
     )
 

--- a/templates/analytics/activity_details_template.html
+++ b/templates/analytics/activity_details_template.html
@@ -1,0 +1,22 @@
+{% extends "zerver/base.html" %}
+{% set entrypoint = "activity" %}
+
+{# Template for installation activity pages #}
+
+{% block title %}
+<title>{{ title }} | Zulip analytics</title>
+{% endblock %}
+
+
+{% block content %}
+
+    {% if not is_home %}
+    <a class="show-all" href="/activity">Home</a>
+    <br />
+    {% endif %}
+
+    <div class="container">
+        {{ data|safe }}
+    </div>
+
+{% endblock %}

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -2,6 +2,13 @@
 
 <p style="text-align: center;">{{ utctime }}</p>
 
+<h4>Installation information:</h4>
+<ul>
+    <li><a href="/stats/installation">Server total /stats style graphs</a></li>
+    <li><a href="/activity/remote">Remote servers</a></li>
+</ul>
+
+<h4>Counts chart key:</h4>
 <ul>
     <li><strong>active (site)</strong> - has ≥5 DAUs</li>
     <li>sites are listed if ≥1 users active in last 2 weeks</li>
@@ -20,7 +27,6 @@
     <li><strong>WAU</strong> (weekly active users) - users active in last 7 * 24hr</li>
     <li><strong>DAT</strong> (daily active time) - total user-activity time in last 24hr</li>
     <li><strong>Human message</strong> - message sent by non-bot user, and not with known-bot client</li>
-    <li><a href="/stats/installation">Server total /stats style graphs</a></li>
 </ul>
 
 <table class="table summary-table sortable table-striped table-bordered">


### PR DESCRIPTION
Moves the "Remote Zulip servers" tab in the "/activity" page for an installation to a separate page, "/activity/remote".

Prototype for moving other tabs in "/activity" to separate pages.

**Notes**:
- Updates tests for new query counts. Not sure what other testing we might want to add.
- Adds linking to/from the main activity page and the remote servers activity page.
- Reorganizes the bulleted list in the main activity page slightly for clarity.
- Changed the link to the remote server's stats page to be only the pi chart icon; prep for having the hostname link to the remote server support page.
- Same manual testing procedure as outlined in #27033; copy/pasted below.

<details>
<summary>Manual testing procedure</summary>

- Set up test data in manage.py shell:

```
n = 20
from zilencer.models import RemoteZulipServer
import uuid

for i in range(0, 20):
    hostname = f"zulip-{i}.example.com"
    RemoteZulipServer.objects.create(hostname=hostname, contact_email=f"admin@{hostname}", plan_type=1, uuid=uuid.uuid4())
```

- Log in as Iago (this user has .is_staff enabled) and go to http://localhost:9991/activity/remote/support
</details>

---

**Screenshots and screen captures:**

<details>
<summary>Updated main activity page</summary>

![Screenshot from 2023-10-04 21-05-07](https://github.com/zulip/zulip/assets/63245456/1e048f2c-f8eb-43a2-8374-45f3364ac661)
</details>
<details>
<summary>Current main activity page</summary>

![Screenshot from 2023-10-04 21-12-38](https://github.com/zulip/zulip/assets/63245456/da38d67c-4f4d-473e-a7b6-7adb585fe55d)
</details>
<details>
<summary>New remote servers activity page</summary>

![Screenshot from 2023-10-04 21-11-23](https://github.com/zulip/zulip/assets/63245456/e6ef5870-9e5b-4877-a5e2-e404b3efa1c7)
</details>
<details>
<summary>Current remote servers tab</summary>

![Screenshot from 2023-10-04 21-14-27](https://github.com/zulip/zulip/assets/63245456/d8423c66-0f60-4a29-b188-b44cce259b6c)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
