### PR TITLE
compose: When editing the selected message, quote into the edit box.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -346,6 +346,9 @@ export function initialize() {
         const row_id = rows.id($(this).closest(".message_row"));
         $(`#edit_form_${CSS.escape(row_id)} .file_input`).trigger("click");
     });
+    $("body").on("focus", ".message_edit_form .message_edit_content", (e) => {
+        compose_state.set_last_focused_compose_type_input(e.target);
+    });
 
     $("body").on("click", ".message_edit_form .markdown_preview", (e) => {
         e.preventDefault();
@@ -702,6 +705,10 @@ export function initialize() {
 
     $("body").on("click", "#compose_close", () => {
         compose_actions.cancel();
+    });
+
+    $("body").on("focus", "#compose-textarea", (e) => {
+        compose_state.set_last_focused_compose_type_input(e.target);
     });
 
     // LEFT SIDEBAR

--- a/web/src/compose_reply.js
+++ b/web/src/compose_reply.js
@@ -126,8 +126,8 @@ export function reply_with_mention(opts) {
 
 export function quote_and_reply(opts) {
     const $textarea = $("textarea#compose-textarea");
-    const message_id = message_lists.current.selected_id();
-    const message = message_lists.current.selected_message();
+    const message_id = opts.message_id || message_lists.current.selected_id();
+    const message = message_lists.current.get(message_id);
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
     if (!compose_state.has_message_content()) {

--- a/web/src/compose_reply.js
+++ b/web/src/compose_reply.js
@@ -42,7 +42,8 @@ export function respond_to_message(opts) {
         }
         message = message_opts.message;
     } else {
-        message = message_lists.current.selected_message();
+        message =
+            message_lists.current.get(opts.message_id) || message_lists.current.selected_message();
 
         if (message === undefined) {
             // empty narrow implementation

--- a/web/src/compose_reply.js
+++ b/web/src/compose_reply.js
@@ -125,13 +125,19 @@ export function reply_with_mention(opts) {
 }
 
 export function quote_and_reply(opts) {
-    const $textarea = $("textarea#compose-textarea");
     const message_id = opts.message_id || message_lists.current.selected_id();
     const message = message_lists.current.get(message_id);
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
-    if (!compose_state.has_message_content()) {
+    // If the last compose type textarea focused on is still in the DOM, we add
+    // the quote in that textarea, else we default to the compose box.
+    const $textarea = compose_state.get_last_focused_compose_type_input()?.isConnected
+        ? $(compose_state.get_last_focused_compose_type_input())
+        : $("textarea#compose-textarea");
+
+    if ($textarea.attr("id") === "compose-textarea" && !compose_state.has_message_content()) {
         // The user has not started typing a message,
+        // but is quoting into the compose box,
         // so we will re-open the compose box.
         // (If you did re-open the compose box, you
         // are prone to glitches where you select the
@@ -160,7 +166,7 @@ export function quote_and_reply(opts) {
         content += `${fence}quote\n${message.raw_content}\n${fence}`;
 
         compose_ui.replace_syntax(quoting_placeholder, content, $textarea);
-        compose_ui.autosize_textarea($("textarea#compose-textarea"));
+        compose_ui.autosize_textarea($textarea);
     }
 
     if (message && message.raw_content) {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -7,6 +7,7 @@ import * as sub_store from "./sub_store";
 
 let message_type: "stream" | "private" | false = false;
 let recipient_edited_manually = false;
+let last_focused_compose_type_input: HTMLInputElement | false = false; // an HTML input element or false-y
 
 // We use this variable to keep track of whether user has viewed the topic resolved
 // banner for the current compose session, for a narrow. This prevents the banner
@@ -22,6 +23,14 @@ export function set_recipient_edited_manually(flag: boolean): void {
 
 export function is_recipient_edited_manually(): boolean {
     return recipient_edited_manually;
+}
+
+export function set_last_focused_compose_type_input(element: HTMLInputElement): void {
+    last_focused_compose_type_input = element;
+}
+
+export function get_last_focused_compose_type_input(): HTMLInputElement | false {
+    return last_focused_compose_type_input;
 }
 
 export function set_message_type(msg_type: "stream" | "private" | false): void {

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -90,7 +90,6 @@ export function initialize() {
             popover_menus.on_show_prep(instance);
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
-            message_lists.current.select_id(message_id);
             const args = popover_menus_data.get_actions_popover_content_context(message_id);
             instance.setContent(parse_html(render_actions_popover(args)));
             $row.addClass("has_actions_popover");

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -106,12 +106,8 @@ export function initialize() {
             // instance.hide gets called.
             const $popper = $(instance.popper);
             $popper.one("click", ".respond_button", (e) => {
-                // Arguably, we should fetch the message ID to respond to from
-                // e.target, but that should always be the current selected
-                // message in the current message list (and
-                // compose_reply.respond_to_message doesn't take a message
-                // argument).
-                compose_reply.quote_and_reply({trigger: "popover respond"});
+                const message_id = $(e.currentTarget).data("message-id");
+                compose_reply.quote_and_reply({trigger: "popover respond", message_id});
                 e.preventDefault();
                 e.stopPropagation();
                 instance.hide();

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -414,6 +414,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     };
 
     $("textarea#compose-textarea").caret = noop;
+    $("textarea#compose-textarea").attr("id", "compose-textarea");
 
     replaced = false;
     expected_replacement =

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -372,8 +372,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     override_private_message_recipient({override});
 
     let selected_message;
-    override(message_lists.current, "get", (_id) => undefined);
-    override(message_lists.current, "selected_message", () => selected_message);
+    override(message_lists.current, "get", (id) => (id === 100 ? selected_message : undefined));
 
     let expected_replacement;
     let replaced;
@@ -404,8 +403,6 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
         success_function = opts.success;
     });
 
-    override(message_lists.current, "selected_id", () => 100);
-
     override(compose_ui, "insert_syntax_and_focus", (syntax, _$textarea, mode) => {
         assert.equal(syntax, "translated: [Quoting…]");
         assert.equal(mode, "block");
@@ -413,6 +410,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     const opts = {
         reply_type: "personal",
+        message_id: 100,
     };
 
     $("textarea#compose-textarea").caret = noop;
@@ -441,6 +439,10 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     disallow(channel, "get");
     quote_and_reply(opts);
     assert.ok(replaced);
+
+    delete opts.message_id;
+    override(message_lists.current, "selected_id", () => 100);
+    override(message_lists.current, "selected_message", () => selected_message);
 
     selected_message = {
         type: "stream",

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -263,10 +263,11 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
         type: "private",
         sender_id: person.user_id,
     };
-    override(message_lists.current, "selected_message", () => msg);
+    override(message_lists.current, "get", (id) => (id === 100 ? msg : undefined));
 
     let opts = {
         reply_type: "personal",
+        message_id: 100,
     };
 
     respond_to_message(opts);
@@ -286,6 +287,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
         stream_id: denmark.stream_id,
         topic: "python",
     };
+    override(message_lists.current, "selected_message", () => msg);
 
     opts = {};
 
@@ -319,6 +321,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
         sender_full_name: "Bob Roberts",
         sender_id: 40,
     };
+    override(message_lists.current, "get", (_id) => undefined);
     override(message_lists.current, "selected_message", () => msg);
 
     let syntax_to_insert;
@@ -369,6 +372,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     override_private_message_recipient({override});
 
     let selected_message;
+    override(message_lists.current, "get", (_id) => undefined);
     override(message_lists.current, "selected_message", () => selected_message);
 
     let expected_replacement;

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -285,8 +285,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         () => "https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado",
     );
 
-    override(message_lists.current, "selected_message", () => selected_message);
-    override(message_lists.current, "selected_id", () => 100);
+    override(message_lists.current, "get", (id) => (id === 100 ? selected_message : undefined));
 
     let success_function;
     override(channel, "get", (opts) => {
@@ -368,7 +367,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     let quote_text = "Testing caret position";
     override_with_quote_text(quote_text);
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
-    compose_reply.quote_and_reply();
+    compose_reply.quote_and_reply({message_id: 100});
 
     success_function({
         raw_content: quote_text,
@@ -383,7 +382,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         assert.equal(syntax, "translated: [Quoting…]\n\n");
     });
     set_compose_content_with_caret("%hello there");
-    compose_reply.quote_and_reply();
+    compose_reply.quote_and_reply({message_id: 100});
 
     quote_text = "Testing with caret initially positioned at 0.";
     override_with_quote_text(quote_text);
@@ -403,7 +402,8 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     // If the compose-box is close, or open with no content while
     // quoting a message, the quoted message should be placed
     // at the beginning of compose-box.
-    compose_reply.quote_and_reply();
+    override(message_lists.current, "selected_id", () => 100);
+    compose_reply.quote_and_reply({});
 
     quote_text = "Testing with compose-box closed initially.";
     override_with_quote_text(quote_text);
@@ -418,7 +418,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     // newlines), the compose-box should re-open and thus the quoted
     // message should start from the beginning of compose-box.
     set_compose_content_with_caret("  \n\n \n %");
-    compose_reply.quote_and_reply();
+    compose_reply.quote_and_reply({});
 
     quote_text = "Testing with compose-box containing whitespaces and newlines only.";
     override_with_quote_text(quote_text);
@@ -435,7 +435,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         assert.equal(syntax, "\ntranslated: [Quoting…]\n");
     });
     set_compose_content_with_caret("1st line\n%\n2nd line");
-    compose_reply.quote_and_reply();
+    compose_reply.quote_and_reply({});
 
     quote_text = "Testing with caret on a new line between 2 lines of text.";
     override_with_quote_text(quote_text);
@@ -452,7 +452,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         assert.equal(syntax, "translated: [Quoting…]");
     });
     set_compose_content_with_caret("lots of\n\n\n\n%\n\n\nnewlines");
-    compose_reply.quote_and_reply();
+    compose_reply.quote_and_reply({});
 
     quote_text = "Testing with caret on a new line between many empty newlines.";
     override_with_quote_text(quote_text);

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -328,6 +328,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         }
     };
     $("textarea#compose-textarea")[0] = "compose-textarea";
+    $("textarea#compose-textarea").attr("id", "compose-textarea");
     override(text_field_edit, "insert", (elt, syntax) => {
         assert.equal(elt, "compose-textarea");
         assert.equal(syntax, "\n\ntranslated: [Quoting…]\n\n");


### PR DESCRIPTION
Until now, when a user quoted and replied to a message, even while editing another, the quote would be inserted into the compose box. There was no way to quote into the edit box.

Detecting the edit box to add content too was tricky, since on opening the message actions popover, that message would be selected, while the edit box would lose focus.

Now we don't shift focus on opening the message actions popover, and add the quote content to the edit box when its message is selected.

Fixes: #20380.

compose: Do not select message row on opening message actions popover.

Now since all actions available in the message actions popover operate
on that message itself, we don't need to select the message row when
opening the popover.

compose: Pass in the message_id when quoting from the message's popover.

compose: Allow `message_id` to be passed into `quote_and_reply`.

compose: Allow message_id to be passed to `respond_to_message`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/67810944-bc2b-424d-9f3a-1df7d8e952a0)
![image](https://github.com/zulip/zulip/assets/68962290/ddf189a5-b51a-4b15-a8fc-69f956f37777)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
