### PR TITLE
help: Document bot owners can delete messages sent by their bots.

### DIFF
--- a/help/delete-a-message.md
+++ b/help/delete-a-message.md
@@ -73,6 +73,11 @@ you also delete the message.
 
 {end_tabs}
 
+!!! tip ""
+
+    You can delete messages sent by [bots that you
+    own](/help/view-your-bots) just like messages you sent yourself.
+
 ## Restoring deleted messages
 
 For protection against accidental or immediately regretted

--- a/help/restrict-message-editing-and-deletion.md
+++ b/help/restrict-message-editing-and-deletion.md
@@ -13,7 +13,7 @@ Note that if a user can edit a message, they can also "delete" it by removing
 all the message content. This is different from proper message deletion in two
 ways: the original content will still show up in [message edit
 history](/help/view-a-messages-edit-history), and will be included in
-[exports](/help/export-your-organization). Deletion permanently (and
+[data exports](/help/export-your-organization). Deletion permanently (and
 irretrievably) removes the message from Zulip.
 
 ## Configure message editing permissions
@@ -51,6 +51,11 @@ irretrievably) removes the message from Zulip.
 {!save-changes.md!}
 
 {end_tabs}
+
+!!! tip ""
+
+    A user can delete messages sent by [bots that they
+    own](/help/view-your-bots) just like messages they sent themself.
 
 ## Related articles
 

--- a/help/view-your-bots.md
+++ b/help/view-your-bots.md
@@ -1,7 +1,6 @@
 # View your bots
 
-You can view the bots you have added to your Zulip organization, including
-deactivated bots.
+You can view the bots that you own, including deactivated bots.
 
 You can also [deactivate](/help/deactivate-or-reactivate-a-bot#deactivate-a-bot),
 [reactivate](/help/deactivate-or-reactivate-a-bot#reactivate-a-bot) or


### PR DESCRIPTION
This is a follow-up PR to document the new feature added in #26008.

Fixes: #27189.

**Screenshots and screen captures:**
- https://zulip.com/help/delete-a-message
![image](https://github.com/zulip/zulip/assets/2343554/d9694206-647a-4cb7-af1c-262fb5a6f4d0)
- https://zulip.com/help/view-your-bots
![image](https://github.com/zulip/zulip/assets/2343554/24c8c7e7-a847-46e1-9bc9-4008ea11b296)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Feature.
- [x] Visual appearance of the changes.
- [x] Links.
</details>

