### PR TITLE
left_sidebar: Header row CSS Grid rewrites.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -315,7 +315,7 @@ async function test_search_venice(page: Page): Promise<void> {
     await page.waitForSelector(await get_stream_li(page, "Venice"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
 
-    await page.click("#streams_header .sidebar-title");
+    await page.click("#streams_header .left-sidebar-title");
     await page.waitForSelector(".input-append.notdisplayed");
 }
 
@@ -323,7 +323,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     console.log("Filter streams using left side bar");
 
     await page.waitForSelector(".input-append.notdisplayed"); // Stream filter box invisible initially
-    await page.click("#streams_header .sidebar-title");
+    await page.click("#streams_header .left-sidebar-title");
 
     await page.waitForSelector("#streams_list .input-append.notdisplayed", {hidden: true});
 
@@ -377,7 +377,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await test_search_venice(page);
 
     // Search for beginning of "Verona".
-    await page.click("#streams_header .sidebar-title");
+    await page.click("#streams_header .left-sidebar-title");
     await page.type(".stream-list-filter", "ver");
     await page.waitForSelector(await get_stream_li(page, "core team"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});

--- a/web/src/hotspots.js
+++ b/web/src/hotspots.js
@@ -25,7 +25,7 @@ const HOTSPOT_LOCATIONS = new Map([
     [
         "intro_streams",
         {
-            element: "#streams_header .sidebar-title",
+            element: "#streams_header .left-sidebar-title",
             offset_x: 1.35,
             offset_y: 0.39,
         },

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -194,7 +194,7 @@ export function initialize() {
     $("body").on("click", "#views-label-container", (e) => {
         if (
             $(e.currentTarget).hasClass("showing-condensed-navigation") &&
-            !($(e.target).hasClass("sidebar-title") || $(e.target).hasClass("fa-caret-right"))
+            !($(e.target).hasClass("left-sidebar-title") || $(e.target).hasClass("fa-caret-right"))
         ) {
             // Ignore clicks on condensed nav items
             return;

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -887,11 +887,13 @@ export function clear_search(e) {
 }
 
 export function show_search_section() {
+    $("#streams_header").addClass("showing-stream-search-section");
     $(".stream_search_section").expectOne().removeClass("notdisplayed");
     resize.resize_stream_filters_container();
 }
 
 export function hide_search_section() {
+    $("#streams_header").removeClass("showing-stream-search-section");
     $(".stream_search_section").expectOne().addClass("notdisplayed");
     resize.resize_stream_filters_container();
 }

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -215,7 +215,7 @@ export function initialize() {
 
     delegate("body", {
         target: [
-            "#streams_header .sidebar-title",
+            "#streams_header .left-sidebar-title",
             "#userlist-title",
             "#user_filter_icon",
             "#scroll-to-bottom-button-clickable-area",

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -445,11 +445,6 @@
         opacity: 0.5;
     }
 
-    .sidebar-title {
-        color: inherit;
-        opacity: 0.75;
-    }
-
     .rendered_markdown button,
     .new-style .button {
         background-color: hsl(0deg 0% 0% / 20%);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -48,6 +48,13 @@ $before_unread_count_padding: 3px;
     }
 }
 
+.left-sidebar-title {
+    color: var(--color-text-sidebar-heading);
+    font-size: inherit;
+    font-weight: normal;
+    display: inline;
+}
+
 .sidebar-topic-check,
 .topic-name,
 .topic-markers-and-controls {
@@ -769,7 +776,7 @@ li.top_left_scheduled_messages {
         }
         /* Give the sidebar title through the end of the markers
            area, if needed. */
-        .sidebar-title {
+        .left-sidebar-title {
             grid-column: row-content-start / markers-and-controls-end;
         }
     }
@@ -799,7 +806,7 @@ li.top_left_scheduled_messages {
         margin-left: 0;
     }
 
-    .sidebar-title {
+    .left-sidebar-title {
         grid-area: row-content;
         /* Override heading margin from Bootstrap. */
         margin: 0;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -85,20 +85,12 @@ li.show-more-topics {
 
 #streams_inline_icon,
 .streams_filter_icon {
-    float: right;
     opacity: 0.5;
-    padding: 3px;
-    margin-left: 4px;
 
     &:hover {
         opacity: 1;
         cursor: pointer;
     }
-}
-
-.streams_inline_icon_wrapper {
-    float: right;
-    margin-right: 8px;
 }
 
 .streams_filter_icon.web_public {
@@ -750,7 +742,6 @@ li.top_left_scheduled_messages {
 #views-label-container,
 .top_left_row,
 .left-sidebar-navigation-label-container,
-#private_messages_section_header,
 .dm-box,
 .subscription_block,
 .topic-box {
@@ -769,6 +760,23 @@ li.top_left_scheduled_messages {
        (which alters the box size) or `margin` (which notoriously bleeds outside
        of the element it's defined on). */
     grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
+}
+
+#private_messages_section_header,
+#streams_header {
+    display: grid;
+    align-items: center;
+    /* This extends the general pattern of left sidebar rows, but includes a
+       second grid row for placing filter boxes. This pattern keeps the box
+       aligned with the text content in `row-content` and includes the
+       `ending-anchor-element` space.
+
+       There is currently no filter box on DM rows, but we can prepare for
+       that now by having it share this grid template. Its row and column
+       definitions have the final say about dimensions and placement. */
+    grid-template-areas:
+        "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset"
+        ".               .                       filter-box  filter-box           filter-box            .            ";
 }
 
 #views-label-container {
@@ -1141,26 +1149,108 @@ li.topic-list-item {
 }
 
 #streams_header {
-    margin-right: 12px;
+    grid-template-columns: 0 0 minmax(0, 1fr) minmax(17px, max-content) 30px 12px;
+    /* Keep the stream-search area rows collapsed. */
+    grid-template-rows: 24px 0 0;
     cursor: pointer;
     padding: $sections_vertical_gutter 0 3px calc($far_left_gutter_size + 2px);
     position: sticky;
     background-color: var(--color-background);
     /* Ideally, 0px should work here, but maybe simplebar is doing something
        that is creating `0.5px` extra gap in zoomed-in windows. */
-    top: -0.5px;
     z-index: 1;
 
+    &.showing-stream-search-section {
+        /* Open up the stream-search rows. The 10px
+           row maintains space with the streams list
+           below. */
+        grid-template-rows: 24px 28px 10px;
+    }
+
+    .left-sidebar-title {
+        grid-area: row-content;
+    }
+
+    .heading-markers-and-controls {
+        grid-area: markers-and-controls;
+        height: 100%;
+    }
+
+    #filter_streams_tooltip {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* Filter streams tooltip is just a block,
+           not a flex or grid item at present,
+           so we fill the row height this way. */
+        height: 100%;
+    }
+
+    /* TODO: In the redesign, the streams icons will
+       be grouped and placed to the left of a new
+       unread count on Streams. */
+    #add_streams_tooltip {
+        grid-area: ending-anchor-element;
+        align-self: stretch;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     .input-append {
+        grid-area: filter-box;
+        display: flex;
+        justify-content: stretch;
+        /* Set an even line-height for better
+           vertical centering. */
+        line-height: 20px;
         white-space: nowrap;
-        margin-bottom: 10px;
 
         & input {
-            padding-right: 20px;
+            /* Use the border-box model so flex
+               can do its thing despite whatever
+               padding and border we specify. */
+            box-sizing: border-box;
+            flex: 1 0 100%;
+            /* Match the input height exactly
+               with the row height for a perfect
+               fit and better vertical alignment. */
+            height: 28px;
+            /* Pad the entire clear-button area,
+               so that input text does not bleed
+               into there. */
+            padding-right: 30px;
         }
 
         .clear_search_button {
-            margin-left: -1px;
+            /* Use the border-box model so flex
+               can do its thing despite whatever
+               padding and border we specify. */
+            box-sizing: border-box;
+            /* Clear inherited positioning. */
+            position: static;
+            /* We're going to use flexbox, not
+               positioning, to get the clear button
+               over top of the input. This -30px
+               margin accomplishes that, in tandem
+               with the 30px width of this element,
+               which is shared with the ending
+               anchor element in left sidebar header
+               rows. */
+            width: 30px;
+            margin-left: -30px;
+            /* Flexbox respects z-index; this just
+               ensures the button remains over top
+               of the input. */
+            z-index: 1;
+            /* Make the button itself a flex container,
+               so we can perfectly center the X icon. */
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            /* Flexbox will pull the element open
+               to make a generous clickable area. */
+            padding: 0;
         }
     }
 }
@@ -1203,7 +1293,6 @@ li.topic-list-item {
 }
 
 .stream-list-filter {
-    width: 216px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -53,6 +53,13 @@ $before_unread_count_padding: 3px;
     font-size: inherit;
     font-weight: normal;
     display: inline;
+    /* Override heading margin from Bootstrap. */
+    margin: 0;
+    /* Show an ellipsis on a heading when
+       it won't sit adjacent other icons
+       or controls in the row. */
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .sidebar-topic-check,
@@ -808,13 +815,6 @@ li.top_left_scheduled_messages {
 
     .left-sidebar-title {
         grid-area: row-content;
-        /* Override heading margin from Bootstrap. */
-        margin: 0;
-        /* Show an ellipsis on the VIEWS header when
-           it won't sit adjacent the icons in their
-           most condensed presentation. */
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     #left-sidebar-navigation-list-condensed {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -372,8 +372,14 @@ li.show-more-topics {
     &.top_left_row:hover,
     &.bottom_left_row:hover {
         background-color: var(--color-background-hover-narrow-filter);
-        border-radius: 4px;
     }
+}
+
+.top_left_row,
+.bottom_left_row {
+    /* Ensure a border radius on any interactive
+       state that might show a highlight. */
+    border-radius: 4px;
 }
 
 #stream_filters .narrow-filter.highlighted_stream {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -246,33 +246,43 @@ li.show-more-topics {
 }
 
 .direct-messages-container {
-    margin-right: 16px;
-    margin-left: 6px;
-    z-index: 1;
-
     #private_messages_section_header {
+        grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 12px;
+        grid-template-rows: 24px;
+        /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
+           value and the styles dependent on it so that this kind of
+           1990s layout shenanigans is made unnecessary. */
+        margin-left: -3px;
         cursor: pointer;
-        padding: 0 10px 1px 6px;
         white-space: nowrap;
 
+        #toggle_private_messages_section_icon {
+            grid-area: starting-anchor-element;
+        }
+
+        .left-sidebar-title {
+            grid-area: row-content;
+        }
+
+        .heading-markers-and-controls {
+            grid-area: markers-and-controls;
+        }
+
         #show_all_private_messages {
-            right: 0;
-            float: right;
-            position: absolute;
+            grid-area: ending-anchor-element;
+            /* Make the clickable area large
+               around the icon. */
+            align-self: stretch;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             opacity: 0.7;
             text-decoration: none;
             color: inherit;
-            margin-right: 21px;
-            margin-top: 1px;
 
             &:hover {
                 opacity: 1;
             }
-        }
-
-        .unread_count {
-            margin-right: 16px;
-            margin-top: 2px;
         }
     }
 
@@ -324,8 +334,6 @@ li.show-more-topics {
 #toggle_private_messages_section_icon,
 #toggle-top-left-navigation-area-icon {
     opacity: 0.7;
-    margin-left: -15px;
-    min-width: 12px;
 
     &.fa-caret-right {
         position: relative;
@@ -742,6 +750,7 @@ li.top_left_scheduled_messages {
 #views-label-container,
 .top_left_row,
 .left-sidebar-navigation-label-container,
+#private_messages_section_header,
 .dm-box,
 .subscription_block,
 .topic-box {
@@ -807,10 +816,6 @@ li.top_left_scheduled_messages {
 
     #toggle-top-left-navigation-area-icon {
         grid-area: starting-anchor-element;
-        /* Remove negative left margin. This should be cleaned
-           up along with the `--left-sidebar-collapse-widget-gutter`
-           matters above. */
-        margin-left: 0;
     }
 
     .left-sidebar-title {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -7,6 +7,13 @@ $user_status_emoji_width: 24px;
     }
 }
 
+.right-sidebar-title {
+    color: var(--color-text-sidebar-heading);
+    font-size: inherit;
+    font-weight: normal;
+    display: inline;
+}
+
 #buddy_list_wrapper {
     position: relative;
     margin-left: 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1171,13 +1171,6 @@ strong {
     white-space: nowrap;
 }
 
-.sidebar-title {
-    color: var(--color-text-sidebar-heading);
-    font-size: inherit;
-    font-weight: normal;
-    display: inline;
-}
-
 .tooltip {
     &.in {
         font-size: 12px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -254,6 +254,7 @@ body {
     --color-text-item: hsl(0deg 0% 40%);
     --color-text-personal-menu-no-status: hsl(0deg 0% 50%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
+    --color-text-sidebar-heading: hsl(0deg 0% 43%);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 8% 65% / 100%);
@@ -464,6 +465,15 @@ body {
     --color-text-item: hsl(0deg 0% 50%);
     --color-text-personal-menu-no-status: hsl(0deg 0% 100% 35%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 100% 50%);
+    /* 75% opacity of --color-text-default against --color-background.
+       We use color-mix here to avoid defining a separate, compounding
+       `opacity` property, and also to preserve a record of the
+       relationship of the color of sidebar headings to other colors. */
+    --color-text-sidebar-heading: color-mix(
+        in srgb,
+        hsl(0deg 0% 75%) 75%,
+        hsl(0deg 0% 11%)
+    );
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);
@@ -1162,7 +1172,7 @@ strong {
 }
 
 .sidebar-title {
-    color: hsl(0deg 0% 43%);
+    color: var(--color-text-sidebar-heading);
     font-size: inherit;
     font-weight: normal;
     display: inline;

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -157,11 +157,14 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="left-sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
-                <span id="add_streams_tooltip" class="streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+            <div id="streams_header" class="zoom-in-hide">
+                <h4 class="left-sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
+                <div class="heading-markers-and-controls">
+                    <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                </div>
+                <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -3,7 +3,7 @@
         <div id="views-label-container" class="showing-expanded-navigation hidden-for-spectators">
             <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down" aria-hidden="true"></i>
             {{~!-- squash whitespace --~}}
-            <h4 class="sidebar-title">{{t 'VIEWS' }}</h4>
+            <h4 class="left-sidebar-title">{{t 'VIEWS' }}</h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
                 <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
                     <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
@@ -138,7 +138,7 @@
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <span id="pm_tooltip_container">
                     <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-                    <h4 class="sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
+                    <h4 class="left-sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
                 </span>
                 <span class="unread_count"></span>
                 <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
@@ -157,7 +157,7 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
+            <div id="streams_header" class="zoom-in-hide"><h4 class="left-sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
                 <span id="add_streams_tooltip" class="streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -136,11 +136,11 @@
     <div id="private_messages_sticky_header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
-                <span id="pm_tooltip_container">
-                    <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-                    <h4 class="left-sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
-                </span>
-                <span class="unread_count"></span>
+                <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+                <h4 id="pm_tooltip_container" class="left-sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
+                <div class="heading-markers-and-controls">
+                    <span class="unread_count"></span>
+                </div>
                 <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
                     <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
                 </a>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -2,7 +2,7 @@
     <div class="right-sidebar-items">
         <div id="user-list">
             <div id="userlist-header">
-                <h4 class='sidebar-title' data-tooltip-template-id="search-people-tooltip-template"
+                <h4 class='right-sidebar-title' data-tooltip-template-id="search-people-tooltip-template"
                   id='userlist-title'>
                     {{t 'USERS' }}
                 </h4>


### PR DESCRIPTION
This PR provides a gridded rewrite to the header rows in the left sidebar.

Among the changes in this PR are the establishment of a uniform 24px height for all heading rows (minus any filter boxes); that value is derived from the 24px height in place on the Views heading row, and fits with a broader plan to create even-valued heights where vertical centering is essential. Those heights also account for the very slight vertical layout shifts in the screenshots below.

Fixes parts of: #27559 (this presents the current icon and unread layouts as-is; those newer layouts will probably be coupled together with #27380)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="380" alt="left-sidebar-headers-before" src="https://github.com/zulip/zulip/assets/170719/231df55e-68fb-493c-937e-a7c2721be7e9"> | <img width="380" alt="left-sidebar-headers-after" src="https://github.com/zulip/zulip/assets/170719/f4b6c841-7c90-4e1f-b059-9c5e3862613b"> |
| <img width="380" alt="left-sidebar-headers-dark-before" src="https://github.com/zulip/zulip/assets/170719/c18aca7d-0e26-4032-9548-2de656f394f6"> | <img width="380" alt="left-sidebar-headers-dark-after" src="https://github.com/zulip/zulip/assets/170719/6a6def26-7f7f-4291-89b4-2fe891c6b50a"> |

Here are the changes with grid lines showing. Note that there is now pixel-perfect alignment of the + for adding Streams as well as with the X in the filter box--which itself is here laid out entirely using flexbox, rather than CSS positioning (which is pretty cool and exciting in its own right). Also, these images were captured prior to a correction, now part of the PR, in how heading text-colors were specified...it was actually in capturing these images that I discovered the color issue.

| Grids showing, expanded | Grids showing, collapsed |
| --- | --- |
| <img width="380" alt="dms-expanded-showing-grid" src="https://github.com/zulip/zulip/assets/170719/5e4968e9-267b-411a-96e1-c194794d69a3"> | <img width="380" alt="dms-collapsed-showing-grid" src="https://github.com/zulip/zulip/assets/170719/a8aea58f-9983-4754-89e1-6c49348913ed"> |
| <img width="380" alt="filter-open-showing-grid" src="https://github.com/zulip/zulip/assets/170719/8ea7515c-767b-4393-90d4-802c3d201ecf"> | <img width="380" alt="filter-closed-showing-grid" src="https://github.com/zulip/zulip/assets/170719/d13da8de-b06e-4afe-9e10-fb57a3ee11db"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>