### PR TITLE
api-docs: Update description for update_message_flags add event.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2755,7 +2755,44 @@ paths:
                                 Event sent to a user when [message flags][message-flags] are added
                                 to messages.
 
+                                This can reflect a direct user action, or can be the indirect
+                                consequence of another action. Whatever the cause, if there's a change
+                                in the set of message flags that the user has for a message, then an
+                                `update_message_flags` event will be sent with the change. Note
+                                that this applies when the user already had access to the message, and
+                                continues to have access to it. When a message newly appears or
+                                disappears, a [`message`][message-event] or
+                                [`delete_message`][message-delete] event is sent instead.
+
+                                Some examples of actions that trigger an `update_message_flags`
+                                event:
+
+                                - The `"starred"` flag is added when the user chooses to [star a
+                                  message](/help/star-a-message).
+                                - The `"read"` flag is added when the user marks messages as read by
+                                  scrolling through them, or uses [Mark all messages as read][all-read]
+                                  on a conversation.
+                                - The `"read"` flag is added when the user [mutes](/help/mute-a-user) a
+                                  message's sender.
+                                - The `"read"` flag is added after the user unsubscribes from a stream,
+                                  or messages are moved to a not-subscribed stream, provided the user
+                                  can still access the messages at all. Note a
+                                  [`delete_message`][message-delete] event is sent in the case where the
+                                  user can no longer access the messages.
+
+                                In some cases, a change in message flags that's caused by another change
+                                may happen a short while after the original change, rather than
+                                simultaneously. For example, when messages that were unread are moved to
+                                a stream where the user is not subscribed, the resulting change in
+                                message flags (and the corresponding `update_message_flags` event with
+                                flag `"read"`) may happen later than the message move itself. The delay
+                                in that example is typically at most a few hundred milliseconds and can
+                                in rare cases be minutes or longer.
+
                                 [message-flags]: /api/update-message-flags#available-flags
+                                [message-event]: /api/get-events#message
+                                [message-delete]: /api/get-events#delete_message
+                                [all-read]: /help/marking-messages-as-read#mark-all-messages-as-read
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2813,6 +2850,10 @@ paths:
                               description: |
                                 Event sent to a user when [message flags][message-flags] are
                                 removed from messages.
+
+                                See the description for the [`update_message_flags` op:
+                                `add`](/api/get-events#update_message_flags-add) event for
+                                more details about these events.
 
                                 [message-flags]: /api/update-message-flags#available-flags
                               properties:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1961,9 +1961,16 @@ paths:
                                 Event sent when a message has been deleted.
                                 Sent to all users who received the message.
 
+                                This event is also sent when the user loses access to a message,
+                                such as when it is [moved to a stream][message-move-stream] that
+                                the user does not [have permission to access][stream-access].
+
                                 **Changes**: Before Zulip 5.0 (feature level 77), events
                                 for direct messages contained additional `sender_id` and
                                 `recipient_id` fields.
+
+                                [message-move-stream]: /help/move-content-to-another-stream
+                                [stream-access]: /help/stream-permissions
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"


### PR DESCRIPTION
Updates the description of the `update_message_flags op: add` event in the get events documentation; see [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/unreads.3A.20messages.20from.20muted.20users.3F/near/1660912).

@gnprice and @chrisbobbe mentioning you here for a review these changes. I did make a few small edits and added some more links to the text drafted in the conversation in CZO (linked above).

**Screenshots and screen captures:**

<details>
<summary>Updated update_message_flags op: add description</summary>

[Current documentation](https://zulip.com/api/get-events#update_message_flags-add)
![Screenshot from 2023-10-24 15-21-00](https://github.com/zulip/zulip/assets/63245456/257ac664-50e4-40ac-a206-57a392a759b4)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
