### PR TITLE
stream-membership-input: Fix selecting all text and backspacing.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -339,11 +339,14 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 return;
             }
 
-            // if the user backspaces and there is input, just do normal char
-            // deletion, otherwise delete the last pill in the sequence.
+            const selection = window.getSelection();
+            // If no text is selected, and the cursor is just to the
+            // right of the last pill (with or without text in the
+            // input), then backspace deletes the last pill.
             if (
+                selection?.type !== "range" &&
                 e.key === "Backspace" &&
-                (funcs.value(e.target).length === 0 || window.getSelection()?.anchorOffset === 0)
+                (funcs.value(e.target).length === 0 || selection?.anchorOffset === 0)
             ) {
                 e.preventDefault();
                 funcs.removeLastPill();
@@ -355,7 +358,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             // should switch to focus the last pill in the list.
             // the rest of the events then will be taken care of in the function
             // below that handles events on the ".pill" class.
-            if (e.key === "ArrowLeft" && window.getSelection()?.anchorOffset === 0) {
+            if (e.key === "ArrowLeft" && selection?.anchorOffset === 0) {
                 store.$parent.find(".pill").last().trigger("focus");
             }
 


### PR DESCRIPTION
This PR aims at resolving the issues of irregularities in the Stream Membership input field, along with fixing the **Select all and backspacing issue**

Fixes: [#19544](https://github.com/zulip/zulip/issues/19544) Stream membership input: Selecting all text and backspacing does nothing.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**BEFORE FIX**:
- ```ctrl+a``` backspace  doesn't work but if selection made from any point except starting point, and ```backspace pressed```, it works fine.
![brave_uLDzvJmRjW](https://github.com/zulip/zulip/assets/97049524/4b59d51b-924c-4fb7-9f9a-91d660796dc9)

- After one or more pills are added, and then the ```ctrl+a``` backspace is done for remaining text, it removes the Last Pill rather than the text.
![brave_8hzG4INjGv](https://github.com/zulip/zulip/assets/97049524/0309ee6c-0633-4f5b-b631-cfa940c18355)

- If the input being entered has a TYPEAHEAD, then it ```ctrl+a``` backspace works as expected:
![brave_jietLp1DN7](https://github.com/zulip/zulip/assets/97049524/56c8c87d-2226-43f3-a9bf-821fb59fffc8)


**REASON FOR BEHAVIOR**: 
- This irregularity in the Stream Membership Input occurs only when Backspace is pressed with some selection with its ```anchorOffset === 0``` or with the Input field size 0
- This occurs because, the [snippet](https://github.com/zulip/zulip/blob/a7890f046bef8ae308f9909f0de08f2fa997251f/static/js/input_pill.js#L268-L278) conditionality treats Inputs with no typeahead, and inputs with a typeahead in the same way i.e., **removing the last Pill from the ```store.pills``` array, and removing its element (even in cases when there is no pill to remove or selection is not made to pill but to the text)**.
- Inputs which have a typeahead are added to the ```store.pills``` array with their ```display_value``` Pill suggested by typeahead. Hence, their behaviour is as expected but for those with no typeahead are not tracked and dealt in same way.

**FIX**: 
- The Issue is Fixed by adding a conditionality  ``` if (funcs.value(e.target).length === 0)```, which checks out if the input field is empty or not -> if not empty, then backspace deletion is normal.
- If empty -> then, it suggests that the text input is empty with/without Pill(s).
- Hence, the default behaviour backspace deletion is prevented and the ```removeLastPill()``` executed to remove the Last Pill on backspace.
 
![brave_0VU8kFtF3J](https://github.com/zulip/zulip/assets/97049524/b1f34f46-4f08-4158-920c-7859fe8342ad)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
