### PR TITLE
Fix PostgreSQL backups when postgresql-client-16 is installed

### DIFF
--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -52,6 +52,7 @@ class Command(ZulipBaseCommand):
 
             with open(os.path.join(tmp, "zulip-backup", "postgres-version"), "w") as f:
                 pg_server_version = connection.cursor().connection.server_version
+                major_pg_version = pg_server_version // 10000
                 print(pg_server_version, file=f)
             members.append("zulip-backup/postgres-version")
 
@@ -68,7 +69,7 @@ class Command(ZulipBaseCommand):
 
             if not options["skip_db"]:
                 pg_dump_command = [
-                    "pg_dump",
+                    f"/usr/lib/postgresql/{major_pg_version}/bin/pg_dump",
                     "--format=directory",
                     "--file=" + os.path.join(tmp, "zulip-backup", "database"),
                     "--host=" + settings.DATABASES["default"]["HOST"],

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -72,12 +72,15 @@ class Command(ZulipBaseCommand):
                     f"/usr/lib/postgresql/{major_pg_version}/bin/pg_dump",
                     "--format=directory",
                     "--file=" + os.path.join(tmp, "zulip-backup", "database"),
-                    "--host=" + settings.DATABASES["default"]["HOST"],
-                    "--port=" + settings.DATABASES["default"]["PORT"],
                     "--username=" + settings.DATABASES["default"]["USER"],
                     "--dbname=" + settings.DATABASES["default"]["NAME"],
                     "--no-password",
                 ]
+                if settings.DATABASES["default"]["HOST"] != "":
+                    pg_dump_command += ["--host=" + settings.DATABASES["default"]["HOST"]]
+                if settings.DATABASES["default"]["PORT"] != "":
+                    pg_dump_command += ["--port=" + settings.DATABASES["default"]["PORT"]]
+
                 os.environ["PGPASSWORD"] = settings.DATABASES["default"]["PASSWORD"]
 
                 run(

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -2,12 +2,11 @@ import os
 import re
 import tempfile
 from argparse import ArgumentParser, RawTextHelpFormatter
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.conf import settings
 from django.core.management.base import CommandParser
 from django.db import connection
-from django.db.backends.postgresql.base import DatabaseWrapper
 from django.utils.timezone import now as timezone_now
 
 from scripts.lib.zulip_tools import TIMESTAMP_FORMAT, parse_os_release, run
@@ -52,13 +51,8 @@ class Command(ZulipBaseCommand):
             members.append("zulip-backup/os-version")
 
             with open(os.path.join(tmp, "zulip-backup", "postgres-version"), "w") as f:
-                # We are accessing a backend specific attribute via a proxy object, whose type
-                # cannot be narrowed with a regular isinstance assertion.
-                # This can be potentially fixed more cleanly with the recently added
-                # connection.get_database_version().
-                if TYPE_CHECKING:
-                    assert isinstance(connection, DatabaseWrapper)
-                print(connection.pg_version, file=f)
+                pg_server_version = connection.cursor().connection.server_version
+                print(pg_server_version, file=f)
             members.append("zulip-backup/postgres-version")
 
             if settings.DEVELOPMENT:


### PR DESCRIPTION
`/usr/bin/pg_dump` on Ubuntu and Debian is actually a tool which
attempts to choose which `pg_dump` binary from all of the
`postgresql-client-*` packages that are installed to run.  However,
its logic is confused by passing empty `--host` and `--port` options
-- instead of looking at the running server instance on the server, it
instead assumes some remote host and chooses the highest versioned
`pg_dump` which is installed.

Because Zulip writes binary database backups, they are sensitive to
the version of the client `pg_dump` binary is used -- and the output
may not be backwards compatible.  Using a PostgreSQL 16 `pg_dump`
writes archive format 1.15, which cannot be read by a PostgreSQL 15
`pg_restore`.

Zulip does not currently support PostgreSQL 16 as a server.  This
means that backups on servers with `postgresql-client-16` installed
did not successfully round-trip Zulip backups -- their backups are
written using PostgreSQL 16's client, and the `pg_restore` chosen on
restore was correctly chosen as the one whose version matched the
server (PostgreSQL 15 or below), and thus did not understand the new
archive format.

Existing `./manage.py backups` taken since `postgresql-client-16` were
installed are thus not directly usable by the `restore-backup` script.
They are not useless, however, since they can theoretically be
converted into a format readable by PostgreSQL 15 -- by importing into
a PostgreSQL 16 instance, and re-dumping with a PostgreSQL 15
`pg_dump`.

Fix this issue by hard-coding path to the binary whose version matches
the version of the server we are connected to.  This may theoretically
fail if we are connected to a remote PostgreSQL instance and we do not
have a `postgresql-client` package locally installed which matches the
remote PostgreSQL server's version.  However, choosing a matching
version is the only way to ensure that it will be able to be imported
cleanly -- and it is preferable that we fail the backup process rather
than write backups that we cannot easily restore from.

Fixes: #27118.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
