### PR TITLE
wildcard_mention: accounts for large stream threshold

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -346,7 +346,7 @@ export function wildcard_mention_allowed() {
 
     // For subscriber counts not greater than the large stream threshold
     if (
-        subscriber_count <= 
+        subscriber_count <=
         wildcard_mention_large_stream_threshold
     ) {
         if (page_params.is_guest) {

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -350,7 +350,7 @@ export function wildcard_mention_allowed() {
 
     // If subscriber count is greater than the global large stream threshold variable
     if (subscriber_count > wildcard_mention_large_stream_threshold) {
-        
+
         // check organization permission settings for appropriate permissions.
         if (
             page_params.realm_wildcard_mention_policy ===

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -341,47 +341,67 @@ function check_unsubscribed_stream_for_send(stream_name, autosubscribe) {
 }
 
 export function wildcard_mention_allowed() {
-    if (
-        page_params.realm_wildcard_mention_policy ===
-        settings_config.wildcard_mention_policy_values.by_everyone.code
-    ) {
-        return true;
-    }
-    if (
-        page_params.realm_wildcard_mention_policy ===
-        settings_config.wildcard_mention_policy_values.nobody.code
-    ) {
-        return false;
-    }
-    if (
-        page_params.realm_wildcard_mention_policy ===
-        settings_config.wildcard_mention_policy_values.by_admins_only.code
-    ) {
-        return page_params.is_admin;
-    }
 
-    if (
-        page_params.realm_wildcard_mention_policy ===
-        settings_config.wildcard_mention_policy_values.by_moderators_only.code
-    ) {
-        return page_params.is_admin || page_params.is_moderator;
-    }
+    // Get the stream_id of the current compose state
+    const stream_id = compose_state.stream_id();
 
-    if (
-        page_params.realm_wildcard_mention_policy ===
-        settings_config.wildcard_mention_policy_values.by_full_members.code
-    ) {
-        if (page_params.is_admin) {
+    // Use the stream_id to get the subscriber count
+    const subscriber_count = peer_data.get_subscriber_count(stream_id) || 0;
+
+    // If subscriber count is greater than the global large stream threshold variable
+    if (subscriber_count > wildcard_mention_large_stream_threshold) {
+        
+        // check organization permission settings for appropriate permissions.
+        if (
+            page_params.realm_wildcard_mention_policy ===
+            settings_config.wildcard_mention_policy_values.by_everyone.code
+        ) {
             return true;
         }
-        const person = people.get_by_user_id(page_params.user_id);
-        const current_datetime = new Date(Date.now());
-        const person_date_joined = new Date(person.date_joined);
-        const days = (current_datetime - person_date_joined) / 1000 / 86400;
+        if (
+            page_params.realm_wildcard_mention_policy ===
+            settings_config.wildcard_mention_policy_values.nobody.code
+        ) {
+            return false;
+        }
+        if (
+            page_params.realm_wildcard_mention_policy ===
+            settings_config.wildcard_mention_policy_values.by_admins_only.code
+        ) {
+            return page_params.is_admin;
+        }
 
-        return days >= page_params.realm_waiting_period_threshold && !page_params.is_guest;
+        if (
+            page_params.realm_wildcard_mention_policy ===
+            settings_config.wildcard_mention_policy_values.by_moderators_only.code
+        ) {
+            return page_params.is_admin || page_params.is_moderator;
+        }
+
+        if (
+            page_params.realm_wildcard_mention_policy ===
+            settings_config.wildcard_mention_policy_values.by_full_members.code
+        ) {
+            if (page_params.is_admin) {
+                return true;
+            }
+            const person = people.get_by_user_id(page_params.user_id);
+            const current_datetime = new Date(Date.now());
+            const person_date_joined = new Date(person.date_joined);
+            const days = (current_datetime - person_date_joined) / 1000 / 86400;
+
+            return days >= page_params.realm_waiting_period_threshold && !page_params.is_guest;
+        }
+        return !page_params.is_guest;
+
     }
-    return !page_params.is_guest;
+
+    // For subscriber counts not greater than the threshold
+    if (page_params.is_guest) {
+        return false;  // Guests may not use wildcard mentions
+    }
+
+    return true;  // Allow wildcard mention for non-guests
 }
 
 export function set_wildcard_mention_large_stream_threshold(value) {

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -324,7 +324,7 @@ test_ui("get_invalid_recipient_emails", ({override_rewire}) => {
     assert.deepEqual(compose_validate.get_invalid_recipient_emails(), []);
 });
 
-test_ui("test_wildcard_mention_allowed", () => {
+test_ui("test_wildcard_mention_allowed", ({override_rewire}) => {
     page_params.user_id = me.user_id;
     page_params.realm_mandatory_topics = false;
 

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -326,6 +326,21 @@ test_ui("get_invalid_recipient_emails", ({override_rewire}) => {
 
 test_ui("test_wildcard_mention_allowed", () => {
     page_params.user_id = me.user_id;
+    page_params.realm_mandatory_topics = false;
+
+    const special_sub = {
+        stream_id: 101,
+        name: "special",
+        subscribed: true,
+    };
+    stream_data.add_sub(special_sub);
+
+    compose_state.set_stream_id(special_sub.stream_id);
+
+    override_rewire(peer_data, "get_subscriber_count", (stream_id) => {
+        assert.equal(stream_id, 101);
+        return 16;
+    });
 
     page_params.realm_wildcard_mention_policy =
         settings_config.wildcard_mention_policy_values.by_everyone.code;


### PR DESCRIPTION
I added a logic wrapper to the wildcard_mention_allowed function so it's aware of the large streams threshold when applying permissions for auto completing wild card mentions. This specifically applies to Full Members trying to auto complete wildcards mentions in streams that do not exceed the Large Streams threshold (default is 15 subscribers). It also maintains Guests may never wild card mention, even if the stream subscriber count doesn't exceed the large streams threshold.

Fixes: The function `wildcard_mention_allowed() ` did not take into consideration the Subscriber Count and Large Stream threshold for wildcard mentions during typeahead/autocomplete in the compose text box. This prevented Full Members from having `@**all**`, `@**everyone**`, and `@**stream**` auto completions when messaging streams that do not exceed the Large Streams threshold.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
