### PR TITLE
puppet: Fix buggy media-src Content-Security-Policy.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
@@ -2,7 +2,7 @@
 location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
     internal;
     include /etc/nginx/zulip-include/headers;
-    add_header Content-Security-Policy "default-src 'none'; media-src: 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+    add_header Content-Security-Policy "default-src 'none'; media-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
 
     # The components of this path are originally double-URI-escaped
     # (see zerver/view/upload.py).  "location" matches are on
@@ -46,7 +46,7 @@ location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
 location /internal/local/uploads {
     internal;
     include /etc/nginx/zulip-include/headers;
-    add_header Content-Security-Policy "default-src 'none'; media-src: 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
+    add_header Content-Security-Policy "default-src 'none'; media-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
 
     # Django handles setting Content-Type, Content-Disposition, and Cache-Control.
 


### PR DESCRIPTION
The colon is invalid syntax. Verified the updated policy using an online CSP checker.
