### PR TITLE
stream_edit: Fix set_stream_property usage

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -301,7 +301,7 @@ function stream_is_muted_changed(e) {
         sub,
         "is_muted",
         e.target.checked,
-        `#stream_change_property_status${CSS.escape(sub.stream_id)}`,
+        $(`#stream_change_property_status${CSS.escape(sub.stream_id)}`),
     );
 }
 


### PR DESCRIPTION
Fixes a regression exposed by eb6ac7bd98089bf08556b66fa7255e64e2cda2c4 (#27053).

[Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Error.20while.20muting.20stream/near/1665169).