### PR TITLE
buddy list: Set is_search_users when esc from search.

### DIFF
--- a/web/src/user_search.js
+++ b/web/src/user_search.js
@@ -58,6 +58,8 @@ export class UserSearch {
     }
 
     escape_search() {
+        buddy_data.set_is_searching_users(false);
+
         if (this.empty()) {
             this.close_widget();
             return;


### PR DESCRIPTION
This fixes an existing bug that arose from calling buddy_data.set_is_searching_users in clear_search
but not escape_search.

See bug reported here:
https://chat.zulip.org/#narrow/stream/101-design/topic/buddy.20list.20split.20users/near/1673185
