### PR TITLE
settings: add tooltip to clarify invalid Jitsi URL

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -25,6 +25,7 @@ IGNORED_PHRASES = [
     r"IDs",
     r"IP",
     r"JSON",
+    r"Jitsi",
     r"Kerberos",
     r"LinkedIn",
     r"LDAP",

--- a/web/src/settings_components.js
+++ b/web/src/settings_components.js
@@ -681,22 +681,40 @@ function enable_or_disable_save_button($subsection_elem) {
         disable_save_btn = should_disable_save_button_for_time_limit_settings(time_limit_settings);
     } else if ($subsection_elem.attr("id") === "org-other-settings") {
         disable_save_btn = should_disable_save_button_for_jitsi_server_url_setting();
+        const $button_wrapper = $subsection_elem.find(".subsection-changes-save");
+        const is_tippy = $button_wrapper.get(0)._tippy;
+        if (disable_save_btn) {
+            // avoid duplication of tippy
+            if (!is_tippy) {
+                const opts = {placement: "top"};
+                initialize_disable_btn_hint_popover(
+                    $button_wrapper,
+                    $t({defaultMessage: "Cannot save invalid Jitsi server URL."}),
+                    opts,
+                );
+            }
+        } else {
+            if (is_tippy) {
+                is_tippy.destroy();
+            }
+        }
     }
 
     $subsection_elem.find(".subsection-changes-save button").prop("disabled", disable_save_btn);
 }
 
-export function initialize_disable_btn_hint_popover($btn_wrapper, hint_text) {
-    const opts = {
+export function initialize_disable_btn_hint_popover($btn_wrapper, hint_text, opts) {
+    const tippy_opts = {
         animation: false,
         hideOnClick: false,
         placement: "bottom",
+        ...opts,
     };
 
     // If hint_text is undefined, we use the HTML content of a
     // <template> whose id is given by data-tooltip-template-id
     if (hint_text !== undefined) {
-        opts.content = hint_text;
+        tippy_opts.content = hint_text;
     }
-    tippy($btn_wrapper[0], opts);
+    tippy($btn_wrapper[0], tippy_opts);
 }

--- a/web/src/settings_components.js
+++ b/web/src/settings_components.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import tippy from "tippy.js";
 
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 
@@ -683,4 +684,19 @@ function enable_or_disable_save_button($subsection_elem) {
     }
 
     $subsection_elem.find(".subsection-changes-save button").prop("disabled", disable_save_btn);
+}
+
+export function initialize_disable_btn_hint_popover($btn_wrapper, hint_text) {
+    const opts = {
+        animation: false,
+        hideOnClick: false,
+        placement: "bottom",
+    };
+
+    // If hint_text is undefined, we use the HTML content of a
+    // <template> whose id is given by data-tooltip-template-id
+    if (hint_text !== undefined) {
+        opts.content = hint_text;
+    }
+    tippy($btn_wrapper[0], opts);
 }

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import tippy from "tippy.js";
 
 import render_announce_stream_checkbox from "../templates/stream_settings/announce_stream_checkbox.hbs";
 import render_stream_privacy_icon from "../templates/stream_settings/stream_privacy_icon.hbs";
@@ -8,6 +7,7 @@ import render_stream_settings_tip from "../templates/stream_settings/stream_sett
 import * as hash_parser from "./hash_parser";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
+import * as settings_components from "./settings_components";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_org from "./settings_org";
@@ -117,24 +117,9 @@ export function update_private_stream_privacy_option_state($container, is_defaul
         .toggleClass("default_stream_private_tooltip", is_default_stream);
 }
 
-export function initialize_disable_btn_hint_popover($btn_wrapper, hint_text) {
-    const opts = {
-        animation: false,
-        hideOnClick: false,
-        placement: "bottom",
-    };
-
-    // If hint_text is undefined, we use the HTML content of a
-    // <template> whose id is given by data-tooltip-template-id
-    if (hint_text !== undefined) {
-        opts.content = hint_text;
-    }
-    tippy($btn_wrapper[0], opts);
-}
-
 export function initialize_cant_subscribe_popover() {
     const $button_wrapper = $(".settings .stream_settings_header .sub_unsub_button_wrapper");
-    initialize_disable_btn_hint_popover($button_wrapper);
+    settings_components.initialize_disable_btn_hint_popover($button_wrapper);
 }
 
 export function update_toggler_for_sub(sub) {
@@ -380,7 +365,10 @@ export function update_add_subscriptions_elements(sub) {
                 defaultMessage: "Only stream members can add users to a private stream.",
             });
         }
-        initialize_disable_btn_hint_popover($add_subscribers_container, tooltip_message);
+        settings_components.initialize_disable_btn_hint_popover(
+            $add_subscribers_container,
+            tooltip_message,
+        );
     }
 }
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -23,7 +23,6 @@ import * as scroll_util from "./scroll_util";
 import * as settings_components from "./settings_components";
 import * as settings_data from "./settings_data";
 import * as settings_org from "./settings_org";
-import * as stream_ui_updates from "./stream_ui_updates";
 import * as ui_report from "./ui_report";
 import * as user_group_components from "./user_group_components";
 import * as user_group_create from "./user_group_create";
@@ -101,7 +100,7 @@ function update_add_members_elements(group) {
         $button_element.prop("disabled", true);
         $add_members_container.addClass("add_members_disabled");
 
-        stream_ui_updates.initialize_disable_btn_hint_popover(
+        settings_components.initialize_disable_btn_hint_popover(
             $add_members_container,
             $t({defaultMessage: "Only group members can add users to a group."}),
         );
@@ -154,7 +153,7 @@ function initialize_tooltip_for_membership_button(group_id) {
     } else {
         tooltip_message = $t({defaultMessage: "You do not have permission to join this group."});
     }
-    stream_ui_updates.initialize_disable_btn_hint_popover($tooltip_wrapper, tooltip_message);
+    settings_components.initialize_disable_btn_hint_popover($tooltip_wrapper, tooltip_message);
 }
 
 function update_group_membership_button(group_id) {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -28,11 +28,11 @@ import * as modals from "./modals";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
+import * as settings_components from "./settings_components";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
-import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
 import * as subscriber_api from "./subscriber_api";
 import * as timerender from "./timerender";
@@ -139,7 +139,7 @@ function change_state_of_subscribe_button(event, dropdown) {
 
 function reset_subscribe_widget() {
     $("#user-profile-modal .add-subscription-button").prop("disabled", true);
-    stream_ui_updates.initialize_disable_btn_hint_popover(
+    settings_components.initialize_disable_btn_hint_popover(
         $("#user-profile-modal .add-subscription-button-wrapper"),
         $t({defaultMessage: "Select a stream to subscribe"}),
     );


### PR DESCRIPTION
Added tooltip to clearify why save button is disabled when invalid Jitsi URL.
Co-authored-by: Angelica Ferlin <angelica.ferlin@gmail.com>

<!-- Describe your pull request here.-->
Fixes #27511.

**Screenshots and screen captures:**
Gif belows shows the new tooltip. 

![chrome-capture-2023-11-8](https://github.com/zulip/zulip/assets/64125524/60846063-f524-4d4e-aa17-af592c5cee11)








<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [] End-to-end functionality of buttons, interactions and flows.
- [] Corner cases, error conditions, and easily imagined bugs.
</details>
