### PR TITLE
help: Document "Start new conversation" button.

### DIFF
--- a/help/direct-messages.md
+++ b/help/direct-messages.md
@@ -19,13 +19,18 @@ and do not appear in your list of streams.
 
 {tab|desktop-web}
 
-1. Click the **New direct message** button at the bottom of the app, or
-   use the <kbd>X</kbd> keyboard shortcut.
+1. Click the **New direct message** button at the bottom of the app, or the
+   **Start new conversation** button if you are in a direct message view.
 
 1. Start typing the name of the person you want to message, and
    select their name from the list of suggestions.
 
 {!compose-and-send-message.md!}
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>X</kbd> keyboard shortcut to start a new direct
+    message conversation.
 
 !!! tip ""
 

--- a/help/include/how-to-start-a-new-topic.md
+++ b/help/include/how-to-start-a-new-topic.md
@@ -1,9 +1,13 @@
 {start_tabs}
 
-{tab|stream}
+{tab|desktop-web}
 
-1. Click the **New topic** button at the bottom of the app, or
+1. Click the **Start new conversation** button at the bottom of the app, or
    use the <kbd>C</kbd> keyboard shortcut.
+
+1. _(optional)_ You can change the destination stream for your message using
+   the dropdown in the top left of the compose box. You can start typing to
+   filter streams.
 
 1. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
@@ -12,27 +16,9 @@
 
 !!! tip ""
 
-    You can change the destination stream for your message using the dropdown
-    in the top left of the compose box.
-
-!!! warn ""
-
-    In Zulip, you can compose a message to a different place than the one you
-    are viewing. In this situation, the message feed will fade to indicate
-    what's going on.
-
-{tab|not-stream}
-
-1. Click the **New topic** button at the bottom of the app, or
-   use the <kbd>C</kbd> keyboard shortcut.
-
-1. Select a stream from the dropdown in the top left of the compose box. You can
-   start typing to filter streams.
-
-1. Enter a topic name. Auto-complete will provide suggestions for previously
-   used topics.
-
-{!compose-and-send-message.md!}
+    You can click on the
+    **Clear topic** (<i class="zulip-icon zulip-icon-close"></i>) icon
+    near the upper right of the compose box to erase the topic name.
 
 !!! warn ""
 

--- a/help/include/send-group-dm.md
+++ b/help/include/send-group-dm.md
@@ -2,14 +2,19 @@
 
 {tab|desktop-web}
 
-1. Click the **New direct message** button at the bottom of the app, or
-   use the <kbd>X</kbd> keyboard shortcut.
+1. Click the **New direct message** button at the bottom of the app, or the
+   **Start new conversation** button if you are in a direct message view.
 
 1. Start typing the name of the person you want to message, and
    select their name from the list of suggestions. You can continue
    adding as many message recipients as you like.
 
 {!compose-and-send-message.md!}
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>X</kbd> keyboard shortcut to start a new direct
+    message conversation.
 
 !!! tip ""
 

--- a/help/open-the-compose-box.md
+++ b/help/open-the-compose-box.md
@@ -7,7 +7,7 @@ space for the message feed. There are a number of ways to open the compose box.
 
 * Click on any message.
 
-* Click on **Message...**, **New topic**, or **New direct message** at the
+* Click on **Start new conversation**, or **New direct message** at the
   bottom of the app.
 
 ## Using the keyboard


### PR DESCRIPTION
- Documents the new contextually-aware button since the instructions now differ depending on whether you're currently in a direct message view or not.
- Simplifies the new topic instructions by combining the first two tabs into a single web/desktop tab, with an optional step 2 to change the destination stream.

Fixes #27159.

**Screenshots and screen captures:**
- http://zulip.com/help/starting-a-new-topic
![image](https://github.com/zulip/zulip/assets/2343554/a5c63cde-c7a7-4e62-b813-2e91f80b1879)

- http://zulip.com//help/starting-a-new-direct-message
- http://zulip.com/help/direct-messages
![image](https://github.com/zulip/zulip/assets/2343554/5a09f75c-6b83-4af7-9154-d1590973d361)

- http://zulip.com/help/open-the-compose-box
![image](https://github.com/zulip/zulip/assets/2343554/4ada463e-1267-4b51-a461-bb1c716e13d7)
