### PR TITLE
bots: added join/leave notifications in private streams via notification bot.

### DIFF
--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -106,8 +106,12 @@ def setup_shell_profile(shell_profile: str) -> None:
             with open(shell_profile_path, "w") as shell_profile_file:
                 shell_profile_file.writelines(command + "\n")
 
-    source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
-    write_command(source_activate_command)
+    host_machine_wsl = os.path.exists("/proc/sys/fs/binfmt_misc/WSLInterop")
+    host_machine_native_linux = os.path.exists("/etc/os-release")
+    if not host_machine_wsl or not host_machine_native_linux:
+        source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
+        write_command(source_activate_command)
+
     if os.path.exists("/srv/zulip"):
         write_command("cd /srv/zulip")
 


### PR DESCRIPTION
user (un)subscription events now will be send out via notification bot in private streams Fixes #2746
[discussion.](https://chat.zulip.org/#narrow/stream/2-general/topic/Non.20PR.20code.20review)

<!-- Describe your pull request here.-->
Added two function in `zerver/actions/streams.py` and `zerver/views/streams.py` to send user-left and user-join notifications via notification bot. I also added few test cases to account for the new notifications.

Fixes: <!-- Issue link, or clear description.--> [#2746](https://github.com/zulip/zulip/issues/2746)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**  As seen in the pictures, there are different messages for 1, 2, or >3 people being added and also the user left message.
![notification_bot](https://github.com/zulip/zulip/assets/69990740/6ffaeb36-a895-4051-9cab-7b1d905a2b44)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
