### PR TITLE
global: Remove type stub for Bootstrap modal

### DIFF
--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -26,7 +26,6 @@ interface JQuery {
     expectOne(): this;
     get_offset_to_window(): DOMRect;
     tab(action?: string): this; // From web/third/bootstrap
-    modal(action?: string): this; // From web/third/bootstrap
 
     // Types for jquery-caret-plugin
     caret(): number;


### PR DESCRIPTION
Commit 747b62d0508737254fa31899c044b32e7269dc0d (#27124) removed the code.