### PR TITLE
lightbox_view: Fix media title update on change in title.

### DIFF
--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -314,6 +314,13 @@ function display_video(payload) {
     $(".media-actions .open").attr("href", payload.url);
 }
 
+function get_asset_map_key_for_media($preview_src, $media) {
+    return asset_map.get([
+        $preview_src,
+        $media.parent().attr("aria-label") || $media.parent().attr("href"),
+    ]);
+}
+
 export function build_open_media_function(on_close) {
     if (on_close === undefined) {
         on_close = function () {
@@ -327,7 +334,7 @@ export function build_open_media_function(on_close) {
         // if the asset_map already contains the metadata required to display the
         // asset, just recall that metadata.
         let $preview_src = $media.attr("src");
-        let payload = asset_map.get($preview_src);
+        let payload = get_asset_map_key_for_media($preview_src, $media);
         if (payload === undefined) {
             if ($preview_src.endsWith("&size=full")) {
                 // while fetching an image for canvas, `src` attribute supplies
@@ -341,7 +348,7 @@ export function build_open_media_function(on_close) {
                 // `data-thumbnail-src` attribute that we add to the
                 // canvas elements.
                 $preview_src = $preview_src.slice(0, -"full".length) + "thumbnail";
-                payload = asset_map.get($preview_src);
+                payload = get_asset_map_key_for_media($preview_src, $media);
             }
             if (payload === undefined) {
                 payload = parse_media_data($media);
@@ -430,7 +437,7 @@ export function parse_media_data(media) {
 
     if (asset_map.has(preview_src)) {
         // check if media's data is already present in asset_map.
-        return asset_map.get(preview_src);
+        return get_asset_map_key_for_media(preview_src, $media);
     }
 
     // if wrapped in the .youtube-video class, it will be length = 1, and therefore
@@ -497,7 +504,7 @@ export function parse_media_data(media) {
         url: util.is_valid_url(url) ? url : "",
     };
 
-    asset_map.set(preview_src, payload);
+    asset_map.set([preview_src, $parent.attr("aria-label") || $parent.attr("href")], payload);
     return payload;
 }
 


### PR DESCRIPTION
Presently in a session when an image or video title is updated, the same change is not reflected in the lightbox view of them, until a new session is made.

This is because the metadata of the media is stored in Map for the session with the ```preview_src``` as keys, and hence, when title is changed the ```preview_src``` being same, the title change is not reflected inside lightbox view.

This is fixed by modifing the ```asset_map``` (cache map) keys from ```preview_src``` to an array of ```preview_src```, and the media title. Hence, when title is modified now, the keys won't map to the existing value, and hence new metadata would be shown.

Fixes: #21311

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![brave_iPrN3Yvbkh](https://github.com/zulip/zulip/assets/97049524/77fd8dc8-34ca-4ab4-8df3-e1353e57da4b)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
