### PR TITLE
compose: Display one warning for same private stream double mention

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -129,7 +129,11 @@ export function warn_if_private_stream_is_linked(linked_stream, $textarea) {
         classname: compose_banner.CLASSNAMES.private_stream_warning,
     });
     const $container = compose_banner.get_compose_banner_container($textarea);
-    compose_banner.append_compose_banner_to_banner_list(new_row, $container);
+    compose_banner.update_or_append_banner(
+        new_row,
+        compose_banner.CLASSNAMES.private_stream_warning,
+        $container,
+    );
 }
 
 export function warn_if_mentioning_unsubscribed_user(mentioned, $textarea) {


### PR DESCRIPTION
When a private stream is mentioned multiple times, the warning banner tend to display as many as that number of mention.

This changes maintains one warning banner display for when a private stream is mentioned multiple times.

Fixes: #26914

**Screenshots and screen captures:**
<img width="742" alt="Screenshot 2023-10-27 at 07 58 36" src="https://github.com/zulip/zulip/assets/96547471/bc97f6e3-bff3-4a8b-b166-2f45ca34c75e">


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
