### PR TITLE
Fixed Issue #27375 : Fix order of group direct message recipients

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -199,7 +199,7 @@ function get_users_for_recipient_row(message) {
     });
 
     function compare_by_name(a, b) {
-        return a.full_name < b.full_name ? -1 : a.full_name > b.full_name ? 1 : 0;
+        return a.full_name.toLowerCase() < b.full_name.toLowerCase() ? -1 : a.full_name.toLowerCase() > b.full_name.toLowerCase() ? 1 : 0;
     }
 
     return users.sort(compare_by_name);

--- a/web/src/message_store.js
+++ b/web/src/message_store.js
@@ -45,15 +45,14 @@ export function get_pm_emails(message) {
                 return "?";
             }
             return person.email;
-        })
-        .sort();
+        });
 
-    return emails.join(", ");
+    return people.sortEmails(emails,user_ids).join(", ");
 }
 
 export function get_pm_full_names(message) {
     const user_ids = people.pm_with_user_ids(message);
-    const names = people.get_display_full_names(user_ids).sort();
+    const names = people.sortNames(people.get_display_full_names(user_ids));
 
     return names.join(", ");
 }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -112,6 +112,40 @@ export function init(): void {
 // WE INITIALIZE DATA STRUCTURES HERE!
 init();
 
+// A function that sorts Email according to the user's full name
+export function sortEmails(emails: string[], user_ids:number[]): string[] {
+    const namesArray = user_ids.map((user_id) => {
+        const person = people_by_user_id_dict.get(user_id);
+        return person?.full_name;
+    });
+    
+    // Combine the non-undefined elements
+    const combinedArray = namesArray
+        .map((name, index) => ({
+            name,
+            email: emails[index],
+        }))
+        .filter((item) => item.name !== undefined);
+    
+    // Sort the combined array based on the 'name' property.
+    combinedArray.sort((a, b) => {
+        const nameA = a.name!.toLowerCase(); // Use ! to assert that a.name is not undefined
+        const nameB = b.name!.toLowerCase(); // Use ! to assert that b.name is not undefined
+        return nameA.localeCompare(nameB);
+    });
+    
+    const sortedemails = combinedArray.map((item) => item.email);
+    return sortedemails;
+}
+
+export function sortNames(names: string[]): string[] {
+    return names.sort((a,b)=>{
+        const nameA = a!.toLowerCase(); // Use ! to assert that a.name is not undefined
+        const nameB = b!.toLowerCase(); // Use ! to assert that b.name is not undefined
+        return nameA.localeCompare(nameB);
+    });
+}
+
 export function split_to_ints(lst: string): number[] {
     return lst.split(",").map((s) => Number.parseInt(s, 10));
 }
@@ -294,11 +328,7 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
         return undefined;
     }
 
-    emails = emails.map((email) => email.toLowerCase());
-
-    emails.sort();
-
-    return emails.join(",");
+    return sortEmails(emails,user_ids).join(",");
 }
 
 export function user_ids_string_to_ids_array(user_ids_string: string): number[] {
@@ -470,7 +500,7 @@ export function get_recipients(user_ids_string: string): string {
         return my_full_name();
     }
 
-    const names = get_display_full_names(other_ids).sort();
+    const names = sortNames(get_display_full_names(other_ids));
     return names.join(", ");
 }
 
@@ -500,9 +530,7 @@ export function pm_reply_to(message: Message): string | undefined {
         return person.email;
     });
 
-    emails.sort();
-
-    const reply_to = emails.join(",");
+    const reply_to = sortEmails(emails,user_ids).join(",");
 
     return reply_to;
 }
@@ -1668,7 +1696,7 @@ export function is_my_user_id(user_id: number | string): boolean {
 }
 
 export function compare_by_name(a: User, b: User): number {
-    return util.strcmp(a.full_name, b.full_name);
+    return util.strcmp(a.full_name.toLowerCase(), b.full_name.toLowerCase());
 }
 
 export function sort_but_pin_current_user_on_top(users: User[]): void {


### PR DESCRIPTION
This fix is about consistency of order of names in the chat.

**Expected behavior** : The order of names should be consistent at all places and should be like we have it in the right sidebar, i.e. the names are sorted considering all letters are lowercase

**Issue** : some orders were according to the sorted order of email and others were according to the name of the user.

**My Approach** : I made two functions that **sort email and name according to the lowercase name** of the user and used it to the required places. By doing it, the order of the name is consistent at left sidebar, search bar title, private message header, compose box placeholder, recipient pill input, compose button, etc.

Fixes: Fixed Issue #27375  Fix order of group direct message recipients 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
[Screencast from 28-10-23 04:36:33 AM IST.webm](https://github.com/zulip/zulip/assets/118374765/58fa6be7-8cbe-4e2a-bc47-920c064dc23c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
