### PR TITLE
left_sidebar: DM rows structural prep.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -117,7 +117,7 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
         you_and_cordelia_selector,
     );
     const cordelia_user_id = await common.get_user_id_from_name(page, "Cordelia, Lear's daughter");
-    const pm_list_selector = `li[data-user-ids-string="${cordelia_user_id}"].pm-list-item.active-sub-filter`;
+    const pm_list_selector = `li[data-user-ids-string="${cordelia_user_id}"].dm-list-item.active-sub-filter`;
     await page.waitForSelector(pm_list_selector, {visible: true});
     await close_compose_box(page);
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -713,7 +713,7 @@ export function initialize() {
 
     $("body").on(
         "click",
-        ".private_messages_container.zoom-out #private_messages_section_header",
+        ".direct-messages-container.zoom-out #private_messages_section_header",
         (e) => {
             if ($(e.target).closest("#show_all_private_messages").length === 1) {
                 // Let the browser handle the "all direct messages" widget.
@@ -747,7 +747,7 @@ export function initialize() {
      * this click handler rather than just a link. */
     $("body").on(
         "click",
-        ".private_messages_container.zoom-in #private_messages_section_header",
+        ".direct-messages-container.zoom-in #private_messages_section_header",
         (e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -574,7 +574,7 @@ export function initialize() {
     });
 
     // DIRECT MESSAGE LIST TOOLTIPS (not displayed on touch devices)
-    $("body").on("mouseenter", ".pm_user_status", (e) => {
+    $("body").on("mouseenter", ".dm-user-status", (e) => {
         e.stopPropagation();
         const $elem = $(e.currentTarget);
         const user_ids_string = $elem.attr("data-user-ids-string");

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -592,7 +592,7 @@ export function initialize() {
         function check_reference_removed(mutation, instance) {
             return Array.prototype.includes.call(
                 mutation.removedNodes,
-                $(instance.reference).parents(".pm-list")[0],
+                $(instance.reference).parents(".dm-list")[0],
             );
         }
 

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -86,7 +86,7 @@ export function update_private_messages() {
             set_dom_to(new_dom);
         } else {
             // Otherwise, empty the section.
-            $(".pm-list").empty();
+            $(".dm-list").empty();
             prior_dom = undefined;
         }
     } else {

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -21,7 +21,7 @@ let zoomed = false;
 
 function get_private_messages_section_header() {
     return $(
-        ".private_messages_container #private_messages_section #private_messages_section_header",
+        ".direct-messages-container #private_messages_section #private_messages_section_header",
     );
 }
 
@@ -118,11 +118,11 @@ export function update_dom_with_unread_counts(counts) {
 }
 
 export function highlight_all_private_messages_view() {
-    $(".private_messages_container").addClass("active_private_messages_section");
+    $(".direct-messages-container").addClass("active_private_messages_section");
 }
 
 function unhighlight_all_private_messages_view() {
-    $(".private_messages_container").removeClass("active_private_messages_section");
+    $(".direct-messages-container").removeClass("active_private_messages_section");
 }
 
 function scroll_pm_into_view($target_li) {
@@ -188,7 +188,7 @@ export function toggle_private_messages_section() {
 function zoom_in() {
     zoomed = true;
     update_private_messages();
-    $(".private_messages_container").removeClass("zoom-out").addClass("zoom-in");
+    $(".direct-messages-container").removeClass("zoom-out").addClass("zoom-in");
     $("#streams_list").hide();
     $(".left-sidebar .right-sidebar-items").hide();
 }
@@ -196,20 +196,20 @@ function zoom_in() {
 function zoom_out() {
     zoomed = false;
     update_private_messages();
-    $(".private_messages_container").removeClass("zoom-in").addClass("zoom-out");
+    $(".direct-messages-container").removeClass("zoom-in").addClass("zoom-out");
     $("#streams_list").show();
     $(".left-sidebar .right-sidebar-items").show();
 }
 
 export function initialize() {
-    $(".private_messages_container").on("click", "#show-more-direct-messages", (e) => {
+    $(".direct-messages-container").on("click", "#show-more-direct-messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
 
         zoom_in();
     });
 
-    $(".private_messages_container").on("click", "#hide-more-direct-messages", (e) => {
+    $(".direct-messages-container").on("click", "#hide-more-direct-messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
 

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -37,7 +37,7 @@ export function close() {
     update_private_messages();
 }
 
-export function _build_private_messages_list() {
+export function _build_direct_messages_list() {
     const conversations = pm_list_data.get_conversations();
     const pm_list_info = pm_list_data.get_list_info(zoomed);
     const conversations_to_be_shown = pm_list_info.conversations_to_be_shown;
@@ -58,7 +58,7 @@ export function _build_private_messages_list() {
 }
 
 function set_dom_to(new_dom) {
-    const $container = scroll_util.get_content_element($("#private_messages_list"));
+    const $container = scroll_util.get_content_element($("#direct-messages-list"));
 
     function replace_content(html) {
         $container.html(html);
@@ -90,7 +90,7 @@ export function update_private_messages() {
             prior_dom = undefined;
         }
     } else {
-        const new_dom = _build_private_messages_list();
+        const new_dom = _build_direct_messages_list();
         set_dom_to(new_dom);
     }
     // Make sure to update the left sidebar heights after updating

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -202,14 +202,14 @@ function zoom_out() {
 }
 
 export function initialize() {
-    $(".private_messages_container").on("click", "#show_more_private_messages", (e) => {
+    $(".private_messages_container").on("click", "#show-more-direct-messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
 
         zoom_in();
     });
 
-    $(".private_messages_container").on("click", "#hide_more_private_messages", (e) => {
+    $(".private_messages_container").on("click", "#hide-more-direct-messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
 

--- a/web/src/pm_list_dom.ts
+++ b/web/src/pm_list_dom.ts
@@ -60,7 +60,7 @@ export function more_private_conversations_li(
 
 export function pm_ul(nodes: vdom.Node[]): vdom.Tag {
     const attrs: [string, string][] = [
-        ["class", "pm-list"],
+        ["class", "dm-list"],
         ["data-name", "private"],
     ];
     return vdom.ul({

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -817,7 +817,7 @@ export function set_event_handlers({on_stream_click}) {
         const scroll_position = $(
             "#left_sidebar_scroll_container .simplebar-content-wrapper",
         ).scrollTop();
-        const pm_list_height = $("#private_messages_list").height();
+        const pm_list_height = $("#direct-messages-list").height();
         if (scroll_position > pm_list_height) {
             $("#toggle_private_messages_section_icon").addClass("fa-caret-right");
             $("#toggle_private_messages_section_icon").removeClass("fa-caret-down");

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -423,7 +423,7 @@ export function initialize() {
     delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
-            if ($(".private_messages_container").hasClass("zoom-in")) {
+            if ($(".direct-messages-container").hasClass("zoom-in")) {
                 return false;
             }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -431,7 +431,7 @@
     .active_private_messages_section {
         #private_messages_section,
         #private_messages_list,
-        #hide_more_private_messages {
+        #hide-more-direct-messages {
             background-color: hsl(199deg 33% 46% / 20%);
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -34,7 +34,7 @@
         }
     }
 
-    & ul.pm-list,
+    & ul.dm-list,
     & ul.filters {
         color: hsl(0deg 0% 100% / 80%);
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -430,7 +430,7 @@
 
     .active_private_messages_section {
         #private_messages_section,
-        #private_messages_list,
+        #direct-messages-list,
         #hide-more-direct-messages {
             background-color: hsl(199deg 33% 46% / 20%);
         }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -224,7 +224,7 @@
     .app-main,
     .column-middle,
     #streams_header,
-    .private_messages_container {
+    .direct-messages-container {
         background-color: var(--color-background);
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -270,12 +270,23 @@ li.show-more-topics {
                 color: inherit;
             }
 
-            .pm_left_col {
-                min-width: $left_col_size;
+            /* TODO: Consolidate and eliminate these temporary
+               styles once CSS Grid is in place, taking care to
+               preserve the opacity on icons that need it. */
+            .fa-group,
+            .zulip-icon,
+            .user_circle {
+                display: block;
+            }
 
-                & span:not(.user_circle) {
-                    opacity: 0.7;
-                }
+            .fa-group,
+            .zulip-icon {
+                min-width: $left_col_size;
+                opacity: 0.7;
+            }
+
+            .user_circle {
+                margin-right: 7px;
             }
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -260,7 +260,7 @@ li.show-more-topics {
             font-size: 90%;
         }
 
-        & li.pm-list-item {
+        & li.dm-list-item {
             position: relative;
             padding: 1px 10px 1px 4px;
             margin-left: 2px;
@@ -290,7 +290,7 @@ li.show-more-topics {
             }
         }
 
-        & li#show_more_private_messages {
+        & li#show-more-direct-messages {
             cursor: pointer;
             padding-right: 26px;
             padding-left: 6px;
@@ -336,7 +336,7 @@ li.show-more-topics {
 .active_private_messages_section {
     #private_messages_section,
     #private_messages_list,
-    #hide_more_private_messages {
+    #hide-more-direct-messages {
         background-color: hsl(202deg 56% 91%);
     }
 
@@ -1027,7 +1027,7 @@ li.topic-list-item {
     }
 }
 
-.zero-pm-unreads .dm-box {
+.zero-dm-unreads .dm-box {
     margin-right: 15px;
 }
 
@@ -1176,7 +1176,7 @@ li.topic-list-item {
         display: inline;
     }
 
-    #hide_more_private_messages {
+    #hide-more-direct-messages {
         display: block;
         text-decoration: none;
         color: inherit;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -250,7 +250,7 @@ li.show-more-topics {
         }
     }
 
-    & ul.pm-list {
+    & ul.dm-list {
         list-style-type: none;
         font-weight: 400;
         margin-left: 0;
@@ -1168,7 +1168,7 @@ li.topic-list-item {
         display: none;
     }
 
-    &.direct-messages-container ul.pm-list {
+    &.direct-messages-container ul.dm-list {
         margin-bottom: $bottom_scrolling_buffer;
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1005,7 +1005,7 @@ li.topic-list-item {
     padding-right: 5px;
 }
 
-.pm-box {
+.dm-box {
     display: flex;
     padding-top: 1px;
     margin-right: 16px;
@@ -1027,7 +1027,7 @@ li.topic-list-item {
     }
 }
 
-.zero-pm-unreads .pm-box {
+.zero-pm-unreads .dm-box {
     margin-right: 15px;
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -219,7 +219,7 @@ li.show-more-topics {
     width: 100%;
 }
 
-.private_messages_container {
+.direct-messages-container {
     margin-right: 16px;
     margin-left: 6px;
     z-index: 1;
@@ -1168,7 +1168,7 @@ li.topic-list-item {
         display: none;
     }
 
-    &.private_messages_container ul.pm-list {
+    &.direct-messages-container ul.pm-list {
         margin-bottom: $bottom_scrolling_buffer;
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -335,7 +335,7 @@ li.show-more-topics {
 
 .active_private_messages_section {
     #private_messages_section,
-    #private_messages_list,
+    #direct-messages-list,
     #hide-more-direct-messages {
         background-color: hsl(202deg 56% 91%);
     }
@@ -344,7 +344,7 @@ li.show-more-topics {
         border-radius: 4px 4px 0 0;
     }
 
-    #private_messages_list {
+    #direct-messages-list {
         border-radius: 0 0 4px 4px;
     }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -149,7 +149,7 @@
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar>
         <div class="direct-messages-container zoom-out hidden-for-spectators">
-            <div id="private_messages_list"></div>
+            <div id="direct-messages-list"></div>
         </div>
 
         <div id="streams_list" class="zoom-out">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -129,7 +129,7 @@
         </ul>
     </div>
 
-    <div id="private_messages_sticky_header" class="private_messages_container zoom-out hidden-for-spectators">
+    <div id="private_messages_sticky_header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <span id="pm_tooltip_container">
@@ -148,7 +148,7 @@
     </div>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar>
-        <div class="private_messages_container zoom-out hidden-for-spectators">
+        <div class="direct-messages-container zoom-out hidden-for-spectators">
             <div id="private_messages_list"></div>
         </div>
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -142,7 +142,7 @@
                 </a>
             </div>
         </div>
-        <a class="zoom-out-hide" id="hide_more_private_messages">
+        <a class="zoom-out-hide" id="hide-more-direct-messages">
             <span> {{t 'back to streams' }}</span>
         </a>
     </div>

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,6 +1,6 @@
-<li id="show_more_private_messages" class="pm-list-item bottom_left_row {{#unless more_conversations_unread_count}}zero-pm-unreads{{/unless}}">
+<li id="show-more-direct-messages" class="dm-list-item bottom_left_row {{#unless more_conversations_unread_count}}zero-dm-unreads{{/unless}}">
     <span>
-        <a class="pm-name" tabindex="0">{{t "more conversations" }}</a>
+        <a class="dm-name" tabindex="0">{{t "more conversations" }}</a>
         <span class="unread_count {{#unless more_conversations_unread_count}}zero_count{{/unless}}">
             {{more_conversations_unread_count}}
         </span>

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -1,4 +1,4 @@
-<li class="{{#if is_active}}active-sub-filter{{/if}} {{#if is_zero}}zero-pm-unreads{{/if}} pm-list-item bottom_left_row" data-user-ids-string="{{user_ids_string}}">
+<li class="{{#if is_active}}active-sub-filter{{/if}} {{#if is_zero}}zero-dm-unreads{{/if}} dm-list-item bottom_left_row" data-user-ids-string="{{user_ids_string}}">
     <div class="dm-box dm-user-status" data-user-ids-string="{{user_ids_string}}" data-is-group="{{is_group}}">
 
         {{#if is_group}}

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -1,22 +1,20 @@
-<li class='{{#if is_active}}active-sub-filter{{/if}} {{#if is_zero}}zero-pm-unreads{{/if}} pm-list-item bottom_left_row' data-user-ids-string='{{user_ids_string}}'>
-    <span class='pm-box pm_user_status' data-user-ids-string='{{user_ids_string}}' data-is-group='{{is_group}}'>
+<li class="{{#if is_active}}active-sub-filter{{/if}} {{#if is_zero}}zero-pm-unreads{{/if}} pm-list-item bottom_left_row" data-user-ids-string="{{user_ids_string}}">
+    <div class="pm-box pm_user_status" data-user-ids-string="{{user_ids_string}}" data-is-group="{{is_group}}">
 
-        <div class="pm_left_col">
-            {{#if is_group}}
-            <span class="fa fa-group"></span>
-            {{else if is_bot}}
-            <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
-            {{else}}
-            <span class="{{user_circle_class}} user_circle"></span>
-            {{/if}}
-        </div>
+        {{#if is_group}}
+        <span class="fa fa-group"></span>
+        {{else if is_bot}}
+        <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
+        {{else}}
+        <span class="{{user_circle_class}} user_circle"></span>
+        {{/if}}
 
-        <a href='{{url}}' class="conversation-partners">
+        <a href="{{url}}" class="conversation-partners">
             <span class="conversation-partners-list">{{recipients}}</span>
             {{> status_emoji status_emoji_info}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}
         </span>
-    </span>
+    </div>
 </li>

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -1,5 +1,5 @@
 <li class="{{#if is_active}}active-sub-filter{{/if}} {{#if is_zero}}zero-pm-unreads{{/if}} pm-list-item bottom_left_row" data-user-ids-string="{{user_ids_string}}">
-    <div class="pm-box pm_user_status" data-user-ids-string="{{user_ids_string}}" data-is-group="{{is_group}}">
+    <div class="dm-box dm-user-status" data-user-ids-string="{{user_ids_string}}" data-is-group="{{is_group}}">
 
         {{#if is_group}}
         <span class="fa fa-group"></span>

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -18,7 +18,7 @@ run_test("update_dom_with_unread_counts", () => {
 
     const $total_count = $.create("total-count-stub");
     const $private_li = $(
-        ".private_messages_container #private_messages_section #private_messages_section_header",
+        ".direct-messages-container #private_messages_section #private_messages_section_header",
     );
     $private_li.set_find_results(".unread_count", $total_count);
 

--- a/web/tests/vdom.test.js
+++ b/web/tests/vdom.test.js
@@ -26,7 +26,7 @@ run_test("basics", () => {
 
 run_test("attribute escaping", () => {
     // So far most of the time our attributes are
-    // hard-coded classes like "pm-list",
+    // hard-coded classes like "dm-list",
     // but we need to be defensive about future code
     // that might use data from possibly malicious users.
     const opts = {


### PR DESCRIPTION
This PR renames classes and IDs and a couple of related functions to use "direct message" references, rather than "private messages." There are no visual or behavioral changes here; these adjustments are only make the innermost DM rows read better, while some temporary styles maintain the current layout--though those will be removed in the row work these commits prepare for.

As these changes are focused on the innermost DM rows, there are a couple of places where this PR leaves an awkward blend of direct- and private-message references. Those blended classes will be cleaned up in subsequent work on gridding the DM heading area.

File names are another consideration; those changed here still all reference _pm_, but there is a [CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Renaming.20pm_list.2Ejs/near/1671568) about this.

| Before | After (no change) |
| --- | --- |
| ![dm-row-prep-before](https://github.com/zulip/zulip/assets/170719/e9c7271e-fc7e-4c6d-add7-b22cb05456e6) | ![dm-row-prep-after](https://github.com/zulip/zulip/assets/170719/f083d903-040f-409e-901e-ee9a1254a783) |

