### PR TITLE
compose_ui: use Intl.ListFormat rather than .join(", ").

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -8,8 +8,8 @@ import {insert, replace, set, wrapSelection} from "text-field-edit";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as common from "./common";
 import {$t} from "./i18n";
-import {page_params} from "./page_params";
 import * as loading from "./loading";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
 import * as rtl from "./rtl";
@@ -250,15 +250,15 @@ export function compute_placeholder_text(opts) {
     // For direct messages
     if (opts.private_message_recipient) {
         const recipient_list = opts.private_message_recipient.split(",");
-        const recipient_names = new Intl.ListFormat(page_params.request_language).format(recipient_list
-            .map((recipient) => {
+        const recipient_names = new Intl.ListFormat(page_params.request_language).format(
+            recipient_list.map((recipient) => {
                 const user = people.get_by_email(recipient);
                 if (people.should_add_guest_user_indicator(user.user_id)) {
                     return $t({defaultMessage: "{name} (guest)"}, {name: user.full_name});
                 }
                 return user.full_name;
-            })
-        )
+            }),
+        );
 
         if (recipient_list.length === 1) {
             // If it's a single user, display status text if available

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -8,6 +8,7 @@ import {insert, replace, set, wrapSelection} from "text-field-edit";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as common from "./common";
 import {$t} from "./i18n";
+import {page_params} from "./page_params";
 import * as loading from "./loading";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
@@ -249,7 +250,7 @@ export function compute_placeholder_text(opts) {
     // For direct messages
     if (opts.private_message_recipient) {
         const recipient_list = opts.private_message_recipient.split(",");
-        const recipient_names = recipient_list
+        const recipient_names = new Intl.ListFormat(page_params.request_language).format(recipient_list
             .map((recipient) => {
                 const user = people.get_by_email(recipient);
                 if (people.should_add_guest_user_indicator(user.user_id)) {
@@ -257,7 +258,7 @@ export function compute_placeholder_text(opts) {
                 }
                 return user.full_name;
             })
-            .join(", ");
+        )
 
         if (recipient_list.length === 1) {
             // If it's a single user, display status text if available

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -247,20 +247,20 @@ run_test("compute_placeholder_text", () => {
     opts.private_message_recipient = "alice@zulip.com,bob@zulip.com";
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
-        $t({defaultMessage: "Message Alice, Bob"}),
+        $t({defaultMessage: "Message Alice and Bob"}),
     );
 
     alice.is_guest = true;
     page_params.realm_enable_guest_user_indicator = true;
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
-        $t({defaultMessage: "Message translated: Alice (guest), Bob"}),
+        $t({defaultMessage: "Message translated: Alice (guest) and Bob"}),
     );
 
     page_params.realm_enable_guest_user_indicator = false;
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
-        $t({defaultMessage: "Message Alice, Bob"}),
+        $t({defaultMessage: "Message Alice and Bob"}),
     );
 });
 


### PR DESCRIPTION


<!-- Describe your pull request here.-->
The commit resolves an issue with incorrect string formatting in the Intl.ListFormat implementation. The previous code was using .join(", ") which resulted in inconsistencies. This fix replaces the .join method with Intl.ListFormat for more accurate and localized list formatting.

Fixes: zulip#26936.<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**English**:

![image](https://github.com/zulip/zulip/assets/117565630/20d5d529-6a24-41a5-b914-01dc36b51720)

**Espanol:**

![image](https://github.com/zulip/zulip/assets/117565630/f2d1cee6-29d3-48d0-885e-2b7eaae43065)






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
