### PR TITLE
help: Add documentation on font configuration for unsupported languages

### DIFF
--- a/help/change-your-language.md
+++ b/help/change-your-language.md
@@ -37,6 +37,44 @@ messages you receive.
 
 {end_tabs}
 
+## Languages supported by Zulip font
+
+Zulip's default font style is Source Sans 3 VF. Check if your language is supported by the font.
+
+{start_tabs}
+1. Go to [Source Sans 3 VF](https://fonts.adobe.com/fonts/source-sans-3).
+
+1. Scroll to the bottom of the page.
+
+1. Check to see if the **LANGUAGE SUPPORT** section has your language listed.
+
+
+{end_tabs}
+
+!!! tip ""
+
+      if your language choice is not supported by the font, Zulip will attempt to use the default font style set in your browser. You can [Change the font style in your browser](/help/change-your-language#change-the-font-style-in-your-browser).
+
+## Change the font style in your browser
+
+Note that this will change the font style for every website you visit.
+
+{start_tabs}
+
+{tab|chrome}
+
+1. Go to [chrome ](https://support.google.com/chrome/answer/96810?hl=en&co=GENIE.Platform%3DDesktop&sjid=1411821099150922893-EU)
+
+1. Follow the instructions on **font size for all webpages** to customize the font.
+
+{tab|firefox}
+
+1. Go to [firefox ](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use)
+
+1. Follow the instructions on **changing font** to customize the font.
+
+{end_tabs}
+
 ## Related articles
 
 * [Configure organization language for automated messages and invitation emails][org-lang]


### PR DESCRIPTION
- Updates `change-your-language.md`. adds instructions on how to check whether the Zulip font supports selected language and steps to configure browser font.

Fixes: #26986

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/101357449/0b01e6fc-5d00-4f41-9b0e-bf50b91438d9)

- https://zulip.com/help/change-your-language

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
