### PR TITLE
help: Add documentation on configuring default language for new users

### DIFF
--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -12,30 +12,51 @@ users will be able to customize their own settings once they
 join. Administrators can customize defaults for all personal
 preference settings, including the following:
 
-* Privacy settings, including:
+* Privacy settings:
     * [Displaying availability to other users](/help/status-and-availability)
     * [Allowing others to see when the user has read messages](/help/read-receipts)
-* Preferences, including:
+
+* Preferences:
+    * [Language](/help/change-your-language)
+    * [Time format](/help/change-the-time-format)
+    * [Light theme vs. dark theme](/help/dark-theme)
+    * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)
     * [Default view](/help/configure-default-view)
       ([Inbox](/help/inbox) vs.
       [Recent conversations](/help/recent-conversations) vs.
       [All messages](/help/reading-strategies#all-messages))
-    * [Light theme vs. dark theme](/help/dark-theme)
-    * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)
-    * [Time format](/help/change-the-time-format)
-* Notification settings, including:
+
+* Notification settings:
     * [What types of messages trigger notifications][default-notifications]
     * [Configurations for email notifications](/help/email-notifications)
 
 [default-notifications]: /help/stream-notifications#configure-default-notifications-for-all-streams
 
-## How to configure default settings for new users
+## Configure default settings for new users
 
 {start_tabs}
 
 {settings_tab|default-user-settings}
 
 1. Review all settings and adjust as needed.
+
+{end_tabs}
+
+## Configure default language for new users
+
+Your organization's [language](/help/configure-organization-language) will be
+the default language for new users when Zulip cannot detect their language
+preferences from their browser, including all users [created via the Zulip
+API](/api/create-user).
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Automated messages and emails**, change the **Language for
+   automated messages and invitation emails**.
+
+{!save-changes.md!}
 
 {end_tabs}
 

--- a/help/configure-organization-language.md
+++ b/help/configure-organization-language.md
@@ -38,6 +38,7 @@ automated messages and invitation emails. This setting:
 
 * [Change your language][user-lang]
 * [Configure multi-language search](/help/configure-multi-language-search)
+* [Configure default settings for new users](/help/configure-default-new-user-settings)
 
 [api-create-user]: https://zulip.com/api/create-user
 [user-lang]: /help/change-your-language


### PR DESCRIPTION
[CZO thread](https://chat.zulip.org/#narrow/stream/31-production-help/topic/default.20language.20for.20new.20users/near/1649589)

This PR replaces #27080.

**Screenshots and screen captures:**
- https://chat.zulip.org/help/configure-default-new-user-settings

<img width="717" alt="Screenshot 2023-10-12 at 4 40 18 PM" src="https://github.com/zulip/zulip/assets/2090066/88284614-311d-4b0b-a680-012893244022">
