### PR TITLE
Added "Copied!" confirmation for user invite link

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -11,6 +11,7 @@ import render_settings_dev_env_email_access from "../templates/settings/dev_env_
 
 import * as channel from "./channel";
 import * as common from "./common";
+import {show_copied_confirmation} from "./copied_tooltip";
 import {csrf_token} from "./csrf";
 import * as dialog_widget from "./dialog_widget";
 import {$t, $t_html} from "./i18n";
@@ -184,7 +185,16 @@ function generate_multiuse_invite(): void {
         success(data) {
             const copy_link_html = copy_invite_link(data);
             ui_report.success(copy_link_html, $invite_status);
-            new ClipboardJS("#copy_generated_invite_link");
+            const clipboard = new ClipboardJS("#copy_generated_invite_link");
+
+            clipboard.on("success", () => {
+                const tippy_timeout_in_ms = 800;
+                show_copied_confirmation(
+                    $("#copy_generated_invite_link")[0],
+                    () => {},
+                    tippy_timeout_in_ms,
+                );
+            });
         },
         error(xhr) {
             ui_report.error("", xhr, $invite_status);

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -196,6 +196,7 @@ export function initialize() {
             "#filter_streams_tooltip",
             ".error-icon-message-recipient .zulip-icon",
             "#personal-menu-dropdown .status-circle",
+            "#copy_generated_invite_link",
         ],
         appendTo: () => document.body,
     });

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1255,14 +1255,6 @@
         box-shadow: 0 5px 10px hsl(0deg 0% 0% / 40%);
     }
 
-    #invite-user-modal {
-        #clipboard_image {
-            & path {
-                fill: hsl(236deg 33% 90%);
-            }
-        }
-    }
-
     #user-profile-modal {
         #default-section {
             .default-field {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -328,6 +328,8 @@ body {
     --color-gear-menu-blue-text: hsl(217deg 100% 50%);
     --color-header-button-hover: hsl(0deg 0% 0% / 5%);
     --color-header-button-focus: hsl(0deg 0% 0% / 8%);
+    --color-fill-hover-copy-icon: hsl(200deg 100% 40%);
+    --color-fill-user-invite-copy-icon: hsl(0deg 0% 46.7%);
 }
 
 %dark-theme {
@@ -482,6 +484,7 @@ body {
     --color-gear-menu-blue-text: hsl(217deg 100% 65%);
     --color-header-button-hover: hsl(0deg 0% 100% / 4%);
     --color-header-button-focus: hsl(0deg 0% 100% / 7%);
+    --color-fill-user-invite-copy-icon: hsl(236deg 33% 90%);
 }
 
 @media screen {
@@ -1013,7 +1016,7 @@ li,
     z-index: 2;
 
     &:hover svg path {
-        fill: hsl(200deg 100% 40%);
+        fill: var(--color-fill-hover-copy-icon);
     }
 }
 
@@ -1042,6 +1045,14 @@ li,
     /* This property nullifies the box-shadow rendered by .btn class */
     &:active {
         box-shadow: none;
+    }
+
+    & path {
+        fill: var(--color-fill-user-invite-copy-icon);
+    }
+
+    &:hover svg path {
+        fill: var(--color-fill-hover-copy-icon);
     }
 }
 

--- a/web/templates/copy_invite_link.hbs
+++ b/web/templates/copy_invite_link.hbs
@@ -1,7 +1,7 @@
 {{t "Link:" }}
 <a href="{{ invite_link }}" id="multiuse_invite_link">{{ invite_link }}</a>
 &nbsp;
-<a class="btn copy_button_base tippy-zulip-tooltip" data-tippy-content="{{t 'Copy link' }}" aria-label="{{t 'Copy link' }}"
+<a class="btn copy_button_base" data-tippy-content="{{t 'Copy link' }}" data-tippy-placement="top" aria-label="{{t 'Copy link' }}"
   id='copy_generated_invite_link' data-clipboard-text="{{ invite_link }}">
     {{> copy_to_clipboard_svg }}
 </a>


### PR DESCRIPTION
Added a "Copied!" confirmation tooltip for "Copy link" button in the "Invite users" modal.

Fixes: Issue #26872

Remaining: The tooltip is now in top position, might want to move the tooltip to bottom because the before "Copy link" tooltip is in the bottom position.

Screenshot:
<img width="454" alt="Skärmavbild 2023-10-09 kl  16 02 28" src="https://github.com/zulip/zulip/assets/125546709/1ede716d-aa8b-48b7-81c3-a182042708a1">
