### PR TITLE
help: Document settings to automatically unmute and follow topics.

### DIFF
--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -1,6 +1,7 @@
 # Follow a topic
 
-Zulip lets you follow topics you are interested in. You can configure how you get notified about new messages for topics you follow.
+Zulip lets you follow topics you are interested in. You can configure how you
+get notified about new messages for topics you follow.
 
 In muted streams, topics you follow are automatically treated as
 [unmuted](/help/mute-a-topic).
@@ -11,14 +12,7 @@ In muted streams, topics you follow are automatically treated as
 
 {tab|desktop-web}
 
-{!topic-actions.md!}
-
-1. Configure topic notifications using the row of icons at the top of the menu.
-
-!!! tip ""
-
-    You can also configure notifications by clicking the topic notifications status
-    icon in the message recipient bar or in **Recent conversations**.
+{!configure-topic-notifications-desktop-web.md!}
 
 {end_tabs}
 
@@ -39,10 +33,7 @@ In muted streams, topics you follow are automatically treated as
 
 {tab|desktop-web}
 
-{settings_tab|topics}
-
-1. Configure notifications for each topic by selecting the desired option from
-   the dropdown in the **Status** column.
+{!manage-configured-topics-desktop-web.md!}
 
 {end_tabs}
 

--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -18,14 +18,11 @@ In muted streams, topics you follow are automatically treated as
 
 ## Configure notifications for followed topics
 
-{start_tabs}
+{!configure-notifications-for-followed-topics.md!}
 
-{settings_tab|notifications}
+## Automatically follow topics
 
-1. In the **Notification triggers** table,
-   toggle the settings for **Followed topics**.
-
-{end_tabs}
+{!automatically-follow-topics.md!}
 
 ## Manage configured topics
 
@@ -39,6 +36,7 @@ In muted streams, topics you follow are automatically treated as
 
 ## Related articles
 
+* [Topic notifications](/help/topic-notifications)
 * [Stream notifications](/help/stream-notifications)
 * [Mute or unmute a topic](/help/mute-a-topic)
 * [Mute or unmute a stream](/help/mute-a-stream)

--- a/help/include/automatically-follow-topics.md
+++ b/help/include/automatically-follow-topics.md
@@ -1,0 +1,10 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|notifications}
+
+1. Under **Topic notifications**, select the desired option from the
+   **Automatically follow topics** dropdown.
+
+{end_tabs}

--- a/help/include/automatically-unmute-topics-in-muted-streams.md
+++ b/help/include/automatically-unmute-topics-in-muted-streams.md
@@ -1,0 +1,10 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|notifications}
+
+1. Under **Topic notifications**, select the desired option from the
+   **Automatically unmute topics in muted streams** dropdown.
+
+{end_tabs}

--- a/help/include/configure-notifications-for-followed-topics.md
+++ b/help/include/configure-notifications-for-followed-topics.md
@@ -1,0 +1,15 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|notifications}
+
+1. In the **Notification triggers** table,
+   toggle the settings for **Followed topics**.
+
+{end_tabs}
+
+!!! tip ""
+
+    You will receive both followed topics notifications and
+    [stream notifications](/help/stream-notifications) in topics you follow.

--- a/help/include/configure-topic-notifications-desktop-web.md
+++ b/help/include/configure-topic-notifications-desktop-web.md
@@ -1,0 +1,11 @@
+{!topic-actions.md!}
+
+1. Configure topic notifications using the row of icons at the top of the menu.
+
+!!! tip ""
+
+    You can also configure notifications by clicking the topic notifications
+    status icon (<i class="zulip-icon zulip-icon-mute-new"></i>,
+    <i class="zulip-icon zulip-icon-unmute-new"></i>, or
+    <i class="zulip-icon zulip-icon-follow"></i>) in the message recipient bar,
+    in the **Inbox view**, or in **Recent conversations**.

--- a/help/include/configure-topic-notifications.md
+++ b/help/include/configure-topic-notifications.md
@@ -2,15 +2,7 @@
 
 {tab|desktop-web}
 
-{!topic-actions.md!}
-
-1. Configure topic notifications using the row of icons at the top of the menu.
-
-!!! tip ""
-
-    You can also configure notifications by clicking the topic notifications status
-    icon in the message recipient bar, in the **Inbox view**, or in
-    **Recent conversations**.
+{!configure-topic-notifications-desktop-web.md!}
 
 {tab|mobile}
 

--- a/help/include/manage-configured-topics-desktop-web.md
+++ b/help/include/manage-configured-topics-desktop-web.md
@@ -1,0 +1,4 @@
+{settings_tab|topics}
+
+1. Configure notifications for each topic by selecting the desired option from
+   the dropdown in the **Status** column.

--- a/help/include/manage-configured-topics.md
+++ b/help/include/manage-configured-topics.md
@@ -2,10 +2,7 @@
 
 {tab|desktop-web}
 
-{settings_tab|topics}
-
-1. Configure notifications for each topic by selecting the desired option from
-   the dropdown in the **Status** column.
+{!manage-configured-topics-desktop-web.md!}
 
 {tab|mobile}
 

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -137,6 +137,7 @@
 
 ## Notifications
 * [Stream notifications](/help/stream-notifications)
+* [Topic notifications](/help/topic-notifications)
 * [Follow a topic](/help/follow-a-topic)
 * [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
 * [Mute or unmute a stream](/help/mute-a-stream)

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -6,6 +6,10 @@
 
 {!configure-topic-notifications.md!}
 
+## Automatically unmute topics in muted streams
+
+{!automatically-unmute-topics-in-muted-streams.md!}
+
 ## Manage configured topics
 
 {!manage-configured-topics.md!}
@@ -14,4 +18,5 @@
 
 * [Mute or unmute a stream](/help/mute-a-stream)
 * [Follow a topic](/help/follow-a-topic)
+* [Topic notifications](/help/topic-notifications)
 * [Mute a user](/help/mute-a-user)

--- a/help/topic-notifications.md
+++ b/help/topic-notifications.md
@@ -1,0 +1,27 @@
+# Topic notifications
+
+In Zulip, you can configure how you get notified about new messages for topics
+you follow.
+
+In muted streams, topics you follow are automatically treated as
+[unmuted](/help/mute-a-topic), and you can configure when to automatically
+unmute topics.
+
+## Configure notifications for followed topics
+
+{!configure-notifications-for-followed-topics.md!}
+
+## Automatically follow topics
+
+{!automatically-follow-topics.md!}
+
+## Automatically unmute topics in muted streams
+
+{!automatically-unmute-topics-in-muted-streams.md!}
+
+## Related articles
+
+* [Follow a topic](/help/follow-a-topic)
+* [Stream notifications](/help/stream-notifications)
+* [Mute or unmute a topic](/help/mute-a-topic)
+* [Mute or unmute a stream](/help/mute-a-stream)

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -51,10 +51,16 @@
 
         <div class="subsection-header inline-block">
             <h3>{{t "Topic notifications" }}
-                {{> ../help_link_widget link="/help/mute-a-topic" }}
+                {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="topic-notifications-settings" show_only_indicator=(not for_realm_settings) }}
-            <p>{{t "You will automatically follow topics that you have configured to both follow and unmute." }}</p>
+            <p>
+                {{#tr}}
+                    You will automatically follow topics that you have configured to both <z-follow>follow</z-follow> and <z-unmute>unmute</z-unmute>.
+                    {{#*inline "z-follow"}}<a href="/help/follow-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                    {{#*inline "z-unmute"}}<a href="/help/mute-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{/tr}}
+            </p>
         </div>
 
         <div class="input-group">

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -10,14 +10,14 @@
                 Zulip lets you mute topics and streams to avoid receiving notifications messages you are not interested in.
                 Muting a stream effectively mutes all topics in that stream. You can also manually mute a topic in an unmuted stream,
                 or unmute a topic in a muted stream. <z-link>Learn more.</z-link>
-                {{#*inline "z-link"}}<a href="/help/mute-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link"}}<a href="/help/topic-notifications" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{/if}}
     </p>
     <div class="settings_panel_list_header">
         {{#if development}}
             <h3>{{t "Topic settings"}}
-                {{> ../help_link_widget link="/help/mute-a-topic" }}
+                {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
         {{else}}
             <h3>{{t "Topic settings"}}</h3>


### PR DESCRIPTION
- Updates `follow-a-topic.md` adding Markdown include blocks for reusability in `mute-a-topic.md`.

- Adds a "Topic notifications" page, just under "Stream notifications" in the left sidebar, using Markdown include blocks for reusability in `follow-a-topic.md` and `mute-a-topic.md`.
- Adds a tip block to clarify that disabling followed topic global settings will not stop notifications if you already have stream level settings enabled.

- Updates the `?` link on "Topic notifications" and "Topic settings" to go to the new /help/topic-notifications page.
- Adds links to /help/follow-a-topic and /help/mute-a-topic.

Fixes: #27297.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/9e6d1c78-a1e5-4b38-8d69-abf1ce53c628)

- http://chat.zulip.org/help/follow-a-topic
![image](https://github.com/zulip/zulip/assets/2343554/77a85256-022a-4eb3-af85-3017cdd1c5fb)

- http://chat.zulip.org/help/mute-a-topic
![image](https://github.com/zulip/zulip/assets/2343554/72fd2126-aa4c-4ebf-b2c4-7b5fa85391ea)

http://chat.zulip.org/#settings/notifications
![image](https://github.com/zulip/zulip/assets/2343554/04da8244-1e83-40cd-8a6a-24825e7e8aa3)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Highlights technical choices
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
