### PR TITLE
Personal menu status color changes

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1233,9 +1233,11 @@ ul {
     margin-left: auto;
     color: hsl(0deg 0% 40%) !important;
     border-radius: 4px;
+    opacity: 0.5;
 
     &:hover,
     &:focus {
+        opacity: 0.9;
         text-decoration: none;
     }
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1250,6 +1250,14 @@ ul {
     gap: 5px;
 }
 
+.personal-menu-status-text {
+    color: var(--color-text-personal-menu-some-status);
+}
+
+.personal-menu-no-status-text {
+    color: var(--color-text-personal-menu-no-status);
+}
+
 #gear-menu-dropdown {
     padding: 5px 0;
     box-shadow: var(--box-shadow-gear-menu);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -248,6 +248,8 @@ body {
     --color-text-dropdown-menu: hsl(0deg 0% 15%);
     --color-text-full-name: hsl(0deg 0% 15%);
     --color-text-item: hsl(0deg 0% 40%);
+    --color-text-personal-menu-no-status: hsl(0deg 0% 50%);
+    --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 8% 65% / 100%);
@@ -443,6 +445,8 @@ body {
     --color-text-dropdown-menu: hsl(0deg 0% 100% / 80%);
     --color-text-full-name: hsl(0deg 0% 100%);
     --color-text-item: hsl(0deg 0% 50%);
+    --color-text-personal-menu-no-status: hsl(0deg 0% 100% 35%);
+    --color-text-personal-menu-some-status: hsl(0deg 0% 100% 50%);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);

--- a/web/templates/personal_menu.hbs
+++ b/web/templates/personal_menu.hbs
@@ -38,9 +38,9 @@
                                     <span class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></span>
                                     {{/if}}
                                 {{/if}}
-                                <span class="status_text">
+                                <span class="status_text personal-menu-status-text">
                                     {{#if show_placeholder_for_status_text}}
-                                        <i>{{t "No status text"}}</i>
+                                        <i class="personal-menu-no-status-text">{{t "No status text"}}</i>
                                     {{else}}
                                         {{status_text}}
                                     {{/if}}


### PR DESCRIPTION
| before | after |
| --- | --- |
| <img width="369" alt="Screenshot 2023-11-01 at 11 44 38 AM" src="https://github.com/zulip/zulip/assets/25124304/fffd2cfa-96dd-451a-a14a-73e1a6335f35"> | <img width="369" alt="Screenshot 2023-11-01 at 11 42 58 AM" src="https://github.com/zulip/zulip/assets/25124304/32853adb-a442-4aa9-9bb0-4e32ce8606a6"> |
| <img width="369" alt="Screenshot 2023-11-01 at 11 44 30 AM" src="https://github.com/zulip/zulip/assets/25124304/cd0ecac2-9591-47d2-aeec-ea809d1ee15e"> | <img width="369" alt="Screenshot 2023-11-01 at 11 43 36 AM" src="https://github.com/zulip/zulip/assets/25124304/a35d2b13-cc1a-4990-b004-0909249d2de0">
