### PR TITLE
When inside a code block, paste plainly and don't automatically add bullets / numbers

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -9,6 +9,7 @@ import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as common from "./common";
 import {$t} from "./i18n";
 import * as loading from "./loading";
+import * as markdown from "./markdown";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
 import * as rtl from "./rtl";
@@ -360,6 +361,26 @@ export function handle_keyup(_event, $textarea) {
     }
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea($textarea);
+}
+
+export function cursor_inside_code_block($textarea) {
+    // Returns whether the cursor is at a point that would be inside
+    // a code block on rendering the textarea content as markdown.
+    const cursor_position = $textarea.caret();
+    const current_content = $textarea.val();
+
+    let unique_insert = "UNIQUEINSERT:" + Math.random();
+    while (current_content.includes(unique_insert)) {
+        unique_insert = "UNIQUEINSERT:" + Math.random();
+    }
+    const content =
+        current_content.slice(0, cursor_position) +
+        unique_insert +
+        current_content.slice(cursor_position);
+    const rendered_content = markdown.parse_non_message(content);
+    const rendered_html = new DOMParser().parseFromString(rendered_content, "text/html");
+    const code_blocks = rendered_html.querySelectorAll("pre > code");
+    return [...code_blocks].some((code_block) => code_block.textContent.includes(unique_insert));
 }
 
 export function format_text($textarea, type, inserted_content) {

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -153,6 +153,10 @@ export function should_enter_send(e) {
 }
 
 function handle_bulleting_or_numbering($textarea, e) {
+    // We only want this functionality if the cursor is not in a code block
+    if (compose_ui.cursor_inside_code_block($textarea)) {
+        return;
+    }
     // handles automatic insertion or removal of bulleting or numbering
     const before_text = split_at_cursor($textarea.val(), $textarea)[0];
     const previous_line = bulleted_numbered_list_util.get_last_line(before_text);

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -543,10 +543,16 @@ export function paste_handler(event) {
             return;
         }
 
+        // We do not paste formatted markdoown when inside a code block.
         // Unlike Chrome, Firefox doesn't automatically paste plainly on using Ctrl+Shift+V,
         // hence we need to handle it ourselves, by checking if shift key is pressed, and only
         // if not, we proceed with the default formatted paste.
-        if (paste_html && !compose_ui.shift_pressed && page_params.development_environment) {
+        if (
+            !compose_ui.cursor_inside_code_block($textarea) &&
+            paste_html &&
+            !compose_ui.shift_pressed &&
+            page_params.development_environment
+        ) {
             event.preventDefault();
             event.stopPropagation();
             const text = paste_handler_converter(paste_html);

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -338,6 +338,12 @@ export function paste_handler_converter(paste_html) {
         codeBlockStyle: "fenced",
         headingStyle: "atx",
     });
+    turndownService.addRule("style", {
+        filter: "style",
+        replacement() {
+            return "";
+        },
+    });
     turndownService.addRule("strikethrough", {
         filter: ["del", "s", "strike"],
         replacement(content) {

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -319,7 +319,7 @@ export function paste_handler_converter(paste_html) {
         copied_html_fragment.childNodes.length === 1 &&
         copied_html_fragment.firstElementChild &&
         copied_html_fragment.firstElementChild.innerHTML;
-    const outer_elements_to_retain = ["PRE", "OL", "A"];
+    const outer_elements_to_retain = ["PRE", "UL", "OL", "A"];
     // If the entire selection copied is within a single HTML element (like an
     // `h1`), we don't want to retain its styling, except when it is needed to
     // identify the intended structure of the copied content.

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -17,6 +17,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
     autosize_textarea() {
         autosize_called = true;
     },
+    cursor_inside_code_block: () => false,
 });
 const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -115,4 +115,9 @@ run_test("paste_handler_converter", () => {
         copy_and_paste.paste_handler_converter(input),
         'const compose_ui = mock_esm("../src/compose_ui");\n\nset_global("document", document);',
     );
+
+    // Pasting from Google Sheets (remove <style> elements completely)
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style><span style="font-size:10pt;font-family:Arial;font-style:normal;text-align:right;" data-sheets-value="{&quot;1&quot;:3,&quot;3&quot;:123}" data-sheets-userformat="{&quot;2&quot;:769,&quot;3&quot;:{&quot;1&quot;:0},&quot;11&quot;:3,&quot;12&quot;:0}">123</span>';
+    assert.equal(copy_and_paste.paste_handler_converter(input), "123");
 });


### PR DESCRIPTION
compose: Completely remove style elements when pasting HTML as markdown.
    
Turndown would strip `<style>` tags, but retain the content enclosed. This resulted in unwanted content being pasted, like the comment nodes inside the `<style>` tag when pasting cell/s copied from Google Sheets.

compose: Always retain `ul` tag when pasting content enclosed by it.

This functionally makes no difference, but we add it along with `ol` for consistency.

commit: Disable automatic numbering / bulleting when inside code block.

compose: Do not paste formatted markdown when inside a code block.

We usually default to pasting formatted markdown (unless the Shift key is used to paste plainly instead), but when we're inside a code block, we always want to paste plainly.

compose: Add a function checking whether the cursor is in a code block.

This is a prep commit for the following 2 commits, so we can opt out of the formatted paste and automatic bulleting / numbering behaviors when inside a code block.

Fixes: [Issues brought up here](https://chat.zulip.org/#narrow/stream/101-design/topic/pasting.20HTML.20into.20compose/near/1677532)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
