### PR TITLE
lightbox: Fix video playing in background after closing.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
@@ -2,7 +2,7 @@
 location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
     internal;
     include /etc/nginx/zulip-include/headers;
-    add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+    add_header Content-Security-Policy "default-src 'none'; media-src: 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
 
     # The components of this path are originally double-URI-escaped
     # (see zerver/view/upload.py).  "location" matches are on
@@ -46,7 +46,7 @@ location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
 location /internal/local/uploads {
     internal;
     include /etc/nginx/zulip-include/headers;
-    add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+    add_header Content-Security-Policy "default-src 'none'; media-src: 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
 
     # Django handles setting Content-Type, Content-Disposition, and Cache-Control.
 

--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -317,7 +317,7 @@ function display_video(payload) {
 export function build_open_media_function(on_close) {
     if (on_close === undefined) {
         on_close = function () {
-            $(".player-container iframe").remove();
+            remove_video_players();
             is_open = false;
             document.activeElement.blur();
         };
@@ -509,6 +509,13 @@ export function next() {
     $(".image-list .image.selected").next().trigger("click");
 }
 
+function remove_video_players() {
+    // Remove video players from the DOM. Used when closing lightbox
+    // so that videos doesn't keep playing in the background.
+    $(".player-container iframe").remove();
+    $("#lightbox_overlay .video-player").html("");
+}
+
 // this is a block of events that are required for the lightbox to work.
 export function initialize() {
     // Renders the DOM for the lightbox.
@@ -521,7 +528,7 @@ export function initialize() {
     );
 
     const reset_lightbox_state = function () {
-        $(".player-container iframe").remove();
+        remove_video_players();
         is_open = false;
         document.activeElement.blur();
         if (pan_zoom_control.isActive()) {


### PR DESCRIPTION
If the video was playing, it didn't stop playing even after the lightbox was closed. We could pause it but removing it from DOM seems like the better thing to do.

A video for testing it.
https://github.com/zulip/zulip/assets/25124304/3ac52c5b-cd23-4840-99fe-e5eb5e6fe3cf


discussion: https://chat.zulip.org/#narrow/stream/137-feedback/topic/Inline.20video.20preview