### PR TITLE
message edit: Use a default error message for failed edits.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1069,15 +1069,20 @@ export function save_message_row_edit($row) {
                 }
 
                 hide_message_edit_spinner($row);
-                const message = channel.xhr_error_message("", xhr);
-                const $container = compose_banner.get_compose_banner_container(
-                    $row.find("textarea"),
-                );
-                compose_banner.show_error_message(
-                    message,
-                    compose_banner.CLASSNAMES.generic_compose_error,
-                    $container,
-                );
+                if (xhr.readyState !== 0) {
+                    const message = channel.xhr_error_message(
+                        $t({defaultMessage: "Error editing message"}),
+                        xhr,
+                    );
+                    const $container = compose_banner.get_compose_banner_container(
+                        $row.find("textarea"),
+                    );
+                    compose_banner.show_error_message(
+                        message,
+                        compose_banner.CLASSNAMES.generic_compose_error,
+                        $container,
+                    );
+                }
             }
         },
     });


### PR DESCRIPTION
Bug reported here:
https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/Error.3A.20The.20partial.20.40partial-block.20could.20not.20be.20found/near/1673466

The issue was happening because `channel.xhr_error_message` can return the empty string sometimes, and `render_compose_banner` shows the banner text if it exists and otherwise tries to render a `@partial-block`. Unfortunately the empty string acts as falsy in the template, leading to the partial block error.
