### PR TITLE
integrations: Use stream ID for incoming webhook URL generated in modal.

### DIFF
--- a/web/src/integration_url_modal.js
+++ b/web/src/integration_url_modal.js
@@ -20,7 +20,7 @@ export function show_generate_integration_url_modal(api_key) {
     };
     const direct_messages_option = {
         name: $t_html({defaultMessage: "Direct message to me"}),
-        unique_id: "",
+        unique_id: -1,
         is_direct_message: true,
     };
     const html_body = render_generate_integration_url_modal({
@@ -65,12 +65,12 @@ export function show_generate_integration_url_modal(api_key) {
                 return;
             }
 
-            const stream_name = stream_input_dropdown_widget.value();
+            const stream_id = stream_input_dropdown_widget.value();
             const topic_name = $topic_input.val();
 
             const params = new URLSearchParams({api_key});
-            if (stream_name !== "") {
-                params.set("stream", stream_name);
+            if (stream_id !== -1) {
+                params.set("stream", stream_id);
                 if (topic_name !== "") {
                     params.set("topic", topic_name);
                 }
@@ -130,18 +130,20 @@ export function show_generate_integration_url_modal(api_key) {
                 placement: "bottom-start",
             },
             default_id: direct_messages_option.unique_id,
-            unique_id_type: dropdown_widget.DATA_TYPES.STRING,
+            unique_id_type: dropdown_widget.DATA_TYPES.NUMBER,
         });
         stream_input_dropdown_widget.setup();
 
         function get_options_for_stream_dropdown_widget() {
             const options = [
                 direct_messages_option,
-                ...streams.map((stream) => ({
-                    name: stream.name,
-                    unique_id: stream.name,
-                    stream,
-                })),
+                ...streams
+                    .filter((stream) => stream_data.can_post_messages_in_stream(stream))
+                    .map((stream) => ({
+                        name: stream.name,
+                        unique_id: stream.stream_id,
+                        stream,
+                    })),
             ];
             return options;
         }


### PR DESCRIPTION
Instead of using the stream name for the incoming webhook URL that is generated in the web-app, we used the stream ID instead.

Also, limits the streams listed in the dropdown widget to streams that the bot owner has permission to post in.

**Notes**:
- The [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), which is being used to append the stream ID and topic to the URL, encodes spaces as `+` in the search query. In the screenshots, one can see that other reserved characters are being encoded.

**Screenshots and screen captures:**

<details>
<summary>Example with Iago - can post in #announce stream</summary>

![Screenshot from 2023-11-01 14-46-19](https://github.com/zulip/zulip/assets/63245456/00f2c344-bf77-4716-9428-13c77fcddb95)
</details>
<details>
<summary>Examples with Aaron - can't post in #announce stream</summary>

![Screenshot from 2023-11-01 14-47-27](https://github.com/zulip/zulip/assets/63245456/92ea454d-60e2-48dc-9163-e376733b5426)
![Screenshot from 2023-11-01 14-46-56](https://github.com/zulip/zulip/assets/63245456/b49043d1-84e9-4725-98e2-48cf10209dfb)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
