### PR TITLE
Update both Slack integration articles (revised)

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -5,17 +5,22 @@ See also the [Slack-compatible webhook](/integrations/doc/slack_incoming).
 
 1. {!create-stream.md!}
 
-1. {!create-bot-construct-url.md!}
+1. {!create-an-incoming-webhook.md!}
 
-    If you'd like to map Slack channels to different topics within the same
-    stream, add `&channels_map_to_topics=1` to the end of the URL. The `topic`
-    parameter will be ignored.
+    Construct the URL for the {{ integration_display_name }}
+    bot using the bot's API key:
+
+    `{{ api_url }}{{ integration_url }}?api_key=abcdefgh`
+
+    If you'd like to map Slack channels to different topics within the
+    same stream, add `&channels_map_to_topics=1` to the end of the URL.
+    This is the default behavior of the integration.
 
     If you'd like to map Slack channels to different streams, add
-    `&channels_map_to_topics=0` to the end of the URL. The `stream`
-    parameter will be ignored. Make sure you create
-    streams for all your public Slack channels, and that the name of each
-    stream is the same as the name of the Slack channel it maps to.
+    `&channels_map_to_topics=0` to the end of the URL. Make sure you
+    create streams for all your public Slack channels, and that the name
+    of each stream is the same as the name of the Slack channel it maps
+    to.
 
 1. Go to <https://my.slack.com/services/new/outgoing-webhook>
    and click **Add Outgoing WebHooks integration**.

--- a/zerver/webhooks/slack_incoming/doc.md
+++ b/zerver/webhooks/slack_incoming/doc.md
@@ -2,25 +2,27 @@ This beta Zulip integration supports for processing incoming webhook
 messages written to work with Slack's [incoming webhook
 API](https://api.slack.com/messaging/webhooks).
 
-1. {!create-stream.md!}
-
-1. {!create-bot-construct-url.md!}
-
-1. Use your new webhook URL any place that you would use a Slack webhook.
-
-{!congrats.md!}
-
 Where possible, we prefer to create native Zulip integrations that
 make optimal use of Zulip's topics and don't require translating
 formatting, but this is a useful stopgap, especially for getting
 messages from third-party vendors that only offer a Slack integration
 (with no generic outgoing webhook API).
 
-This integration, by its nature, involves a somewhat complex
-translation between Slack's formatting system and Zulip's.  We
-appreciate [feedback and bug reports](/help/contact-support) on any
-cases where the resulting Zulip formatting is poor, so that we can
-either improve the formatting or add an appropriate native integration.
+!!! warn ""
+
+    This integration, by its nature, involves a somewhat complex
+    translation between Slack's formatting system and Zulip's.  We
+    appreciate [feedback and bug reports](/help/contact-support) on any
+    cases where the resulting Zulip formatting is poor, so that we can
+    either improve the formatting or add an appropriate native integration.
 
 See also the [Slack notifications](/integrations/doc/slack)
 integration for mirroring content from a Slack instance into Zulip.
+
+1. {!create-stream.md!}
+
+1. {!create-bot-construct-url.md!}
+
+1. Use your new webhook URL any place that you would use a Slack webhook.
+
+**Congratulations! You're done!**

--- a/zerver/webhooks/slack_incoming/doc.md
+++ b/zerver/webhooks/slack_incoming/doc.md
@@ -1,23 +1,14 @@
-This beta Zulip integration supports for processing incoming webhook
-messages written to work with Slack's [incoming webhook
-API](https://api.slack.com/messaging/webhooks).
-
-Where possible, we prefer to create native Zulip integrations that
-make optimal use of Zulip's topics and don't require translating
-formatting, but this is a useful stopgap, especially for getting
-messages from third-party vendors that only offer a Slack integration
-(with no generic outgoing webhook API).
+Zulip can process incoming webhook messages written to work with Slack's
+[incoming webhook API](https://api.slack.com/messaging/webhooks). This makes it
+easy to quickly move your integrations when migrating your organization from
+Slack to Zulip. See also the [Slack integration](/integrations/doc/slack) for
+mirroring content from a Slack instance into Zulip.
 
 !!! warn ""
 
-    This integration, by its nature, involves a somewhat complex
-    translation between Slack's formatting system and Zulip's.  We
-    appreciate [feedback and bug reports](/help/contact-support) on any
-    cases where the resulting Zulip formatting is poor, so that we can
-    either improve the formatting or add an appropriate native integration.
-
-See also the [Slack notifications](/integrations/doc/slack)
-integration for mirroring content from a Slack instance into Zulip.
+     In the long term, the recommended approach is to use Zulip's native
+     integrations, which take advantage of Zulip's topics. There may also be
+     some quirks when Slack's formatting system is translated into Zulip's.
 
 1. {!create-stream.md!}
 


### PR DESCRIPTION
This PR is based on #27599.

I rewrote the intro content for the Slack-compatible integration doc; my commit can be squashed if desired.

I did not make any changes to:
- Instructions
- The Slack integration doc

**Screenshots and screen captures:**

<details>
<summary>Slack integration doc (copied from #27599)</summary>

[Current documentation](https://zulip.com/integrations/doc/slack)
![Screenshot from 2023-11-07 16-11-52](https://github.com/zulip/zulip/assets/63245456/2ad7a7e4-b482-432b-99a9-2e61eb417cb7)

</details>
<details>
<summary>Slack-compatible integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/slack_incoming)
![Screenshot 2023-11-07 at 11 53 35 AM](https://github.com/zulip/zulip/assets/2090066/0902061a-9895-42cc-8fd6-8dbb749501bc)


</details>