### PR TITLE
narrow: Cut import of hashchange

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -61,6 +61,7 @@ EXEMPT_FILES = make_set(
         "web/src/billing/upgrade.ts",
         "web/src/blueslip.ts",
         "web/src/blueslip_stacktrace.ts",
+        "web/src/browser_history.ts",
         "web/src/click_handlers.js",
         "web/src/compose.js",
         "web/src/compose_actions.js",

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -35,57 +35,6 @@ import {user_settings} from "./user_settings";
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 // or locally: docs/subsystems/hashchange-system.md
 
-function get_full_url(hash) {
-    const location = window.location;
-
-    if (hash.charAt(0) !== "#" && hash !== "") {
-        hash = "#" + hash;
-    }
-
-    // IE returns pathname as undefined and missing the leading /
-    let pathname = location.pathname;
-    if (pathname === undefined) {
-        pathname = "/";
-    } else if (pathname === "" || pathname.charAt(0) !== "/") {
-        pathname = "/" + pathname;
-    }
-
-    // Build a full URL to not have same origin problems
-    const url = location.protocol + "//" + location.host + pathname + hash;
-    return url;
-}
-
-function set_hash(hash) {
-    if (hash === window.location.hash) {
-        // Avoid adding duplicate entries in browser history.
-        return;
-    }
-    if (history.pushState) {
-        const url = get_full_url(hash);
-        try {
-            history.pushState(null, null, url);
-            browser_history.update_web_public_hash(hash);
-        } catch (error) {
-            if (error instanceof TypeError) {
-                // The window has been destroyed and the history object has been marked dead, so cannot
-                // be updated.  Silently do nothing, since there's nothing we can do.
-            } else {
-                throw error;
-            }
-        }
-    } else {
-        // pushState has 97% global support according to caniuse. So, we will ideally never reach here.
-        // TODO: Delete this case if we don't see any error reports in a while.
-        if (hash === "" || hash === "#") {
-            // Setting empty hash here would scroll to the top.
-            hash = user_settings.default_view;
-        }
-
-        blueslip.error("browser does not support pushState");
-        window.location.hash = hash;
-    }
-}
-
 function maybe_hide_recent_view() {
     if (recent_view_util.is_visible()) {
         recent_view_ui.hide();
@@ -100,22 +49,6 @@ function maybe_hide_inbox() {
         return true;
     }
     return false;
-}
-
-export function changehash(newhash) {
-    if (browser_history.state.changing_hash) {
-        return;
-    }
-    message_viewport.stop_auto_scrolling();
-    set_hash(newhash);
-}
-
-export function save_narrow(operators) {
-    if (browser_history.state.changing_hash) {
-        return;
-    }
-    const new_hash = hash_util.operators_to_hash(operators);
-    changehash(new_hash);
 }
 
 function show_all_message_view() {
@@ -140,7 +73,7 @@ export function set_hash_to_default_view() {
         // hash. So, we use `pushState` which simply updates the current URL
         // but doesn't trigger `hashchange`. So, we trigger hashchange directly
         // here to let it handle the whole rendering process for us.
-        set_hash("");
+        browser_history.set_hash("");
         hashchanged(false);
     }
 }
@@ -310,12 +243,12 @@ function do_hashchange_overlay(old_hash) {
         history.replaceState(
             null,
             "",
-            get_full_url(base + "/" + settings_panel_object.current_tab()),
+            browser_history.get_full_url(base + "/" + settings_panel_object.current_tab()),
         );
     }
 
     if (base === "streams" && !section) {
-        history.replaceState(null, "", get_full_url("streams/subscribed"));
+        history.replaceState(null, "", browser_history.get_full_url("streams/subscribed"));
     }
 
     // Start by handling the specific case of going

--- a/web/src/reload_setup.js
+++ b/web/src/reload_setup.js
@@ -2,8 +2,8 @@ import * as activity from "./activity";
 import * as blueslip from "./blueslip";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
-import * as hashchange from "./hashchange";
 import {localstorage} from "./localstorage";
+import * as narrow from "./narrow";
 import {page_params} from "./page_params";
 
 // Check if we're doing a compose-preserving reload.  This must be
@@ -27,7 +27,7 @@ export function initialize() {
         // exist, but be log it so that it's available for future
         // debugging if an exception happens later.
         blueslip.info("Invalid hash change reload token");
-        hashchange.changehash("");
+        narrow.changehash("");
         return;
     }
     ls.remove(hash_fragment);
@@ -87,5 +87,5 @@ export function initialize() {
     }
 
     activity.set_new_user_input(false);
-    hashchange.changehash(vars.oldhash);
+    narrow.changehash(vars.oldhash);
 }

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -11,11 +11,13 @@ mock_esm("../src/resize", {
 });
 
 const all_messages_data = mock_esm("../src/all_messages_data");
+const browser_history = mock_esm("../src/browser_history", {
+    state: {changing_hash: false},
+});
 const compose_actions = mock_esm("../src/compose_actions");
 const compose_banner = mock_esm("../src/compose_banner");
 const compose_closed_ui = mock_esm("../src/compose_closed_ui");
 const compose_recipient = mock_esm("../src/compose_recipient");
-const hashchange = mock_esm("../src/hashchange");
 const message_fetch = mock_esm("../src/message_fetch");
 const message_list = mock_esm("../src/message_list");
 const message_lists = mock_esm("../src/message_lists", {
@@ -28,6 +30,7 @@ const message_lists = mock_esm("../src/message_lists", {
 const message_feed_top_notices = mock_esm("../src/message_feed_top_notices");
 const message_feed_loading = mock_esm("../src/message_feed_loading");
 const message_view_header = mock_esm("../src/message_view_header");
+const message_viewport = mock_esm("../src/message_viewport");
 const narrow_history = mock_esm("../src/narrow_history");
 const narrow_title = mock_esm("../src/narrow_title");
 const stream_list = mock_esm("../src/stream_list");
@@ -76,16 +79,17 @@ function test_helper({override}) {
         });
     }
 
+    stub(browser_history, "set_hash");
     stub(compose_banner, "clear_message_sent_banners");
     stub(compose_actions, "on_narrow");
     stub(compose_closed_ui, "update_reply_recipient_label");
     stub(narrow_history, "save_narrow_state_and_flush");
-    stub(hashchange, "save_narrow");
     stub(message_feed_loading, "hide_indicators");
     stub(message_feed_top_notices, "hide_top_of_narrow_notices");
     stub(narrow_title, "update_narrow_title");
     stub(stream_list, "handle_narrow_activated");
     stub(message_view_header, "render_title_area");
+    stub(message_viewport, "stop_auto_scrolling");
     stub(left_sidebar_navigation_area, "handle_narrow_activated");
     stub(typing_events, "render_notifications_for_narrow");
     stub(compose_recipient, "update_narrow_to_recipient_visibility");
@@ -185,7 +189,8 @@ run_test("basics", ({override}) => {
         [compose_banner, "clear_message_sent_banners"],
         [unread_ops, "process_visible"],
         [narrow_history, "save_narrow_state_and_flush"],
-        [hashchange, "save_narrow"],
+        [message_viewport, "stop_auto_scrolling"],
+        [browser_history, "set_hash"],
         [typing_events, "render_notifications_for_narrow"],
         [compose_closed_ui, "update_buttons_for_stream"],
         [compose_closed_ui, "update_reply_recipient_label"],


### PR DESCRIPTION
(48, 15) → (46, 14), and reduces the cyclic component of 49 to three components of 33, 5, 2.