### PR TITLE
scroll_bar: Hook to window resize event instead of ResizeObserver.

### DIFF
--- a/web/src/resize_handler.js
+++ b/web/src/resize_handler.js
@@ -5,6 +5,7 @@ import * as condense from "./condense";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as resize from "./resize";
+import * as scroll_bar from "./scroll_bar";
 import * as sidebar_ui from "./sidebar_ui";
 import * as util from "./util";
 
@@ -24,6 +25,7 @@ export function handler() {
     resize.resize_page_components();
     compose_ui.autosize_textarea($("textarea#compose-textarea"));
     resize.update_recent_view_filters_height();
+    scroll_bar.handle_overlay_scrollbars();
 
     // Re-compute and display/remove 'Show more' buttons to messages
     condense.condense_and_collapse(message_lists.all_current_message_rows());

--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -29,8 +29,4 @@ export function handle_overlay_scrollbars(): void {
 
 export function initialize(): void {
     set_layout_width();
-    handle_overlay_scrollbars();
-    const middle_column = $(".app .column-middle").expectOne()[0];
-    const resize_observer = new ResizeObserver(handle_overlay_scrollbars);
-    resize_observer.observe(middle_column);
 }


### PR DESCRIPTION
ResizeObserver isn't supported for Safari iOS versions we support.

We support iOS Safari ≥ 12.2 but ResizeObserver support requires iOS Safari >=13.4. So if they're on iOS Safari >= 12.2 and < 13.4, it crashes.

