### PR TITLE
help: Improve user stream management docs

### DIFF
--- a/help/manage-user-stream-subscriptions.md
+++ b/help/manage-user-stream-subscriptions.md
@@ -23,6 +23,8 @@ other users to a stream][configure-invites].
 
 {start_tabs}
 
+{tab|via-stream-settings}
+
 {relative|stream|all}
 
 1. Select a stream.
@@ -32,6 +34,17 @@ other users to a stream][configure-invites].
 1. Under **Add subscribers**, enter the user's name or email address.
 
 1. Click **Add**.
+
+{tab|via-user-profile}
+
+{!right-sidebar-view-profile.md!}
+
+1. Select the **Streams** tab.
+
+1. Under **Subscribe user to streams**, select a stream from the
+   dropdown list. You can start typing to filter streams.
+
+1. Click the **Subscribe** button.
 
 {end_tabs}
 
@@ -45,6 +58,21 @@ Anyone can always [unsubscribe themselves from a
 stream](/help/unsubscribe-from-a-stream).
 
 {start_tabs}
+
+{tab|via-stream-settings}
+
+{relative|stream|all}
+
+1. Select a stream.
+
+{!select-stream-view-subscribers.md!}
+
+1. Under **Subscribers**, find the user you would like
+   to remove from the stream.
+
+1. In the **Actions** column, click the **Unsubscribe** button in that row.
+
+{tab|via-user-profile}
 
 {!right-sidebar-view-profile.md!}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -83,6 +83,7 @@ TAB_SECTION_LABELS = {
     "via-user-profile": "Via user profile",
     "via-organization-settings": "Via organization settings",
     "via-personal-settings": "Via personal settings",
+    "via-stream-settings": "Via stream settings",
     "default-subdomain": "Default subdomain",
     "custom-subdomain": "Custom subdomain",
     "zulip-cloud": "Zulip Cloud",


### PR DESCRIPTION
Fixes #26902
- Documents the procedure to subscribe / unsubscribe a user via their profile and general stream settings.
- Both methods are separated into tabs in the documentation.
- Earlier only one of the method was documented for subscribing and unsubscribing.

Link to the current [documentation](https://zulip.com/help/manage-user-stream-subscriptions)

---

**Screenshots and screen captures:**

<details>
<summary>Previous Look</summary>

<img width="600"  src="https://github.com/zulip/zulip/assets/11803841/3b806efd-66c5-4dd5-b9ff-1a5a7c9ff6db">
</details>

<details>
<summary>After updating the docs</summary>
<img width="600" src="https://github.com/zulip/zulip/assets/11803841/acc071bb-15e5-45b2-9246-30ba32a0ec42">
<img  width="600" src="https://github.com/zulip/zulip/assets/11803841/0672cb9f-457a-4652-ae8d-aeb1e8b6263b">
</details>
<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
