### PR TITLE
compose: Add contextually-aware "Start new conversation" button

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -54,9 +54,9 @@ async function create_private_message_draft(page: Page): Promise<void> {
 }
 
 async function open_compose_markdown_preview(page: Page): Promise<void> {
-    const new_topic_button = "#left_bar_compose_stream_button_big";
-    await page.waitForSelector(new_topic_button, {visible: true});
-    await page.click(new_topic_button);
+    const new_conversation_button = "#new_conversation_button";
+    await page.waitForSelector(new_conversation_button, {visible: true});
+    await page.click(new_conversation_button);
 
     const markdown_preview_button = "#compose .markdown_preview"; // eye icon.
     await page.waitForSelector(markdown_preview_button, {visible: true});

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -41,8 +41,8 @@ async function expect_verona_stream_test_topic(page: Page): Promise<void> {
         ["Verona > test", ["verona test a", "verona test b", "verona test d"]],
     ]);
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
-        "New topic",
+        await common.get_text_from_selector(page, "#new_conversation_button"),
+        "Start new conversation",
     );
 }
 
@@ -274,8 +274,8 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
         ["You and Cordelia, Lear's daughter", ["direct message e"]],
     ]);
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
-        "New stream message",
+        await common.get_text_from_selector(page, "#new_conversation_button"),
+        "Start new conversation",
     );
     assert.strictEqual(await page.title(), "All direct messages - Zulip Dev - Zulip");
 }

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -56,7 +56,7 @@ function hide_box() {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
     blur_compose_inputs();
-    $("#stream_message_recipient_topic").hide();
+    $("#compose_recipient_box").hide();
     $("#compose-direct-recipient").hide();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -200,13 +200,14 @@ export function start(msg_type, opts) {
     expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
+    const is_clear_topic_button_triggered = opts.trigger === "clear topic button";
 
     // If we are invoked by a compose hotkey (c or x) or new topic
     // button, do not assume that we know what the message's topic or
     // direct message recipient should be.
     if (
         opts.trigger === "compose_hotkey" ||
-        opts.trigger === "new topic button" ||
+        is_clear_topic_button_triggered ||
         opts.trigger === "new direct message"
     ) {
         opts.topic = "";
@@ -216,7 +217,7 @@ export function start(msg_type, opts) {
     const subbed_streams = stream_data.subscribed_subs();
     if (
         subbed_streams.length === 1 &&
-        (opts.trigger === "new topic button" ||
+        (is_clear_topic_button_triggered ||
             (opts.trigger === "compose_hotkey" && msg_type === "stream"))
     ) {
         opts.stream_id = subbed_streams[0].stream_id;
@@ -270,6 +271,13 @@ export function start(msg_type, opts) {
         // resize the compose box, or display that it's too long.
         compose_ui.autosize_textarea($("#compose-textarea"));
         compose_validate.check_overflow_text();
+    }
+
+    const $clear_topic_button = $("#recipient_box_clear_topic_button");
+    if (is_clear_topic_button_triggered || opts.topic.length === 0) {
+        $clear_topic_button.hide();
+    } else {
+        $clear_topic_button.show();
     }
 
     // Show a warning if topic is resolved

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -119,7 +119,7 @@ export function update_buttons_for_private() {
     update_buttons(text_stream, disable_reply);
 }
 
-export function update_buttons_for_stream() {
+export function update_buttons_for_stream_views() {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     $("#new_conversation_button").attr(
         "data-tooltip-template-id",
@@ -128,7 +128,7 @@ export function update_buttons_for_stream() {
     update_buttons(text_stream);
 }
 
-export function update_buttons_for_recent_view() {
+export function update_buttons_for_non_stream_views() {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     $("#new_conversation_button").attr(
         "data-tooltip-template-id",

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -138,7 +138,7 @@ export function update_buttons_for_recent_view() {
 }
 
 function set_reply_button_label(label) {
-    $(".compose_reply_button_label").text(label);
+    $("#left_bar_compose_reply_button_big").text(label);
 }
 
 export function set_standard_text_for_reply_button() {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -169,7 +169,7 @@ export function initialize() {
 
     // Click handlers for buttons in the compose box.
     $("body").on("click", ".compose_stream_button", () => {
-        compose_actions.start("stream", {trigger: "new topic button"});
+        compose_actions.start("stream", {trigger: "clear topic button"});
     });
 
     $("body").on("click", ".compose_private_button", () => {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -101,11 +101,21 @@ function update_new_direct_message_button(btn_text) {
     $("#new_direct_message_button").text(btn_text);
 }
 
+function toggle_direct_message_button_visibility(is_direct_message_narrow) {
+    const $new_direct_message_button_container = $(".new_direct_message_button_container");
+    if (is_direct_message_narrow) {
+        $new_direct_message_button_container.hide();
+    } else {
+        $new_direct_message_button_container.show();
+    }
+}
+
 function update_buttons(text_stream, is_direct_message_narrow, disable_reply) {
     const text_conversation = $t({defaultMessage: "New direct message"});
     update_new_conversation_button(text_stream, is_direct_message_narrow);
     update_new_direct_message_button(text_conversation);
     update_reply_button_state(disable_reply);
+    toggle_direct_message_button_visibility(is_direct_message_narrow);
 }
 
 export function update_buttons_for_private() {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -81,8 +81,8 @@ function update_reply_button_state(disable = false) {
     }
 }
 
-function update_stream_button(btn_text) {
-    $("#left_bar_compose_stream_button_big").text(btn_text);
+function update_new_conversation_button(btn_text) {
+    $("#new_conversation_button").text(btn_text);
 }
 
 function update_conversation_button(btn_text) {
@@ -91,18 +91,18 @@ function update_conversation_button(btn_text) {
 
 function update_buttons(text_stream, disable_reply) {
     const text_conversation = $t({defaultMessage: "New direct message"});
-    update_stream_button(text_stream);
+    update_new_conversation_button(text_stream);
     update_conversation_button(text_conversation);
     update_reply_button_state(disable_reply);
 }
 
 export function update_buttons_for_private() {
-    const text_stream = $t({defaultMessage: "New stream message"});
+    const text_stream = $t({defaultMessage: "Start new conversation"});
     if (
         !narrow_state.pm_ids_string() ||
         people.user_can_direct_message(narrow_state.pm_ids_string())
     ) {
-        $("#left_bar_compose_stream_button_big").attr(
+        $("#new_conversation_button").attr(
             "data-tooltip-template-id",
             "new_stream_message_button_tooltip_template",
         );
@@ -120,8 +120,8 @@ export function update_buttons_for_private() {
 }
 
 export function update_buttons_for_stream() {
-    const text_stream = $t({defaultMessage: "New topic"});
-    $("#left_bar_compose_stream_button_big").attr(
+    const text_stream = $t({defaultMessage: "Start new conversation"});
+    $("#new_conversation_button").attr(
         "data-tooltip-template-id",
         "new_topic_message_button_tooltip_template",
     );
@@ -129,8 +129,8 @@ export function update_buttons_for_stream() {
 }
 
 export function update_buttons_for_recent_view() {
-    const text_stream = $t({defaultMessage: "New stream message"});
-    $("#left_bar_compose_stream_button_big").attr(
+    const text_stream = $t({defaultMessage: "Start new conversation"});
+    $("#new_conversation_button").attr(
         "data-tooltip-template-id",
         "new_stream_message_button_tooltip_template",
     );
@@ -168,7 +168,7 @@ export function initialize() {
     });
 
     // Click handlers for buttons in the compose box.
-    $("body").on("click", ".compose_stream_button", () => {
+    $("body").on("click", ".compose_new_conversation_button", () => {
         compose_actions.start("stream", {trigger: "clear topic button"});
     });
 

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -62,19 +62,19 @@ export function get_recipient_label(message) {
 function update_reply_button_state(disable = false) {
     $(".compose_reply_button").attr("disabled", disable);
     if (disable) {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_button_disabled_tooltip_template",
         );
         return;
     }
     if (narrow_state.is_message_feed_visible()) {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_message_button_tooltip_template",
         );
     } else {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_selected_topic_button_tooltip_template",
         );
@@ -135,7 +135,7 @@ export function update_buttons_for_private() {
     // disable the [Message X] button when in a private narrow
     // if the user cannot dm the current recipient
     const disable_reply = true;
-    $("#compose_buttons > .reply_button_container").attr(
+    $("#compose_buttons .compose_reply_button").attr(
         "data-tooltip-template-id",
         "disable_reply_compose_reply_button_tooltip_template",
     );

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -81,32 +81,45 @@ function update_reply_button_state(disable = false) {
     }
 }
 
-function update_new_conversation_button(btn_text) {
-    $("#new_conversation_button").text(btn_text);
+function update_new_conversation_button(btn_text, is_direct_message_narrow) {
+    const $new_conversation_button = $("#new_conversation_button");
+    $new_conversation_button.text(btn_text);
+    // In a direct-message narrow, the new conversation button should act
+    // like a new direct message button
+    if (is_direct_message_narrow) {
+        $new_conversation_button.addClass("compose_new_direct_message_button");
+        $new_conversation_button.removeClass("compose_new_conversation_button");
+    } else {
+        // Restore the usual new conversation button class, if it was
+        // changed after a previous direct-message narrow visit
+        $new_conversation_button.addClass("compose_new_conversation_button");
+        $new_conversation_button.removeClass("compose_new_direct_message_button");
+    }
 }
 
 function update_new_direct_message_button(btn_text) {
     $("#new_direct_message_button").text(btn_text);
 }
 
-function update_buttons(text_stream, disable_reply) {
+function update_buttons(text_stream, is_direct_message_narrow, disable_reply) {
     const text_conversation = $t({defaultMessage: "New direct message"});
-    update_new_conversation_button(text_stream);
+    update_new_conversation_button(text_stream, is_direct_message_narrow);
     update_new_direct_message_button(text_conversation);
     update_reply_button_state(disable_reply);
 }
 
 export function update_buttons_for_private() {
     const text_stream = $t({defaultMessage: "Start new conversation"});
+    const is_direct_message_narrow = true;
     if (
         !narrow_state.pm_ids_string() ||
         people.user_can_direct_message(narrow_state.pm_ids_string())
     ) {
         $("#new_conversation_button").attr(
             "data-tooltip-template-id",
-            "new_stream_message_button_tooltip_template",
+            "new_direct_message_button_tooltip_template",
         );
-        update_buttons(text_stream);
+        update_buttons(text_stream, is_direct_message_narrow);
         return;
     }
     // disable the [Message X] button when in a private narrow
@@ -116,7 +129,7 @@ export function update_buttons_for_private() {
         "data-tooltip-template-id",
         "disable_reply_compose_reply_button_tooltip_template",
     );
-    update_buttons(text_stream, disable_reply);
+    update_buttons(text_stream, is_direct_message_narrow, disable_reply);
 }
 
 export function update_buttons_for_stream_views() {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -85,14 +85,14 @@ function update_new_conversation_button(btn_text) {
     $("#new_conversation_button").text(btn_text);
 }
 
-function update_conversation_button(btn_text) {
-    $("#left_bar_compose_private_button_big").text(btn_text);
+function update_new_direct_message_button(btn_text) {
+    $("#new_direct_message_button").text(btn_text);
 }
 
 function update_buttons(text_stream, disable_reply) {
     const text_conversation = $t({defaultMessage: "New direct message"});
     update_new_conversation_button(text_stream);
-    update_conversation_button(text_conversation);
+    update_new_direct_message_button(text_conversation);
     update_reply_button_state(disable_reply);
 }
 
@@ -172,7 +172,7 @@ export function initialize() {
         compose_actions.start("stream", {trigger: "clear topic button"});
     });
 
-    $("body").on("click", ".compose_private_button", () => {
+    $("body").on("click", ".compose_new_direct_message_button", () => {
         compose_actions.start("private", {trigger: "new direct message"});
     });
 

--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -43,7 +43,7 @@ export function initialize() {
         onMount(instance) {
             const $popper = $(instance.popper);
             $popper.one("click", ".compose_mobile_stream_button", (e) => {
-                compose_actions.start("stream", {trigger: "new topic button"});
+                compose_actions.start("stream", {trigger: "clear topic button"});
                 e.stopPropagation();
                 instance.hide();
             });

--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -47,7 +47,7 @@ export function initialize() {
                 e.stopPropagation();
                 instance.hide();
             });
-            $popper.one("click", ".compose_mobile_private_button", (e) => {
+            $popper.one("click", ".compose_mobile_direct_message_button", (e) => {
                 compose_actions.start("private");
                 e.stopPropagation();
                 instance.hide();

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -165,14 +165,14 @@ function update_recipient_label(stream_id) {
 export function update_compose_for_message_type(message_type, opts) {
     if (message_type === "stream") {
         $("#compose-direct-recipient").hide();
-        $("#stream_message_recipient_topic").show();
+        $("#compose_recipient_box").show();
         $("#stream_toggle").addClass("active");
         $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
         update_recipient_label(opts.stream_id);
     } else {
         $("#compose-direct-recipient").show();
-        $("#stream_message_recipient_topic").hide();
+        $("#compose_recipient_box").hide();
         $("#stream_toggle").removeClass("active");
         $("#private_message_toggle").addClass("active");
         $("#compose-recipient").addClass("compose-recipient-direct-selected");

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -362,6 +362,25 @@ export function initialize() {
         compose_recipient.update_placeholder_text();
     });
 
+    $("#compose_recipient_box").on("click", "#recipient_box_clear_topic_button", () => {
+        const $input = $("#stream_message_recipient_topic");
+        const $button = $("#recipient_box_clear_topic_button");
+
+        $input.val("");
+        $input.trigger("focus");
+        $button.hide();
+    });
+
+    $("#compose_recipient_box").on("input", "#stream_message_recipient_topic", (e) => {
+        const $button = $("#recipient_box_clear_topic_button");
+        const value = $(e.target).val();
+        if (value.length === 0) {
+            $button.hide();
+        } else {
+            $button.show();
+        }
+    });
+
     $("#stream_message_recipient_topic").on("focus", () => {
         compose_recipient.update_placeholder_text();
     });

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -19,7 +19,7 @@ export function initialize() {
             // reply button's actual area is its containing span.
             "#compose_buttons > .reply_button_container",
             "#left_bar_compose_mobile_button_big",
-            "#left_bar_compose_stream_button_big",
+            "#new_conversation_button",
             "#left_bar_compose_private_button_big",
         ],
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -17,7 +17,7 @@ export function initialize() {
         target: [
             // Ideally this would be `#compose_buttons .button`, but the
             // reply button's actual area is its containing span.
-            "#compose_buttons > .reply_button_container",
+            "#compose_buttons .compose_reply_button",
             "#left_bar_compose_mobile_button_big",
             "#new_conversation_button",
             "#new_direct_message_button",

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -20,7 +20,7 @@ export function initialize() {
             "#compose_buttons > .reply_button_container",
             "#left_bar_compose_mobile_button_big",
             "#new_conversation_button",
-            "#left_bar_compose_private_button_big",
+            "#new_direct_message_button",
         ],
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -36,7 +36,8 @@ export function autosize_textarea($textarea) {
 }
 
 function get_focus_area(msg_type, opts) {
-    // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
+    // Set focus to "Topic" when narrowed to a stream+topic
+    // and "Start new conversation" button clicked.
     if (msg_type === "stream" && opts.stream_id && !opts.topic) {
         return "#stream_message_recipient_topic";
     } else if (

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -43,7 +43,7 @@ function get_focus_area(msg_type, opts) {
         (msg_type === "stream" && opts.stream_id) ||
         (msg_type === "private" && opts.private_message_recipient)
     ) {
-        if (opts.trigger === "new topic button") {
+        if (opts.trigger === "clear topic button") {
             return "#stream_message_recipient_topic";
         }
         return "#compose-textarea";

--- a/web/src/hotspots.js
+++ b/web/src/hotspots.js
@@ -50,7 +50,7 @@ const HOTSPOT_LOCATIONS = new Map([
     [
         "intro_compose",
         {
-            element: "#left_bar_compose_stream_button_big",
+            element: "#new_conversation_button",
             offset_x: 0,
             offset_y: 0,
         },

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -936,8 +936,10 @@ function handle_post_view_change(msg_list) {
 
     if (filter.contains_only_private_messages()) {
         compose_closed_ui.update_buttons_for_private();
+    } else if (filter.is_conversation_view() || filter.includes_full_stream_history()) {
+        compose_closed_ui.update_buttons_for_stream_views();
     } else {
-        compose_closed_ui.update_buttons_for_stream();
+        compose_closed_ui.update_buttons_for_non_stream_views();
     }
     compose_closed_ui.update_reply_recipient_label();
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -919,7 +919,7 @@ export function show() {
         // We want to show `new stream message` instead of
         // `new topic`, which we are already doing in this
         // function. So, we reuse it here.
-        update_compose: compose_closed_ui.update_buttons_for_recent_view,
+        update_compose: compose_closed_ui.update_buttons_for_non_stream_views,
         is_recent_view: true,
         is_visible,
         set_visible,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -42,7 +42,7 @@
         }
     }
 
-    .stream_button_container,
+    .new_conversation_button_container,
     .private_button_container {
         @media (width < $sm_min) {
             display: none;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -576,7 +576,7 @@ textarea.new_message_textarea {
 }
 
 textarea.new_message_textarea,
-.compose_table .recipient_box {
+#compose_recipient_box {
     border: 1px solid hsl(0deg 0% 0% / 20%);
     box-shadow: none;
     transition: border 0.2s ease;
@@ -589,11 +589,64 @@ textarea.new_message_textarea,
     }
 }
 
-input.recipient_box {
-    margin: 0;
-    padding: 0 6px;
-    height: auto;
+#compose_recipient_box {
+    display: flex;
+    flex: 1 1 0;
     border-radius: 3px;
+    background: hsl(0deg 0% 100%);
+
+    /* Give the recipient box, a `<div>`, the
+       correct styles when focus is in the
+       #stream_message_recipient_topic `<input>` */
+    &:focus-within {
+        outline: 0;
+        border: 1px solid hsl(0deg 0% 67%);
+        box-shadow: none;
+    }
+
+    #stream_message_recipient_topic,
+    #recipient_box_clear_topic_button {
+        background: none;
+        border: none;
+    }
+
+    /* Styles for input in the recipient_box */
+    #stream_message_recipient_topic {
+        /* Override inherited widths; flexbox will ensure
+           that it grows to fit. */
+        width: 0;
+        flex: 1 1 0;
+
+        /* Override flexbox's effective `max-content` min-width */
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        box-shadow: none;
+        outline: none;
+
+        padding: 4px 6px;
+    }
+
+    /* Styles for new conversation button in the recipient_box */
+    #recipient_box_clear_topic_button {
+        /* Set the border radius smaller, relative to the parent */
+        border-radius: 2px;
+        padding: 6px;
+        margin: 1px;
+
+        .zulip-icon {
+            display: block;
+        }
+
+        &:hover {
+            background-color: hsl(231deg 100% 90% / 20%);
+        }
+    }
+
+    /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
+    & input {
+        margin-bottom: 0;
+    }
 }
 
 #compose_select_recipient_widget {
@@ -604,14 +657,6 @@ input.recipient_box {
     &.dropdown-widget-button {
         padding: 0 6px;
     }
-}
-
-#stream_message_recipient_topic.recipient_box {
-    width: 100%;
-    /* This width roughly corresponds to how long of a topic can appear in
-       the left sidebar with a single digit unread count without being
-       cut off. */
-    max-width: 175px;
 }
 
 #private_message_recipient.recipient_box {
@@ -707,7 +752,7 @@ input.recipient_box {
 
 #compose-recipient {
     display: flex;
-    width: 100%;
+    flex: 1 1 0;
     /* Use this containing flex element to
       establish the minimum height of all its
       children; the default `align-items: stretch`

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1,12 +1,11 @@
 #compose_buttons {
     text-align: right;
     display: flex;
+    column-gap: 4px;
     flex-direction: row;
     align-items: center;
 
     .new_message_button {
-        margin-left: 4px;
-
         .button.small {
             font-size: 1em;
             padding: 3px 10px;
@@ -23,16 +22,65 @@
     }
 
     .reply_button_container {
-        flex: 1;
-        min-width: 0;
-        margin-left: 0;
+        display: flex;
+        flex-grow: 1;
 
-        .compose_reply_button {
-            width: 100%;
+        /* Adjust flexbox default `min-width` to allow smaller container sizes. */
+        min-width: 0;
+
+        /* Button-like styling */
+        border-radius: 4px;
+        background-color: var(
+            --color-compose-collapsed-reply-button-area-background
+        );
+        border: 1px solid
+            var(--color-compose-collapsed-reply-button-area-border);
+        transition: all 0.2s ease;
+
+        &:hover,
+        &:focus {
+            background-color: var(
+                --color-compose-collapsed-reply-button-area-background-interactive
+            );
+            border-color: var(
+                --color-compose-collapsed-reply-button-area-border-interactive
+            );
+        }
+
+        #left_bar_compose_reply_button_big,
+        #new_conversation_button {
+            /* Remove the border inherited from `.button` styles. */
+            border: none;
+            background: var(--color-compose-embedded-button-background);
+            border-radius: 3px;
+        }
+
+        #left_bar_compose_reply_button_big {
+            flex-grow: 1;
             text-align: left;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+        }
+
+        #new_conversation_button {
+            /* Remove the  `padding` to prevent margin from affecting parent height. */
+            padding: 0 10px;
+            /* Removing the `min-width` inherited from the `.button` styles. */
+            min-width: inherit;
+            margin: 1px;
+            flex-shrink: 0;
+
+            transition: background-color 0.2s ease;
+
+            color: var(--color-compose-embedded-button-text-color);
+
+            &:hover {
+                background-color: var(
+                    --color-compose-embedded-button-background-hover
+                );
+                color: var(--color-compose-embedded-button-text-color-hover);
+            }
         }
     }
 
@@ -42,10 +90,13 @@
         }
     }
 
-    .new_conversation_button_container,
+    #new_conversation_button,
     .new_direct_message_button_container {
+        flex-shrink: 0;
+
         @media (width < $sm_min) {
-            display: none;
+            /* Override inline style injected by jQuery hide() */
+            display: none !important;
         }
     }
 }
@@ -633,13 +684,21 @@ textarea.new_message_textarea,
         border-radius: 2px;
         padding: 6px;
         margin: 1px;
+        color: var(--color-compose-embedded-button-text-color);
 
         .zulip-icon {
             display: block;
         }
 
         &:hover {
-            background-color: hsl(231deg 100% 90% / 20%);
+            background-color: var(
+                --color-compose-embedded-button-background-hover
+            );
+            color: var(--color-compose-embedded-button-text-color-hover);
+        }
+
+        &:focus {
+            outline: 0;
         }
     }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -43,7 +43,7 @@
     }
 
     .new_conversation_button_container,
-    .private_button_container {
+    .new_direct_message_button_container {
         @media (width < $sm_min) {
             display: none;
         }
@@ -960,7 +960,7 @@ textarea.new_message_textarea,
 }
 
 .compose_mobile_stream_button i,
-.compose_mobile_private_button i {
+.compose_mobile_direct_message_button i {
     margin-right: 4px;
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -489,7 +489,8 @@
     .pill-container,
     .user-status-content-wrapper,
     #custom-expiration-time-input,
-    #org-join-settings .dropdown-widget-button {
+    #org-join-settings .dropdown-widget-button,
+    #compose_recipient_box {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;
@@ -603,7 +604,7 @@
     input[type="number"]:focus,
     textarea:focus,
     textarea.new_message_textarea:focus,
-    .compose_table .recipient_box:focus {
+    #compose_recipient_box:focus {
         border-color: hsl(0deg 0% 0% / 90%);
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -190,6 +190,22 @@ body {
     --color-search-shadow-tight: hsl(0deg 0% 0% / 10%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 10%);
 
+    /* Compose box colors */
+    --color-compose-collapsed-reply-button-area-background: hsl(0deg 0% 100%);
+    --color-compose-collapsed-reply-button-area-background-interactive: var(
+        --color-compose-collapsed-reply-button-area-background
+    );
+    --color-compose-collapsed-reply-button-area-border: hsl(0deg 0% 80%);
+    --color-compose-collapsed-reply-button-area-border-interactive: hsl(
+        0deg 0% 60%
+    );
+    --color-compose-embedded-button-text-color: hsl(231deg 20% 55%);
+    --color-compose-embedded-button-text-color-hover: hsl(231deg 20% 30%);
+    --color-compose-embedded-button-background: transparent;
+    --color-compose-embedded-button-background-hover: hsl(
+        231deg 100% 90% / 50%
+    );
+
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
     --color-text-message-default: hsl(0deg 0% 15%);
@@ -285,6 +301,24 @@ body {
     --color-background-search-option-hover: hsl(0deg 0% 30%);
     --color-search-box-hover-shadow: hsl(0deg 0% 0% / 30%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 35%);
+
+    /* Compose box colors */
+    --color-compose-collapsed-reply-button-area-background: hsl(
+        0deg 0% 0% / 20%
+    );
+    --color-compose-collapsed-reply-button-area-background-interactive: hsl(
+        0deg 0% 0% / 15%
+    );
+    --color-compose-collapsed-reply-button-area-border: hsl(0deg 0% 0% / 60%);
+    --color-compose-collapsed-reply-button-area-border-interactive: var(
+        --color-compose-collapsed-reply-button-area-border
+    );
+    --color-compose-embedded-button-text-color: hsl(231deg 30% 65%);
+    --color-compose-embedded-button-text-color-hover: hsl(231deg 30% 70%);
+    --color-compose-embedded-button-background: transparent;
+    --color-compose-embedded-button-background-hover: hsl(
+        235deg 100% 70% / 11%
+    );
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -15,21 +15,21 @@
             <span class="new_message_button reply_button_container" data-tooltip-template-id="compose_reply_message_button_tooltip_template">
                 <button type="button" class="button small rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big">
-                    <span class="compose_reply_button_label">{{t 'Compose message' }}</span>
+                    {{t 'Compose message' }}
                 </button>
             </span>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
-                    <span>+</span>
+                    +
                 </button>
             </span>
             <span class="new_message_button stream_button_container">
                 <button type="button" class="button small rounded compose_stream_button"
                   id="left_bar_compose_stream_button_big"
                   data-tooltip-template-id="new_topic_message_button_tooltip_template">
-                    <span class="compose_stream_button_label">{{t 'New topic' }}</span>
+                    {{t 'New topic' }}
                 </button>
             </span>
             {{#unless embedded }}
@@ -37,7 +37,7 @@
                 <button type="button" class="button small rounded compose_private_button"
                   id="left_bar_compose_private_button_big"
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
-                    <span class="compose_private_button_label">{{t 'New direct message' }}</span>
+                    {{t 'New direct message' }}
                 </button>
             </span>
             {{/unless}}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -25,11 +25,11 @@
                     +
                 </button>
             </span>
-            <span class="new_message_button stream_button_container">
-                <button type="button" class="button small rounded compose_stream_button"
-                  id="left_bar_compose_stream_button_big"
-                  data-tooltip-template-id="new_topic_message_button_tooltip_template">
-                    {{t 'New topic' }}
+            <span class="new_message_button new_conversation_button_container">
+                <button type="button" class="button small rounded compose_new_conversation_button"
+                  id="new_conversation_button"
+                  data-tooltip-template-id="new_stream_message_button_tooltip_template">
+                    {{t 'Start new conversation' }}
                 </button>
             </span>
             {{#unless embedded }}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -63,7 +63,12 @@
                             <div class="topic-marker-container">
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                             </div>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                            <div id="compose_recipient_box">
+                                <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <button type="button" id="recipient_box_clear_topic_button" class="button tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Clear topic' }}" tabindex="-1">
+                                    <i class="zulip-icon zulip-icon-close"></i>
+                                </button>
+                            </div>
                             <div id="compose-direct-recipient" class="pill-container" data-before="{{t 'You and' }}">
                                 <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
                             </div>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -33,9 +33,9 @@
                 </button>
             </span>
             {{#unless embedded }}
-            <span class="new_message_button private_button_container">
-                <button type="button" class="button small rounded compose_private_button"
-                  id="left_bar_compose_private_button_big"
+            <span class="new_message_button new_direct_message_button_container">
+                <button type="button" class="button small rounded compose_new_direct_message_button"
+                  id="new_direct_message_button"
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
                     {{t 'New direct message' }}
                 </button>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -12,24 +12,23 @@
     </div>
     <div id="compose_controls" class="new-style">
         <div id="compose_buttons">
-            <span class="new_message_button reply_button_container" data-tooltip-template-id="compose_reply_message_button_tooltip_template">
-                <button type="button" class="button small rounded compose_reply_button"
-                  id="left_bar_compose_reply_button_big">
+            <div class="new_message_button reply_button_container">
+                <button type="button" class="button small compose_reply_button"
+                  id="left_bar_compose_reply_button_big"
+                  data-tooltip-template-id="compose_reply_message_button_tooltip_template">
                     {{t 'Compose message' }}
                 </button>
-            </span>
+                <button type="button" class="button compose_new_conversation_button"
+                  id="new_conversation_button"
+                  data-tooltip-template-id="new_stream_message_button_tooltip_template">
+                    {{t 'Start new conversation' }}
+                </button>
+            </div>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
                     +
-                </button>
-            </span>
-            <span class="new_message_button new_conversation_button_container">
-                <button type="button" class="button small rounded compose_new_conversation_button"
-                  id="new_conversation_button"
-                  data-tooltip-template-id="new_stream_message_button_tooltip_template">
-                    {{t 'Start new conversation' }}
                 </button>
             </span>
             {{#unless embedded }}

--- a/web/templates/popovers/mobile_message_buttons_popover.hbs
+++ b/web/templates/popovers/mobile_message_buttons_popover.hbs
@@ -10,7 +10,7 @@
         </a>
     </li>
     <li>
-        <a class="compose_mobile_private_button">
+        <a class="compose_mobile_direct_message_button">
             <i class="fa fa-envelope" aria-hidden="true"></i>
             {{#if is_in_private_narrow }}
             {{t "New direct message" }}

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -776,8 +776,8 @@ test_ui("narrow_button_titles", ({override}) => {
     override(narrow_state, "is_message_feed_visible", () => true);
     compose_closed_ui.update_buttons_for_private();
     assert.equal(
-        $("#left_bar_compose_stream_button_big").text(),
-        $t({defaultMessage: "New stream message"}),
+        $("#new_conversation_button").text(),
+        $t({defaultMessage: "Start new conversation"}),
     );
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),
@@ -786,8 +786,8 @@ test_ui("narrow_button_titles", ({override}) => {
 
     compose_closed_ui.update_buttons_for_stream();
     assert.equal(
-        $("#left_bar_compose_stream_button_big").text(),
-        $t({defaultMessage: "New topic"}),
+        $("#new_conversation_button").text(),
+        $t({defaultMessage: "Start new conversation"}),
     );
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -780,7 +780,7 @@ test_ui("narrow_button_titles", ({override}) => {
         $t({defaultMessage: "Start new conversation"}),
     );
     assert.equal(
-        $("#left_bar_compose_private_button_big").text(),
+        $("#new_direct_message_button").text(),
         $t({defaultMessage: "New direct message"}),
     );
 
@@ -790,7 +790,7 @@ test_ui("narrow_button_titles", ({override}) => {
         $t({defaultMessage: "Start new conversation"}),
     );
     assert.equal(
-        $("#left_bar_compose_private_button_big").text(),
+        $("#new_direct_message_button").text(),
         $t({defaultMessage: "New direct message"}),
     );
 });

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -784,7 +784,7 @@ test_ui("narrow_button_titles", ({override}) => {
         $t({defaultMessage: "New direct message"}),
     );
 
-    compose_closed_ui.update_buttons_for_stream();
+    compose_closed_ui.update_buttons_for_stream_views();
     assert.equal(
         $("#new_conversation_button").text(),
         $t({defaultMessage: "Start new conversation"}),

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -136,7 +136,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     let opts = {};
     start("stream", opts);
 
-    assert_visible("#stream_message_recipient_topic");
+    assert_visible("#compose_recipient_box");
     assert_hidden("#compose-direct-recipient");
 
     assert.equal(compose_state.stream_name(), "");

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -154,7 +154,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     stream_data.add_sub(denmark);
 
     compose_defaults = {
-        trigger: "new topic button",
+        trigger: "clear topic button",
     };
 
     opts = {};

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -32,7 +32,7 @@ const {MessageList} = zrequire("message_list");
 
 // Helper test function
 function test_reply_label(expected_label) {
-    const label = $(".compose_reply_button_label").text();
+    const label = $("#left_bar_compose_reply_button_big").text();
     const prepend_text_length = "translated: Message ".length;
     assert.equal(
         label.slice(prepend_text_length),
@@ -134,6 +134,6 @@ run_test("test_custom_message_input", () => {
 run_test("empty_narrow", () => {
     message_lists.current.visibly_empty = () => true;
     compose_closed_ui.update_reply_recipient_label();
-    const label = $(".compose_reply_button_label").text();
+    const label = $("#left_bar_compose_reply_button_big").text();
     assert.equal(label, "translated: Compose message");
 });

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -879,7 +879,7 @@ run_test("get_focus_area", () => {
         get_focus_area("stream", {
             stream_id: 4,
             topic: "more",
-            trigger: "new topic button",
+            trigger: "clear topic button",
         }),
         "#stream_message_recipient_topic",
     );

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -93,7 +93,7 @@ function test_helper({override}) {
     stub(typing_events, "render_notifications_for_narrow");
     stub(compose_recipient, "update_narrow_to_recipient_visibility");
     stub(unread_ops, "process_visible");
-    stub(compose_closed_ui, "update_buttons_for_stream");
+    stub(compose_closed_ui, "update_buttons_for_stream_views");
     stub(compose_closed_ui, "update_buttons_for_private");
     // We don't test the css calls; we just skip over them.
     $("#mark_read_on_scroll_state_banner").toggleClass = () => {};
@@ -190,7 +190,7 @@ run_test("basics", ({override}) => {
         [narrow_history, "save_narrow_state_and_flush"],
         [hashchange, "save_narrow"],
         [typing_events, "render_notifications_for_narrow"],
-        [compose_closed_ui, "update_buttons_for_stream"],
+        [compose_closed_ui, "update_buttons_for_stream_views"],
         [compose_closed_ui, "update_reply_recipient_label"],
         [message_view_header, "render_title_area"],
         [narrow_title, "update_narrow_title"],

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -89,7 +89,7 @@ const ListWidget = mock_esm("../src/list_widget", {
 
 mock_esm("../src/compose_closed_ui", {
     set_standard_text_for_reply_button: noop,
-    update_buttons_for_recent_view: noop,
+    update_buttons_for_non_stream_views: noop,
 });
 mock_esm("../src/hash_util", {
     by_stream_url: test_url,


### PR DESCRIPTION
This PR is a rewrite of what was previously known as the "New topic" button.

Some relentless QA is needed here, especially as concerns the tooltips and actions triggered by the "Start new conversation" button when moving from narrow to narrows, or from a narrow to an unnarrowed view.

Fixes: #24889

TODOs:

- [x] Add additional screen shots and screen captures
- [x] Clean up the CSS in the final commit, after some QA, etc. to ensure that the CSS is worth cleaning up, or needs further rewrites
- [ ] Discuss whether to continue hiding the "New direct message" button in DM narrows
- [ ] Discuss whether to continue hiding the contextual "Start new conversation" button at mobile views


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Tooltip and button in Recent converesations view:
<img width="800" alt="snc-recent-conversations" src="https://github.com/zulip/zulip/assets/170719/aedb3e45-d2b5-4c71-bd07-acc81793252a">

Tooltip and button in an interleaved stream view:
<img width="800" alt="snc-streams" src="https://github.com/zulip/zulip/assets/170719/59946728-83c3-4bd2-a995-bd174994714b">

After clicking the Start new conversation button in an interleaved stream view; tooltip on the clear-topic-box button (X):
<img width="800" alt="snc-clear-topic-box" src="https://github.com/zulip/zulip/assets/170719/2ef7dbf8-e236-440f-bdee-bca76e7ad971">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
