### PR TITLE
puppet: Serve /etc/zulip/well-known/ in nginx as /.well-known/.

### DIFF
--- a/puppet/zulip_ops/files/nginx/zulip-include-app.d/well-known.conf
+++ b/puppet/zulip_ops/files/nginx/zulip-include-app.d/well-known.conf
@@ -1,0 +1,3 @@
+location /.well-known/ {
+    alias /etc/zulip/well-known/;
+}

--- a/puppet/zulip_ops/manifests/app_frontend.pp
+++ b/puppet/zulip_ops/manifests/app_frontend.pp
@@ -34,6 +34,16 @@ class zulip_ops::app_frontend {
     content => zulipsecret('secrets', 'redis_password', ''),
   }
 
+  # Mount /etc/zulip/well-known/ as /.well-known/
+  file { '/etc/nginx/zulip-include/app.d/well-known.conf':
+    require => File['/etc/nginx/zulip-include/app.d'],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/zulip_ops/nginx/zulip-include-app.d/well-known.conf',
+    notify  => Service['nginx'],
+  }
+
   # Each server does its own fetching of contributor data, since
   # we don't have a way to synchronize that among several servers.
   file { '/etc/cron.d/fetch-contributor-data':


### PR DESCRIPTION
Note this is only for `zulip_ops`, not for default installs.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
