### PR TITLE
compose banners: Improve padding, layout, and behavior.

### DIFF
--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -405,6 +405,8 @@ export function setup_upload(config) {
 
     uppy.on("upload-error", (file, _error, response) => {
         const message = response ? response.body.msg : undefined;
+        // Hide the upload status banner on error so only the error banner shows
+        hide_upload_banner(uppy, config, file.id);
         show_error_message(config, message, file.id);
         compose_ui.replace_syntax(get_translated_status(file), "", get_item("textarea", config));
         compose_ui.autosize_textarea(get_item("textarea", config));

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -271,18 +271,13 @@
     border-radius: 5px;
     border: 1px solid;
     display: flex;
-    /* Baseline alignment ensures the closing X
-       appears centered with the banner text. */
-    align-items: baseline;
+    align-items: center;
     font-size: 15px;
     line-height: 18px;
 
     .main-view-banner-elements-wrapper {
         display: flex;
-        /* Baseline alignment ensures the banner
-           and button text appear centered with
-           each other. */
-        align-items: baseline;
+        align-items: center;
         /* Allow this flex container to grow or
            shrink to fit the outer container. */
         flex: 1 1 auto;
@@ -366,10 +361,50 @@
         }
     }
 
+    .main-view-banner-action-button {
+        /* Establish a uniform top and bottom
+           space around the button, which also
+           works with the space around the message
+           text. */
+        margin-top: 8px;
+        margin-bottom: 8px;
+        /* Make as tall as two lines of banner message
+           text, which have a line-height of 18px, but
+           no more. */
+        max-height: 36px;
+        /* Keep to the top of the box, but stretch
+           taller based on how the box is flexing. */
+        min-height: 0;
+        align-self: stretch;
+    }
+
     .main-view-banner-close-button {
         font-size: 16px;
         text-decoration: none;
-        padding: 9px 8px;
+        padding: 0 8px;
+        /* Let the close button's box stretch,
+           but no larger than the height of the
+           banner box when the action button
+           achieves its full height (margin,
+           padding, and height), which keeps
+           the X vertically centered with it. */
+        align-self: stretch;
+        max-height: 52px;
+        /* Display as flexbox to better control
+           the X icon's position. This creates
+           an anonymous flexbox item out of the
+           ::before content where the icon sits. */
+        display: flex;
+        align-items: center;
+    }
+
+    .banner_content + .main-view-banner-close-button {
+        /* When there's no action button, set the max
+           height for the typical height of the box
+           when it contains only banner message text.
+           This will keep the action button aligned
+           with the first or only line of text. */
+        max-height: 34px;
     }
 
     &.success {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -294,9 +294,10 @@
         flex-wrap: wrap;
     }
 
-    & .banner_content,
-    & > p {
-        margin: 0; /* override bootstrap */
+    & .banner_content {
+        /* Override Bootstrap when .banner_content is
+           a paragraph element. */
+        margin: 0;
         /* 5px right padding + 10px left-margin of the neighbouring button will match the left padding */
         padding: 8px 5px 8px 15px;
         /* The banner text uses a flex-basis of 150px,
@@ -304,6 +305,13 @@
            text lines are still comfortably readable.
            Still, it can grow and shrink as needed. */
         flex: 1 1 150px;
+
+        & .banner_message {
+            /* Override Bootstrap when .banner_content
+               contains an inner .banner_message
+               paragraph. */
+            margin: 0;
+        }
     }
 
     .main-view-banner-action-button,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -512,17 +512,6 @@
         top: 0;
         bottom: 0;
     }
-
-    .upload_msg {
-        flex-grow: 1;
-    }
-
-    .upload_msg,
-    .main-view-banner-close-button,
-    .upload_banner_cancel_button {
-        z-index: 1;
-        position: relative;
-    }
 }
 
 .composition-area {

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -1,5 +1,5 @@
 <div class="above_compose_banner main-view-banner success {{classname}}">
-    <p>
+    <p class="banner_content">
         {{banner_text}}
         {{#if link_text}} <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
     </p>

--- a/web/templates/compose_banner/not_subscribed_warning.hbs
+++ b/web/templates/compose_banner/not_subscribed_warning.hbs
@@ -1,7 +1,9 @@
 {{#> compose_banner }}
-    {{#if can_subscribe_other_users}}
-        <p>{{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}</p>
-    {{else}}
-        <p>{{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}</p>
-    {{/if}}
+    <p class="banner_message">
+        {{#if can_subscribe_other_users}}
+            {{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}
+        {{else}}
+            {{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}
+        {{/if}}
+    </p>
 {{/compose_banner}}

--- a/web/templates/compose_banner/private_stream_warning.hbs
+++ b/web/templates/compose_banner/private_stream_warning.hbs
@@ -1,3 +1,5 @@
 {{#> compose_banner }}
-    <p>{{#tr}}Warning: <strong>#{stream_name}</strong> is a private stream.{{/tr}}</p>
+    <p class="banner_message">
+        {{#tr}}Warning: <strong>#{stream_name}</strong> is a private stream.{{/tr}}
+    </p>
 {{/compose_banner}}

--- a/web/templates/compose_banner/stream_does_not_exist_error.hbs
+++ b/web/templates/compose_banner/stream_does_not_exist_error.hbs
@@ -1,5 +1,5 @@
 {{#> compose_banner }}
-    <p>
+    <p class="banner_message">
         {{#tr}}
         The stream <b>#{stream_name}</b> does not exist. Manage your subscriptions
         <z-link>on your Streams page</z-link>.

--- a/web/templates/compose_banner/unmute_topic_banner.hbs
+++ b/web/templates/compose_banner/unmute_topic_banner.hbs
@@ -1,5 +1,5 @@
 {{#> compose_banner }}
-    <p>
+    <p class="banner_message">
         {{#if (eq muted_narrow "stream")}}
             {{#tr}}Your message was sent to a stream you have muted.{{/tr}}
         {{else if (eq muted_narrow "topic")}}

--- a/web/templates/compose_banner/upload_banner.hbs
+++ b/web/templates/compose_banner/upload_banner.hbs
@@ -1,6 +1,6 @@
 <div class="upload_banner file_{{file_id}} main-view-banner {{banner_type}}">
     <div class="moving_bar"></div>
-    <p class="upload_msg">{{banner_text}}</p>
+    <p class="upload_msg banner_content">{{banner_text}}</p>
     {{#if is_upload_process_tracker}}
         <button class="upload_banner_cancel_button">{{t 'Cancel' }}</button>
     {{/if}}

--- a/web/templates/compose_banner/wildcard_warning.hbs
+++ b/web/templates/compose_banner/wildcard_warning.hbs
@@ -1,5 +1,5 @@
 {{#> compose_banner }}
-    <p>
+    <p class="banner_message">
         {{#tr}}
         Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{stream_name}? If not, please edit your message to remove the <strong>@{wildcard_mention}</strong> mention.
         {{/tr}}

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -611,6 +611,12 @@ test("uppy_events", ({override_rewire, mock_template}) => {
     };
     on_info_visible_callback();
 
+    let hide_upload_banner_called = false;
+    override_rewire(upload, "hide_upload_banner", (_uppy, config) => {
+        hide_upload_banner_called = true;
+        assert.equal(config.mode, "compose");
+    });
+
     const on_upload_error_callback = callbacks["upload-error"];
     $("#compose_banners .upload_banner .upload_msg").text("");
     compose_ui_replace_syntax_called = false;
@@ -627,6 +633,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
     assert.ok(compose_ui_replace_syntax_called);
 
     $("#compose_banners .upload_banner .upload_msg").text("");
+    assert.ok(hide_upload_banner_called);
     $("#compose-textarea").val("user modified text");
     on_upload_error_callback(file, null);
     assert.ok(compose_ui_replace_syntax_called);


### PR DESCRIPTION
This PR introduces a number of fixes to the compose banners. It:

1. Adds missing `.banner_content` classes to elements that needed it, including the upload banner, helping to make banner styles apply uniformly.
2. Adds a new `.banner_message` class to paragraph elements that are children of `.banner_content` elements, which makes it possible to remove Bootstrap-inherited styles without use of a `p` element selector.
3. Introduces an improved top-aligned style for action and cancel buttons, which give a more uniform, less jumbled look to the vertical alignment of banner elements.
4. Fixes the display of the upload progress banner when an upload fails by removing the progress banner in the error condition.

Fixes: #26922

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/unmute.20topic.20banner.20padding/near/1656040)

**Screenshots and screen captures:**

| Muted stream, before (incorrect message padding) | Muted stream, after (corrected padding, button sized to match 2 lines of message text; see also intrinsic layout animation below) |
| --- | --- |
| ![muted-stream-before](https://github.com/zulip/zulip/assets/170719/57099382-b6bf-4d69-862f-a6beeecc00ab) | ![muted-stream-after](https://github.com/zulip/zulip/assets/170719/0fb98fae-3986-47d0-b222-7faea5a120ba) |

| No action button, before | No action button, after (better vertical centering) |
| --- | --- |
| ![no-action-button-before](https://github.com/zulip/zulip/assets/170719/1067b683-34e1-48de-8717-d5f40349ad0c) | ![no-action-button-after](https://github.com/zulip/zulip/assets/170719/14820da6-a99a-4084-81c3-345158cbc6fd) |

| Intrinsic layout, before | Intrinsic layout, after |
| --- | --- |
| ![banner-expansion-before](https://github.com/zulip/zulip/assets/170719/57ade6d1-e538-460d-b032-669f01d6b11c) | ![banner-expansion-after](https://github.com/zulip/zulip/assets/170719/4d6088ca-e198-45a6-b763-1230dd36d497) |

| File error banners, before | File error banners, after (upload progress removed) |
| --- | --- |
| ![upload-failure-before](https://github.com/zulip/zulip/assets/170719/6c56efdc-d7da-4d00-ac5b-3444081559ee) | ![upload-failure-after](https://github.com/zulip/zulip/assets/170719/9d98260d-ac88-496a-b1d5-c268821d8c9a) |






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
