### PR TITLE
input_pill: Fix backspace behavior on selecting text from start.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -344,9 +344,9 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             // right of the last pill (with or without text in the
             // input), then backspace deletes the last pill.
             if (
-                selection?.type !== "range" &&
                 e.key === "Backspace" &&
-                (funcs.value(e.target).length === 0 || selection?.anchorOffset === 0)
+                (funcs.value(e.target).length === 0 ||
+                    (selection?.anchorOffset === 0 && selection?.toString()?.length === 0))
             ) {
                 e.preventDefault();
                 funcs.removeLastPill();


### PR DESCRIPTION
This commit fixes the behavior of trying to remove the selected text when selection is made from start in stream membership input and compose box dm using backspace button.

Previously the selected text was not removed if no typeahead was shown for the text and it instead removed the last pill.

Now we remove the selected text and not any input pills on pressing the backspace button irrespective whether tyepeahead is shown or not.

This commit updated the code to remove pill only when there is no other text or when the pointer is at start of input but its selection
 length is 0, in the input and let it follow the default behavior in
cases when there is any text (other than user pills) in the input to fix the bug.

<!-- Describe your pull request here.-->

Fixes: [#27403](https://github.com/zulip/zulip/issues/27403) Irregular behaviour of input pill of the compose box (DM) and Stream Membership Input

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

The fix of adding ```selection?.toString()?.length === 0``` fixes the issue because:
- It prevents the default behaviour only when you're either trying to remove last pill with empty input field, or
- you're trying to remove last pill with some input present and backspace pressed at anchorOffset=0 but size of the selection is 0

**Screenshots and screen captures:**
![jy5c9VdwGK](https://github.com/zulip/zulip/assets/97049524/a06086ae-c801-40da-800c-f2a4d0228f8d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
