### PR TITLE
hotkey: Make g + left / right arrow work to open navbar dropdowns.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -201,6 +201,8 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **Toggle gear menu**: <kbd>G</kbd>
 
+* **Open personal menu**: <kbd>G</kbd> + <kbd class="arrow-key">→</kbd>
+
 ### For a selected message (outlined in blue)
 
 * **Toggle emoji reactions menu**: <kbd>:</kbd>

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -203,6 +203,8 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **Open personal menu**: <kbd>G</kbd> + <kbd class="arrow-key">→</kbd>
 
+* **Open help menu**: <kbd>G</kbd> + <kbd class="arrow-key">←</kbd>
+
 ### For a selected message (outlined in blue)
 
 * **Toggle emoji reactions menu**: <kbd>:</kbd>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -152,6 +152,7 @@ EXEMPT_FILES = make_set(
         "web/src/narrow_history.js",
         "web/src/narrow_title.js",
         "web/src/navbar_alerts.js",
+        "web/src/navbar_menus.js",
         "web/src/navigate.js",
         "web/src/overlay_util.ts",
         "web/src/overlays.ts",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -152,6 +152,7 @@ EXEMPT_FILES = make_set(
         "web/src/narrow_history.js",
         "web/src/narrow_title.js",
         "web/src/navbar_alerts.js",
+        "web/src/navbar_help_menu.js",
         "web/src/navbar_menus.js",
         "web/src/navigate.js",
         "web/src/overlay_util.ts",

--- a/web/src/activity_ui.js
+++ b/web/src/activity_ui.js
@@ -210,6 +210,7 @@ export function set_cursor_and_filter() {
 
 export function initiate_search() {
     if (user_filter) {
+        popovers.hide_all();
         user_filter.initiate_search();
     }
 }

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -17,6 +17,7 @@ import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as popovers from "./popovers";
 import * as reload_state from "./reload_state";
 import * as resize from "./resize";
 import * as settings_config from "./settings_config";
@@ -191,6 +192,7 @@ export function start(msg_type, opts) {
         blueslip.warn("Empty message type in compose.start");
     }
 
+    popovers.hide_all();
     autosize_message_content();
 
     if (reload_state.is_in_progress()) {

--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -111,11 +111,6 @@ export function initialize() {
         onMount(instance) {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.gear_menu = instance;
-            $(".focus-dropdown").on("focus", (e) => {
-                e.preventDefault();
-                $("#gear-menu-dropdown").find(".org-version a").trigger("focus");
-            });
-
             $popper.on("click", ".webathena_login", (e) => {
                 $("#zephyr-mirror-error").removeClass("show");
                 const principal = ["zephyr", "zephyr"];

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -34,6 +34,7 @@ import * as message_scroll_state from "./message_scroll_state";
 import * as modals from "./modals";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
+import * as navbar_menus from "./navbar_menus";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -733,31 +734,6 @@ export function process_hotkey(e, hotkey) {
         return false;
     }
 
-    // We don't need to process arrow keys in navbar menus for spectators
-    // since they only have gear menu present.
-    if (
-        popover_menus.is_personal_menu_popover_displayed() &&
-        event_name === "left_arrow" &&
-        !page_params.is_spectator
-    ) {
-        // Open gear menu popover on left arrow.
-        $("#personal-menu").trigger("click");
-        gear_menu.toggle();
-        return true;
-    }
-
-    if (popover_menus.is_gear_menu_popover_displayed()) {
-        if (event_name === "gear_menu") {
-            gear_menu.toggle();
-            return true;
-        } else if (event_name === "right_arrow" && !page_params.is_spectator) {
-            // Open personal menu popover on g + right arrow.
-            gear_menu.toggle();
-            $("#personal-menu").trigger("click");
-            return true;
-        }
-    }
-
     if (overlays.settings_open() && !user_card_popover.user_card.is_open()) {
         return false;
     }
@@ -789,6 +765,14 @@ export function process_hotkey(e, hotkey) {
     }
 
     if (menu_dropdown_hotkeys.has(event_name) && handle_popover_events(event_name)) {
+        return true;
+    }
+
+    // Handle hotkeys for active popovers here which can handle keys other than `menu_dropdown_hotkeys`.
+    if (
+        navbar_menus.is_navbar_menus_displayed() &&
+        navbar_menus.handle_keyboard_events(event_name)
+    ) {
         return true;
     }
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -733,15 +733,29 @@ export function process_hotkey(e, hotkey) {
         return false;
     }
 
-    if (hotkey.message_view_only && popover_menus.is_gear_menu_popover_displayed()) {
-        // Inside the gear menu, we don't process most hotkeys; the
-        // exception is that the gear_menu hotkey should toggle the
-        // menu closed again.
+    // We don't need to process arrow keys in navbar menus for spectators
+    // since they only have gear menu present.
+    if (
+        popover_menus.is_personal_menu_popover_displayed() &&
+        event_name === "left_arrow" &&
+        !page_params.is_spectator
+    ) {
+        // Open gear menu popover on left arrow.
+        $("#personal-menu").trigger("click");
+        gear_menu.toggle();
+        return true;
+    }
+
+    if (popover_menus.is_gear_menu_popover_displayed()) {
         if (event_name === "gear_menu") {
             gear_menu.toggle();
             return true;
+        } else if (event_name === "right_arrow" && !page_params.is_spectator) {
+            // Open personal menu popover on g + right arrow.
+            gear_menu.toggle();
+            $("#personal-menu").trigger("click");
+            return true;
         }
-        return false;
     }
 
     if (overlays.settings_open() && !user_card_popover.user_card.is_open()) {

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -13,6 +13,7 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as popover_menus from "./popover_menus";
 import * as popover_menus_data from "./popover_menus_data";
+import * as popovers from "./popovers";
 import * as read_receipts from "./read_receipts";
 import * as rows from "./rows";
 import * as stream_popover from "./stream_popover";
@@ -39,6 +40,11 @@ function focus_first_action_popover_item() {
 }
 
 export function toggle_message_actions_menu(message) {
+    if (popover_menus.is_message_actions_popover_displayed()) {
+        popovers.hide_all();
+        return true;
+    }
+
     if (message.locally_echoed || message_edit.is_editing(message.id)) {
         // Don't open the popup for locally echoed messages for now.
         // It creates bugs with things like keyboard handlers when
@@ -47,6 +53,12 @@ export function toggle_message_actions_menu(message) {
         // including previews, when a user tries to reach them from the
         // keyboard.
         return true;
+    }
+
+    // Since this can be called via hotkey, we need to
+    // hide any other popovers that may be open before.
+    if (popovers.any_active()) {
+        popovers.hide_all();
     }
 
     message_viewport.maybe_scroll_to_show_message_top();

--- a/web/src/navbar_help_menu.js
+++ b/web/src/navbar_help_menu.js
@@ -1,0 +1,52 @@
+import $ from "jquery";
+
+import render_navbar_help_menu from "../templates/navbar_help_menu.hbs";
+
+import {page_params} from "./page_params";
+import * as popover_menus from "./popover_menus";
+import {parse_html} from "./ui_util";
+
+export function initialize() {
+    popover_menus.register_popover_menu("#help-menu", {
+        theme: "navbar-dropdown-menu",
+        placement: "bottom",
+        offset: [-50, 0],
+        // The strategy: "fixed"; and eventlisteners modifier option
+        // ensure that the personal menu does not modify its position
+        // or disappear when user zooms the page.
+        popperOptions: {
+            strategy: "fixed",
+            modifiers: [
+                {
+                    name: "eventListeners",
+                    options: {
+                        scroll: false,
+                    },
+                },
+            ],
+        },
+        onMount(instance) {
+            popover_menus.popover_instances.help_menu = instance;
+        },
+        onShow(instance) {
+            instance.setContent(
+                parse_html(
+                    render_navbar_help_menu({
+                        corporate_enabled: page_params.corporate_enabled,
+                    }),
+                ),
+            );
+        },
+        onHidden(instance) {
+            instance.destroy();
+            popover_menus.popover_instances.help_menu = undefined;
+        },
+    });
+}
+
+export function toggle() {
+    // NOTE: Since to open help menu, you need to click on help navbar icon (which calls
+    // tippyjs.hideAll()), or go via gear menu if using hotkeys, we don't need to
+    // call tippyjs.hideAll() for it.
+    $("#help-menu").trigger("click");
+}

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -1,4 +1,5 @@
 import * as gear_menu from "./gear_menu";
+import * as navbar_help_menu from "./navbar_help_menu";
 import {page_params} from "./page_params";
 import * as personal_menu_popover from "./personal_menu_popover";
 import * as popover_menus from "./popover_menus";
@@ -6,7 +7,8 @@ import * as popover_menus from "./popover_menus";
 export function is_navbar_menus_displayed() {
     return (
         popover_menus.is_personal_menu_popover_displayed() ||
-        popover_menus.is_gear_menu_popover_displayed()
+        popover_menus.is_gear_menu_popover_displayed() ||
+        popover_menus.is_help_menu_popover_displayed()
     );
 }
 
@@ -24,6 +26,16 @@ export function handle_keyboard_events(event_name) {
         return true;
     }
 
+    if (
+        popover_menus.is_help_menu_popover_displayed() &&
+        (event_name === "right_arrow" || event_name === "gear_menu")
+    ) {
+        // Open gear menu popover on right arrow.
+        navbar_help_menu.toggle();
+        gear_menu.toggle();
+        return true;
+    }
+
     if (popover_menus.is_gear_menu_popover_displayed()) {
         if (event_name === "gear_menu") {
             gear_menu.toggle();
@@ -32,6 +44,11 @@ export function handle_keyboard_events(event_name) {
             // Open personal menu popover on g + right arrow.
             gear_menu.toggle();
             personal_menu_popover.toggle();
+            return true;
+        } else if (event_name === "left_arrow") {
+            // Open help menu popover on g + left arrow.
+            gear_menu.toggle();
+            navbar_help_menu.toggle();
             return true;
         }
     }

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -1,0 +1,40 @@
+import * as gear_menu from "./gear_menu";
+import {page_params} from "./page_params";
+import * as personal_menu_popover from "./personal_menu_popover";
+import * as popover_menus from "./popover_menus";
+
+export function is_navbar_menus_displayed() {
+    return (
+        popover_menus.is_personal_menu_popover_displayed() ||
+        popover_menus.is_gear_menu_popover_displayed()
+    );
+}
+
+export function handle_keyboard_events(event_name) {
+    // We don't need to process arrow keys in navbar menus for spectators
+    // since they only have gear menu present.
+    if (
+        popover_menus.is_personal_menu_popover_displayed() &&
+        (event_name === "left_arrow" || event_name === "gear_menu") &&
+        !page_params.is_spectator
+    ) {
+        // Open gear menu popover on left arrow.
+        personal_menu_popover.toggle();
+        gear_menu.toggle();
+        return true;
+    }
+
+    if (popover_menus.is_gear_menu_popover_displayed()) {
+        if (event_name === "gear_menu") {
+            gear_menu.toggle();
+            return true;
+        } else if (event_name === "right_arrow" && !page_params.is_spectator) {
+            // Open personal menu popover on g + right arrow.
+            gear_menu.toggle();
+            personal_menu_popover.toggle();
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/web/src/personal_menu_popover.js
+++ b/web/src/personal_menu_popover.js
@@ -89,12 +89,6 @@ export function initialize() {
                 popovers.hide_all();
                 e.preventDefault();
             });
-
-            $(".focus-dropdown").on("focus", (e) => {
-                e.preventDefault();
-                $popper.find("li:visible a").eq(0).trigger("focus");
-            });
-
             instance.popperInstance.update();
         },
         onShow(instance) {

--- a/web/src/personal_menu_popover.js
+++ b/web/src/personal_menu_popover.js
@@ -107,3 +107,10 @@ export function initialize() {
         },
     });
 }
+
+export function toggle() {
+    // NOTE: Since to open personal menu, you need to click on your avatar (which calls
+    // tippyjs.hideAll()), or go via gear menu if using hotkeys, we don't need to
+    // call tippyjs.hideAll() for it.
+    $("#personal-menu").trigger("click");
+}

--- a/web/src/personal_menu_popover.js
+++ b/web/src/personal_menu_popover.js
@@ -40,13 +40,13 @@ export function initialize() {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.personal_menu = instance;
 
-            tippy(".clear_status", {
+            tippy(".personal-menu-clear-status", {
                 placement: "top",
                 appendTo: document.body,
                 interactive: true,
             });
 
-            $popper.one("click", ".clear_status", (e) => {
+            $popper.one("click", ".personal-menu-clear-status", (e) => {
                 e.preventDefault();
                 const me = page_params.user_id;
                 user_status.server_update_status({

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -37,6 +37,7 @@ export const popover_instances = {
     change_visibility_policy: null,
     personal_menu: null,
     gear_menu: null,
+    help_menu: null,
 };
 
 /* Keyboard UI functions */
@@ -109,6 +110,10 @@ export function is_gear_menu_popover_displayed() {
 
 export function get_gear_menu_instance() {
     return popover_instances.gear_menu;
+}
+
+export function is_help_menu_popover_displayed() {
+    return popover_instances.help_menu?.state.isVisible;
 }
 
 export function is_message_actions_popover_displayed() {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -111,6 +111,10 @@ export function get_gear_menu_instance() {
     return popover_instances.gear_menu;
 }
 
+export function is_message_actions_popover_displayed() {
+    return popover_instances.message_actions?.state.isVisible;
+}
+
 function get_popover_items_for_instance(instance) {
     const $current_elem = $(instance.popper);
     const class_name = $current_elem.attr("class");

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -99,6 +99,10 @@ export function is_compose_enter_sends_popover_displayed() {
     return popover_instances.compose_enter_sends?.state.isVisible;
 }
 
+export function is_personal_menu_popover_displayed() {
+    return popover_instances.personal_menu?.state.isVisible;
+}
+
 export function is_gear_menu_popover_displayed() {
     return popover_instances.gear_menu?.state.isVisible;
 }

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -202,7 +202,6 @@ export function get_gear_menu_content_context() {
         apps_page_url: page_params.apps_page_url,
         can_create_multiuse_invite: settings_data.user_can_create_multiuse_invite(),
         can_invite_users_by_email: settings_data.user_can_invite_users_by_email(),
-        corporate_enabled: page_params.corporate_enabled,
         is_guest: page_params.is_guest,
         login_link: page_params.development_environment ? "/devlogin/" : "/login/",
         promote_sponsoring_zulip: page_params.promote_sponsoring_zulip,

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -238,6 +238,7 @@ export function open_search_bar_and_close_narrow_description() {
     }
     $(".navbar-search").addClass("expanded");
     $("#message_view_header").addClass("hidden");
+    popovers.hide_all();
 }
 
 export function close_search_bar_and_open_narrow_description() {

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -907,6 +907,7 @@ export function hide_search_section() {
 }
 
 export function initiate_search() {
+    popovers.hide_all();
     show_search_section();
 
     const $filter = $(".stream-list-filter").expectOne();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -75,6 +75,7 @@ import * as narrow_history from "./narrow_history";
 import * as narrow_state from "./narrow_state";
 import * as narrow_title from "./narrow_title";
 import * as navbar_alerts from "./navbar_alerts";
+import * as navbar_help_menu from "./navbar_help_menu";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -696,6 +697,7 @@ export function initialize_everything() {
     });
     unread_ops.initialize();
     gear_menu.initialize();
+    navbar_help_menu.initialize();
     giphy.initialize();
     presence.initialize(presence_params);
     settings_display.initialize();

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -680,7 +680,7 @@ function register_click_handlers() {
         e.preventDefault();
     });
 
-    $("body").on("click", ".user-card-popover-actions .clear_status", (e) => {
+    $("body").on("click", ".user-card-popover-actions .personal-menu-clear-status", (e) => {
         e.preventDefault();
         const me = elem_to_user_id($(e.target).parents("ul"));
         user_status.server_update_status({

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1310,6 +1310,10 @@ ul {
     }
 }
 
+#help-menu-dropdown {
+    padding-bottom: 5px;
+}
+
 ul.navbar-dropdown-menu-outer-list {
     list-style: none;
     margin: 0;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1339,3 +1339,16 @@ ul.navbar-dropdown-menu-outer-list {
         display: block;
     }
 }
+
+.navbar-dropdown-hotkey-hint {
+    color: var(--color-hotkey-hint);
+    text-align: center;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 14px;
+    padding: 1px 4px 2px;
+    border-radius: 3px;
+    border: 1px solid var(--color-hotkey-hint);
+    margin-left: auto;
+}

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1217,12 +1217,21 @@ ul {
 }
 
 .personal-menu-clear-status {
+    display: flex;
+    padding: 3px;
+    align-items: center;
     margin-left: auto;
     color: hsl(0deg 0% 40%) !important;
+    border-radius: 4px;
 
-    &:hover {
+    &:hover,
+    &:focus {
         text-decoration: none;
     }
+}
+
+.personal-menu-clear-status .personal-menu-clear-status-icon {
+    top: 0;
 }
 
 #gear-menu-dropdown {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1205,15 +1205,6 @@ ul {
         }
     }
 
-    .clear_status {
-        margin-left: auto;
-        color: hsl(0deg 0% 40%) !important;
-
-        &:hover {
-            text-decoration: none;
-        }
-    }
-
     .status_emoji {
         width: 16px;
         height: 16px;
@@ -1222,6 +1213,15 @@ ul {
     .zulip-icon {
         position: relative;
         top: -1px;
+    }
+}
+
+.personal-menu-clear-status {
+    margin-left: auto;
+    color: hsl(0deg 0% 40%) !important;
+
+    &:hover {
+        text-decoration: none;
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1152,9 +1152,10 @@ ul {
         flex-flow: row nowrap;
         align-items: center;
         gap: 5px;
-        padding: 5px 10px;
+        padding: 0 10px;
         font-size: 15px;
         line-height: 16px;
+        height: 26px;
 
         .navbar-dropdown-icon {
             width: 16px;
@@ -1184,12 +1185,7 @@ ul {
         .navbar-dropdown-menu-link {
             color: var(--color-text-dropdown-menu) !important;
             text-decoration: none;
-            display: flex;
-            flex-flow: row nowrap;
             flex-grow: 1;
-            align-items: center;
-            gap: 5px;
-            padding: 5px 10px;
 
             &:hover {
                 background: var(--color-background-hover-dropdown-menu);

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -185,14 +185,6 @@
         height: var(--search-box-height);
     }
 
-    @media ($md_min <= width < $xl_min) {
-        /* Add some space between the search input and the userlist toggle
-           in this width range so that hover state of userlist-toggle looks good. */
-        .navbar-search:not(.expanded) {
-            right: 2px;
-        }
-    }
-
     @media (width >= $md_min) {
         .navbar-search {
             background: var(--color-background-search);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3468,12 +3468,3 @@ select.invite-as {
         border: 1px solid var(--color-border-personal-menu-avatar);
     }
 }
-
-.keyboard-shortcut-option {
-    & span.tooltip-hotkey-hint {
-        margin-left: auto;
-        padding: 0 4px;
-        color: var(--color-hotkey-hint);
-        border-color: var(--color-hotkey-hint);
-    }
-}

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -837,10 +837,11 @@ body.has-overlay-scrollbar {
         display: flex;
         justify-content: space-evenly;
         position: absolute;
-        top: 10px;
-        right: 40px;
-        /* width of right column - width of gear icon - right margin of column-right (250px - 40px -7px) */
-        width: 203px;
+        top: 8px;
+        /* gear menu + help menu width (40px * 2) */
+        right: 80px;
+        /* width of right column - width of gear icon - right margin of column-right (250px - 40px - 40px -7px) */
+        width: 163px;
 
         & a {
             font-size: calc(16em / 14);
@@ -2990,9 +2991,11 @@ select.invite-as {
 
     .spectator-view {
         #navbar-middle {
-            margin-right: 85px;
+            /* = 40px (width of button) * 3 (number of buttons) + 10px extra margin. */
+            margin-right: 130px;
         }
 
+        #help-menu,
         #gear-menu {
             position: relative;
             right: 40px;
@@ -3039,7 +3042,8 @@ select.invite-as {
     }
 
     #navbar-middle {
-        margin-right: 127px;
+        /* = 40px (width of button) * 4 (number of buttons) + 10px extra margin. */
+        margin-right: 170px;
     }
 }
 
@@ -3143,16 +3147,19 @@ select.invite-as {
 
     .spectator-view {
         #navbar-middle {
-            margin-right: 65px;
+            /* = 30px (width of button) * 3 (number of buttons) + 10px extra margin. */
+            margin-right: 100px;
         }
 
+        #help-menu,
         #gear-menu {
-            right: 35px;
+            right: 30px;
         }
     }
 
     #navbar-middle {
-        margin-right: 97px;
+        /* = 30px (width of button) * 4 (number of buttons) + 10px extra margin. */
+        margin-right: 130px;
     }
 
     .nav .dropdown-menu {
@@ -3412,9 +3419,6 @@ select.invite-as {
     display: flex;
     justify-content: center;
     align-items: center;
-    position: relative;
-    top: 0;
-    right: 0;
 
     &:hover,
     &:focus {
@@ -3442,8 +3446,15 @@ select.invite-as {
         font-size: 18px;
     }
 
+    .zulip-icon-help,
     .zulip-icon-triple-users {
         font-size: 20px;
+    }
+
+    .zulip-icon-help {
+        position: relative;
+        top: 0.5px;
+        right: -0.5px;
     }
 }
 

--- a/web/templates/gear_menu_popover.hbs
+++ b/web/templates/gear_menu_popover.hbs
@@ -85,43 +85,6 @@
                 </li>
             </ul>
         </li>
-        <li class="navbar-dropdown-menu-outer-list-item">
-            <ul class="navbar-dropdown-menu-inner-list">
-                <li class="link-item navbar-dropdown-menu-inner-list-item">
-                    <a href="/help/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter navbar-dropdown-menu-link">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-help" aria-hidden="true"></i> {{t 'Help center' }}
-                    </a>
-                </li>
-                <li class="link-item navbar-dropdown-menu-inner-list-item">
-                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="keyboard-shortcuts">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="hotkey-hint">(?)</span>
-                    </a>
-                </li>
-                <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">
-                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="message-formatting">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i> {{t 'Message formatting' }}
-                    </a>
-                </li>
-                <li class="link-item navbar-dropdown-menu-inner-list-item">
-                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="search-operators">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-manage-search" aria-hidden="true"></i> {{t 'Search filters' }}
-                    </a>
-                </li>
-                <li class="link-item navbar-dropdown-menu-inner-list-item" id="gear_menu_about_zulip">
-                    <a href="#about-zulip" class="navigate-link-on-enter navbar-dropdown-menu-link">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-info"></i>
-                        {{t "About Zulip" }}
-                    </a>
-                </li>
-                {{#if corporate_enabled}}
-                <li class="link-item navbar-dropdown-menu-inner-list-item">
-                    <a href="/help/contact-support" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter navbar-dropdown-menu-link">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-life-buoy" aria-hidden="true"></i> {{t 'Contact support' }}
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
-        </li>
         <li class="hidden-for-spectators navbar-dropdown-menu-outer-list-item">
             <ul class="navbar-dropdown-menu-inner-list">
                 <li class="link-item navbar-dropdown-menu-inner-list-item">

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -318,6 +318,10 @@
                     <td><span class="hotkey"><kbd>G</kbd><kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Open help menu' }}</td>
+                    <td><span class="hotkey"><kbd>G</kbd><kbd class="arrow-key">←</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Open message menu' }}</td>
                     <td><span class="hotkey"><kbd>I</kbd></span></td>
                 </tr>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -314,6 +314,10 @@
                     <td><span class="hotkey"><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Open personal menu' }}</td>
+                    <td><span class="hotkey"><kbd>G</kbd><kbd class="arrow-key">→</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Open message menu' }}</td>
                     <td><span class="hotkey"><kbd>I</kbd></span></td>
                 </tr>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -55,19 +55,16 @@
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="help-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-help" aria-hidden="true"></i>
                 </a>
-                <span tabindex="0" class="focus-dropdown"></span>
             </div>
             <div id="gear-menu" class="{{#if embedded}}hide-navbar-buttons-visibility{{/if}}">
                 <a id="settings-dropdown" tabindex="0" role="button" class="header-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="gear-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-gear" aria-hidden="true"></i>
                 </a>
-                <span tabindex="0" class="focus-dropdown"></span>
             </div>
             <div id="personal-menu" class="hidden-for-spectators">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="personal-menu-tooltip-template">
                     <img class="header-button-avatar" src="{{user_avatar}}"/>
                 </a>
-                <span tabindex="0" class="focus-dropdown"></span>
             </div>
         </div>
     </nav>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -58,7 +58,7 @@
                 <span tabindex="0" class="focus-dropdown"></span>
             </div>
             <div id="personal-menu" class="hidden-for-spectators">
-                <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tippy-content="{{t 'Personal menu' }}">
+                <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="personal-menu-tooltip-template">
                     <img class="header-button-avatar" src="{{user_avatar}}"/>
                 </a>
                 <span tabindex="0" class="focus-dropdown"></span>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -51,6 +51,12 @@
                     <span id="userlist-toggle-unreadcount">0</span>
                 </a>
             </div>
+            <div id="help-menu">
+                <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="help-menu-tooltip-template">
+                    <i class="zulip-icon zulip-icon-help" aria-hidden="true"></i>
+                </a>
+                <span tabindex="0" class="focus-dropdown"></span>
+            </div>
             <div id="gear-menu" class="{{#if embedded}}hide-navbar-buttons-visibility{{/if}}">
                 <a id="settings-dropdown" tabindex="0" role="button" class="header-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="gear-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-gear" aria-hidden="true"></i>

--- a/web/templates/navbar_help_menu.hbs
+++ b/web/templates/navbar_help_menu.hbs
@@ -1,0 +1,41 @@
+<div class="navbar-dropdown-menu" id="help-menu-dropdown" aria-labelledby="help-menu" data-simplebar>
+    <ul class="navbar-dropdown-menu-outer-list">
+        <li class="navbar-dropdown-menu-outer-list-item">
+            <ul class="navbar-dropdown-menu-inner-list">
+                <li class="link-item navbar-dropdown-menu-inner-list-item">
+                    <a href="/help/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter navbar-dropdown-menu-link">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-help" aria-hidden="true"></i> {{t 'Help center' }}
+                    </a>
+                </li>
+                <li class="link-item navbar-dropdown-menu-inner-list-item">
+                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="keyboard-shortcuts">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="hotkey-hint">(?)</span>
+                    </a>
+                </li>
+                <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">
+                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="message-formatting">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i> {{t 'Message formatting' }}
+                    </a>
+                </li>
+                <li class="link-item navbar-dropdown-menu-inner-list-item">
+                    <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="search-operators">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-manage-search" aria-hidden="true"></i> {{t 'Search filters' }}
+                    </a>
+                </li>
+                <li class="link-item navbar-dropdown-menu-inner-list-item" id="gear_menu_about_zulip">
+                    <a href="#about-zulip" class="navigate-link-on-enter navbar-dropdown-menu-link">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-info"></i>
+                        {{t "About Zulip" }}
+                    </a>
+                </li>
+                {{#if corporate_enabled}}
+                <li class="link-item navbar-dropdown-menu-inner-list-item">
+                    <a href="/help/contact-support" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter navbar-dropdown-menu-link">
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-life-buoy" aria-hidden="true"></i> {{t 'Contact support' }}
+                    </a>
+                </li>
+                {{/if}}
+            </ul>
+        </li>
+    </ul>
+</div>

--- a/web/templates/navbar_help_menu.hbs
+++ b/web/templates/navbar_help_menu.hbs
@@ -9,7 +9,7 @@
                 </li>
                 <li class="link-item navbar-dropdown-menu-inner-list-item">
                     <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="keyboard-shortcuts">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="hotkey-hint">(?)</span>
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="navbar-dropdown-hotkey-hint">?</span>
                     </a>
                 </li>
                 <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">

--- a/web/templates/personal_menu.hbs
+++ b/web/templates/personal_menu.hbs
@@ -43,7 +43,7 @@
                                 </span>
                             </span>
                             <a href="" class="personal-menu-clear-status navbar-dropdown-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
-                                <i class="navbar-dropdown-icon zulip-icon zulip-icon-x-circle"></i>
+                                <i class="personal-menu-clear-status-icon navbar-dropdown-icon zulip-icon zulip-icon-x-circle"></i>
                             </a>
                         </li>
                         <li class="link-item navbar-dropdown-menu-inner-list-item">

--- a/web/templates/personal_menu.hbs
+++ b/web/templates/personal_menu.hbs
@@ -42,7 +42,7 @@
                                     {{status_text}}
                                 </span>
                             </span>
-                            <a href="" class="clear_status navbar-dropdown-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
+                            <a href="" class="personal-menu-clear-status navbar-dropdown-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
                                 <i class="navbar-dropdown-icon zulip-icon zulip-icon-x-circle"></i>
                             </a>
                         </li>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -71,6 +71,10 @@
     {{t 'Main menu' }}
     {{tooltip_hotkey_hints "G"}}
 </template>
+<template id="personal-menu-tooltip-template">
+    {{t 'Personal menu' }}
+    {{tooltip_hotkey_hints "G" "→"}}
+</template>
 <template id="all-message-tooltip-template">
     {{t 'All messages' }}
     {{tooltip_hotkey_hints "A"}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -75,6 +75,10 @@
     {{t 'Personal menu' }}
     {{tooltip_hotkey_hints "G" "→"}}
 </template>
+<template id="help-menu-tooltip-template">
+    {{t 'Help menu' }}
+    {{tooltip_hotkey_hints "G" "←"}}
+</template>
 <template id="all-message-tooltip-template">
     {{t 'All messages' }}
     {{tooltip_hotkey_hints "A"}}

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -58,6 +58,9 @@ mock_esm("../src/message_lists", {
 mock_esm("../src/resize", {
     reset_compose_message_max_height: noop,
 });
+mock_esm("../src/popovers", {
+    hide_all: noop,
+});
 
 const people = zrequire("people");
 

--- a/web/tests/stream_search.test.js
+++ b/web/tests/stream_search.test.js
@@ -17,7 +17,9 @@ mock_esm("../src/resize", {
     resize_stream_filters_container: noop,
 });
 
-const popovers = mock_esm("../src/popovers");
+const popovers = mock_esm("../src/popovers", {
+    hide_all: noop,
+});
 const sidebar_ui = mock_esm("../src/sidebar_ui");
 
 const stream_list = zrequire("stream_list");
@@ -188,5 +190,9 @@ run_test("expanding_sidebar", () => {
 
     stream_list.initiate_search();
 
-    assert.deepEqual(events, ["popovers.hide_all", "sidebar_ui.show_streamlist_sidebar"]);
+    assert.deepEqual(events, [
+        "popovers.hide_all",
+        "popovers.hide_all",
+        "sidebar_ui.show_streamlist_sidebar",
+    ]);
 });


### PR DESCRIPTION
While gear menu is open, press right arrow to go to personal menu and left arrow to open gear menu again.

<img width="369" alt="Screenshot 2023-10-21 at 5 07 46 AM" src="https://github.com/zulip/zulip/assets/25124304/4d8d548a-d615-469a-8fe5-3bf794ec9ec9">
<img width="526" alt="Screenshot 2023-10-21 at 5 08 23 AM" src="https://github.com/zulip/zulip/assets/25124304/0be71378-d525-4787-8a06-0492fd2c4ce1">


discussioN: https://chat.zulip.org/#narrow/stream/101-design/topic/keyboard.20nav.20for.20personal.20menu