### PR TITLE
search typeahead: Add "All messages" to search typeahead  when typed.

### DIFF
--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -500,8 +500,11 @@ function get_special_filter_suggestions(last, operators, suggestions) {
         );
     });
 
-    // Only show home if there's an empty bar
-    if (operators.length === 0 && last_string === "") {
+    // Show home if there's an empty bar or if the user starts to type it
+    if (
+        operators.length === 0 &&
+        (last_string === "" || common.phrase_match(last_string, "All messages"))
+    ) {
         suggestions.unshift({search_string: "", description_html: "All messages"});
     }
     return suggestions;


### PR DESCRIPTION
Previously, the "All messages" typeahead only appeared when the search bar was empty. This change makes "All messages" work like all other search suggestions and appears in the dropdown after being searched for.

Fixes: #25060

![image](https://github.com/zulip/zulip/assets/105482178/ea6ded0c-6171-4598-bd02-013693e488a9)



