### PR TITLE
add_subscribers : used stream_subscription_request_result and assigned

### DIFF
--- a/web/src/add_subscribers_pill.js
+++ b/web/src/add_subscribers_pill.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 import * as input_pill from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import * as pill_typeahead from "./pill_typeahead";
@@ -61,6 +63,7 @@ export function create({$pill_container, get_potential_subscribers}) {
 
     const $pill_widget_input = $pill_container.find(".input");
     const $pill_widget_button = $pill_container.parent().find(".add-subscriber-button");
+    const $stream_subscription_req_result_elem = $(".stream_subscription_request_result")[0];
     // Disable the add button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 
@@ -70,12 +73,13 @@ export function create({$pill_container, get_potential_subscribers}) {
     );
     // Disable the add button when there is no pending text that can be converted
     // into a pill and the number of existing pills is zero.
-    $pill_widget_input.on("input", () =>
+    $pill_widget_input.on("input", () => {
         $pill_widget_button.prop(
             "disabled",
             !pill_widget.is_pending() && pill_widget.items().length === 0,
-        ),
-    );
+        );
+        $stream_subscription_req_result_elem.innerHTML = "";
+    });
 
     return pill_widget;
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR grabs the `stream_subscription_request_result` element and utilizes `innerHTML` and assign it to empty string whenever user inputs data into the input box which result in removal of both error and success messages of that div

Fixes: #27438 

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/88829894/66e64ca4-c6ff-4bac-90ab-1bfd783200ed

<details>

