### PR TITLE
popovers: Fix bug where modals persisted on hashchange.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -14,6 +14,7 @@ import * as info_overlay from "./info_overlay";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as message_viewport from "./message_viewport";
+import * as modals from "./modals";
 import * as narrow from "./narrow";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -407,6 +408,7 @@ function hashchanged(from_reload, e) {
     overlays.close_for_hash_change();
     sidebar_ui.hide_all();
     popovers.hide_all();
+    modals.close_active_if_any();
     browser_history.state.changing_hash = true;
     const ret = do_hashchange_normal(from_reload);
     browser_history.state.changing_hash = false;

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -237,3 +237,9 @@ export function close_active(): void {
     const $micromodal = $(".micromodal.modal--open");
     Micromodal.close(`${CSS.escape($micromodal.attr("id") ?? "")}`);
 }
+
+export function close_active_if_any(): void {
+    if (any_active()) {
+        close_active();
+    }
+}


### PR DESCRIPTION
Modals like those for Read receipts, Schedule message, Message edit history, User profile, etc would not close when the hash changed.

Now we close any active modal whenever the hash changes; we add a new function in `modals.ts` to do this, and call it from `hashchange.js`.

Fixes: [Issue described here on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Read.20receipts.20popover.20persists.20on.20going.20back.20in.20history)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
