### PR TITLE
Search: Add is:followed search filter.

### DIFF
--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -99,6 +99,8 @@ Zulip offers the following filters based on the location of the message.
 
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
+* `is:followed`: Search messages in [topics followed](/help/follow-a-topic) by you.
+* `-is:followed`: Search messages in topics [not followed](/help/follow-a-topic) by you.
 * `is:unread`: Search your unread messages.
 
 ### Search by message ID

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -151,6 +151,11 @@ function message_matches_search_term(message: Message, operator: string, operand
                     return unread.message_unread(message);
                 case "resolved":
                     return message.type === "stream" && resolved_topic.is_resolved(message.topic);
+                case "followed":
+                    return (
+                        message.type === "stream" &&
+                        user_topics.is_topic_followed(message.stream_id, message.topic)
+                    );
                 default:
                     return false; // is:whatever returns false
             }
@@ -480,6 +485,7 @@ export class Filter {
             "is-starred",
             "is-unread",
             "is-resolved",
+            "is-followed",
             "has-link",
             "has-image",
             "has-attachment",
@@ -728,6 +734,8 @@ export class Filter {
             "not-is-dm",
             "is-resolved",
             "not-is-resolved",
+            "is-followed",
+            "not-is-followed",
             "in-home",
             "in-all",
             "streams-public",
@@ -828,6 +836,9 @@ export class Filter {
         if (_.isEqual(term_types, ["sender"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["is-followed"])) {
+            return true;
+        }
         return false;
     }
 
@@ -882,6 +893,8 @@ export class Filter {
                     return "/#narrow/dm/" + people.emails_to_slug(this.operands("dm").join(","));
                 case "is-resolved":
                     return "/#narrow/topics/is/resolved";
+                case "is-followed":
+                    return "/#narrow/topics/is/followed";
                 // TODO: It is ambiguous how we want to handle the 'sender' case,
                 // we may remove it in the future based on design decisions
                 case "sender":
@@ -1013,6 +1026,8 @@ export class Filter {
                     return $t({defaultMessage: "All direct messages"});
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
+                case "is-followed":
+                    return $t({defaultMessage: "Topics followed"});
                 // These cases return false for is_common_narrow, and therefore are not
                 // formatted in the message view header. They are used in narrow.js to
                 // update the browser title.

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -239,6 +239,10 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                     return {
                         title: $t({defaultMessage: "No topics are marked as resolved."}),
                     };
+                case "followed":
+                    return {
+                        title: $t({defaultMessage: "No topics are followed by you."}),
+                    };
             }
             // fallthrough to default case if no match is found
             break;

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -606,6 +606,11 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
                 {operator: "dm-including"},
             ],
         },
+        {
+            search_string: "is:followed",
+            description_html: "topics followed",
+            incompatible_patterns: [{operator: "is", operand: "followed"}],
+        },
     ];
     return get_special_filter_suggestions(last, terms, suggestions);
 }

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -31,6 +31,10 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}topics marked as resolved
             {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "followed")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}topics followed
+            {{~!-- squash whitespace --~}}
         {{else}}
             {{~!-- squash whitespace --~}}
             invalid {{this.operand}} operand for is operator

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -124,6 +124,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">is:followed</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in followed topics.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">is:unread</td>
                         <td class="definition">
                             {{t 'Narrow to unread messages.'}}

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -296,6 +296,7 @@ test("basics", () => {
     // filter.supports_collapsing_recipients loop.
     terms = [
         {operator: "is", operand: "resolved", negated: true},
+        {operator: "is", operand: "followed", negated: true},
         {operator: "is", operand: "dm", negated: true},
         {operator: "stream", operand: "stream_name", negated: true},
         {operator: "streams", operand: "web-public", negated: true},
@@ -400,6 +401,10 @@ function assert_not_mark_read_with_is_operands(additional_terms_to_test) {
     }
 
     is_operator = [{operator: "is", operand: "resolved", negated: true}];
+    filter = new Filter([...additional_terms_to_test, ...is_operator]);
+    assert.ok(!filter.can_mark_messages_read());
+
+    is_operator = [{operator: "is", operand: "followed", negated: true}];
     filter = new Filter([...additional_terms_to_test, ...is_operator]);
     assert.ok(!filter.can_mark_messages_read());
 }
@@ -757,6 +762,9 @@ test("predicate_basics", () => {
     const resolved_topic_name = resolved_topic.resolve_name("foo");
     assert.ok(predicate({type: "stream", topic: resolved_topic_name}));
     assert.ok(!predicate({topic: resolved_topic_name}));
+    assert.ok(!predicate({type: "stream", topic: "foo"}));
+
+    predicate = get_predicate([["is", "followed"]]);
     assert.ok(!predicate({type: "stream", topic: "foo"}));
 
     const unknown_stream_id = 999;
@@ -1232,6 +1240,10 @@ test("describe", ({mock_template}) => {
     string = "topics marked as resolved";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
+    narrow = [{operator: "is", operand: "followed"}];
+    string = "topics followed";
+    assert.equal(Filter.search_description_as_html(narrow), string);
+
     narrow = [{operator: "is", operand: "something_we_do_not_support"}];
     string = "invalid something_we_do_not_support operand for is operator";
     assert.equal(Filter.search_description_as_html(narrow), string);
@@ -1542,6 +1554,7 @@ test("navbar_helpers", () => {
     const is_dm = [{operator: "is", operand: "dm"}];
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const is_resolved = [{operator: "is", operand: "resolved"}];
+    const is_followed = [{operator: "is", operand: "followed"}];
     const streams_public = [{operator: "streams", operand: "public"}];
     const stream_topic_terms = [
         {operator: "stream", operand: "foo"},
@@ -1636,6 +1649,12 @@ test("navbar_helpers", () => {
             icon: "check",
             title: "translated: Topics marked as resolved",
             redirect_url_with_search: "/#narrow/topics/is/resolved",
+        },
+        {
+            terms: is_followed,
+            is_common_narrow: true,
+            title: "translated: Topics followed",
+            redirect_url_with_search: "/#narrow/topics/is/followed",
         },
         {
             terms: stream_topic_terms,

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -334,6 +334,13 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         empty_narrow_html("translated: No topics are marked as resolved."),
     );
 
+    set_filter([["is", "followed"]]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: No topics are followed by you."),
+    );
+
     // organization has disabled sending direct messages
     realm.realm_private_message_policy =
         settings_config.private_message_policy_values.disabled.code;

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -426,6 +426,7 @@ test("empty_query_suggestions", () => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "is:followed",
         "sender:myself@zulip.com",
         "stream:devel",
         "stream:office",
@@ -445,6 +446,7 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:followed"), "Topics followed");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
     assert.equal(describe("has:link"), "Messages that contain links");
     assert.equal(describe("has:image"), "Messages that contain images");
@@ -530,6 +532,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "is:followed",
         "sender:alice@zulip.com",
         "dm:alice@zulip.com",
         "dm-including:alice@zulip.com",
@@ -547,6 +550,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:followed"), "Topics followed");
 
     query = "-i";
     suggestions = get_suggestions(query);
@@ -558,6 +562,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "-is:alerted",
         "-is:unread",
         "-is:resolved",
+        "-is:followed",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -567,12 +572,21 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Exclude topics marked as resolved");
+    assert.equal(describe("-is:followed"), "Exclude topics followed");
 
     // operand suggestions follow.
 
     query = "is:";
     suggestions = get_suggestions(query);
-    expected = ["is:dm", "is:starred", "is:mentioned", "is:alerted", "is:unread", "is:resolved"];
+    expected = [
+        "is:dm",
+        "is:starred",
+        "is:mentioned",
+        "is:alerted",
+        "is:unread",
+        "is:resolved",
+        "is:followed",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:st";

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -60,6 +60,7 @@ from zerver.lib.streams import (
 )
 from zerver.lib.topic import (
     RESOLVED_TOPIC_PREFIX,
+    get_followed_topic_condition_sa,
     get_resolved_topic_condition_sa,
     get_topic_from_message_info,
     topic_column_sa,
@@ -175,6 +176,8 @@ def build_narrow_predicate(
                 topic_name = get_topic_from_message_info(message)
                 if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
                     return False
+            elif operator == "is" and operand == "followed" and message["type"] != "stream":
+                return False
             return True
 
         for narrow_term in narrow:
@@ -382,6 +385,9 @@ class NarrowBuilder:
             return query.where(maybe_negate(cond))
         elif operand == "resolved":
             cond = get_resolved_topic_condition_sa()
+            return query.where(maybe_negate(cond))
+        elif operand == "followed":
+            cond = get_followed_topic_condition_sa()
             return query.where(maybe_negate(cond))
         raise BadNarrowOperatorError("unknown 'is' operand " + operand)
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -11,7 +11,7 @@ from sqlalchemy.types import Boolean, Text
 from zerver.lib.request import REQ
 from zerver.lib.types import EditHistoryEvent
 from zerver.lib.utils import assert_is_not_none
-from zerver.models import Message, Reaction, Stream, UserMessage, UserProfile
+from zerver.models import Message, Reaction, Stream, UserMessage, UserProfile, UserTopic
 
 # Only use these constants for events.
 ORIG_TOPIC = "orig_subject"
@@ -82,6 +82,13 @@ def topic_match_sa(topic_name: str) -> ColumnElement[Boolean]:
 def get_resolved_topic_condition_sa() -> ColumnElement[Boolean]:
     resolved_topic_cond = column("subject", Text).startswith(RESOLVED_TOPIC_PREFIX)
     return resolved_topic_cond
+
+
+def get_followed_topic_condition_sa() -> ColumnElement[Boolean]:
+    followed_topic = UserTopic.objects.filter(visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED)
+    followed_topic_names = [topic["topic_name"] for topic in followed_topic.values("topic_name")]
+    follow_topic_cond = column("subject", Text).in_(followed_topic_names)
+    return follow_topic_cond
 
 
 def topic_column_sa() -> ColumnElement[Text]:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -268,6 +268,10 @@ class NarrowBuilderTest(ZulipTestCase):
         term = dict(operator="is", operand="resolved", negated=True)
         self._do_add_term_test(term, "WHERE (subject NOT LIKE %(subject_1)s || '%%'")
 
+    def test_add_term_using_is_operator_for_negated_followed_topics(self) -> None:
+        term = dict(operator="is", operand="followed", negated=True)
+        self._do_add_term_test(term, "WHERE (subject NOT IN (__[POSTCOMPILE_subject_1]))")
+
     def test_add_term_using_non_supported_operator_should_raise_error(self) -> None:
         term = dict(operator="is", operand="non_supported")
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
@@ -852,6 +856,24 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertFalse(
             narrow_predicate(
                 message={"type": "stream", "subject": "java"},
+                flags=[],
+            )
+        )
+
+        ###
+
+        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="followed")])
+
+        self.assertTrue(
+            narrow_predicate(
+                message={"type": "stream"},
+                flags=[],
+            )
+        )
+
+        self.assertFalse(
+            narrow_predicate(
+                message={"type": "private"},
                 flags=[],
             )
         )


### PR DESCRIPTION
<!-- Describe your pull request here.-->
### Description
With the `is:followed` filter, users can easily narrow down their message search results to include only those messages within topics they are actively following. Similarly `-is:followed` filter, excludes topics that are followed by the user.

Fixes: #27309 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/91622060/e47a5eb3-a07e-4909-b75f-c0842d7b7593

Help Center 

![image](https://github.com/zulip/zulip/assets/91622060/ebc408cd-25d4-4ba1-9f62-9cf31f92666d)

**Improvements for the future:** Creating more effective test cases. As this was my initial attempt at writing tests, there's room for improvement in both `filter.test.js` and `test_message_fetch.py`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
