### PR TITLE
Fix #26835: Resolve Unsubscribe Button Alignment Issue in Stream Settings

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -2,6 +2,10 @@
     margin: 10px auto;
 }
 
+#remove_subscriber_stream {
+    margin-right: 20px;
+}
+
 .member_list_loading_indicator,
 .subscriber_list_loading_indicator {
     margin: 10px auto;

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -12,7 +12,7 @@
     <td class="unsubscribe">
         <div class="subscriber_list_remove">
             <form class="remove-subscriber-form">
-                <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded btn-danger">
+                <button type="submit" name="unsubscribe" id="remove_subscriber_stream" class="remove-subscriber-button button small rounded btn-danger">
                     {{t 'Unsubscribe' }}
                 </button>
             </form>


### PR DESCRIPTION
## Description
This pull request addresses issue #26835, which reported an alignment issue with the Unsubscribe buttons in the stream settings. The problem resulted in the sidebar overlapping the buttons.

## Changes Made
To resolve the alignment issue, the following changes have been made:
- Applied a precise right margin (20px) to the Unsubscribe buttons.
- Ensured proper alignment and eliminated overlap.
![image](https://github.com/zulip/zulip/assets/64744694/c0dc7613-e1b8-46de-acc4-eac47f0095b5)

## Issue Resolved
Closes #26835

## Testing
I have thoroughly tested these changes to confirm that the Unsubscribe buttons now display correctly in the user interface without any alignment issues. The right margin has been meticulously calculated to provide the desired layout.

## Checklist
- [x] Commits follow the commit discipline guidelines.
- [x] Commit messages are clear and descriptive.
- [x] Code has been reviewed and tested.
- [x] The PR description is complete and informative.
- [ ] All automated tests pass.

Please review and merge this pull request to resolve the reported alignment issue and enhance the user interface layout.


