### PR TITLE
help: Document option to paste URL to create a named link.

### DIFF
--- a/help/insert-a-link.md
+++ b/help/insert-a-link.md
@@ -10,6 +10,19 @@
 
 {start_tabs}
 
+{tab|via-paste}
+
+{!start-composing.md!}
+
+1. Select the text you want to linkify.
+
+1. Paste a URL to turn the selected text into a named link.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
+    to insert link formatting.
+
 {tab|via-markdown}
 
 {!start-composing.md!}

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -98,6 +98,7 @@ TAB_SECTION_LABELS = {
     "user": "User",
     "bot": "Bot",
     "on-sign-up": "On sign-up",
+    "via-paste": "Via paste",
     "via-markdown": "Via Markdown",
     "via-compose-box-buttons": "Via compose box buttons",
     "stream-compose": "Compose to a stream",


### PR DESCRIPTION
- Adds a "Via paste" tab to document the new functionality.

Fixes #26892.

**Screenshots and screen captures:**

- http://chat.zulip.org/help/insert-a-link
![image](https://github.com/zulip/zulip/assets/2343554/fb74410b-ba8b-4834-8a9b-b8171055f767)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>