### PR TITLE
user_mention: Fix mentions of deactivated users.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1895,6 +1895,8 @@ class UserMentionPattern(CompiledInlineProcessor):
                     self.zmd.zulip_rendering_result.mentions_topic_wildcard = True
             elif user is not None:
                 assert isinstance(user, FullNameInfo)
+                if not user.is_active:
+                    silent = True
 
                 if not silent:
                     self.zmd.zulip_rendering_result.mentions_user_ids.add(user.id)

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -27,6 +27,7 @@ stream_wildcards = frozenset(["all", "everyone", "stream"])
 class FullNameInfo:
     id: int
     full_name: str
+    is_active: bool
 
 
 @dataclass
@@ -94,17 +95,20 @@ class MentionBackend:
                 UserProfile.objects.filter(
                     Q(realm_id=self.realm_id) | Q(email__in=settings.CROSS_REALM_BOT_EMAILS),
                 )
-                .filter(is_active=True)
                 .filter(
                     functools.reduce(lambda a, b: a | b, q_list),
                 )
                 .only(
                     "id",
                     "full_name",
+                    "is_active",
                 )
             )
 
-            user_list = [FullNameInfo(id=row.id, full_name=row.full_name) for row in rows]
+            user_list = [
+                FullNameInfo(id=row.id, full_name=row.full_name, is_active=row.is_active)
+                for row in rows
+            ]
 
             # We expect callers who take advantage of our cache to supply both
             # id and full_name in the user mentions in their messages.


### PR DESCRIPTION
Previously, when a deactivated user was mentioned, he wasn't rendered as a Pill. This is because the dataset for validating mentions only included active users, which is fixed by removing that filter.

To allow only silent mentions of them, an extra is_active property added to FullNameInfo class, which is populated from the query, which tells if user is deactivated. This is used to convert any mentions of them to silent mentions in the backend markdown.

Fixes: #26857 User pills for mentions of deactivated users

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![VP7zuF9FjS](https://github.com/zulip/zulip/assets/97049524/e930f11b-3cfe-4e4d-b158-8bda981e45c9)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
