### PR TITLE
test_event_queue: Add missing "super call" in 'MissedMessageHookTest'.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -183,6 +183,7 @@ class MissedMessageHookTest(ZulipTestCase):
             )
 
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("hamlet")
         self.cordelia = self.example_user("cordelia")
         do_change_user_setting(
@@ -196,6 +197,7 @@ class MissedMessageHookTest(ZulipTestCase):
 
     def tearDown(self) -> None:
         self.destroy_event_queue(self.user_profile, self.client_descriptor.event_queue.id)
+        super().tearDown()
 
     def test_basic(self) -> None:
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/Flaky.20backend.20test/near/1658021)

Fixes the [flaky backend test failures](https://github.com/zulip/zulip/actions/runs/6442021073/job/17492406447?pr=27110#step:19:4628) we noticed recently.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
