### PR TITLE
help: Document reactivating a user via user profile.

### DIFF
--- a/help/change-a-users-name.md
+++ b/help/change-a-users-name.md
@@ -20,11 +20,7 @@ Organization administrators can always change any user's name.
 
 {!save-changes.md!}
 
-!!! tip ""
-
-    You can also access the **Manage user** tab by clicking the **pencil and
-    paper** (<i class="fa fa-edit"></i>) icon at the top of the [user
-    profile](/help/view-someones-profile).
+{!manage-user-tab-tip.md!}
 
 {tab|via-organization-settings}
 

--- a/help/change-a-users-role.md
+++ b/help/change-a-users-role.md
@@ -27,11 +27,7 @@ organization](/help/deactivate-your-organization) instead).
 
 1. Click **Save changes**. The new permissions will take effect immediately.
 
-!!! tip ""
-
-    You can also access the **Manage user** tab by clicking the **pencil and
-    paper** (<i class="fa fa-edit"></i>) icon at the top of the [user
-    profile](/help/view-someones-profile).
+{!manage-user-tab-tip.md!}
 
 {tab|via-organization-settings}
 

--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -78,14 +78,32 @@ bots will be deactivated until the user manually
 
 {start_tabs}
 
+{tab|via-organization-settings}
+
 {settings_tab|deactivated-users-admin}
 
 1. Click the **Reactivate** button to the right of the user account that you
-want to reactivate.
+   want to reactivate.
+
+{tab|via-user-profile}
+
+1. Click on a user's profile picture or name on a message they sent
+   to open their **user card**.
+
+1. Click **View profile**.
+
+1. Select the **Manage user** tab.
+
+1. Click **Reactivate user** at the bottom of the **Manage user** menu.
+
+1. Approve by clicking **Confirm**.
+
+{!manage-user-tab-tip.md!}
 
 {end_tabs}
 
 !!! tip ""
+
     You may want to [review and adjust](/help/manage-user-stream-subscriptions)
     the reactivated user's stream subscriptions.
 

--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -23,6 +23,7 @@ When you deactivate a user:
   this user will not be able to rejoin with the same email account.
 
 !!! warn ""
+
     You must go through the deactivation process below to fully remove a user's
     access to your Zulip organization. Changing a user's password or removing
     their single sign-on account will not log them out of their open Zulip
@@ -32,7 +33,7 @@ When you deactivate a user:
 
 {start_tabs}
 
-{tab|via-user-card}
+{tab|via-user-profile}
 
 {!manage-this-user.md!}
 
@@ -43,16 +44,7 @@ When you deactivate a user:
 
 1. Approve by clicking **Deactivate**.
 
-{tab|via-user-profile}
-
-{!manage-this-user-via-user-profile.md!}
-
-1. Click **Deactivate user** at the bottom of the **Manage user** menu.
-
-1. *(optional)* Select **Notify this user by email?** if desired, and enter a
-   custom comment to include in the notification email.
-
-1. Approve by clicking **Deactivate**.
+{!manage-user-tab-tip.md!}
 
 {tab|via-organization-settings}
 
@@ -61,14 +53,15 @@ When you deactivate a user:
 1. In the **Actions** column, click the **deactivate** (<i class="fa
    fa-user-times"></i>) icon for the user you want to deactivate.
 
-2. *(optional)* Select **Notify this user by email?** if desired, and enter a
+1. *(optional)* Select **Notify this user by email?** if desired, and enter a
    custom comment to include in the notification email.
 
-3. Approve by clicking **Deactivate**.
+1. Approve by clicking **Deactivate**.
 
 {end_tabs}
 
 !!! tip ""
+
     Organization administrators cannot deactivate organization owners.
 
 ## Reactivating a user

--- a/help/include/manage-user-tab-tip.md
+++ b/help/include/manage-user-tab-tip.md
@@ -1,0 +1,5 @@
+!!! tip ""
+
+    You can also access the **Manage user** tab by clicking the **pencil and
+    paper** (<i class="fa fa-edit"></i>) icon at the top of the [user
+    profile](/help/view-someones-profile).


### PR DESCRIPTION
- Adds instructions tab for reactivating a user via the user profile.
- Simplifies instructions for deactivating a user.

**Notes**
- There seems to be a bug when clicking on **Reactivate this user** in the three dot menu of a deactivated user's card; the user card just goes away and then nothing happens.
![image](https://github.com/zulip/zulip/assets/2343554/193892f9-15a2-4f26-9a7b-045ed01836c2)

Fixes #26906.

**Screenshots and screen captures:**
- http://chat.zulip.org/help/deactivate-or-reactivate-a-user
![image](https://github.com/zulip/zulip/assets/2343554/a0ddda93-0e70-4cbf-96eb-2dd58c873e22)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.
- [x] Highlights technical choices and bugs encountered.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
