### PR TITLE
communities: Allow user to filter orgs by type.

### DIFF
--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -143,9 +143,16 @@ def communities_view(request: HttpRequest) -> HttpResponse:
             )
             unique_org_type_ids.add(realm.org_type)
 
+    # Custom list of org types to show.
+    ORG_TYPES_TO_SHOW = [
+        "opensource",
+        "research",
+        "community",
+    ]
+
     # Remove org_types for which there are no open organizations.
     org_types = dict()
-    for org_type in Realm.ORG_TYPES:
+    for org_type in ORG_TYPES_TO_SHOW:
         if Realm.ORG_TYPES[org_type]["id"] in unique_org_type_ids:
             org_types[org_type] = Realm.ORG_TYPES[org_type]
 

--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -54,7 +54,7 @@
                 </div>
 
                 <div class="catalog">
-                    <div class="integration-categories-sidebar hide">
+                    <div class="integration-categories-sidebar">
                         <h3>{% trans %}Categories{% endtrans %}</h3>
                         <a href="#all">
                             <h4 data-category="all" class="realm-category selected">{% trans %}All{% endtrans %}</h4>

--- a/web/src/portico/communities.ts
+++ b/web/src/portico/communities.ts
@@ -14,10 +14,19 @@ function sync_open_organizations_page_with_current_hash(): void {
     }
 }
 
+function toggle_categories_dropdown(): void {
+    const $dropdown_list = $(".integration-categories-dropdown .dropdown-list");
+    $dropdown_list.slideToggle(250);
+}
+
 // init
 $(() => {
     sync_open_organizations_page_with_current_hash();
     $(window).on("hashchange", () => {
         sync_open_organizations_page_with_current_hash();
+    });
+
+    $(".integration-categories-dropdown .dropdown-toggle").on("click", () => {
+        toggle_categories_dropdown();
     });
 });

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -217,8 +217,7 @@ $category-text: hsl(219deg 23% 33%);
         }
 
         @media (width <= 906px) {
-            /* Change it to `display: block` when enabling categories. */
-            display: none;
+            display: block;
             width: 670px;
 
             & h3,
@@ -616,8 +615,7 @@ $category-text: hsl(219deg 23% 33%);
     }
 
     .catalog {
-        margin: 50px auto 0;
-        max-width: 700px;
+        margin-top: 50px;
     }
 
     .eligible_realms {


### PR DESCRIPTION

Org category filters were hidden in
https://github.com/zulip/zulip/commit/60eb408bb069e7990e7e16cadedf69b723c2b66c.

<img width="991" alt="Screenshot 2023-10-06 at 7 24 17 PM" src="https://github.com/zulip/zulip/assets/25124304/3b141b4d-babd-4c30-ad1d-b36c249f12e2">


**First commit is to help with testing. Should be dropped before merging this.**