### PR TITLE
recent_view: Update rendered time when user becomes active.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -62,6 +62,7 @@ type BaseListWidget = {
 
 export type ListWidget<Key, Item = Key> = BaseListWidget & {
     get_current_list: () => Item[];
+    get_rendered_list: () => Item[];
     filter_and_sort: () => void;
     retain_selected_items: () => void;
     all_rendered: () => boolean;
@@ -292,6 +293,10 @@ export function create<Key, Item = Key>(
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
+        },
+
+        get_rendered_list() {
+            return meta.filtered_list.slice(0, meta.offset);
         },
 
         filter_and_sort() {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -493,6 +493,7 @@ export function initialize_everything(state_data) {
 
     realm_logo.initialize();
     message_lists.initialize();
+    // Needs to be initialized before activity to register window.focus event.
     recent_view_ui.initialize({
         on_click_participant(avatar_element, participant_user_id) {
             const user = people.get_by_user_id(participant_user_id);


### PR DESCRIPTION
Fixes #23005

Update rendered time in recent view when user comes back after being idle.
