### PR TITLE
user_status: Remove useless number coercion for object keys

### DIFF
--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -38,7 +38,7 @@ const user_status_schema = z.union([
     }),
 ]);
 
-const user_status_param_schema = z.record(z.coerce.number(), user_status_schema);
+const user_status_param_schema = z.record(z.string(), user_status_schema);
 
 const user_info = new Map<number, string>();
 const user_status_emoji_info = new Map<number, UserStatusEmojiInfo>();


### PR DESCRIPTION
There’s no such thing as a numeric object key in JavaScript.

Cc @Lalit3716 (#26776)