### PR TITLE
resize: Use correct id for recent view filter buttons.   @amanagr

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -871,21 +871,21 @@ function topic_offset_to_visible_area(topic_row) {
         return undefined;
     }
     const $scroll_container = $("#recent_view_table .table_fix_head");
-    const thead_height = 30;
-    const under_closed_compose_region_height = 50;
+    const thead_height = $scroll_container.find("thead").outerHeight(true);
+    const scroll_container_props = $scroll_container[0].getBoundingClientRect();
 
-    const scroll_container_top = $scroll_container.offset().top + thead_height;
-    const scroll_container_bottom =
-        scroll_container_top + $scroll_container.height() - under_closed_compose_region_height;
+    // Since user cannot see row under thead, exclude it as part of the scroll container.
+    const scroll_container_top = scroll_container_props.top + thead_height;
+    const compose_height = $("#compose").outerHeight(true);
+    const scroll_container_bottom = scroll_container_props.bottom - compose_height;
 
-    const topic_row_top = $topic_row.offset().top;
-    const topic_row_bottom = topic_row_top + $topic_row.height();
+    const topic_props = $topic_row[0].getBoundingClientRect();
 
     // Topic is above the visible scroll region.
-    if (topic_row_top < scroll_container_top) {
+    if (topic_props.top < scroll_container_top) {
         return "above";
         // Topic is below the visible scroll region.
-    } else if (topic_row_bottom > scroll_container_bottom) {
+    } else if (topic_props.bottom > scroll_container_bottom) {
         return "below";
     }
 

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -175,7 +175,7 @@ export function resize_sidebars() {
 }
 
 export function update_recent_view_filters_height() {
-    const recent_view_filters_height = $("#recent_topics_filter_buttons").outerHeight(true) ?? 0;
+    const recent_view_filters_height = $("#recent_view_filter_buttons").outerHeight(true) ?? 0;
     $("html").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
 }
 

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -42,7 +42,6 @@ export function show(opts) {
     compose_recipient.handle_middle_pane_transition();
     search.clear_search_form();
     opts.complete_rerender();
-    resize.update_recent_view_filters_height();
 
     // Misc.
     if (opts.is_recent_view) {


### PR DESCRIPTION
This seems to have left out in the renaming of recent view from
recent table -> recent conversations -> recent view.

`recent_view_filters_height` being `0` resulted in table having
more height than it should have, so when focus was set on a
hidden row, it somehow scrolled the whole table.


discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Row.20of.20buttons.20disappear.20in.20.22Recent.20conversations.22