### PR TITLE
help: Document new help menu.

### DIFF
--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -154,7 +154,9 @@ A summary of the formatting syntax above is available in the Zulip app.
 
 {start_tabs}
 
-{relative|gear|message-formatting}
+{tab|desktop-web}
+
+{relative|help|message-formatting}
 
 !!! tip ""
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -240,7 +240,13 @@ A summary of the keyboard shortcuts above is available in the Zulip app.
 
 {start_tabs}
 
-{relative|gear|keyboard-shortcuts}
+{tab|desktop-web}
+
+{relative|help|keyboard-shortcuts}
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>?</kbd> to open the keyboard shortcuts reference.
 
 {end_tabs}
 

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -154,7 +154,9 @@ A summary of the search filters above is available in the Zulip app.
 
 {start_tabs}
 
-{relative|gear|search-filters}
+{tab|desktop-web}
+
+{relative|help|search-filters}
 
 {end_tabs}
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -29,15 +29,6 @@ gear_info = {
     "stats": ['<i class="fa fa-bar-chart"></i> Usage statistics', "/stats"],
     "plans": ['<i class="fa fa-rocket"></i> Plans and pricing', "/plans/"],
     "billing": ['<i class="fa fa-credit-card"></i> Billing', "/billing/"],
-    "keyboard-shortcuts": [
-        '<i class="fa fa-keyboard-o"></i> Keyboard shortcuts (?)',
-        "/#keyboard-shortcuts",
-    ],
-    "message-formatting": [
-        '<i class="fa fa-pencil"></i> Message formatting',
-        "/#message-formatting",
-    ],
-    "search-filters": ['<i class="fa fa-search"></i> Search filters', "/#search-operators"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 
@@ -55,6 +46,41 @@ def gear_handle_match(key: str) -> str:
     else:
         item = f"**{gear_info[key][0]}**"
     return gear_instructions.format(item=item)
+
+
+help_info = {
+    # The pattern is key: [name, link]
+    # key is from REGEXP: `{relative|help|key}`
+    # name is what the item is called in the help menu: `Select **name**.`
+    # link is used for relative links: `Select [name](link).`
+    "keyboard-shortcuts": [
+        '<i class="zulip-icon zulip-icon-keyboard"></i> Keyboard shortcuts',
+        "/#keyboard-shortcuts",
+    ],
+    "message-formatting": [
+        '<i class="zulip-icon zulip-icon-edit"></i> Message formatting',
+        "/#message-formatting",
+    ],
+    "search-filters": [
+        '<i class="zulip-icon zulip-icon-manage-search"></i> Search filters',
+        "/#search-operators",
+    ],
+}
+
+help_instructions = """
+1. Click on the **Help menu** (<i class="zulip-icon zulip-icon-help"></i>) icon
+   in the upper right corner of the app.
+
+1. Select {item}.
+"""
+
+
+def help_handle_match(key: str) -> str:
+    if relative_help_links:
+        item = f"[{help_info[key][0]}]({help_info[key][1]})"
+    else:
+        item = f"**{help_info[key][0]}**"
+    return help_instructions.format(item=item)
 
 
 stream_info = {
@@ -136,6 +162,7 @@ LINK_TYPE_HANDLERS = {
     "gear": gear_handle_match,
     "stream": stream_handle_match,
     "message": message_handle_match,
+    "help": help_handle_match,
 }
 
 


### PR DESCRIPTION
- Updates help center docs to reflect the new dedicated help menu.
- Adds `keyboard_tip` to document the `?` keyboard shortcut.

Fixes #27384.

**Screenshots and screen captures:**

- https://chat.zulip.org/help/keyboard-shortcuts#keyboard-shortcuts-reference
![image](https://github.com/zulip/zulip/assets/2343554/11d64bf6-3b64-41ff-b3fc-23adf0bbc785)

- https://chat.zulip.org/help/format-your-message-using-markdown#message-formatting-reference
![image](https://github.com/zulip/zulip/assets/2343554/c5342356-15ae-4670-9431-d6ffdbfc6478)

- https://chat.zulip.org/help/search-for-messages#search-filters-reference
![image](https://github.com/zulip/zulip/assets/2343554/f74c7919-2d13-49ed-b6fe-439f1b42c805)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>