### PR TITLE
Don't hide popovers on scrolling / resize.

### DIFF
--- a/web/src/message_viewport.js
+++ b/web/src/message_viewport.js
@@ -3,7 +3,6 @@ import $ from "jquery";
 import * as blueslip from "./blueslip";
 import * as message_lists from "./message_lists";
 import * as message_scroll_state from "./message_scroll_state";
-import * as popover_menus from "./popover_menus";
 import * as rows from "./rows";
 import * as util from "./util";
 
@@ -403,7 +402,6 @@ export function maybe_scroll_to_show_message_top() {
     const message_height = $selected_message.outerHeight(true) ?? 0;
     if (message_top < viewport_info.visible_top) {
         set_message_position(message_top, message_height, viewport_info, 0);
-        popover_menus.set_suppress_scroll_hide();
     }
 }
 

--- a/web/src/personal_menu_popover.js
+++ b/web/src/personal_menu_popover.js
@@ -43,7 +43,6 @@ export function initialize() {
             tippy(".personal-menu-clear-status", {
                 placement: "top",
                 appendTo: document.body,
-                interactive: true,
             });
 
             $popper.one("click", ".personal-menu-clear-status", (e) => {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -11,17 +11,6 @@ import * as modals from "./modals";
 import * as overlays from "./overlays";
 import * as popovers from "./popovers";
 
-// On mobile web, opening the keyboard can trigger a resize event
-// (which in turn can trigger a scroll event).  This will have the
-// side effect of closing popovers, which we don't want.  So we
-// suppress the first hide from scrolling after a resize using this
-// variable.
-let suppress_scroll_hide = false;
-
-export function set_suppress_scroll_hide() {
-    suppress_scroll_hide = true;
-}
-
 export const popover_instances = {
     compose_control_buttons: null,
     starred_messages: null,
@@ -288,25 +277,4 @@ export function initialize() {
     overlays.register_pre_close_hook(popovers.hide_all);
     modals.register_pre_open_hook(popovers.hide_all);
     modals.register_pre_close_hook(popovers.hide_all);
-
-    let last_scroll = 0;
-
-    $(document).on("scroll", () => {
-        if (suppress_scroll_hide) {
-            suppress_scroll_hide = false;
-            return;
-        }
-
-        const date = Date.now();
-
-        // only run `popovers.hide_all()` if the last scroll was more
-        // than 250ms ago.
-        if (date - last_scroll > 250) {
-            popovers.hide_all();
-        }
-
-        // update the scroll time on every event to make sure it doesn't
-        // retrigger `hide_all` while still scrolling.
-        last_scroll = date;
-    });
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -225,6 +225,11 @@ function get_props_for_popover_centering(popover_props) {
 // shortcuts and similar alternative ways to open a popover menu.
 export function toggle_popover_menu(target, popover_props, options) {
     const instance = target._tippy;
+    if (instance) {
+        instance.hide();
+        return;
+    }
+
     let mobile_popover_props = {};
 
     // If the window is mobile-sized, we will render the
@@ -233,11 +238,6 @@ export function toggle_popover_menu(target, popover_props, options) {
         mobile_popover_props = {
             ...get_props_for_popover_centering(popover_props),
         };
-    }
-
-    if (instance) {
-        instance.hide();
-        return;
     }
 
     tippy(target, {

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -993,9 +993,6 @@ export function complete_rerender() {
         callback_after_render: () => setTimeout(revive_current_focus, 0),
         is_scroll_position_for_render,
         post_scroll__pre_render_callback() {
-            // Hide popovers on scroll in recent conversations.
-            popovers.hide_all();
-
             // Update the focused element for keyboard navigation if needed.
             recenter_focus_if_off_screen();
         },

--- a/web/src/resize_handler.js
+++ b/web/src/resize_handler.js
@@ -4,8 +4,6 @@ import * as compose_ui from "./compose_ui";
 import * as condense from "./condense";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
-import * as popover_menus from "./popover_menus";
-import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as sidebar_ui from "./sidebar_ui";
 import * as util from "./util";
@@ -15,13 +13,9 @@ export let _old_width = $(window).width();
 export function handler() {
     const new_width = $(window).width();
 
-    // On mobile web, we want to avoid hiding a popover here on height change,
-    // especially if this resize was triggered by a virtual keyboard
-    // popping up when the user opened that very popover.
     const mobile = util.is_mobile();
     if (!mobile || new_width !== _old_width) {
         sidebar_ui.hide_all();
-        popovers.hide_all();
     }
 
     if (new_width !== _old_width) {
@@ -38,10 +32,6 @@ export function handler() {
     // but before we've loaded in the messages; in that case, don't
     // try to scroll to one.
     if (message_lists.current.selected_id() !== -1) {
-        if (mobile) {
-            popover_menus.set_suppress_scroll_hide();
-        }
-
         message_viewport.scroll_to_selected();
     }
 }


### PR DESCRIPTION
There are few things to notice:
* It doesn't work perfectly for resize as the `reference` can hide during the reisze which triggers the popover to hide, but I don't think that's a real issue since for mobile overlay popovers, it works to not hide the popovers with `show-when-reference-hidden` class.
* If the reference goes under fixed / sticky element, but not outside the window, the popover would still be visible but the reference not. It is super expensive to do that check so, instead we just check compose, navbar or sticky message header not obscuring the reference which is where it makes a real difference.