### PR TITLE
left_sidebar: Set grid on DM rows.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -217,6 +217,19 @@ li.show-more-topics {
     position: relative;
     z-index: 0;
     width: 100%;
+
+    .direct-messages-container {
+        /* TODO: Clean up this value and the
+           analogous one on #stream-filters;
+           this could be done alongside the
+           --left-sidebar-collapse-widget-gutter
+           cleanup so that all of the left sidebar
+           space is better, more uniformly handled.
+           That will be an essential pre-condition
+           for a resizable left sidebar. */
+        margin-right: 12px;
+        margin-left: 0;
+    }
 }
 
 .direct-messages-container {
@@ -261,32 +274,14 @@ li.show-more-topics {
         }
 
         & li.dm-list-item {
-            position: relative;
-            padding: 1px 10px 1px 4px;
-            margin-left: 2px;
-
             & a {
                 text-decoration: none;
                 color: inherit;
             }
 
-            /* TODO: Consolidate and eliminate these temporary
-               styles once CSS Grid is in place, taking care to
-               preserve the opacity on icons that need it. */
-            .fa-group,
-            .zulip-icon,
-            .user_circle {
-                display: block;
-            }
-
             .fa-group,
             .zulip-icon {
-                min-width: $left_col_size;
                 opacity: 0.7;
-            }
-
-            .user_circle {
-                margin-right: 7px;
             }
         }
 
@@ -664,10 +659,10 @@ li.top_left_scheduled_messages {
 }
 
 .conversation-partners {
+    grid-area: row-content;
     line-height: 1.25;
-    display: flex;
-    width: 100%;
     overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .conversation-partners .status-emoji {
@@ -680,6 +675,7 @@ li.top_left_scheduled_messages {
 #views-label-container,
 .top_left_row,
 .left-sidebar-navigation-label-container,
+.dm-box,
 .subscription_block,
 .topic-box {
     display: grid;
@@ -891,8 +887,6 @@ li.top_left_scheduled_messages {
 
 .conversation-partners-list,
 .stream-name {
-    flex: auto;
-    min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;
     overflow-x: clip;
@@ -901,9 +895,10 @@ li.top_left_scheduled_messages {
 }
 
 .conversation-partners-list {
-    /* Don't allow growth, so that status emoji
-       remain adjacent the username. */
-    flex: 0 1 auto;
+    /* TODO: See about consolidating or re-expressing
+       .stream-name spacing so as to not require
+       padding there, either. */
+    padding: 0;
 }
 
 /*
@@ -1006,29 +1001,34 @@ li.topic-list-item {
 }
 
 .dm-box {
-    display: flex;
-    padding-top: 1px;
-    margin-right: 16px;
-    align-items: baseline; /* Sets .user_circle alignment relative to text; standard icons do not participate in flex. */
+    grid-template-columns: 7px 22px minmax(0, 1fr) minmax(0, max-content) 30px 0;
+    /* This padding maintains the legacy 22.5px height
+       on DM rows. */
+    padding: 2.5px 0;
+
+    .conversation-partners-icon {
+        grid-area: starting-anchor-element;
+        justify-self: center;
+        align-self: center;
+    }
 
     .user_circle {
-        min-width: 8px;
+        width: 8px;
         height: 8px;
-        margin-top: 0;
-        margin-bottom: 0;
-        margin-left: 2px;
-        position: relative;
-        top: 0;
+        /* TODO: Remove these after right-sidebar
+           row rewrites. */
+        float: none;
+        position: static;
     }
 
     .zulip-icon.zulip-icon-bot {
         font-size: 90%; /* Reduce the bulkiness of this icon */
         padding: 3px 0 3px 1px; /* Shift reduced icon a pixel left to maintain horizontal centering. */
     }
-}
 
-.zero-dm-unreads .dm-box {
-    margin-right: 15px;
+    .unread_count {
+        grid-area: markers-and-controls;
+    }
 }
 
 .zoom-out {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -666,6 +666,18 @@ li.top_left_scheduled_messages {
     line-height: 18px;
     overflow: hidden;
     text-overflow: ellipsis;
+    /* Use an inline grid to provide a modern layout
+       for status emoji in DM rows, while preserving
+       the expected ellipsis behavior on long usernames
+       or large DM groups.
+       The 16px-tall emoji will also align well
+       vertically with the 18px line-height here. */
+    display: inline-grid;
+    /* Provide a two-column grid, sized to accommodate
+       the content of the conversation list and status
+       emoji, if any. */
+    grid-template-columns: repeat(2, minmax(0, max-content));
+    align-items: center;
 }
 
 .conversation-partners .status-emoji {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -660,7 +660,10 @@ li.top_left_scheduled_messages {
 
 .conversation-partners {
     grid-area: row-content;
-    line-height: 1.25;
+    /* Set an 18px line-height to better vertically
+       center user circles and icons (both of which
+       have even heights). */
+    line-height: 18px;
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -1002,9 +1005,8 @@ li.topic-list-item {
 
 .dm-box {
     grid-template-columns: 7px 22px minmax(0, 1fr) minmax(0, max-content) 30px 0;
-    /* This padding maintains the legacy 22.5px height
-       on DM rows. */
-    padding: 2.5px 0;
+    /* This padding maintains a 22px height on DM rows. */
+    padding: 2.25px 0;
 
     .conversation-partners-icon {
         grid-area: starting-anchor-element;
@@ -1028,6 +1030,22 @@ li.topic-list-item {
 
     .unread_count {
         grid-area: markers-and-controls;
+        /* TODO: This is an alternative method
+           for presenting a 16px-tall unread
+           counter, regardless of context. This
+           method could be used app-wide once
+           all of the layout methods for presenting
+           unreads have been modernized.
+
+           Set the line-height to match the
+           font-size, so that the numerals sit in
+           a 12px box. */
+        line-height: 12px;
+        /* Use flexbox to vertically center
+           the 12px-high text node within the
+           16px-high unread box. */
+        display: flex;
+        align-items: center;
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -288,7 +288,14 @@ li.show-more-topics {
         & li#show-more-direct-messages {
             cursor: pointer;
             padding-right: 26px;
-            padding-left: 6px;
+            /* TODO: Rewrite the show-more and show-less
+               buttons as grids alongside the left sidebar
+               header rewrites. This padding value
+               is a stopgap to provide the same lefthand
+               alignment as the "more topics" text, which
+               aligns with the topic above--just as this
+               aligns with the DM row above. */
+            padding-left: 29px;
 
             & a {
                 font-size: 12px;
@@ -1214,7 +1221,12 @@ li.topic-list-item {
 
         & span {
             display: block;
-            padding: 2px 0 2px 4px;
+            /* TODO: Rewrite the show-more and show-less
+               buttons as grids alongside the left sidebar
+               header rewrites. The 6px left padding here
+               aligns the "back to streams" text with the
+               DIRECT MESSAGES heading above. */
+            padding: 2px 0 2px 6px;
         }
 
         &:hover {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -49,8 +49,8 @@
             </div>
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
-            <li class="top_left_inbox top_left_row hidden-for-spectators">
-                <a href="#inbox" class="tippy-views-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="inbox-tooltip-template">
+            <li class="tippy-views-tooltip top_left_inbox top_left_row hidden-for-spectators" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
@@ -60,8 +60,8 @@
                 </a>
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_view top_left_row">
-                <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+            <li class="tippy-views-tooltip top_left_recent_view top_left_row" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-clock" aria-hidden="true"></i>
                     </span>
@@ -72,8 +72,8 @@
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>
-            <li class="top_left_all_messages top_left_row">
-                <a href="#all_messages" class="home-link tippy-views-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="all-message-tooltip-template">
+            <li class="tippy-views-tooltip top_left_all_messages top_left_row" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#all_messages" class="home-link left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
@@ -105,8 +105,8 @@
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_drafts top_left_row hidden-for-spectators">
-                <a href="#drafts" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="drafts-tooltip-template">
+            <li class="tippy-left-sidebar-tooltip top_left_drafts top_left_row hidden-for-spectators" data-tooltip-template-id="drafts-tooltip-template">
+                <a href="#drafts" class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                     </span>

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -2,11 +2,11 @@
     <div class="dm-box dm-user-status" data-user-ids-string="{{user_ids_string}}" data-is-group="{{is_group}}">
 
         {{#if is_group}}
-        <span class="fa fa-group"></span>
+        <span class="conversation-partners-icon fa fa-group"></span>
         {{else if is_bot}}
-        <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
+        <span class="conversation-partners-icon zulip-icon zulip-icon-bot" aria-hidden="true"></span>
         {{else}}
-        <span class="{{user_circle_class}} user_circle"></span>
+        <span class="conversation-partners-icon {{user_circle_class}} user_circle"></span>
         {{/if}}
 
         <a href="{{url}}" class="conversation-partners">


### PR DESCRIPTION
This PR applies CSS Grid to the DM rows. This brings DMs in line with the navigation, streams, and topic rows, and for the first time, introduces a uniform alignment of icons, labels, and unreads up and down the left sidebar.

Additionally, as a bit of a piggy-back, this PR includes a commit that displays the navigation tooltips fully to the side of the expanded nav items--bringing that in line with the tooltips on DM rows, which this PR also corrects.

**Screenshots and screen captures:**

| Before | After | 
| --- | --- |
| <img width="295" alt="lsb-dm-rows-before" src="https://github.com/zulip/zulip/assets/170719/d7bd53fd-a4d0-4ce4-ad43-f6b724c88e0c"> | <img width="295" alt="lsb-dm-rows-after-more-convo-fix" src="https://github.com/zulip/zulip/assets/170719/0f01f305-3fac-4702-89df-4115a1248966"> |

**Showing grid lines extended up and down the left sidebar:**
<img width="295" alt="lsb-dm-rows-after-showing-grid" src="https://github.com/zulip/zulip/assets/170719/66995ede-fa79-4646-949c-d8e085703963">

**Status emoji inline-grid with long username:**
<img width="295" alt="lsb-dm-rows-inline-grid-emoji" src="https://github.com/zulip/zulip/assets/170719/be172ece-a36f-4a74-b62a-d06c46fb4731">

**DM row interactions:**
![lsb-dm-row-interactions](https://github.com/zulip/zulip/assets/170719/288dd7b8-1df0-497c-9e31-98292fca1c0d)

**Navigation row tooltips:**
![lsb-nav-tooltips](https://github.com/zulip/zulip/assets/170719/5dbdf073-c8d5-497f-9057-239a4b163a3c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>