### PR TITLE
gear_menu: Use new style to show hotkey.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1335,3 +1335,16 @@ ul.navbar-dropdown-menu-outer-list {
         display: block;
     }
 }
+
+.navbar-dropdown-hotkey-hint {
+    color: var(--color-hotkey-hint);
+    text-align: center;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 14px;
+    padding: 1px 4px 2px;
+    border-radius: 3px;
+    border: 1px solid var(--color-hotkey-hint);
+    margin-left: auto;
+}

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1152,9 +1152,10 @@ ul {
         flex-flow: row nowrap;
         align-items: center;
         gap: 5px;
-        padding: 5px 10px;
+        padding: 0 10px;
         font-size: 15px;
         line-height: 16px;
+        height: 26px;
 
         .navbar-dropdown-icon {
             width: 16px;
@@ -1184,12 +1185,7 @@ ul {
         .navbar-dropdown-menu-link {
             color: var(--color-text-dropdown-menu) !important;
             text-decoration: none;
-            display: flex;
-            flex-flow: row nowrap;
             flex-grow: 1;
-            align-items: center;
-            gap: 5px;
-            padding: 5px 10px;
 
             &:hover {
                 background: var(--color-background-hover-dropdown-menu);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3444,12 +3444,3 @@ select.invite-as {
         border: 1px solid var(--color-border-personal-menu-avatar);
     }
 }
-
-.keyboard-shortcut-option {
-    & span.tooltip-hotkey-hint {
-        margin-left: auto;
-        padding: 0 4px;
-        color: var(--color-hotkey-hint);
-        border-color: var(--color-hotkey-hint);
-    }
-}

--- a/web/templates/gear_menu_popover.hbs
+++ b/web/templates/gear_menu_popover.hbs
@@ -94,7 +94,7 @@
                 </li>
                 <li class="link-item navbar-dropdown-menu-inner-list-item">
                     <a tabindex="0" class="navigate-link-on-enter navbar-dropdown-menu-link" data-overlay-trigger="keyboard-shortcuts">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="hotkey-hint">(?)</span>
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i> {{t 'Keyboard shortcuts' }} <span class="navbar-dropdown-hotkey-hint">?</span>
                     </a>
                 </li>
                 <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">


### PR DESCRIPTION
This is according to Vlad's design in figma which differs from the style we have in `tooltip-hotkey-hint`.
<img width="273" alt="Screenshot 2023-10-21 at 5 31 29 AM" src="https://github.com/zulip/zulip/assets/25124304/607b213f-399f-430f-9ec5-8f554073c0de">
<img width="283" alt="Screenshot 2023-10-21 at 5 31 10 AM" src="https://github.com/zulip/zulip/assets/25124304/ee697897-06cd-4193-8ed1-aeaac4d0ed22">
