### PR TITLE
left_sidebar: Register mark-all-as-read handlers on home views.

### DIFF
--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -34,6 +34,12 @@ function common_click_handlers() {
         popovers.hide_all();
     });
 }
+// This callback is called from the popovers on all home views
+function register_mark_all_read_handler(event) {
+    const {instance} = event.data;
+    unread_ops.confirm_mark_all_as_read();
+    instance.hide();
+}
 
 export function initialize() {
     // Starred messages popover
@@ -114,10 +120,12 @@ export function initialize() {
             popover_menus.popover_instances.left_sidebar_inbox_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
 
-            $popper.one("click", "#mark_all_messages_as_read", () => {
-                unread_ops.confirm_mark_all_as_read();
-                instance.hide();
-            });
+            $popper.one(
+                "click",
+                "#mark_all_messages_as_read",
+                {instance},
+                register_mark_all_read_handler,
+            );
         },
         onShow(instance) {
             popovers.hide_all();
@@ -141,6 +149,15 @@ export function initialize() {
     // All messages popover
     popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
+        onMount(instance) {
+            const $popper = $(instance.popper);
+            $popper.one(
+                "click",
+                "#mark_all_messages_as_read",
+                {instance},
+                register_mark_all_read_handler,
+            );
+        },
         onShow(instance) {
             popover_menus.popover_instances.left_sidebar_all_messages_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
@@ -165,6 +182,15 @@ export function initialize() {
     // Recent view popover
     popover_menus.register_popover_menu(".recent-view-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
+        onMount(instance) {
+            const $popper = $(instance.popper);
+            $popper.one(
+                "click",
+                "#mark_all_messages_as_read",
+                {instance},
+                register_mark_all_read_handler,
+            );
+        },
         onShow(instance) {
             popover_menus.popover_instances.left_sidebar_recent_view_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);


### PR DESCRIPTION
This adds click-handlers to the "Mark all messages as read" popover items for Recent conversations and All messages, which did not get them as part of #27501.

<!-- Describe your pull request here.-->

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/mark.20all.20messages.20as.20read/near/1677814)

**Screenshots and screen captures:**
![home-views-mark-as-read](https://github.com/zulip/zulip/assets/170719/833ee70c-6808-4d5c-8272-5105f09814c3)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>