### PR TITLE
registration: Handle race conditions with duplicate emails.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2350,34 +2350,8 @@ class UserSignUpTest(ZulipTestCase):
         email = "newguy@zulip.com"
         password = "newpassword"
 
-        result = self.client_post("/accounts/home/", {"email": email})
-        self.assertEqual(result.status_code, 302)
-        self.assertTrue(
-            result["Location"].endswith(
-                f"/accounts/send_confirm/?email={urllib.parse.quote(email)}"
-            )
-        )
-        result = self.client_get(result["Location"])
-        self.assert_in_response("check your email", result)
-
-        # Visit the confirmation link.
-        confirmation_url = self.get_confirmation_url_from_outbox(email)
-        result = self.client_get(confirmation_url)
-        self.assertEqual(result.status_code, 200)
-
-        result = self.client_post(
-            "/accounts/register/",
-            {
-                "password": password,
-                "key": find_key_by_email(email),
-                "terms": True,
-                "full_name": "New Guy",
-                "from_confirmation": "1",
-            },
-        )
-        self.assert_in_success_response(
-            ["Enter your account details to complete registration."], result
-        )
+        result = self.verify_signup(email=email, password=password)
+        assert isinstance(result, UserProfile)
 
     def test_signup_with_email_address_race(self) -> None:
         """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2343,10 +2343,9 @@ class UserSignUpTest(ZulipTestCase):
 
         self.assertEqual(outbox[0].extra_headers["List-Id"], "Zulip Dev <zulip.testserver>")
 
-    def test_signup_with_full_name(self) -> None:
+    def test_correct_signup(self) -> None:
         """
-        Check if signing up without a full name redirects to a registration
-        form.
+        Verify the happy path of signing up with name and email address.
         """
         email = "newguy@zulip.com"
         password = "newpassword"

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2387,8 +2387,7 @@ class UserSignUpTest(ZulipTestCase):
 
     def test_signup_with_weak_password(self) -> None:
         """
-        Check if signing up without a full name redirects to a registration
-        form.
+        Check if signing up with a weak password fails.
         """
         email = "newguy@zulip.com"
 


### PR DESCRIPTION
Two registration requests for the same email address can race, leading to an IntegrityError when making the second user.

Catch this and redirect them to the login page for their existing email.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
