### PR TITLE
corporate: Move `setup_upgrade_checkout_session_and_payment_intent` to BillingSession class.

### DIFF
--- a/corporate/views/session.py
+++ b/corporate/views/session.py
@@ -5,7 +5,8 @@ import stripe
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
-from corporate.models import PaymentIntent, Session, get_customer_by_realm
+from corporate.lib.stripe import RealmBillingSession
+from corporate.models import PaymentIntent, Session
 from zerver.decorator import require_billing_access, require_organization_member
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
@@ -18,23 +19,14 @@ billing_logger = logging.getLogger("corporate.stripe")
 @require_billing_access
 @has_request_variables
 def start_card_update_stripe_session(request: HttpRequest, user: UserProfile) -> HttpResponse:
-    customer = get_customer_by_realm(user.realm)
-    assert customer
-    stripe_session = stripe.checkout.Session.create(
-        cancel_url=f"{user.realm.uri}/billing/",
-        customer=customer.stripe_customer_id,
-        metadata={
-            "type": "card_update",
-            "user_id": user.id,
-        },
-        mode="setup",
-        payment_method_types=["card"],
-        success_url=f"{user.realm.uri}/billing/event_status?stripe_session_id={{CHECKOUT_SESSION_ID}}",
-    )
-    Session.objects.create(
-        stripe_session_id=stripe_session.id,
-        customer=customer,
-        type=Session.CARD_UPDATE_FROM_BILLING_PAGE,
+    billing_session = RealmBillingSession(user)
+    assert billing_session.get_customer() is not None
+    metadata = {
+        "type": "card_update",
+        "user_id": user.id,
+    }
+    stripe_session = billing_session.create_stripe_checkout_session(
+        metadata, Session.CARD_UPDATE_FROM_BILLING_PAGE
     )
     return json_success(
         request,
@@ -50,7 +42,8 @@ def start_card_update_stripe_session(request: HttpRequest, user: UserProfile) ->
 def start_retry_payment_intent_session(
     request: HttpRequest, user: UserProfile, stripe_payment_intent_id: str = REQ()
 ) -> HttpResponse:
-    customer = get_customer_by_realm(user.realm)
+    billing_session = RealmBillingSession(user)
+    customer = billing_session.get_customer()
     if customer is None:
         raise JsonableError(_("Please create a customer first."))
 
@@ -75,24 +68,9 @@ def start_retry_payment_intent_session(
         "user_id": user.id,
     }
     metadata.update(stripe_payment_intent.metadata)
-    stripe_session = stripe.checkout.Session.create(
-        cancel_url=f"{user.realm.uri}/upgrade/",
-        customer=customer.stripe_customer_id,
-        metadata=metadata,
-        setup_intent_data={"metadata": metadata},
-        mode="setup",
-        payment_method_types=["card"],
-        success_url=f"{user.realm.uri}/billing/event_status?stripe_session_id={{CHECKOUT_SESSION_ID}}",
+    stripe_session = billing_session.create_stripe_checkout_session(
+        metadata, Session.RETRY_UPGRADE_WITH_ANOTHER_PAYMENT_METHOD, payment_intent
     )
-    session = Session.objects.create(
-        stripe_session_id=stripe_session.id,
-        customer=customer,
-        type=Session.RETRY_UPGRADE_WITH_ANOTHER_PAYMENT_METHOD,
-    )
-
-    session.payment_intent = payment_intent
-    session.save(update_fields=["payment_intent"])
-    session.save()
     return json_success(
         request,
         data={

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -133,21 +133,9 @@ def setup_upgrade_checkout_session_and_payment_intent(
             stripe_payment_intent_id=stripe_payment_intent.id,
             status=PaymentIntent.get_status_integer_from_status_text(stripe_payment_intent.status),
         )
-    stripe_session = stripe.checkout.Session.create(
-        cancel_url=f"{user.realm.uri}/upgrade/",
-        customer=customer.stripe_customer_id,
-        mode="setup",
-        payment_method_types=["card"],
-        metadata=metadata,
-        setup_intent_data={"metadata": metadata},
-        success_url=f"{user.realm.uri}/billing/event_status?stripe_session_id={{CHECKOUT_SESSION_ID}}",
+    stripe_session = billing_session.create_stripe_checkout_session(
+        metadata, session_type, payment_intent
     )
-    session = Session.objects.create(
-        customer=customer, stripe_session_id=stripe_session.id, type=session_type
-    )
-    if payment_intent is not None:
-        session.payment_intent = payment_intent
-        session.save(update_fields=["payment_intent"])
     return stripe_session
 
 


### PR DESCRIPTION
Refactors `setup_upgrade_checkout_session_and_payment_intent` to be part of the `BillingSystem` abstract class.

**Notes**:
- Prep commit to replace `compute_plan_parameters` with `get_price_per_license` since that's the only information that `setup_upgrade_checkout_session_and_payment_intent` was using.
- Second commit moves the logic for creating `stripe.checkout.Session` and `Session` object to the `BillingSession` abstract class. This happens in three code paths: the initial upgrade for the 'charge automatically' path, if the initial card added to the account fails to charge, changing an existing card on account to a new card.
- Third commit moves the logic for creating `stripe.PaymentIntent` and `PaymentIntent` object to the `BillingSession` abstract class, which only happens in the initial upgrade for the  'charge automatically' path.
- No changes need to existing automated tests. Manually tested the three flows for creating checkout sessions (initial upgrade working card, initial upgrade non-working card, change existing card on account) with varying inputs (monthly/annual, automanage licenses/manual license management) for the initial upgrade with payment.

----

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
