### PR TITLE
help: Document font configuration for unsupported languages.

### DIFF
--- a/help/change-your-language.md
+++ b/help/change-your-language.md
@@ -37,6 +37,20 @@ messages you receive.
 
 {end_tabs}
 
+## Font configuration for unsupported languages
+
+Zulip uses the Source Sans 3 font, which [supports over 30 languages][adobe-docs].
+If Source Sans 3 does not support your language, you may need to configure your
+browser to use a different font or adjust the default font size to properly
+display all the characters. See the documentation for [Chrome][chrome-docs],
+[Firefox][firefox-docs], or [Edge][edge-docs] for more information on how to
+configure your browser's default font.
+
+[adobe-docs]: https://fonts.adobe.com/fonts/source-sans-3#details-section
+[chrome-docs]: https://support.google.com/chrome/answer/96810
+[firefox-docs]: https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use#w_custom-fonts
+[edge-docs]: https://support.microsoft.com/en-us/microsoft-edge/increase-default-text-size-in-microsoft-edge-c62f80af-381d-0716-25a3-c4856dd3806c
+
 ## Related articles
 
 * [Configure organization language for automated messages and invitation emails][org-lang]


### PR DESCRIPTION
Documents how to figure out whether the Zulip font supports a language and what to do about unsupported languages, providing links to official font / browser documentation rather than step-by-step instructions in case the instructions change.

Fixes #26986.
Replaces #27322.

**Screenshots and screen captures:**
- http://zulip.com/help/change-your-language
![image](https://github.com/zulip/zulip/assets/2343554/bdebec8b-c609-44f2-80e8-163b9309d832)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>