### PR TITLE
settings: Display translated message after updating default language.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -394,6 +394,13 @@ async function test_default_language_setting(page: Page): Promise<void> {
     await change_language(page, chinese_language_data_code);
     // Check that the saved indicator appears
     await check_language_setting_status(page);
+    // TODO: Uncomment lines below when the translation in locale/zh_Hans/LC_MESSAGES/django.po is available.
+    // const text = await common.get_text_from_selector(
+    //     page,
+    //     "#user-preferences .general-settings-status",
+    // );
+    // assert.equal(text, "已保存。请重新加载使更改生效。");
+
     await page.click(".reload_link");
     await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,

--- a/web/src/settings_display.js
+++ b/web/src/settings_display.js
@@ -7,7 +7,7 @@ import * as channel from "./channel";
 import * as dialog_widget from "./dialog_widget";
 import * as emojisets from "./emojisets";
 import * as hash_parser from "./hash_parser";
-import {$t_html, get_language_list_columns, get_language_name} from "./i18n";
+import {$t, $t_html, get_language_list_columns, get_language_name} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -100,21 +100,25 @@ function user_default_language_modal_post_render() {
                 setting_value,
             );
 
-            change_display_setting(
+            const $spinner = $("#settings_content").find(".general-settings-status");
+            $spinner.fadeTo(0, 1);
+            loading.make_indicator($spinner, {text: $t({defaultMessage: "Saving"})});
+            channel.patch({
+                url: "/json/settings",
                 data,
-                $("#settings_content").find(".general-settings-status"),
-                $t_html(
-                    {
-                        defaultMessage:
-                            "Saved. Please <z-link>reload</z-link> for the change to take effect.",
-                    },
-                    {
-                        "z-link": (content_html) =>
-                            `<a class='reload_link'>${content_html.join("")}</a>`,
-                    },
-                ),
-                true,
-            );
+                success(response_data) {
+                    const appear_after = 500;
+                    const success_msg_html =
+                        response_data.msg || $t_html({defaultMessage: "Saved"});
+                    setTimeout(() => {
+                        ui_report.success(success_msg_html, $spinner);
+                        settings_ui.display_checkmark($spinner);
+                    }, appear_after);
+                },
+                error(xhr) {
+                    ui_report.error($t_html({defaultMessage: "Save failed"}), xhr, $spinner);
+                },
+            });
         });
 }
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -384,7 +384,14 @@ class ChangeSettingsTest(ZulipTestCase):
             data = {setting_name: orjson.dumps(test_value).decode()}
 
         result = self.client_patch("/json/settings", data)
-        self.assert_json_success(result)
+        json_result = self.assert_json_success(result)
+        if setting_name == "default_language":
+            self.assertEqual(
+                json_result["msg"],
+                "Saved. Please <a class='reload_link'>reload</a> for the change to take effect.",
+            )
+        else:
+            self.assertEqual(json_result["msg"], "")
         user_profile = self.example_user("hamlet")
         self.assertEqual(getattr(user_profile, setting_name), test_value)
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -12,6 +12,7 @@ from django.utils.html import escape
 from django.utils.safestring import SafeString
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.utils.translation import override as override_language
 
 from confirmation.models import (
     Confirmation,
@@ -378,6 +379,11 @@ def json_change_settings(
     request_settings = {k: v for k, v in locals().items() if k in user_profile.property_types}
     for k, v in request_settings.items():
         if v is not None and getattr(user_profile, k) != v:
+            if k == "default_language":
+                with override_language(v):
+                    result["msg"] = _(
+                        "Saved. Please <a class='reload_link'>reload</a> for the change to take effect."
+                    )
             do_change_user_setting(user_profile, k, v, acting_user=user_profile)
 
     if timezone is not None and user_profile.timezone != timezone:


### PR DESCRIPTION
This commit updates the /json/settings endpoint to return a message in the preferred language that tells the user to reload the browser and updates the UI to display the message when the default language has been changed.

The translated message is returned as the `msg` property of the response data, but I am not sure that is the intended usage of the `msg` property and whether it is more desirable to add a new field to the response.

The test in `settings.test.ts` relies on the Simplified Chinese translation of the helper message. The test is currently commented out because we don't have the necessary translation in `locale/zh_Hans/LC_MESSAGES/django.po`.

<!-- Describe your pull request here.-->

Fixes: #25552

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

(Note: to view the effect of this PR, the `django.po` file for different languages should have a translation for the sentence "Saved. Please <a class='reload_link'>reload</a> for the change to take effect." I manually added one to `locale/zh_Hans/LC_MESSAGES/django.po` before taking the screenshot below.)

The screenshot shows the message displayed after the default language is changed from English to Simplified Chinese.

![translated_reload_message](https://github.com/zulip/zulip/assets/7645930/bde12576-173e-48aa-872f-7bbee1d7122f)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
