### PR TITLE
Make push notifications work for multiple iOS app IDs, part 2/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 ## Config files for the dev environment
 /zproject/apns-dev.pem
+/zproject/apns-dev-key.p8
 /zproject/dev-secrets.conf
 /tools/conf.ini
 /tools/custom_provision

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -226,9 +226,6 @@ push notifications through the new app is quite straightforward:
     `APNS_TOKEN_KEY_ID` to the corresponding 10-character key ID, and
     `APNS_TEAM_ID` to your 10-character Apple team ID.
 
-- Set the `APNS_TOPIC` setting to the ID for
-  your app (for the official Zulip apps, it's `org.zulip.Zulip`).
-
 - Restart the Zulip server.
 
 [apple-doc-cert]: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -213,13 +213,23 @@ push notifications through the new app is quite straightforward:
   [FCM push notifications](https://firebase.google.com/docs/cloud-messaging)
   key in the Google Developer console and set `android_gcm_api_key` in
   `/etc/zulip/zulip-secrets.conf` to that key.
-- Register for a
-  [mobile push notification certificate][apple-docs]
-  from Apple's developer console. Set `APNS_SANDBOX=False` and
-  `APNS_CERT_FILE` to be the path of your APNS certificate file in
-  `/etc/zulip/settings.py`.
+
+- In Apple's developer console, register a [token][apple-doc-token] or
+  [certificate][apple-doc-cert] for sending push notifications.
+  Then in `/etc/zulip/settings.py`, set `APNS_SANDBOX=False`, and:
+
+  - If using APNs [certificate-based authentication][apple-doc-cert],
+    set `APNS_CERT_FILE` to the path of your APNs certificate file.
+
+  - If using APNs [token-based authentication][apple-doc-token],
+    set `APNS_TOKEN_KEY_FILE` to the path of your APNs token key file,
+    `APNS_TOKEN_KEY_ID` to the corresponding 10-character key ID, and
+    `APNS_TEAM_ID` to your 10-character Apple team ID.
+
 - Set the `APNS_TOPIC` setting to the ID for
   your app (for the official Zulip apps, it's `org.zulip.Zulip`).
+
 - Restart the Zulip server.
 
-[apple-docs]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html
+[apple-doc-cert]: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns
+[apple-doc-token]: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -94,7 +94,7 @@ tornado
 orjson
 
 # Needed for iOS push notifications
-aioapns
+https://github.com/zulip/aioapns/archive/2d69284481d328bd3e4168c631d75a38268eddb9.zip#egg=aioapns==3.1+git  # https://github.com/Fatal1ty/aioapns/pull/52
 
 python-twitter
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,9 +7,8 @@
 #
 # For details, see requirements/README.md .
 #
-aioapns==3.1 \
-    --hash=sha256:0544912030317952a566d79880665990c7149fa840a357d609bb997076575215 \
-    --hash=sha256:6220827c156be7f7aceb40cc388b0129c6a33221b06cc73399b39a7d2997c338
+https://github.com/zulip/aioapns/archive/2d69284481d328bd3e4168c631d75a38268eddb9.zip#egg=aioapns==3.1+git \
+    --hash=sha256:e8ffed2c251b3383c75c08a538fb04392480ac19f97887ff8f113fe4a45cf96c
     # via -r requirements/common.in
 aiohttp==3.8.6 \
     --hash=sha256:002f23e6ea8d3dd8d149e569fd580c999232b5fbc601c48d55398fbc2e582e8c \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,9 +7,8 @@
 #
 # For details, see requirements/README.md .
 #
-aioapns==3.1 \
-    --hash=sha256:0544912030317952a566d79880665990c7149fa840a357d609bb997076575215 \
-    --hash=sha256:6220827c156be7f7aceb40cc388b0129c6a33221b06cc73399b39a7d2997c338
+https://github.com/zulip/aioapns/archive/2d69284481d328bd3e4168c631d75a38268eddb9.zip#egg=aioapns==3.1+git \
+    --hash=sha256:e8ffed2c251b3383c75c08a538fb04392480ac19f97887ff8f113fe4a45cf96c
     # via -r requirements/common.in
 aiohttp==3.8.6 \
     --hash=sha256:002f23e6ea8d3dd8d149e569fd580c999232b5fbc601c48d55398fbc2e582e8c \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 226
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (253, 0)
+PROVISION_VERSION = (253, 1)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -405,8 +405,8 @@ APNS_TOKEN_KEY_FILE: Optional[str] = None
 APNS_TOKEN_KEY_ID = get_secret("apns_token_key_id", development_only=True)
 APNS_TEAM_ID = get_secret("apns_team_id", development_only=True)
 APNS_SANDBOX = True
-APNS_TOPIC = "org.zulip.Zulip"
-# ZULIP_IOS_APP_ID is obsolete
+# APNS_TOPIC is obsolete. Clients now pass the APNs topic to use.
+# ZULIP_IOS_APP_ID is obsolete. Clients now pass the iOS app ID to use for APNs.
 
 # Limits related to the size of file uploads; last few in MB.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -401,6 +401,9 @@ POST_MIGRATION_CACHE_FLUSHING = False
 # rebuilding the mobile app with a different push notifications
 # server.
 APNS_CERT_FILE: Optional[str] = None
+APNS_TOKEN_KEY_FILE: Optional[str] = None
+APNS_TOKEN_KEY_ID = get_secret("apns_token_key_id", development_only=True)
+APNS_TEAM_ID = get_secret("apns_team_id", development_only=True)
 APNS_SANDBOX = True
 APNS_TOPIC = "org.zulip.Zulip"
 # ZULIP_IOS_APP_ID is obsolete

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -100,11 +100,14 @@ USING_PGROONGA = True
 # Flush cache after migration.
 POST_MIGRATION_CACHE_FLUSHING = True
 
-# If a sandbox APNs cert is provided, use it.
-# To create such a cert, see instructions at:
+# If a sandbox APNs key or cert is provided, use it.
+# To create such a key or cert, see instructions at:
 #   https://github.com/zulip/zulip-mobile/blob/main/docs/howto/push-notifications.md#ios
+_candidate_apns_token_key_file = "zproject/apns-dev-key.p8"
 _candidate_apns_cert_file = "zproject/apns-dev.pem"
-if os.path.isfile(_candidate_apns_cert_file):
+if os.path.isfile(_candidate_apns_token_key_file):
+    APNS_TOKEN_KEY_FILE = _candidate_apns_token_key_file
+elif os.path.isfile(_candidate_apns_cert_file):
     APNS_CERT_FILE = _candidate_apns_cert_file
 
 # Don't require anything about password strength in development

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -156,7 +156,8 @@ INLINE_URL_EMBED_PREVIEW = False
 HOME_NOT_LOGGED_IN = "/login/"
 LOGIN_URL = "/accounts/login/"
 
-# If dev_settings.py found a cert file to use here, ignore it.
+# If dev_settings.py found a key or cert file to use here, ignore it.
+APNS_TOKEN_KEY_FILE: Optional[str] = None
 APNS_CERT_FILE: Optional[str] = None
 
 # By default will not send emails when login occurs.


### PR DESCRIPTION
This is a followup to #27590, after it was split as discussed at https://github.com/zulip/zulip/pull/27590#issuecomment-1800407932 and [in `#api design`](https://chat.zulip.org/#narrow/stream/378-api-design/topic/iOS.20app.20IDs.20in.20registering.20push.20device.20tokens/near/1677679).

In this PR, we arrange for our APNs connection to use [token-based authentication](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns) if a key is provided for that, as well as the existing [certificate-based authentication](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns) if a cert is provided instead. Token-based authentication is a prerequisite to sending notifications to multiple apps over the same HTTP connection.

Then we proceed with the two commits that were originally at the tip of #27590, to actually send such notifications. There's a revision there for @alexmv's comment at https://github.com/zulip/zulip/pull/27590#discussion_r1385332248 .

### Deployment

As before, I've tested this end-to-end using my own dev server. In order for these changes to be deployed and in effect for everyone, what'll be needed is to:
* deploy it on Zulip Cloud, therefore to the bouncer;
* then get a token key from Apple and configure it in server settings as documented here, replacing `APNS_CERT_FILE`. Happy to assist with that in case anything isn't clear in the docs.

After the first step and before the second, everything should continue working as before.

Happily there's no need for either these changes or #27590 to be deployed to an individual Zulip server in order for people to get notifications from it with the pre-release Flutter app (as long as it's using the bouncer); servers have always been sending the app ID to the bouncer, and what's needed is only for the bouncer to take it from there.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
