### PR TITLE
onboarding-emails: Add new onboarding email for organization creator.

### DIFF
--- a/templates/zerver/emails/onboarding_team_to_zulip.html
+++ b/templates/zerver/emails/onboarding_team_to_zulip.html
@@ -1,0 +1,40 @@
+{% extends "zerver/emails/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_url }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+
+<p>
+    {% trans %}If you've already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
+</p>
+<p>
+    {% trans %}Otherwise, here is some advice we often hear from customers for evaluating <i>any</i> team chat product:{% endtrans %}
+    <ol>
+        <li>{% trans %}<a href="{{ invite_users }}"><b>Invite your teammates</b></a> to explore with you and share their unique perspectives.{% endtrans %}
+            {% trans %}Use the app itself to chat about your impressions.{% endtrans %}
+        </li>
+        <li>{% trans %}<a href="{{ trying_out_zulip}}"><b>Run a week-long trial</b></a> with your team, without using any other chat tools. This is the only way to truly experience how a new chat app will help your team communicate.{% endtrans %}
+        </li>
+    </ol>
+</p>
+<p>
+    {% trans %}Zulip is designed to <a href="{{ why_zulip }}">enable efficient communication</a>, and we hope these tips help your team experience it in action.{% endtrans %}
+</p>
+
+<p>
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
+</p>
+
+{% endblock %}
+
+{% block manage_preferences %}
+
+<p><a href="{{ unsubscribe_link }}">{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}</a></p>
+
+{% endblock %}

--- a/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
@@ -1,0 +1,1 @@
+{{ _("Choosing the chat app for your team") }}

--- a/templates/zerver/emails/onboarding_team_to_zulip.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.txt
@@ -1,0 +1,19 @@
+{% trans %}If you've already decided to use Zulip for your organization, welcome! You can use our guide for setting up your organization to get started.{% endtrans %} [ {{ get_organization_started }} ]
+
+{% trans %}Otherwise, here is some advice we often hear from customers for evaluating any team chat product:{% endtrans %}
+
+
+1. {% trans %}Invite your teammates to explore with you and share their unique perspectives.{% endtrans %} [ {{ invite_users }} ] {% trans %}Use the app itself to chat about your impressions.{% endtrans %}
+
+2. {% trans %}Run a week-long trial with your team, without using any other chat tools. This is the only way to truly experience how a new chat app will help your team communicate.{% endtrans %} [ {{ trying_out_zulip }} ]
+
+{% trans %}Zulip is designed to enable efficient communication, and we hope these tips help your team experience it in action.{% endtrans %} [ {{ why_zulip }} ]
+
+{% if corporate_enabled %}
+    {% trans %}Do you have questions or feedback to share? Contact us at {{ support_email }} — we'd love to help!{% endtrans %}
+{% else %}
+    {% trans %}If you have any questions, please contact this Zulip server's administrators at {{ support_email }}.{% endtrans %}
+{% endif %}
+
+----
+{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}: {{ unsubscribe_link }}

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4635,6 +4635,7 @@ EMAIL_TYPES = {
     "account_registered": ScheduledEmail.WELCOME,
     "onboarding_zulip_topics": ScheduledEmail.WELCOME,
     "onboarding_zulip_guide": ScheduledEmail.WELCOME,
+    "onboarding_team_to_zulip": ScheduledEmail.WELCOME,
     "digest": ScheduledEmail.DIGEST,
     "invitation_reminder": ScheduledEmail.INVITATION_REMINDER,
 }

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -26,7 +26,7 @@ class EmailLogTest(ZulipTestCase):
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
-            self.assertEqual(m.output, [output_log for i in range(17)])
+            self.assertEqual(m.output, [output_log for i in range(18)])
 
     def test_forward_address_details(self) -> None:
         try:

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -402,7 +402,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
             # logger.output is a list of all the log messages captured. Verify it is as expected.
-            self.assertEqual(logger.output, [output_log] * 17)
+            self.assertEqual(logger.output, [output_log] * 18)
 
             # Now, lets actually go the URL the above call redirects to, i.e., /emails/
             result = self.client_get(result["Location"])

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -147,7 +147,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     send_account_registered_email(get_user_by_delivery_email("iago@zulip.com", realm))
 
     # Onboarding emails for admin user
-    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm))
+    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm), realm_creation=True)
 
     # Realm reactivation email
     do_send_realm_reactivation_email(realm, acting_user=None)


### PR DESCRIPTION
Updated version of #26713, which adds a new onboarding email `onboarding_team_to_zulip` for the user who created the new Zulip organization. This PR squashes the commits and updates the text version for the updated HTML version text.

Currently, the URLs in the text version of this new email are in angle brackets ("<") except for the unsubscribe link at the bottom of the email; see [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/URLs.20in.20plain.20text.20versions.20of.20emails/near/1664341) about how we may want to standardize how we format links in the text versions of emails in general.

**Screenshots and screen captures:**

Email subject line, which is not in the screenshots, is **Choosing the chat app for your team**.

<details>
<summary>HTML version in dev environment</summary>

![Screenshot 2023-10-18 at 12 50 17](https://github.com/zulip/zulip/assets/63245456/6fbadfb9-9b28-4942-b036-48aca9e38677)
</details>
<details>
<summary>text version in dev environment</summary>

![Screenshot 2023-10-18 at 12 50 31](https://github.com/zulip/zulip/assets/63245456/193aa4c1-0c2d-4646-b256-4a89bcba741a)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
