### PR TITLE
toggle-stream-subtopics: Expand or collapse stream subtopics on clicking the respective stream topics.

### DIFF
--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -788,13 +788,21 @@ export function set_event_handlers({on_stream_click}) {
         if (e.metaKey || e.ctrlKey) {
             return;
         }
-        const stream_id = stream_id_for_elt($(e.target).parents("li"));
-        on_stream_click(stream_id, "sidebar");
 
-        clear_and_hide_search();
+        if ($("ul#stream_filters li").hasClass("active-filter stream-expanded")) {
+            $("ul#stream_filters li").removeClass("active-filter stream-expanded");
+            $("ul.topic-list").hide();
+        } else {
+            $("ul#stream_filters li").addClass("active-filter stream-expanded");
+            $("ul.topic-list").show();
+            const stream_id = stream_id_for_elt($(e.target).parents("li"));
+            on_stream_click(stream_id, "sidebar");
 
-        e.preventDefault();
-        e.stopPropagation();
+            clear_and_hide_search();
+
+            e.preventDefault();
+            e.stopPropagation();
+        }
     });
 
     $("#clear_search_stream_button").on("click", clear_search);


### PR DESCRIPTION
This Pull Request changes the Side-bar UX to toggle the Stream subtopic open/collapse upon clicking the Stream Topics, along with preserving its previous tendency to collapse other subtopics when new stream topic is clicked. 

Fixes: [#16492](https://github.com/zulip/zulip/issues/16492) Double tap not working to toggle the stream sub topics . 


**Brief Summary of the Commit/Fix**

- First, the ```$("ul#stream_filters li")``` element is checked if it is expanded or not through ```"active-filter stream-expanded"``` existence.
- Upon finding that the topic is expanded, it is collapsed by hiding subtopics ``` $("ul.topic-list").hide();``` and removing the class ```"active-filter stream-expanded"```
- If the topic is not expanded, then the previous behaviour of code is followed.
- When the topic is expanded, and a subtopic is selected, then upon Double-Click on Topic, the Topic is collapsed.

- Expand/Collapse on single click:
![brave_rarV0Jp8dv](https://github.com/zulip/zulip/assets/97049524/9f8ce933-d9c1-48b8-bda1-68df58215f12)

- Collapse on double click if a stream subtopic selected:
![brave_V23YTeFSMD](https://github.com/zulip/zulip/assets/97049524/7af087d5-5b0a-4067-a3bb-1049ac06d1af)

- Preserving previous feature:
![brave_97MW8ZrZ7l](https://github.com/zulip/zulip/assets/97049524/201b1b9e-244c-44ce-9dd4-8cd1f25d5b8f)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
