### PR TITLE
popovers: Fix topic visibility popover in sticky header not working.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -180,7 +180,11 @@ export const default_popover_props = {
                     // hiding elements outside the message feed is tricky and expensive due to stacking context.
                     // References in overlays, modal, sidebar overlays, popovers, etc. can make the below logic hard
                     // to live with if we take elements outside message feed into account.
-                    if ($reference.parents("#message_feed_container").length !== 1) {
+                    // Since `.sticky_header` is inside `#message_feed_container`, we allow popovers from reference inside
+                    // `.sticky_header` to be visible.
+                    if (
+                        $reference.parents("#message_feed_container, .sticky_header").length !== 1
+                    ) {
                         return;
                     }
 


### PR DESCRIPTION
The popover didn't open since sticky_header is part of message feed and we were hiding popovers if `elements_at_reference_position` had `sticky_header`. Now, we just don't do that check if the reference is part of sticky_header.


Super sorry for not checking popovers in sticky_header !
