### PR TITLE
Make push notifications work for multiple iOS app IDs

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -27,6 +27,12 @@ format used by the Zulip server that they are interacting with.
   Previously it defaulted to the server setting `ZULIP_IOS_APP_ID`,
   defaulting to "org.zulip.Zulip".
 
+* `POST /remotes/server/register`: The `ios_app_id` parameter is now
+  required when `kind` is 1, i.e. when registering an APNs token.
+  Previously it was ignored, and the push bouncer effectively
+  assumed its value was the server setting `APNS_TOPIC`,
+  defaulting to "org.zulip.Zulip".
+
 **Feature level 222**
 
 * [`GET /events`](/api/get-events): When a user is deactivated or

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 223**
+
+* `POST /users/me/apns_device_token`:
+  The `appid` parameter is now required.
+  Previously it defaulted to the server setting `ZULIP_IOS_APP_ID`,
+  defaulting to "org.zulip.Zulip".
+
 **Feature level 222**
 
 * [`GET /events`](/api/get-events): When a user is deactivated or

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -246,8 +246,8 @@ push notifications through the new app is quite straightforward:
   from Apple's developer console. Set `APNS_SANDBOX=False` and
   `APNS_CERT_FILE` to be the path of your APNS certificate file in
   `/etc/zulip/settings.py`.
-- Set the `APNS_TOPIC` and `ZULIP_IOS_APP_ID` settings to the ID for
-  your app (for the official Zulip apps, they are both `org.zulip.Zulip`).
+- Set the `APNS_TOPIC` setting to the ID for
+  your app (for the official Zulip apps, it's `org.zulip.Zulip`).
 - Restart the Zulip server.
 
 [apple-docs]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 222
+API_FEATURE_LEVEL = 223
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -258,6 +258,14 @@ def send_apple_push_notification(
     payload_data = dict(modernize_apns_payload(payload_data))
     message = {**payload_data.pop("custom", {}), "aps": payload_data}
 
+    for device in devices:
+        if device.ios_app_id is None:
+            # This should be present for all APNs tokens, as an invariant maintained
+            # by the views that add the token to our database.
+            logger.error(
+                "APNs: Missing ios_app_id for user %s device %s", user_identity, device.token
+            )
+
     async def send_all_notifications() -> Iterable[
         Tuple[DeviceToken, Union[aioapns.common.NotificationResult, BaseException]]
     ]:

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -525,6 +525,17 @@ class PushBouncerNotificationTest(BouncerTestCase):
         )
         self.assert_json_success(result)
 
+    def test_register_validate_ios_app_id(self) -> None:
+        endpoint = "/api/v1/remotes/push/register"
+        args = {"user_id": 11, "token": "1122", "token_kind": PushDeviceToken.APNS}
+
+        result = self.uuid_post(
+            self.server_uuid,
+            endpoint,
+            {**args, "ios_app_id": "'; tables --"},
+        )
+        self.assert_json_error(result, "Invalid app ID")
+
     def test_register_device_deduplication(self) -> None:
         hamlet = self.example_user("hamlet")
         token = "111222"

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -780,6 +780,11 @@ class PushBouncerNotificationTest(BouncerTestCase):
             result = self.client_delete(endpoint, {"token": broken_token}, subdomain="zulip")
             self.assert_json_error(result, "Empty or invalid length token")
 
+            # Try adding without appid...
+            if appid:
+                result = self.client_post(endpoint, {"token": token}, subdomain="zulip")
+                self.assert_json_error(result, "Missing 'appid' argument")
+
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"}, subdomain="zulip")
             self.assert_json_error(result, "Token does not exist")
@@ -2805,6 +2810,11 @@ class TestPushApi(BouncerTestCase):
 
             result = self.client_delete(endpoint, {"token": broken_token})
             self.assert_json_error(result, "Empty or invalid length token")
+
+            # Try adding without appid...
+            if appid:
+                result = self.client_post(endpoint, {"token": label})
+                self.assert_json_error(result, "Missing 'appid' argument")
 
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"})

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2277,6 +2277,24 @@ class TestAPNs(PushNotificationTest):
                 logger.output,
             )
 
+    def test_log_missing_ios_app_id(self) -> None:
+        device = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token="1234",
+            ios_app_id=None,
+            user_id=self.user_profile.id,
+            server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+        )
+        with self.mock_apns() as (apns_context, send_notification), self.assertLogs(
+            "zerver.lib.push_notifications", level="INFO"
+        ) as logger:
+            send_notification.return_value.is_successful = True
+            self.send(devices=[device])
+            self.assertIn(
+                f"ERROR:zerver.lib.push_notifications:APNs: Missing ios_app_id for user <id:{self.user_profile.id}> device {device.token}",
+                logger.output,
+            )
+
     def test_modernize_apns_payload(self) -> None:
         payload = {
             "alert": "Message from Hamlet",

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -500,6 +500,31 @@ class PushBouncerNotificationTest(BouncerTestCase):
             401,
         )
 
+    def test_register_require_ios_app_id(self) -> None:
+        endpoint = "/api/v1/remotes/push/register"
+        args = {"user_id": 11, "token": "1122"}
+
+        result = self.uuid_post(
+            self.server_uuid,
+            endpoint,
+            {**args, "token_kind": PushDeviceToken.APNS},
+        )
+        self.assert_json_error(result, "Missing ios_app_id")
+
+        result = self.uuid_post(
+            self.server_uuid,
+            endpoint,
+            {**args, "token_kind": PushDeviceToken.APNS, "ios_app_id": "example.app"},
+        )
+        self.assert_json_success(result)
+
+        result = self.uuid_post(
+            self.server_uuid,
+            endpoint,
+            {**args, "token_kind": PushDeviceToken.GCM},
+        )
+        self.assert_json_success(result)
+
     def test_register_device_deduplication(self) -> None:
         hamlet = self.example_user("hamlet")
         token = "111222"

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -769,20 +769,14 @@ class PushBouncerNotificationTest(BouncerTestCase):
         for endpoint, token, kind in endpoints:
             # Try adding/removing tokens that are too big...
             broken_token = "a" * 5000  # too big
-            result = self.client_post(
-                endpoint, {"token": broken_token, "token_kind": kind}, subdomain="zulip"
-            )
+            result = self.client_post(endpoint, {"token": broken_token}, subdomain="zulip")
             self.assert_json_error(result, "Empty or invalid length token")
 
-            result = self.client_delete(
-                endpoint, {"token": broken_token, "token_kind": kind}, subdomain="zulip"
-            )
+            result = self.client_delete(endpoint, {"token": broken_token}, subdomain="zulip")
             self.assert_json_error(result, "Empty or invalid length token")
 
             # Try to remove a non-existent token...
-            result = self.client_delete(
-                endpoint, {"token": "abcd1234", "token_kind": kind}, subdomain="zulip"
-            )
+            result = self.client_delete(endpoint, {"token": "abcd1234"}, subdomain="zulip")
             self.assert_json_error(result, "Token does not exist")
 
             assert settings.PUSH_NOTIFICATION_BOUNCER_URL is not None

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -838,7 +838,8 @@ class PushBouncerNotificationTest(BouncerTestCase):
                 )
             )
             self.assert_length(tokens, 1)
-            self.assertEqual(tokens[0].token, token)
+            self.assertEqual(tokens[0].kind, kind)
+            self.assertEqual(tokens[0].ios_app_id, appid.get("appid"))
 
         # User should have tokens for both devices now.
         tokens = list(RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server))

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1337,7 +1337,7 @@ class PushNotificationTest(BouncerTestCase):
                 kind=PushDeviceToken.APNS,
                 token=hex_to_b64(token),
                 user=self.user_profile,
-                ios_app_id=settings.ZULIP_IOS_APP_ID,
+                ios_app_id="org.zulip.Zulip",
             )
 
         self.remote_tokens = [("cccc", "ffff")]

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -780,10 +780,15 @@ class PushBouncerNotificationTest(BouncerTestCase):
             result = self.client_delete(endpoint, {"token": broken_token}, subdomain="zulip")
             self.assert_json_error(result, "Empty or invalid length token")
 
-            # Try adding without appid...
+            # Try adding with missing or invalid appid...
             if appid:
                 result = self.client_post(endpoint, {"token": token}, subdomain="zulip")
                 self.assert_json_error(result, "Missing 'appid' argument")
+
+                result = self.client_post(
+                    endpoint, {"token": token, "appid": "'; tables --"}, subdomain="zulip"
+                )
+                self.assert_json_error(result, "Invalid app ID")
 
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"}, subdomain="zulip")
@@ -2811,10 +2816,13 @@ class TestPushApi(BouncerTestCase):
             result = self.client_delete(endpoint, {"token": broken_token})
             self.assert_json_error(result, "Empty or invalid length token")
 
-            # Try adding without appid...
+            # Try adding with missing or invalid appid...
             if appid:
                 result = self.client_post(endpoint, {"token": label})
                 self.assert_json_error(result, "Missing 'appid' argument")
+
+                result = self.client_post(endpoint, {"token": label, "appid": "'; tables --"})
+                self.assert_json_error(result, "Invalid app ID")
 
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"})

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
@@ -35,7 +34,7 @@ def add_apns_device_token(
     request: HttpRequest,
     user_profile: UserProfile,
     token: str = REQ(),
-    appid: str = REQ(default=settings.ZULIP_IOS_APP_ID),
+    appid: str = REQ(),
 ) -> HttpResponse:
     validate_token(token, PushDeviceToken.APNS)
     add_push_device_token(user_profile, token, PushDeviceToken.APNS, ios_app_id=appid)

--- a/zilencer/migrations/0032_remotepushdevicetoken_backfill_ios_app_id.py
+++ b/zilencer/migrations/0032_remotepushdevicetoken_backfill_ios_app_id.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """
+    Previous versions of zilencer dropped the ios_app_id on the floor
+    when registering a push token, and then effectively assumed
+    the value was "org.zulip.Zulip".
+
+    We're going to start actually using that parameter.  To preserve
+    the existing behavior for existing tokens, backfill the value.
+    """
+
+    dependencies = [
+        ("zilencer", "0031_alter_remoteinstallationcount_remote_id_and_more"),
+    ]
+
+    FORMERLY_IMPLICIT_IOS_APP_ID = "org.zulip.Zulip"
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                (
+                    """
+            UPDATE zilencer_remotepushdevicetoken
+            SET ios_app_id = %s
+            WHERE kind = 1 AND ios_app_id IS NULL
+            """,
+                    [FORMERLY_IMPLICIT_IOS_APP_ID],
+                )
+            ],
+            # The updated table is still valid with the old schema;
+            # so to reverse, a no-op suffices.
+            reverse_sql=[],
+        ),
+    ]

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -162,7 +162,7 @@ def register_remote_push_device(
     user_uuid: Optional[str] = REQ(default=None),
     token: str = REQ(),
     token_kind: int = REQ(json_validator=check_int),
-    ios_app_id: Optional[str] = None,
+    ios_app_id: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
     validate_bouncer_token_request(token, token_kind)
 

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -48,7 +48,7 @@ from zerver.lib.validator import (
     check_string_fixed_length,
     check_union,
 )
-from zerver.views.push_notifications import validate_token
+from zerver.views.push_notifications import check_app_id, validate_token
 from zilencer.auth import InvalidZulipServerKeyError
 from zilencer.models import (
     RemoteInstallationCount,
@@ -162,7 +162,7 @@ def register_remote_push_device(
     user_uuid: Optional[str] = REQ(default=None),
     token: str = REQ(),
     token_kind: int = REQ(json_validator=check_int),
-    ios_app_id: Optional[str] = REQ(default=None),
+    ios_app_id: Optional[str] = REQ(str_validator=check_app_id, default=None),
 ) -> HttpResponse:
     validate_bouncer_token_request(token, token_kind)
     if token_kind == RemotePushDeviceToken.APNS and ios_app_id is None:

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -206,7 +206,6 @@ def unregister_remote_push_device(
     token_kind: int = REQ(json_validator=check_int),
     user_id: Optional[int] = REQ(json_validator=check_int, default=None),
     user_uuid: Optional[str] = REQ(default=None),
-    ios_app_id: Optional[str] = None,
 ) -> HttpResponse:
     validate_bouncer_token_request(token, token_kind)
     user_identity = UserPushIdentityCompat(user_id=user_id, user_uuid=user_uuid)

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -165,6 +165,8 @@ def register_remote_push_device(
     ios_app_id: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
     validate_bouncer_token_request(token, token_kind)
+    if token_kind == RemotePushDeviceToken.APNS and ios_app_id is None:
+        raise JsonableError(_("Missing ios_app_id"))
 
     if user_id is None and user_uuid is None:
         raise JsonableError(_("Missing user_id or user_uuid"))

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -403,7 +403,7 @@ POST_MIGRATION_CACHE_FLUSHING = False
 APNS_CERT_FILE: Optional[str] = None
 APNS_SANDBOX = True
 APNS_TOPIC = "org.zulip.Zulip"
-ZULIP_IOS_APP_ID = "org.zulip.Zulip"
+# ZULIP_IOS_APP_ID is obsolete
 
 # Limits related to the size of file uploads; last few in MB.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -156,6 +156,9 @@ INLINE_URL_EMBED_PREVIEW = False
 HOME_NOT_LOGGED_IN = "/login/"
 LOGIN_URL = "/accounts/login/"
 
+# If dev_settings.py found a cert file to use here, ignore it.
+APNS_CERT_FILE: Optional[str] = None
+
 # By default will not send emails when login occurs.
 # Explicitly set this to True within tests that must have this on.
 SEND_LOGIN_EMAILS = False


### PR DESCRIPTION
The existing notifications code assumes that all iOS clients getting notifications through APNs have the same app ID. In particular all such notifications going through the bouncer are assumed to be for the same app ID, `org.zulip.Zulip`, which corresponds to the main Zulip mobile app.

For the new Flutter-based app, we have a separate app ID `com.zulip.flutter` we'll be using through the Flutter app's beta period, so that it can be installed alongside the existing app. In order to get notifications there, then (zulip/zulip-flutter#321), we'll need the same servers to be able to send notifications to both `org.zulip.Zulip` and `com.zulip.flutter`.

Some of the pieces needed for handling this are already present in the code — notably, an `ios_app_id` field on the `PushDeviceToken` model. In this PR, we refurbish a couple of spots where that pipeline has been leaky, and then start using it.

In addition to the various tests added here to the test suite, I've tested this manually end-to-end: with some draft changes to zulip-flutter, I can get notifications on an iOS device sent from my Zulip dev server.

One of the commits here pulls in a small PR I sent upstream to `aioapns` for a needed feature:
* https://github.com/Fatal1ty/aioapns/pull/52

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
