### PR TITLE
compose_banner: Display time for messages with < 5 mins scheduled time.

### DIFF
--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -33,21 +33,6 @@ function compute_send_times(now = new Date()) {
     return send_times;
 }
 
-export function is_send_later_timestamp_missing_or_expired(
-    timestamp_in_seconds,
-    current_time_in_seconds,
-) {
-    if (!timestamp_in_seconds) {
-        return true;
-    }
-    // Determine if the selected timestamp is less than the minimum
-    // scheduled message delay
-    if (timestamp_in_seconds - current_time_in_seconds < MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS) {
-        return true;
-    }
-    return false;
-}
-
 export function add_scheduled_messages(scheduled_messages) {
     for (const scheduled_message of scheduled_messages) {
         scheduled_messages_data[scheduled_message.scheduled_message_id] = scheduled_message;
@@ -194,8 +179,7 @@ export function get_selected_send_later_timestamp() {
 }
 
 export function get_formatted_selected_send_later_time() {
-    const current_time = Date.now() / 1000; // seconds, like selected_send_later_timestamp
-    if (is_send_later_timestamp_missing_or_expired(selected_send_later_timestamp, current_time)) {
+    if (!selected_send_later_timestamp) {
         return undefined;
     }
     return timerender.get_full_datetime(new Date(selected_send_later_timestamp * 1000), "time");

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -142,25 +142,6 @@ run_test("scheduled_modal_opts", () => {
     }
 });
 
-run_test("missing_or_expired_timestamps", () => {
-    let now_in_seconds = new Date("2023-05-03T08:54:00").getTime();
-    // The today at 9am option is not expired as of 8:54am (false)
-    assert.ok(
-        !scheduled_messages.is_send_later_timestamp_missing_or_expired(
-            per_day_stamps["2023-05-03"].today_nine_am / 1000,
-            now_in_seconds / 1000,
-        ),
-    );
-    // The today at 9am option is expired as of 8:57am (true)
-    now_in_seconds = new Date("2023-05-03T08:57:00").getTime();
-    assert.ok(
-        scheduled_messages.is_send_later_timestamp_missing_or_expired(
-            per_day_stamps["2023-05-03"].today_nine_am / 1000,
-            now_in_seconds / 1000,
-        ),
-    );
-});
-
 run_test("should_update_send_later_options", () => {
     // We should rerender at midnight
     const start_of_the_day = new Date();


### PR DESCRIPTION
This PR addresses the issue where scheduling a message for a time less than 5 minutes in the future resulted in the confirmation banner not displaying the scheduled time, which should have actually been 5 minutes in the future, as enforced at the UI level by the MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS variable.

We remove the `is_send_later_timestamp_missing_or_expired` method along with it's tests since `selected_send_later_timestamp` is already set to the minimum of 5 minutes in the future through the `minDate` option of the flatpickr.

Edit: Also note that  `is_send_later_timestamp_missing_or_expired` was only being used to display the formatted date and isn't linked with any logic of scheduled timestamp handling.

Fixes: #26784.

Rebased from #26789.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Peek 2023-10-23 04-01](https://github.com/zulip/zulip/assets/82862779/6b0aeea0-34b9-4d49-9e41-96c7452a28e7)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
