### PR TITLE
create_user: Use silent mentions in personal notification.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -254,7 +254,7 @@ def process_new_human_user(
                 get_system_bot(settings.NOTIFICATION_BOT, prereg_user.referred_by.realm_id),
                 prereg_user.referred_by,
                 _("{user} accepted your invitation to join Zulip!").format(
-                    user=f"{user_profile.full_name} <`{user_profile.email}`>"
+                    user=silent_mention_syntax_for_user(user_profile)
                 ),
             )
 

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -957,7 +957,7 @@ class InviteUserTest(InviteUserBase):
         self.assertEqual(inviter_msg.sender.email, "notification-bot@zulip.com")
         self.assertTrue(
             inviter_msg.content.startswith(
-                f"alice_zulip.com <`{invitee_profile.email}`> accepted your",
+                f"@_**{invitee_profile.full_name}|{invitee_profile.id}** accepted your",
             )
         )
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -826,7 +826,7 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
-        with self.assert_database_query_count(92):
+        with self.assert_database_query_count(93):
             with self.assert_memcached_count(23):
                 with self.capture_send_event_calls(expected_num_events=11) as events:
                     fred = do_create_user(


### PR DESCRIPTION
Fixes #27243

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> Use silent mentions in personal notification that invite was accepted.

Added new query because my change requests for user_profile.full_name 

sql: SELECT "zerver_userprofile"."id", "zerver_userprofile"."full_name" FROM "zerver_userprofile" WHERE ("zerver_userprofile"."is_active" AND "zerver_userprofile"."realm_id" = 2 AND UPPER("zerver_userprofile"."full_name"::text) = UPPER('Fred Flintstone'))

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| ![Screenshot from 2023-10-17 23-51-36](https://github.com/zulip/zulip/assets/90370535/ab735651-dd68-4cb2-9dae-0423b47905fa)| ![Screenshot from 2023-10-17 14-19-35](https://github.com/zulip/zulip/assets/90370535/89aa45d3-e0b6-4f23-a33f-5b2a575e565f)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
