### PR TITLE
markdown: Add support for inline audio files playback

### DIFF
--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -241,10 +241,11 @@ assume that messages sent prior to the introduction of thumbnailing
 have been re-rendered to use the new format or have thumbnails
 available.
 
-## Video previews
+## Video embeddings and previews
 
-When a Zulip message is sent linking to an uploaded video, Zulip will
+When a Zulip message is sent linking to an uploaded video, Zulip may
 generate a video preview element with the following format.
+
 
 ``` html
 <div class="message_inline_image message_inline_video">
@@ -254,6 +255,29 @@ generate a video preview element with the following format.
   </a>
 </div>
 ```
+
+## Audio previews
+
+When a Zulip message is sent linking to an uploaded audio file, Zulip
+will generate an HTML audio player element with the following format.
+
+``` html
+<audio class="media_container_audio" controls preload="metadata"
+  src="/user_uploads/path/to/audio.mp3">
+</audio>
+```
+
+If the Zulip server has rewritten the URL of the audio file, it will
+provide the URL in a `data-original-url` parameter.
+
+``` html
+<audio class="media_container_audio" controls preload="metadata"
+  data-original-url="https://example.com/path/to/original/file.mp3"
+  src="https://example.com/path/to/playable/file.mp3">
+</audio>
+```
+
+**Changes**: New in Zulip 11.0 (feature level ZF-59bb5b).
 
 ## Mentions and silent mentions
 

--- a/api_docs/unmerged.d/ZF-59bb5b.md
+++ b/api_docs/unmerged.d/ZF-59bb5b.md
@@ -1,0 +1,2 @@
+* [Message formatting](/api/message-formatting): Added new HTML
+  formatting for uploaded audio files generating a player experience.

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -23,10 +23,10 @@ import * as util from "./util.ts";
 // If we see preview-related syntax in our content, we will need the
 // backend to render it.
 const preview_regexes = [
-    // Inline image and video previews, check for contiguous chars ending in image and video suffix
+    // Inline media previews, check for contiguous chars ending in media suffix
     // To keep the below regexes simple, split them out for the end-of-message case
 
-    /\S*(?:\.bmp|\.gif|\.jpg|\.jpeg|\.png|\.webp|\.mp4|\.webm)\)?(\s+|$)/m,
+    /\S*(?:\.bmp|\.gif|\.jpg|\.jpeg|\.png|\.webp|\.mp4|\.webm|\.mp3|\.aac|\.ogg)\)?(\s+|$)/m,
 
     // Twitter and youtube links are given previews
 

--- a/zerver/lib/mime_types.py
+++ b/zerver/lib/mime_types.py
@@ -39,6 +39,9 @@ INLINE_MIME_TYPES = [
     "text/plain",
     "video/mp4",
     "video/webm",
+    "audio/mpeg",
+    "audio/aac",
+    "audio/ogg",
     # To avoid cross-site scripting attacks, DO NOT add types such
     # as application/xhtml+xml, application/x-shockwave-flash,
     # image/svg+xml, text/html, or text/xml.

--- a/zerver/lib/url_preview/types.py
+++ b/zerver/lib/url_preview/types.py
@@ -21,5 +21,5 @@ class UrlEmbedData:
 
 @dataclass
 class UrlOEmbedData(UrlEmbedData):
-    type: Literal["photo", "video"]
+    type: Literal["photo", "video", "audio"]
     html: str | None = None

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -472,6 +472,19 @@
       "text_content": "Google link\n"
     },
     {
+      "name": "only_inline_audio",
+      "input": "http://example.com/audio.mp3",
+      "expected_output": "<audio class=\"media_container_audio\" controls data-original-url=\"http://example.com/audio.mp3\" preload=\"metadata\" src=\"https://external-content.zulipcdn.net/external_content/57cf2db553c3f6cc2af6781c11232e70983f4762/687474703a2f2f6578616d706c652e636f6d2f617564696f2e6d7033\"></audio>",
+      "backend_only_rendering": true
+    },
+    {
+      "name": "only_named_inline_audio",
+      "input": "[Audio link](http://example.com/audio.mp3)",
+      "expected_output": "<p><a href=\"http://example.com/audio.mp3\">Audio link</a></p>\n<audio class=\"media_container_audio\" controls data-original-url=\"http://example.com/audio.mp3\" preload=\"metadata\" src=\"https://external-content.zulipcdn.net/external_content/57cf2db553c3f6cc2af6781c11232e70983f4762/687474703a2f2f6578616d706c652e636f6d2f617564696f2e6d7033\"></audio>",
+      "backend_only_rendering": true,
+      "text_content": "Audio link\n"
+    },
+    {
       "name": "link_with_text",
       "input": "[hello](https://github.com)",
       "expected_output": "<p><a href=\"https://github.com\">hello</a></p>"

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -657,7 +657,7 @@ class PreviewTestCase(ZulipTestCase):
     def test_link_preview_non_html_data(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)
-        url = "http://test.org/audio.mp3"
+        url = "http://test.org/audio.wav"
         with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
@@ -673,14 +673,14 @@ class PreviewTestCase(ZulipTestCase):
                 FetchLinksEmbedData().consume(event)
                 cached_data = cache_get(preview_url_cache_key(url))[0]
             self.assertTrue(
-                "INFO:root:Time spent on get_link_embed_data for http://test.org/audio.mp3: "
+                "INFO:root:Time spent on get_link_embed_data for http://test.org/audio.wav: "
                 in info_logs.output[0]
             )
 
         self.assertIsNone(cached_data)
         msg = Message.objects.select_related("sender").get(id=msg_id)
         self.assertEqual(
-            '<p><a href="http://test.org/audio.mp3">http://test.org/audio.mp3</a></p>',
+            '<p><a href="http://test.org/audio.wav">http://test.org/audio.wav</a></p>',
             msg.rendered_content,
         )
 


### PR DESCRIPTION
**This PR adds the backend markdown for supporting playback of inline audio files without leaving the browser.**

Fixes: [#27007](https://github.com/zulip/zulip/issues/27007) Enable playback of audio files.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![JNhjyZCH0g](https://github.com/zulip/zulip/assets/97049524/ce003b31-37b1-4217-9d7a-8e7151f5e5cb)


- Currently added support only for ```mp3``` (mpeg) and ```aac``` audio formats only.
- Tested Audio from [link](https://file-examples.com/index.php/sample-audio-files/sample-mp3-download/).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
