### PR TITLE
stream_list_sort: Fix stream marked as active on click.

### DIFF
--- a/web/src/message_list_data.js
+++ b/web/src/message_list_data.js
@@ -590,4 +590,8 @@ export class MessageListData {
         const msg = this._items[msg_index];
         return msg;
     }
+
+    has_message_from_stream(stream_id) {
+        return this._items.some((message) => message.stream_id === stream_id);
+    }
 }

--- a/web/src/stream_list_sort.js
+++ b/web/src/stream_list_sort.js
@@ -1,6 +1,6 @@
+import {all_messages_data} from "./all_messages_data";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
-import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
@@ -68,7 +68,7 @@ export function has_recent_activity(sub) {
         // to set_filter_out_inactives.
         return true;
     }
-    return stream_topic_history.stream_has_topics(sub.stream_id) || sub.newly_subscribed;
+    return all_messages_data.has_message_from_stream(sub.stream_id) || sub.newly_subscribed;
 }
 
 export function has_recent_activity_but_muted(sub) {

--- a/web/tests/stream_list_sort.test.js
+++ b/web/tests/stream_list_sort.test.js
@@ -10,7 +10,7 @@ const {user_settings} = require("./lib/zpage_params");
 
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
-const stream_topic_history = zrequire("stream_topic_history");
+const all_messages_data = zrequire("all_messages_data");
 const stream_list_sort = zrequire("stream_list_sort");
 const settings_config = zrequire("settings_config");
 
@@ -222,12 +222,8 @@ test("has_recent_activity", () => {
     assert.ok(stream_list_sort.has_recent_activity(sub));
     sub.pin_to_top = false;
 
-    const opts = {
-        stream_id: 222,
-        message_id: 108,
-        topic_name: "topic2",
-    };
-    stream_topic_history.add_message(opts);
+    const messages = [{id: 108, stream_id: 222}];
+    all_messages_data.all_messages_data.add_messages(messages);
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
@@ -256,7 +252,7 @@ test("has_recent_activity", () => {
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
-    stream_topic_history.add_message(opts);
+    all_messages_data.all_messages_data.add_messages(messages);
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
@@ -279,7 +275,7 @@ test("has_recent_activity", () => {
     sub.pin_to_top = true;
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
-    stream_topic_history.add_message(opts);
+    all_messages_data.all_messages_data.add_messages(messages);
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 });

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -6,7 +6,7 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const {page_params, user_settings} = require("./lib/zpage_params");
 
-const stream_topic_history = mock_esm("../src/stream_topic_history");
+const all_messages_data = mock_esm("../src/all_messages_data");
 
 const settings_config = zrequire("settings_config");
 const pm_conversations = zrequire("pm_conversations");
@@ -169,11 +169,11 @@ test("sort_streams", ({override}) => {
     );
 
     stream_list_sort.set_filter_out_inactives();
-    override(
-        stream_topic_history,
-        "stream_has_topics",
-        (stream_id) => ![105, 205].includes(stream_id),
-    );
+    all_messages_data.all_messages_data = {
+        has_message_from_stream(stream_id) {
+            return ![105, 205].includes(stream_id);
+        },
+    };
 
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Denmark"); // Pinned streams first


### PR DESCRIPTION
Earlier, a stream in the inactive section was moved to the active section in the left sidebar on click.

Now, we mark a stream as active only when it has at least one message included in `all_messages_data` (home view).

Fixes #27009.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
