### PR TITLE
Paste improvements

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -16,6 +16,7 @@ import * as stream_data from "./stream_data";
 import * as user_status from "./user_status";
 
 export let compose_spinner_visible = false;
+export let shift_pressed = false; // true or false
 let full_size_status = false; // true or false
 
 // Some functions to handle the full size status explicitly
@@ -325,6 +326,9 @@ export function make_compose_box_original_size() {
 }
 
 export function handle_keydown(event, $textarea) {
+    if (event.key === "Shift") {
+        shift_pressed = true;
+    }
     // The event.key property will have uppercase letter if
     // the "Shift + <key>" combo was used or the Caps Lock
     // key was on. We turn to key to lowercase so the key bindings
@@ -350,6 +354,9 @@ export function handle_keydown(event, $textarea) {
 }
 
 export function handle_keyup(_event, $textarea) {
+    if (_event?.key === "Shift") {
+        shift_pressed = false;
+    }
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea($textarea);
 }

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -543,7 +543,10 @@ export function paste_handler(event) {
             return;
         }
 
-        if (paste_html && page_params.development_environment) {
+        // Unlike Chrome, Firefox doesn't automatically paste plainly on using Ctrl+Shift+V,
+        // hence we need to handle it ourselves, by checking if shift key is pressed, and only
+        // if not, we proceed with the default formatted paste.
+        if (paste_html && !compose_ui.shift_pressed && page_params.development_environment) {
             event.preventDefault();
             event.stopPropagation();
             const text = paste_handler_converter(paste_html);

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -319,9 +319,14 @@ export function paste_handler_converter(paste_html) {
         copied_html_fragment.childNodes.length === 1 &&
         copied_html_fragment.firstElementChild &&
         copied_html_fragment.firstElementChild.innerHTML;
+    const outer_elements_to_retain = ["PRE", "OL"];
     // If the entire selection copied is within a single HTML element (like an
-    // `h1`), we don't want to retain its styling. We retain `pre` for code blocks.
-    if (copied_within_single_element && copied_html_fragment.firstElementChild.nodeName !== "PRE") {
+    // `h1`), we don't want to retain its styling, except when it helps identify
+    // the intended structure of the copied content (like `pre` and `ol`).
+    if (
+        copied_within_single_element &&
+        !outer_elements_to_retain.includes(copied_html_fragment.firstElementChild.nodeName)
+    ) {
         paste_html = copied_html_fragment.firstChild.innerHTML;
     }
 

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -547,7 +547,7 @@ export function paste_handler(event) {
             event.preventDefault();
             event.stopPropagation();
             const text = paste_handler_converter(paste_html);
-            compose_ui.insert_syntax_and_focus(text, $textarea);
+            compose_ui.insert_and_scroll_into_view(text, $textarea);
         }
     }
 }

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -51,15 +51,19 @@ run_test("paste_handler_converter", () => {
         "normal text [Contributing guide](https://zulip.readthedocs.io/en/latest/contributing/contributing.html)",
     );
 
-    // Numbered list item
+    // Only numbered list (list style retained)
     input =
-        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><span style="color: hsl(0, 0%, 0%); font-family: &quot;Helvetica Neue&quot;, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 100%); text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">1. text</span>';
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><ol><li>text</li></ol>';
     assert.equal(copy_and_paste.paste_handler_converter(input), "1. text");
 
     // Heading
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><h1 style="box-sizing: border-box; font-size: 2em; margin-top: 0px !important; margin-right: 0px; margin-bottom: 16px; margin-left: 0px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid hsl(216, 14%, 93%); color: hsl(210, 12%, 16%); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial;">Zulip overview</h1><p>normal text</p>';
     assert.equal(copy_and_paste.paste_handler_converter(input), "# Zulip overview\n\nnormal text");
+    // Only heading (strip heading style)
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><h1 style="box-sizing: border-box; font-size: 2em; margin-top: 0px !important; margin-right: 0px; margin-bottom: 16px; margin-left: 0px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid hsl(216, 14%, 93%); color: hsl(210, 12%, 16%); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial;">Zulip overview</h1>';
+    assert.equal(copy_and_paste.paste_handler_converter(input), "Zulip overview");
 
     // Italic text
     input =


### PR DESCRIPTION
compose: Allow pasting plainly, when Shift is held down, for Firefox.

We introduce a state variable `shift_pressed` for the purpose of detecting whether the Shift key is pressed when pasting content. Only if it is not, do we proceed with the default formatted paste behavior.

In Chrome, plain paste works out of the box for `Ctrl+Shift+V`, but in Firefox, we need to handle it ourselves.

compose: Paste content into the compose box without adding any space.

We replace the call to `insert_syntax_and_focus` with a direct call to `insert_and_scroll_into_view` when pasting content into the compose box, which fixes the bug where leading and trailing spaces were added to any pasted content.

compose: Always retain `ol` tag when pasting content enclosed by it.

Fixes: [Issues discussed in this CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Github.20issue.20number.20copy.20paste.20bug)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
