### PR TITLE
compose: Always retain link formatting when pasting just a link.

### DIFF
--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -319,10 +319,10 @@ export function paste_handler_converter(paste_html) {
         copied_html_fragment.childNodes.length === 1 &&
         copied_html_fragment.firstElementChild &&
         copied_html_fragment.firstElementChild.innerHTML;
-    const outer_elements_to_retain = ["PRE", "OL"];
+    const outer_elements_to_retain = ["PRE", "OL", "A"];
     // If the entire selection copied is within a single HTML element (like an
-    // `h1`), we don't want to retain its styling, except when it helps identify
-    // the intended structure of the copied content (like `pre` and `ol`).
+    // `h1`), we don't want to retain its styling, except when it is needed to
+    // identify the intended structure of the copied content.
     if (
         copied_within_single_element &&
         !outer_elements_to_retain.includes(copied_html_fragment.firstElementChild.nodeName)

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -45,10 +45,10 @@ run_test("paste_handler_converter", () => {
 
     // Links with custom text
     input =
-        '<meta http-equiv="content-type" content="text/html; charset=utf-8">normal text <a class="reference external" href="https://zulip.readthedocs.io/en/latest/contributing/contributing.html" style="box-sizing: border-box; color: hsl(283, 39%, 53%); text-decoration: none; cursor: pointer; outline: 0px; font-family: Lato, proxima-nova, &quot;Helvetica Neue&quot;, Arial, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 99%);">Contributing guide</a>';
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><a class="reference external" href="https://zulip.readthedocs.io/en/latest/contributing/contributing.html" style="box-sizing: border-box; color: hsl(283, 39%, 53%); text-decoration: none; cursor: pointer; outline: 0px; font-family: Lato, proxima-nova, &quot;Helvetica Neue&quot;, Arial, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 99%);">Contributing guide</a>';
     assert.equal(
         copy_and_paste.paste_handler_converter(input),
-        "normal text [Contributing guide](https://zulip.readthedocs.io/en/latest/contributing/contributing.html)",
+        "[Contributing guide](https://zulip.readthedocs.io/en/latest/contributing/contributing.html)",
     );
 
     // Only numbered list (list style retained)


### PR DESCRIPTION
We add anchors to the list of enclosing elements we don't strip away.

Fixes: [Issue discussed here](https://chat.zulip.org/#narrow/stream/9-issues/topic/Github.20issue.20number.20copy.20paste.20bug/near/1677091)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
