### PR TITLE
tests: Fix missing setUp calls in ZulipTestCase subclasses.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5883,6 +5883,7 @@ class TestJWTLogin(ZulipTestCase):
 
 class DjangoToLDAPUsernameTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.init_default_ldap_database()
         self.backend = ZulipLDAPAuthBackend()
 

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -115,6 +115,7 @@ class UserPresenceTests(ZulipTestCase):
         Create some initial, old presence data to make the intended set up
         simpler for the tests.
         """
+        super().setUp()
         realm = get_realm("zulip")
         now = timezone_now()
         initial_presence = now - timedelta(days=365)

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -38,6 +38,7 @@ class RateLimiterBackendBase(ZulipTestCase, ABC):
     backend: Type[RateLimiterBackend]
 
     def setUp(self) -> None:
+        super().setUp()
         self.requests_record: Dict[str, List[float]] = {}
 
     def create_object(self, name: str, rules: List[Tuple[int, int]]) -> RateLimitedTestObject:

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -14,6 +14,7 @@ from zerver.models import DomainNotAllowedForRealmError, RealmDomain, UserProfil
 
 class RealmDomainTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         realm = get_realm("zulip")
         do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
 


### PR DESCRIPTION
This may save us from bugs like the ones fixed in
78683c1b9c3bfae70cce196382aa0ed5c28c8eb4 in the future.
