### PR TITLE
analytics: Remove "Durations" tab and hourly columns.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -31,7 +31,7 @@ class ActivityTest(ZulipTestCase):
         user_profile.is_staff = True
         user_profile.save(update_fields=["is_staff"])
 
-        with self.assert_database_query_count(12):
+        with self.assert_database_query_count(11):
             result = self.client_get("/activity")
             self.assertEqual(result.status_code, 200)
 

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -1,9 +1,5 @@
-import itertools
-import time
 from collections import defaultdict
-from contextlib import suppress
-from datetime import timedelta
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 
 from django.conf import settings
 from django.db import connection
@@ -26,8 +22,7 @@ from analytics.views.activity_common import (
 from analytics.views.support import get_plan_name
 from zerver.decorator import require_server_admin
 from zerver.lib.request import has_request_variables
-from zerver.lib.timestamp import timestamp_to_datetime
-from zerver.models import Realm, UserActivityInterval, get_org_type_display_name
+from zerver.models import Realm, get_org_type_display_name
 
 if settings.BILLING_ENABLED:
     from corporate.lib.stripe import (
@@ -92,7 +87,7 @@ def get_realm_day_counts() -> Dict[str, Dict[str, Markup]]:
     return result
 
 
-def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
+def realm_summary_table() -> str:
     now = timezone_now()
 
     query = SQL(
@@ -230,17 +225,6 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
     for row in rows:
         row["org_type_string"] = get_org_type_display_name(row["org_type"])
 
-    # augment data with realm_minutes
-    total_hours = 0.0
-    for row in rows:
-        string_id = row["string_id"]
-        minutes = realm_minutes.get(string_id, 0.0)
-        hours = minutes / 60.0
-        total_hours += hours
-        row["hours"] = str(int(hours))
-        with suppress(Exception):
-            row["hours_per_user"] = "{:.1f}".format(hours / row["dau_count"])
-
     # formatting
     for row in rows:
         row["realm_url"] = realm_url_link(row["string_id"])
@@ -275,7 +259,6 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
         dau_count=total_dau_count,
         user_profile_count=total_user_profile_count,
         bot_count=total_bot_count,
-        hours=int(total_hours),
         wau_count=total_wau_count,
     )
 
@@ -293,74 +276,15 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
     return content
 
 
-def user_activity_intervals() -> Tuple[Markup, Dict[str, float]]:
-    day_end = timestamp_to_datetime(time.time())
-    day_start = day_end - timedelta(hours=24)
-
-    output = Markup()
-    output += "Per-user online duration for the last 24 hours:\n"
-    total_duration = timedelta(0)
-
-    all_intervals = (
-        UserActivityInterval.objects.filter(
-            end__gte=day_start,
-            start__lte=day_end,
-        )
-        .select_related(
-            "user_profile",
-            "user_profile__realm",
-        )
-        .only(
-            "start",
-            "end",
-            "user_profile__delivery_email",
-            "user_profile__realm__string_id",
-        )
-        .order_by(
-            "user_profile__realm__string_id",
-            "user_profile__delivery_email",
-        )
-    )
-
-    by_string_id = lambda row: row.user_profile.realm.string_id
-    by_email = lambda row: row.user_profile.delivery_email
-
-    realm_minutes = {}
-
-    for string_id, realm_intervals in itertools.groupby(all_intervals, by_string_id):
-        realm_duration = timedelta(0)
-        output += Markup("<hr>") + f"{string_id}\n"
-        for email, intervals in itertools.groupby(realm_intervals, by_email):
-            duration = timedelta(0)
-            for interval in intervals:
-                start = max(day_start, interval.start)
-                end = min(day_end, interval.end)
-                duration += end - start
-
-            total_duration += duration
-            realm_duration += duration
-            output += f"  {email:<37}{duration}\n"
-
-        realm_minutes[string_id] = realm_duration.total_seconds() / 60
-
-    output += f"\nTotal duration:                      {total_duration}\n"
-    output += f"\nTotal duration in minutes:           {total_duration.total_seconds() / 60.}\n"
-    output += f"Total duration amortized to a month: {total_duration.total_seconds() * 30. / 60.}"
-    content = Markup("<pre>{}</pre>").format(output)
-    return content, realm_minutes
-
-
 @require_server_admin
 @has_request_variables
 def get_installation_activity(request: HttpRequest) -> HttpResponse:
-    duration_content, realm_minutes = user_activity_intervals()
-    counts_content: str = realm_summary_table(realm_minutes)
+    counts_content: str = realm_summary_table()
     data = [
         ("Counts", counts_content),
-        ("Durations", duration_content),
     ]
 
-    title = "Activity"
+    title = "Installation Activity"
 
     return render(
         request,

--- a/templates/analytics/activity.html
+++ b/templates/analytics/activity.html
@@ -17,7 +17,7 @@
 
     <h4>{{ title }} {% if realm_stats_link %}{{ realm_stats_link }}{% endif %}</h4>
 
-
+    {% if not is_home %}
     <ul class="nav nav-tabs">
         {% for name, activity in data %}
         <li {% if loop.first %} class="active" {% endif %}>
@@ -25,6 +25,7 @@
         </li>
         {% endfor %}
     </ul>
+    {% endif %}
 
     <div class="tab-content">
 

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -26,7 +26,6 @@
     </li>
     <li><strong>DAU</strong> (daily active users) - users active in last 24hr</li>
     <li><strong>WAU</strong> (weekly active users) - users active in last 7 * 24hr</li>
-    <li><strong>DAT</strong> (daily active time) - total user-activity time in last 24hr</li>
     <li><strong>Human message</strong> - message sent by non-bot user, and not with known-bot client</li>
 </ul>
 
@@ -47,8 +46,6 @@
             <th>WAU</th>
             <th>Total users</th>
             <th>Bots</th>
-            <th>DAT/DAU (hr)</th>
-            <th>DAT (hr)</th>
             <th></th>
             <th colspan=8>Human messages sent, last 8 UTC days (today-so-far first)</th>
         </tr>
@@ -112,16 +109,6 @@
 
             <td class="number">
                 {{ row.bot_count }}
-            </td>
-
-            <td class="number">
-                {% if row.hours_per_user %}
-                {{ row.hours_per_user }}
-                {% endif %}
-            </td>
-
-            <td class="number">
-                {{ row.hours }}
             </td>
 
             <td>&nbsp;</td>


### PR DESCRIPTION
Removed "Durations" tab from the main installation activity page.

**Notes**:
- Since there's now only one tab on the installation activity page, updated the template (`/activity.html`), which is also used for the realm and user activity pages, to only create tabs for pages that aren't the "home" view. Also, changed the page title string to be "Installation Activity" instead of "Activity".
- Removed the DAT/DAU (hr) and DAT (hr) columns from the realm summary chart.
- Added a comment to the `user_activity_intervals` function that did the database query to get the data for the "Durations" tab and the above columns to explain why the function isn't currently in use. Alternatively, we could just delete the function with these changes.

<details>
<summary>Updated installation activity page in dev environment</summary>

![Screenshot from 2023-10-27 16-47-00](https://github.com/zulip/zulip/assets/63245456/781d8f69-dd17-4f25-94fc-2375f098b6b5)
</details>
<details>
<summary>Pre-changes installation activity page in dev environment</summary>

![Screenshot from 2023-10-27 17-39-27](https://github.com/zulip/zulip/assets/63245456/5b055cb4-172f-4b78-ac33-edd570253084)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
