### PR TITLE
integrations: Add support for Big Blue Button audio only calls.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+
+**Feature level 271**
+
+* `POST /calls/bigbluebutton/create`: Added a `voice_only` parameter
+  controlling whether the call should be voice-only, in which case we
+  keep cameras disabled for this call. The side effects are that now we
+  only support BigBlueButton 2.4 and above, and that only the call creator
+  is a moderator and all other joinees are viewers.
+
 **Feature level 270**
 
 * `PATCH /realm`, [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,9 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-
-API_FEATURE_LEVEL = 270  # Last bumped for direct_message_permission_group
-
+API_FEATURE_LEVEL = 271
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -39,7 +39,9 @@ export function compute_show_audio_chat_button(): boolean {
             get_jitsi_server_url() !== null &&
             realm.realm_video_chat_provider === available_providers.jitsi_meet.id) ||
         (available_providers.zoom &&
-            realm.realm_video_chat_provider === available_providers.zoom.id)
+            realm.realm_video_chat_provider === available_providers.zoom.id) ||
+        (available_providers.big_blue_button &&
+            realm.realm_video_chat_provider === available_providers.big_blue_button.id)
     ) {
         return true;
     }

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -120,19 +120,21 @@ export function generate_and_insert_audio_or_video_call_link(
         available_providers.big_blue_button &&
         realm.realm_video_chat_provider === available_providers.big_blue_button.id
     ) {
-        if (is_audio_call) {
-            // TODO: Add support for audio-only BigBlueButton calls here.
-            return;
-        }
         const meeting_name = get_recipient_label() + " meeting";
+        const request = {
+            meeting_name,
+            voice_only: is_audio_call,
+        };
         void channel.get({
             url: "/json/calls/bigbluebutton/create",
-            data: {
-                meeting_name,
-            },
+            data: request,
             success(response) {
                 const data = call_response_schema.parse(response);
-                insert_video_call_url(data.url, $target_textarea);
+                if (is_audio_call) {
+                    insert_audio_call_url(data.url, $target_textarea);
+                } else {
+                    insert_video_call_url(data.url, $target_textarea);
+                }
             },
         });
     } else {

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -203,7 +203,7 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, audio_link_regex);
     })();
 
-    (function test_bbb_video_link_compose_clicked() {
+    (function test_bbb_audio_and_video_links_compose_clicked() {
         let syntax_to_insert;
         let called = false;
 
@@ -223,7 +223,6 @@ test("videos", ({override}) => {
             called = true;
         });
 
-        const handler = $("body").get_on_handler("click", ".video_link");
         $("textarea#compose-textarea").val("");
 
         realm.realm_video_chat_provider = realm_available_video_chat_providers.big_blue_button.id;
@@ -236,15 +235,28 @@ test("videos", ({override}) => {
             options.success({
                 result: "success",
                 msg: "",
-                url: "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
+                url:
+                    "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=" +
+                    options.data.voice_only +
+                    "&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
             });
         };
 
-        handler(ev);
+        $("textarea#compose-textarea").val("");
+
+        const video_handler = $("body").get_on_handler("click", ".video_link");
+        video_handler(ev);
         const video_link_regex =
-            /\[translated: Join video call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
+            /\[translated: Join video call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=false&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
+
+        const audio_handler = $("body").get_on_handler("click", ".audio_link");
+        audio_handler(ev);
+        const audio_link_regex =
+            /\[translated: Join voice call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=true&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
+        assert.ok(called);
+        assert.match(syntax_to_insert, audio_link_regex);
     })();
 });
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19923,6 +19923,14 @@ paths:
           description: |
             Meeting name for the BigBlueButton video call.
           example: "test_channel meeting"
+        - in: query
+          name: voice_only
+          schema:
+            type: boolean
+          required: true
+          description: |
+            Whether the call should be voice-only, in which case we keep
+            cameras disabled for this call.
       responses:
         "200":
           description: Success.

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -22,7 +22,17 @@ class TestVideoCall(ZulipTestCase):
             {
                 "meeting_id": "a",
                 "name": "a",
-                "password": "a",
+                "lock_settings_disable_cam": True,
+                "moderator": self.user.id,
+            }
+        )
+        # For testing viewer role (different creator / moderator from self)
+        self.signed_bbb_a_object_different_creator = self.signer.sign_object(
+            {
+                "meeting_id": "a",
+                "name": "a",
+                "lock_settings_disable_cam": True,
+                "moderator": self.example_user("cordelia").id,
             }
         )
 
@@ -230,11 +240,10 @@ class TestVideoCall(ZulipTestCase):
         self.assert_json_success(response)
 
     def test_create_bigbluebutton_link(self) -> None:
-        with mock.patch("zerver.views.video_calls.random.randint", return_value="1"), mock.patch(
-            "secrets.token_bytes", return_value=b"\x00" * 20
-        ):
+        with mock.patch("zerver.views.video_calls.random.randint", return_value="1"):
+            # Testing for video call
             response = self.client_get(
-                "/json/calls/bigbluebutton/create?meeting_name=general > meeting"
+                "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=false"
             )
             response_dict = self.assert_json_success(response)
             self.assertEqual(
@@ -246,7 +255,29 @@ class TestVideoCall(ZulipTestCase):
                         {
                             "meeting_id": "zulip-1",
                             "name": "general > meeting",
-                            "password": "A" * 32,
+                            "lock_settings_disable_cam": False,
+                            "moderator": self.user.id,
+                        }
+                    ),
+                ),
+            )
+
+            # Testing for audio call
+            response = self.client_get(
+                "/json/calls/bigbluebutton/create?meeting_name=general > meeting&voice_only=true"
+            )
+            response_dict = self.assert_json_success(response)
+            self.assertEqual(
+                response_dict["url"],
+                append_url_query_string(
+                    "/calls/bigbluebutton/join",
+                    "bigbluebutton="
+                    + self.signer.sign_object(
+                        {
+                            "meeting_id": "zulip-1",
+                            "name": "general > meeting",
+                            "lock_settings_disable_cam": True,
+                            "moderator": self.user.id,
                         }
                     ),
                 ),
@@ -256,8 +287,8 @@ class TestVideoCall(ZulipTestCase):
     def test_join_bigbluebutton_redirect(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a"
-            "&moderatorPW=a&attendeePW=a&checksum=131bdec35f62fc63d5436e6f791d6d7aed7cf79ef256c03597e51d320d042823",
+            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True"
+            "&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
             "<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
         )
         response = self.client_get(
@@ -268,15 +299,27 @@ class TestVideoCall(ZulipTestCase):
         self.assertEqual(
             response["Location"],
             "https://bbb.example.com/bigbluebutton/api/join?meetingID=a&"
-            "password=a&fullName=King%20Hamlet&createTime=0&checksum=47ca959b4ff5c8047a5a56d6e99c07e17eac43dbf792afc0a2a9f6491ec0048b",
+            "role=MODERATOR&fullName=King%20Hamlet&createTime=0&checksum=54259b884a7c20ddcd7b280a1b62e59d7990568fe4f22001812bc4bcfd161a46",
+        )
+        # Testing for viewer role
+        response = self.client_get(
+            "/calls/bigbluebutton/join",
+            {"bigbluebutton": self.signed_bbb_a_object_different_creator},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(isinstance(response, HttpResponseRedirect), True)
+        self.assertEqual(
+            response["Location"],
+            "https://bbb.example.com/bigbluebutton/api/join?meetingID=a&"
+            "role=VIEWER&fullName=King%20Hamlet&createTime=0&checksum=52efaf64109ca4ec5a20a1d295f315af53f9e6ec30b50ed3707fd2909ac6bd94",
         )
 
     @responses.activate
     def test_join_bigbluebutton_invalid_signature(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a"
-            "&moderatorPW=a&attendeePW=a&checksum=131bdec35f62fc63d5436e6f791d6d7aed7cf79ef256c03597e51d320d042823",
+            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True"
+            "&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
             "<response><returncode>SUCCESS</returncode><messageKey/><createTime>0</createTime></response>",
         )
         response = self.client_get(
@@ -288,7 +331,7 @@ class TestVideoCall(ZulipTestCase):
     def test_join_bigbluebutton_redirect_wrong_big_blue_button_checksum(self) -> None:
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&moderatorPW=a&attendeePW=a&checksum=131bdec35f62fc63d5436e6f791d6d7aed7cf79ef256c03597e51d320d042823",
+            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
             "<response><returncode>FAILED</returncode><messageKey>checksumError</messageKey>"
             "<message>You did not pass the checksum security check</message></response>",
         )
@@ -303,7 +346,7 @@ class TestVideoCall(ZulipTestCase):
         # Simulate bbb server error
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&moderatorPW=a&attendeePW=a&checksum=131bdec35f62fc63d5436e6f791d6d7aed7cf79ef256c03597e51d320d042823",
+            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
             "",
             status=500,
         )
@@ -318,7 +361,7 @@ class TestVideoCall(ZulipTestCase):
         # Simulate bbb server error
         responses.add(
             responses.GET,
-            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&moderatorPW=a&attendeePW=a&checksum=131bdec35f62fc63d5436e6f791d6d7aed7cf79ef256c03597e51d320d042823",
+            "https://bbb.example.com/bigbluebutton/api/create?meetingID=a&name=a&lockSettingsDisableCam=True&checksum=33349e6374ca9b2d15a0c6e51a42bc3e8f770de13f88660815c6449859856e20",
             "<response><returncode>FAILURE</returncode><messageKey>otherFailure</messageKey></response>",
         )
         response = self.client_get(

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -1,8 +1,6 @@
 import hashlib
 import json
 import random
-import secrets
-from base64 import b32encode
 from typing import Dict
 from urllib.parse import quote, urlencode, urljoin
 
@@ -196,12 +194,14 @@ def deauthorize_zoom_user(request: HttpRequest) -> HttpResponse:
 
 @has_request_variables
 def get_bigbluebutton_url(
-    request: HttpRequest, user_profile: UserProfile, meeting_name: str = REQ()
+    request: HttpRequest,
+    user_profile: UserProfile,
+    meeting_name: str = REQ(),
+    voice_only: bool = REQ(json_validator=check_bool, default=False),
 ) -> HttpResponse:
     # https://docs.bigbluebutton.org/dev/api.html#create for reference on the API calls
     # https://docs.bigbluebutton.org/dev/api.html#usage for reference for checksum
     id = "zulip-" + str(random.randint(100000000000, 999999999999))
-    password = b32encode(secrets.token_bytes(20)).decode()  # 20 bytes means 32 characters
 
     # We sign our data here to ensure a Zulip user cannot tamper with
     # the join link to gain access to other meetings that are on the
@@ -210,7 +210,8 @@ def get_bigbluebutton_url(
         {
             "meeting_id": id,
             "name": meeting_name,
-            "password": password,
+            "lock_settings_disable_cam": voice_only,
+            "moderator": request.user.id,
         }
     )
     url = append_url_query_string("/calls/bigbluebutton/join", "bigbluebutton=" + signed)
@@ -240,14 +241,7 @@ def join_bigbluebutton(request: HttpRequest, bigbluebutton: str = REQ()) -> Http
         {
             "meetingID": bigbluebutton_data["meeting_id"],
             "name": bigbluebutton_data["name"],
-            "moderatorPW": bigbluebutton_data["password"],
-            # We generate the attendee password from moderatorPW,
-            # because the BigBlueButton API requires a separate
-            # password. This integration is designed to have all users
-            # join as moderators, so we generate attendeePW by
-            # truncating the moderatorPW while keeping it long enough
-            # to not be vulnerable to brute force attacks.
-            "attendeePW": bigbluebutton_data["password"][:16],
+            "lockSettingsDisableCam": bigbluebutton_data["lock_settings_disable_cam"],
         },
         quote_via=quote,
     )
@@ -276,9 +270,11 @@ def join_bigbluebutton(request: HttpRequest, bigbluebutton: str = REQ()) -> Http
     join_params = urlencode(
         {
             "meetingID": bigbluebutton_data["meeting_id"],
-            # We use the moderator password here to grant ever user
-            # full moderator permissions to the bigbluebutton session.
-            "password": bigbluebutton_data["password"],
+            # We use the moderator role only for the user who created the
+            # meeting, the attendee role for everyone else, so that only
+            # the user who created the meeting can convert a voice-only
+            # call to a video call.
+            "role": "MODERATOR" if bigbluebutton_data["moderator"] == request.user.id else "VIEWER",
             "fullName": request.user.full_name,
             # https://docs.bigbluebutton.org/dev/api.html#create
             # The createTime option is used to have the user redirected to a link


### PR DESCRIPTION
We now allow users to create voice calls when their call provider is Big Blue Button. This is done by creating a call where cameras are disabled for all participants in the call -- a voice call.

Fixes: #26550.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
