### PR TITLE
streams: Fix sending stream-related events to guests.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,17 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 220**
+
+* [`GET /events`](/api/get-events): Stream creation events for web-public
+  streams are now sent to all guest users in the organization as well.
+
+* [`GET /events`](/api/get-events): The `subscription` events for `op:
+  "peer_add"` and `op: "peer_remove"` are now sent to subscribed guest
+  users for public streams and to all the guest users for web-public
+  streams; previously, they incorrectly only received these for
+  private streams.
+
 **Feature level 219**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults)

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 219
+API_FEATURE_LEVEL = 220
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -674,5 +674,5 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserP
         realm=user_profile.realm,
         altered_user_dict=altered_user_dict,
         stream_dict=stream_dict,
-        private_peer_dict=subscriber_peer_info.private_peer_dict,
+        subscriber_peer_info=subscriber_peer_info,
     )

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -639,6 +639,10 @@ def bulk_add_subscriptions(
             sub_info = SubInfo(user_profile, sub, stream)
             subs_to_add.append(sub_info)
 
+    if len(subs_to_add) == 0 and len(subs_to_activate) == 0:
+        # We can return early if users are already subscribed to all the streams.
+        return ([], already_subscribed)
+
     bulk_add_subs_to_db_with_logging(
         realm=realm,
         acting_user=acting_user,
@@ -807,6 +811,11 @@ def bulk_remove_subscriptions(
     subs_to_deactivate = [
         sub_info for sub_infos in existing_subs_by_user.values() for sub_info in sub_infos
     ]
+
+    if len(subs_to_deactivate) == 0:
+        # We can return early if users are not subscribed to any of the streams.
+        return ([], not_subscribed)
+
     sub_ids_to_deactivate = [sub_info.sub.id for sub_info in subs_to_deactivate]
     streams_to_unsubscribe = [sub_info.stream for sub_info in subs_to_deactivate]
     # We do all the database changes in a transaction to ensure

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -198,8 +198,7 @@ def bulk_get_subscriber_peer_info(
         realm_admin_ids = {user.id for user in realm.get_admin_users_and_bots()}
 
         for stream_id in private_stream_ids:
-            # This is the same business rule as we use in
-            # bulk_get_private_peers. Realm admins can see all private stream
+            # Realm admins can see all private stream
             # subscribers.
             subscribed_user_ids = stream_user_ids.get(stream_id, set())
             subscribed_ids[stream_id] = subscribed_user_ids
@@ -213,34 +212,6 @@ def bulk_get_subscriber_peer_info(
         subscribed_ids=subscribed_ids,
         private_peer_dict=private_peer_dict,
     )
-
-
-def bulk_get_private_peers(
-    realm: Realm,
-    private_streams: List[Stream],
-) -> Dict[int, Set[int]]:
-    if not private_streams:
-        return {}
-
-    for stream in private_streams:
-        # Our caller should only pass us private streams.
-        assert stream.invite_only
-
-    peer_ids: Dict[int, Set[int]] = {}
-
-    realm_admin_ids = {user.id for user in realm.get_admin_users_and_bots()}
-
-    stream_ids = {stream.id for stream in private_streams}
-    stream_user_ids = get_user_ids_for_streams(stream_ids)
-
-    for stream in private_streams:
-        # This is the same business rule as we use in
-        # bulk_get_subscriber_peer_info.  Realm admins can see all private
-        # stream subscribers.
-        subscribed_user_ids = stream_user_ids.get(stream.id, set())
-        peer_ids[stream.id] = subscribed_user_ids | realm_admin_ids
-
-    return peer_ids
 
 
 def handle_stream_notifications_compatibility(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -31,6 +31,7 @@ from zerver.models import (
     UserGroup,
     UserProfile,
     active_non_guest_user_ids,
+    active_user_ids,
     bulk_get_streams,
     get_realm_stream,
     get_stream,
@@ -179,7 +180,11 @@ def create_stream_if_needed(
             )
     if created:
         if stream.is_public():
-            send_stream_creation_event(realm, stream, active_non_guest_user_ids(stream.realm_id))
+            if stream.is_web_public:
+                notify_user_ids = active_user_ids(stream.realm_id)
+            else:
+                notify_user_ids = active_non_guest_user_ids(stream.realm_id)
+            send_stream_creation_event(realm, stream, notify_user_ids)
         else:
             realm_admin_ids = [user.id for user in stream.realm.get_admin_users_and_bots()]
             send_stream_creation_event(realm, stream, realm_admin_ids)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1389,14 +1389,18 @@ Output:
 
     # Subscribe to a stream directly
     def subscribe(
-        self, user_profile: UserProfile, stream_name: str, invite_only: bool = False
+        self,
+        user_profile: UserProfile,
+        stream_name: str,
+        invite_only: bool = False,
+        is_web_public: bool = False,
     ) -> Stream:
         realm = user_profile.realm
         try:
             stream = get_stream(stream_name, user_profile.realm)
         except Stream.DoesNotExist:
             stream, from_stream_creation = create_stream_if_needed(
-                realm, stream_name, invite_only=invite_only
+                realm, stream_name, invite_only=invite_only, is_web_public=is_web_public
             )
         bulk_add_subscriptions(realm, [stream], [user_profile], acting_user=None)
         return stream

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -782,8 +782,12 @@ paths:
                                 to see a given stream's subscriber list, they will receive this event
                                 for the existing subscriptions to the stream.
 
-                                **Changes**: Prior to Zulip 8.0 (feature level 205), this event was not
-                                sent when a user gained access to a stream due to their [role
+                                **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
+                                incorrectly not sent to guest users when subscribers to web-public
+                                streams and subscribed public streams changed.
+
+                                Prior to Zulip 8.0 (feature level 205), this event was not sent when
+                                a user gained access to a stream due to their [role
                                 changing](/help/roles-and-permissions).
 
                                 Prior to Zulip 6.0 (feature level 134), this event was not sent when a
@@ -841,10 +845,13 @@ paths:
                                 from streams. Sent to all users if the stream is public or to only
                                 the existing subscribers if the stream is private.
 
-                                **Changes**: In Zulip 4.0 (feature level 35), the singular
-                                `user_id` and `stream_id` integers included in this event
-                                were replaced with plural `user_ids` and `stream_ids` integer
-                                arrays.
+                                **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
+                                incorrectly not sent to guest users when subscribers to web-public
+                                streams and subscribed public streams changed.
+
+                                In Zulip 4.0 (feature level 35), the singular `user_id` and
+                                `stream_id` integers included in this event were replaced
+                                with plural `user_ids` and `stream_ids` integer arrays.
 
                                 In Zulip 3.0 (feature level 19), the `stream_id` field was
                                 added to identify the stream the user unsubscribed from,
@@ -1197,9 +1204,11 @@ paths:
                                 Note that organization administrators who are not subscribed will
                                 not be able to see content on the stream; just that it exists.
 
-                                **Changes**: Prior to Zulip 8.0 (feature level 205), this event was
-                                not sent when a user gained access to a stream due to their role
-                                changing.
+                                **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
+                                incorrectly not sent to guest users a web-public stream was created.
+
+                                Prior to Zulip 8.0 (feature level 205), this event was not sent
+                                when a user gained access to a stream due to their role changing.
 
                                 Prior to Zulip 8.0 (feature level 192), this event was not sent
                                 when guest users gained access to a public stream by being

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3551,7 +3551,7 @@ class UserDisplayActionTest(BaseAction):
         check_stream_create("events[0]", events[0])
         check_subscription_add("events[1]", events[1])
 
-        # Check that guest user does not receive stream creation itself of public
+        # Check that guest user does not receive stream creation event of public
         # stream.
         self.user_profile = self.example_user("polonius")
         action = lambda: self.subscribe(self.example_user("hamlet"), "Test stream 2")

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -142,7 +142,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, new_user_email)
 
-        with self.assert_database_query_count(12):
+        with self.assert_database_query_count(13):
             set_up_streams_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=prereg_user,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2712,13 +2712,26 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(json["removed"], 2)
         self.assert_length(json["not_removed"], 0)
 
+    def test_remove_unsubbed_user_along_with_subbed(self) -> None:
+        result = self.attempt_unsubscribe_of_principal(
+            query_count=17,
+            target_users=[self.example_user("cordelia"), self.example_user("iago")],
+            is_realm_admin=True,
+            is_subbed=True,
+            invite_only=False,
+            target_users_subbed=False,
+        )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assert_length(json["not_removed"], 1)
+
     def test_remove_already_not_subbed(self) -> None:
         """
         Trying to unsubscribe someone who already isn't subscribed to a stream
         fails gracefully.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=11,
+            query_count=9,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2598,7 +2598,7 @@ class StreamAdminTest(ZulipTestCase):
         those you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=17,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -2625,7 +2625,7 @@ class StreamAdminTest(ZulipTestCase):
             for name in ["cordelia", "prospero", "iago", "hamlet", "outgoing_webhook_bot"]
         ]
         result = self.attempt_unsubscribe_of_principal(
-            query_count=27,
+            query_count=28,
             cache_count=8,
             target_users=target_users,
             is_realm_admin=True,
@@ -2686,7 +2686,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=17,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -2700,7 +2700,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_multiple_users_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=19,
+            query_count=20,
             target_users=[self.example_user("cordelia"), self.example_user("prospero")],
             is_realm_admin=True,
             is_subbed=True,
@@ -2747,7 +2747,7 @@ class StreamAdminTest(ZulipTestCase):
         webhook_bot = self.example_user("webhook_bot")
         do_change_bot_owner(webhook_bot, bot_owner=user_profile, acting_user=user_profile)
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=14,
             target_users=[webhook_bot],
             is_realm_admin=False,
             is_subbed=True,


### PR DESCRIPTION
Previous behavior-
- Guest did not receive stream creation events for new web-public streams.
- Guest did not receive `peer_add` and `peer_remove` events for web-public and subscribed public streams.

This PR fixes the behavior to be -
- Guests now receive stream creation events for new web-public streams.
- Guest now receive `peer_add` and `peer_remove` events for web-public and subscribed public streams.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
