### PR TITLE
stream: added join/leave notifications in private streams via notification bot.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -477,17 +477,37 @@ def send_stream_creation_events_for_previously_inaccessible_streams(
             send_stream_creation_event(realm, stream, notify_user_ids, recent_traffic)
 
 
+def send_leave_notifications_to_private_streams(
+    private_stream: Stream,
+    unsubscribers: List[UserProfile],
+    realm: Realm,
+) -> None:
+    for unsubscribed_user in unsubscribers:
+        if unsubscribed_user.is_bot:
+            # Prevent 'state mismatch' issues when removing peers from a private stream during a change in the bot owner.
+            # see more at - https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#testing
+            continue
+        sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+        msg = _("@_**{user}** left this stream.").format(user=unsubscribed_user.full_name)
+        internal_send_stream_message(
+            sender=sender, stream=private_stream, topic="stream events", content=msg
+        )
+
+
 def send_peer_subscriber_events(
     op: str,
     realm: Realm,
     stream_dict: Dict[int, Stream],
     altered_user_dict: Dict[int, Set[int]],
     subscriber_peer_info: SubscriberPeerInfo,
+    user_profile_from_id: Optional[Dict[int, UserProfile]] = None,
 ) -> None:
     # Send peer_add/peer_remove events to other users who are tracking the
     # subscribers lists of streams in their browser; everyone for
     # public streams and only existing subscribers for private streams.
 
+    if user_profile_from_id is None:
+        user_profile_from_id = defaultdict(UserProfile)
     assert op in ["peer_add", "peer_remove"]
 
     private_stream_ids = [
@@ -498,6 +518,15 @@ def send_peer_subscriber_events(
     for stream_id in private_stream_ids:
         altered_user_ids = altered_user_dict[stream_id]
         peer_user_ids = private_peer_dict[stream_id] - altered_user_ids
+
+        if op == "peer_remove":
+            unsubscribers = [user_profile_from_id[id] for id in altered_user_ids]
+            # send user-left notification via notification-bot in private streams
+            send_leave_notifications_to_private_streams(
+                private_stream=stream_dict[stream_id],
+                unsubscribers=unsubscribers,
+                realm=realm,
+            )
 
         if peer_user_ids and altered_user_ids:
             event = dict(
@@ -721,6 +750,7 @@ def send_peer_remove_events(
     realm: Realm,
     streams: List[Stream],
     altered_user_dict: Dict[int, Set[int]],
+    user_profile_by_id: Dict[int, UserProfile],
 ) -> None:
     subscriber_peer_info = bulk_get_subscriber_peer_info(
         realm=realm,
@@ -734,6 +764,7 @@ def send_peer_remove_events(
         stream_dict=stream_dict,
         altered_user_dict=altered_user_dict,
         subscriber_peer_info=subscriber_peer_info,
+        user_profile_from_id=user_profile_by_id,
     )
 
 
@@ -758,9 +789,11 @@ def send_subscription_remove_events(
 ) -> None:
     altered_user_dict: Dict[int, Set[int]] = defaultdict(set)
     streams_by_user: Dict[int, List[Stream]] = defaultdict(list)
+    user_profile_by_id: Dict[int, UserProfile] = defaultdict(UserProfile)
     for user, stream in removed_subs:
         streams_by_user[user.id].append(stream)
         altered_user_dict[stream.id].add(user.id)
+        user_profile_by_id[user.id] = user
 
     for user_profile in users:
         if len(streams_by_user[user_profile.id]) == 0:
@@ -780,6 +813,7 @@ def send_subscription_remove_events(
         realm=realm,
         streams=streams,
         altered_user_dict=altered_user_dict,
+        user_profile_by_id=user_profile_by_id,
     )
 
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -126,7 +126,7 @@ def add_emoji_to_message() -> Dict[str, object]:
 
     # The message ID here is hardcoded based on the corresponding value
     # for the example message IDs we use in zulip.yaml.
-    message_id = 47
+    message_id = 43
     emoji_name = "octopus"
     emoji_code = "1f419"
     reaction_type = "unicode_emoji"

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -674,11 +674,18 @@ def add_subscriptions_backend(
     result: Dict[str, Any] = dict(
         subscribed=defaultdict(list), already_subscribed=defaultdict(list)
     )
+
+    private_streams_add_subscribers: Dict[Stream, List[UserProfile]] = defaultdict(list)
+
     for sub_info in subscribed:
         subscriber = sub_info.user
         stream = sub_info.stream
         result["subscribed"][subscriber.email].append(stream.name)
         email_to_user_profile[subscriber.email] = subscriber
+        # Filtering out only private streams and subscribers
+        if stream.invite_only and subscriber != user_profile and not subscriber.is_bot:
+            private_streams_add_subscribers[stream].append(subscriber)
+
     for sub_info in already_subscribed:
         subscriber = sub_info.user
         stream = sub_info.stream
@@ -696,11 +703,41 @@ def add_subscriptions_backend(
         announce=announce,
     )
 
+    # Using notification bot to notify other private members that, someone got added
+    send_add_notifications_to_private_streams(
+        realm=realm,
+        user_profile=user_profile,
+        private_streams_add_subscribers=private_streams_add_subscribers,
+    )
+
     result["subscribed"] = dict(result["subscribed"])
     result["already_subscribed"] = dict(result["already_subscribed"])
     if not authorization_errors_fatal:
         result["unauthorized"] = [s.name for s in unauthorized_streams]
     return json_success(request, data=result)
+
+
+def send_add_notifications_to_private_streams(
+    realm: Realm,
+    user_profile: UserProfile,
+    private_streams_add_subscribers: Dict[Stream, List[UserProfile]],
+) -> None:
+    notifications = []
+    for private_stream in private_streams_add_subscribers:
+        subscribers = private_streams_add_subscribers[private_stream]
+        sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+        for subscriber in subscribers:
+            msg = _("@_**{user1}** added @_**{user2}** to this stream.").format(
+                user1=user_profile.full_name, user2=subscriber.full_name
+            )
+            notifications.append(
+                internal_prep_stream_message(
+                    sender=sender, stream=private_stream, content=msg, topic="stream events"
+                )
+            )
+
+    if len(notifications) > 0:
+        do_send_messages(notifications, mark_as_read=[user_profile.id])
 
 
 def send_messages_for_new_subscribers(


### PR DESCRIPTION
user (un)subscription events now will be send out via notification bot in private streams.
[discussion.](https://chat.zulip.org/#narrow/stream/2-general/topic/Non.20PR.20code.20review)

<!-- Describe your pull request here.-->
Added two function in `zerver/actions/streams.py` and `zerver/views/streams.py`  to send user-left and user-join notifications respectively via notification bot. I also added few test cases to account for the new notifications.

Fixes: <!-- Issue link, or clear description.--> #2746

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:** As seen here there will be different message for adding 1, 2 or more users to a private stream, user-left messages are unchanged for every unsubscription.
![notification_bot](https://github.com/zulip/zulip/assets/69990740/023bc589-9703-4640-ad82-036ed93d3350)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
