### PR TITLE
push_notifs: In dev, automatically use dev APNs cert if provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # See `git help ignore` for details on the format.
 
 ## Config files for the dev environment
+/zproject/apns-dev.pem
 /zproject/dev-secrets.conf
 /tools/conf.ini
 /tools/custom_provision

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -100,6 +100,13 @@ USING_PGROONGA = True
 # Flush cache after migration.
 POST_MIGRATION_CACHE_FLUSHING = True
 
+# If a sandbox APNs cert is provided, use it.
+# To create such a cert, see instructions at:
+#   https://github.com/zulip/zulip-mobile/blob/main/docs/howto/push-notifications.md#ios
+_candidate_apns_cert_file = "zproject/apns-dev.pem"
+if os.path.isfile(_candidate_apns_cert_file):
+    APNS_CERT_FILE = _candidate_apns_cert_file
+
 # Don't require anything about password strength in development
 PASSWORD_MIN_LENGTH = 0
 PASSWORD_MIN_GUESSES = 0


### PR DESCRIPTION
This lets us simplify the instructions for testing push notifications with a development client on iOS.

(They'll still be kind of annoying — see [current version](https://github.com/zulip/zulip-mobile/blob/9133ae3e5084969646db3985367d5a5e403b4498/docs/howto/push-notifications.md#ios), which comes after a different simplification I made today — but a couple of the later steps will go away.)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
