### PR TITLE
ui-experiment: Go to top topic instead of interleaved view

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -394,7 +394,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
-    await expect_verona_stream(page);
+    await expect_verona_stream_top_topic(page);
     assert.strictEqual(
         await common.get_text_from_selector(page, ".stream-list-filter"),
         "",

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -25,6 +25,14 @@ async function expect_home(page: Page): Promise<void> {
     ]);
 }
 
+async function expect_verona_stream_top_topic(page: Page): Promise<void> {
+    await page.waitForSelector("#zfilt", {visible: true});
+    await common.check_messages_sent(page, "zfilt", [
+        ["Verona > test", ["verona test a", "verona test b", "verona test d"]],
+    ]);
+    assert.strictEqual(await page.title(), "#Verona > test - Zulip Dev - Zulip");
+}
+
 async function expect_verona_stream(page: Page): Promise<void> {
     await page.waitForSelector("#zfilt", {visible: true});
     await common.check_messages_sent(page, "zfilt", [
@@ -285,6 +293,9 @@ async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<voi
 
     await page.click((await get_stream_li(page, "Verona")) + " a");
     await expect_verona_stream(page);
+
+    await page.click((await get_stream_li(page, "Verona")) + " .stream-name");
+    await expect_verona_stream_top_topic(page);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages a");
     await expect_home(page);

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -787,7 +787,7 @@ export function initialize({on_stream_click}) {
 }
 
 export function set_event_handlers({on_stream_click}) {
-    $("#stream_filters").on("click", "li .subscription_block", (e) => {
+    $("#stream_filters").on("click", "li .subscription_block a", (e) => {
         if (e.metaKey || e.ctrlKey) {
             return;
         }

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -8,6 +8,7 @@ import render_stream_subheader from "../templates/streams_subheader.hbs";
 import render_subscribe_to_more_streams from "../templates/subscribe_to_more_streams.hbs";
 
 import * as blueslip from "./blueslip";
+import * as browser_history from "./browser_history";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as keydown_util from "./keydown_util";
@@ -21,10 +22,12 @@ import * as settings_data from "./settings_data";
 import * as sidebar_ui from "./sidebar_ui";
 import * as stream_data from "./stream_data";
 import * as stream_list_sort from "./stream_list_sort";
+import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
 import * as topic_list from "./topic_list";
 import * as ui_util from "./ui_util";
 import * as unread from "./unread";
+import * as user_topics from "./user_topics";
 
 let pending_stream_list_rerender = false;
 let zoomed_in = false;
@@ -793,6 +796,26 @@ export function set_event_handlers({on_stream_click}) {
 
         clear_and_hide_search();
 
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    // Go to the top topic of a stream when clicking on the name of a stream,
+    // in the left sidebar view
+    $("#stream_filters").on("click", "li .subscription_block .stream-name", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+        const stream_id = stream_id_for_elt($(e.target).parents("li"));
+        const topics = stream_topic_history.get_recent_topic_names(stream_id);
+        const top_unmuted_topic = topics.find(
+            (topic) => !user_topics.is_topic_muted(stream_id, topic),
+        );
+        browser_history.go_to_location(hash_util.by_stream_topic_url(stream_id, top_unmuted_topic));
+
+        popovers.hide_all();
+
+        clear_and_hide_search();
         e.preventDefault();
         e.stopPropagation();
     });

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -933,6 +933,14 @@ li.top_left_scheduled_messages {
            definition. */
         height: auto;
     }
+
+    .fa {
+        color: var(--color-left-sidebar-navigation-icon);
+    }
+
+    .fa:hover {
+        color: var(--color-text-message-header);
+    }
 }
 
 .bottom_left_row .sidebar-menu-icon {

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
+            <span title="{{name}}" class="stream-name">{{name}}</span>
 
             <div class="stream-markers-and-controls">
                 <span class="unread_mention_info"></span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -11,6 +11,7 @@
             <span title="{{name}}" class="stream-name">{{name}}</span>
 
             <div class="stream-markers-and-controls">
+                <a href="{{url}}" class="fa fa-align-right"></a>
                 <span class="unread_mention_info"></span>
                 <span class="unread_count"></span>
                 <span class="masked_unread_count"></span>


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/26937.
This is an UI-experiment that contains:

- Added click event in stream_list event handlers so that clicking on the name of a stream in the left sidebar goes to the top topic in the left sidebar view of that stream, rather than an interleaved view.
- Added an "interleaved" button to the stream header row in the left sidebar, as well as a click event so that clicking the interleaved button leads to an interleaved view of that stream.

I was unsure if it was necessary to write new tests for this ui-experiment. If that was the case I would gladly receive any kind of tips on how to think regarding these tests.


**Screenshots and screen captures:**

*Light mode*

![Skärmavbild 2023-11-22 kl  16 58 54](https://github.com/zulip/zulip/assets/36896949/6caa0283-6357-445e-a2a9-6d20f814f1ba)
![Skärmavbild 2023-11-22 kl  16 58 39](https://github.com/zulip/zulip/assets/36896949/406ce27c-2397-46b1-b12d-a131ef46940f)
![Skärmavbild 2023-11-22 kl  17 00 34](https://github.com/zulip/zulip/assets/36896949/63235349-eb1b-4c38-bf74-b7631489da0d)
![Skärmavbild 2023-11-22 kl  17 00 47](https://github.com/zulip/zulip/assets/36896949/40f0d930-0d86-4961-962e-3cbdb98d00d0)

*Dark mode*
<img width="447" alt="Skärmavbild 2023-11-24 kl  13 45 36" src="https://github.com/zulip/zulip/assets/36896949/43583ad5-101b-47f6-8921-5809b7018acc">
<img width="445" alt="Skärmavbild 2023-11-24 kl  16 41 51" src="https://github.com/zulip/zulip/assets/36896949/c1fcc6ed-d178-4f29-b662-898db18d6ab6">
<img width="407" alt="Skärmavbild 2023-11-24 kl  13 45 41" src="https://github.com/zulip/zulip/assets/36896949/d2acfe55-d21e-4757-9baa-0b4929b2c07e">


<summary>Self-review checklist</summary>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
