### PR TITLE
left sidebar: Collapsed views prep.

### DIFF
--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -28,7 +28,7 @@ async function toggle_test_star_message(page: Page): Promise<void> {
 }
 
 async function test_narrow_to_starred_messages(page: Page): Promise<void> {
-    await page.click('#global_filters a[href^="#narrow/is/starred"]');
+    await page.click('#left-sidebar-navigation-list a[href^="#narrow/is/starred"]');
     await common.check_messages_sent(page, "zfilt", [["Verona > stars", [message]]]);
 
     // Go back to all messages narrow.

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -627,7 +627,9 @@ export function initialize() {
     // MISC
 
     {
-        const sel = ["#stream_filters", "#global_filters", "#user_presences"].join(", ");
+        const sel = ["#stream_filters", "#left-sidebar-navigation-list", "#user_presences"].join(
+            ", ",
+        );
 
         $(sel).on("click", "a", function () {
             this.blur();
@@ -801,7 +803,7 @@ export function initialize() {
     // End Webathena code
 
     // disable the draggability for left-sidebar components
-    $("#stream_filters, #global_filters").on("dragstart", (e) => {
+    $("#stream_filters, #left-sidebar-navigation-list").on("dragstart", (e) => {
         e.target.blur();
         return false;
     });

--- a/web/src/list_util.ts
+++ b/web/src/list_util.ts
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 const list_selectors = [
     "#stream_filters",
-    "#global_filters",
+    "#left-sidebar-navigation-list",
     "#user_presences",
     "#send_later_options",
 ];

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -18,9 +18,9 @@ function get_new_heights() {
     res.stream_filters_max_height =
         viewport_height -
         Number.parseInt($("#left-sidebar").css("paddingTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginBottom"), 10) -
-        ($("#global_filters").outerHeight(true) ?? 0) -
+        Number.parseInt($("#left-sidebar-navigation-area").css("marginTop"), 10) -
+        Number.parseInt($("#left-sidebar-navigation-area").css("marginBottom"), 10) -
+        ($("#left-sidebar-navigation-list").outerHeight(true) ?? 0) -
         ($("#private_messages_sticky_header").outerHeight(true) ?? 0);
 
     // Don't let us crush the stream sidebar completely out of view

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -623,7 +623,7 @@ div.overlay {
     font-size: 12px;
     font-weight: normal;
     border-radius: 4px;
-    background-color: hsl(105deg 2% 50%);
+    background-color: var(--color-background-unread-counter);
     color: hsl(0deg 0% 100%);
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -777,7 +777,7 @@
 
     #topics_header {
         .show-all-streams {
-            color: hsl(236deg 33% 90%);
+            color: hsl(0deg 0% 100% / 75%);
             opacity: 0.75;
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -512,13 +512,6 @@
         color: hsl(236deg 33% 90%);
     }
 
-    .unread_count,
-    /* The actions_popover unread_count object has its own variable CSS,
-       and thus needs to be repeated here with all three classes for precedence) */
-    .actions_popover .mark_as_unread .unread_count {
-        background-color: hsl(105deg 2% 50% / 50%);
-    }
-
     .pill-container {
         border-style: solid;
         border-width: 1px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -54,13 +54,13 @@ $before_unread_count_padding: 3px;
     cursor: pointer;
 }
 
-#global_filters .filter-icon i {
+#left-sidebar-navigation-list .filter-icon i {
     padding-right: 3px;
-    color: var(--color-global-filter-icon);
+    color: var(--color-left-sidebar-navigation-icon);
 }
 
 #stream_filters,
-#global_filters {
+#left-sidebar-navigation-list {
     margin-right: 12px;
 }
 
@@ -203,7 +203,7 @@ li.show-more-topics {
     }
 }
 
-.narrows_panel {
+.left-sidebar-navigation-area {
     & li a {
         margin-top: 1px;
 
@@ -485,14 +485,14 @@ li.active-sub-filter {
     }
 }
 
-#global_filters {
+#left-sidebar-navigation-list {
     margin-bottom: $sections_vertical_gutter;
 
-    .global-filter-container {
+    .left-sidebar-navigation-label-container {
         display: flex;
         padding-right: 20px;
 
-        .global-filter-name {
+        .left-sidebar-navigation-label {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -522,7 +522,8 @@ li.active-sub-filter {
         margin-top: 1px !important;
     }
 
-    .zulip-icon-inbox {
+    .zulip-icon-inbox,
+    .zulip-icon-star-filled {
         font-size: 14px;
         top: 2px;
         position: relative;
@@ -568,8 +569,7 @@ li.top_left_scheduled_messages {
     font-size: 15px;
 }
 
-.top_left_mentions i.fa-at,
-.top_left_starred_messages i.fa-star {
+.top_left_mentions i.fa-at {
     font-size: 13px;
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -278,7 +278,9 @@ ul {
             font-size: 11px;
             font-weight: 600;
             margin-right: 2px;
-            background-color: hsl(200deg 100% 40%);
+            background-color: var(
+                --color-background-unread-counter-popover-menu
+            );
             /* Override random undesired bootstrap style */
             text-shadow: none;
             /* Not center aligned but looks better. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -189,6 +189,8 @@ body {
     --color-search-shadow-wide: hsl(0deg 0% 0% / 25%);
     --color-search-shadow-tight: hsl(0deg 0% 0% / 10%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 10%);
+    --color-background-unread-counter: hsl(105deg 2% 50%);
+    --color-background-unread-counter-popover-menu: hsl(200deg 100% 40%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -285,6 +287,8 @@ body {
     --color-background-search-option-hover: hsl(0deg 0% 30%);
     --color-search-box-hover-shadow: hsl(0deg 0% 0% / 30%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 35%);
+    --color-background-unread-counter: hsl(105deg 2% 50% / 50%);
+    --color-background-unread-counter-popover-menu: hsl(105deg 2% 50% / 50%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -212,7 +212,7 @@ body {
     --color-message-star-action: hsl(41deg 100% 47% / 100%);
     /* The gray on the filter icons is the same as
        what's set on ul.filters, but with 70% opacity. */
-    --color-global-filter-icon: hsl(0deg 0% 20% / 70%);
+    --color-left-sidebar-navigation-icon: hsl(0deg 0% 20% / 70%);
     --color-vdots-hint: hsl(0deg 0% 0% / 30%);
     --color-vdots-visible: hsl(0deg 0% 0% / 53%);
     --color-vdots-hover: hsl(0deg 0% 0%);
@@ -311,7 +311,7 @@ body {
     --color-icon-bot: hsl(180deg 5% 50% / 100%);
     --color-message-action-visible: hsl(217deg 41% 90% / 50%);
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
-    --color-global-filter-icon: hsl(0deg 0% 100% / 56%);
+    --color-left-sidebar-navigation-icon: hsl(0deg 0% 100% / 56%);
     --color-vdots-hint: hsl(0deg 0% 100% / 30%);
     --color-vdots-visible: hsl(236deg 33% 80%);
     --color-vdots-hover: hsl(0deg 0% 100%);
@@ -3112,7 +3112,7 @@ select.invite-as {
             }
         }
 
-        .narrows_panel {
+        .left-sidebar-navigation-area {
             margin-top: 10px;
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2098,7 +2098,8 @@ div.focused-message-list {
             }
         }
 
-        .zulip-icon-inbox {
+        .zulip-icon-inbox,
+        .zulip-icon-star-filled {
             position: relative;
             top: 2px;
         }
@@ -3326,5 +3327,13 @@ select.invite-as {
 
     .zulip-icon {
         padding: 5px;
+    }
+}
+
+#unstar_all_messages,
+.emoji-popover-tab-item {
+    .zulip-icon-star {
+        position: relative;
+        top: 2px;
     }
 }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -43,7 +43,7 @@
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">
-                        <i class="fa fa-star" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-star-filled" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,74 +1,74 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
-    <div class="narrows_panel">
-        <ul id="global_filters" class="filters">
+    <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
+        <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
             <li class="top_left_inbox top_left_row hidden-for-spectators">
-                <a href="#inbox" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="inbox-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Inbox' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Inbox' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_view top_left_row">
-                <a href="#recent" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Recent conversations' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
                 </a>
             </li>
             <li class="top_left_all_messages top_left_row">
-                <a href="#all_messages" class="home-link tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#all_messages" class="home-link tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'All messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
                 </a>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#narrow/is/mentioned">
+                <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Mentions' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#narrow/is/starred">
+                <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Starred messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators">
-                <a href="#drafts" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="drafts-tooltip-template">
+                <a href="#drafts" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Drafts' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#scheduled">
+                <a class="left-sidebar-navigation-label-container" href="#scheduled">
                     <span class="filter-icon">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Scheduled messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Scheduled messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>

--- a/web/templates/starred_messages_sidebar_actions.hbs
+++ b/web/templates/starred_messages_sidebar_actions.hbs
@@ -4,7 +4,7 @@
     {{#if show_unstar_all_button}}
     <li>
         <a tabindex="0" id="unstar_all_messages">
-            <i class="fa fa-star-o" aria-hidden="true"></i>
+            <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
             {{t "Unstar all messages" }}
         </a>
     </li>

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -68,7 +68,7 @@
     {{#if has_starred_messages}}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-unstar-all-in-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-star-o" aria-hidden="true"></i>
+            <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
             {{t "Unstar all messages in topic" }}
         </a>
     </li>


### PR DESCRIPTION
This PR provides needed prep work on the left sidebar ahead of the collapsed-views feature.

Specifically, the commits in this PR:

* Clean up some color inconsistencies, including CSS color variables
* Restructure the "filters" area of the left sidebar using `left-sidebar-navigation` class and ID references
* Place the new custom Zulip star icon in the left sidebar and star-related popovers on Starred messages and any topic containing starred messages

Apart from the new star icon, there are no visual changes introduced by this PR.

Fixes a small part of: #25902 

| Left-sidebar nav area, before | Left-sidebar nav area, after (star icon only difference) |
| --- | --- |
|  <img width="280" alt="lsb-prep-before" src="https://github.com/zulip/zulip/assets/170719/d5d7cfcc-a73c-476f-ad7b-f00d4f4f0fe1"> | <img width="280" alt="lsb-prep-after" src="https://github.com/zulip/zulip/assets/170719/70e0e3eb-e1c9-462d-98f6-05deae70c9be"> |

| Unstar popover, before | Unstar popover, after |
| --- | --- |
| <img width="500" alt="lsb-unstar-popover-before" src="https://github.com/zulip/zulip/assets/170719/49e891d1-b561-48cf-a957-645fe89bf964"> | <img width="500" alt="lsb-unstar-popover-after" src="https://github.com/zulip/zulip/assets/170719/7a4871dd-1d63-416a-a19d-5f4f89679a7b"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>