### PR TITLE
compose_tooltips: Don't show tooltip on focus.

### DIFF
--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -23,6 +23,10 @@ export function initialize() {
             "#new_direct_message_button",
         ],
         delay: EXTRA_LONG_HOVER_DELAY,
+        // Only show on mouseenter since for spectators, clicking on these
+        // buttons opens login modal, and Micromodal returns focus to the
+        // trigger after it closes, which results in tooltip being displayed.
+        trigger: "mouseenter",
         appendTo: () => document.body,
         onHidden(instance) {
             instance.destroy();


### PR DESCRIPTION
Fixes #27383

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/Micromodal.20returning.20focus.20to.20trigger.20.2327383
