### PR TITLE
add_subscribers : used stream_subscription_request_result and assigned

### DIFF
--- a/web/src/add_subscribers_pill.js
+++ b/web/src/add_subscribers_pill.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 import * as input_pill from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import * as pill_typeahead from "./pill_typeahead";
@@ -61,6 +63,7 @@ export function create({$pill_container, get_potential_subscribers}) {
 
     const $pill_widget_input = $pill_container.find(".input");
     const $pill_widget_button = $pill_container.parent().find(".add-subscriber-button");
+    const $stream_subscription_req_result_elem = $(".stream_subscription_request_result")[0];
     // Disable the add button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 
@@ -70,12 +73,13 @@ export function create({$pill_container, get_potential_subscribers}) {
     );
     // Disable the add button when there is no pending text that can be converted
     // into a pill and the number of existing pills is zero.
-    $pill_widget_input.on("input", () =>
+    $pill_widget_input.on("input", () => {
         $pill_widget_button.prop(
             "disabled",
             !pill_widget.is_pending() && pill_widget.items().length === 0,
-        ),
-    );
+        );
+        $stream_subscription_req_result_elem.innerHTML = "";
+    });
 
     return pill_widget;
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously when user inputs wrong pills into the input box it results in error message it but this message does not fade away even when user does not input anything 

To acheive this the message in the  `stream_subscription_request_result` div and made it empty 
 whenever user inputs data into the input box which result in removal of message in that div


Fixes: #27438


**Screenshots and screen captures:**
**Before:**

https://github.com/zulip/zulip/assets/88829894/0ccf3962-9936-4f35-8fbb-77245419eb9d

**After:**

https://github.com/zulip/zulip/assets/88829894/66e64ca4-c6ff-4bac-90ab-1bfd783200ed

<details>

nshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
