### PR TITLE
help: Fix missing icons in "Stream permissions".

### DIFF
--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -93,7 +93,7 @@
 
     .legend_symbol {
         position: absolute;
-        left: calc(40px);
+        left: calc(340px);
         transform: translateX(-50%);
 
         /* Adjust for 50px closed left sidebar state */


### PR DESCRIPTION
This PR restores the icons in the legend for the Stream permissions tables that disappeared somehow.

Fixes CZO issue: [missing help center icons](https://chat.zulip.org/#narrow/stream/9-issues/topic/missing.20help.20center.20icons).

**Screenshots and screen captures:**

- **Before:**
![image](https://github.com/zulip/zulip/assets/2343554/37843ce5-6f62-4feb-a41e-ed95e8314bd7)

- **After:**
![image](https://github.com/zulip/zulip/assets/2343554/b0bda193-645d-4881-b433-1c55564c9229)
