### PR TITLE
uploads: Extend drag and drop upload area to blank areas after sidebars.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -159,6 +159,8 @@
 
 <div id="user-profile-modal-holder"></div>
 
+<div id="about-zulip-modal-container"></div>
+
 <audio id="user-notification-sound-audio">
     <source class="notification-sound-source-ogg" type="audio/ogg" />
     <source class="notification-sound-source-mp3" type="audio/mpeg" />

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -279,9 +279,10 @@
         <div class="column-right" id="right-sidebar-container">
         </div><!--/right sidebar-->
     </div><!--/row-->
-    <div class="hidden">
-        <form id="logout_form" action="/accounts/logout/" method="POST">{{ csrf_input }}
-        </form>
-    </div>
+</div>
+
+<div class="hidden">
+    <form id="logout_form" action="/accounts/logout/" method="POST">{{ csrf_input }}
+    </form>
 </div>
 {% endblock %}

--- a/web/src/about_zulip.ts
+++ b/web/src/about_zulip.ts
@@ -32,5 +32,5 @@ export function initialize(): void {
             page_params.zulip_merge_base &&
             page_params.zulip_merge_base !== page_params.zulip_version,
     });
-    $(".app").append(rendered_about_zulip);
+    $("#about-zulip-modal-container").append(rendered_about_zulip);
 }

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -427,12 +427,12 @@ export function initialize() {
     });
 
     // Allow the app panel to receive drag/drop events.
-    $(".app").on("dragover", (event) => event.preventDefault());
+    $(".app, #navbar-fixed-container").on("dragover", (event) => event.preventDefault());
 
     // TODO: Do something visual to hint that drag/drop will work.
-    $(".app").on("dragenter", (event) => event.preventDefault());
+    $(".app, #navbar-fixed-container").on("dragenter", (event) => event.preventDefault());
 
-    $(".app").on("drop", (event) => {
+    $(".app, #navbar-fixed-container").on("drop", (event) => {
         event.preventDefault();
 
         const $drag_drop_edit_containers = $(".message_edit_form form");

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -426,13 +426,13 @@ export function initialize() {
         mode: "compose",
     });
 
-    // Allow the main panel to receive drag/drop events.
-    $(".app-main").on("dragover", (event) => event.preventDefault());
+    // Allow the app panel to receive drag/drop events.
+    $(".app").on("dragover", (event) => event.preventDefault());
 
     // TODO: Do something visual to hint that drag/drop will work.
-    $(".app-main").on("dragenter", (event) => event.preventDefault());
+    $(".app").on("dragenter", (event) => event.preventDefault());
 
-    $(".app-main").on("drop", (event) => {
+    $(".app").on("drop", (event) => {
         event.preventDefault();
 
         const $drag_drop_edit_containers = $(".message_edit_form form");

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -834,8 +834,8 @@ p.n-margin {
 }
 
 .app {
-    width: 100%;
-    height: 100%;
+    min-width: 100%;
+    min-height: 100%;
     z-index: 99;
 }
 

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -662,12 +662,12 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
     };
 
     // dragover event test
-    const dragover_handler = $(".app").get_on_handler("dragover");
+    const dragover_handler = $(".app, #navbar-fixed-container").get_on_handler("dragover");
     dragover_handler(drag_event);
     assert.equal(prevent_default_counter, 1);
 
     // dragenter event test
-    const dragenter_handler = $(".app").get_on_handler("dragenter");
+    const dragenter_handler = $(".app, #navbar-fixed-container").get_on_handler("dragenter");
     dragenter_handler(drag_event);
     assert.equal(prevent_default_counter, 2);
 
@@ -686,7 +686,7 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
 
     $(".message_edit_form form").last = () => ({length: 0});
 
-    const drop_handler = $(".app").get_on_handler("drop");
+    const drop_handler = $(".app, #navbar-fixed-container").get_on_handler("drop");
 
     // Test drop on compose box
     let upload_files_called = false;
@@ -764,11 +764,11 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
     const $drag_drop_container = $(`#zfilt${CSS.escape(40)} .message_edit_form`);
 
     // Dragover event test
-    const dragover_handler = $(".app").get_on_handler("dragover");
+    const dragover_handler = $(".app, #navbar-fixed-container").get_on_handler("dragover");
     dragover_handler(drag_event);
     assert.equal(prevent_default_counter, 1);
     // Dragenter event test
-    const dragenter_handler = $(".app").get_on_handler("dragenter");
+    const dragenter_handler = $(".app, #navbar-fixed-container").get_on_handler("dragenter");
     dragenter_handler(drag_event);
     assert.equal(prevent_default_counter, 2);
 
@@ -784,7 +784,7 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
             },
         },
     };
-    const drop_handler = $(".app").get_on_handler("drop");
+    const drop_handler = $(".app, #navbar-fixed-container").get_on_handler("drop");
     let upload_files_called = false;
     let dropped_row_id = -1;
     override_rewire(upload, "upload_files", (_, config) => {

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -662,12 +662,12 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
     };
 
     // dragover event test
-    const dragover_handler = $(".app-main").get_on_handler("dragover");
+    const dragover_handler = $(".app").get_on_handler("dragover");
     dragover_handler(drag_event);
     assert.equal(prevent_default_counter, 1);
 
     // dragenter event test
-    const dragenter_handler = $(".app-main").get_on_handler("dragenter");
+    const dragenter_handler = $(".app").get_on_handler("dragenter");
     dragenter_handler(drag_event);
     assert.equal(prevent_default_counter, 2);
 
@@ -686,7 +686,7 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
 
     $(".message_edit_form form").last = () => ({length: 0});
 
-    const drop_handler = $(".app-main").get_on_handler("drop");
+    const drop_handler = $(".app").get_on_handler("drop");
 
     // Test drop on compose box
     let upload_files_called = false;
@@ -764,11 +764,11 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
     const $drag_drop_container = $(`#zfilt${CSS.escape(40)} .message_edit_form`);
 
     // Dragover event test
-    const dragover_handler = $(".app-main").get_on_handler("dragover");
+    const dragover_handler = $(".app").get_on_handler("dragover");
     dragover_handler(drag_event);
     assert.equal(prevent_default_counter, 1);
     // Dragenter event test
-    const dragenter_handler = $(".app-main").get_on_handler("dragenter");
+    const dragenter_handler = $(".app").get_on_handler("dragenter");
     dragenter_handler(drag_event);
     assert.equal(prevent_default_counter, 2);
 
@@ -784,7 +784,7 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
             },
         },
     };
-    const drop_handler = $(".app-main").get_on_handler("drop");
+    const drop_handler = $(".app").get_on_handler("drop");
     let upload_files_called = false;
     let dropped_row_id = -1;
     override_rewire(upload, "upload_files", (_, config) => {


### PR DESCRIPTION
With respect to the documentation added in #27536 we should extend the drag-and-drop upload area to the blank spaces on either end of the app just after the sidebars.

<!-- Describe your pull request here.-->

Fixes: #27550.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Beyond Left Sidebar
![left-blank-upload](https://github.com/zulip/zulip/assets/82862779/70ccba36-4937-4d68-bdcb-46408e789452)
- Beyond Right Sidebar
![right-blank-upload](https://github.com/zulip/zulip/assets/82862779/aa241a26-01e1-4b78-b4a4-ac7e4a518933)
- Normal App area upload
![main-upload](https://github.com/zulip/zulip/assets/82862779/4af81bdf-5a5e-4398-bca9-fc0a585c1ce8)

(Edit 1)
- Sidebars + Navbar
![drag-and-drop](https://github.com/zulip/zulip/assets/82862779/c50e8681-8273-467b-b0a2-6d4992c7d49a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
