### PR TITLE
shared: Bump version to 0.0.19

### DIFF
--- a/web/shared/package.json
+++ b/web/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "rm -rf lib && tsc && cp src/*.flow lib",

--- a/web/shared/tools/npm-version
+++ b/web/shared/tools/npm-version
@@ -4,5 +4,5 @@ set -eu -o pipefail
 # expect this to run as NPM script
 : "${npm_package_version?}"
 
-git commit -am "shared: Bump version to ${npm_package_version}"
+git commit -am "shared: Bump version to ${npm_package_version}."
 git tag "shared-${npm_package_version}"


### PR DESCRIPTION
Once this is merged, we should tag the merged commit with shared-0.0.19.

-----

This (specifically the change in 9b3306acf2d6b1d8895cf053e63ada49e926efce) will make the "followed topic" icon available to zulip-mobile, for zulip/zulip-mobile#5770.