### PR TITLE
user-profile: deactivated user profile indicator has been added to us…

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -356,6 +356,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         email: user.delivery_email,
         profile_data,
         user_avatar: people.medium_avatar_url_for_person(user),
+        active_user_id: people.is_person_active(user.user_id),
         is_me: people.is_current_user(user.email),
         is_bot: user.is_bot,
         date_joined: timerender.get_localized_date_or_time_for_format(

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -3,9 +3,13 @@
         <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <div class="modal__header">
                 {{#unless is_bot}}
+                {{#if active_user_id}}
                 <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
                     <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
                 </div>
+                {{else}}
+                <i class="fa fa-ban tippy-zulip-tooltip" data-tippy-content="User Deactivated"></i>
+                {{/if}}
                 {{/unless}}
                 <h1 class="modal__title user_profile_name_heading" id="name">
                     {{#if is_bot}}


### PR DESCRIPTION
Deactivated user indicator has been added to the user profile header. Hence deactivated user can be seen as deactivated

Fixes: Issue [link-](https://github.com/zulip/zulip/issues/26861)

### Before Implementation
<img width="1440" alt="Before-Implementation" src="https://github.com/zulip/zulip/assets/83077756/2ea8dd4c-eb46-4c6c-8591-c2da94489fc7">

### After Implementation
<img width="1436" alt="After-Implementation" src="https://github.com/zulip/zulip/assets/83077756/88e3d5a0-3706-478a-bf97-c41b21bcc33b">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
