### PR TITLE
corporate: Refactor ensure_realm_does_not_have_active_plan.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -628,14 +628,14 @@ def is_free_trial_offer_enabled() -> bool:
     return settings.FREE_TRIAL_DAYS not in (None, 0)
 
 
-def ensure_realm_does_not_have_active_plan(realm: Realm) -> None:
-    if get_current_plan_by_realm(realm) is not None:
+def ensure_customer_does_not_have_active_plan(customer: Customer) -> None:
+    if get_current_plan_by_customer(customer) is not None:
         # Unlikely race condition from two people upgrading (clicking "Make payment")
         # at exactly the same time. Doesn't fully resolve the race condition, but having
         # a check here reduces the likelihood.
         billing_logger.warning(
             "Upgrade of %s failed because of existing active plan.",
-            realm.string_id,
+            str(customer),
         )
         raise UpgradeWithExistingPlanError
 
@@ -685,7 +685,7 @@ def process_initial_upgrade(
     customer = update_or_create_stripe_customer(user)
     assert customer.stripe_customer_id is not None  # for mypy
     assert customer.realm is not None
-    ensure_realm_does_not_have_active_plan(customer.realm)
+    ensure_customer_does_not_have_active_plan(customer)
     (
         billing_cycle_anchor,
         next_invoice_date,

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -39,7 +39,10 @@ class Customer(models.Model):
 
     @override
     def __str__(self) -> str:
-        return f"{self.realm!r} {self.stripe_customer_id}"
+        if self.realm is not None:
+            return f"{self.realm!r} (with stripe_customer_id: {self.stripe_customer_id})"
+        else:
+            return f"{self.remote_server!r} (with stripe_customer_id: {self.stripe_customer_id})"
 
 
 def get_customer_by_realm(realm: Realm) -> Optional[Customer]:

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -624,7 +624,7 @@ class StripeTestCase(ZulipTestCase):
         class StripeMock(Mock):
             def __init__(self, depth: int = 1) -> None:
                 super().__init__(spec=stripe.Card)
-                self.id = "id"
+                self.id = "cus_123"
                 self.created = "1000"
                 self.last4 = "4242"
 
@@ -1894,7 +1894,7 @@ class StripeTest(StripeTestCase):
         )
         self.assertEqual(
             m.output[0],
-            "WARNING:corporate.stripe:Upgrade of zulip failed because of existing active plan.",
+            "WARNING:corporate.stripe:Upgrade of <Realm: zulip 2> (with stripe_customer_id: cus_123) failed because of existing active plan.",
         )
         self.assert_length(m.output, 1)
 
@@ -3247,7 +3247,7 @@ class StripeTest(StripeTestCase):
                 self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, True, False)
         self.assertEqual(
             m.output[0],
-            "WARNING:corporate.stripe:Upgrade of zulip failed because of existing active plan.",
+            "WARNING:corporate.stripe:Upgrade of <Realm: zulip 2> (with stripe_customer_id: cus_123) failed because of existing active plan.",
         )
         self.assertEqual(
             context.exception.error_description, "subscribing with existing subscription"


### PR DESCRIPTION
Refactors `ensure_realm_does_not_have_active_plan` to instead directly check the customer: `ensure_customer_does_not_have_active_plan`,

**Notes**:
- Prep commit that updates the `__str__` method on the Customer model to account for Customer objects with `realm=None`.
- `ensure_realm_does_not_have_active_plan` was first getting the Customer for the Realm, so these changes are just removing that circular step since in all the places the function was used there was already (or would be) a customer object.
- The new function uses the updated Customer string for the billing_logger warning if there is error raised.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
