### PR TITLE
user_status: Fix press enter to open status emoji picker.

### DIFF
--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -790,10 +790,10 @@ function register_click_handlers() {
         );
     });
 
-    $("body").on("click", "#set-user-status-modal #selected_emoji", (e) => {
+    $("body").on("click", "#set-user-status-modal #selected_emoji .status-emoji-wrapper", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        toggle_emoji_popover(e.target, undefined, {placement: "bottom"});
+        toggle_emoji_popover(e.currentTarget, undefined, {placement: "bottom"});
         if (is_open()) {
             // Because the emoji picker gets drawn on top of the user
             // status modal, we need this hack to make clicking outside
@@ -805,6 +805,12 @@ function register_click_handlers() {
             );
         }
     });
+
+    $("body").on(
+        "keydown",
+        "#set-user-status-modal #selected_emoji .status-emoji-wrapper",
+        ui_util.convert_enter_to_click,
+    );
 
     $(document).on("click", ".emoji-popover-emoji.status-emoji", function (e) {
         e.preventDefault();

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -61,7 +61,8 @@
         padding-top: 15px;
         padding-left: 2px;
 
-        & button.user-status-value:hover {
+        & button.user-status-value:hover,
+        & button.user-status-value:focus {
             /* Important is required for generic night them styling to not
                have precedence over this. */
             color: hsl(200deg 100% 40%) !important;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -23,7 +23,7 @@
         .status-emoji-wrapper {
             padding: 4px 8px;
             border-right: 1px solid;
-            border-color: inherit;
+            border-color: hsl(0deg 0% 0% / 60%);
             cursor: pointer;
 
             .selected-emoji {

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -1,6 +1,8 @@
 <div class="new-style user-status-content-wrapper">
-    <div class="status-emoji-wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
-        {{> status_emoji_selector}}
+    <div class="tippy-zulip-tooltip" data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}" id="selected_emoji">
+        <div class="status-emoji-wrapper" tabindex="0">
+            {{> status_emoji_selector}}
+        </div>
     </div>
     <input type="text" class="user-status modal_text_input" placeholder="{{t 'Your status' }}" maxlength="60"/>
     <button type="button" class="btn clear_search_button" id="clear_status_message_button" disabled="disabled">


### PR DESCRIPTION
As reported on [#27270](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), the emoji picker in the set status modal was not opening when pressing enter. This commit adds a keypress event listener to the emoji picker in the set status modal, and opens the
emoji picker when the enter key is pressed.

Fixes part of #27270.

Relevant discussion: https://github.com/zulip/zulip/issues/27270#issuecomment-1791107342

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![enter-to-save-status-emoji](https://github.com/zulip/zulip/assets/82862779/2e3d77ed-7d1e-4bfd-97d7-2462e202d444)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
