### PR TITLE
help: Update Views docs for logged-in users and document collapsed views.

### DIFF
--- a/help/inbox.md
+++ b/help/inbox.md
@@ -23,7 +23,7 @@ conversations.
 
 {tab|desktop-web}
 
-{relative|message|inbox}
+{!go-to-inbox.md!}
 
 1. Toggle **Include muted** next to the filter box at the top.
 
@@ -35,7 +35,7 @@ conversations.
 
 {tab|desktop-web}
 
-{relative|message|inbox}
+{!go-to-inbox.md!}
 
 1. Use the **Filter** box at the top to find a conversation.
    You can filter by stream, topic, or direct message participants.

--- a/help/include/all-messages.md
+++ b/help/include/all-messages.md
@@ -9,7 +9,7 @@ view](/help/configure-home-view#configure-home-view) for the Zulip web app.
 
 {tab|desktop-web}
 
-{relative|message|all}
+{!go-to-all-messages.md!}
 
 {tab|mobile}
 

--- a/help/include/go-to-all-messages.md
+++ b/help/include/go-to-all-messages.md
@@ -1,0 +1,4 @@
+1. Click on <i class="zulip-icon zulip-icon-all-messages"></i> **All messages**
+   (or <i class="zulip-icon zulip-icon-all-messages"></i> if the **views**
+   section is collapsed) in the left sidebar,
+   or use the <kbd>A</kbd> keyboard shortcut.

--- a/help/include/go-to-draft-messages.md
+++ b/help/include/go-to-draft-messages.md
@@ -1,0 +1,4 @@
+1. Click on <i class="zulip-icon zulip-icon-drafts"></i>**Drafts**
+   in the left sidebar. If the **views** section is collapsed, click on
+   the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>),
+   and select <i class="zulip-icon zulip-icon-drafts"></i>**Drafts**.

--- a/help/include/go-to-inbox.md
+++ b/help/include/go-to-inbox.md
@@ -1,0 +1,4 @@
+1. Click on <i class="zulip-icon zulip-icon-inbox"></i> **Inbox**
+   (or <i class="zulip-icon zulip-icon-inbox"></i> if the **views**
+   section is collapsed) in the left sidebar,
+   or use the <kbd>Shift</kbd> + <kbd>I</kbd> keyboard shortcut.

--- a/help/include/go-to-recent-conversations.md
+++ b/help/include/go-to-recent-conversations.md
@@ -1,0 +1,4 @@
+1. Click on <i class="zulip-icon zulip-icon-clock"></i> **Recent conversations**
+   (or <i class="zulip-icon zulip-icon-clock"></i> if the **views**
+   section is collapsed) in the left sidebar,
+   or use the <kbd>T</kbd> keyboard shortcut.

--- a/help/include/go-to-scheduled-messages.md
+++ b/help/include/go-to-scheduled-messages.md
@@ -1,0 +1,4 @@
+1. Click on <i class="zulip-icon zulip-icon-scheduled-messages"></i>**Scheduled messages**
+   in the left sidebar. If the **views** section is collapsed, click on
+   the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>), and
+   select <i class="zulip-icon zulip-icon-scheduled-messages"></i>**Scheduled messages**.

--- a/help/include/inbox-instructions.md
+++ b/help/include/inbox-instructions.md
@@ -2,7 +2,7 @@
 
 {tab|desktop-web}
 
-{relative|message|inbox}
+{!go-to-inbox.md!}
 
 1. Click on a conversation you're interested in to view it. You can return to
    **Inbox** when done to select the next conversation.

--- a/help/include/recent-conversations.md
+++ b/help/include/recent-conversations.md
@@ -6,7 +6,7 @@ for catching up on messages sent while you were away.
 
 {tab|desktop-web}
 
-{relative|message|recent}
+{!go-to-recent-conversations.md!}
 
 1. The filters at the top help you quickly find relevant conversations.
    For example, select **Participated** to narrow to the conversations you

--- a/help/include/view-mentions.md
+++ b/help/include/view-mentions.md
@@ -2,14 +2,17 @@
 
 {tab|desktop-web}
 
-1. Click **Mentions** in the left sidebar.
+1. Click on <i class="zulip-icon zulip-icon-at-sign"></i> **Mentions**
+   (or <i class="zulip-icon zulip-icon-at-sign"></i> if the **views**
+   section is collapsed) in the left sidebar.
 
 1. Browse your mentions. You can click on a message recipient bar to go
    to the [conversation](/help/recent-conversations) where you were mentioned.
 
 !!! tip ""
+
     You can also [search your mentions](/help/search-for-messages) using the
-    `is:mentioned` flag.
+    `is:mentioned` filter.
 
 {tab|mobile}
 

--- a/help/include/view-starred-messages.md
+++ b/help/include/view-starred-messages.md
@@ -2,7 +2,14 @@
 
 {tab|desktop}
 
-{relative|message|starred}
+1. Click on <i class="zulip-icon zulip-icon-star-filled"></i> **Starred messages**
+   (or <i class="zulip-icon zulip-icon-star-filled"></i> if the **views**
+   section is collapsed) in the left sidebar.
+
+!!! tip ""
+
+    You can also [search your starred messages](/help/search-for-messages)
+    using the `is:starred` filter.
 
 {tab|mobile}
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -83,7 +83,7 @@ stream or topic as read**.
 
 {tab|via-recent-conversations}
 
-{relative|message|recent}
+{!go-to-recent-conversations.md!}
 
 1. Click on an unread messages counter in the **Topic** column to mark all
    messages in that topic as read.

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -73,7 +73,7 @@ stream or topic as read**.
 
 {tab|via-inbox-view}
 
-{relative|message|inbox}
+{!go-to-inbox.md!}
 
 1. Hover over a stream or topic in the left sidebar.
 

--- a/help/schedule-a-message.md
+++ b/help/schedule-a-message.md
@@ -34,7 +34,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 {tab|desktop-web}
 
-{relative|message|scheduled}
+{!go-to-scheduled-messages.md!}
 
 1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the message you
    want to edit or reschedule.
@@ -60,7 +60,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 {tab|desktop-web}
 
-{relative|message|scheduled}
+{!go-to-scheduled-messages.md!}
 
 1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the message you
    want to send now.
@@ -82,7 +82,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 {tab|desktop-web}
 
-{relative|message|scheduled}
+{!go-to-scheduled-messages.md!}
 
 1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the message you
    want to delete.
@@ -100,7 +100,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 {tab|desktop-web}
 
-{relative|message|scheduled}
+{!go-to-scheduled-messages.md!}
 
 !!! tip ""
 

--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -37,7 +37,7 @@ saved for 30 days.
 
 {tab|desktop-web}
 
-{relative|message|drafts}
+{!go-to-draft-messages.md!}
 
 1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the draft you
    want to edit.
@@ -57,7 +57,7 @@ saved for 30 days.
 
 {tab|desktop-web}
 
-{relative|message|drafts}
+{!go-to-draft-messages.md!}
 
 1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the draft you
    want to delete.
@@ -75,7 +75,7 @@ saved for 30 days.
 
 {tab|desktop-web}
 
-{relative|message|drafts}
+{!go-to-draft-messages.md!}
 
 !!! keyboard_tip ""
 

--- a/help/view-your-mentions.md
+++ b/help/view-your-mentions.md
@@ -7,14 +7,15 @@ the messages where you were mentioned from a dedicated tab.
 !!! warn ""
 
     Because [silent mentions](/help/mention-a-user-or-group#silently-mention-a-user)
-    are designed not to attract attention, they are excluded from the **Mentions** tab.
+    are designed not to attract attention, they are excluded from the
+    **Mentions** tab.
 
 ## View your mentions
 
 {!view-mentions.md!}
 
-Topics with unread @-mentions are marked with an **@** indicator next to the number
-of unread messages.
+Topics with unread @-mentions are marked with an **@** indicator next to the
+number of unread messages.
 
 ## Related articles
 


### PR DESCRIPTION
This PR replaces special links with include / instructions blocks so that users can learn how to access views in the left sidebar from the documentation.

Fixes #27326.
Fixes part of #27359.

**Notes:**

For **Inbox**, **Recent Conversations**, and **All messages** views, I added the keyboard shortcut as part of the instruction so that it doesn't look too cluttered since these sections already have other `tips`. Similarly, I think a single-line instruction for **Drafts** and **Scheduled Messages** would work best.

**Screenshots and screen captures:**

- http://chat.zulip.org/help/inbox
![image](https://github.com/zulip/zulip/assets/2343554/eb837658-377f-463e-837a-092ff0d300e1)

- http://chat.zulip.org/help/recent-conversations
![image](https://github.com/zulip/zulip/assets/2343554/603b802b-06e2-4b9a-97bd-2ace471a6d29)

- http://chat.zulip.org/help/all-messages
![image](https://github.com/zulip/zulip/assets/2343554/41a49062-8704-45ef-b64c-c20681337aa6)

- http://chat.zulip.org/help/view-your-mentions
![image](https://github.com/zulip/zulip/assets/2343554/aee0fc30-dac0-4102-89a9-16c4ec3773da)

- http://chat.zulip.org/help/star-a-message
![image](https://github.com/zulip/zulip/assets/2343554/71ff43e0-05ba-4f13-883e-6855bf57cc4b)

- http://chat.zulip.org/help/view-and-edit-your-message-drafts
![image](https://github.com/zulip/zulip/assets/2343554/ef649780-9f6d-4a3d-b0a8-68737e0c7a8c)

- http://chat.zulip.org/help/schedule-a-message
![image](https://github.com/zulip/zulip/assets/2343554/8a7b9b11-eeab-4910-8862-9614d5ef6280)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>