### PR TITLE
sent_messages: Finish .received → .saw_event rename

### DIFF
--- a/web/src/sent_messages.js
+++ b/web/src/sent_messages.js
@@ -70,7 +70,7 @@ export class MessageState {
         // or took a while to process it, but there is nothing
         // wrong with our event loop.
 
-        if (!this.received) {
+        if (!this.saw_event) {
             setTimeout(() => this.maybe_restart_event_loop(), 5000);
         }
     }


### PR DESCRIPTION
Commit 3cc2adcd3bd894f8ad8e42ea475d908594c07d54 (#25423) missed this in the rename, resulting in extra creation of no-op timers.