### PR TITLE
compose_banner: Restore CSS overzealously removed in #27097.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -555,6 +555,15 @@
         top: 0;
         bottom: 0;
     }
+
+    /* Keep these elements visible above the
+       .moving_bar element on file uploads. */
+    .upload_msg,
+    .main-view-banner-close-button,
+    .upload_banner_cancel_button {
+        z-index: 1;
+        position: relative;
+    }
 }
 
 .composition-area {


### PR DESCRIPTION
This restoration also includes a comment for future contributors, explaining why these styles are necessary.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/upload.20banners.20issue/near/1659117)
