### PR TITLE
(draft) message_ui: Show recipient bar controls on hover

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -475,6 +475,18 @@ export function initialize() {
         narrow.by_topic(row_id, {trigger: "message header"});
     });
 
+    // Hover on recipient bar to show the controls / options for the topic
+    // Options are visible by default on the sticky headers
+    $("body").on("mouseenter", ".message_header", (e) => {
+        const $bar_controls = $(e.target).find(".recipient_bar_controls");
+        $bar_controls.removeClass("hide-recipient-bar-controls");
+    });
+
+    $("body").on("mouseleave", ".message_header", (e) => {
+        const $bar_controls = $(e.target).find(".recipient_bar_controls");
+        $bar_controls.addClass("hide-recipient-bar-controls");
+    });
+
     // SIDEBARS
     $("#user_presences")
         .expectOne()

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1589,6 +1589,10 @@ td.pointer {
             .recipient_row_date {
                 display: block;
             }
+
+            .hide-recipient-bar-controls {
+                visibility: visible;
+            }
         }
 
         .hide-recipient-bar-controls {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1590,6 +1590,10 @@ td.pointer {
                 display: block;
             }
         }
+
+        .hide-recipient-bar-controls {
+            visibility: hidden;
+        }
     }
 }
 

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -30,7 +30,7 @@
                 {{/if}}
             </a>
         </span>
-        <span class="recipient_bar_controls no-select">
+        <span class="recipient_bar_controls no-select hide-recipient-bar-controls">
             <span class="topic_edit hidden-for-spectators">
                 <span class="topic_edit_form"></span>
             </span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #26852 

[CZO thread (design discussion)](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20recipient.20bar/near/1598308)

- Recipient bars show the action buttons on cursor hover, except for the sticky recipient bar.
- There is a `mouseenter` and `mouseleave` event attached to recipient bar which triggers addition of the CSS property `visibility: hidden;` to the options div.
- This is implemented by toggling the class `hide-recipient-bar-controls` whenever the appropriate events occur.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Final Look
![zulip-268](https://github.com/zulip/zulip/assets/11803841/269af734-bcca-49d5-831f-9bc993f32c9b)

<details>
<summary><strong>
*Previously* (All controls visible)
</strong></summary>
<img width="600" src="https://github.com/zulip/zulip/assets/11803841/fea24578-27a3-42b9-adef-221b65b48949">
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
