### PR TITLE
user topics: Delay rerendering all messages.

### DIFF
--- a/web/src/user_topics_ui.js
+++ b/web/src/user_topics_ui.js
@@ -18,9 +18,6 @@ export function handle_topic_updates(user_topic_event) {
     stream_list.update_streams_sidebar();
     unread_ui.update_unread_counts();
     message_lists.current.update_muting_and_rerender();
-    if (message_lists.current !== message_lists.home) {
-        message_lists.home.update_muting_and_rerender();
-    }
     recent_view_ui.update_topic_visibility_policy(
         user_topic_event.stream_id,
         user_topic_event.topic_name,
@@ -48,6 +45,14 @@ export function handle_topic_updates(user_topic_event) {
             settings_user_topics.populate_list();
         }
     }
+
+    setTimeout(0, () => {
+        /* Rerender "all messages" if necessary, but defer until after
+         * the browser has rendered the DOM updates scheduled above. */
+        if (message_lists.current !== message_lists.home) {
+            message_lists.home.update_muting_and_rerender();
+        }
+    });
 }
 
 export function toggle_topic_visibility_policy(message) {


### PR DESCRIPTION
Rerendering of "all messages" is slow, and by definition, not visible to the user, so make sure the browser gets an opportunity to rerender the content that is visible before starting that expensive computation.

Addresses https://chat.zulip.org/#narrow/stream/9-issues/topic/lag.20in.20closing.20topic.20menu.20after.20choosing.20following/near/1662023