### PR TITLE
Fix: The issue #26970 added logic for variable timestamp width

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -12,6 +12,7 @@ import {page_params} from "./page_params";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
+import {calculateFormattedTimeWidth} from "./timestamp_width_handler";
 import {LONG_HOVER_DELAY} from "./tippyjs";
 import {parse_html} from "./ui_util";
 
@@ -183,6 +184,7 @@ export function initialize() {
             if (message.locally_echoed) {
                 return false;
             }
+            calculateFormattedTimeWidth();
             const time = new Date(message.timestamp * 1000);
             instance.setContent(timerender.get_full_datetime_clarification(time));
             return true;

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -88,7 +88,7 @@ function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTimeForma
     }
 }
 
-function get_user_locale(): string {
+export function get_user_locale(): string {
     const user_default_language = user_settings.default_language;
     let locale = "";
     try {

--- a/web/src/timestamp_width_handler.js
+++ b/web/src/timestamp_width_handler.js
@@ -1,0 +1,56 @@
+import * as timerender from "./timerender";
+import {user_settings} from "./user_settings";
+
+const maxlength_all_lang = {
+    "id": { "length_12hr": 8, "length_24hr": 5, "name": "Bahasa Indonesia" },
+    "en-GB": { "length_12hr": 8, "length_24hr": 5, "name": "British English" },
+    "ca": { "length_12hr": 11, "length_24hr": 5, "name": "Català" },
+    "cs": { "length_12hr": 10, "length_24hr": 5, "name": "česky" },
+    "zh-TW": { "length_12hr": 7, "length_24hr": 5, "name": "繁體中文" },
+    "cy": { "length_12hr": 8, "length_24hr": 5, "name": "Cymraeg" },
+    "de": { "length_12hr": 8, "length_24hr": 5, "name": "Deutsch" },
+    "es": { "length_12hr": 11, "length_24hr": 5, "name": "Español" },
+    "fr": { "length_12hr": 8, "length_24hr": 5, "name": "Français" },
+    "it": { "length_12hr": 8, "length_24hr": 5, "name": "Italiano" },
+    "lt": { "length_12hr": 15, "length_24hr": 5, "name": "Lietuviškai" },
+    "lrc": { "length_12hr": 8, "length_24hr": 5, "name": "Luri (Bakhtiari)" },
+    "hu": { "length_12hr": 9, "length_24hr": 5, "name": "Magyar" },
+    "mn": { "length_12hr": 10, "length_24hr": 5, "name": "Mongolian" },
+    "nl": { "length_12hr": 10, "length_24hr": 5, "name": "Nederlands" },
+    "pl": { "length_12hr": 8, "length_24hr": 5, "name": "Polski" },
+    "pt": { "length_12hr": 8, "length_24hr": 5, "name": "Português" },
+    "pt-BR": { "length_12hr": 8, "length_24hr": 5, "name": "Português Brasileiro" },
+    "pt-PT": { "length_12hr": 14, "length_24hr": 5, "name": "Portuguese (Portugal)" },
+    "ro": { "length_12hr": 10, "length_24hr": 5, "name": "Română" },
+    "si": { "length_12hr": 11, "length_24hr": 5, "name": "Sinhala" },
+    "fi": { "length_12hr": 9, "length_24hr": 5, "name": "Suomi" },
+    "sv": { "length_12hr": 8, "length_24hr": 5, "name": "Svenska" },
+    "tl": { "length_12hr": 8, "length_24hr": 5, "name": "Tagalog" },
+    "vi": { "length_12hr": 8, "length_24hr": 5, "name": "Tiếng Việt" },
+    "tr": { "length_12hr": 8, "length_24hr": 5, "name": "Türkçe" },
+    "be": { "length_12hr": 8, "length_24hr": 5, "name": "Беларуская" },
+    "bg": { "length_12hr": 15, "length_24hr": 8, "name": "Български" },
+    "ru": { "length_12hr": 8, "length_24hr": 5, "name": "Русский" },
+    "sr": { "length_12hr": 8, "length_24hr": 5, "name": "Српски" },
+    "uk": { "length_12hr": 8, "length_24hr": 5, "name": "Українська" },
+    "ar": { "length_12hr": 7, "length_24hr": 5, "name": "العربيّة" },
+    "fa": { "length_12hr": 15, "length_24hr": 5, "name": "فارسی" },
+    "hi": { "length_12hr": 8, "length_24hr": 5, "name": "हिंदी" },
+    "ta": { "length_12hr": 14, "length_24hr": 5, "name": "தமிழ்" },
+    "ml": { "length_12hr": 8, "length_24hr": 5, "name": "മലയാളം" },
+    "ko": { "length_12hr": 8, "length_24hr": 5, "name": "한국어" },
+    "ja": { "length_12hr": 7, "length_24hr": 5, "name": "日本語" },
+    "zh-CN": { "length_12hr": 7, "length_24hr": 5, "name": "简体中文" }
+};
+
+export function calculateFormattedTimeWidth() {
+    const locale = timerender.get_user_locale();
+    const localeData = maxlength_all_lang[locale];
+    let formattedTimeWidth = 8; // Default width if locale is not found
+
+    if (localeData) {
+        formattedTimeWidth = user_settings.twenty_four_hour_time ? localeData.length_24hr : localeData.length_12hr;
+    }
+    formattedTimeWidth+=1; //Extra space for alignment
+    document.documentElement.style.setProperty('--formatted-time-width', `${formattedTimeWidth}ch`);
+}

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -15,6 +15,10 @@ $message_box_margin: 3px;
    anything wider than 60px. */
 $time_column_min_width: 42px; /* + padding */
 
+:root {
+    --formatted-time-width: 8ch;
+}
+
 .message_row {
     display: grid;
     /* Prevent the messagebox column from overflowing the 1fr
@@ -180,6 +184,7 @@ $time_column_min_width: 42px; /* + padding */
         .message_time {
             justify-self: end;
             padding-right: 5px;
+            width: var(--formatted-time-width);
             /* Maintain first-line baseline regardless of
                what happens in the message-content area (e.g., a
                collapsed message, or source/edit view). This


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes:  #26970 The Timestamp column should have a calculated width.
<!-- Issue link, or clear description.-->

Solved the issue in the following steps:

Step 1: As suggested in the [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/redesigned.20hover.20icons.20.2326283/near/1622267) thread we wanted to calculate widest timestamps from all the languages supported by zulip.
So I fetched all the languages supported by zulip and ran this [CODE](https://github.com/aryan-bhokare/zulip-temp-files/blob/main/timestamp.js) to create a dictionary where I can have max-width in all languages.

Step 2: When the timestamps are loaded,  we check the locale language.

Step 3: According to the Locale language and the time format (24 or 12) set the variable width of the message_time element.

Step 4: Tested UI on various languages supported by Zulip.

<!-- If the PR makes UI changes, always include one or more screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**

Before (Not Aligned) :
![Screenshot (290)](https://github.com/zulip/zulip/assets/92683836/fa449128-d331-47f0-97c7-c8f9a1b28708)

![Screenshot (291)](https://github.com/zulip/zulip/assets/92683836/be49429e-f473-43b1-b310-69f66192f52b)


After (Aligned) :
![Screenshot (292)](https://github.com/zulip/zulip/assets/92683836/e79ce001-bb0e-479a-b9bd-81035728c534)

![Screenshot (293)](https://github.com/zulip/zulip/assets/92683836/3a051962-c615-4e3f-a3ca-2654ff2f64da)

Bug:
At first, when the page loads the alignment is wrong like this for a few seconds.
This delay is caused because the function calculateFormattedTimeWidth Function hasn't finished executing
![Screenshot (294)](https://github.com/zulip/zulip/assets/92683836/67331652-5def-447e-8801-42d723b74fe9)





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed them, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
