### PR TITLE
openapi: Remove unused display_brief_error parameter

### DIFF
--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -360,11 +360,7 @@ def fix_events(content: Dict[str, Any]) -> None:
 
 
 def validate_against_openapi_schema(
-    content: Dict[str, Any],
-    path: str,
-    method: str,
-    status_code: str,
-    display_brief_error: bool = False,
+    content: Dict[str, Any], path: str, method: str, status_code: str
 ) -> bool:
     """Compare a "content" dict with the defined schema for a specific method
     in an endpoint. Return true if validated and false if skipped.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -346,7 +346,7 @@ class BaseAction(ZulipTestCase):
             "msg": "",
             "result": "success",
         }
-        validate_against_openapi_schema(content, "/events", "get", "200", display_brief_error=True)
+        validate_against_openapi_schema(content, "/events", "get", "200")
         self.assert_length(events, num_events)
         initial_state = copy.deepcopy(hybrid_state)
         post_process_state(self.user_profile, initial_state, notification_settings_null)


### PR DESCRIPTION
It’s unused since commit a881918a05503574d144fd90669e3a60d8d07684 (#24979).