### PR TITLE
typing_notifications: Don't notify long_term_idle subscribers.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1186,6 +1186,17 @@ Output:
 
         return [subscription.user_profile for subscription in subscriptions]
 
+    def not_long_term_idle_subscriber_ids(self, stream_name: str, realm: Realm) -> Set[int]:
+        stream = Stream.objects.get(name=stream_name, realm=realm)
+        recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
+
+        subscriptions = Subscription.objects.filter(
+            recipient=recipient, active=True, is_user_active=True
+        ).exclude(user_profile__long_term_idle=True)
+        user_profile_ids = set(subscriptions.values_list("user_profile_id", flat=True))
+
+        return user_profile_ids
+
     def assert_json_success(
         self,
         result: Union["TestHttpResponse", HttpResponse],

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -372,10 +372,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids = self.not_long_term_idle_subscriber_ids(stream_name, sender.realm)
 
         params = dict(
             type="stream",
@@ -406,10 +403,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids = self.not_long_term_idle_subscriber_ids(stream_name, sender.realm)
 
         params = dict(
             type="stream",
@@ -433,6 +427,50 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         self.assertEqual(topic, event["topic"])
         self.assertEqual("typing", event["type"])
         self.assertEqual("stop", event["op"])
+
+    def test_notify_not_long_term_idle_subscribers_only(self) -> None:
+        sender = self.example_user("hamlet")
+        stream_name = self.get_streams(sender)[0]
+        stream_id = self.get_stream_id(stream_name)
+        topic = "Some topic"
+
+        aaron = self.example_user("aaron")
+        iago = self.example_user("iago")
+        for user in [aaron, iago]:
+            self.subscribe(user, stream_name)
+            self.soft_deactivate_user(user)
+
+        subscriber_ids = {
+            user_profile.id
+            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
+        }
+        not_long_term_idle_subscriber_ids = subscriber_ids - {aaron.id, iago.id}
+
+        params = dict(
+            type="stream",
+            op="start",
+            stream_id=str(stream_id),
+            topic=topic,
+        )
+
+        with self.assert_database_query_count(5):
+            with self.capture_send_event_calls(expected_num_events=1) as events:
+                result = self.api_post(sender, "/api/v1/typing", params)
+        self.assert_json_success(result)
+        self.assert_length(events, 1)
+
+        event = events[0]["event"]
+        event_user_ids = set(events[0]["users"])
+
+        # Only subscribers who are not long_term_idle are notified for typing notifications.
+        self.assertNotEqual(subscriber_ids, event_user_ids)
+        self.assertEqual(not_long_term_idle_subscriber_ids, event_user_ids)
+
+        self.assertEqual(sender.email, event["sender"]["email"])
+        self.assertEqual(stream_id, event["stream_id"])
+        self.assertEqual(topic, event["topic"])
+        self.assertEqual("typing", event["type"])
+        self.assertEqual("start", event["op"])
 
 
 class TestSendTypingNotificationsSettings(ZulipTestCase):
@@ -475,10 +513,7 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         stream_id = self.get_stream_id(stream_name)
         topic = "Some topic"
 
-        expected_user_ids = {
-            user_profile.id
-            for user_profile in self.users_subscribed_to_stream(stream_name, sender.realm)
-        }
+        expected_user_ids = self.not_long_term_idle_subscriber_ids(stream_name, sender.realm)
 
         params = dict(
             type="stream",


### PR DESCRIPTION
The event for stream typing notifications is no longer sent to the long_term_idle subscribers of the stream.

This helps to reduce the tornado's work of parsing super-long JSON-encoded lists of user IDs in large streams. Now the lists are shorter.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
