### PR TITLE
queue_processors: Link to SETTINGS/DATA EXPORTS from data export completion notification

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1113,8 +1113,8 @@ class DeferredWorker(QueueProcessingWorker):
             # triggered the export know the export finished.
             with override_language(user_profile.default_language):
                 content = _(
-                    "Your data export is complete and has been uploaded here:\n\n{public_url}"
-                ).format(public_url=public_url)
+                    "Your data export is complete. [View and download exports]({export_settings_link})."
+                ).format(export_settings_link="/#organization/data-exports-admin")
             internal_send_private_message(
                 sender=get_system_bot(settings.NOTIFICATION_BOT, realm.id),
                 recipient_user=user_profile,


### PR DESCRIPTION
This commit changes the url of the notification message to point to settings/data exports instructing the user to follow the link to download the exported data.

Fixes:#26923


**Screenshots and screen captures:**
<img width="883" alt="Screenshot 2023-10-05 at 23 06 18" src="https://github.com/zulip/zulip/assets/96547471/456ff8cf-56d6-458c-b544-d74a4a090cbf">
<img width="886" alt="Screenshot 2023-10-10 at 22 58 04" src="https://github.com/zulip/zulip/assets/96547471/2c2cfda6-14c0-404e-b706-771801d2d6de">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
