### PR TITLE
help: Document default language for new users setting.

### DIFF
--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -24,6 +24,8 @@ preference settings, including the following:
 * Notification settings, including:
     * [What types of messages trigger notifications][default-notifications]
     * [Configurations for email notifications](/help/email-notifications)
+* Organization settings:
+    * [Default language for new users](/help/configure-organization-language)
 
 [default-notifications]: /help/stream-notifications#set-default-notifications-for-all-streams
 


### PR DESCRIPTION
As discussed in this [CZO thread](https://chat.zulip.org/#narrow/stream/31-production-help/topic/default.20language.20for.20new.20users/near/1649589), this PR adds a link to the [Configure organization language](https://zulip.com/help/configure-organization-language) page since this org setting doubles as the default language for new users.

**Screenshots and screen captures:**
- https://chat.zulip.org/help/configure-default-new-user-settings
![image](https://github.com/zulip/zulip/assets/2343554/9585854e-bb02-4d9e-8277-7cb0e328a44d)