### PR TITLE
message_ui: Show non-sticky recipient bar action buttons on hover.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1020,6 +1020,13 @@ export class MessageListView {
             }
         }
 
+        const is_conversation_view = this.list.data.filter.is_conversation_view();
+        if (is_conversation_view) {
+            $(".focused-message-list").addClass("is-conversation-view");
+        } else {
+            $(".focused-message-list").removeClass("is-conversation-view");
+        }
+
         return undefined;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1120,6 +1120,23 @@ td.pointer {
                 top: -0.5px;
             }
         }
+
+        .recipient_bar_controls {
+            visibility: hidden;
+        }
+
+        /* Show the bar controls on hover and when the bar is sticky */
+        &:hover {
+            .recipient_bar_controls {
+                visibility: visible;
+            }
+        }
+
+        &.sticky_header {
+            .recipient_bar_controls {
+                visibility: visible;
+            }
+        }
     }
 }
 
@@ -1478,6 +1495,13 @@ div.message-list {
 
 div.focused-message-list {
     display: block;
+}
+
+/* In conversation view, always show the recipient bar action buttons */
+div.focused-message-list.is-conversation-view .recipient_row {
+    & .recipient_bar_controls {
+        visibility: visible;
+    }
 }
 
 .rtl {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1125,6 +1125,11 @@ td.pointer {
             visibility: hidden;
         }
 
+        /* When any of the actions are focused, don't hide them */
+        .recipient_bar_controls:focus-within {
+            visibility: visible;
+        }
+
         /* Show the bar controls on hover and when the bar is sticky */
         &:hover {
             .recipient_bar_controls {
@@ -1511,6 +1516,7 @@ div.focused-message-list.is-conversation-view .recipient_row {
 .topic_edit {
     display: none;
     line-height: 22px;
+    visibility: visible;
 
     .alert {
         display: inline-block;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #26852 

[CZO thread (The design idea discussion)](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20recipient.20bar/near/1598308)
[CZO thread (Implementation approach discussion)](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Show.20action.20buttons.20on.20hover.20.28recipient.20bars.29)

- Recipient bars show the action buttons on hover, except for the sticky recipient bar which always shows the action buttons.
- The CSS rule `visibility: hidden;` is toggled on hover, and `visibility: visible;` applied if the bar is sticky.
- The disappearance of the action buttons when action UI (notification menu, topic editing UI) is shown is prevented by using `:focus-within` CSS pseudo class on the recipient_bar to add `visibility: visible` to the action buttons.
- In case of conversation views, since there is a single message box present, the controls are made forever visible by using the CSS `:only-child` pseudo selector.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Final Look
![zulip-268](https://github.com/zulip/zulip/assets/11803841/269af734-bcca-49d5-831f-9bc993f32c9b)

<details><summary>Action UI remains intact</summary>
<img width="600" src="https://github.com/zulip/zulip/assets/11803841/e305502d-3bb1-4f45-9d34-7fedac930ec0">
</details>

<details>
<summary><strong>
Previously (All controls visible)
</strong></summary>
<img width="600" src="https://github.com/zulip/zulip/assets/11803841/fea24578-27a3-42b9-adef-221b65b48949">
</details>

<details><summary>Conversation view</summary>
<img src="https://github.com/zulip/zulip/assets/11803841/2b94919f-774b-4d08-8788-e44881a747c7" width="1000"/>
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
