### PR TITLE
Update the mark_stream_as_read and mark_topic_as_read to use the new api

### DIFF
--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -546,12 +546,14 @@ export function mark_stream_as_read(stream_id) {
     mark_bulk_as_read(narrow)
 
 }
-export function mark_topic_as_read(stream_id, topic, cont) {
-    channel.post({
-        url: "/json/mark_topic_as_read",
-        data: {stream_id, topic_name: topic},
-        success: cont,
-    });
+export function mark_topic_as_read(stream_id, topic) {
+
+    const narrow = JSON.stringify([
+        {operator: "stream", operand: stream_id},
+        {operator: "topic", operand: topic},
+    ]);
+
+    mark_bulk_as_read(narrow)
 }
 
 export function mark_pm_as_read(user_ids_string) {

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -446,16 +446,14 @@ export function mark_current_list_as_read(options) {
     notify_server_messages_read(message_lists.current.all_messages(), options);
 }
 
-export function mark_stream_as_read(
-    stream_id,
+function mark_bulk_as_read(
+    narrow,
+    anchor = "first_unread",
     messages_marked_read_till_now = 0,
-    batch_size = INITIAL_BATCH_SIZE,
+    batch_size = INITIAL_BATCH_SIZE
 ) {
-    message_lists.current.prevent_reading();
-    const narrow = JSON.stringify([{operator: "stream", operand: stream_id}]);
-
     const opts = {
-        anchor: "first_unread",
+        anchor,
         num_before: 0,
         // The first message is not counted
         num_after: batch_size - 1,
@@ -491,7 +489,7 @@ export function mark_stream_as_read(
                     loading_indicator_displayed = true;
                 }
 
-                mark_stream_as_read(stream_id, messages_marked_read_till_now, FOLLOWUP_BATCH_SIZE);
+                mark_bulk_as_read(narrow, anchor, messages_marked_read_till_now, FOLLOWUP_BATCH_SIZE);
             } else if (loading_indicator_displayed) {
                 // If we were showing a loading indicator, then
                 // display that we finished. For the common case where
@@ -540,6 +538,14 @@ export function mark_stream_as_read(
     });
 }
 
+export function mark_stream_as_read(stream_id) {
+
+    message_lists.current.prevent_reading();
+    const narrow = JSON.stringify([{operator: "stream", operand: stream_id}]);
+
+    mark_bulk_as_read(narrow)
+
+}
 export function mark_topic_as_read(stream_id, topic, cont) {
     channel.post({
         url: "/json/mark_topic_as_read",


### PR DESCRIPTION
The code is heavly inspired by the mark_all_as_read function on the same file and so gains the batch and ui reporting features

The pull request aims to basically refactor the two functions `mark_stream_as_read` and `mark_topic_as_read` to use the new `messages/narrow` api.

Fixes: #27372

![image](https://github.com/zulip/zulip/assets/47862158/ff586b44-aa44-4904-a25b-9a92ddc4b937)

(In the screenshot the batch size is manually shrink to make the pop-up appear even with only 4 messages. The default batch size is 1000 messages per batch)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
