### PR TITLE
typo: change bot-type link to help center docs.

### DIFF
--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -3,7 +3,7 @@
         <div class="input-group">
             <label for="bot_type">
                 {{t "Bot type" }}
-                <i class="fa fa-question-circle settings-info-icon bot_type_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content='{{t "Incoming webhooks can only send messages." }}'></i>
+                {{> ../help_link_widget link="/help/bots-and-integrations#bot-type" }}
             </label>
             <select name="bot_type" id="create_bot_type" class="modal_select bootstrap-focus-style">
                 {{#each bot_types}}


### PR DESCRIPTION
 The tooltip is removed from the '?' and it is linked to the help path.

Fixes: #27047

**Screenshots and screen captures:**
<img src="https://github.com/zulip/zulip/assets/127927123/2716e85a-2655-49ec-8d8d-a67587aed207" width="300" >
<img src="https://github.com/zulip/zulip/assets/127927123/fc9cec4c-ec90-40f5-a185-198989607ce0" width="300" >



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>





