### PR TITLE
emails: Suggest resetting password if having trouble logging in.

### DIFF
--- a/help/include/change-password-via-email-confirmation.md
+++ b/help/include/change-password-via-email-confirmation.md
@@ -2,7 +2,7 @@
 
 1. If you are logged in, start by [logging out](/help/logging-out).
 
-2. Go to your organization's log in page at `https://<organization-url>/login/`.
+2. Go to your organization's login page at `https://<organization-url>/login/`.
 
 3. Click the **Forgot your password?** link below the **Log in** button or
    buttons.

--- a/templates/zerver/emails/find_team.html
+++ b/templates/zerver/emails/find_team.html
@@ -15,7 +15,11 @@
     {% endfor %}
 </ul>
 
-<p>{% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}</p>
+<p>
+    {% trans help_url="https://zulip.com/help/change-your-password#if-youve-forgotten-or-never-had-a-password" %}
+    If you have trouble logging in, you can <a href="{{ help_url }}">reset your password</a>.
+    {% endtrans %}
+</p>
 
 <p>{{ _("Thanks for using Zulip!") }}</p>
 {% endblock %}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -9,7 +9,8 @@ Your email address {{ email }} has accounts with the following Zulip organizatio
 * {{ realm.name }}: {{ realm.uri }}
 {% endfor %}
 
-{% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}
-
+{% trans help_url="https://zulip.com/help/change-your-password#if-youve-forgotten-or-never-had-a-password" %}
+If you have trouble logging in, you can reset your password ({{ help_url }}).
+{% endtrans %}
 
 {{ _("Thanks for using Zulip!") }}


### PR DESCRIPTION
This suggests resetting the user's password, rather than contacting support, if a user has trouble logging in after finding their account. (Proposed by @timabbott )

## Questions 
- Should this be implemented with a variable for the help center URL? I wasn't sure where to put it if so.

<img width="703" alt="Screenshot 2023-10-16 at 3 49 47 PM" src="https://github.com/zulip/zulip/assets/2090066/cbc0b0d9-da18-43cc-980a-56ea7601d54d">
