### PR TITLE
input_pill: Remove over defensive if checks for `create` function.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -75,22 +75,7 @@ export type InputPillContainer<T> = {
     _get_pills_for_testing: () => InputPill<T>[];
 };
 
-export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T> | undefined {
-    if (!opts.$container) {
-        blueslip.error("Pill needs container.");
-        return undefined;
-    }
-
-    if (!opts.create_item_from_text) {
-        blueslip.error("Pill needs create_item_from_text");
-        return undefined;
-    }
-
-    if (!opts.get_text_from_item) {
-        blueslip.error("Pill needs get_text_from_item");
-        return undefined;
-    }
-
+export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T> {
     // a stateful object of this `pill_container` instance.
     // all unique instance information is stored in here.
     const store: InputPillStore<T> = {

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -51,28 +51,18 @@ run_test("basics", ({mock_template}) => {
         return html;
     });
 
-    const config = {};
-
-    blueslip.expect("error", "Pill needs container.");
-    input_pill.create(config);
-
     const $pill_input = $.create("pill_input");
     const $container = $.create("container");
     $container.set_find_results(".input", $pill_input);
 
-    blueslip.expect("error", "Pill needs create_item_from_text");
-    config.$container = $container;
-    input_pill.create(config);
-
-    blueslip.expect("error", "Pill needs get_text_from_item");
-    config.create_item_from_text = noop;
-    input_pill.create(config);
-
-    config.get_text_from_item = noop;
-    config.pill_config = {
-        show_user_status_emoji: true,
-    };
-    const widget = input_pill.create(config);
+    const widget = input_pill.create({
+        $container,
+        create_item_from_text: noop,
+        get_text_from_item: noop,
+        pill_config: {
+            show_user_status_emoji: true,
+        },
+    });
     const status_emoji_info = {emoji_code: 5};
 
     // type for a pill can be any string but it needs to be


### PR DESCRIPTION
We should remove this overly defensive code and remove the `undefined` type from the return type of this function to avoid handling unexpected `undefined` values in the downstream code.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/input_pill.20typescript).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
