### PR TITLE
left sidebar: Set new icons and grid-based layout on expanded views rows

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -561,6 +561,8 @@ li.active-sub-filter {
         /* TODO: Set this 24px height value as a variable.
            Keep filter-icon height the full height of the box. */
         height: 24px;
+        /* Enlarge icons slightly in condensed views. */
+        font-size: 15px;
         color: var(--color-left-sidebar-navigation-icon);
     }
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -54,6 +54,10 @@ $before_unread_count_padding: 3px;
     cursor: pointer;
 }
 
+#left-sidebar-navigation-list .filter-icon i {
+    color: var(--color-left-sidebar-navigation-icon);
+}
+
 #stream_filters,
 #left-sidebar-navigation-list {
     margin-right: 12px;
@@ -200,8 +204,6 @@ li.show-more-topics {
 
 .left-sidebar-navigation-area {
     & li a {
-        margin-top: 1px;
-
         &:hover {
             text-decoration: none;
         }
@@ -567,43 +569,11 @@ li.active-sub-filter {
     margin-bottom: $sections_vertical_gutter;
 
     .left-sidebar-navigation-label-container {
-        display: flex;
-        padding-right: 20px;
-
         .left-sidebar-navigation-label {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
-
-            flex-grow: 1;
         }
-    }
-
-    .filter-icon {
-        display: inline-block;
-        min-width: $left_col_size;
-        text-align: center;
-    }
-
-    .filter-icon i {
-        padding-right: 3px;
-        color: var(--color-left-sidebar-navigation-icon);
-    }
-
-    i.fa-align-left {
-        position: relative;
-        font-size: 15px;
-    }
-
-    .top_left_row .unread_count {
-        margin-top: 2px;
-    }
-
-    .zulip-icon-inbox,
-    .zulip-icon-star-filled {
-        font-size: 14px;
-        top: 2px;
-        position: relative;
     }
 }
 
@@ -626,13 +596,9 @@ li.top_left_drafts,
 li.top_left_inbox,
 li.top_left_recent_view,
 li.top_left_scheduled_messages {
+    /* TODO: Clean this up with other vdots
+       positioning stuff. */
     position: relative;
-    padding-top: 1px;
-    padding-bottom: 1px;
-
-    & a {
-        display: block;
-    }
 }
 
 /* Don't show the scheduled messages item... */
@@ -640,13 +606,63 @@ li.top_left_scheduled_messages {
     display: none;
     /* ...unless there are scheduled messages to show. */
     &.show-with-scheduled-messages {
-        display: list-item;
+        /* Use display: grid to preserve the grid
+           layout when visible. */
+        display: grid;
     }
 }
 
 .top_left_row {
-    padding-left: $far_left_gutter_size;
-    padding-right: 10px;
+    /* The row grid for the outer .top_left_row
+       is chiefly for lefthand spacing and placing
+       the inner row content and vdots. */
+    grid-template-columns: 7px 0 minmax(0, 1fr) 0 30px 0;
+
+    .sidebar-menu-icon {
+        grid-area: ending-anchor-element;
+        justify-self: center;
+        /* TODO: Clean up the .sidebar-menu-icon descendant
+           styles up and down the left sidebar. */
+        position: static;
+        font-size: 17px;
+        text-align: center;
+    }
+}
+
+.left-sidebar-navigation-label-container {
+    grid-area: row-content;
+    /* The label container itself is also a grid,
+       for laying out the items that are its
+       children. Same template areas, different
+       column widths. */
+    grid-template-columns: 0 22px minmax(0, 1fr) max-content 0 0;
+    /* This is a legacy value, from a former
+       1px of top padding on top_left_row plus
+       an inner 1px top margin on `<a>` elements.
+
+       These are added here, rather than on the label
+       container, to keep all hovered/highlighted areas
+       clickable.
+
+       This complicates true centering within a
+       row highlight. It might be better to make
+       these both 2px.
+    */
+    padding-top: 2px;
+    padding-bottom: 1px;
+
+    .filter-icon {
+        grid-area: starting-anchor-element;
+        text-align: center;
+    }
+
+    .left-sidebar-navigation-label {
+        grid-area: row-content;
+    }
+
+    .unread_count {
+        grid-area: markers-and-controls;
+    }
 }
 
 .conversation-partners {
@@ -664,6 +680,8 @@ li.top_left_scheduled_messages {
 
 /* New .topic-box grid definitions here. */
 #views-label-container,
+.top_left_row,
+.left-sidebar-navigation-label-container,
 .subscription_block,
 .topic-box {
     display: grid;
@@ -721,7 +739,7 @@ li.top_left_scheduled_messages {
             /* ...except when there is an active filter in place:
                that row should still be shown. */
             & .top_left_row.active-filter {
-                display: block;
+                display: grid;
             }
         }
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -653,7 +653,10 @@ li.top_left_scheduled_messages {
 
     .filter-icon {
         grid-area: starting-anchor-element;
-        text-align: center;
+        /* Use a flex container to handle
+           icon centering within the grid area. */
+        display: flex;
+        justify-content: center;
     }
 
     .left-sidebar-navigation-label {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -662,10 +662,6 @@ li.top_left_scheduled_messages {
     margin-right: 3px;
 }
 
-.top_left_mentions i.fa-at {
-    font-size: 13px;
-}
-
 /* New .topic-box grid definitions here. */
 #views-label-container,
 .subscription_block,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -584,21 +584,6 @@ li.active-sub-filter {
     background-color: unset;
     color: inherit;
     border: 0.5px solid var(--color-border-unread-counter);
-    /* The border takes up space, so we need to
-       subtract 1px from the usual 2px margin-top */
-    margin-top: 1px !important;
-}
-
-li.top_left_all_messages,
-li.top_left_mentions,
-li.top_left_starred_messages,
-li.top_left_drafts,
-li.top_left_inbox,
-li.top_left_recent_view,
-li.top_left_scheduled_messages {
-    /* TODO: Clean this up with other vdots
-       positioning stuff. */
-    position: relative;
 }
 
 /* Don't show the scheduled messages item... */
@@ -620,12 +605,6 @@ li.top_left_scheduled_messages {
 
     .sidebar-menu-icon {
         grid-area: ending-anchor-element;
-        justify-self: center;
-        /* TODO: Clean up the .sidebar-menu-icon descendant
-           styles up and down the left sidebar. */
-        position: static;
-        font-size: 17px;
-        text-align: center;
     }
 }
 
@@ -707,7 +686,7 @@ li.top_left_scheduled_messages {
 #views-label-container {
     grid-template-columns:
         0 15px minmax(0, 0.5fr) minmax(0, 1fr)
-        20px 20px;
+        30px 12px;
     /* Base height on 24px icon-target area from Vlad's design. */
     grid-template-rows: 24px;
     /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
@@ -890,9 +869,7 @@ li.top_left_scheduled_messages {
     }
 }
 
-.bottom_left_row .subscription_block .sidebar-menu-icon,
-.bottom_left_row .topic-box .sidebar-menu-icon {
-    position: static;
+.bottom_left_row .sidebar-menu-icon {
     grid-area: ending-anchor-element;
 }
 
@@ -913,31 +890,23 @@ li.top_left_scheduled_messages {
     flex: 0 1 auto;
 }
 
-.left_sidebar_menu_icon_visible {
-    display: block !important;
-}
-
 /*
     All of our left sidebar handlers use absolute
     positioning.  We should fix that.
 */
-.top_left_row .sidebar-menu-icon,
-.bottom_left_row .sidebar-menu-icon {
-    position: absolute;
+.sidebar-menu-icon {
     display: none;
-    top: 1px;
-    right: 0;
-    font-size: 1em;
+    width: 100%;
+    cursor: pointer;
+    /* Use a flex container to handle
+       icon centering within the grid area.
+       :hover actually sets the `display: flex`,
+       so it remains hidden otherwise. */
+    justify-content: center;
     text-align: center;
-    padding: 0 6px;
-
-    & i {
-        padding-right: 0.35em;
-        display: inline-block;
-        width: 13px;
-        font-size: 17px;
-        vertical-align: middle;
-    }
+    /* Set the icon size, which will be inherited
+       by .zulip-icon */
+    font-size: 17px;
 
     /*
         If you hover directly over the ellipsis itself,
@@ -956,7 +925,7 @@ li.top_left_scheduled_messages {
     */
 
     @media (hover: none) {
-        display: block;
+        display: flex;
         /* Show dots on touchscreens in a less distracting,
            lighter shade. */
         color: var(--color-vdots-hint);
@@ -974,8 +943,12 @@ li.top_left_scheduled_messages {
 #stream_filters li:hover .stream-sidebar-menu-icon,
 .top_left_row:hover .sidebar-menu-icon,
 .bottom_left_row:hover .sidebar-menu-icon {
-    display: inline;
-    cursor: pointer;
+    /* We push against `display: none` with
+       `display: flex` because the sidebar vdots
+       all expect to be displayed as flex items
+       when visible. Their vertical alignment
+       depends on it, too. */
+    display: flex;
     color: var(--color-vdots-visible);
 
     /*
@@ -992,12 +965,13 @@ li.top_left_scheduled_messages {
     font to show they're "lower" in the hierarchy,
     which also affects it positioning.
 */
-.bottom_left_row .topic-sidebar-menu-icon {
-    font-size: 0.9em;
-    /* Strip the line height back to the font size,
-       so that vertical positioning is handled by
-       grid exclusively. */
-    line-height: 1;
+.topic-sidebar-menu-icon {
+    /* 0.9em, but with a pixel value because the
+       ordinary 17px vdots size is not inherited
+       here, so we can't express an em-value
+       directly. Pixels are easier to reason
+       about with icons, anyway. */
+    font-size: 15.3px;
 }
 
 ul.topic-list {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -63,7 +63,7 @@
             <li class="top_left_recent_view top_left_row">
                 <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
-                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-clock" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
@@ -72,7 +72,7 @@
             <li class="top_left_all_messages top_left_row">
                 <a href="#all_messages" class="home-link tippy-views-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
-                        <i class="fa fa-align-left" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
@@ -81,7 +81,7 @@
             <li class="top_left_mentions top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
                     <span class="filter-icon">
-                        <i class="fa fa-at" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Mentions' }}</span>
@@ -102,7 +102,7 @@
             <li class="top_left_drafts top_left_row hidden-for-spectators">
                 <a href="#drafts" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
-                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Drafts' }}</span>
@@ -113,7 +113,7 @@
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#scheduled">
                     <span class="filter-icon">
-                        <i class="fa fa-calendar" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-scheduled-messages" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Scheduled messages' }}</span>


### PR DESCRIPTION
This PR establishes a grid-based layout for the expanded views navigation, in addition to referencing the new icons introduced in #27190, with the condensed views.

It ensures correct and uniform horizontal and vertical alignment of the vdots icons up and down the left sidebar.

As an [addendum](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20views.20section.20collapsible.20feedback/near/1668229), icons for the condensed views are bumped up in size to 15px.

Once this PR is merged, there will remain only three areas of the left-sidebar for gridded row rewrites:

* Direct Messages header
* Direct messages rows
* Streams header

In the screenshots below, you'll see slight misalignment of those areas (e.g., the direct messages row text is further to the right than the names of streams; also the + icon on the Streams header is not center aligned). Those will be taken care of in subsequent PRs.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20views.20section.20collapsible.20feedback/near/1666288)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_All screenshots have the vdots artificially visible, for easier study of the alignment._

| Expanded views, before | Expanded views, after |
| --- | --- |
| <img width="335" alt="expanded-showing-vddots-before" src="https://github.com/zulip/zulip/assets/170719/be27a88e-d36a-4563-91ce-e377d2265806"> | <img width="335" alt="expanded-showing-vdots-after" src="https://github.com/zulip/zulip/assets/170719/11f5e5de-80a9-45ce-8ccf-44c8294dd252"> |

_With the grid showing on the Rome stream row, with lines extending indefinitely to show alignment across grid:_

| Sidebar-wide alignment, expanded views | Sidebar-wide alignment, condensed views |
| --- | --- |
| <img width="335" alt="grid-showing-vdots-expanded" src="https://github.com/zulip/zulip/assets/170719/9f201257-048a-4c36-aa77-9e0a0ad59182"> | <img width="335" alt="grid-showing-vdots-collapsed" src="https://github.com/zulip/zulip/assets/170719/a0f3dd36-70b8-48ca-98fb-65446ddd29b5"> |

| Condensed icons, before | Condensed icons, after |
| --- | --- |
| <img width="335" alt="collapsed-icons-before" src="https://github.com/zulip/zulip/assets/170719/43ebf08f-e7b4-45e7-84d8-921df0ca76b2"> | <img width="335" alt="collapsed-icons-after" src="https://github.com/zulip/zulip/assets/170719/108accd1-b0e7-47ee-aafa-2591689a85bb"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


