### PR TITLE
26898 correction

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -958,16 +958,6 @@
             background-color: hsl(22deg 70% 35%);
         }
 
-        .codehilite code,
-        .codehilite pre {
-            color: hsl(212deg 98% 82%);
-            background-color: hsl(212deg 0% 11%);
-        }
-
-        .codehilite pre {
-            border: 1px solid hsl(0deg 0% 0% / 50%);
-        }
-
         .codehilite .hll {
             background-color: hsl(0deg 0% 13%);
         }
@@ -1356,7 +1346,6 @@
     }
 
     #feedback_container,
-    code,
     .typeahead.dropdown-menu {
         background-color: hsl(212deg 25% 15%);
         border-color: hsl(0deg 0% 0% / 50%);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -692,6 +692,8 @@
         padding: 0;
         white-space: inherit;
         overflow-x: scroll;
+        /* Unset to avoid compounding alpha values */
+        background-color: unset;
         color: inherit;
         border: 0;
     }
@@ -704,7 +706,7 @@
         unicode-bidi: embed;
         direction: ltr;
         white-space: pre-wrap;
-        padding: 0 4px;
+        padding: 0 3px;
         color: var(--color-markdown-code-text);
         background-color: var(--color-markdown-code-background);
         border: 1px solid var(--color-markdown-code-border);
@@ -739,6 +741,24 @@
         &:hover {
             color: hsl(200deg 100% 40%);
         }
+    }
+}
+
+.group_mention,
+.direct_mention {
+    & .rendered_markdown pre {
+        background-color: var(--color-markdown-pre-background-mentions);
+        border-color: var(--color-markdown-pre-border-mentions);
+    }
+
+    & .rendered_markdown code {
+        background-color: var(--color-markdown-code-background-mentions);
+        border-color: var(--color-markdown-code-border-mentions);
+    }
+
+    & .rendered_markdown pre code {
+        background-color: unset;
+        border-color: unset;
     }
 }
 
@@ -804,13 +824,9 @@
     border: none !important;
     background: none !important;
 
-    & code,
     & pre {
         color: var(--color-markdown-pre-text);
         background-color: var(--color-markdown-pre-background);
-    }
-
-    & pre {
         border: 1px solid var(--color-markdown-pre-border);
     }
 }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -824,6 +824,8 @@
 
     & pre {
         color: var(--color-markdown-pre-text);
+        /* This is necessary to remove the background color
+           set by Pygments. */
         background-color: var(--color-markdown-pre-background);
         border: 1px solid var(--color-markdown-pre-border);
     }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -649,20 +649,20 @@
     }
 
     & a {
-        color: hsl(200deg 100% 40%);
+        color: var(--color-markdown-link);
         text-decoration: none;
 
         & code {
-            color: hsl(200deg 100% 40%);
+            color: var(--color-markdown-code-link);
         }
 
         &:hover,
         &:focus {
-            color: hsl(200deg 100% 25%);
+            color: var(--color-markdown-link-hover);
             text-decoration: underline;
 
             & code {
-                color: hsl(200deg 100% 25%);
+                color: var(--color-markdown-code-link-hover);
             }
         }
     }
@@ -703,11 +703,11 @@
         font-size: 0.825em;
         unicode-bidi: embed;
         direction: ltr;
-        color: hsl(0deg 0% 0%);
         white-space: pre-wrap;
         padding: 0 4px;
-        background-color: hsl(0deg 0% 100%);
-        border: 1px solid hsl(240deg 13% 90%);
+        color: var(--color-markdown-code-text);
+        background-color: var(--color-markdown-code-background);
+        border: 1px solid var(--color-markdown-code-border);
         border-radius: 3px;
     }
 
@@ -803,6 +803,16 @@
     display: block !important;
     border: none !important;
     background: none !important;
+
+    & code,
+    & pre {
+        color: var(--color-markdown-pre-text);
+        background-color: var(--color-markdown-pre-background);
+    }
+
+    & pre {
+        border: 1px solid var(--color-markdown-pre-border);
+    }
 }
 
 /* Both the horizontal scrollbar in <pre/> as well as

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -678,9 +678,7 @@
         word-wrap: normal;
         margin: 5px 0;
         padding: 5px 7px 3px;
-        color: hsl(0deg 0% 20%);
         display: block;
-        border: 1px solid hsl(0deg 0% 0% / 15%);
         border-radius: 4px;
 
         &:hover .copy_codeblock,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -706,10 +706,9 @@
         unicode-bidi: embed;
         direction: ltr;
         white-space: pre-wrap;
-        padding: 0 3px;
+        padding: 1px 2px;
         color: var(--color-markdown-code-text);
         background-color: var(--color-markdown-code-background);
-        border: 1px solid var(--color-markdown-code-border);
         border-radius: 3px;
     }
 
@@ -753,7 +752,6 @@
 
     & .rendered_markdown code {
         background-color: var(--color-markdown-code-background-mentions);
-        border-color: var(--color-markdown-code-border-mentions);
     }
 
     & .rendered_markdown pre code {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -244,6 +244,18 @@ body {
     --color-text-full-name: hsl(0deg 0% 15%);
     --color-text-item: hsl(0deg 0% 40%);
 
+    /* Markdown code colors */
+    --color-markdown-code-text: hsl(0deg 0% 0%);
+    --color-markdown-code-background: hsl(0deg 0% 100%);
+    --color-markdown-code-border: hsl(240deg 13% 90%);
+    --color-markdown-pre-text: hsl(0deg 0% 20%);
+    --color-markdown-pre-background: hsl(0deg 0% 100%);
+    --color-markdown-pre-border: hsl(0deg 0% 0% / 15%);
+    --color-markdown-link: hsl(200deg 100% 40%);
+    --color-markdown-link-hover: hsl(200deg 100% 25%);
+    --color-markdown-code-link: var(--color-markdown-link);
+    --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+
     /* Icon colors */
     --color-icon-bot: hsl(180deg 8% 65% / 100%);
     --color-message-action-visible: hsl(216deg 43% 20% / 50%);
@@ -380,6 +392,16 @@ body {
     --color-text-dropdown-menu: hsl(0deg 0% 100% / 80%);
     --color-text-full-name: hsl(0deg 0% 100%);
     --color-text-item: hsl(0deg 0% 50%);
+
+    /* Markdown code colors */
+    /* Note that Markdown code-link colors are identical
+       to light theme, and so are not redeclared here. */
+    --color-markdown-code-text: var(--color-text-message-default);
+    --color-markdown-code-background: hsl(212deg 25% 15%);
+    --color-markdown-code-border: hsl(0deg 0% 0% / 50%);
+    --color-markdown-pre-text: hsl(212deg 98% 82%);
+    --color-markdown-pre-background: hsl(212deg 0% 11%);
+    --color-markdown-pre-border: hsl(0deg 0% 0% / 50%);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -249,10 +249,10 @@ body {
     --color-markdown-code-background: hsl(208deg 5% 88% / 88%);
     --color-markdown-code-background-mentions: hsl(0deg 0% 100%);
     --color-markdown-pre-text: var(--color-markdown-code-text);
-    --color-markdown-pre-background: hsl(208deg 5% 97% / 85%);
     --color-markdown-pre-border: hsl(208deg 10% 70% / 30%);
+    --color-markdown-pre-background: unset;
     --color-markdown-pre-background-mentions: var(
-        --color-markdown-code-background-mentions
+        --color-background-stream-message-content
     );
     --color-markdown-pre-border-mentions: hsl(208deg 10% 70% / 50%);
     --color-markdown-link: hsl(200deg 100% 40%);
@@ -406,10 +406,10 @@ body {
         --color-markdown-code-background
     );
     --color-markdown-pre-text: var(--color-markdown-code-text);
-    --color-markdown-pre-background: var(--color-markdown-code-background);
     --color-markdown-pre-border: hsl(0deg 0% 100% / 15%);
+    --color-markdown-pre-background: unset;
     --color-markdown-pre-background-mentions: var(
-        --color-markdown-code-background
+        --color-background-stream-message-content
     );
     --color-markdown-pre-border-mentions: var(--color-markdown-pre-border);
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -246,14 +246,22 @@ body {
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
-    --color-markdown-code-background: hsl(0deg 0% 100%);
-    --color-markdown-code-border: hsl(240deg 13% 90%);
-    --color-markdown-pre-text: hsl(0deg 0% 20%);
-    --color-markdown-pre-background: hsl(0deg 0% 100%);
-    --color-markdown-pre-border: hsl(0deg 0% 0% / 15%);
+    --color-markdown-code-background: hsl(208deg 5% 95% / 85%);
+    --color-markdown-code-border: hsl(208deg 10% 70% / 30%);
+    --color-markdown-code-background-mentions: hsl(0deg 0% 100%);
+    --color-markdown-code-border-mentions: hsl(208deg 10% 70% / 50%);
+    --color-markdown-pre-text: var(--color-markdown-code-text);
+    --color-markdown-pre-background: hsl(208deg 5% 97% / 85%);
+    --color-markdown-pre-border: var(--color-markdown-code-border);
+    --color-markdown-pre-background-mentions: var(
+        --color-markdown-code-background-mentions
+    );
+    --color-markdown-pre-border-mentions: var(
+        --color-markdown-code-border-mentions
+    );
     --color-markdown-link: hsl(200deg 100% 40%);
-    --color-markdown-link-hover: hsl(200deg 100% 25%);
     --color-markdown-code-link: var(--color-markdown-link);
+    --color-markdown-link-hover: hsl(200deg 100% 25%);
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
 
     /* Icon colors */
@@ -396,12 +404,20 @@ body {
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical
        to light theme, and so are not redeclared here. */
-    --color-markdown-code-text: var(--color-text-message-default);
-    --color-markdown-code-background: hsl(212deg 25% 15%);
-    --color-markdown-code-border: hsl(0deg 0% 0% / 50%);
-    --color-markdown-pre-text: hsl(212deg 98% 82%);
-    --color-markdown-pre-background: hsl(212deg 0% 11%);
-    --color-markdown-pre-border: hsl(0deg 0% 0% / 50%);
+    --color-markdown-code-text: hsl(0deg 0% 100% / 80%);
+    --color-markdown-code-background: hsl(0deg 0% 100% / 4%);
+    --color-markdown-code-border: hsl(0deg 0% 100% / 15%);
+    --color-markdown-code-background-mentions: var(
+        --color-markdown-code-background
+    );
+    --color-markdown-code-border-mentions: var(--color-markdown-code-border);
+    --color-markdown-pre-text: var(--color-markdown-code-text);
+    --color-markdown-pre-background: var(--color-markdown-code-background);
+    --color-markdown-pre-border: var(--color-markdown-code-border);
+    --color-markdown-pre-background-mentions: var(
+        --color-markdown-code-background
+    );
+    --color-markdown-pre-border-mentions: var(--color-markdown-code-border);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -246,19 +246,15 @@ body {
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
-    --color-markdown-code-background: hsl(208deg 5% 95% / 85%);
-    --color-markdown-code-border: hsl(208deg 10% 70% / 30%);
+    --color-markdown-code-background: hsl(208deg 5% 88% / 88%);
     --color-markdown-code-background-mentions: hsl(0deg 0% 100%);
-    --color-markdown-code-border-mentions: hsl(208deg 10% 70% / 50%);
     --color-markdown-pre-text: var(--color-markdown-code-text);
     --color-markdown-pre-background: hsl(208deg 5% 97% / 85%);
-    --color-markdown-pre-border: var(--color-markdown-code-border);
+    --color-markdown-pre-border: hsl(208deg 10% 70% / 30%);
     --color-markdown-pre-background-mentions: var(
         --color-markdown-code-background-mentions
     );
-    --color-markdown-pre-border-mentions: var(
-        --color-markdown-code-border-mentions
-    );
+    --color-markdown-pre-border-mentions: hsl(208deg 10% 70% / 50%);
     --color-markdown-link: hsl(200deg 100% 40%);
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: hsl(200deg 100% 25%);
@@ -405,19 +401,17 @@ body {
     /* Note that Markdown code-link colors are identical
        to light theme, and so are not redeclared here. */
     --color-markdown-code-text: hsl(0deg 0% 100% / 80%);
-    --color-markdown-code-background: hsl(0deg 0% 100% / 4%);
-    --color-markdown-code-border: hsl(0deg 0% 100% / 15%);
+    --color-markdown-code-background: hsl(0deg 0% 100% / 10%);
     --color-markdown-code-background-mentions: var(
         --color-markdown-code-background
     );
-    --color-markdown-code-border-mentions: var(--color-markdown-code-border);
     --color-markdown-pre-text: var(--color-markdown-code-text);
     --color-markdown-pre-background: var(--color-markdown-code-background);
-    --color-markdown-pre-border: var(--color-markdown-code-border);
+    --color-markdown-pre-border: hsl(0deg 0% 100% / 15%);
     --color-markdown-pre-background-mentions: var(
         --color-markdown-code-background
     );
-    --color-markdown-pre-border-mentions: var(--color-markdown-code-border);
+    --color-markdown-pre-border-mentions: var(--color-markdown-pre-border);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -246,15 +246,13 @@ body {
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
-    --color-markdown-code-background: hsl(208deg 5% 88% / 88%);
-    --color-markdown-code-background-mentions: hsl(0deg 0% 100%);
+    --color-markdown-code-background: hsl(0deg 0% 0% / 6%);
+    --color-markdown-code-background-mentions: hsl(0deg 0% 0% / 7%);
     --color-markdown-pre-text: var(--color-markdown-code-text);
-    --color-markdown-pre-border: hsl(208deg 10% 70% / 30%);
-    --color-markdown-pre-background: unset;
-    --color-markdown-pre-background-mentions: var(
-        --color-background-stream-message-content
-    );
-    --color-markdown-pre-border-mentions: hsl(208deg 10% 70% / 50%);
+    --color-markdown-pre-border: transparent;
+    --color-markdown-pre-background: hsl(0deg 0% 0% / 4%);
+    --color-markdown-pre-background-mentions: hsl(0deg 0% 0% / 4%);
+    --color-markdown-pre-border-mentions: transparent;
     --color-markdown-link: hsl(200deg 100% 40%);
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: hsl(200deg 100% 25%);
@@ -400,17 +398,13 @@ body {
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical
        to light theme, and so are not redeclared here. */
-    --color-markdown-code-text: hsl(0deg 0% 100% / 80%);
-    --color-markdown-code-background: hsl(0deg 0% 100% / 10%);
-    --color-markdown-code-background-mentions: var(
-        --color-markdown-code-background
-    );
+    --color-markdown-code-text: hsl(0deg 0% 100% / 85%);
+    --color-markdown-code-background: hsl(0deg 0% 100% / 8%);
+    --color-markdown-code-background-mentions: var(--color-markdown-code-background);
     --color-markdown-pre-text: var(--color-markdown-code-text);
-    --color-markdown-pre-border: hsl(0deg 0% 100% / 15%);
-    --color-markdown-pre-background: unset;
-    --color-markdown-pre-background-mentions: var(
-        --color-background-stream-message-content
-    );
+    --color-markdown-pre-border: transparent;
+    --color-markdown-pre-background: hsl(0deg 0% 100% / 4%);
+    --color-markdown-pre-background-mentions: hsl(0deg 0% 100% / 5%);
     --color-markdown-pre-border-mentions: var(--color-markdown-pre-border);
 
     /* Icon colors */


### PR DESCRIPTION
Color corrections for https://github.com/zulip/zulip/pull/26898

Light:
<img width="891" alt="image" src="https://github.com/zulip/zulip/assets/1903309/5c1688e6-8822-471e-82fe-a0e9fe90590d">
<img width="882" alt="image" src="https://github.com/zulip/zulip/assets/1903309/36aa1f44-9bdb-4354-98fb-e6bcdc219f8a">

Dark:
<img width="891" alt="image" src="https://github.com/zulip/zulip/assets/1903309/0a52f578-009f-4004-b76d-35a5161166c1">
<img width="882" alt="image" src="https://github.com/zulip/zulip/assets/1903309/8c00d24c-90ed-4ff7-9df8-f3810b916337">
