### PR TITLE
settings: Add default typing indicator user settings.

### DIFF
--- a/web/src/realm_user_settings_defaults.ts
+++ b/web/src/realm_user_settings_defaults.ts
@@ -34,6 +34,8 @@ export type RealmDefaultSettings = {
     notification_sound: string;
     pm_content_in_desktop_notifications: boolean;
     presence_enabled: boolean;
+    send_private_typing_notifications: boolean;
+    send_stream_typing_notifications: boolean;
     realm_name_in_email_notifications_policy: number;
     starred_message_counts: boolean;
     translate_emoticons: boolean;

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -604,6 +604,12 @@ export const realm_user_settings_defaults_labels = {
     realm_presence_enabled_parens_text: $t({defaultMessage: "invisible mode off"}),
     realm_enter_sends: $t({defaultMessage: "Enter sends when composing a message"}),
     realm_send_read_receipts: $t({defaultMessage: "Allow other users to view read receipts"}),
+    realm_send_private_typing_notifications: $t({
+        defaultMessage: "Let recipients see when a user is typing direct messages",
+    }),
+    realm_send_stream_typing_notifications: $t({
+        defaultMessage: "Let recipients see when a user is typing stream messages",
+    }),
 };
 
 // NOTIFICATIONS

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -16,6 +16,16 @@
             {{> settings_save_discard_widget section_name="privacy-setting" show_only_indicator=false }}
         </div>
         {{> settings_checkbox
+          setting_name="send_private_typing_notifications"
+          is_checked=settings_object.send_private_typing_notifications
+          label=settings_label.realm_send_private_typing_notifications
+          prefix="realm_"}}
+        {{> settings_checkbox
+          setting_name="send_stream_typing_notifications"
+          is_checked=settings_object.send_stream_typing_notifications
+          label=settings_label.realm_send_stream_typing_notifications
+          prefix="realm_"}}
+        {{> settings_checkbox
           setting_name="presence_enabled"
           is_checked=settings_object.presence_enabled
           label=settings_label.realm_presence_enabled


### PR DESCRIPTION
This PR adds the following two settings to 'SETTINGS / DEFAULT USER SETTINGS':
* Let recipients see when a user is typing direct messages
* Let recipients see when a user is typing stream messages

![image](https://github.com/zulip/zulip/assets/56781761/a65f1fd8-e17b-4e38-b335-bbb1350bc035)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
