### PR TITLE
left_sidebar: Display dark-mode condensed unreads without alpha.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -534,6 +534,7 @@ li.active-sub-filter {
             .unread_count {
                 top: -6px;
                 right: -6px;
+                background: var(--color-background-unread-counter-no-alpha);
             }
         }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -395,6 +395,18 @@ body {
     --color-border-dropdown-menu: hsl(0deg 0% 0%);
     --color-border-personal-menu-avatar: hsl(0deg 0% 100% / 20%);
     --color-background-unread-counter: hsl(105deg 2% 50% / 50%);
+    /* When unreads are hovered on the condensed
+       views, they should not have an alpha.
+
+       The second color aligns with dark mode's
+       --color-background. We use the value
+       directly so that this gets compiled down to
+       an rgb() value by PostCSS Preset Env. */
+    --color-background-unread-counter-no-alpha: color-mix(
+        in srgb,
+        hsl(105deg 2% 50%) 50%,
+        hsl(0deg 0% 11%)
+    );
     --color-background-unread-counter-dot: hsl(105deg 2% 50% / 90%);
     --color-background-unread-counter-popover-menu: hsl(105deg 2% 50% / 50%);
     --color-border-unread-counter: hsl(105deg 2% 50%);


### PR DESCRIPTION
This fixes a difficult-to-spot problem with the background color on unreads in the condensed view hover state. An alpha in dark mode was allowing the icon highlight to show through.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/condensed.20view.20dark.20mode.20unreads/near/1674956)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![detail-condensed-unread-hover-before](https://github.com/zulip/zulip/assets/170719/2797a33a-91ce-4cc5-b482-b2c6de681435) | ![detail-condensed-unread-hover-after](https://github.com/zulip/zulip/assets/170719/6cc592a6-600f-4219-b72b-293e3bd484b3) |
| ![condensed-unread-hover-before](https://github.com/zulip/zulip/assets/170719/990ab56d-a801-47b6-afa0-5bca76bb0420) | ![condensed-unread-hover-after](https://github.com/zulip/zulip/assets/170719/1537b6ba-46e3-4bba-92b7-4ffa834f859d) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

