### PR TITLE
issue :focus resolved

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -191,7 +191,7 @@ input::placeholder {
         }
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             border-color: hsl(0deg 0% 60%);
         }
 
@@ -206,7 +206,7 @@ input::placeholder {
             border-color: hsl(156deg 28% 70%);
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 border-color: hsl(156deg 30% 50%);
             }
 
@@ -222,7 +222,7 @@ input::placeholder {
             border-color: hsl(35deg 98% 84%);
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 border-color: hsl(35deg 55% 70%);
             }
 
@@ -238,7 +238,7 @@ input::placeholder {
             border-color: hsl(4deg 56% 82%);
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 border-color: hsl(2deg 46% 68%);
             }
 
@@ -254,7 +254,7 @@ input::placeholder {
             text-decoration: none;
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 color: hsl(208deg 56% 38%);
             }
         }
@@ -295,9 +295,9 @@ input::placeholder {
             justify-content: center;
             align-items: center;
 
-            &:focus {
+            &:focus:not(:focus-visible) {
                 outline: none;
-            }
+             }
 
             &:not(.selected) {
                 border: 1px solid hsl(0deg 0% 80%);
@@ -413,7 +413,7 @@ div.overlay {
     }
 
     &,
-    &:focus,
+    &:focus-visible,
     &:active,
     &:disabled:hover {
         position: relative;
@@ -604,10 +604,9 @@ div.overlay {
     }
 
     .convert-demo-organization-button {
-        &:focus {
-            outline: 1px solid hsl(200deg 100% 25%);
-            outline-offset: 0;
-        }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
     }
 }
 
@@ -705,7 +704,7 @@ div.overlay {
         box-shadow: 0 1px 4px hsl(0deg 0% 0% / 30%);
     }
 
-    &:focus {
+    &:focus-visible {
         background-color: hsl(240deg 41% 50%);
         box-shadow: 0 1px 4px 0 hsl(235deg 18% 7%);
         outline: none;
@@ -886,7 +885,7 @@ div.overlay {
         vertical-align: text-bottom;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             border: 1px solid hsl(0deg 0% 61%);
 
             .discard-button.save-discard-widget-button-text {
@@ -900,7 +899,7 @@ div.overlay {
             border: 1px solid hsl(155deg 30% 50%);
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 background-color: hsl(166deg 35% 57%);
                 border: 1px solid hsl(166deg 35% 57%);
             }
@@ -1173,13 +1172,15 @@ div.overlay {
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
     border-radius: 4px;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
-        outline: 0;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 /* Icon-based tab picker used for topics popover. */

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1178,7 +1178,7 @@ div.overlay {
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
-    &:focus:not(:focus-visible) {
+    &:focus-visible {
         outline: none;
      }
 }

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -135,7 +135,7 @@ button.dropdown-toggle {
         outline-offset: -2px;
         transition: none;
     }
-    &:focus:not(:focus-visible) {
+    &:focus-visible {
         outline: none !important;
      }
 }

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -129,10 +129,13 @@ input::-ms-reveal {
 
 select.bootstrap-focus-style,
 button.dropdown-toggle {
-    &:focus {
+    &:focus-visible {
         outline: 1px dotted hsl(0deg 0% 20%);
         outline: 5px auto -webkit-focus-ring-color;
         outline-offset: -2px;
         transition: none;
     }
+    &:focus:not(:focus-visible) {
+        outline: none !important;
+     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -554,7 +554,7 @@ textarea.new_message_textarea {
     background-color: hsl(0deg 0% 100%);
 
     &.over_limit,
-    &.over_limit:focus {
+    &.over_limit:focus-visible {
         box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
 
         &.flash {
@@ -569,7 +569,7 @@ textarea.new_message_textarea {
     }
 
     &.invalid,
-    &.invalid:focus {
+    &.invalid:focus-visible {
         border: 1px solid hsl(3deg 57% 33%);
         box-shadow: 0 0 2px hsl(3deg 57% 33%);
     }
@@ -582,11 +582,13 @@ textarea.new_message_textarea,
     transition: border 0.2s ease;
     color: var(--color-text-default);
 
-    &:focus {
-        outline: 0;
+    &:focus-visible {
         border: 1px solid hsl(0deg 0% 67%);
         box-shadow: none;
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 input.recipient_box {
@@ -645,11 +647,14 @@ input.recipient_box {
             cursor: pointer;
             margin: 4px 0 0;
 
-            &:focus {
+            &:focus-visible {
                 outline: 1px dotted hsl(0deg 0% 20%);
                 outline: 5px auto -webkit-focus-ring-color;
                 outline-offset: -2px;
             }
+            &:focus:not(:focus-visible) {
+                outline: none !important;
+             }
         }
 
         &:first-child {
@@ -942,7 +947,7 @@ input.recipient_box {
     }
 
     &:hover,
-    &:focus {
+    &:focus-visible {
         box-shadow: none;
     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -585,10 +585,8 @@ textarea.new_message_textarea,
     &:focus-visible {
         border: 1px solid hsl(0deg 0% 67%);
         box-shadow: none;
-    }
-    &:focus:not(:focus-visible) {
         outline: none;
-     }
+    } 
 }
 
 input.recipient_box {
@@ -652,9 +650,9 @@ input.recipient_box {
                 outline: 5px auto -webkit-focus-ring-color;
                 outline-offset: -2px;
             }
-            &:focus:not(:focus-visible) {
+            /* &:focus:not(:focus-visible) {
                 outline: none !important;
-             }
+             } */
         }
 
         &:first-child {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -19,7 +19,7 @@
         color: hsl(3deg 73% 80%);
 
         .convert-demo-organization-button {
-            &:focus {
+            &:focus-visible {
                 color: hsl(200deg 79% 66%);
                 outline-color: hsl(200deg 79% 66%);
             }
@@ -190,7 +190,7 @@
     }
 
     .dropdown-list-container .dropdown-list .list-item {
-        &:focus {
+        &:focus-visible {
             background-color: hsl(220deg 12% 95.1% / 5%);
         }
 
@@ -368,7 +368,7 @@
 
     & textarea.new_message_textarea {
         &.invalid,
-        &.invalid:focus {
+        &.invalid:focus-visible {
             border-color: hsl(3deg 73% 74%);
             box-shadow: 0 0 2px hsl(3deg 73% 74%);
         }
@@ -463,7 +463,7 @@
         }
 
         &:hover,
-        &:focus,
+        &:focus-visible,
         &:active {
             background-color: hsl(0deg 0% 0% / 15%);
         }
@@ -495,7 +495,7 @@
         color: inherit;
     }
 
-    .dropdown-list-search .dropdown-list-search-input:focus {
+    .dropdown-list-search .dropdown-list-search-input:focus-visible {
         background-color: hsl(225deg 6% 7%);
         border: 1px solid hsl(0deg 0% 100% / 50%);
         box-shadow: 0 0 5px hsl(0deg 0% 100% / 40%);
@@ -594,16 +594,16 @@
         }
     }
 
-    .emoji-popover .reaction:focus {
+    .emoji-popover .reaction:focus-visible {
         box-shadow: 0 0 1px hsl(0deg 0% 98%);
     }
 
-    & input[type="text"]:focus,
-    input[type="email"]:focus,
-    input[type="number"]:focus,
-    textarea:focus,
-    textarea.new_message_textarea:focus,
-    .compose_table .recipient_box:focus {
+    & input[type="text"]:focus-visible,
+    input[type="email"]:focus-visible,
+    input[type="number"]:focus-visible,
+    textarea:focus-visible,
+    textarea.new_message_textarea:focus-visible,
+    .compose_table .recipient_box:focus-visible {
         border-color: hsl(0deg 0% 0% / 90%);
     }
 
@@ -656,7 +656,7 @@
         #user_group_creating_indicator:not(:empty),
     .emoji-picker-popover
         .emoji-popover
-        .emoji-popover-emoji:not(.reacted):focus {
+        .emoji-popover-emoji:not(.reacted):focus-visible {
         background-color: hsl(212deg 28% 8% / 75%);
     }
 
@@ -729,7 +729,7 @@
     .expand_composebox_button,
     .collapse_composebox_button,
     .clear_search_button,
-    .clear_search_button:focus,
+    .clear_search_button:focus-visible,
     .clear_search_button:active,
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
@@ -807,10 +807,12 @@
         border-color: hsl(0deg 0% 0%);
         color: hsl(0deg 0% 100%);
 
-        &:focus {
+        &:focus-visible {
             background-color: hsl(0deg 0% 0% / 50%) !important;
-            outline: 0;
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         &.fake_disabled_button {
             cursor: not-allowed;
@@ -866,13 +868,13 @@
         }
     }
 
-    .drafts-container .header-body .delete-drafts-group > *:focus {
+    .drafts-container .header-body .delete-drafts-group > *:focus-visible {
         background-color: hsl(228deg 11% 17%);
     }
 
     & thead,
     .drafts-container .drafts-header,
-    .nav > li > a:focus,
+    .nav > li > a:focus-visible,
     .nav > li > a:hover,
     .subscriptions-container .subscriptions-header,
     .user-groups-container .user-groups-header,
@@ -1414,16 +1416,16 @@
         }
     }
 
-    & a:not(:active):focus,
-    button:focus,
-    .new-style label.checkbox input[type="checkbox"]:focus ~ span,
-    i.fa:focus,
-    i.zulip-icon:focus,
-    [role="button"]:focus {
+    & a:not(:active):focus-visible,
+    button:focus-visible,
+    .new-style label.checkbox input[type="checkbox"]:focus-visible ~ span,
+    i.fa:focus-visible,
+    i.zulip-icon:focus-visible,
+    [role="button"]:focus-visible {
         outline-color: hsl(0deg 0% 67%);
     }
 
-    .animated-purple-button:focus {
+    .animated-purple-button:focus-visible {
         box-shadow: 0 1px 4px 0 hsl(0deg 0% 100% / 66.6%);
     }
 
@@ -1451,7 +1453,7 @@
                 background-color: hsl(185deg 20% 20%);
             }
 
-            &:focus {
+            &:focus-visible {
                 color: hsl(185deg 50% 65%);
                 border-color: hsl(185deg 40% 50%);
                 background-color: hsl(185deg 40% 35%);
@@ -1481,7 +1483,7 @@
                     background-color: hsl(185deg 40% 45%);
                 }
 
-                &:focus ~ span {
+                &:focus-visible ~ span {
                     outline-color: hsl(0deg 0% 100% / 0%);
                 }
             }
@@ -1508,7 +1510,7 @@
         }
 
         &:active,
-        &:focus {
+        &:focus-visible {
             background-color: hsl(0deg 0% 100% / 10%);
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -809,10 +809,8 @@
 
         &:focus-visible {
             background-color: hsl(0deg 0% 0% / 50%) !important;
-        }
-        &:focus:not(:focus-visible) {
             outline: none;
-         }
+        }
 
         &.fake_disabled_button {
             cursor: not-allowed;

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -22,7 +22,7 @@
             gap: 10px;
 
             .delete-selected-drafts-button {
-                &:focus {
+                &:focus-visible {
                     background-color: hsl(0deg 0% 93%);
                 }
             }
@@ -35,7 +35,7 @@
                 padding-left: 15px;
                 padding-right: 15px;
 
-                &:focus {
+                &:focus-visible {
                     background-color: hsl(0deg 0% 93%);
                 }
             }

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -67,7 +67,7 @@
         padding: 0 10px;
     }
 
-    .image-delete-button:focus,
+    .image-delete-button:focus-visible,
     .image-delete-button:hover {
         color: hsl(0deg 0% 100%);
     }

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -48,10 +48,8 @@
 
             &:focus-visible {
                 background-color: var(--color-background-btn-inbox-focus);
-            }
-            &:focus:not(:focus-visible) {
                 outline: none;
-             }
+            }
         }
 
         .btn-inbox-selected {
@@ -135,10 +133,11 @@
                 background-color: var(--color-background-inbox-search-focus);
                 border: 1px solid var(--color-border-inbox-search-focus);
                 box-shadow: 0 0 5px var(--color-box-shadow-inbox-search-focus);
-            }
-            &:focus:not(:focus-visible) {
                 outline: none;
-             }
+            }
+            /* &:focus:not(:focus-visible) {
+                outline: none;
+             } */
         }
 
         #inbox-list {
@@ -205,10 +204,11 @@
                     .toggle-inbox-header-icon {
                         opacity: 1;
                     }
-                }
-                &:focus:not(:focus-visible) {
                     outline: none;
-                 }
+                }
+                /* &:focus:not(:focus-visible) {
+                    outline: none;
+                 } */
             }
 
             .fa-lock {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -46,10 +46,12 @@
             padding: 5px 10px;
             margin-left: 10px;
 
-            &:focus {
+            &:focus-visible {
                 background-color: var(--color-background-btn-inbox-focus);
-                outline: 0;
             }
+            &:focus:not(:focus-visible) {
+                outline: none;
+             }
         }
 
         .btn-inbox-selected {
@@ -85,9 +87,9 @@
                 top: 0;
                 right: 30px;
 
-                &:focus {
+                &:focus:not(:focus-visible) {
                     outline: none;
-                }
+                 }
 
                 &:hover,
                 &:focus-visible {
@@ -129,12 +131,14 @@
                 border: 1px solid var(--color-border-inbox-search-hover);
             }
 
-            &:focus {
-                outline: none;
+            &:focus-visible {
                 background-color: var(--color-background-inbox-search-focus);
                 border: 1px solid var(--color-border-inbox-search-focus);
                 box-shadow: 0 0 5px var(--color-box-shadow-inbox-search-focus);
             }
+            &:focus:not(:focus-visible) {
+                outline: none;
+             }
         }
 
         #inbox-list {
@@ -188,14 +192,12 @@
                         overflow: hidden;
                     }
 
-                    &:focus a {
+                    &:focus-visible a {
                         box-shadow: inset 0 -3px 0 var(--color-outline-focus);
                     }
                 }
 
-                &:focus {
-                    outline: 0;
-
+                &:focus-visible {
                     .inbox-focus-border {
                         border-color: var(--color-outline-focus);
                     }
@@ -204,6 +206,9 @@
                         opacity: 1;
                     }
                 }
+                &:focus:not(:focus-visible) {
+                    outline: none;
+                 }
             }
 
             .fa-lock {
@@ -263,7 +268,7 @@
                     background: var(--color-background-inbox-row-hover);
                 }
 
-                &:focus {
+                &:focus-visible {
                     .inbox-focus-border {
                         border: 2px solid var(--color-outline-focus);
                         border-radius: 3px;
@@ -334,7 +339,7 @@
                 /* Since a direct message row can have span to multiple lines,
                    having an underline focus will not work very well.
                 */
-                .inbox-row:focus {
+                .inbox-row:focus-visible {
                     box-shadow: inset 0 0 0 2px var(--color-outline-focus);
                 }
             }
@@ -416,7 +421,7 @@
 
         .inbox-row,
         .inbox-header {
-            &:focus,
+            &:focus-visible,
             &:focus-within,
             &:hover {
                 .inbox-action-button {
@@ -435,7 +440,7 @@
                 display: none;
             }
 
-            &:focus {
+            &:focus-visible {
                 box-shadow: 0 0 0 2px var(--color-outline-focus);
             }
 

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -28,10 +28,11 @@
             color: hsl(0deg 0% 100%);
             border: 1px solid hsl(176deg 78% 28%);
             background-color: hsl(176deg 49% 42%);
-        }
-        &:focus:not(:focus-visible) {
             outline: none;
-         }
+        }
+        /* &:focus:not(:focus-visible) {
+            outline: none;
+         } */
 
         .pill-image {
             height: 20px;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -24,12 +24,14 @@
         background-color: hsl(0deg 0% 0% / 7%);
         cursor: pointer;
 
-        &:focus {
+        &:focus-visible {
             color: hsl(0deg 0% 100%);
             border: 1px solid hsl(176deg 78% 28%);
             background-color: hsl(176deg 49% 42%);
-            outline: none;
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         .pill-image {
             height: 20px;
@@ -75,7 +77,7 @@
             padding-right: 4px;
             cursor: not-allowed;
 
-            &:focus {
+            &:focus-visible {
                 color: inherit;
                 border: 1px solid hsl(0deg 0% 0% / 15%);
                 background-color: hsl(0deg 0% 0% / 7%);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -379,7 +379,7 @@ ul.filters {
     & a {
         color: inherit;
 
-        &:focus {
+        &:focus-visible {
             text-decoration: none;
         }
     }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -129,7 +129,7 @@
     }
 }
 
-.modal__btn:focus,
+.modal__btn:focus-visible,
 .modal__btn:hover {
     transform: scale(1.05);
 }
@@ -233,10 +233,12 @@
             }
 
             &:active,
-            &:focus {
+            &:focus-visible {
                 background-color: hsl(0deg 0% 0% / 10%);
-                outline: none;
             }
+            &:focus:not(:focus-visible) {
+                outline: none;
+             }
         }
     }
 }
@@ -383,11 +385,13 @@
     margin-bottom: 10px;
     width: 206px;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
-        outline: 0;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -235,10 +235,11 @@
             &:active,
             &:focus-visible {
                 background-color: hsl(0deg 0% 0% / 10%);
-            }
-            &:focus:not(:focus-visible) {
                 outline: none;
-             }
+            }
+            /* &:focus:not(:focus-visible) {
+                outline: none;
+             } */
         }
     }
 }
@@ -390,8 +391,10 @@
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
-    }
-    &:focus:not(:focus-visible) {
+
         outline: none;
-     }
+    }
+    /* &:focus:not(:focus-visible) {
+        outline: none;
+     } */
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -104,7 +104,7 @@
 
 .user-card-popover-manage-menu-btn {
     &:hover,
-    &:focus {
+    &:focus-visible {
         text-decoration: none;
     }
 }
@@ -140,7 +140,7 @@
             background-color: transparent !important;
         }
 
-        &:focus {
+        &:focus-visible {
             background-color: transparent !important;
         }
     }
@@ -170,9 +170,9 @@
             }
         }
 
-        &:focus {
+        &:focus:not(:focus-visible) {
             outline: none;
-        }
+         }
     }
 }
 
@@ -853,7 +853,7 @@ ul {
         cursor: pointer;
     }
 
-    .giphy-gif-img:focus {
+    .giphy-gif-img:focus-visible {
         /* Red outline for clear visibility
          * of which image is in focus.
          */
@@ -877,7 +877,7 @@ ul {
             right: 3px;
             font-size: 16px;
 
-            &:focus {
+            &:focus-visible {
                 .fa-remove {
                     outline: 2px solid var(--color-outline-focus);
                 }

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -111,7 +111,7 @@ tr.admin td:first-child {
         vertical-align: middle;
         font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
-        &:focus {
+        &:focus:not(:focus-visible)  {
             outline: 1px dotted hsl(0deg 0% 20%);
             outline: 5px auto -webkit-focus-ring-color;
             outline-offset: -2px;
@@ -130,7 +130,7 @@ tr.admin td:first-child {
             box-shadow linear 0.2s;
         box-shadow: inset 0 1px 1px hsla(0deg 0% 0% / 7.5%);
 
-        &:focus {
+        &:focus:not(:focus-visible)  {
             border-color: hsl(206deg 80% 62% / 80%);
             outline: 0;
             box-shadow:
@@ -230,7 +230,7 @@ tr.admin td:first-child {
         box-shadow linear 0.2s;
     color: hsl(0deg 0% 33%);
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
         outline: 0;
         box-shadow:

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -355,7 +355,7 @@ input[name="licenses"] {
             box-shadow linear 0.2s;
         box-shadow: inset 0 1px 1px hsla(0deg 0 0 / 7.5%);
 
-        &:focus {
+        &:focus-visible{
             border-color: hsl(206deg 80% 62% / 80%);
             outline: 0;
             box-shadow:
@@ -386,7 +386,7 @@ input[name="licenses"] {
             border linear 0.2s,
             box-shadow linear 0.2s;
 
-        &:focus {
+        &:focus-visible {
             border-color: hsl(206.5deg 80% 62% / 80%);
             outline: 0;
 

--- a/web/styles/portico/email_log.css
+++ b/web/styles/portico/email_log.css
@@ -40,7 +40,7 @@
             margin: 4px 0 0 -20px;
             line-height: normal;
 
-            &:focus {
+            &:focus:not(:focus-visible) {
                 outline: 1px dotted hsl(0deg 0% 20%);
                 outline: 5px auto -webkit-focus-ring-color;
                 outline-offset: -2px;
@@ -59,7 +59,7 @@
             margin-bottom: 10px;
             width: 206px;
 
-            &:focus {
+            &:focus-visible{
                 border-color: hsl(206deg 80% 62% / 80%);
                 outline: 0;
                 box-shadow:
@@ -73,7 +73,7 @@
         width: auto;
         cursor: pointer;
 
-        &:focus {
+        &:focus-visible{
             outline: 1px dotted hsl(0deg 0% 20%);
             outline: 5px auto -webkit-focus-ring-color;
             outline-offset: -2px;

--- a/web/styles/portico/footer.css
+++ b/web/styles/portico/footer.css
@@ -76,7 +76,7 @@
     }
 
     & a:hover,
-    a:focus {
+    a:focus-visible{
         color: var(--color-links);
         border-bottom: 1px solid var(--color-links);
         transition: none;

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -126,7 +126,7 @@ $category-text: hsl(219deg 23% 33%);
                         border linear 0.2s,
                         box-shadow linear 0.2s;
 
-                    &:focus {
+                    &:focus-visible{
                         border: 1px solid $border-green;
                         outline: 0;
                     }

--- a/web/styles/portico/integrations_dev_panel.css
+++ b/web/styles/portico/integrations_dev_panel.css
@@ -27,7 +27,7 @@
             border linear 0.2s,
             box-shadow linear 0.2s;
 
-        &:focus {
+        &:focus-visible{
             border-color: hsl(206.5deg 80% 62% / 80%);
             outline: 0;
 
@@ -72,7 +72,7 @@
             box-shadow linear 0.2s;
         margin-bottom: 10px;
 
-        &:focus {
+        &:focus-visible{
             border-color: hsl(206deg 80% 62% / 80%);
             outline: 0;
             box-shadow:
@@ -122,7 +122,7 @@
 
         &:hover,
         &:active,
-        &:focus {
+        &:focus-visible{
             background-color: hsl(208deg 56% 45%);
             border-color: hsl(208deg 56% 36%);
         }

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -1959,7 +1959,7 @@ button {
     transition: all 0.3s ease;
 }
 
-.pricing-model .pricing-container .price-box::focus-visible  {
+.pricing-model .pricing-container .price-box:focus-visible  {
     outline: none;
 }
 

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -56,7 +56,7 @@ a {
     }
 
     &:hover,
-    &:focus {
+    &focus-visible {
         text-decoration: none;
     }
 
@@ -1959,11 +1959,11 @@ button {
     transition: all 0.3s ease;
 }
 
-.pricing-model .pricing-container .price-box:focus {
+.pricing-model .pricing-container .price-box::focus-visible  {
     outline: none;
 }
 
-.pricing-model .pricing-container .price-box:focus .button {
+.pricing-model .pricing-container .price-box:focus-visible .button {
     box-shadow: 0 0 25px hsl(169deg 48% 60%);
     animation: box-shadow-pulse 2s infinite;
 }
@@ -2786,7 +2786,7 @@ button {
     font-weight: 700;
     padding: 15px 5px;
 
-    &:focus {
+    &:focus:not(:focus-visible)  {
         outline: none;
     }
 

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -409,7 +409,7 @@
         right: 10px;
         line-height: 3px;
 
-        &:focus {
+        &:focus-visible {
             outline-offset: -1px;
             outline-color: hsl(176deg 46% 41%);
         }

--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -54,7 +54,7 @@ details summary::-webkit-details-marker {
 .top-menu-mobile a {
     &,
     &:hover,
-    &:focus,
+    &:focus-visible,
     &:visited {
         color: hsl(0deg 0% 100% / 80%);
     }

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -405,7 +405,7 @@ input.text-error {
         }
 
         & a,
-        a:focus,
+        a:focus-visible,
         a:hover {
             text-decoration: none;
             color: hsl(0deg 0% 20%);

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -437,7 +437,7 @@ html {
             background-color: hsl(214deg 28% 16%);
         }
 
-        &:focus {
+        &:focus-visible {
             outline: 3px solid hsl(213deg 81% 79%);
         }
 
@@ -538,12 +538,12 @@ html {
 
             transition: border 0.3s ease;
 
-            &:focus:invalid {
+            &:focus-visible:invalid {
                 box-shadow: none;
                 color: hsl(0deg 0% 27%);
             }
 
-            &:focus {
+            &:focus-visible {
                 border: 1px solid hsl(0deg 0% 53%);
                 outline: 0;
             }
@@ -577,10 +577,10 @@ html {
         }
 
         & label,
-        input[type="text"]:focus + label,
-        input[type="email"]:focus + label,
-        input[type="password"]:focus + label,
-        select:focus + label,
+        input[type="text"]:focus-visible + label,
+        input[type="email"]:focus-visible + label,
+        input[type="password"]:focus-visible + label,
+        select:focus-visible + label,
         input[type="text"]:valid + label,
         input[type="email"]:valid + label,
         input[type="password"]:valid + label,
@@ -967,9 +967,9 @@ button#register_auth_button_gitlab {
                 vertical-align: middle;
                 background-color: hsl(0deg 0% 100%);
 
-                &:focus {
-                    outline: 0;
-                }
+                :focus:not(:focus-visible) {
+                    outline: none;
+                 }
             }
         }
     }

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -259,11 +259,11 @@
             &.reacted.reaction:focus-visible
              {
                 background-color: hsl(195deg 55% 88%);
-
-            }
-            &.reacted.reaction:focus:not(:focus-visible) {
                 outline: none;
-             }
+            }
+            /* &.reacted.reaction:focus:not(:focus-visible) {
+                outline: none;
+             } */
 
             &:not(.reacted):focus-visible {
                 background-color: hsl(0deg 0% 93%);

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -256,12 +256,16 @@
             height: 25px;
             width: 25px;
 
-            &.reacted.reaction:focus {
+            &.reacted.reaction:focus-visible
+             {
                 background-color: hsl(195deg 55% 88%);
-                outline: none;
-            }
 
-            &:not(.reacted):focus {
+            }
+            &.reacted.reaction:focus:not(:focus-visible) {
+                outline: none;
+             }
+
+            &:not(.reacted):focus-visible {
                 background-color: hsl(0deg 0% 93%);
                 outline: none;
             }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -159,10 +159,11 @@
 
             &:focus-visible {
                 background-color: hsl(0deg 0% 80%);
-            }
-            &:focus:not(:focus-visible) {
                 outline: none;
-             }
+            }
+            /* &:focus:not(:focus-visible) {
+                outline: none;
+             } */
             &.fake_disabled_button {
                 cursor: not-allowed;
                 opacity: 0.5;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -157,11 +157,12 @@
             border-radius: 40px;
             margin: 0 5px 10px 0;
 
-            &:focus {
+            &:focus-visible {
                 background-color: hsl(0deg 0% 80%);
-                outline: 0;
             }
-
+            &:focus:not(:focus-visible) {
+                outline: none;
+             }
             &.fake_disabled_button {
                 cursor: not-allowed;
                 opacity: 0.5;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -657,7 +657,7 @@
         }
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: hsl(200deg 100% 25%);
             text-decoration: underline;
 
@@ -723,9 +723,9 @@
         margin-top: -4px;
 
         /* Remove the outline when clicking on the copy-to-clipboard button */
-        &:focus {
+        &:focus:not(:focus-visible) {
             outline: none;
-        }
+         }
     }
 
     .code_external_link {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -19,9 +19,9 @@
         cursor: default;
 
         &:active,
-        &:focus {
+        &:focus:not(:focus-visible) {
             outline: none;
-        }
+         }
 
         &:disabled {
             visibility: hidden;
@@ -39,7 +39,7 @@
         /* Leave room for the focus outline. */
         margin-right: 1px;
 
-        &:focus {
+        &:focus-visible {
             /* Reduce height to leave 1px on top and bottom for the outline. */
             height: calc(100% - 2px);
         }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1127,11 +1127,14 @@ label.display-settings-radio-choice-label {
         width: auto;
         cursor: pointer;
 
-        &:focus {
+        &:focus-visible {
             outline: 1px dotted hsl(0deg 0% 20%);
             outline: 5px auto -webkit-focus-ring-color;
             outline-offset: -2px;
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         &:disabled {
             cursor: not-allowed;
@@ -1237,7 +1240,7 @@ $option_title_width: 180px;
             }
         }
 
-        & span[contenteditable]:focus,
+        & span[contenteditable]:focus-visible,
         span[contenteditable="true"]:hover {
             border-bottom: 1px solid hsl(0deg 0% 80%);
             margin-bottom: -1px;
@@ -1542,13 +1545,15 @@ $option_title_width: 180px;
         border linear 0.2s,
         box-shadow linear 0.2s;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
-        outline: 0;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 #realm_jitsi_server_url_setting {
@@ -1839,15 +1844,16 @@ $option_title_width: 180px;
         border linear 0.2s,
         box-shadow linear 0.2s;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206.5deg 80% 62% / 80%);
-        outline: 0;
 
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
-
+    &:focus:not(:focus-visible) {
+    outline: none;
+    }
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
@@ -2075,13 +2081,15 @@ $option_title_width: 180px;
     elements in settings) */
     width: 311px;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
-        outline: 0;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 #generate-integration-url-modal {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1131,10 +1131,11 @@ label.display-settings-radio-choice-label {
             outline: 1px dotted hsl(0deg 0% 20%);
             outline: 5px auto -webkit-focus-ring-color;
             outline-offset: -2px;
-        }
-        &:focus:not(:focus-visible) {
             outline: none;
-         }
+        }
+        /* &:focus:not(:focus-visible) {
+            outline: none;
+         } */
 
         &:disabled {
             cursor: not-allowed;
@@ -1550,10 +1551,12 @@ $option_title_width: 180px;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
-    }
-    &:focus:not(:focus-visible) {
+
         outline: none;
-     }
+    }
+    /* &:focus:not(:focus-visible) {
+        outline: none;
+     } */
 }
 
 #realm_jitsi_server_url_setting {
@@ -1846,14 +1849,14 @@ $option_title_width: 180px;
 
     &:focus-visible {
         border-color: hsl(206.5deg 80% 62% / 80%);
-
+        outline: none;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
-    &:focus:not(:focus-visible) {
+    /* &:focus:not(:focus-visible) {
     outline: none;
-    }
+    } */
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
@@ -2083,13 +2086,14 @@ $option_title_width: 180px;
 
     &:focus-visible {
         border-color: hsl(206deg 80% 62% / 80%);
+        outline: none;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
-    &:focus:not(:focus-visible) {
+    /* &:focus:not(:focus-visible) {
         outline: none;
-     }
+     } */
 }
 
 #generate-integration-url-modal {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -435,7 +435,7 @@ h4.user_group_setting_subsection_title {
         color: hsl(0deg 0% 27%);
         text-align: center;
 
-        &:focus {
+        &:focus-visible {
             text-align: left;
         }
 
@@ -986,11 +986,9 @@ div.settings-radio-input-parent {
         cursor: pointer;
         margin: 3.5px 0 1px;
 
-        &:focus {
-            outline: 1px dotted hsl(0deg 0% 20%);
-            outline: 5px auto -webkit-focus-ring-color;
-            outline-offset: -2px;
-        }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         &:disabled {
             cursor: not-allowed;

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -62,7 +62,7 @@
                 border-color: hsl(156deg 30% 50%);
             }
 
-            &:focus ~ span {
+            &:focus-visible ~ span {
                 outline-color: hsl(0deg 0% 100% / 0%);
             }
         }
@@ -109,12 +109,14 @@
         border-radius: 4px;
         color: hsl(0deg 0% 33%);
 
-        &:focus {
+        &:focus-visible {
             border-color: hsl(206deg 80% 62% / 80%);
-            outline: 0;
             box-shadow: none;
             background-color: var(--color-background-widget-input);
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
     }
 }
 
@@ -157,10 +159,12 @@
             border-color: hsl(156deg 30% 50%);
         }
 
-        &:focus {
-            outline: 0;
+        &:focus-visible {
             background-color: hsl(156deg 41% 90%);
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
     }
 
     .poll-names {
@@ -198,10 +202,12 @@ button {
         transition: all 0.2s ease;
 
         &:hover,
-        &:focus {
-            outline: 0;
+        &:focus-visible {
             border-color: hsl(156deg 30% 50%);
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         &:active {
             border-color: hsl(156deg 30% 40%);

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -112,11 +112,12 @@
         &:focus-visible {
             border-color: hsl(206deg 80% 62% / 80%);
             box-shadow: none;
+            outline: none;
             background-color: var(--color-background-widget-input);
         }
-        &:focus:not(:focus-visible) {
+        /* &:focus:not(:focus-visible) {
             outline: none;
-         }
+         } */
     }
 }
 
@@ -161,10 +162,11 @@
 
         &:focus-visible {
             background-color: hsl(156deg 41% 90%);
-        }
-        &:focus:not(:focus-visible) {
             outline: none;
-         }
+        }
+        /* &:focus:not(:focus-visible) {
+            outline: none;
+         } */
     }
 
     .poll-names {
@@ -204,10 +206,11 @@ button {
         &:hover,
         &:focus-visible {
             border-color: hsl(156deg 30% 50%);
-        }
-        &:focus:not(:focus-visible) {
             outline: none;
-         }
+        }
+        /* &:focus:not(:focus-visible) {
+            outline: none;
+         } */
 
         &:active {
             border-color: hsl(156deg 30% 40%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1897,13 +1897,14 @@ div.focused-message-list {
 
         &:focus-visible {
             border-color: hsl(206deg 80% 62% / 80%);
+            outline: none;
             box-shadow:
                 inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
                 0 0 8px hsl(206deg 80% 62% / 60%);
         }
-        &:focus:not(:focus-visible) {
+        /* &:focus:not(:focus-visible) {
             outline: none;
-         }
+         } */
     }
 }
 
@@ -2540,15 +2541,14 @@ textarea.invitee_emails {
 
     &:focus-visible {
         border-color: hsl(206.5deg 80% 62% / 80%);
-
+        outline: none;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
-    &:focus:not(:focus-visible) {
+    /* &:focus:not(:focus-visible) {
         outline: none;
-     }
-
+     } */
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
@@ -2625,13 +2625,14 @@ select.invite-as {
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);
+        outline: none;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
-    &:focus:not(:focus-visible) {
+    /* &:focus:not(:focus-visible) {
         outline: none;
-     }
+     } */
 }
 
 #custom-expiration-time-unit {
@@ -2814,15 +2815,14 @@ select.invite-as {
 
         &:focus-visible {
             border-color: hsl(206.5deg 80% 62% / 80%);
-
+            outline: none;
             box-shadow:
                 inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
                 0 0 8px hsl(206.5deg 80% 62% / 60%);
         }
-        &:focus:not(:focus-visible) {
+        /* &:focus:not(:focus-visible) {
             outline: none;
-         }
-
+         } */
         &:read-only,
         &:disabled {
             cursor: not-allowed;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -878,12 +878,12 @@ label {
 }
 
 /* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
-a:not(:active):focus,
-button:focus,
-.new-style label.checkbox input[type="checkbox"]:focus ~ span,
-i.fa:focus,
+a:not(:active):focus-visible,
+button:focus-visible,
+.new-style label.checkbox input[type="checkbox"]:focus-visible ~ span,
+i.fa:focus-visible,
 i.zulip-icon:focus-visible,
-[role="button"]:focus {
+[role="button"]:focus-visible {
     outline: 2px solid var(--color-outline-focus);
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
 }
@@ -1090,7 +1090,7 @@ strong {
                 text-decoration: none;
             }
 
-            &:focus {
+            &:focus-visible {
                 color: hsl(0deg 0% 100%);
                 text-decoration: none;
                 background-color: hsl(200deg 100% 38%);
@@ -1139,7 +1139,7 @@ strong {
 }
 
 /* Copied from bootstrap 2.1.1 CSS for dropdown-menu li > a:focus */
-li.actual-dropdown-menu > a:focus {
+li.actual-dropdown-menu > a:focus-visible {
     color: hsl(0deg 0% 100%);
     text-decoration: none;
     background-color: transparent;
@@ -1296,14 +1296,9 @@ td.pointer {
                 transition: unset;
             }
 
-            &:focus {
-                /* Remove the outline but do not color on focus;
-                   focus-visible is more appropriate for the color
-                   changes, as it only applies color when focus
-                   is achieved from a keyboard or other pointerless
-                   device. */
-                outline: 0;
-            }
+            &:focus:not(:focus-visible) {
+                outline: none;
+             }
 
             &:hover,
             &:focus-visible {
@@ -1782,11 +1777,9 @@ td.pointer {
     pointer-events: all !important;
     opacity: 1 !important;
 
-    & i:focus {
-        /* Avoid displaying a focus outline outside the popover on the \vdots
-           icon when opened via the mouse. */
-        outline: 0 !important;
-    }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 .has_actions_popover .info {
@@ -1902,13 +1895,15 @@ div.focused-message-list {
             border linear 0.2s,
             box-shadow linear 0.2s;
 
-        &:focus {
+        &:focus-visible {
             border-color: hsl(206deg 80% 62% / 80%);
-            outline: 0;
             box-shadow:
                 inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
                 0 0 8px hsl(206deg 80% 62% / 60%);
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
     }
 }
 
@@ -1922,8 +1917,8 @@ div.focused-message-list {
     justify-content: flex-start;
 }
 
-.inline_topic_edit:focus,
-#message_edit_topic:focus {
+.inline_topic_edit:focus-visible,
+#message_edit_topic:focus-visible {
     outline: none;
 }
 
@@ -2476,9 +2471,9 @@ nav {
     border-radius: 4px;
     margin-bottom: 3px;
 
-    &:focus {
+    &:focus:not(:focus-visible) {
         outline: none;
-    }
+     }
 
     &.small_square_x {
         background-color: hsl(0deg 0% 100%);
@@ -2543,14 +2538,16 @@ textarea.invitee_emails {
         border linear 0.2s,
         box-shadow linear 0.2s;
 
-    &:focus {
+    &:focus-visible {
         border-color: hsl(206.5deg 80% 62% / 80%);
-        outline: 0;
 
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 
     &:disabled {
         cursor: not-allowed;
@@ -2628,11 +2625,13 @@ select.invite-as {
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);
-        outline: 0;
         box-shadow:
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+    &:focus:not(:focus-visible) {
+        outline: none;
+     }
 }
 
 #custom-expiration-time-unit {
@@ -2813,14 +2812,16 @@ select.invite-as {
             border linear 0.2s,
             box-shadow linear 0.2s;
 
-        &:focus {
+        &:focus-visible {
             border-color: hsl(206.5deg 80% 62% / 80%);
-            outline: 0;
 
             box-shadow:
                 inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
                 0 0 8px hsl(206.5deg 80% 62% / 60%);
         }
+        &:focus:not(:focus-visible) {
+            outline: none;
+         }
 
         &:read-only,
         &:disabled {
@@ -3252,7 +3253,7 @@ select.invite-as {
             width: 100%;
             margin: 4px 4px 2px;
 
-            &:focus {
+            &:focus-visible {
                 background: hsl(0deg 0% 100%);
                 border: 1px solid hsl(229.09deg 21.57% 10% / 80%);
                 box-shadow: 0 0 6px hsl(228deg 9.8% 20% / 30%);
@@ -3276,7 +3277,7 @@ select.invite-as {
             list-style: none;
             margin: 0;
 
-            .list-item:focus {
+            .list-item:focus-visible {
                 background-color: hsl(220deg 12% 4.9% / 5%);
                 outline: none;
             }
@@ -3297,10 +3298,10 @@ select.invite-as {
                     background-color: hsl(220deg 12% 4.9% / 5%);
                 }
 
-                &:focus {
+                &:focus:not(:focus-visible) {
                     text-decoration: none;
                     outline: none;
-                }
+                 }
             }
         }
     }


### PR DESCRIPTION
**Resolved** :focus issue and replaced it with :focus-visible at every instance

Fixes: Issue [#27117](https://github.com/zulip/zulip/pull/27117)
Using [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) instead of:focus across the app if we want to modify the appearance of the focus outline across the app. This will remove any outline on interactive elements on click, but show the outline while navigating via keyboard.
To use the browser default outline color by removing all overrides.