### PR TITLE
portico: Remove now-unnecessary twitter-tweet CSS and JS.

### DIFF
--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -192,21 +192,6 @@ $(() => {
         delete page_params.contributors;
         render_tabs(contributors);
     }
-
-    // Source: https://stackoverflow.com/questions/819416/adjust-width-and-height-of-iframe-to-fit-with-content-in-it
-    // Resize tweet to avoid overlapping with image. Since tweet uses an iframe which doesn't adjust with
-    // screen resize, we need to manually adjust its width.
-
-    function resize_iframe_to_fit_content(iFrame) {
-        $(iFrame).width("38vw");
-    }
-
-    window.addEventListener("resize", () => {
-        const iframes = document.querySelectorAll(".twitter-tweet iframe");
-        for (const iframe of iframes) {
-            resize_iframe_to_fit_content(iframe);
-        }
-    });
 });
 
 // Scroll to anchor link when clicked. Note that help.js has a similar

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -2650,10 +2650,6 @@ button {
         .feature-text {
             margin-bottom: 10px;
         }
-
-        .twitter-tweet {
-            margin: 30px auto !important;
-        }
     }
 
     @media (width >= 768px) {
@@ -2739,22 +2735,6 @@ button {
 
     .topics-image {
         border: solid 2px hsl(0deg 0% 60%);
-    }
-}
-
-.twitter-tweet {
-    margin: auto;
-}
-
-blockquote.twitter-tweet {
-    padding: 0 0 0 15px;
-    border-left: 5px solid hsl(0deg 0% 93%);
-
-    & p {
-        margin-bottom: 0;
-        font-size: 17.5px;
-        font-weight: 300;
-        line-height: 1.25;
     }
 }
 


### PR DESCRIPTION
The content that this affected was removed in acd0c5568a96.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
