### PR TITLE
navbar: Correct for alpha background on unread dot's border.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -327,7 +327,35 @@ body {
     --color-gear-menu-lighter-text: hsl(0deg 0% 40%);
     --color-gear-menu-blue-text: hsl(217deg 100% 50%);
     --color-header-button-hover: hsl(0deg 0% 0% / 5%);
+    /* This is a technique for directing CSS to do
+       the color mixing ordinarily handled by the
+       alpha channel in hsl(); here, the alpha value
+       is omitted from the hsl() syntax and instead
+       used as the percentage for mixing over top of
+       the navbar background. This is needed so that
+       elements like the unread-count dot can make
+       use of the color, but neither compound alpha
+       values or apply alpha values over different
+       colors, such as the background color on the
+       unread dot.
+
+       The second color value aligns with
+       --color-background-navbar. We use the value
+       directly so that this gets compiled down to
+       an rgb() value by PostCSS Preset Env. */
+    --color-header-button-hover-no-alpha: color-mix(
+        in srgb,
+        hsl(0deg 0% 0%) 5%,
+        hsl(0deg 0% 97%)
+    );
     --color-header-button-focus: hsl(0deg 0% 0% / 8%);
+    /* The second color value aligns with
+       --color-background-navbar */
+    --color-header-button-focus-no-alpha: color-mix(
+        in srgb,
+        hsl(0deg 0% 0%) 8%,
+        hsl(0deg 0% 97%)
+    );
     --color-fill-hover-copy-icon: hsl(200deg 100% 40%);
     --color-fill-user-invite-copy-icon: hsl(0deg 0% 46.7%);
 }
@@ -483,7 +511,21 @@ body {
     --color-gear-menu-lighter-text: hsl(0deg 0% 50%);
     --color-gear-menu-blue-text: hsl(217deg 100% 65%);
     --color-header-button-hover: hsl(0deg 0% 100% / 4%);
+    /* The second color value aligns with
+       --color-background-navbar */
+    --color-header-button-hover-no-alpha: color-mix(
+        in srgb,
+        hsl(0deg 0% 100%) 4%,
+        hsl(0deg 0% 13%)
+    );
     --color-header-button-focus: hsl(0deg 0% 100% / 7%);
+    /* The second color value aligns with
+       --color-background-navbar */
+    --color-header-button-focus-no-alpha: color-mix(
+        in srgb,
+        hsl(0deg 0% 100%) 7%,
+        hsl(0deg 0% 13%)
+    );
     --color-fill-user-invite-copy-icon: hsl(236deg 33% 90%);
 }
 
@@ -2295,6 +2337,10 @@ div.focused-message-list {
 
     &:hover {
         background-color: var(--color-header-button-hover);
+
+        #streamlist-toggle-unreadcount {
+            border-color: var(--color-header-button-hover-no-alpha);
+        }
     }
 
     &:active {
@@ -2308,6 +2354,13 @@ div.focused-message-list {
     &:focus-visible {
         outline: none;
         background-color: var(--color-header-button-focus);
+    }
+
+    &:active,
+    &:focus-visible {
+        #streamlist-toggle-unreadcount {
+            border-color: var(--color-header-button-focus-no-alpha);
+        }
     }
 }
 


### PR DESCRIPTION
This PR addresses the case where the use of alpha channels in HSL color values shows its limits. Specifically, [it corrects the faint "halo" visible](https://github.com/zulip/zulip/pull/27390#issuecomment-1781444484) due to a color mismatch on the border around the unread dot.

The use of an alpha channel is necessary for the background elements for the top navbar elements, because they sit over the top of the navbar's bottom border (actually an inset shaddow).

However, it's impossible to use the alpha-channel based color on elements like the unread dot, where the border actually sits on top of the element itself--meaning that the effect would be a larger dot with an imperceptibly darker ring around it.

What this commit does is use a technique suggested by Anders Kaseorg for using CSS's `color-mix()` functional notation to calculate an opaque version of the alpha color for use on elements that do not or cannot directly take the color with the alpha channel.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/alphas.20in.20color.20definitions/near/1670102)

| Hover, light mode | Hover, dark mode |
| --- | --- |
| ![light-dot-hover](https://github.com/zulip/zulip/assets/170719/7733f87d-5d3a-49c5-b991-5e4c3f629796) | ![dark-dot-hover](https://github.com/zulip/zulip/assets/170719/206126b2-7d7b-4256-9918-67d61c549d6e) |

| Active/focus-visible, light mode | Active/focus-visible, dark mode |
| --- | --- |
| ![light-dot-focus-visible](https://github.com/zulip/zulip/assets/170719/f2fe8722-b4a6-4086-a63e-c2951a178f47) | ![dark-dot-focus-visible](https://github.com/zulip/zulip/assets/170719/e3ef2409-96f4-442b-b2fa-dc91cc2059df) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
