### PR TITLE
help: Document ability to drag-and-drop anywhere to upload a file.

### DIFF
--- a/help/share-and-upload-files.md
+++ b/help/share-and-upload-files.md
@@ -12,12 +12,27 @@ and you can click on a thumbnail to [view the full image](/help/view-and-browse-
 
 {start_tabs}
 
-{tab|via-markdown}
+{tab|via-drag-and-drop}
+
+1. Drag and drop one or more files anywhere in the Zulip app,
+   whether or not the compose box is open.
+   Zulip will upload the files, and insert named links using
+   [Markdown formatting](/help/format-your-message-using-markdown#links):
+   `[Link text](URL)`.
+
+1. _(optional)_ Modify the link text as desired.
+
+!!! tip ""
+
+    You can [preview the message](/help/preview-your-message-before-sending)
+    before sending to see what your uploaded files will look like.
+
+{tab|via-paste}
 
 {!start-composing.md!}
 
-1. Drag and drop files, or copy and paste one or more files into the compose
-   box. Zulip will upload the files, and insert named links using
+1. Copy and paste one or more files into the compose box.
+   Zulip will upload the files, and insert named links using
    [Markdown formatting](/help/format-your-message-using-markdown#links):
    `[Link text](URL)`.
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -99,6 +99,7 @@ TAB_SECTION_LABELS = {
     "bot": "Bot",
     "on-sign-up": "On sign-up",
     "via-paste": "Via paste",
+    "via-drag-and-drop": "Via drag-and-drop",
     "via-markdown": "Via Markdown",
     "via-compose-box-buttons": "Via compose box buttons",
     "stream-compose": "Compose to a stream",


### PR DESCRIPTION
- Replaces the "Via Markdown" tab with "Via drag-and-drop", and modifies the instructions to explain that you can drag and drop anywhere in the app, whether or not the compose box is open.
- Adds "Via paste" tab for the copy-pasting instructions.

Fixes #26894.

**Screenshots and screen captures:**
- https://zulip.com/help/share-and-upload-files
![image](https://github.com/zulip/zulip/assets/2343554/206d1770-9903-4286-8762-31ed0d26abde)
![image](https://github.com/zulip/zulip/assets/2343554/acc96199-5ee4-4014-be91-b1d5a64db56b)
