### PR TITLE
Dhruvgupta3377/added new typeaheads issue

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -445,6 +445,7 @@ export const slash_commands = [
         text: $t({defaultMessage: "/me (Action Message)"}),
         name: "me",
         aliases: "",
+        placeholder: $t({defaultMessage: "is …"}),
     },
     {
         text: $t({defaultMessage: "/poll (Create a poll)"}),

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -442,18 +442,18 @@ export const dev_only_slash_commands = [
 
 export const slash_commands = [
     {
-        text: $t({defaultMessage: "/me is excited (Display action text)"}),
+        text: $t({defaultMessage: "/me (Action Message)"}),
         name: "me",
         aliases: "",
     },
     {
-        text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),
+        text: $t({defaultMessage: "/poll (Create a poll)"}),
         name: "poll",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
     },
     {
-        text: $t({defaultMessage: "/todo (Create a todo list)"}),
+        text: $t({defaultMessage: "/todo (Create a collaborative to-do list)"}),
         name: "todo",
         aliases: "",
     },

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -181,7 +181,7 @@ const emoji_list = [...emojis_by_name.values()].map((emoji_dict) => ({
 const me_slash = {
     name: "me",
     aliases: "",
-    text: "translated: /me is excited (Display action text)",
+    text: "translated: /me (Action Message)",
 };
 
 const my_slash = {
@@ -1552,11 +1552,11 @@ test("content_highlighter", ({override_rewire}) => {
     fake_this = {completing: "slash"};
     let th_render_slash_command_called = false;
     const me_slash = {
-        text: "/me is excited (Display action text)",
+        text: "/me (Action Message)",
     };
     override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
         assert.deepEqual(item, {
-            primary: "/me is excited (Display action text)",
+            primary: "/me (Action Message)",
         });
         th_render_slash_command_called = true;
     });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Updated typeaheads
Fixes: <!-- Issue link, or clear description.-->
issue #27391
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

screenshot from the currently deployed version

![image](https://github.com/zulip/zulip/assets/90503781/f12913c5-d170-4c13-8627-07f1fd7e0488)

final result screenshot

![image](https://github.com/zulip/zulip/assets/90503781/666ebff7-be90-4b46-bb35-2d70738577d7)

<details>

Changes are needed to be made in translations for these updated typeaheads.

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

Changes are needed to be made translations for these new typeaheads.


- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>