### PR TITLE
inbox: Fix empty text visible with visible unread rows.

### DIFF
--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -1020,7 +1020,10 @@ export function update() {
         if (stream_unread_count > 0) {
             // Stream isn't rendered.
             if (topics_dict.get(stream_key) === undefined) {
-                has_topics_post_filter = insert_stream(stream_id, topic_dict);
+                const is_stream_visible = insert_stream(stream_id, topic_dict);
+                if (is_stream_visible) {
+                    has_topics_post_filter = true;
+                }
                 continue;
             }
 


### PR DESCRIPTION
If the last returned value of `insert_stream` was false, `has_topics_post_filter` was false and hence this empty text was visible.

We only need one of the inserted streams to visible to hide the empty text.
![image](https://github.com/zulip/zulip/assets/25124304/65053f28-e2d9-42b3-a60b-15e2e62375fb)

Reproducer:

* Mark all messages as read.
* mark one message in denmark as unread.
* mute #support (any stream that would come later to denmak alphabetically)
* sent a message support from a different user while inbox is open.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Inbox.20no.20messages.20incorrect.20in.20pinned.20tab