### PR TITLE
invite: Add setup tips to user invite modal.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -7,10 +7,12 @@ import assert from "minimalistic-assert";
 import copy_invite_link from "../templates/copy_invite_link.hbs";
 import render_invitation_failed_error from "../templates/invitation_failed_error.hbs";
 import render_invite_user_modal from "../templates/invite_user_modal.hbs";
+import render_invite_tips_banner from "../templates/modal_banner/invite_tips_banner.hbs";
 import render_settings_dev_env_email_access from "../templates/settings/dev_env_email_access.hbs";
 
 import * as channel from "./channel";
 import * as common from "./common";
+import * as compose_banner from "./compose_banner";
 import {show_copied_confirmation} from "./copied_tooltip";
 import {csrf_token} from "./csrf";
 import * as dialog_widget from "./dialog_widget";
@@ -288,6 +290,18 @@ function set_streams_to_join_list_visibility(): void {
     }
 }
 
+function generate_invite_tips_data(): Record<string, boolean> {
+    const {realm_description, realm_icon_source, custom_profile_fields} = page_params;
+
+    return {
+        realm_has_description:
+            realm_description !== "" &&
+            !/^Organization imported from [A-Za-z]+[!.]$/.test(realm_description),
+        realm_has_user_set_icon: realm_icon_source !== "G",
+        realm_has_custom_profile_fields: custom_profile_fields.length > 0,
+    };
+}
+
 function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void {
     e.stopPropagation();
     e.preventDefault();
@@ -328,6 +342,15 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         set_custom_time_inputs_visibility();
         set_expires_on_text();
         set_streams_to_join_list_visibility();
+
+        $("#invite-user-modal").on("click", ".setup-tips-container .banner_content a", () => {
+            dialog_widget.close();
+        });
+
+        $("#invite-user-modal").on("click", ".main-view-banner-close-button", (e) => {
+            e.preventDefault();
+            $(e.target).parent().remove();
+        });
 
         function toggle_invite_submit_button(): void {
             $("#invite-user-modal .dialog_submit_button").prop(
@@ -415,6 +438,17 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             $("#generate_multiuse_invite_radio").prop("checked", true);
             $("#generate_multiuse_invite_radio").trigger("change");
         }
+
+        const invite_tips_data = generate_invite_tips_data();
+
+        const context = {
+            banner_type: compose_banner.WARNING,
+            classname: "setup_tips_warning",
+            banner_html: "",
+            ...invite_tips_data,
+        };
+
+        $("#invite-user-form .setup-tips-container").html(render_invite_tips_banner(context));
     }
 
     function invite_users(): void {

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -57,6 +57,7 @@ export const page_params: {
     realm_create_public_stream_policy: number;
     realm_create_web_public_stream_policy: number;
     realm_delete_own_message_policy: number;
+    realm_description: string;
     realm_edit_topic_policy: number;
     realm_email_changes_disabled: boolean;
     realm_enable_spectator_access: boolean;

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -1,4 +1,5 @@
 <form id="invite-user-form">
+    <div class="setup-tips-container {{#unless is_admin}}hide{{/unless}}"></div>
     {{#if development_environment}}
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}

--- a/web/templates/modal_banner/invite_tips_banner.hbs
+++ b/web/templates/modal_banner/invite_tips_banner.hbs
@@ -1,0 +1,30 @@
+{{#unless realm_has_description}}
+    {{#> modal_banner }}
+        <p class="banner_message">
+            {{#tr}}
+                You may want to <z-link>configure</z-link> your organization's login page prior to inviting users.
+                {{#*inline "z-link"}}<a href="#organization/organization-profile">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
+    {{/modal_banner}}
+{{else unless realm_has_user_set_icon}}
+    {{#> modal_banner }}
+        <p class="banner_message">
+            {{#tr}}
+                You may want to <z-link>upload a profile picture</z-link> for your organization prior to inviting users.
+                {{#*inline "z-link"}}<a href="#organization/organization-profile">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
+    {{/modal_banner}}
+{{/unless}}
+{{#unless realm_has_custom_profile_fields}}
+    {{#> modal_banner }}
+        <p class="banner_message">
+            {{#tr}}
+                You may want to configure <z-link-1>default new user settings</z-link-1> and <z-link-2>custom profile fields</z-link-2> prior to inviting users.
+                {{#*inline "z-link-1"}}<a href="#organization/organization-level-user-defaults">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link-2"}}<a href="#organization/profile-field-settings">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
+    {{/modal_banner}}
+{{/unless}}

--- a/web/templates/modal_banner/modal_banner.hbs
+++ b/web/templates/modal_banner/modal_banner.hbs
@@ -1,0 +1,15 @@
+<div class="main-view-banner {{banner_type}} {{classname}}">
+    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+        {{#if banner_text}}
+        <p class="banner_content">{{banner_text}}</p>
+        {{else}}
+        <div class="banner_content">{{> @partial-block}}</div>
+        {{/if}}
+        {{#if button_text}}
+        <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}">{{button_text}}</button>
+        {{/if}}
+    </div>
+    {{#unless hide_close_button}}
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    {{/unless}}
+</div>


### PR DESCRIPTION
We include setup tips to the user invite modal for the following
cases:

(At the top of the invite modal)
- If the org description is missing.
- If the org profile picture is missing.
- If the custom profile fields have not been added.

We also use the new banner ui to display these tips. In doing so, we extract the banner component from `compose_banner.hbs` to `popover_banner.hbs`, removing any compose specific code from the banner component.

Fixes: #24262

Previous Work: #24273 

> [!NOTE]  
> - This PR includes the newer compose banner system as suggested in https://github.com/zulip/zulip/pull/24273#issuecomment-1716341552.
> - This PR includes setup tips pointing to default new user settings but does not actually check for any changes from the original default new user settings since we don't have a good way to fetch that information atm. Thus for the time being we merge the default new user setup tip with the custom profile fields setup tip.
See [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Comparing.20User.20Default.20Settings.3F/near/1543272) and https://github.com/zulip/zulip/pull/25040
> - This PR doesn't include setup tips for when no new streams have been created, again due to the unavailability of a good way to check that. See [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/setup.20tips.20in.20user.20invite.20modal/near/1684370),


<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/82862779/d1a96a77-ae32-4528-88c4-2b7b65fabde0)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
