### PR TITLE
navbar: Redesign left-sidebar toggle and unread indicator.

### DIFF
--- a/web/src/unread_ui.js
+++ b/web/src/unread_ui.js
@@ -62,16 +62,9 @@ export function notify_messages_remain_unread() {
 
 export function set_count_toggle_button($elem, count) {
     if (count === 0) {
-        if ($elem.is(":animated")) {
-            return $elem.stop(true, true).hide();
-        }
-        return $elem.hide(500);
-    } else if (count > 0 && count < 1000) {
-        $elem.show(500);
-        return $elem.text(count);
+        return $elem.hide();
     }
-    $elem.show(500);
-    return $elem.text("1k+");
+    return $elem.show();
 }
 
 export function update_unread_counts(skip_animations = false) {
@@ -86,8 +79,7 @@ export function update_unread_counts(skip_animations = false) {
         hook(res, skip_animations);
     }
 
-    // Set the unread counts that we show in the buttons that
-    // toggle open the sidebar menus when we have a thin window.
+    // Set the unread indicator on the toggle for the left sidebar
     set_count_toggle_button($("#streamlist-toggle-unreadcount"), res.home_unread_messages);
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -733,14 +733,8 @@
         color: hsl(236deg 33% 90%);
     }
 
-    #streamlist-toggle,
     #userlist-toggle {
         color: inherit;
-    }
-
-    #streamlist-toggle-button {
-        color: inherit;
-        background-color: inherit;
     }
 
     #userlist-toggle-button {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -733,18 +733,6 @@
         color: hsl(236deg 33% 90%);
     }
 
-    #userlist-toggle {
-        color: inherit;
-    }
-
-    #userlist-toggle-button {
-        color: hsl(221deg 9% 54%);
-
-        &:hover {
-            color: inherit;
-        }
-    }
-
     .zoom-in {
         #topics_header {
             background-color: var(--color-background);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3118,14 +3118,20 @@ select.invite-as {
 @media (width < $sm_min) {
     .column-right.expanded .right-sidebar,
     .column-left.expanded .left-sidebar {
-        margin-top: 31px;
+        margin-top: var(--navbar-fixed-height);
+        /* For very small sizes, skip the relatively large top padding. */
+        padding-top: 0;
+    }
+
+    /* TODO: Properly and accurately align the
+       topmost headers on the left and right
+       sidebar. */
+    .column-right.expanded .right-sidebar-items {
+        margin-top: 10px;
     }
 
     .column-left.expanded {
         .left-sidebar {
-            /* For very small sizes, skip the relatively large top padding. */
-            padding-top: 0;
-
             #streams_header {
                 padding-right: 10px;
             }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2277,8 +2277,6 @@ div.focused-message-list {
     top: 0;
     left: 0;
     text-align: center;
-    vertical-align: middle;
-    /* border-right: 2px solid hsl(204, 20%, 74%); */
 }
 
 .hide-streamlist-toggle-visibility,
@@ -2289,12 +2287,11 @@ div.focused-message-list {
 #streamlist-toggle-button {
     text-decoration: none;
     color: hsl(0deg 0% 52%);
-    display: block;
-    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 40px;
-    height: 19px;
-    padding-top: 12px;
-    padding-bottom: 9px;
+    height: 40px;
 }
 
 #streamlist-toggle-unreadcount {
@@ -3189,8 +3186,6 @@ select.invite-as {
 
     #streamlist-toggle-button {
         height: var(--header-height);
-        padding-top: 0;
-        padding-bottom: 0;
     }
 
     .column-right #personal-menu .header-button-avatar {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2286,12 +2286,29 @@ div.focused-message-list {
 
 #streamlist-toggle-button {
     text-decoration: none;
-    color: hsl(0deg 0% 52%);
+    color: var(--color-navbar-icon);
     display: flex;
     align-items: center;
     justify-content: center;
     width: 40px;
     height: 40px;
+
+    &:hover {
+        background-color: var(--color-header-button-hover);
+    }
+
+    &:active {
+        background-color: var(--color-header-button-focus);
+    }
+
+    &:focus {
+        outline: 0;
+    }
+
+    &:focus-visible {
+        outline: none;
+        background-color: var(--color-header-button-focus);
+    }
 }
 
 #streamlist-toggle-unreadcount {
@@ -2299,7 +2316,7 @@ div.focused-message-list {
     display: none;
     height: 6px;
     width: 6px;
-    background-color: var(--color-background-unread-counter-dot);
+    background-color: var(--color-navbar-icon);
     top: 10px;
     right: 9px;
     border: 2px solid var(--color-background-navbar);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2297,20 +2297,15 @@ div.focused-message-list {
 #streamlist-toggle-unreadcount {
     position: absolute;
     display: none;
-    height: 12px;
-    min-width: 12px;
-    line-height: 12px;
-    background-color: hsl(0deg 100% 20%);
-    top: 4px;
-    right: 4px;
-    border: 1px solid hsl(0deg 0% 93%);
-    box-shadow: 0 0 1px hsl(0deg 0% 0% / 20%);
-    border-radius: 12px;
-    padding: 1px;
-    font-size: 9px;
-    z-index: 15;
-    font-weight: normal;
-    color: hsl(0deg 0% 100%);
+    height: 6px;
+    width: 6px;
+    background-color: var(--color-background-unread-counter-dot);
+    top: 10px;
+    right: 9px;
+    border: 2px solid var(--color-background-navbar);
+    border-radius: 6px;
+    padding: 0;
+    font-size: 0;
 }
 
 .nav .dropdown-menu {
@@ -3186,6 +3181,11 @@ select.invite-as {
 
     #streamlist-toggle-button {
         height: var(--header-height);
+    }
+
+    #streamlist-toggle-unreadcount {
+        /* Adjust in response to shorter navbar. */
+        top: 5px;
     }
 
     .column-right #personal-menu .header-button-avatar {


### PR DESCRIPTION
This implements an unread dot and redesigned icon colors, including for hover and visible focus interactions, for the left-sidebar/streams toggle.

It also corrects some layout issues with the revealed sidebars under certain conditions. Note that those fixes are to a certain degree stop-gap. Forthcoming layout work in the right sidebar will result in a pixel-perfect vertical alignment shared with both the VIEWS and USERS headings.

Finally, there's a commit that just removes a bit of unnecessary cruft related to the users toggle--colors and interactions there are already handled using CSS variables.

Fixes: #27357

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/unread.20counts.20in.20top.20bar/near/1663455); also [regarding dark mode colors](https://chat.zulip.org/#narrow/stream/101-design/topic/dark-mode.20toggle.20colors/near/1669363), and [regarding sidebar layout](https://chat.zulip.org/#narrow/stream/9-issues/topic/toggled.20sidebar.20layout.20inconsistencies/near/1669305)

**Screenshots and screen captures:**

| Toggle interactions, light | Toggle interactions, dark |
| --- | --- |
| ![toggle-interactions-light](https://github.com/zulip/zulip/assets/170719/f04015ee-8053-44c3-99b7-ebca8840d337) | ![toggle-interactions-dark](https://github.com/zulip/zulip/assets/170719/3e3c3e5c-239c-426e-9d28-25344187fe50) |

| Toggle display, before | Toggle display, after |
| --- | --- |
| ![lsb-toggle-light-before](https://github.com/zulip/zulip/assets/170719/953fb8d0-58b2-4274-94d4-6ebae51ff9ef) | ![lsb-toggle-light-after](https://github.com/zulip/zulip/assets/170719/bc5d4ba3-c3da-4ab3-8724-1c7ce5560182) |
| ![lsb-toggle-dark-before](https://github.com/zulip/zulip/assets/170719/a1e94a1a-b1ae-4409-82e1-2c96a327702e) | ![lsb-toggle-dark-after](https://github.com/zulip/zulip/assets/170719/7403556e-820c-4fd4-a450-d18d695ea98a) |

| Extra-small sidebars, before | Extra-small sidebars, after |
| --- | --- |
| ![banner-xsm-before](https://github.com/zulip/zulip/assets/170719/60155be2-3a52-4d21-bf24-c2548ac729cd) | ![banner-xsm-after](https://github.com/zulip/zulip/assets/170719/6734c521-51fc-4930-8cc4-b18e102bcaf6) |
| ![no-banner-xsm-before](https://github.com/zulip/zulip/assets/170719/ffed77ae-26ea-4bf3-8469-ca032cf28824) | ![no-banner-xsm-after](https://github.com/zulip/zulip/assets/170719/f176f67c-a240-4133-b233-6ef59138c5f2) |

| Small sidebars, before | Small sidebars, after |
| --- | --- |
| ![banner-sm-before](https://github.com/zulip/zulip/assets/170719/12f769ad-7ae9-4320-8e86-d13ff0c41613) | ![banner-sm-after](https://github.com/zulip/zulip/assets/170719/29937602-5931-4511-8e90-5538226534f9) |
| ![no-banner-sm-before](https://github.com/zulip/zulip/assets/170719/d16693d9-bd60-4e20-97c6-6504c6a34830) | ![no-banner-sm-after](https://github.com/zulip/zulip/assets/170719/0853ddd4-4526-43a8-9d27-78d0e20a7b1f) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>