### PR TITLE
left_sidebar: Place home view based on user preference.

### DIFF
--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -4,6 +4,7 @@ import * as resize from "./resize";
 import * as scheduled_messages from "./scheduled_messages";
 import * as settings_config from "./settings_config";
 import * as ui_util from "./ui_util";
+import * as unread from "./unread";
 
 let last_mention_count = 0;
 
@@ -143,6 +144,33 @@ export function highlight_inbox_view() {
     }, 0);
 }
 
+function handle_home_view_order(home_view) {
+    // Remove class and tabindex from current home view
+    const $current_home_view = $(".selected-home-view");
+    $current_home_view.removeAttr("tabindex");
+    $current_home_view.removeClass("selected-home-view");
+
+    const $all_messages_rows = $(".top_left_all_messages");
+    const $recent_views_rows = $(".top_left_recent_view");
+    const $inbox_rows = $(".top_left_inbox");
+
+    const res = unread.get_counts();
+
+    // Add the class and tabindex to the matching home view
+    if (home_view === settings_config.web_home_view_values.all_messages.code) {
+        $all_messages_rows.addClass("selected-home-view");
+        $all_messages_rows.find("a").attr("tabindex", 0);
+    } else if (home_view === settings_config.web_home_view_values.recent_topics.code) {
+        $recent_views_rows.addClass("selected-home-view");
+        $recent_views_rows.find("a").attr("tabindex", 0);
+    } else {
+        // Inbox is home view.
+        $inbox_rows.addClass("selected-home-view");
+        $inbox_rows.find("a").attr("tabindex", 0);
+    }
+    update_dom_with_unread_counts(res, true);
+}
+
 export function handle_home_view_changed(new_home_view) {
     const $recent_view_sidebar_menu_icon = $(".recent-view-sidebar-menu-icon");
     const $all_messages_sidebar_menu_icon = $(".all-messages-sidebar-menu-icon");
@@ -157,6 +185,7 @@ export function handle_home_view_changed(new_home_view) {
         $recent_view_sidebar_menu_icon.removeClass("hide");
         $all_messages_sidebar_menu_icon.removeClass("hide");
     }
+    handle_home_view_order(new_home_view);
 }
 
 export function initialize() {

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -26,12 +26,12 @@ export function update_scheduled_messages_row() {
 export function update_dom_with_unread_counts(counts, skip_animations) {
     // Note that direct message counts are handled in pm_list.js.
 
-    // mentioned/inbox have simple integer counts
+    // mentioned/home views have simple integer counts
     const $mentioned_li = $(".top_left_mentions");
-    const $inbox_li = $(".top_left_inbox");
+    const $home_view_li = $(".selected-home-view");
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
-    ui_util.update_unread_count_in_dom($inbox_li, counts.home_unread_messages);
+    ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
 
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);

--- a/web/src/sidebar_ui.js
+++ b/web/src/sidebar_ui.js
@@ -138,6 +138,8 @@ export function initialize_left_sidebar() {
     const rendered_sidebar = render_left_sidebar({
         is_guest: page_params.is_guest,
         development_environment: page_params.development_environment,
+        is_inbox_home_view:
+            user_settings.web_home_view === settings_config.web_home_view_values.inbox.code,
         is_all_messages_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code,
         is_recent_view_home_view:

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -603,6 +603,19 @@ li.active-sub-filter {
     border: 0.5px solid var(--color-border-unread-counter);
 }
 
+/* Don't show unread counts on views... */
+.top_left_inbox,
+.top_left_recent_view,
+.top_left_all_messages {
+    .unread_count {
+        visibility: hidden;
+    }
+    /* ...unless it's the selected home view. */
+    &.selected-home-view .unread_count {
+        visibility: visible;
+    }
+}
+
 /* Don't show the scheduled messages item... */
 li.top_left_scheduled_messages {
     display: none;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -584,6 +584,11 @@ li.active-sub-filter {
 
 #left-sidebar-navigation-list {
     margin-bottom: $sections_vertical_gutter;
+    /* We display this as a grid only to control
+       the order of home views, using a single
+       named grid area. */
+    display: grid;
+    grid-template-areas: "selected-home-view";
 
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {
@@ -592,6 +597,19 @@ li.active-sub-filter {
             white-space: nowrap;
         }
     }
+}
+
+.selected-home-view {
+    /* This bumps the selected view to the
+       top of the grid (expanded list).
+       Others items will auto place in the
+       remaining auto-generated grid rows. */
+    grid-area: selected-home-view;
+    /* The condensed view is a flexbox, so
+       here we'll use a negative order to
+       bump the selected home view to the
+       start of the flexbox (lefthand side). */
+    order: -1;
 }
 
 .top_left_starred_messages .unread_count,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -973,10 +973,6 @@ li.top_left_scheduled_messages {
        by .zulip-icon */
     font-size: 17px;
 
-    &.hide {
-        display: none !important;
-    }
-
     /*
         If you hover directly over the ellipsis itself,
         show it in black.

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -5,26 +5,28 @@
             {{~!-- squash whitespace --~}}
             <h4 class="sidebar-title">{{t 'VIEWS' }}</h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
-                <li class="top_left_inbox left-sidebar-navigation-condensed-item">
-                    <a href="#inbox" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
+                <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
+                    <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                         </span>
                         <span class="unread_count"></span>
                     </a>
                 </li>
-                <li class="top_left_recent_view left-sidebar-navigation-condensed-item">
-                    <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <li class="top_left_recent_view left-sidebar-navigation-condensed-item {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
+                    <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-clock" aria-hidden="true"></i>
                         </span>
+                        <span class="unread_count"></span>
                     </a>
                 </li>
-                <li class="top_left_all_messages left-sidebar-navigation-condensed-item">
-                    <a href="#all_messages" class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
+                <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
+                    <a href="#all_messages" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                         </span>
+                        <span class="unread_count"></span>
                     </a>
                 </li>
                 <li class="top_left_mentions left-sidebar-navigation-condensed-item">
@@ -49,8 +51,8 @@
             </div>
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
-            <li class="tippy-views-tooltip top_left_inbox top_left_row hidden-for-spectators" data-tooltip-template-id="inbox-tooltip-template">
-                <a href="#inbox" class="left-sidebar-navigation-label-container">
+            <li class="tippy-views-tooltip top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
@@ -60,25 +62,27 @@
                 </a>
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="tippy-views-tooltip top_left_recent_view top_left_row" data-tooltip-template-id="recent-conversations-tooltip-template">
-                <a href="#recent" class="left-sidebar-navigation-label-container">
+            <li class="tippy-views-tooltip top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-clock" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
+                    <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon recent-view-sidebar-menu-icon hidden-for-spectators {{#if is_recent_view_home_view}}hide{{/if}}">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>
-            <li class="tippy-views-tooltip top_left_all_messages top_left_row" data-tooltip-template-id="all-message-tooltip-template">
-                <a href="#all_messages" class="home-link left-sidebar-navigation-label-container">
+            <li class="tippy-views-tooltip top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#all_messages" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
+                    <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>

--- a/web/templates/popovers/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar_all_messages_popover.hbs
@@ -1,4 +1,14 @@
 <ul class="nav nav-list">
+    {{#if is_home_view}}
+    <li>
+        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
+        <a tabindex="0" id="mark_all_messages_as_read">
+            <i class="fa fa-book" aria-hidden="true"></i>
+            {{t "Mark all messages as read" }}
+        </a>
+    </li>
+    {{/if}}
+    {{#unless is_home_view}}
     <li>
         <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
             <i class="fa fa-home" aria-hidden="true"></i>
@@ -7,4 +17,5 @@
             {{/tr}}
         </a>
     </li>
+    {{/unless}}
 </ul>

--- a/web/templates/popovers/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar_inbox_popover.hbs
@@ -1,4 +1,5 @@
 <ul class="nav nav-list">
+    {{#if is_home_view}}
     <li>
         {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
         <a tabindex="0" id="mark_all_messages_as_read">
@@ -6,6 +7,7 @@
             {{t "Mark all messages as read" }}
         </a>
     </li>
+    {{/if}}
     {{#unless is_home_view}}
     <li>
         <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">

--- a/web/templates/popovers/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar_recent_view_popover.hbs
@@ -1,4 +1,14 @@
 <ul class="nav nav-list">
+    {{#if is_home_view}}
+    <li>
+        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
+        <a tabindex="0" id="mark_all_messages_as_read">
+            <i class="fa fa-book" aria-hidden="true"></i>
+            {{t "Mark all messages as read" }}
+        </a>
+    </li>
+    {{/if}}
+    {{#unless is_home_view}}
     <li>
         <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
             <i class="fa fa-home" aria-hidden="true"></i>
@@ -7,4 +17,5 @@
             {{/tr}}
         </a>
     </li>
+    {{/unless}}
 </ul>

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -80,6 +80,8 @@ run_test("update_count_in_dom", () => {
 
     make_elem($(".top_left_inbox"), "<home-count>");
 
+    make_elem($(".selected-home-view"), "<home-count>");
+
     make_elem($(".top_left_starred_messages"), "<starred-count>");
 
     make_elem($(".top_left_scheduled_messages"), "<scheduled-count>");


### PR DESCRIPTION
This PR places the selected home view both atop the expanded navigation list, and to the start of the flexbox (far left) of the condensed navigation list.

Additionally, it ensures that the unread count and "Mark all as read" vdots menu follows the selected home view.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/reordering.20views/near/1674084)

TODOs:
- [x] I'm not proud of how I'm handling the unread-count update when a user changes their default home view. There's probably some better way to do it than calling `unread_ui.update_unread_counts()`, but this at least proves the concept for an initial round of review. [Fixed, using more targeted logic that Tim suggested.]

**Screenshots and screen captures:**
![place-selected-home-view](https://github.com/zulip/zulip/assets/170719/733f7315-d0b6-4b2a-9904-98b9df4d565c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>