### PR TITLE
Fix: Issue #27361 Drop stream subs count.

### DIFF
--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -10,14 +10,6 @@ import * as recent_view_util from "./recent_view_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
 
-function get_formatted_sub_count(sub_count) {
-    if (sub_count >= 1000) {
-        // parseInt() is used to floor the value of division to an integer
-        sub_count = Number.parseInt(sub_count / 1000, 10) + "k";
-    }
-    return sub_count;
-}
-
 function make_message_view_header(filter) {
     const message_view_header = {};
     if (recent_view_util.is_visible()) {
@@ -56,7 +48,6 @@ function make_message_view_header(filter) {
         message_view_header.rendered_narrow_description = current_stream.rendered_description;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
         message_view_header.sub_count = sub_count;
-        message_view_header.formatted_sub_count = get_formatted_sub_count(sub_count);
         // the "title" is passed as a variable and doesn't get translated (nor should it)
         message_view_header.sub_count_tooltip_text = $t(
             {defaultMessage: "This stream has {count} subscribers."},

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -642,13 +642,6 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
-    #message_view_header .sub_count {
-        &::before,
-        &::after {
-            color: hsl(0deg 0% 100% / 50%);
-        }
-    }
-
     & div.overlay,
     #subscription_overlay
         #stream-creation

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2161,7 +2161,6 @@ div.focused-message-list {
         display: none;
     }
 
-    .sub_count,
     .message-header-stream-settings-button,
     & > span {
         white-space: nowrap;
@@ -2208,8 +2207,6 @@ div.focused-message-list {
         text-overflow: clip;
         color: inherit;
         text-decoration: none;
-        /* The first ~3px of padding here overlaps with the left padding from sub_count for some reason. */
-        padding-right: calc(3px + 10px);
         /* Don't yield any space needed for the stream name. */
         flex-shrink: 0;
 
@@ -2226,55 +2223,6 @@ div.focused-message-list {
         margin: 0 3px;
     }
 
-    .sub_count,
-    .narrow_description {
-        background: none;
-        font-size: 14px;
-        color: inherit;
-        font-weight: 400;
-        line-height: 20px;
-    }
-
-    .sub_count {
-        padding-left: 10px;
-        margin-left: 1px;
-        padding-right: 10px;
-        margin-right: 1px;
-        overflow: visible;
-
-        .fa.fa-user-o {
-            margin-left: 0;
-        }
-
-        &::before,
-        &::after {
-            content: "|";
-            position: absolute;
-            top: 25%;
-            height: 50%;
-            color: hsl(0deg 0% 88%);
-            font-size: 20px;
-
-            @media (width < $sm_min) {
-                top: 10%;
-            }
-        }
-
-        &::before {
-            left: -3px;
-
-            @media (width < $sm_min) {
-                /* this ensures the before "|" doesn't overlap
-                   with the stream name text on small narrows */
-                left: 0;
-            }
-        }
-
-        &::after {
-            right: -3px;
-        }
-    }
-
     .narrow_description {
         /* the actual value of flex shrink does not matter, it is the
            ratio of this value to other flex items that determines the
@@ -2286,6 +2234,11 @@ div.focused-message-list {
         white-space: nowrap;
         padding: 12px 0;
         padding-left: 10px;
+        background: none;
+        font-size: 14px;
+        color: inherit;
+        font-weight: 400;
+        line-height: 20px;
 
         @media (width < $sm_min) {
             padding: 7px 0;

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -2,10 +2,6 @@
 <a class="message-header-stream-settings-button" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
-<div class="divider only-visible-for-spectators">|</div>
-<a class="sub_count no-style tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
-    <i class="fa fa-user-o"></i>{{formatted_sub_count}}
-</a>
 <span class="narrow_description rendered_markdown">
     {{#if rendered_narrow_description}}
     {{rendered_markdown rendered_narrow_description}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #27361 Drop number of stream subscribers from top bar 
<!-- Issue link, or clear description.-->

Removed the element showing Subscribers count on the top bar along with it's CSS.  

**Screenshots and screen captures:**
<details>
<summary>Screenshots</summary>

Before
![Screenshot from 2023-10-27 13-16-33](https://github.com/zulip/zulip/assets/92683836/f74936d4-e6a7-4ee0-8f3a-6dd1da8b70e4)

After
![image](https://github.com/zulip/zulip/assets/92683836/2da87bdd-7d4d-4dde-a426-d2326acf9954)

![Screenshot from 2023-11-14 17-42-49](https://github.com/zulip/zulip/assets/92683836/ffb01b79-cf59-4a83-8595-c4c40480d2f3)

</details>


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
