### PR TITLE
emoji_picker: Stop propagating enter keypress to message.

### DIFF
--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -309,6 +309,7 @@ function is_status_emoji(emoji) {
 function process_enter_while_filtering(e) {
     if (keydown_util.is_enter_event(e)) {
         e.preventDefault();
+        e.stopPropagation();
         const $first_emoji = get_rendered_emoji(0, 0);
         if ($first_emoji) {
             if (is_composition($first_emoji)) {


### PR DESCRIPTION
Similar to emoji_picker.process_keypress, process_enter_while_filtering should have a stopPropagation.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/popover.20event.20propagation.20bug