### PR TITLE
Consistently show bot icon after bot name #26831

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -7,6 +7,7 @@ import render_input_pill from "../templates/input_pill.hbs";
 import * as blueslip from "./blueslip";
 import type {EmojiRenderingDetails} from "./emoji";
 import * as keydown_util from "./keydown_util";
+import * as people from "./people";
 import * as ui_util from "./ui_util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
@@ -15,6 +16,7 @@ export type InputPillItem<T> = {
     display_value: string;
     type: string;
     img_src?: string;
+    user_id?: number;
     deactivated?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code: boolean}; // TODO: Move this in user_status.js
 } & T;
@@ -54,6 +56,7 @@ type InputPillRenderingDetails = {
     img_src?: string;
     deactivated?: boolean;
     has_status?: boolean;
+    is_bot?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code: boolean};
 };
 
@@ -161,6 +164,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             if (has_image) {
                 opts.img_src = item.img_src;
             }
+
+            opts.is_bot = item.user_id ? people.user_is_bot(item.user_id) : false;
 
             if (store.pill_config?.show_user_status_emoji === true) {
                 const has_status = item.status_emoji_info !== undefined;

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -99,6 +99,13 @@ i.zulip-icon.zulip-icon-bot {
     padding: 0 2px;
 }
 
+.pill-label {
+    & .zulip-icon-bot {
+        font-size: 12px;
+        padding: 0 0 0 5px !important;
+    }
+}
+
 .tippy-content {
     /* Set the default font size for tooltips. Popovers override this with
        a rule looking at the data-theme.

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -7,6 +7,9 @@
         {{~#if has_status~}}
             {{~> status_emoji status_emoji_info~}}
         {{~/if~}}
+        {{~#if is_bot~}}
+            <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+        {{~/if~}}
     </span>
     <div class="exit">
         <span aria-hidden="true">&times;</span>

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -173,7 +173,12 @@ run_test("pills", ({override, override_rewire}) => {
     const persons = [othello, iago, hamlet];
     const items = compose_pm_pill.filter_taken_users(persons);
     assert.deepEqual(items, [
-        {email: "iago@zulip.com", user_id: 2, full_name: "Iago", is_moderator: false},
+        {
+            email: "iago@zulip.com",
+            user_id: 2,
+            full_name: "Iago",
+            is_moderator: false,
+        },
     ]);
 
     test_create_item(create_item_handler);


### PR DESCRIPTION
**Description**:
Add bot icon in Compose Message after bot name.
Adding an **is_bot** property in **input_pill's** `create` method.

**Fixes**:
Showing bot icon after bot name in compose message - [Link](https://github.com/zulip/zulip/issues/26831)

**Screenshots**:

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html

**Screenshots and screen captures:**

![Compose Message{caption=Compose Message}](https://github.com/zulip/zulip/assets/24247490/8e22eaea-c7c2-4a1a-8b96-a3c3fe3be79c)
![Chat List{caption=Chat List}](https://github.com/zulip/zulip/assets/24247490/23333ec1-2ce0-4c14-a1b8-09d5ba6fc51f)
![Message List{caption=Message List}](https://github.com/zulip/zulip/assets/24247490/88e3f1bb-6fdf-4ce3-b50c-9fcfc0e85cef)

<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
