### PR TITLE
help: Document "Load more" recent conversations.

### DIFF
--- a/help/recent-conversations.md
+++ b/help/recent-conversations.md
@@ -9,6 +9,29 @@
     The arrow keys and vim navigation keys (<kbd>J</kbd>, <kbd>K</kbd>,
     <kbd>L</kbd>, <kbd>H</kbd>) can be used to move between elements.
 
+## Load more conversations
+
+The **recent conversations** view displays a limited number of conversations
+containing the most recent messages.
+
+!!! tip ""
+
+    Use the [search bar](/help/search-for-messages) at the top of the web app
+    to search through all conversations, not just recent ones.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!go-to-recent-conversations.md!}
+
+1. Scroll to the bottom of the list of conversations, or bring the bottom into
+   view by filtering for a non-existent keyword.
+
+1. Click the **Load more** button in the banner at the bottom.
+
+{end_tabs}
+
 ## Related articles
 * [Finding a conversation to read](/help/finding-a-conversation-to-read)
 * [Reading conversations](/help/reading-conversations)


### PR DESCRIPTION
This PR is an edited version of #27608.

Adds a new section with a short intro and instructions that explain how to load more conversations.

Fixes #27253.

Current page:

New section:
<img width="830" alt="Screenshot 2023-11-07 at 11 56 57 PM" src="https://github.com/zulip/zulip/assets/2090066/d28f52dc-5ae8-4875-9268-587af9b4fdd4">
