### PR TITLE
compose: Automatically change @ mentions to silent mentions in 1:1 DMs.

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -691,3 +691,22 @@ export function validate(scheduling_message) {
     }
     return validate_stream_message(scheduling_message);
 }
+
+export function convert_mentions_to_silent_in_direct_messages(mention_text, full_name, user_id) {
+    if (compose_state.get_message_type() !== "private") {
+        return mention_text;
+    }
+
+    const recipient_user_id = compose_pm_pill.get_user_ids();
+    if (recipient_user_id.toString() !== user_id.toString()) {
+        return mention_text;
+    }
+
+    const mention_str = people.get_mention_syntax(full_name, user_id, false);
+    const silent_mention_str = people.get_mention_syntax(full_name, user_id, true);
+    mention_text = mention_text.replace(mention_str, silent_mention_str);
+    // also replace other mentions...
+    compose_ui.replace_syntax(mention_str, silent_mention_str);
+
+    return mention_text;
+}

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -862,15 +862,20 @@ export function content_typeahead_selected(item, event) {
                 // that functionality yet, and we haven't gotten much
                 // feedback on this being an actual pitfall.
             } else {
-                const mention_text = people.get_mention_syntax(
+                let mention_text = people.get_mention_syntax(
                     item.full_name,
                     item.user_id,
                     is_silent,
                 );
-                beginning += mention_text + " ";
                 if (!is_silent) {
                     compose_validate.warn_if_mentioning_unsubscribed_user(item, $textbox);
+                    mention_text = compose_validate.convert_mentions_to_silent_in_direct_messages(
+                        mention_text,
+                        item.full_name,
+                        item.user_id,
+                    );
                 }
+                beginning += mention_text + " ";
             }
             break;
         }

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -476,6 +476,11 @@ test("content_typeahead_selected", ({override}) => {
     fake_this.completing = "mention";
 
     override(compose_validate, "warn_if_mentioning_unsubscribed_user", () => {});
+    override(
+        compose_validate,
+        "convert_mentions_to_silent_in_direct_messages",
+        (mention_text) => mention_text,
+    );
 
     fake_this.query = "@**Mark Tw";
     fake_this.token = "Mark Tw";


### PR DESCRIPTION
It is common for users in other chat tools to start off a direct message
with @ mentioning the addressee. However, this results in potentially
unexpected behavior in Zulip, where the message is highlighted and shows
up in @ mentions in addition to DMs. We want to prevent this behaviour by
automatically changing the @ mentions to silent @ mentions for the user.

Fixes: #17998.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/62449508/0cae3336-a04b-4b90-a101-9aee87408934)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
