### PR TITLE
settings_users: Remove get_status_field

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -15,7 +15,6 @@ import * as presence from "./presence";
 import * as scroll_util from "./scroll_util";
 import * as settings_bots from "./settings_bots";
 import * as settings_data from "./settings_data";
-import * as settings_panel_menu from "./settings_panel_menu";
 import * as timerender from "./timerender";
 import * as user_deactivation_ui from "./user_deactivation_ui";
 import * as user_profile from "./user_profile";
@@ -91,25 +90,10 @@ function update_view_on_reactivate($row) {
     $row.addClass("reactivated_user");
 }
 
-function get_status_field() {
-    const current_tab = settings_panel_menu.org_settings.current_tab();
-    switch (current_tab) {
-        case "deactivated-users-admin":
-            return $("#deactivated-user-field-status").expectOne();
-        case "user-list-admin":
-            return $("#user-field-status").expectOne();
-        case "bot-list-admin":
-            return $("#bot-field-status").expectOne();
-        default:
-            throw new Error("Invalid admin settings page");
-    }
-}
-
 function failed_listing_users() {
     loading.destroy_indicator($("#subs_page_loading_indicator"));
-    const status = get_status_field();
     const user_id = people.my_current_user_id();
-    blueslip.error("Error while listing users for user_id", {user_id, status});
+    blueslip.error("Error while listing users for user_id", {user_id});
 }
 
 function populate_users() {


### PR DESCRIPTION
(29, 8) → (28, 7).

It’s effectively unused since commit 2d5c6786143e775712f43f8f78cddcb3b5aaeedb (#25061), as predicted by commit d45f0171cb8067dbcae2284ff2e72786613567bc (#14919).