### PR TITLE
corporate: Make `process_initial_upgrade` not reliant on customer with realm.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -362,6 +362,10 @@ class BillingSession(ABC):
         pass
 
     @abstractmethod
+    def current_count_for_billed_licenses(self) -> int:
+        pass
+
+    @abstractmethod
     def get_audit_log_event(self, event_type: AuditLogEventType) -> int:
         pass
 
@@ -616,6 +620,10 @@ class RealmBillingSession(BillingSession):
     @override
     def get_customer(self) -> Optional[Customer]:
         return get_customer_by_realm(self.realm)
+
+    @override
+    def current_count_for_billed_licenses(self) -> int:
+        return get_latest_seat_count(self.realm)
 
     @override
     def get_audit_log_event(self, event_type: AuditLogEventType) -> int:
@@ -1064,7 +1072,8 @@ def process_initial_upgrade(
         else:
             # billed_licenses can be greater than licenses if users are added between the start of
             # this function (process_initial_upgrade) and now
-            billed_licenses = max(get_latest_seat_count(customer.realm), licenses)
+            current_licenses_count = billing_session.current_count_for_billed_licenses()
+            billed_licenses = max(current_licenses_count, licenses)
         plan_params = {
             "automanage_licenses": automanage_licenses,
             "charge_automatically": charge_automatically,

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -746,7 +746,7 @@ class RealmBillingSession(BillingSession):
             plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         elif tier == CustomerPlan.STANDARD:
             plan_type = Realm.PLAN_TYPE_STANDARD
-        elif tier == CustomerPlan.PLUS:
+        elif tier == CustomerPlan.PLUS:  # nocoverage # Plus plan doesn't use this code path yet.
             plan_type = Realm.PLAN_TYPE_PLUS
         else:
             raise AssertionError("Unexpected tier")
@@ -1059,6 +1059,7 @@ def do_deactivate_remote_server(remote_server: RemoteZulipServer) -> None:
 @catch_stripe_errors
 def process_initial_upgrade(
     user: UserProfile,
+    plan_tier: int,
     licenses: int,
     automanage_licenses: bool,
     billing_schedule: int,
@@ -1075,7 +1076,7 @@ def process_initial_upgrade(
         period_end,
         price_per_license,
     ) = compute_plan_parameters(
-        CustomerPlan.STANDARD,
+        plan_tier,
         automanage_licenses,
         billing_schedule,
         customer.default_discount,
@@ -1099,7 +1100,7 @@ def process_initial_upgrade(
             "discount": customer.default_discount,
             "billing_cycle_anchor": billing_cycle_anchor,
             "billing_schedule": billing_schedule,
-            "tier": CustomerPlan.STANDARD,
+            "tier": plan_tier,
         }
         if free_trial:
             plan_params["status"] = CustomerPlan.FREE_TRIAL
@@ -1151,7 +1152,7 @@ def process_initial_upgrade(
         )
         stripe.Invoice.finalize_invoice(stripe_invoice)
 
-    billing_session.do_change_plan_type(tier=CustomerPlan.STANDARD)
+    billing_session.do_change_plan_type(tier=plan_tier)
 
 
 def update_license_ledger_for_manual_plan(

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1125,7 +1125,7 @@ def process_initial_upgrade(
         stripe.InvoiceItem.create(
             currency="usd",
             customer=customer.stripe_customer_id,
-            description="Zulip Cloud Standard",
+            description=plan.name,
             discountable=False,
             period={
                 "start": datetime_to_timestamp(billing_cycle_anchor),
@@ -1147,7 +1147,7 @@ def process_initial_upgrade(
             collection_method=collection_method,
             customer=customer.stripe_customer_id,
             days_until_due=days_until_due,
-            statement_descriptor="Zulip Cloud Standard",
+            statement_descriptor=plan.name,
         )
         stripe.Invoice.finalize_invoice(stripe_invoice)
 

--- a/corporate/lib/stripe_event_handler.py
+++ b/corporate/lib/stripe_event_handler.py
@@ -12,7 +12,7 @@ from corporate.lib.stripe import (
     ensure_customer_does_not_have_active_plan,
     process_initial_upgrade,
 )
-from corporate.models import Event, PaymentIntent, Session
+from corporate.models import CustomerPlan, Event, PaymentIntent, Session
 from zerver.models import get_active_user_profile_by_id_in_realm
 
 billing_logger = logging.getLogger("corporate.stripe")
@@ -102,6 +102,7 @@ def handle_checkout_session_completed_event(
         billing_session.update_or_create_stripe_customer(payment_method)
         process_initial_upgrade(
             user,
+            CustomerPlan.STANDARD,
             int(stripe_session.metadata["licenses"]),
             stripe_session.metadata["license_management"] == "automatic",
             int(stripe_session.metadata["billing_schedule"]),
@@ -151,6 +152,7 @@ def handle_payment_intent_succeeded_event(
 
     process_initial_upgrade(
         user,
+        CustomerPlan.STANDARD,
         int(metadata["licenses"]),
         metadata["license_management"] == "automatic",
         int(metadata["billing_schedule"]),

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -627,6 +627,7 @@ class StripeTestCase(ZulipTestCase):
         ) -> Any:
             return process_initial_upgrade(
                 self.example_user("hamlet"),
+                CustomerPlan.STANDARD,
                 licenses,
                 automanage_licenses,
                 billing_schedule,

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -142,6 +142,7 @@ def upgrade(
         else:
             process_initial_upgrade(
                 user,
+                CustomerPlan.STANDARD,
                 licenses,
                 automanage_licenses,
                 billing_schedule,


### PR DESCRIPTION
Updates `process_initial_upgrade` so that it doesn't directly rely on a customer having a realm or have hard-coded values related to Zulip Cloud (e.g. `CustomerPlan.STANDARD` for the plan tier or `"Zulip Cloud Standard"` for the plan name).

Probably will need a few rounds of updates/review. Making notes about my specific questions/thoughts in the code changes directly.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
