### PR TITLE
auth: Update AzureADAuthBackend to use the newer Microsoft API.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -2091,6 +2091,15 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
 
 @external_auth_method
 class AzureADAuthBackend(SocialAuthMixin, AzureADOAuth2):
+    # The upstream implementation uses the outdated /oauth2/authorize
+    # API (instead of the v2.0 API), which doesn't allow us to authenticate
+    # users with just a personal Microsoft account. v2.0 API is required.
+    # This requires us to override the default URLs to use it as well
+    # as adjust the requested scopes, to match this new API.
+    AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
+    ACCESS_TOKEN_URL = "{base_url}/oauth2/v2.0/token"
+    DEFAULT_SCOPE = ["User.Read profile openid email"]
+
     sort_order = 50
     name = "azuread-oauth2"
     auth_backend_name = "AzureAD"


### PR DESCRIPTION
As detailed in the comment in the code:

The upstream implementation uses the outdated /oauth2/authorize API (instead of the v2.0 API), which doesn't allow us to authenticate users with just a personal Microsoft account. v2.0 API is required. This requires us to override the default URLs to use it as well as adjust the requested scopes, to match this new API.

The backend in its previous state was only able to authenticate users that were tied to an organizational directory, even if the application settings in Azure were set up to also allow personal accounts. Users trying to use a personal account would face an error from Microsoft:

AADSTS500200: User account 'xxxx@example.com' is a personal Microsoft account. Personal Microsoft accounts are not supported for this application unless explicitly invited to an organization

https://github.com/python-social-auth/social-core/issues/723 is a related upstream issue.

---

Tested this manually by having an app with support for organizational accounts + personal account set up on Azure with the dev environment and verifying that personal accounts don't work before this change - and after this change, both my personal and organizational account successfully authenticate.
