### PR TITLE
help: Document "Jitsi server URL" setting.

### DIFF
--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -2,9 +2,9 @@
 
 {start_tabs}
 
-{!start-composing.md!}
-
 {tab|desktop-web}
+
+{!start-composing.md!}
 
 1. Click the **video camera** (<i class="fa fa-video-camera"></i>) icon at the
    bottom of the compose box. This will insert a **Join video call.** link into
@@ -56,8 +56,8 @@ supported by zulip are:
 
 !!! tip ""
 
-    It is also possible to disable the video call button for your organization by
-    setting the provider to "None".
+    It is also possible to disable the video call button for your organization
+    by setting the provider to "None".
 
 ### Change your organization's video call provider
 
@@ -65,9 +65,29 @@ supported by zulip are:
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings** select appropriate provider from **Call provider** dropdown.
+1. Under **Other settings**, select the desired provider from the
+   **Call provider** dropdown.
 
-1. Click **Save changes**.
+{!save-changes.md!}
+
+{end_tabs}
+
+### Use a self-hosted instance of Jitsi Meet
+
+Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
+as its default video call provider. You can also use a self-hosted
+instance of Jitsi Meet.
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Other settings**, select **Custom URL** from the
+   **Jitsi server URL** dropdown.
+
+1. Enter the URL of your self-hosted Jitsi Meet server.
+
+{!save-changes.md!}
 
 {end_tabs}
 

--- a/templates/zerver/integrations/jitsi.md
+++ b/templates/zerver/integrations/jitsi.md
@@ -1,17 +1,33 @@
-[Jitsi Meet](https://jitsi.org/jitsi-meet/) is Zulip's default video
-call provider. Jitsi Meet is a fully-encrypted, 100% open source video
-conferencing solution.
+By default, Zulip integrates with [Jitsi Meet](https://jitsi.org/jitsi-meet/),
+a fully-encrypted, 100% open source video conferencing solution.
+
+Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
+as its default video call provider. You can also use a self-hosted
+instance of Jitsi Meet.
 
 ### Using Jitsi Meet
 
-1. Set Jitsi as the organization's [video call
-   provider](/help/start-a-call#changing-your-organizations-video-call-provider),
-   if it isn't already.
+{settings_tab|organization-settings}
 
-2. Zulip's [call button](/help/start-a-call) will now create meetings
-   using Jitsi Meet.
+1. Under **Other settings**, select **Jitsi Meet** from the **Call provider**
+   dropdown.
 
-Zulip's default video call provider is the cloud version of [Jitsi
-Meet](https://meet.jit.si/) but it also possible to use Zulip with a
-self-hosted instance of Jitsi Meet; to configure this, just set
-`JITSI_SERVER_URL` in `/etc/zulip/settings.py`.
+1. _(optional)_ Select **Custom URL** from the **Jitsi server URL** dropdown,
+   and enter the URL of your self-hosted Jitsi Meet server. You can also set
+   `JITSI_SERVER_URL` in `/etc/zulip/settings.py` to specify the server's URL.
+
+1. Click **Save changes**, and use <kbd>Esc</kbd> to exit the settings.
+
+1. [Open the compose box](/help/open-the-compose-box), and click the
+   **video camera** (<i class="fa fa-video-camera"></i>) icon to insert
+   a video call link, or the **phone** (<i class="fa fa-phone"></i>) icon
+   to insert an audio call link into your message.
+
+1. Send the message, and click on the link in the message to start or join
+   the call.
+
+!!! tip ""
+
+    You can replace the call link label with any text you like.
+
+[jitsi-server-url]: /help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -108,6 +108,7 @@
                 <div class="input-group">
                     <label for="realm_video_chat_provider" class="dropdown-title">
                         {{t 'Call provider' }}
+                        {{> ../help_link_widget link="/help/start-a-call" }}
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
                         {{#each realm_available_video_chat_providers}}
@@ -119,6 +120,7 @@
                         <div>
                             <label for="id_realm_jitsi_server_url" class="dropdown-title">
                                 {{t "Jitsi server URL" }}
+                                {{> ../help_link_widget link="/help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet" }}
                             </label>
                             <select name="realm_jitsi_server_url" id="id_realm_jitsi_server_url" class="setting-widget prop-element settings_select bootstrap-focus-style" data-setting-widget-type="jitsi-server-url-setting">
                                 {{#if server_jitsi_server_url}}


### PR DESCRIPTION
- Updates "Start a call", fixing misplaced include block for opening the compose box.
- Documents the "Jitsi server URL" setting, and links to it in a (?) from the relevant admin UI.
- Tweaks /integrations documentation, and clarifies that the "Jitsi server URL" setting is not just a server-side setting.
- Updates /integrations instructions to a series of steps to be followed directly, without having to go to the help center.

Fixes #26907.

**Screenshots and screen captures:**
- https://chat.zulip.org/help/start-a-call#change-your-organizations-video-call-provider
![image](https://github.com/zulip/zulip/assets/2343554/9f76ce16-5b9f-4cc9-9fe1-4930c2b2d515)

- https://zulip.com/integrations/doc/jitsi
![image](https://github.com/zulip/zulip/assets/2343554/e8720456-8d6d-40ce-bc69-a22d3862a893)

- https://chat.zulip.org/#organization/organization-settings
![image](https://github.com/zulip/zulip/assets/2343554/67db02fa-1946-42c3-9893-8ef2f5cb7f53)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>