### PR TITLE
change:improve placeholder for empty settings tables

### DIFF
--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -37,7 +37,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_bots_table" class="admin_bot_table"
-              data-empty="{{t 'No bots found.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
+              data-empty="{{t 'There are no bots.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -44,7 +44,7 @@
                 <th>{{t "Status" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_exports_table" data-empty="{{t 'No exports found.' }}"></tbody>
+            <tbody id="admin_exports_table" data-empty="{{t 'There are no exports.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -20,7 +20,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_deactivated_users_table" class="admin_user_table"
-              data-empty="{{t 'No deactivated users found.' }}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
+              data-empty="{{t 'There are no deactivated users.' }}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_deactivated_users_loading_indicator"></div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody data-empty="{{t 'No default streams found.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
+            <tbody data-empty="{{t 'There are no default streams.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -22,7 +22,7 @@
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emojis found.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
+            <tbody id="admin_emoji_table" data-empty="{{t 'There are no custom emoji.' }}" data-search-results-empty="{{t 'No custom emoji match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -23,7 +23,7 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'No invites found.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'There are no invites.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers configured.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>


### PR DESCRIPTION
Fixes: #27250 

This PR fixes the first two items of the issue:

1. Changing the string "No X found" to "There are no X"  in settings tables.
    Using "emoji" rather than "emojis", like elsewhere on this page / in our documentation.
2. Replaces  "No linkifers set." to "No linkifiers configured." (to match the Playgrounds placeholder text)


Before changes
![Screenshot from 2023-11-03 12-15-34](https://github.com/zulip/zulip/assets/147904539/04ab6fae-889c-45cd-9855-8181cd71b08b)

After Changes
![Screenshot from 2023-11-03 12-16-36](https://github.com/zulip/zulip/assets/147904539/91b7cfbe-1256-40d4-8ca7-1618d0d927b2)

