### PR TITLE
left_sidebar: Align no-alpha variable for light mode unreads.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -206,6 +206,11 @@ body {
     --color-border-dropdown-menu: hsl(0deg 0% 0% / 40%);
     --color-border-personal-menu-avatar: hsl(0deg 0% 0% / 10%);
     --color-background-unread-counter: hsl(105deg 2% 50%);
+    /* There's no alpha channel here, but this keeps
+       the variable names in line. */
+    --color-background-unread-counter-no-alpha: var(
+        --color-background-unread-counter
+    );
     --color-background-unread-counter-dot: var(
         --color-background-unread-counter
     );


### PR DESCRIPTION
This fixes a bug introduced in #27520, which left hovered light-mode unreads without a background color in the condensed views row.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/unread.20count.20.28light.20theme.29.20on.20hover.20not.20visible/near/1675367)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Light mode (fixed) | Dark mode (unchanged) |
| --- | --- |
| ![fixed-unreads-light](https://github.com/zulip/zulip/assets/170719/274e1bf1-dd40-4935-92f1-d296b589db28) | ![unreads-dark](https://github.com/zulip/zulip/assets/170719/aefc9535-1e3e-4151-9367-105caac86fc3) |