### PR TITLE
Renaming graph to source

### DIFF
--- a/zerver/webhooks/alertmanager/tests.py
+++ b/zerver/webhooks/alertmanager/tests.py
@@ -10,8 +10,8 @@ class AlertmanagerHookTests(WebhookTestCase):
         expected_topic = "andromeda"
         expected_message = """
 :alert: **FIRING**
-* CPU core temperature is 34.75C ([graph](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
-* CPU core temperature is 17.625C ([graph](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
+* CPU core temperature is 34.75C ([source](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
+* CPU core temperature is 17.625C ([source](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
 """.strip()
 
         self.check_webhook(
@@ -24,7 +24,7 @@ class AlertmanagerHookTests(WebhookTestCase):
     def test_single_error_issue_message(self) -> None:
         expected_topic = "andromeda"
         expected_message = """
-:squared_ok: **Resolved** CPU core temperature is 34.75C ([graph](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
+:squared_ok: **Resolved** CPU core temperature is 34.75C ([source](http://cobalt:9090/graph?g0.expr=avg+by%28host%29+%28sensors_temp_input%7Bfeature%3D~%22core_%5B0-9%5D%2B%22%7D%29+%3E+15&g0.tab=0))
 """.strip()
 
         self.check_webhook(

--- a/zerver/webhooks/alertmanager/view.py
+++ b/zerver/webhooks/alertmanager/view.py
@@ -35,7 +35,7 @@ def api_alertmanager_webhook(
 
         url = alert["generatorURL"].tame(check_string).replace("tab=1", "tab=0")
 
-        body = f"{desc} ([graph]({url}))"
+        body = f"{desc} ([source]({url}))"
         if name not in topics:
             topics[name] = {"firing": [], "resolved": []}
         topics[name][alert["status"].tame(check_string)].append(body)


### PR DESCRIPTION
Renaming "graph" to "source" in Alertmanager's integration messages

Fixes: None

We use Alertmanager as an aggregation place for example for failing CI pipelines, and `graph` does not always reflect the source of the alert. It's called `source` originally and I think it should stay this way. 

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.


