### PR TITLE
stream_edit: Enable notification settings for muted streams.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -181,7 +181,6 @@ export function stream_settings(sub) {
             ret.is_checked =
                 stream_data.receives_notifications(sub.stream_id, setting) &&
                 !check_realm_setting[setting];
-            ret.is_disabled = ret.is_disabled || sub.is_muted;
             return ret;
         }
         ret.is_checked = sub[setting] && !check_realm_setting[setting];
@@ -281,13 +280,10 @@ export function setup_stream_settings(node) {
 
 export function update_muting_rendering(sub) {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
-    const $notification_checkboxes = $edit_container.find(".sub_notification_setting");
     const $is_muted_checkbox = $edit_container.find("#sub_is_muted_setting .sub_setting_control");
 
     $is_muted_checkbox.prop("checked", sub.is_muted);
     $edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
-    $notification_checkboxes.toggleClass("muted-sub", sub.is_muted);
-    $notification_checkboxes.find("input[type='checkbox']").prop("disabled", sub.is_muted);
 }
 
 function stream_is_muted_changed(e) {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -49,12 +49,10 @@
     white-space: normal;
 }
 
-.muted-sub,
 .control-label-disabled {
     color: hsl(0deg 0% 64%);
 }
 
-.sub_setting_checkbox .muted-sub label,
 .sub_setting_checkbox .control-label-disabled label {
     cursor: not-allowed;
 }
@@ -115,6 +113,10 @@ h3.user_group_setting_subsection_title {
     font-size: 1.5em;
     font-weight: normal;
     line-height: 1.5;
+}
+
+h4.stream_setting_subsection_title {
+    margin-bottom: 5px;
 }
 
 h4.stream_setting_subsection_title,

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -4,7 +4,7 @@
             <h3>{{t "Notification triggers" }}</h3>
             {{> settings_save_discard_widget section_name="general-notify-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
-        <p>{{t "Configure how Zulip notifies you about new messages." }}</p>
+        <p>{{t "Configure how Zulip notifies you about new messages. In muted streams, stream notification settings apply only to unmuted topics." }}</p>
         <table class="notification-table table table-bordered wrapped-table">
             <thead>
                 <tr>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -120,13 +120,13 @@
                     </div>
                 </div>
                 <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
+                <p>{{t "In muted streams, stream notification settings apply only to unmuted topics." }}</p>
                 <div class="subsection-parent">
                     {{#each notification_settings}}
                         <div class="input-group">
                             {{> stream_settings_checkbox
                               setting_name=name
                               is_checked=is_checked
-                              is_muted=(lookup ../sub "is_muted")
                               stream_id=(lookup ../sub "stream_id")
                               notification_setting=true
                               disabled_realm_setting=disabled_realm_setting

--- a/web/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/web/templates/stream_settings/stream_settings_checkbox.hbs
@@ -2,7 +2,7 @@
 <div id="sub_{{setting_name}}_setting"
   class="sub_setting_checkbox
   {{#if disabled_realm_setting}}control-label-disabled
-  {{else if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}} new-style">
+  {{else if notification_setting}}sub_notification_setting{{/if}} new-style">
     <label class="checkbox">
         <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}"
           class="sub_setting_control" type="checkbox"


### PR DESCRIPTION
This PR includes the following changes:

- Allow the user to interact with notification settings for muted streams.
- Add "In muted streams, stream notification settings apply only to unmuted topics." line of text in stream settings and decreases the space between "Notification Settings" heading and text.
- Append "In muted streams, stream notification settings apply only to unmuted topics." line of text in notification settings.

Fixes: #27272

![done](https://github.com/zulip/zulip/assets/128511266/5bc8b121-7011-427e-a098-dde063f67b2d)



<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
