### PR TITLE
recent_view: Fix error when user has no messages.

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -136,7 +136,8 @@ export function set_oldest_message_date(msg_list_data) {
     const has_found_oldest = msg_list_data.fetch_status.has_found_oldest();
     const has_found_newest = msg_list_data.fetch_status.has_found_newest();
 
-    oldest_message_timestamp = Math.min(msg_list_data.first().timestamp, oldest_message_timestamp);
+    const first_message_timestamp = msg_list_data.first()?.timestamp ?? Number.POSITIVE_INFINITY;
+    oldest_message_timestamp = Math.min(first_message_timestamp, oldest_message_timestamp);
 
     if (has_found_oldest) {
         loading_state = ALL_MESSAGES_LOADED;


### PR DESCRIPTION
If the user has no messages, `message_list_data` can be empty, so, in that case, we just use the current oldest_message_timestamp.

The bug can also be reproduced if the last 400 messages were
in a muted topic for the user and we process recent_view_message_list_data
before all messages data.

We still process the remaining logic `set_oldest_message_date` to update has_found_newest/oldest.
