### PR TITLE
integrations docs: Clarify instructions for direct messages from Zapier.

### DIFF
--- a/zerver/webhooks/zapier/doc.md
+++ b/zerver/webhooks/zapier/doc.md
@@ -32,7 +32,15 @@ sent by Zapier directly in Zulip.
 1. Under **Action** in the right sidebar, configure **Recipients** for a direct
    message, or **Stream name** and **Topic**, as well as **Message content**.
 
+    !!! tip ""
+        To send direct messages, enter a **Zulip account email** in the
+        **Recipients** box, if the email is [configured](/help/configure-email-visibility)
+        to be visible to **Admins, moderators, members and guests**. Otherwise, enter
+        `user` + [user ID](/help/view-someones-profile) + `@your Zulip domain`. For
+        example: `user123@acme.zulipchat.com`.
+
 1. When everything has been configured as desired, click **Publish** to enable
    your Zap.
+
 
 **Congratulations! You're done!**


### PR DESCRIPTION
Current page: https://chat.zulip.org/integrations/doc/zapier

Updated:
<img width="1057" alt="Screenshot 2023-10-06 at 9 34 39 AM" src="https://github.com/zulip/zulip/assets/2090066/569161cd-fbd2-49ea-843f-7d466c47d19c">

[CZO discussion](https://chat.zulip.org/#narrow/stream/127-integrations/topic/DM.20Zap/near/1655505)

## Notes
- I tried to put the tip just after step 12, but it reset the numbering, and I could figure out how to fix it. The current placement seems basically fine to me, but flagging it anyway.