### PR TITLE
[WIP] error pages: Improve text on page for invalid realm URL.

### DIFF
--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -1,7 +1,7 @@
 {% extends "zerver/portico.html" %}
 
 {% block title %}
-<title>{{ _("Organization does not exist") }} | Zulip</title>
+<title>{{ _("No organization found") }} | Zulip</title>
 {% endblock %}
 
 {% block portico_content %}
@@ -9,13 +9,15 @@
 <div class="app find-account-page flex full-page">
     <div class="inline-block new-style">
         <div class="lead">
-            <h1 class="get-started">{{ _('Organization does not exist') }}…</h1>
+            <h1 class="get-started">{{ _('No organization found') }}</h1>
         </div>
 
         <div class="app-main white-box">
-            {{ _('Hi there! Thank you for your interest in Zulip.') }}
+            {{ _('There is no Zulip organization hosted here. You can
+            double-check the URL,') }}
             <br />
-            {% trans %}There is no Zulip organization hosted at this subdomain.{% endtrans %}
+            find all your Zulip accounts on
+            this server, or contact Zulip support for help.
         </div>
     </div>
 </div>


### PR DESCRIPTION

<img width="719" alt="Screenshot 2023-11-01 at 3 19 52 PM" src="https://github.com/zulip/zulip/assets/2090066/a7e42c5b-a9d4-4ccb-9bee-4b1bc9c8eb56">



Things to fix:
- Link to /accounts/find/ from "find"
- Link to mailto:support@zulip.com from "contact Zulip support"
- Add a conditional for self-hosted servers: "contact Zulip support" -> "contact your Zulip server administrator" (or whatever exact text we have on other pages with this conditional, which I'm failing to find at the moment).
- Translation tags