### PR TITLE
hello: Make logos more visible in light theme.

### DIFF
--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -201,7 +201,6 @@ ul {
     .client-logos div {
         transition: all 0.7s ease-out;
         background-position: center;
-        opacity: 0.7;
     }
 
     .screen-4,
@@ -700,6 +699,10 @@ ul {
 
         & footer {
             background: hsl(238deg 28% 21%);
+        }
+
+        .client-logos div {
+            opacity: 0.7;
         }
     }
 


### PR DESCRIPTION
before:
<img width="1068" alt="Screenshot 2023-10-30 at 7 43 29 PM" src="https://github.com/zulip/zulip/assets/25124304/ae70d253-abed-4916-87a4-f711c0d7330e">


after:
<img width="1068" alt="Screenshot 2023-10-30 at 7 42 53 PM" src="https://github.com/zulip/zulip/assets/25124304/9a46facd-2662-4ac3-b2ef-022dfc432133">

discussion:

https://chat.zulip.org/#narrow/stream/137-feedback/topic/landing.20page