### PR TITLE
popovers: Move "Successfully unsubscribed" to non-intrusive spot 

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -803,26 +803,30 @@ export function initialize() {
         e.preventDefault();
         const stream_id = Number.parseInt(user_profile_subscribe_widget.value(), 10);
         const sub = sub_store.get(stream_id);
+
+        if (!sub) {
+            return;
+        }
+
         const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
+
         function addition_success(data) {
             if (Object.keys(data.subscribed).length > 0) {
                 reset_subscribe_widget();
                 ui_report.success(
                     $t_html({defaultMessage: "Subscribed successfully!"}),
                     $alert_box,
-                    1200,
                 );
             } else {
                 ui_report.client_error(
                     $t_html({defaultMessage: "Already subscribed."}),
                     $alert_box,
-                    1200,
                 );
             }
         }
         function addition_failure(xhr) {
-            ui_report.error("", xhr, $alert_box, 1200);
+            ui_report.error("", xhr, $alert_box);
         }
         subscriber_api.add_user_ids_to_stream(
             [target_user_id],
@@ -837,6 +841,10 @@ export function initialize() {
         const $stream_row = $(e.currentTarget).closest("[data-stream-id]");
         const stream_id = Number.parseInt($stream_row.attr("data-stream-id"), 10);
         const sub = sub_store.get(stream_id);
+
+        if (!sub) {
+            return;
+        }
         const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
 
@@ -845,13 +853,11 @@ export function initialize() {
                 ui_report.success(
                     $t_html({defaultMessage: "Unsubscribed successfully!"}),
                     $alert_box,
-                    1200,
                 );
             } else {
                 ui_report.client_error(
                     $t_html({defaultMessage: "Already not subscribed."}),
                     $alert_box,
-                    1200,
                 );
             }
         }
@@ -870,7 +876,7 @@ export function initialize() {
                 );
             }
 
-            ui_report.client_error(error_message, $alert_box, 1200);
+            ui_report.client_error(error_message, $alert_box);
         }
 
         if (sub.invite_only && people.is_my_user_id(target_user_id)) {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -548,7 +548,8 @@ ul {
 
     #user-profile-streams-tab {
         .stream_list_info {
-            margin-bottom: 8px;
+            margin: 0;
+            background-color: transparent;
         }
 
         .stream-privacy {

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -93,12 +93,12 @@
                     </div>
 
                     <div class="tabcontent" id="user-profile-streams-tab">
-                        <div class="alert stream_list_info"></div>
                         {{#if show_user_subscribe_widget}}
                             <div class="header-section">
                                 <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to streams'}}</h3>
                             </div>
                             {{> user_profile_subscribe_widget}}
+                            <div class="stream_list_info" ></div>
                         {{/if}}
                         <div class="stream-list-top-section">
                             <div class="header-section">


### PR DESCRIPTION
Changed the placing of the "Successfully unsubscribed"/"Successfully subscribed" feedback. It is now under the dropdown dropdown widget. 

This is follows how it looks in "settings" --> "manage streams" --> a stream --> "Subscribers". 

Fixes the,  [issue]( https://github.com/zulip/zulip/issues/26689).

Following the feedback from  [PR](https://github.com/zulip/zulip/pull/26918).

Case before upon click subscribing/unsubscribing, the whole subscribed stream list and header shifts down when the alert pops up.
Before,
<img width="497" alt="Screenshot 2023-09-28 at 21 18 10" src="https://github.com/zulip/zulip/assets/64125524/eb0e963f-6002-4af2-98ad-c81405560201">
<img width="497" alt="Screenshot 2023-09-28 at 21 18 01" src="https://github.com/zulip/zulip/assets/64125524/74982b2f-56b6-417a-ac89-d63a6b6d1e9b">

After,
Moved the popup so it does not disturb.
<img width="469" alt="Screenshot 2023-10-12 at 15 50 28" src="https://github.com/zulip/zulip/assets/64125524/b4d47c69-06a1-466d-b6db-20346fee337e">
<img width="469" alt="Screenshot 2023-10-12 at 15 50 20" src="https://github.com/zulip/zulip/assets/64125524/0aefaffd-f6d7-497d-bdab-c288dd98f931">




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
