### PR TITLE
api_docs: Update the docs for the `POST /messages` response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6200,13 +6200,18 @@ paths:
 
                           Only present if the sender's visibility was in fact changed.
 
-                          Intended to be used by clients where it is important to explicitly display a
-                          notice that the topic's visibility policy has changed automatically due to
-                          the message sent. The information is also important to correctly decide whether to
-                          display a warning or notice suggesting to unmute the topic after sending a message
-                          to a muted stream. Such a notice might feel confusing in the event that the act of
-                          sending the message had already resulted in the user unmuting or following the topic
-                          in question.
+                          The value can be either [unmuted or followed](/api/update-user-topic#parameter-visibility_policy).
+
+                          Clients will also be notified about the change in policy via a
+                          `user_topic` event as usual. This field is intended to be used by clients
+                          to explicitly inform the user when a topic's visibility policy was changed
+                          automatically due to sending a message.
+
+                          For example, the Zulip web application uses this field to decide whether
+                          to display a warning or notice suggesting to unmute the topic after
+                          sending a message to a muted stream. Such a notice would be confusing in
+                          the event that the act of sending the message had already resulted in the
+                          user automatically unmuting or following the topic in question.
 
                           **Changes**: New in Zulip 8.0 (feature level 218).
                     example:


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.2326900.20compose.20banner.20on.20automatic.20follow.2Funmute/near/1666571)

Changes include:
* Explicitly mention that the new visibility policy is still sent as `user_topic` event.
* Adds a link as a way to understand the meaning of the enum values '2' and '3'.

<details><summary>Docs</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/5ca54422-3cb7-4db5-9990-a8feca86e860">
</img>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
