### PR TITLE
tooltips: Add a dedicated tooltip for status-emojis.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -573,6 +573,27 @@ export function initialize() {
             get_target_node,
             check_reference_removed,
         );
+
+        /*
+           The following implements a little tooltip giving the name for status emoji
+           when hovering them in the right sidebar. This requires special logic, to avoid
+           conflicting with the main tooltip or showing duplicate tooltips.
+        */
+        $(".user-presence-link .status-emoji-name").off("mouseenter").off("mouseleave");
+        $(".user-presence-link .status-emoji-name").on("mouseenter", () => {
+            const instance = $elem.parent()[0]._tippy;
+            if (instance && instance.state.isVisible) {
+                instance.destroy();
+            }
+        });
+        $(".user-presence-link .status-emoji-name").on("mouseleave", () => {
+            do_render_buddy_list_tooltip(
+                $elem.parent(),
+                title_data,
+                get_target_node,
+                check_reference_removed,
+            );
+        });
     });
 
     // DIRECT MESSAGE LIST TOOLTIPS (not displayed on touch devices)
@@ -606,6 +627,27 @@ export function initialize() {
             check_reference_removed,
             check_subtree,
         );
+
+        /*
+           The following implements a little tooltip giving the name for status emoji
+           when hovering them in the left sidebar. This requires special logic, to avoid
+           conflicting with the main tooltip or showing duplicate tooltips.
+        */
+        $(".dm-user-status .status-emoji-name").off("mouseenter").off("mouseleave");
+        $(".dm-user-status .status-emoji-name").on("mouseenter", () => {
+            const instance = $elem[0]._tippy;
+            if (instance && instance.state.isVisible) {
+                instance.destroy();
+            }
+        });
+        $(".dm-user-status .status-emoji-name").on("mouseleave", () => {
+            do_render_buddy_list_tooltip(
+                $elem,
+                title_data,
+                get_target_node,
+                check_reference_removed,
+            );
+        });
     });
 
     // Recent conversations direct messages (Not displayed on small widths)

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -5,6 +5,7 @@ import tippy, {delegate} from "tippy.js";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
 import {$t} from "./i18n";
+import * as popovers from "./popovers";
 import {user_settings} from "./user_settings";
 
 // For tooltips without data-tippy-content, we use the HTML content of
@@ -504,6 +505,29 @@ export function initialize(): void {
     delegate("body", {
         target: "#user_info_popover .status-emoji",
         appendTo: () => document.body,
+    });
+
+    delegate("body", {
+        target: ".status-emoji-name",
+        placement: "top",
+        delay: INSTANT_HOVER_DELAY,
+        appendTo: () => document.body,
+
+        /*
+            Status emoji tooltips for most locations in the app. This
+            basic tooltip logic is overridden by separate logic in
+            click_handlers.js for the left and right sidebars, to
+            avoid problematic interactions with the main tooltips for
+            those regions.
+        */
+
+        onShow() {
+            popovers.hide_all();
+        },
+
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 
     delegate("body", {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -503,7 +503,7 @@ export function initialize(): void {
     });
 
     delegate("body", {
-        target: "#user_info_popover .status-emoji",
+        target: ".user-card-status-text .status-emoji",
         appendTo: () => document.body,
     });
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -503,7 +503,7 @@ export function initialize(): void {
     });
 
     delegate("body", {
-        target: ".user-card-status-text .status-emoji",
+        target: ".user-card-status-area .status-emoji",
         appendTo: () => document.body,
     });
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -991,7 +991,7 @@ ul {
     }
 }
 
-.user-card-status-text {
+.user-card-status-area {
     opacity: 0.8;
 
     .status-emoji {

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -64,7 +64,7 @@
         {{/if}}
 
         {{#if status_content_available}}
-            <li class="user-card-status-text">
+            <li class="user-card-status-area">
                 <span id="status_message">
                     {{#if status_emoji_info}}
                         {{#if status_emoji_info.emoji_alt_code}}

--- a/web/templates/status_emoji.hbs
+++ b/web/templates/status_emoji.hbs
@@ -2,11 +2,11 @@
 {{#if emoji_alt_code}}
 <span class="emoji_alt_code">&nbsp;:{{emoji_name}}:</span>
 {{else if still_url}}
-<img src="{{still_url}}" class="emoji status-emoji" data-animated-url="{{url}}" data-still-url="{{still_url}}" />
+<img src="{{still_url}}" class="emoji status-emoji status-emoji-name" data-animated-url="{{url}}" data-still-url="{{still_url}}" data-tippy-content=":{{emoji_name}}:" />
 {{else if url}}
 {{!-- note that we have no still_url --}}
-<img src="{{url}}" class="emoji status-emoji" data-animated-url="{{url}}" />
-{{else if emoji_code}}
-<span class="emoji status-emoji emoji-{{emoji_code}}"></span>
+<img src="{{url}}" class="emoji status-emoji status-emoji-name" data-animated-url="{{url}}" data-tippy-content=":{{emoji_name}}:" />
+{{else if emoji_name}}
+<span class="emoji status-emoji status-emoji-name emoji-{{emoji_code}}" data-tippy-content=":{{emoji_name}}:"></span>
 {{/if}}
 {{/if}}


### PR DESCRIPTION
This issue requires us to add a dedicated tooltip whenever the user hovers over the status-emoji in the left and right sidebar.Currently we don't show the name of status-emoji in sidebars and only show the active-status tooltip.

This PR adds a dedicated tooltip in left and right sidebar whenever user hovers over the status-emoji.
Provisionally, the changes done are - 
1) Whenever the status-emoji is hovered in right sidebar , the buddy list tooltips instance will be hidden and vice-versa for status-emoji-tooltip.
2) Same goes for left sidebar / dm section . 

Fixes: #26772

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="606" alt="Screenshot 2024-01-19 at 8 36 20 PM" src="https://github.com/zulip/zulip/assets/97145463/b7256944-b3fa-45e7-a3ca-37da81ed9a3a">
<img width="606" alt="Screenshot 2024-01-19 at 8 36 41 PM" src="https://github.com/zulip/zulip/assets/97145463/982209aa-c7b9-4c62-b773-bfeb2c807f77">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
