### PR TITLE
Unbreak our Stripe integration

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -55,6 +55,8 @@ DEFAULT_INVOICE_DAYS_UNTIL_DUE = 30
 # The version of Stripe API the billing system supports.
 STRIPE_API_VERSION = "2020-08-27"
 
+stripe.api_version = STRIPE_API_VERSION
+
 
 def get_latest_seat_count(realm: Realm) -> int:
     return get_seat_count(realm, extra_non_guests_count=0, extra_guests_count=0)


### PR DESCRIPTION
Upgrading stripe to 6.0.0 in e32366638aa1b7cfca0fa460a2b4f8e7fb90f331 breaks our Stripe integration due to API version change making us fail to finalize creating an invoice and charge the customer.

For the upstream details see:
https://github.com/stripe/stripe-python/blob/60ab6ac7d7fcfc5774c44490d3a581593ab6ad55/CHANGELOG.md#600---2023-08-16

6.0.0 uses 2023-08-16 Stripe API version unless specified otherwise. We want to use 2020-08-27.

Setting stripe.api_version in corporate/lib/stripe.py is sufficient for it to be set everywhere else. This is supported by the fact that we also only set stripe.api_key in that file.

