### PR TITLE
message_tests: Remove flaky click-and-wait lines.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -142,8 +142,6 @@ async function search_and_check(
     check: (page: Page) => Promise<void>,
     expected_narrow_title: string,
 ): Promise<void> {
-    await page.click(".search_icon");
-    await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", search_str, item_to_select);
     await check(page);
     assert.strictEqual(await page.title(), expected_narrow_title);
@@ -152,8 +150,6 @@ async function search_and_check(
 }
 
 async function search_silent_user(page: Page, str: string, item: string): Promise<void> {
-    await page.click(".search_icon");
-    await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await page.waitForSelector(".empty_feed_notice", {visible: true});
     const expect_message = "You haven't received any messages sent by Email Gateway yet.";
@@ -184,8 +180,6 @@ async function expect_non_existing_users(page: Page): Promise<void> {
 }
 
 async function search_non_existing_user(page: Page, str: string, item: string): Promise<void> {
-    await page.click(".search_icon");
-    await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await expect_non_existing_user(page);
     await un_narrow(page);


### PR DESCRIPTION
These lines have been failing more reguarly in both CI and development, making it a time-consuming task to hunt down genuine failures in other tests.

Note that the tests otherwise continue to pass when these lines are removed, meaning that they really only ever tested the rather obvious behavior of clicking to reveal an expanded search box.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/removing.20flaky.20Puppeteer.20tests/near/1664105)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>