### PR TITLE
compose_banner: Show banner when automatically follow or unmute a topic. 

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -13,11 +13,13 @@ export function set_scroll_to_message_banner_message_id(val: number | null): voi
 // banner types
 export const WARNING = "warning";
 export const ERROR = "error";
+export const SUCCESS = "success";
 
 const MESSAGE_SENT_CLASSNAMES = {
     sent_scroll_to_view: "sent_scroll_to_view",
     narrow_to_recipient: "narrow_to_recipient",
     message_scheduled_success_compose_banner: "message_scheduled_success_compose_banner",
+    automatic_new_visibility_policy: "automatic_new_visibility_policy",
 };
 // Technically, unmute_topic_notification is a message sent banner, but
 // it has distinct behavior / look - it has an associated action button,

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -182,6 +182,17 @@ export function initialize() {
     $("body").on(
         "click",
         `.${CSS.escape(
+            compose_banner.CLASSNAMES.automatic_new_visibility_policy,
+        )} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            window.location.href = "/#settings/notifications";
+        },
+    );
+
+    $("body").on(
+        "click",
+        `.${CSS.escape(
             compose_banner.CLASSNAMES.unscheduled_message,
         )} .main-view-banner-action-button`,
         (event) => {

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -84,15 +84,13 @@ function resend_message(message, $row, {on_send_message_success, send_message}) 
     message.queue_id = page_params.queue_id;
     message.resend = true;
 
-    const local_id = message.local_id;
-
     function on_success(data) {
         const message_id = data.id;
-        const locally_echoed = true;
+        message.locally_echoed = true;
 
         hide_retry_spinner($row);
 
-        on_send_message_success(local_id, message_id, locally_echoed);
+        on_send_message_success(message, data);
 
         // Resend succeeded, so mark as no longer failed
         failed_message_success(message_id);

--- a/web/src/transmit.js
+++ b/web/src/transmit.js
@@ -26,7 +26,8 @@ export function send_message(request, on_success, error) {
             data: request,
             success: function success(data) {
                 // Call back to our callers to do things like closing the compose
-                // box and turning off spinners and reifying locally echoed messages.
+                // box, turning off spinners, reifying locally echoed messages and
+                // displaying visibility policy related compose banners.
                 on_success(data);
                 // Once everything is done, get ready to report times to the server.
                 const state = sent_messages.get_message_state(request.local_id);

--- a/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
+++ b/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
@@ -1,0 +1,10 @@
+{{#> compose_banner }}
+    <p class="banner_message">
+        {{#if followed}}
+            {{#tr}}Now following {{/tr}}
+        {{else}}
+            {{#tr}}Unmuted {{/tr}}
+        {{/if}}
+        <a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{stream_topic}}</a>.
+    </p>
+{{/compose_banner}}


### PR DESCRIPTION
Fixes the first two checkbox of #26900 

[screen-capture (1).webm](https://github.com/zulip/zulip/assets/56781761/3b9cb3a0-6378-4262-964c-094ba18d40ff)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
