### PR TITLE
emoji_picker: Don't autofocus search input on mobile.

### DIFF
--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -22,6 +22,7 @@ import * as spectators from "./spectators";
 import * as ui_util from "./ui_util";
 import {user_settings} from "./user_settings";
 import * as user_status_ui from "./user_status_ui";
+import * as util from "./util";
 
 // The functionalities for reacting to a message with an emoji
 // and composing a message with an emoji share a single widget,
@@ -673,7 +674,12 @@ function get_default_emoji_popover_options() {
             refill_section_head_offsets($popover);
             show_emoji_catalog();
             register_popover_events($popover);
-            change_focus_to_filter();
+            // Don't focus filter box on mobile since it leads to window resize due
+            // to keyboard being open and scrolls the emoji popover out of view while
+            // still open in Chrome Android and can hide it based on device height in Firefox Android.
+            if (!util.is_mobile()) {
+                change_focus_to_filter();
+            }
         },
         onHidden() {
             hide_emoji_popover();

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -10,6 +10,7 @@ import {media_breakpoints_num} from "./css_variables";
 import * as modals from "./modals";
 import * as overlays from "./overlays";
 import * as popovers from "./popovers";
+import * as util from "./util";
 
 export const popover_instances = {
     compose_control_buttons: null,
@@ -269,8 +270,24 @@ function get_props_for_popover_centering(popover_props) {
                         offset({popper}) {
                             // Calculate the offset needed to place the reference in the center
                             const x_offset_to_center = window.innerWidth / 2;
-                            const y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
+                            let y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
 
+                            // Move popover to the top of the screen if user is focused on an element which can
+                            // open keyboard on a mobile device causing the screen to resize.
+                            // Resize doesn't happen on iOS when keyboard is open, and typing text in input field just works.
+                            // For other browsers, we need to check if the focused element is an text field and
+                            // is causing a resize (thus calling this `offset` modifier function), in which case
+                            // we need to move the popover to the top of the screen.
+                            if (util.is_mobile()) {
+                                const $focused_element = $(document.activeElement);
+                                if (
+                                    $focused_element.is(
+                                        "input[type=text], input[type=number], textarea",
+                                    )
+                                ) {
+                                    y_offset_to_center = 10;
+                                }
+                            }
                             return [x_offset_to_center, y_offset_to_center];
                         },
                     },

--- a/web/templates/popovers/emoji/emoji_popover.hbs
+++ b/web/templates/popovers/emoji/emoji_popover.hbs
@@ -1,7 +1,7 @@
 <div class="emoji-picker-popover">
     <div class="emoji-popover">
         <div class="emoji-popover-top">
-            <input class="emoji-popover-filter filter_text_input" type="text" autofocus placeholder="{{t 'Search' }}" />
+            <input class="emoji-popover-filter filter_text_input" type="text" placeholder="{{t 'Search' }}" />
             <i class="fa fa-search" aria-hidden="true"></i>
         </div>
         <div class="emoji-popover-category-tabs">


### PR DESCRIPTION
Fixes #11448

https://github.com/zulip/zulip/assets/25124304/8dc0d45a-90a4-42ed-a078-bace2c429073


Since focus on input elements on mobile opens keyboard which changes window height, emoji popover can hide or scroll out of view. To fix it, we don't focus on search input unless user wants to when emoji popover is open.

Tested on Chrome Android and Firefox Android.

