### PR TITLE
api-docs: Document bulk mark as read endpoints as deprecated.

### DIFF
--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -294,7 +294,10 @@ def generate_openapi_fixture(endpoint: str, method: str) -> List[str]:
 
 def get_openapi_description(endpoint: str, method: str) -> str:
     """Fetch a description from the full spec object."""
-    return openapi_spec.openapi()["paths"][endpoint][method.lower()]["description"]
+    endpoint_documentation = openapi_spec.openapi()["paths"][endpoint][method.lower()]
+    endpoint_description = endpoint_documentation["description"]
+    check_deprecated_consistency(endpoint_documentation, endpoint_description)
+    return endpoint_description
 
 
 def get_openapi_summary(endpoint: str, method: str) -> str:
@@ -432,19 +435,19 @@ def validate_schema(schema: Dict[str, Any]) -> None:
             validate_schema(schema["additionalProperties"])
 
 
-def likely_deprecated_parameter(parameter_description: str) -> bool:
-    if "**Changes**: Deprecated" in parameter_description:
+def deprecated_note_in_description(description: str) -> bool:
+    if "**Changes**: Deprecated" in description:
         return True
 
-    return "**Deprecated**" in parameter_description
+    return "**Deprecated**" in description
 
 
 def check_deprecated_consistency(argument: Mapping[str, Any], description: str) -> None:
     # Test to make sure deprecated parameters are marked so.
-    if likely_deprecated_parameter(description):
+    if deprecated_note_in_description(description):
         assert argument["deprecated"]
     if "deprecated" in argument:
-        assert likely_deprecated_parameter(description)
+        assert deprecated_note_in_description(description)
 
 
 # Skip those JSON endpoints whose query parameters are different from

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9126,6 +9126,7 @@ paths:
                       A typical failed JSON response for when the target stream does not exist:
   /users/me/subscriptions/muted_topics:
     patch:
+      deprecated: true
       operationId: mute-topic
       summary: Topic muting
       tags: ["streams"]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4853,6 +4853,7 @@ paths:
                       An example JSON response for when the supplied stream does not exist:
   /mark_all_as_read:
     post:
+      deprecated: true
       operationId: mark-all-as-read
       summary: Mark all messages as read
       tags: ["messages"]
@@ -4866,7 +4867,11 @@ paths:
         response. If all messages were marked as read, then the success response
         will return `"complete": true`.
 
-        **Changes**: Before Zulip 8.0 (feature level 211), if the server's
+        **Changes**: Deprecated; clients should use the [update personal message
+        flags for narrow](/api/update-message-flags-for-narrow) endpoint instead
+        as this endpoint will be removed in a future release.
+
+        Before Zulip 8.0 (feature level 211), if the server's
         processing was interrupted by a timeout, but some messages were marked
         as read, then it would return `"result": "partially_completed"`, along
         with a `code` field for an error string, in the success response to
@@ -4905,11 +4910,16 @@ paths:
                     example: {"msg": "", "result": "success", "complete": true}
   /mark_stream_as_read:
     post:
+      deprecated: true
       operationId: mark-stream-as-read
       summary: Mark messages in a stream as read
       tags: ["messages"]
       description: |
         Mark all the unread messages in a stream as read.
+
+        **Changes**: Deprecated; clients should use the [update personal message
+        flags for narrow](/api/update-message-flags-for-narrow) endpoint instead
+        as this endpoint will be removed in a future release.
       parameters:
         - name: stream_id
           in: query
@@ -4924,11 +4934,16 @@ paths:
           $ref: "#/components/responses/SimpleSuccess"
   /mark_topic_as_read:
     post:
+      deprecated: true
       operationId: mark-topic-as-read
       summary: Mark messages in a topic as read
       tags: ["messages"]
       description: |
         Mark all the unread messages in a topic as read.
+
+        **Changes**: Deprecated; clients should use the [update personal message
+        flags for narrow](/api/update-message-flags-for-narrow) endpoint instead
+        as this endpoint will be removed in a future release.
       parameters:
         - name: stream_id
           in: query
@@ -6405,9 +6420,6 @@ paths:
 
         See also the endpoint for [updating flags on a range of
         messages within a narrow](/api/update-message-flags-for-narrow).
-        For updating the `read` flag on common collections of messages, see also
-        the
-        [special endpoints for marking message as read in bulk](/api/mark-all-as-read).
       x-parameter-description: |
         ## Available flags
         <div>


### PR DESCRIPTION
Adds a deprecated changes note to the three bulk mark as read endpoints in the API documentation and removes the out of date link/reference to the bulk mark messages as read endpoints in the main description for the [update personal message flags](https://zulip.com/api/update-message-flags) endpoint.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/deprecate.20and.20remove.20legacy.20unread.20endpoints.2C.20.2323598/near/1641286).

Part of work on [#23598](https://github.com/zulip/zulip/issues/23598).

**Screenshots and screen captures:**

<details>
<summary>Mark messages in topic as read endpoint main description</summary>

[Current documentation](https://zulip.com/api/mark-topic-as-read)
![Screenshot from 2023-10-24 16-31-07](https://github.com/zulip/zulip/assets/63245456/0874efa6-5c9d-4f29-a2e0-a539e4788609)
</details>
<details>
<summary>Mark messages in stream as read endpoint main description</summary>

[Current documentation](https://zulip.com/api/mark-stream-as-read)
![Screenshot from 2023-10-24 16-31-03](https://github.com/zulip/zulip/assets/63245456/81c8f630-9b84-4b9a-80b9-294daca1aca4)
</details>
<details>
<summary>Mark all as read endpoint main description</summary>

[Current documentation](https://zulip.com/api/mark-all-as-read)
![Screenshot from 2023-10-24 16-30-55](https://github.com/zulip/zulip/assets/63245456/8be4e210-5861-45d4-ba29-edf85653ca3e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
