### PR TITLE
settings: Fix "message content in message notification emails".

### DIFF
--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -194,7 +194,7 @@ export async function check_form_contents(
 }
 
 export async function get_element_text(element: ElementHandle): Promise<string> {
-    const text = await (await element.getProperty("innerText"))!.jsonValue();
+    const text = await (await element.getProperty("innerText")).jsonValue();
     assert.ok(typeof text === "string");
     return text;
 }

--- a/web/src/message_parser.ts
+++ b/web/src/message_parser.ts
@@ -9,7 +9,7 @@ import type {Message} from "./message_store";
 // one needs an outer element wrapping an object to use this
 // construction.
 function is_element_in_message_content(message: Message, element_selector: string): boolean {
-    return $(`<div>${message.content}</div>`).find(`${element_selector}`).length > 0;
+    return $(`<div>${message.content}</div>`).find(element_selector).length > 0;
 }
 
 export function message_has_link(message: Message): boolean {

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -221,9 +221,9 @@ export function close_if_open(modal_id: string): void {
     }
 
     const $micromodal = $(".micromodal.modal--open");
-    const active_modal_id = CSS.escape(`${CSS.escape($micromodal.attr("id") ?? "")}`);
-    if (active_modal_id === `${CSS.escape(modal_id)}`) {
-        Micromodal.close(`${CSS.escape($micromodal.attr("id") ?? "")}`);
+    const active_modal_id = CSS.escape(CSS.escape($micromodal.attr("id") ?? ""));
+    if (active_modal_id === CSS.escape(modal_id)) {
+        Micromodal.close(CSS.escape($micromodal.attr("id") ?? ""));
     } else {
         blueslip.info(
             `${active_modal_id} is the currently active modal and ${modal_id} is already closed.`,
@@ -238,7 +238,7 @@ export function close_active(): void {
     }
 
     const $micromodal = $(".micromodal.modal--open");
-    Micromodal.close(`${CSS.escape($micromodal.attr("id") ?? "")}`);
+    Micromodal.close(CSS.escape($micromodal.attr("id") ?? ""));
 }
 
 export function close_active_if_any(): void {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -380,7 +380,7 @@ export function emails_to_full_names_string(emails: string[]): string {
 }
 
 export function get_user_time(user_id: number): string | undefined {
-    const user_timezone = get_by_user_id(user_id)!.timezone;
+    const user_timezone = get_by_user_id(user_id).timezone;
     if (user_timezone) {
         try {
             return new Date().toLocaleTimeString(user_settings.default_language, {
@@ -869,7 +869,7 @@ export function sender_info_for_recent_view_row(sender_ids: number[]): SenderInf
     const senders_info = [];
     for (const id of sender_ids) {
         // TODO: Better handling for optional values w/o the assertion.
-        const person = get_by_user_id(id)!;
+        const person = get_by_user_id(id);
         const sender: SenderInfo = {
             ...person,
             avatar_url_small: small_avatar_url_for_person(person),

--- a/web/src/portico/portico_modals.ts
+++ b/web/src/portico/portico_modals.ts
@@ -25,7 +25,7 @@ export function close_active(): void {
     }
 
     const $micromodal = $(".micromodal.modal--open");
-    Micromodal.close(`${CSS.escape($micromodal.attr("id") ?? "")}`);
+    Micromodal.close(CSS.escape($micromodal.attr("id") ?? ""));
 }
 
 export function open(modal_id: string, recursive_call_count = 0): void {

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -105,6 +105,11 @@ export function update_lock_icon_in_sidebar() {
 export function build_page() {
     setup_settings_label();
 
+    const disabled_notification_settings = {
+        message_content_in_email_notifications:
+            !page_params.realm_message_content_allowed_in_email_notifications,
+    };
+
     const rendered_settings_tab = render_settings_tab({
         full_name: people.my_full_name(),
         date_joined_text: get_parsed_date_of_joining(),
@@ -116,6 +121,7 @@ export function build_page() {
         timezones: timezones.timezones,
         can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label,
+        disabled_notification_settings,
         demote_inactive_streams_values: settings_config.demote_inactive_streams_values,
         web_mark_read_on_scroll_policy_values:
             settings_config.web_mark_read_on_scroll_policy_values,

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -434,6 +434,24 @@ export function initialize(): void {
     });
 
     delegate("body", {
+        target: "#user_message_content_in_email_notifications_label",
+        onShow(instance) {
+            if ($("#user_message_content_in_email_notifications").prop("disabled")) {
+                instance.setContent(
+                    $t({
+                        defaultMessage:
+                            "Including message content in message notification emails is not allowed in this organization.",
+                    }),
+                );
+                return undefined;
+            }
+            instance.destroy();
+            return false;
+        },
+        appendTo: () => document.body,
+    });
+
+    delegate("body", {
         target: ".views-tooltip-target",
         onShow(instance) {
             if ($("#toggle-top-left-navigation-area-icon").hasClass("fa-caret-down")) {

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -206,6 +206,7 @@
               setting_name=this
               is_checked=(lookup ../settings_object this)
               label=(lookup ../settings_label this)
+              is_disabled=(lookup ../disabled_notification_settings this)
               prefix=../prefix}}
         {{/each}}
     </div>


### PR DESCRIPTION
> In user settings, if "message content in message notification emails" is disabled at an Organisation level, then the "Allow 
> message content in message notification emails" should be shown both disabled and greyed out. At present a user can still 
> enable this box, and messages notification emails still do not contain message content

This PR fixes this issue.

Fixes: #27262

![Screenshot 2023-11-04 172618](https://github.com/zulip/zulip/assets/116462808/9993d22e-6804-411c-90d5-3d10a9ff6d76)


![Screenshot 2023-11-04 172635](https://github.com/zulip/zulip/assets/116462808/4269895e-bf62-4778-9f70-4ed8883a1795)


![Screenshot 2023-11-04 172702](https://github.com/zulip/zulip/assets/116462808/00b1f912-2d71-4410-bcf5-9ee139c0393f)

![Screenshot 2023-11-09 214355](https://github.com/zulip/zulip/assets/116462808/f5a5e277-f493-4927-bbe1-3ec4e5b52b50)

![ezgif com-optimize](https://github.com/zulip/zulip/assets/116462808/fc5acebc-5a8c-4a92-a8ba-4e06820e53a5)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
