### PR TITLE
Fix: The issue zulip #26970 added logic for variable timestamp width.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -237,6 +237,7 @@ EXEMPT_FILES = make_set(
         "web/src/submessage.js",
         "web/src/subscriber_api.js",
         "web/src/timerender.ts",
+        "web/src/timestamp_width_handler.js",
         "web/src/tippyjs.js",
         "web/src/todo_widget.js",
         "web/src/topic_list.js",

--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -12,6 +12,7 @@ import {page_params} from "./page_params";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
+import {calculateFormattedTimeWidth} from "./timestamp_width_handler";
 import {LONG_HOVER_DELAY} from "./tippyjs";
 import {parse_html} from "./ui_util";
 
@@ -184,6 +185,8 @@ export function initialize() {
                 return false;
             }
             const time = new Date(message.timestamp * 1000);
+            // This functions runs every time the time gets rendered.
+            calculateFormattedTimeWidth();
             instance.setContent(timerender.get_full_datetime_clarification(time));
             return true;
         },

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -94,7 +94,7 @@ function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTimeForma
     }
 }
 
-function get_user_locale(): string {
+export function get_user_locale(): string {
     const user_default_language = user_settings.default_language;
     let locale = "";
     try {

--- a/web/src/timestamp_width_handler.js
+++ b/web/src/timestamp_width_handler.js
@@ -1,0 +1,231 @@
+import * as timerender from "./timerender";
+import {user_settings} from "./user_settings";
+
+// candidate_timestamps are contains max possible timestamps in every locale
+const candidate_timestamps = {
+    id: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Bahasa Indonesia",
+    },
+    "en-GB": {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "British English",
+    },
+    ca: {
+        maxtimestamp12_hr: "11:59 p. m.",
+        maxtimestamp24_hr: "23:59",
+        name: "Català",
+    },
+    cs: {
+        maxtimestamp12_hr: "11:59 odp.",
+        maxtimestamp24_hr: "23:59",
+        name: "česky",
+    },
+    "zh-TW": {
+        maxtimestamp12_hr: "下午11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "繁體中文",
+    },
+    cy: {
+        maxtimestamp12_hr: "11:59 yh",
+        maxtimestamp24_hr: "23:59",
+        name: "Cymraeg",
+    },
+    de: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Deutsch",
+    },
+    es: {
+        maxtimestamp12_hr: "11:59 p. m.",
+        maxtimestamp24_hr: "23:59",
+        name: "Español",
+    },
+    fr: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Français",
+    },
+    it: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Italiano",
+    },
+    lt: {
+        maxtimestamp12_hr: "11:59 popiet",
+        maxtimestamp24_hr: "23:59",
+        name: "Lietuviškai",
+    },
+    lrc: {
+        maxtimestamp12_hr: "۱۱:۵۹ PM",
+        maxtimestamp24_hr: "۲۳:۵۹",
+        name: "Luri (Bakhtiari)",
+    },
+    hu: {
+        maxtimestamp12_hr: "du. 11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "Magyar",
+    },
+    mn: {
+        maxtimestamp12_hr: "11:59 ү.х.",
+        maxtimestamp24_hr: "23:59",
+        name: "Mongolian",
+    },
+    nl: {
+        maxtimestamp12_hr: "11:59 p.m.",
+        maxtimestamp24_hr: "23:59",
+        name: "Nederlands",
+    },
+    pl: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Polski",
+    },
+    pt: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Português",
+    },
+    "pt-BR": {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Português Brasileiro",
+    },
+    "pt-PT": {
+        maxtimestamp12_hr: "11:59 da tarde",
+        maxtimestamp24_hr: "23:59",
+        name: "Portuguese (Portugal)",
+    },
+    ro: {
+        maxtimestamp12_hr: "11:59 p.m.",
+        maxtimestamp24_hr: "23:59",
+        name: "Română",
+    },
+    si: {
+        maxtimestamp12_hr: "ප.ව. 11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "Sinhala",
+    },
+    fi: {
+        maxtimestamp12_hr: "11:59 ip.",
+        maxtimestamp24_hr: "23:59",
+        name: "Suomi",
+    },
+    sv: {
+        maxtimestamp12_hr: "11:59 em",
+        maxtimestamp24_hr: "23:59",
+        name: "Svenska",
+    },
+    tl: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Tagalog",
+    },
+    vi: {
+        maxtimestamp12_hr: "11:59 CH",
+        maxtimestamp24_hr: "23:59",
+        name: "Tiếng Việt",
+    },
+    tr: {
+        maxtimestamp12_hr: "ÖS 11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "Türkçe",
+    },
+    be: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Беларуская",
+    },
+    bg: {
+        maxtimestamp12_hr: "11:59 ч. сл.об.",
+        maxtimestamp24_hr: "23:59 ч.",
+        name: "Български",
+    },
+    ru: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Русский",
+    },
+    sr: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "Српски",
+    },
+    uk: {
+        maxtimestamp12_hr: "11:59 пп",
+        maxtimestamp24_hr: "23:59",
+        name: "Українська",
+    },
+    ar: {
+        maxtimestamp12_hr: "١١:٥٩ م",
+        maxtimestamp24_hr: "٢٣:٥٩",
+        name: "العربيّة",
+    },
+    fa: {
+        maxtimestamp12_hr: "۱۱:۵۹ بعدازظهر",
+        maxtimestamp24_hr: "۲۳:۵۹",
+        name: "فارسی",
+    },
+    hi: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "हिंदी",
+    },
+    ta: {
+        maxtimestamp12_hr: "பிற்பகல் 11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "தமிழ்",
+    },
+    ml: {
+        maxtimestamp12_hr: "11:59 PM",
+        maxtimestamp24_hr: "23:59",
+        name: "മലയാളം",
+    },
+    ko: {
+        maxtimestamp12_hr: "오후 11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "한국어",
+    },
+    ja: {
+        maxtimestamp12_hr: "午後11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "日本語",
+    },
+    "zh-CN": {
+        maxtimestamp12_hr: "下午11:59",
+        maxtimestamp24_hr: "23:59",
+        name: "简体中文",
+    },
+};
+
+export function calculateFormattedTimeWidth() {
+    const locale = timerender.get_user_locale();
+    const localeData = candidate_timestamps[locale];
+    let formattedTimeWidth = 45; // Default width if locale is not found
+
+    if (localeData) {
+        // timestamp contains the string according to timeformat.
+        const timestamp = user_settings.twenty_four_hour_time
+            ? localeData.maxtimestamp24_hr
+            : localeData.maxtimestamp12_hr;
+
+        // logic for rendering timestamp in hidden div and calculating it's width.
+        const hiddenDiv = document.createElement("div");
+
+        hiddenDiv.style.visibility = "hidden";
+        hiddenDiv.style.position = "absolute";
+        hiddenDiv.style.whiteSpace = "nowrap";
+        hiddenDiv.textContent = timestamp;
+
+        document.body.append(hiddenDiv);
+
+        formattedTimeWidth = hiddenDiv.offsetWidth;
+
+        hiddenDiv.remove();
+    }
+
+    formattedTimeWidth += 9; // Extra space for alignment as pixel size differs fontsize.
+    document.documentElement.style.setProperty("--formatted-time-width", `${formattedTimeWidth}px`);
+}

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -15,6 +15,10 @@ $message_box_margin: 3px;
    anything wider than 60px. */
 $time_column_min_width: 42px; /* + padding */
 
+:root {
+    --formatted-time-width: 45px;
+}
+
 .message_row {
     display: grid;
     /* Prevent the messagebox column from overflowing the 1fr
@@ -180,6 +184,7 @@ $time_column_min_width: 42px; /* + padding */
         .message_time {
             justify-self: end;
             padding-right: 5px;
+            width: var(--formatted-time-width);
             /* Maintain first-line baseline regardless of
                what happens in the message-content area (e.g., a
                collapsed message, or source/edit view). This


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes:  #26970 The Timestamp column should have a calculated width.
This is a Draft PR so not all tests run properly.
<!-- Issue link, or clear description.-->

Solves the issue in the following steps:

Step 1: As suggested in the [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/redesigned.20hover.20icons.20.2326283/near/1622267) thread we wanted to calculate widest timestamps from all the languages supported by zulip.
So I fetched all the languages supported by zulip and created a dictionary where I stored possible candidate timestamps in all languages.

Step 2: When the timestamps are loaded,  we check the locale language.

Step 3: According to the Locale language and the time format (24 or 12) set the variable width of the message_time element.

Step 4: Tested UI on various languages supported by Zulip.

<!-- If the PR makes UI changes, always include one or more screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**

Before (Not Aligned) :
<details>
<summary>Screenshot-1</summary>

![Screenshot (290)](https://github.com/zulip/zulip/assets/92683836/fa449128-d331-47f0-97c7-c8f9a1b28708)
</details>
<details>
<summary>Screenshot-2</summary>

![Screenshot (291)](https://github.com/zulip/zulip/assets/92683836/be49429e-f473-43b1-b310-69f66192f52b)


</details>






After (Aligned) :
<details>
<summary>Screenshot-1</summary>

![Screenshot (293)](https://github.com/zulip/zulip/assets/92683836/3a051962-c615-4e3f-a3ca-2654ff2f64da)

</details>
<details>
<summary>Screenshot-2</summary>


![Screenshot (292)](https://github.com/zulip/zulip/assets/92683836/e79ce001-bb0e-479a-b9bd-81035728c534)

</details>


Bug:
At first, when the page loads the alignment is wrong like this for a few seconds.
This delay is caused because the function calculateFormattedTimeWidth Function hasn't finished executing
<details>
<summary>Screenshot</summary>

![Screenshot (294)](https://github.com/zulip/zulip/assets/92683836/67331652-5def-447e-8801-42d723b74fe9)

</details>





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed them, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
