### PR TITLE
help-menu: Center align keyboard shortcut hint.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1356,7 +1356,7 @@ ul.navbar-dropdown-menu-outer-list {
     font-style: normal;
     font-weight: 500;
     line-height: 14px;
-    padding: 1px 4px 2px;
+    padding: 2px 4px;
     border-radius: 3px;
     border: 1px solid var(--color-hotkey-hint);
     margin-left: auto;


### PR DESCRIPTION
before:
<img width="307" alt="Screenshot 2023-10-25 at 1 03 03 AM" src="https://github.com/zulip/zulip/assets/25124304/000c32ca-6d33-4051-be5c-ef42fa2845e7">

after:
<img width="303" alt="Screenshot 2023-10-25 at 1 04 22 AM" src="https://github.com/zulip/zulip/assets/25124304/cf9f7b97-02c2-407b-b806-1388b78b7362">



I think Vlad wanted to use different top / bottom paddings according to the this font used in the figma which we don't use in Zulip.
<img width="303" alt="Screenshot 2023-10-24 at 11 57 26 PM" src="https://github.com/zulip/zulip/assets/25124304/046d458a-61c1-4f2e-8489-48a6530f28fb">