### PR TITLE
compose: Add a placeholder "is …" for the `/me` slash command.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -74,6 +74,7 @@ IGNORED_PHRASES = [
     r"user@example\.com",
     r"acme",
     # Fragments of larger strings
+    r"is …",
     r"your subscriptions on your Streams page",
     r"Add global time<br />Everyone sees global times in their own time zone\.",
     r"user",

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -445,6 +445,7 @@ export const slash_commands = [
         text: $t({defaultMessage: "/me is excited (Display action text)"}),
         name: "me",
         aliases: "",
+        placeholder: $t({defaultMessage: "is …"}),
     },
     {
         text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -182,6 +182,7 @@ const me_slash = {
     name: "me",
     aliases: "",
     text: "translated: /me is excited (Display action text)",
+    placeholder: "translated: is …",
 };
 
 const my_slash = {
@@ -576,7 +577,7 @@ test("content_typeahead_selected", ({override}) => {
     fake_this.query = "/m";
     fake_this.completing = "slash";
     actual_value = ct.content_typeahead_selected.call(fake_this, me_slash);
-    expected_value = "/me ";
+    expected_value = "/me translated: is …";
     assert.equal(actual_value, expected_value);
 
     fake_this.query = "/da";


### PR DESCRIPTION
Fixes: #27399.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/13680558-1712-4314-937d-81bcb0f39f82)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
