### PR TITLE
settings_notifications: Allow users to modify notification settings of muted streams from "Personal settings"

### DIFF
--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -343,16 +343,14 @@ export function update_muted_stream_state(sub) {
         )}']`,
     );
 
-    $row.toggleClass("control-label-disabled", sub.is_muted);
     if (sub.is_muted) {
         $row.find(".unmute_stream").show();
     } else {
         $row.find(".unmute_stream").hide();
     }
-    $row.find("input").prop("disabled", sub.is_muted);
     $row.find('[name="push_notifications"]').prop(
         "disabled",
-        !page_params.realm_push_notifications_enabled || sub.is_muted,
+        !page_params.realm_push_notifications_enabled,
     );
 }
 

--- a/web/templates/settings/notification_settings_checkboxes.hbs
+++ b/web/templates/settings/notification_settings_checkboxes.hbs
@@ -1,7 +1,7 @@
 <td>
     <label class="checkbox">
         <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
-          {{#if (or is_muted is_disabled)}} disabled {{/if}}
+          {{#if is_disabled}} disabled {{/if}}
           {{#if is_checked}}checked="checked"{{/if}} data-setting-widget-type="boolean"
           class="{{setting_name}}{{#unless is_disabled}} prop-element{{/unless}}"/>
         <span></span>

--- a/web/templates/settings/stream_specific_notification_row.hbs
+++ b/web/templates/settings/stream_specific_notification_row.hbs
@@ -1,4 +1,4 @@
-<tr class="stream-notifications-row {{#if muted}}control-label-disabled{{/if}}" data-stream-id="{{stream.stream_id}}">
+<tr class="stream-notifications-row" data-stream-id="{{stream.stream_id}}">
     <td>
         <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
             {{> ../stream_privacy
@@ -15,7 +15,6 @@
           prefix=(lookup ../stream "stream_id")
           is_checked=(lookup ../stream this)
           is_disabled=(lookup ../is_disabled this)
-          is_muted=../muted
           }}
     {{/each}}
 </tr>


### PR DESCRIPTION
This PR enables the user to control notification settings of muted streams through the "Notification" section of Personal settings.

Fixes #27272.

**ScreenShots and screen captures:**

[settings.webm](https://github.com/zulip/zulip/assets/128511266/6013350a-deb8-434c-836d-41b0275ece13)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
