### PR TITLE
Fix selected message in message list being out of view.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -353,7 +353,16 @@ export function activate(raw_operators, opts) {
             if (opts.then_select_offset === undefined) {
                 const $row = message_lists.current.get_row(opts.then_select_id);
                 if ($row.length > 0) {
-                    opts.then_select_offset = $row.get_offset_to_window().top;
+                    const row_props = $row.get_offset_to_window();
+                    const navbar_height = $("#navbar-fixed-container").height();
+                    // 30px height + 10px top margin.
+                    const sticky_header_outer_height = 40;
+                    const min_height_for_message_top_visible =
+                        navbar_height + sticky_header_outer_height;
+                    opts.then_select_offset = Math.max(
+                        row_props.top,
+                        min_height_for_message_top_visible,
+                    );
                 }
             }
         }

--- a/web/src/rows.js
+++ b/web/src/rows.js
@@ -162,7 +162,18 @@ export function recipient_from_group(message_group) {
     return message_store.get(id($(message_group).children(".message_row").first().expectOne()));
 }
 
+export function is_header_of_row_sticky($recipient_row) {
+    return $recipient_row.find(".message_header").hasClass("sticky_header");
+}
+
 export function id_for_recipient_row($recipient_row) {
+    if (is_header_of_row_sticky($recipient_row)) {
+        const msg_id = message_lists.current.view.sticky_recipient_message_id;
+        if (msg_id !== undefined) {
+            return msg_id;
+        }
+    }
+
     const $msg_row = first_message_in_group($recipient_row);
     return id($msg_row);
 }

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -165,6 +165,8 @@ run_test("basics", ({override}) => {
         last: () => ({id: 1100}),
     };
 
+    $("#navbar-fixed-container").set_height(40);
+
     message_fetch.load_messages_for_narrow = (opts) => {
         // Only validates the anchor and set of fields
         assert.deepEqual(opts, {
@@ -181,7 +183,9 @@ run_test("basics", ({override}) => {
     });
 
     assert.equal(message_lists.current.selected_id, selected_id);
-    assert.equal(message_lists.current.view.offset, 25);
+    // 25 was the offset of the selected message but it is low for the
+    // message top to be visible, so we use set offset to navbar height + header height.
+    assert.equal(message_lists.current.view.offset, 80);
     assert.equal(narrow_state.narrowed_to_pms(), false);
 
     helper.assert_events([
@@ -212,4 +216,14 @@ run_test("basics", ({override}) => {
     });
 
     assert.equal(narrow_state.narrowed_to_pms(), true);
+
+    message_lists.current.selected_id = () => -1;
+    row.get_offset_to_window = () => ({top: 100});
+    message_lists.current.get_row = () => row;
+
+    narrow.activate(terms, {
+        then_select_id: selected_id,
+    });
+
+    assert.equal(message_lists.current.view.offset, 100);
 });


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/27489

Opened #27632, first commit is the main fix, second commit is just something I think is an improvement.

Best way to test locally is to run `./manage.py -n 3000 --max-topics=2` and scroll up high in stream so that selected message can be offscreen like in [czo stream in czo](https://chat.zulip.org/#narrow/stream/415-chat.2Ezulip.2Eorg).