### PR TITLE
stream_settings: Improve "Mute stream" option UI in stream settings

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -151,13 +151,17 @@ function show_subscription_settings(sub) {
     });
 }
 
-function is_notification_setting(setting_label) {
+function has_global_notification_setting(setting_label) {
     if (setting_label.includes("_notifications")) {
         return true;
     } else if (setting_label.includes("_notify")) {
         return true;
     }
     return false;
+}
+
+function is_notification_setting(setting_label) {
+    return has_global_notification_setting(setting_label) || setting_label === "is_muted";
 }
 
 export function stream_settings(sub) {
@@ -171,9 +175,9 @@ export function stream_settings(sub) {
             label: settings_labels[setting],
             disabled_realm_setting: check_realm_setting[setting],
             is_disabled: check_realm_setting[setting],
-            is_notification_setting: is_notification_setting(setting),
+            has_global_notification_setting: has_global_notification_setting(setting),
         };
-        if (is_notification_setting(setting)) {
+        if (has_global_notification_setting(setting)) {
             // This block ensures we correctly display to users the
             // current state of stream-level notification settings
             // with a value of `null`, which inherit the user's global
@@ -233,7 +237,7 @@ export function show_settings_for(node) {
 
     const other_settings = [];
     const notification_settings = all_settings.filter((setting) => {
-        if (setting.is_notification_setting) {
+        if (is_notification_setting(setting.name)) {
             return true;
         }
         other_settings.push(setting);
@@ -317,7 +321,7 @@ function stream_setting_changed(e) {
         blueslip.error("undefined sub in stream_setting_changed()");
         return;
     }
-    if (is_notification_setting(setting) && sub[setting] === null) {
+    if (has_global_notification_setting(setting) && sub[setting] === null) {
         sub[setting] =
             user_settings[settings_config.generalize_stream_notification_setting[setting]];
     }

--- a/web/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/web/templates/stream_settings/stream_settings_checkbox.hbs
@@ -18,13 +18,6 @@
     </label>
 
     {{!-- Tooltips for settings --}}
-    {{#if (eq setting_name "is_muted")}}
-    <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">
-        {{#tr}}
-        Muted streams don't show up in "All messages" or generate notifications unless you are mentioned.
-        {{/tr}}
-    </p>
-    {{/if}}
     {{#if (eq setting_name "push_notifications")}}
     <i class="fa fa-question-circle settings-info-icon {{#unless disabled_realm_setting}}hide{{/unless}} tippy-zulip-tooltip"
       data-tippy-content="{{t 'Mobile push notifications are not configured on this server.' }}">

--- a/web/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/web/templates/stream_settings/stream_settings_checkbox.hbs
@@ -10,7 +10,12 @@
           {{#if is_disabled}}disabled="disabled"{{/if}} />
         <span></span>
     </label>
-    <label class="inline" for="{{setting_name}}_{{stream_id}}">{{label}}</label>
+    <label class="inline" for="{{setting_name}}_{{stream_id}}">
+        {{label}}
+        {{#if (eq setting_name "is_muted")}}
+        {{> ../help_link_widget link="/help/mute-a-stream" }}
+        {{/if}}
+    </label>
 
     {{!-- Tooltips for settings --}}
     {{#if (eq setting_name "is_muted")}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
> [!WARNING]  
> In this PR, the "Mute stream" option has been moved to "Notification settings." When the mute stream option is enabled, the notification settings become disabled, including the Mute stream's own checkbox. This leads to a self-restricting state where unmuting the stream is no longer possible. Therefore, #27272 should be considered as a blocker for this PR.

This PR adds the following changes:
- Move "Mute stream" to the top of the "Notification settings" section
- Add a help `?` link to /help/mute-a-stream beside the "Mute stream" label.
- Drop the "Muted streams don't show up in "All messages" or generate notifications unless you are mentioned." text for muted streams.

Fixes: #27274

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Not Muted| Muted |
|:-------------------------:|:-------------------------:|
| ![image](https://github.com/zulip/zulip/assets/82862779/51e3a086-2597-4efd-a974-c3cb10764157) |![image](https://github.com/zulip/zulip/assets/82862779/29233fc7-2836-4f1c-813c-c805cf2886c7) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
