### PR TITLE
left sidebar: Updated and changed functions in left sidebar navigation 

### DIFF
--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -40,16 +40,22 @@ export function update_dom_with_unread_counts(counts, skip_animations) {
 // TODO: Rewrite how we handle activation of narrows when doing the redesign.
 // We don't want to adjust class for all the buttons when switching narrows.
 
-function remove($elem) {
+function remove_active_class($elem) {
     $elem.removeClass("active-filter active-sub-filter");
 }
 
 export function deselect_top_left_corner_items() {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_mentions"));
-    remove($(".top_left_recent_view"));
-    remove($(".top_left_inbox"));
+    const classToRemove = [
+        ".top_left_all_messages",
+        ".top_left_starred_messages",
+        ".top_left_mentions",
+        ".top_left_recent_view",
+        ".top_left_inbox"
+    ]
+
+    for(const classname of classToRemove) {
+        remove_active_class($(classname));
+    }
 }
 
 export function handle_narrow_activated(filter) {
@@ -82,10 +88,7 @@ export function handle_narrow_activated(filter) {
 }
 
 export function highlight_recent_view() {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_mentions"));
-    remove($(".top_left_inbox"));
+    deselect_top_left_corner_items()
     $(".top_left_recent_view").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
@@ -117,10 +120,7 @@ export function initialize() {
 }
 
 export function highlight_inbox_view() {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_recent_view"));
-    remove($(".top_left_mentions"));
+    deselect_top_left_corner_items()
     $(".top_left_inbox").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();


### PR DESCRIPTION
Updated and changed functions in left sidebar navigation area on how we handle activation of narrows in **`left_side_navigation_area.js`**.

Also changed **`remove`** function to **`remove_active_class`** to be used when `**deselect_top_left_corner_items**`
function is called.

Fixes: #26686 

<img width="1280" alt="Screenshot 2023-10-06 at 12 00 36" src="https://github.com/zulip/zulip/assets/87182204/283f5e3c-ea4f-4b74-8ece-43f71d44ea90">
a screenshot of the narrow


@timabbott i'm an outreachy appliciant and i love the zulip project

- I followed zulip commit guidelines.
- changed the functions to zulip snake_case variable naming conventions.
- **`left_sidebar_navigation_area.js`** file doesn't have several calls in each function.

Looking forward to contributing to zulip project!
Thank you.