### PR TITLE
Remove almost all unchecked casts in TypeScript

### DIFF
--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -1,6 +1,6 @@
 import {strict as assert} from "assert";
 
-import type {ElementHandle, Page} from "puppeteer";
+import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
@@ -156,11 +156,9 @@ async function test_organization_permissions(page: Page): Promise<void> {
 async function test_add_emoji(page: Page): Promise<void> {
     await common.fill_form(page, "#add-custom-emoji-form", {name: "zulip logo"});
 
-    const emoji_upload_handle = await page.$("#emoji_file_input");
+    const emoji_upload_handle = await page.$("input#emoji_file_input");
     assert.ok(emoji_upload_handle);
-    await (emoji_upload_handle as ElementHandle<HTMLInputElement>).uploadFile(
-        "static/images/logo/zulip-icon-128x128.png",
-    );
+    await emoji_upload_handle.uploadFile("static/images/logo/zulip-icon-128x128.png");
     await page.click("#add-custom-emoji-modal .dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);
 
@@ -194,11 +192,9 @@ async function test_custom_realm_emoji(page: Page): Promise<void> {
 }
 
 async function test_upload_realm_icon_image(page: Page): Promise<void> {
-    const upload_handle = await page.$("#realm-icon-upload-widget .image_file_input");
+    const upload_handle = await page.$("#realm-icon-upload-widget input.image_file_input");
     assert.ok(upload_handle);
-    await (upload_handle as ElementHandle<HTMLInputElement>).uploadFile(
-        "static/images/logo/zulip-icon-128x128.png",
-    );
+    await upload_handle.uploadFile("static/images/logo/zulip-icon-128x128.png");
 
     await page.waitForSelector("#realm-icon-upload-widget .upload-spinner-background", {
         visible: true,

--- a/web/e2e-tests/copy-and-paste.test.ts
+++ b/web/e2e-tests/copy-and-paste.test.ts
@@ -37,7 +37,7 @@ async function copy_messages(
                     ctrlKey: true,
                     keyCode: 67,
                     which: 67,
-                } as KeyboardEventInit),
+                }),
             );
 
             // find temp div with copied text

--- a/web/e2e-tests/realm-creation.test.ts
+++ b/web/e2e-tests/realm-creation.test.ts
@@ -15,11 +15,11 @@ async function realm_creation_tests(page: Page): Promise<void> {
     await page.waitForSelector("#email");
     await page.type("#email", email);
     await page.type("#id_team_name", organization_name);
-    await page.$eval("#realm_in_root_domain", (el) => (el as HTMLInputElement).click());
+    await page.$eval("input#realm_in_root_domain", (el) => el.click());
 
     await Promise.all([
         page.waitForNavigation(),
-        page.$eval("#create_realm", (form) => (form as HTMLFormElement).submit()),
+        page.$eval("form#create_realm", (form) => form.submit()),
     ]);
 
     // Make sure confirmation email is sent.
@@ -59,7 +59,7 @@ async function realm_creation_tests(page: Page): Promise<void> {
     // For some reason, page.click() does not work this for particular checkbox
     // so use page.$eval here to call the .click method in the browser.
     await common.fill_form(page, "#registration", params);
-    await page.$eval("#registration", (form) => (form as HTMLFormElement).submit());
+    await page.$eval("form#registration", (form) => form.submit());
 
     // Check if realm is created and user is logged in by checking if
     // element of id `lightbox_overlay` exists.

--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -20,7 +20,7 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
     await common.fill_form(page, "form.admin-playground-form", payload);
     // Not sure why, but page.click() doesn't seem to always click the submit button.
     // So we resort to using eval with the button ID instead.
-    await page.$eval("#submit_playground_button", (el) => (el as HTMLInputElement).click());
+    await page.$eval("button#submit_playground_button", (el) => el.click());
 
     // We return the success/failure status message back to the caller.
     await page.waitForSelector(admin_playground_status_selector, {visible: true});

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -1,6 +1,6 @@
 import {strict as assert} from "assert";
 
-import type {ElementHandle, Page} from "puppeteer";
+import type {Page} from "puppeteer";
 
 import {test_credentials} from "../../var/puppeteer/test_credentials";
 
@@ -13,8 +13,8 @@ const zuliprc_regex =
     /^data:application\/octet-stream;charset=utf-8,\[api]\nemail=.+\nkey=.+\nsite=.+\n$/;
 
 async function get_decoded_url_in_selector(page: Page, selector: string): Promise<string> {
-    const a = (await page.$(selector)) as ElementHandle<HTMLAnchorElement>;
-    return decodeURIComponent(await (await a.getProperty("href")).jsonValue());
+    const a = await page.$(`a:is(${selector})`);
+    return decodeURIComponent(await (await a!.getProperty("href")).jsonValue());
 }
 
 async function open_settings(page: Page): Promise<void> {
@@ -198,9 +198,8 @@ async function test_edit_bot_form(page: Page): Promise<void> {
 
     const edit_form_selector = `#bot-edit-form[data-email="${CSS.escape(bot1_email)}"]`;
     await page.waitForSelector(edit_form_selector, {visible: true});
-    const name_field_selector = edit_form_selector + " [name=full_name]";
     assert.equal(
-        await page.$eval(name_field_selector, (el) => (el as HTMLInputElement).value),
+        await page.$eval(`${edit_form_selector} input[name=full_name]`, (el) => el.value),
         "Bot 1",
     );
 
@@ -233,9 +232,8 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
 
     const edit_form_selector = `#bot-edit-form[data-email="${CSS.escape(bot1_email)}"]`;
     await page.waitForSelector(edit_form_selector, {visible: true});
-    const name_field_selector = edit_form_selector + " [name=full_name]";
     assert.equal(
-        await page.$eval(name_field_selector, (el) => (el as HTMLInputElement).value),
+        await page.$eval(`${edit_form_selector} input[name=full_name]`, (el) => el.value),
         "Bot one",
     );
 

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -3,21 +3,18 @@ import type {Page} from "puppeteer";
 import * as common from "./lib/common";
 
 async function open_set_user_status_modal(page: Page): Promise<void> {
-    const menu_icon_selector = ".user_sidebar_entry:first-child .user-list-sidebar-menu-icon";
     // We are clicking on the menu icon with the help of `waitForFunction` because the list
     // re-renders many times and can cause the element to become stale.
-    await page.waitForFunction(
-        (selector: string): boolean => {
-            const menu_icon = document.querySelector(selector);
-            if (menu_icon) {
-                (menu_icon as HTMLSpanElement).click();
-                return true;
-            }
-            return false;
-        },
-        {},
-        menu_icon_selector,
-    );
+    await page.waitForFunction((): boolean => {
+        const menu_icon = document.querySelector<HTMLSpanElement>(
+            ".user_sidebar_entry:first-child span.user-list-sidebar-menu-icon",
+        );
+        if (menu_icon) {
+            menu_icon.click();
+            return true;
+        }
+        return false;
+    });
     await page.waitForSelector(".user_popover_email", {visible: true});
     // We are using evaluate to click because it is very hard to detect if the user info popover has opened.
     await page.evaluate(() =>

--- a/web/shared/src/typing_status.ts
+++ b/web/shared/src/typing_status.ts
@@ -18,13 +18,6 @@ type TypingStatusState = {
     idle_timer: ReturnType<typeof setTimeout>;
 };
 
-function message_type(recipient: Recipient): "direct" | "stream" {
-    if (Array.isArray(recipient)) {
-        return "direct";
-    }
-    return "stream";
-}
-
 function lower_same(a: string, b: string): boolean {
     return a.toLowerCase() === b.toLowerCase();
 }
@@ -39,13 +32,12 @@ function same_recipient(a: Recipient | null, b: Recipient | null): boolean {
         return false;
     }
 
-    if (message_type(a) === "direct" && message_type(b) === "direct") {
+    if (Array.isArray(a) && Array.isArray(b)) {
+        // direct message recipients
         return _.isEqual(a, b);
-    } else if (message_type(a) === "stream" && message_type(b) === "stream") {
-        // type assertions to avoid linter error
-        const aStreamTopic = a as StreamTopic;
-        const bStreamTopic = b as StreamTopic;
-        return same_stream_and_topic(aStreamTopic, bStreamTopic);
+    } else if (!Array.isArray(a) && !Array.isArray(b)) {
+        // stream recipients
+        return same_stream_and_topic(a, b);
     }
 
     return false;

--- a/web/src/billing/billing.ts
+++ b/web/src/billing/billing.ts
@@ -38,7 +38,10 @@ export function initialize(): void {
         }
         e.preventDefault();
         const current_licenses: number = $("#licensechange-input-section").data("licenses");
-        const new_licenses: number = Number.parseInt($("#new_licenses_input").val() as string, 10);
+        const new_licenses: number = Number.parseInt(
+            $<HTMLInputElement>("input#new_licenses_input").val()!,
+            10,
+        );
         if (new_licenses > current_licenses) {
             $("#new_license_count_holder").text(new_licenses);
             $("#current_license_count_holder").text(current_licenses);

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -7,19 +7,18 @@ import {page_params} from "./page_params";
 
 type FormDataObject = Record<string, string>;
 
-export type Prices = {
-    monthly: number;
-    annual: number;
-};
+export const schedule_schema = z.enum(["monthly", "annual"]);
+export type Prices = Record<z.infer<typeof schedule_schema>, number>;
 
-export type DiscountDetails = {
-    opensource: string;
-    research: string;
-    nonprofit: string;
-    event: string;
-    education: string;
-    education_nonprofit: string;
-};
+export const organization_type_schema = z.enum([
+    "opensource",
+    "research",
+    "nonprofit",
+    "event",
+    "education",
+    "education_nonprofit",
+]);
+export type DiscountDetails = Record<z.infer<typeof organization_type_schema>, string>;
 
 export const stripe_session_url_schema = z.object({
     stripe_session_url: z.string(),

--- a/web/src/billing/upgrade.ts
+++ b/web/src/billing/upgrade.ts
@@ -1,7 +1,7 @@
 import $ from "jquery";
 
 import * as helpers from "./helpers";
-import type {DiscountDetails, Prices} from "./helpers";
+import type {Prices} from "./helpers";
 import {page_params} from "./page_params";
 
 export const initialize = (): void => {
@@ -42,14 +42,14 @@ export const initialize = (): void => {
     });
 
     $("input[type=radio][name=schedule]").on("change", function (this: HTMLInputElement) {
-        helpers.update_charged_amount(prices, this.value as keyof Prices);
+        helpers.update_charged_amount(prices, helpers.schedule_schema.parse(this.value));
     });
 
     $("select[name=organization-type]").on("change", (e) => {
         const string_value = $((e.currentTarget as HTMLSelectElement).selectedOptions).attr(
             "data-string-value",
         );
-        helpers.update_discount_details(string_value as keyof DiscountDetails);
+        helpers.update_discount_details(helpers.organization_type_schema.parse(string_value));
     });
 
     $("#autopay_annual_price").text(helpers.format_money(prices.annual));
@@ -63,7 +63,7 @@ export const initialize = (): void => {
     );
     helpers.update_charged_amount(
         prices,
-        $("input[type=radio][name=schedule]:checked").val() as keyof Prices,
+        helpers.schedule_schema.parse($("input[type=radio][name=schedule]:checked").val()),
     );
 };
 

--- a/web/src/billing/upgrade.ts
+++ b/web/src/billing/upgrade.ts
@@ -8,9 +8,9 @@ export const initialize = (): void => {
     helpers.set_tab("upgrade");
     helpers.set_sponsorship_form();
     $("#add-card-button").on("click", (e) => {
-        const license_management: string = $(
+        const license_management = $<HTMLInputElement>(
             "input[type=radio][name=license_management]:checked",
-        ).val() as string;
+        ).val()!;
         if (!helpers.is_valid_input($(`#${CSS.escape(license_management)}_license_count`))) {
             return;
         }
@@ -37,18 +37,16 @@ export const initialize = (): void => {
         monthly: page_params.monthly_price * (1 - page_params.percent_off / 100),
     };
 
-    $("input[type=radio][name=license_management]").on("change", function (this: HTMLInputElement) {
+    $<HTMLInputElement>("input[type=radio][name=license_management]").on("change", function () {
         helpers.show_license_section(this.value);
     });
 
-    $("input[type=radio][name=schedule]").on("change", function (this: HTMLInputElement) {
+    $<HTMLInputElement>("input[type=radio][name=schedule]").on("change", function () {
         helpers.update_charged_amount(prices, helpers.schedule_schema.parse(this.value));
     });
 
-    $("select[name=organization-type]").on("change", (e) => {
-        const string_value = $((e.currentTarget as HTMLSelectElement).selectedOptions).attr(
-            "data-string-value",
-        );
+    $<HTMLSelectElement>("select[name=organization-type]").on("change", (e) => {
+        const string_value = $(e.currentTarget.selectedOptions).attr("data-string-value");
         helpers.update_discount_details(helpers.organization_type_schema.parse(string_value));
     });
 
@@ -59,11 +57,13 @@ export const initialize = (): void => {
     $("#invoice_annual_price_per_month").text(helpers.format_money(prices.annual / 12));
 
     helpers.show_license_section(
-        $("input[type=radio][name=license_management]:checked").val() as string,
+        $<HTMLInputElement>("input[type=radio][name=license_management]:checked").val()!,
     );
     helpers.update_charged_amount(
         prices,
-        helpers.schedule_schema.parse($("input[type=radio][name=schedule]:checked").val()),
+        helpers.schedule_schema.parse(
+            $<HTMLInputElement>("input[type=radio][name=schedule]:checked").val(),
+        ),
     );
 };
 

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -1,6 +1,7 @@
 // todo: Refactor pills subsystem to use modern javascript classes?
 
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import render_input_pill from "../templates/input_pill.hbs";
 
@@ -408,9 +409,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             e.preventDefault();
 
             // get text representation of clipboard
-            const text = ((e.originalEvent ?? e) as ClipboardEvent).clipboardData?.getData(
-                "text/plain",
-            );
+            assert(e.originalEvent instanceof ClipboardEvent);
+            const text = e.originalEvent.clipboardData?.getData("text/plain");
 
             // insert text manually
             document.execCommand("insertText", false, text);
@@ -440,10 +440,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         store.$parent.on("copy", ".pill", (e) => {
             const element: HTMLElement = e.currentTarget;
             const {item} = funcs.getByElement(element)!;
-            (e.originalEvent as ClipboardEvent).clipboardData?.setData(
-                "text/plain",
-                store.get_text_from_item(item),
-            );
+            assert(e.originalEvent instanceof ClipboardEvent);
+            e.originalEvent.clipboardData?.setData("text/plain", store.get_text_from_item(item));
             e.preventDefault();
         });
     }

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -277,7 +277,9 @@ export function create<Key = unknown, Item = Key>(
             if (items?.selected_items) {
                 const data = items.selected_items;
                 for (const value of data) {
-                    const $list_item = $container.find(`li[data-value = "${value as string}"]`);
+                    const $list_item = $container.find(
+                        `li[data-value="${CSS.escape(String(value))}"]`,
+                    );
                     if ($list_item.length) {
                         const $link_elem = $list_item.find("a").expectOne();
                         $list_item.addClass("checked");

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 type Context = {
     items_container_selector: string;
@@ -41,7 +42,8 @@ export function focus_on_sibling_element(context: Context): void {
 
     const $new_focus_element = get_element_by_id(elem_to_be_focused_id ?? "", context);
     if ($new_focus_element.length > 0) {
-        activate_element($new_focus_element[0].children[0] as HTMLElement, context);
+        assert($new_focus_element[0].children[0] instanceof HTMLElement);
+        activate_element($new_focus_element[0].children[0], context);
     }
 }
 
@@ -72,7 +74,8 @@ export function modals_handle_events(event_key: string, context: Context): void 
 export function set_initial_element(element_id: string, context: Context): void {
     if (element_id) {
         const $current_element = get_element_by_id(element_id, context);
-        const focus_element = $current_element[0].children[0] as HTMLElement;
+        const focus_element = $current_element[0].children[0];
+        assert(focus_element instanceof HTMLElement);
         activate_element(focus_element, context);
         $(`.${CSS.escape(context.items_list_selector)}`)[0].scrollTop = 0;
     }
@@ -145,7 +148,8 @@ function initialize_focus(event_name: string, context: Context): void {
         $element = get_first_element();
     }
 
-    const focus_element = $element[0].children[0] as HTMLElement;
+    const focus_element = $element[0].children[0];
+    assert(focus_element instanceof HTMLElement);
     activate_element(focus_element, context);
 }
 
@@ -156,7 +160,8 @@ function scroll_to_element($element: JQuery, context: Context): void {
     if ($element.children.length === 0) {
         return;
     }
-    activate_element($element[0].children[0] as HTMLElement, context);
+    assert($element[0].children[0] instanceof HTMLElement);
+    activate_element($element[0].children[0], context);
 
     const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
     const $items_container = $(`.${CSS.escape(context.items_container_selector)}`);

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Micromodal from "micromodal";
+import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip";
 import * as overlay_util from "./overlay_util";
@@ -105,7 +106,8 @@ export function open(
     const $micromodal = $(id_selector);
 
     $micromodal.find(".modal__container").on("animationend", (event) => {
-        const animation_name = (event.originalEvent as AnimationEvent).animationName;
+        assert(event.originalEvent instanceof AnimationEvent);
+        const animation_name = event.originalEvent.animationName;
         if (animation_name === "mmfadeIn") {
             // Micromodal adds the is-open class before the modal animation
             // is complete, which isn't really helpful since a modal is open after the
@@ -198,7 +200,8 @@ export function close(modal_id: string, conf: Pick<ModalConfig, "on_hidden"> = {
     // mechanism as a convenience for hooks only known when
     // closing the modal.
     $micromodal.find(".modal__container").on("animationend", (event) => {
-        const animation_name = (event.originalEvent as AnimationEvent).animationName;
+        assert(event.originalEvent instanceof AnimationEvent);
+        const animation_name = event.originalEvent.animationName;
         if (animation_name === "mmfadeOut" && conf.on_hidden) {
             conf.on_hidden();
         }

--- a/web/src/portico/portico_modals.ts
+++ b/web/src/portico/portico_modals.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Micromodal from "micromodal";
+import assert from "minimalistic-assert";
 
 import * as blueslip from "../blueslip";
 
@@ -77,7 +78,8 @@ export function open(modal_id: string, recursive_call_count: number = 0): void {
     const $micromodal = $(id_selector);
 
     $micromodal.find(".modal__container").on("animationend", (event) => {
-        const animation_name = (event.originalEvent as AnimationEvent).animationName;
+        assert(event.originalEvent instanceof AnimationEvent);
+        const animation_name = event.originalEvent.animationName;
         if (animation_name === "mmfadeIn") {
             // Micromodal adds the is-open class before the modal animation
             // is complete, which isn't really helpful since a modal is open after the

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -11,21 +11,21 @@ $(() => {
     // NB: this file is included on multiple pages.  In each context,
     // some of the jQuery selectors below will return empty lists.
 
-    const $password_field = $("#id_password, #id_new_password1");
+    const $password_field = $<HTMLInputElement>("input#id_password, input#id_new_password1");
     if ($password_field.length > 0) {
         $.validator.addMethod(
             "password_strength",
             (value: string) => password_quality(value, undefined, $password_field),
-            () => password_warning($password_field.val() as string, $password_field),
+            () => password_warning($password_field.val()!, $password_field),
         );
         // Reset the state of the password strength bar if the page
         // was just reloaded due to a validation failure on the backend.
-        password_quality($password_field.val() as string, $("#pw_strength .bar"), $password_field);
+        password_quality($password_field.val()!, $("#pw_strength .bar"), $password_field);
 
         $password_field.on("input", function () {
             // Update the password strength bar even if we aren't validating
             // the field yet.
-            password_quality($(this).val() as string, $("#pw_strength .bar"), $(this));
+            password_quality($(this).val()!, $("#pw_strength .bar"), $(this));
         });
     }
 
@@ -143,13 +143,13 @@ $(() => {
         },
     });
 
-    $(".register-page #email, .login-page-container #id_username").on(
+    $<HTMLInputElement>(".register-page input#email, .login-page-container input#id_username").on(
         "focusout keydown",
         function (e) {
             // check if it is the "focusout" or if it is a keydown, then check if
             // the keycode was the one for "Enter".
             if (e.type === "focusout" || e.key === "Enter") {
-                $(this).val(($(this).val() as string).trim());
+                $(this).val($(this).val()!.trim());
             }
         },
     );
@@ -239,7 +239,9 @@ $(() => {
 
     $("#change-email-address-visibility-modal .dialog_submit_button").on("click", () => {
         const selected_val = Number.parseInt(
-            $("#new_user_email_address_visibility").val() as string,
+            $<HTMLSelectElement & {type: "select-one"}>(
+                "select:not([multiple])#new_user_email_address_visibility",
+            ).val()!,
             10,
         );
         $("#email_address_visibility").val(selected_val);

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -42,16 +42,10 @@ export function get_playground_info_for_languages(
 function sort_pygments_pretty_names_by_priority(
     comparator_func: (a: string, b: string) => number,
 ): void {
-    const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
-        comparator_func,
+    const priority_sorted_pygments_data = Object.entries(generated_pygments_data.langs).sort(
+        ([a], [b]) => comparator_func(a, b),
     );
-    for (const alias of priority_sorted_pygments_data) {
-        // This variable is just for type safety so that we can access
-        // generated_pygments_data.langs[lang].pretty_name without a type error.
-        // We know that alias is a valid key of generated_pygments_data.langs because
-        // we just got it from Object.keys(generated_pygments_data.langs).
-        const lang = alias as keyof typeof generated_pygments_data.langs;
-        const pretty_name = generated_pygments_data.langs[lang].pretty_name;
+    for (const [alias, {pretty_name}] of priority_sorted_pygments_data) {
         // JS Map remembers the original order of insertion of keys.
         if (map_pygments_pretty_name_to_aliases.has(pretty_name)) {
             map_pygments_pretty_name_to_aliases.get(pretty_name)!.push(alias);

--- a/web/src/stats/stats.ts
+++ b/web/src/stats/stats.ts
@@ -554,9 +554,12 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
             const plotDiv = document.querySelector<Plotly.PlotlyHTMLElement>(
                 "#id_messages_sent_over_time",
             )!;
-            traces.me.visible = (plotDiv.data[0] as Plotly.PlotData).visible;
-            traces.human.visible = (plotDiv.data[1] as Plotly.PlotData).visible;
-            traces.bot.visible = (plotDiv.data[2] as Plotly.PlotData).visible;
+            assert("visible" in plotDiv.data[0]);
+            assert("visible" in plotDiv.data[1]);
+            assert("visible" in plotDiv.data[2]);
+            traces.me.visible = plotDiv.data[0].visible;
+            traces.human.visible = plotDiv.data[1].visible;
+            traces.bot.visible = plotDiv.data[2].visible;
         }
         layout.xaxis!.rangeselector = rangeselector;
         if (clicked_cumulative || initial_draw) {
@@ -693,6 +696,9 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
     }
 
     type PlotDataByMessageClient = PlotTrace & {
+        trace: {
+            x: number[];
+        };
         trace_annotations: Partial<Plotly.PlotData>;
     };
 
@@ -806,8 +812,8 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
     function draw_plot(): void {
         $("#id_messages_sent_by_client > div").removeClass("spinner");
         const data_ = plot_data[user_button][time_button];
-        layout.height = layout.margin!.b! + data_.trace.x!.length * 30;
-        layout.xaxis!.range = [0, Math.max(...(data_.trace.x as number[])) * 1.3];
+        layout.height = layout.margin!.b! + data_.trace.x.length * 30;
+        layout.xaxis!.range = [0, Math.max(...data_.trace.x) * 1.3];
         void Plotly.newPlot(
             "id_messages_sent_by_client",
             [data_.trace, data_.trace_annotations],
@@ -1300,8 +1306,10 @@ function populate_messages_read_over_time(raw_data: unknown): void {
             const plotDiv = document.querySelector<Plotly.PlotlyHTMLElement>(
                 "#id_messages_read_over_time",
             )!;
-            traces.me.visible = (plotDiv.data[0] as Plotly.PlotData).visible;
-            traces.everyone.visible = (plotDiv.data[1] as Plotly.PlotData).visible;
+            assert("visible" in plotDiv.data[0]);
+            assert("visible" in plotDiv.data[1]);
+            traces.me.visible = plotDiv.data[0].visible;
+            traces.everyone.visible = plotDiv.data[1].visible;
         }
         layout.xaxis!.rangeselector = rangeselector;
         if (clicked_cumulative || initial_draw) {

--- a/web/tests/billing.test.js
+++ b/web/tests/billing.test.js
@@ -120,7 +120,7 @@ run_test("licensechange", ({override}) => {
         assert.equal(key, "licenses");
         return 20;
     };
-    $("#new_licenses_input").val = () => 15;
+    $("input#new_licenses_input").val = () => 15;
     create_ajax_request_called = false;
     const update_licenses_button_click_handler =
         $("#update-licenses-button").get_on_handler("click");
@@ -128,7 +128,7 @@ run_test("licensechange", ({override}) => {
     assert.ok(create_ajax_request_called);
     assert.ok(!confirm_license_modal_shown);
 
-    $("#new_licenses_input").val = () => 25;
+    $("input#new_licenses_input").val = () => 25;
     create_ajax_request_called = false;
     update_licenses_button_click_handler({preventDefault() {}});
     assert.ok(!create_ajax_request_called);

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -8,6 +8,8 @@ const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
 set_global("document", {});
+class ClipboardEvent {}
+set_global("ClipboardEvent", ClipboardEvent);
 
 const noop = () => {};
 const example_img_link = "http://example.com/example.png";
@@ -163,16 +165,16 @@ run_test("copy from pill", ({mock_template}) => {
 
     const $pill_stub = "<pill-stub RED>";
 
+    const originalEvent = new ClipboardEvent();
+    originalEvent.clipboardData = {
+        setData(format, text) {
+            assert.equal(format, "text/plain");
+            copied_text = text;
+        },
+    };
     const e = {
         currentTarget: $pill_stub,
-        originalEvent: {
-            clipboardData: {
-                setData(format, text) {
-                    assert.equal(format, "text/plain");
-                    copied_text = text;
-                },
-            },
-        },
+        originalEvent,
         preventDefault: noop,
     };
 
@@ -198,15 +200,15 @@ run_test("paste to input", ({mock_template}) => {
 
     const paste_text = "blue,yellow";
 
-    const e = {
-        originalEvent: {
-            clipboardData: {
-                getData(format) {
-                    assert.equal(format, "text/plain");
-                    return paste_text;
-                },
-            },
+    const originalEvent = new ClipboardEvent();
+    originalEvent.clipboardData = {
+        getData(format) {
+            assert.equal(format, "text/plain");
+            return paste_text;
         },
+    };
+    const e = {
+        originalEvent,
         preventDefault: noop,
     };
 

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -844,7 +844,7 @@ run_test("Multiselect dropdown retain_selected_items", () => {
 
     const expected_value = [
         {
-            element: 'li[data-value = "one"]',
+            element: 'li[data-value="one"]',
             appended_class: "checked",
             prepended_data: "<i>",
         },


### PR DESCRIPTION
There are 7 remaning unchecked casts, of which 3 are in `debug-require-webpack-plugin.ts` and can probably be removed with some investigation of the webpack API:

https://github.com/zulip/zulip/blob/db05d7ef0c8dad631687f32623930a17c0830e47/web/debug-require-webpack-plugin.ts#L23-L53

and 4 are in `list_widget.ts` and are hiding an observable functionality bug (sorting muted users by date in settings doesn’t work) that needs further work:

https://github.com/zulip/zulip/blob/db05d7ef0c8dad631687f32623930a17c0830e47/web/src/list_widget.ts#L128-L155

So it looks like linting against unchecked casts would be reasonable.