### PR TITLE
typeahead: Only return early from blur if parentElement is specified.

### DIFF
--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -546,7 +546,7 @@ import {get_string_diff} from "../../src/util";
   , blur: function (e) {
       // Blurs that move focus to elsewhere within the parent element shouldn't
       // hide the typeahead.
-      if ($(e.relatedTarget).parents(this.options.parentElement).length > 0) {
+      if (this.options.parentElement && $(e.relatedTarget).parents(this.options.parentElement).length > 0) {
         return;
       }
       var that = this


### PR DESCRIPTION
From a bug reported here:
https://chat.zulip.org/#narrow/stream/9-issues/topic/Typeahead.20fails.20to.20automatically.20close/near/1655321
