### PR TITLE
Change "audio" references to "voice"

### DIFF
--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -65,7 +65,7 @@ supported by zulip are:
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings** select appropriate provider from **Video call provider** dropdown.
+1. Under **Other settings** select appropriate provider from **Call provider** dropdown.
 
 1. Click **Save changes**.
 

--- a/web/src/compose_call_ui.js
+++ b/web/src/compose_call_ui.js
@@ -33,7 +33,7 @@ function insert_video_call_url(url, target_textarea) {
 }
 
 function insert_audio_call_url(url, target_textarea) {
-    const link_text = $t({defaultMessage: "Join audio call."});
+    const link_text = $t({defaultMessage: "Join voice call."});
     compose_ui.insert_syntax_and_focus(`[${link_text}](${url})`, target_textarea, "block", 1);
 }
 

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -7,8 +7,8 @@
     {{/if}}
     <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
-    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add audio call' }}">
-        <a role="button" class="compose_control_button fa fa-phone audio_link" aria-label="{{t 'Add audio call' }}" tabindex=0></a>
+    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add voice call' }}">
+        <a role="button" class="compose_control_button fa fa-phone audio_link" aria-label="{{t 'Add voice call' }}" tabindex=0></a>
     </div>
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add video call' }}">
         <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0></a>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -107,7 +107,7 @@
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
                     <label for="realm_video_chat_provider" class="dropdown-title">
-                        {{t 'Video call provider' }}
+                        {{t 'Call provider' }}
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
                         {{#each realm_available_video_chat_providers}}

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -197,7 +197,7 @@ test("videos", ({override}) => {
         $("#compose-textarea").val("");
         const audio_handler = $("body").get_on_handler("click", ".audio_link");
         audio_handler(ev);
-        const audio_link_regex = /\[translated: Join audio call\.]\(example\.zoom\.com\)/;
+        const audio_link_regex = /\[translated: Join voice call\.]\(example\.zoom\.com\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, audio_link_regex);
     })();


### PR DESCRIPTION
This changes:

* The compose-box call button tooltip to read "Add voice call"
* The settings menu to reference "Call provider"
* The help docs to reference the new "Call provider" label in the settings menu

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/audio-only.20calls/near/1663648)

**Screenshots and screen captures:**

Compose-box call button tooltip:
<img width="1002" alt="voice-call-tooltip" src="https://github.com/zulip/zulip/assets/170719/6613c9a3-a385-4496-8715-4441b3e95b0d">

Settings menu label:
![settings-call-provider](https://github.com/zulip/zulip/assets/170719/f414e4d9-d464-4bb5-8a32-79a3e151368b)

Start a call provider documentation:
![start-a-call-docs-change](https://github.com/zulip/zulip/assets/170719/abaf9218-7218-4a7f-9ba0-73eeabcb80c5)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>