### PR TITLE
compose: Fix bug where pasted content would only go to the compose box.

### DIFF
--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -529,7 +529,7 @@ export function paste_handler(event) {
             event.preventDefault();
             event.stopPropagation();
             const text = paste_handler_converter(paste_html);
-            compose_ui.insert_syntax_and_focus(text);
+            compose_ui.insert_syntax_and_focus(text, $textarea);
         }
     }
 }


### PR DESCRIPTION
This commits ensures that we pass in the correct context (compose box or a message being edited) when pasting content.

Fixes: [Issue described in this CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/pasting.20bug.20for.20message.20editing)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
