### PR TITLE
actions_popover: Fix copy link not working on `enter` keypress.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -40,6 +40,10 @@ export function popover_items_handle_keyboard(key, $items) {
     let index = $items.index($items.filter(":focus"));
 
     if (key === "enter" && index >= 0 && index < $items.length) {
+        // This is not enough for some elements which need to trigger
+        // natural click for them to work like ClipboardJS and follow
+        // the link for anchor tags. For those elements, we need to
+        // use `.navigate-link-on-enter` class on them.
         $items.eq(index).trigger("click");
         return;
     }

--- a/web/templates/popovers/actions_popover.hbs
+++ b/web/templates/popovers/actions_popover.hbs
@@ -110,7 +110,7 @@
     {{/if}}
 
     <li>
-        <a class="copy_link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_url }}" tabindex="0">
+        <a class="copy_link navigate-link-on-enter" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_url }}" tabindex="0">
             <i class="fa fa-link" aria-hidden="true"></i> {{t "Copy link to message" }}
         </a>
     </li>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Cannot.20copy.20link.20to.20message.20with.20keyboard