### PR TITLE
alerts: Fix improper copied tooltip location in About Zulip Modal.

### DIFF
--- a/web/src/about_zulip.ts
+++ b/web/src/about_zulip.ts
@@ -17,10 +17,14 @@ export function launch(): void {
         },
     });
 
-    const clipboard = new ClipboardJS("#about-zulip .fa-copy");
+    const zulip_version_clipboard = new ClipboardJS("#about-zulip .fa-copy.zulip-version");
+    zulip_version_clipboard.on("success", () => {
+        show_copied_confirmation($("#about-zulip .fa-copy.zulip-version")[0]);
+    });
 
-    clipboard.on("success", () => {
-        show_copied_confirmation($("#about-zulip .fa-copy")[0]);
+    const zulip_merge_base_clipboard = new ClipboardJS("#about-zulip .fa-copy.zulip-merge-base");
+    zulip_merge_base_clipboard.on("success", () => {
+        show_copied_confirmation($("#about-zulip .fa-copy.zulip-merge-base")[0]);
     });
 }
 

--- a/web/templates/about_zulip.hbs
+++ b/web/templates/about_zulip.hbs
@@ -9,11 +9,11 @@
                 <strong>Zulip Server</strong>
                 <br />
                 {{t "Version {zulip_version}" }}
-                <i class="fa fa-copy tippy-zulip-tooltip" data-tippy-content="{{t 'Copy version' }}" data-tippy-placement="right" data-clipboard-text="{{zulip_version}}"></i>
+                <i class="fa fa-copy tippy-zulip-tooltip zulip-version" data-tippy-content="{{t 'Copy version' }}" data-tippy-placement="right" data-clipboard-text="{{zulip_version}}"></i>
                 {{#if is_fork}}
                     <br />
                     {{t "Forked from upstream at {zulip_merge_base}" }}
-                    <i class="fa fa-copy tippy-zulip-tooltip" data-tippy-content="{{t 'Copy version' }}" data-tippy-placement="right" data-clipboard-text="{{zulip_merge_base}}"></i>
+                    <i class="fa fa-copy tippy-zulip-tooltip zulip-merge-base" data-tippy-content="{{t 'Copy version' }}" data-tippy-placement="right" data-clipboard-text="{{zulip_merge_base}}"></i>
                 {{/if}}
             </p>
             <p>


### PR DESCRIPTION
Previously when a user tries to click on the clipboard to copy the merge base version info, the copied tooltip would appear in the wrong location where the Zulip version is instead. This is caused by both clipboard icon using the same Clipboard instance where the success event would only display the tooltip at the Zulip version. These changes fixes this and allows the clipboards to be independent of each other.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![da28a8d8f9a11b39c896767226da8506](https://github.com/zulip/zulip/assets/62449508/c3944c57-4642-4149-8dd4-7275be9f78c6)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
