### PR TITLE
typing_indicator: Configure the volume of typing events to send.

### DIFF
--- a/web/src/typing_events.js
+++ b/web/src/typing_events.js
@@ -29,7 +29,7 @@ const MAX_USERS_TO_DISPLAY_NAME = 3;
 
 function get_users_typing_for_narrow() {
     if (narrow_state.narrowed_to_topic()) {
-        return typing_data.get_topic_typists(narrow_state.stream_id(), narrow_state.topic());
+        return [];
     }
 
     if (!narrow_state.narrowed_to_pms()) {

--- a/zerver/actions/typing.py
+++ b/zerver/actions/typing.py
@@ -1,3 +1,4 @@
+import random
 from typing import List
 
 from django.utils.translation import gettext as _
@@ -77,6 +78,14 @@ def do_send_stream_typing_notification(
         topic=topic,
     )
 
-    user_ids_to_notify = get_user_ids_for_streams({stream.id})[stream.id]
+    try:
+        with open("/etc/zulip/stream_typing_notifications") as file:
+            probability_to_notify_all = float(file.read())  # nocoverage
+    except FileNotFoundError:
+        probability_to_notify_all = 0
+
+    user_ids_to_notify = set()
+    if random.random() < probability_to_notify_all:
+        user_ids_to_notify = get_user_ids_for_streams({stream.id})[stream.id]  # nocoverage
 
     send_event(sender.realm, event, user_ids_to_notify)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1226,8 +1226,8 @@ class NormalActionsTest(BaseAction):
                 topic,
             ),
             state_change_expected=False,
+            num_events=0,
         )
-        check_typing_start("events[0]", events[0])
 
         events = self.verify_action(
             lambda: do_send_stream_typing_notification(
@@ -1237,8 +1237,8 @@ class NormalActionsTest(BaseAction):
                 topic,
             ),
             state_change_expected=False,
+            num_events=0,
         )
-        check_typing_stop("events[0]", events[0])
 
         # Having client_capability `stream_typing_notification=False`
         # shouldn't produce any events.

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 import orjson
 
 from zerver.lib.test_classes import ZulipTestCase
@@ -372,10 +374,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids: Set[int] = set()
 
         params = dict(
             type="stream",
@@ -384,7 +383,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic,
         )
 
-        with self.assert_database_query_count(5):
+        with self.assert_database_query_count(4):
             with self.capture_send_event_calls(expected_num_events=1) as events:
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
@@ -406,10 +405,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids: Set[int] = set()
 
         params = dict(
             type="stream",
@@ -418,7 +414,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic,
         )
 
-        with self.assert_database_query_count(5):
+        with self.assert_database_query_count(4):
             with self.capture_send_event_calls(expected_num_events=1) as events:
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
@@ -475,10 +471,7 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids: Set[int] = set()
 
         params = dict(
             type="stream",


### PR DESCRIPTION
This PR modifies `do_send_stream_typing_notification` to read a file per API request for the `probability_to_notify_all` value and send events accordingly.




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
