### PR TITLE
integrations-docs: Update both Slack integration articles.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -5,17 +5,22 @@ See also the [Slack-compatible webhook](/integrations/doc/slack_incoming).
 
 1. {!create-stream.md!}
 
-1. {!create-bot-construct-url.md!}
+1. {!create-an-incoming-webhook.md!}
 
-    If you'd like to map Slack channels to different topics within the same
-    stream, add `&channels_map_to_topics=1` to the end of the URL. The `topic`
-    parameter will be ignored.
+    Construct the URL for the {{ integration_display_name }}
+    bot using the bot's API key:
+
+    `{{ api_url }}{{ integration_url }}?api_key=abcdefgh`
+
+    If you'd like to map Slack channels to different topics within the
+    same stream, add `&channels_map_to_topics=1` to the end of the URL.
+    This is the default behavior of the integration.
 
     If you'd like to map Slack channels to different streams, add
-    `&channels_map_to_topics=0` to the end of the URL. The `stream`
-    parameter will be ignored. Make sure you create
-    streams for all your public Slack channels, and that the name of each
-    stream is the same as the name of the Slack channel it maps to.
+    `&channels_map_to_topics=0` to the end of the URL. Make sure you
+    create streams for all your public Slack channels, and that the name
+    of each stream is the same as the name of the Slack channel it maps
+    to.
 
 1. Go to <https://my.slack.com/services/new/outgoing-webhook>
    and click **Add Outgoing WebHooks integration**.

--- a/zerver/webhooks/slack_incoming/doc.md
+++ b/zerver/webhooks/slack_incoming/doc.md
@@ -2,25 +2,27 @@ This beta Zulip integration supports for processing incoming webhook
 messages written to work with Slack's [incoming webhook
 API](https://api.slack.com/messaging/webhooks).
 
-1. {!create-stream.md!}
-
-1. {!create-bot-construct-url.md!}
-
-1. Use your new webhook URL any place that you would use a Slack webhook.
-
-{!congrats.md!}
-
 Where possible, we prefer to create native Zulip integrations that
 make optimal use of Zulip's topics and don't require translating
 formatting, but this is a useful stopgap, especially for getting
 messages from third-party vendors that only offer a Slack integration
 (with no generic outgoing webhook API).
 
-This integration, by its nature, involves a somewhat complex
-translation between Slack's formatting system and Zulip's.  We
-appreciate [feedback and bug reports](/help/contact-support) on any
-cases where the resulting Zulip formatting is poor, so that we can
-either improve the formatting or add an appropriate native integration.
+!!! warn ""
+
+    This integration, by its nature, involves a somewhat complex
+    translation between Slack's formatting system and Zulip's.  We
+    appreciate [feedback and bug reports](/help/contact-support) on any
+    cases where the resulting Zulip formatting is poor, so that we can
+    either improve the formatting or add an appropriate native integration.
 
 See also the [Slack notifications](/integrations/doc/slack)
 integration for mirroring content from a Slack instance into Zulip.
+
+1. {!create-stream.md!}
+
+1. {!create-bot-construct-url.md!}
+
+1. Use your new webhook URL any place that you would use a Slack webhook.
+
+**Congratulations! You're done!**


### PR DESCRIPTION
Updates the Slack integration page to not describe adding a stream or topic parameter to the URL query since that's not supported by the current integration implementation.

Updates the Slack-compatible webhook integration page to have the extra notes about the integration at the top of the page. Also, removes the reference to a screenshot of the webhook since there isn't one.

See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/slack.20webhook.20bug/near/1655623).

**Screenshots and screen captures:**

<details>
<summary>Slack integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/slack)
![Screenshot from 2023-11-07 16-11-52](https://github.com/zulip/zulip/assets/63245456/2ad7a7e4-b482-432b-99a9-2e61eb417cb7)

</details>
<details>
<summary>Slack-compatible integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/slack_incoming)
![Screenshot from 2023-11-07 16-11-59](https://github.com/zulip/zulip/assets/63245456/4b91182b-81af-49ae-be54-25080b943f69)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
