### PR TITLE
left_sidebar: Preserve highlight on All messages after reload.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -76,13 +76,7 @@ export function set_hash_to_home_view() {
     }
 }
 
-function hide_non_message_list_views() {
-    maybe_hide_inbox();
-    maybe_hide_recent_view();
-}
-
 function show_home_view() {
-    hide_non_message_list_views();
     // This function should only be called from the hashchange
     // handlers, as it does not set the hash to "".
     //
@@ -90,14 +84,17 @@ function show_home_view() {
     // rendered without a hash.
     switch (user_settings.web_home_view) {
         case "recent_topics": {
+            maybe_hide_inbox();
             recent_view_ui.show();
             break;
         }
         case "all_messages": {
+            // Hides inbox/recent views internally if open.
             show_all_message_view();
             break;
         }
         case "inbox": {
+            maybe_hide_recent_view();
             inbox_ui.show();
             break;
         }
@@ -124,7 +121,6 @@ function do_hashchange_normal(from_reload) {
 
     switch (hash[0]) {
         case "#narrow": {
-            hide_non_message_list_views();
             let operators;
             try {
                 // TODO: Show possible valid URLs to the user.

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -52,9 +52,6 @@ function maybe_hide_inbox() {
 
 function show_all_message_view() {
     narrow.deactivate();
-    // We need to maybe scroll to the selected message
-    // once we have the proper viewport set up
-    message_viewport.maybe_scroll_to_selected();
 }
 
 export function set_hash_to_home_view() {

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -55,7 +55,7 @@ function show_all_message_view() {
     const coming_from_recent_view = maybe_hide_recent_view();
     const coming_from_inbox = maybe_hide_inbox();
     const is_actively_scrolling = message_scroll.is_actively_scrolling();
-    narrow.deactivate(!(coming_from_recent_view || coming_from_inbox), is_actively_scrolling);
+    narrow.deactivate(coming_from_recent_view || coming_from_inbox, is_actively_scrolling);
     // We need to maybe scroll to the selected message
     // once we have the proper viewport set up
     setTimeout(message_viewport.maybe_scroll_to_selected, 0);

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -51,9 +51,7 @@ function maybe_hide_inbox() {
 }
 
 function show_all_message_view() {
-    const coming_from_recent_view = maybe_hide_recent_view();
-    const coming_from_inbox = maybe_hide_inbox();
-    narrow.deactivate(coming_from_recent_view || coming_from_inbox);
+    narrow.deactivate();
     // We need to maybe scroll to the selected message
     // once we have the proper viewport set up
     message_viewport.maybe_scroll_to_selected();

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -56,7 +56,7 @@ function show_all_message_view() {
     narrow.deactivate(coming_from_recent_view || coming_from_inbox);
     // We need to maybe scroll to the selected message
     // once we have the proper viewport set up
-    setTimeout(message_viewport.maybe_scroll_to_selected, 0);
+    message_viewport.maybe_scroll_to_selected();
 }
 
 export function set_hash_to_home_view() {

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -12,7 +12,6 @@ import * as inbox_ui from "./inbox_ui";
 import * as inbox_util from "./inbox_util";
 import * as info_overlay from "./info_overlay";
 import * as message_lists from "./message_lists";
-import * as message_scroll from "./message_scroll";
 import * as message_viewport from "./message_viewport";
 import * as modals from "./modals";
 import * as narrow from "./narrow";
@@ -54,8 +53,7 @@ function maybe_hide_inbox() {
 function show_all_message_view() {
     const coming_from_recent_view = maybe_hide_recent_view();
     const coming_from_inbox = maybe_hide_inbox();
-    const is_actively_scrolling = message_scroll.is_actively_scrolling();
-    narrow.deactivate(coming_from_recent_view || coming_from_inbox, is_actively_scrolling);
+    narrow.deactivate(coming_from_recent_view || coming_from_inbox);
     // We need to maybe scroll to the selected message
     // once we have the proper viewport set up
     setTimeout(message_viewport.maybe_scroll_to_selected, 0);

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -68,8 +68,7 @@ export function handle_narrow_activated(filter) {
     if (ops.length >= 1) {
         filter_name = ops[0];
         if (filter_name === "home") {
-            $filter_li = $(".top_left_all_messages");
-            $filter_li.addClass("active-filter");
+            highlight_all_messages_view();
         }
     }
     ops = filter.operands("is");
@@ -141,6 +140,17 @@ export function highlight_recent_view() {
     remove($(".top_left_mentions"));
     remove($(".top_left_inbox"));
     $(".top_left_recent_view").addClass("active-filter");
+    setTimeout(() => {
+        resize.resize_stream_filters_container();
+    }, 0);
+}
+
+export function highlight_all_messages_view() {
+    remove($(".top_left_starred_messages"));
+    remove($(".top_left_mentions"));
+    remove($(".top_left_recent_view"));
+    remove($(".top_left_inbox"));
+    $(".top_left_all_messages").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -104,17 +104,6 @@ function toggle_condensed_navigation_area() {
     resize.resize_stream_filters_container();
 }
 
-export function highlight_recent_view() {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_mentions"));
-    remove($(".top_left_inbox"));
-    $(".top_left_recent_view").addClass("active-filter");
-    setTimeout(() => {
-        resize.resize_stream_filters_container();
-    }, 0);
-}
-
 export function animate_mention_changes($li, new_mention_count) {
     if (new_mention_count > last_mention_count) {
         do_new_messages_animation($li);
@@ -141,6 +130,17 @@ export function highlight_inbox_view() {
     remove($(".top_left_recent_view"));
     remove($(".top_left_mentions"));
     $(".top_left_inbox").addClass("active-filter");
+    setTimeout(() => {
+        resize.resize_stream_filters_container();
+    }, 0);
+}
+
+export function highlight_recent_view() {
+    remove($(".top_left_all_messages"));
+    remove($(".top_left_starred_messages"));
+    remove($(".top_left_mentions"));
+    remove($(".top_left_inbox"));
+    $(".top_left_recent_view").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -11,8 +11,6 @@ import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 
-let actively_scrolling = false;
-
 let hide_scroll_to_bottom_timer;
 export function hide_scroll_to_bottom() {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
@@ -57,12 +55,8 @@ $(document).on("keydown", (e) => {
     $("#scroll-to-bottom-button-container").removeClass("show");
 });
 
-export function is_actively_scrolling() {
-    return actively_scrolling;
-}
-
 export function scroll_finished() {
-    actively_scrolling = false;
+    message_scroll_state.set_actively_scrolling(false);
     message_lists.current.view.update_sticky_recipient_headers();
     hide_scroll_to_bottom();
 
@@ -106,7 +100,7 @@ export function scroll_finished() {
 
 let scroll_timer;
 function scroll_finish() {
-    actively_scrolling = true;
+    message_scroll_state.set_actively_scrolling(true);
 
     // Don't present the "scroll to bottom" widget if the current
     // scroll was triggered by the keyboard.

--- a/web/src/message_scroll_state.ts
+++ b/web/src/message_scroll_state.ts
@@ -13,3 +13,10 @@ export let keyboard_triggered_current_scroll = false;
 export function set_keyboard_triggered_current_scroll(value: boolean): void {
     keyboard_triggered_current_scroll = value;
 }
+
+// Whether a scroll is currently occurring.
+export let actively_scrolling = false;
+
+export function set_actively_scrolling(value: boolean): void {
+    actively_scrolling = value;
+}

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -970,7 +970,7 @@ function handle_post_narrow_deactivate_processes(msg_list) {
     message_feed_top_notices.update_top_of_narrow_notices(msg_list);
 }
 
-export function deactivate(coming_from_all_messages = true, is_actively_scrolling = false) {
+export function deactivate(message_feed_previously_hidden = false, is_actively_scrolling = false) {
     // NOTE: Never call this function independently,
     // always use browser_history.go_to_location("#all_messages") to
     // activate All message narrow.
@@ -989,7 +989,7 @@ export function deactivate(coming_from_all_messages = true, is_actively_scrollin
     search.clear_search_form();
     // Both All messages and Recent Conversations have `undefined` filter.
     // Return if already in the All message narrow.
-    if (narrow_state.filter() === undefined && coming_from_all_messages) {
+    if (narrow_state.filter() === undefined && !message_feed_previously_hidden) {
         return;
     }
     blueslip.debug("Unnarrowed");
@@ -997,7 +997,7 @@ export function deactivate(coming_from_all_messages = true, is_actively_scrollin
     if (is_actively_scrolling) {
         // There is no way to intercept in-flight scroll events, and they will
         // cause you to end up in the wrong place if you are actively scrolling
-        // on an unnarrow. Wait a bit and try again once the scrolling is over.
+        // on an unnarrow. Wait a bit and try again once the scrolling is likely over.
         setTimeout(deactivate, 50);
         return;
     }

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -970,6 +970,10 @@ function handle_post_narrow_deactivate_processes(msg_list) {
     message_edit.handle_narrow_deactivated();
     widgetize.set_widgets_for_list();
     message_feed_top_notices.update_top_of_narrow_notices(msg_list);
+
+    // We may need to scroll to the selected message after swapping
+    // the currently displayed center panel to zhome.
+    message_viewport.maybe_scroll_to_selected();
 }
 
 export function deactivate() {

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -28,6 +28,7 @@ import * as message_helper from "./message_helper";
 import * as message_list from "./message_list";
 import {MessageListData} from "./message_list_data";
 import * as message_lists from "./message_lists";
+import * as message_scroll_state from "./message_scroll_state";
 import * as message_store from "./message_store";
 import * as message_view_header from "./message_view_header";
 import * as message_viewport from "./message_viewport";
@@ -970,7 +971,7 @@ function handle_post_narrow_deactivate_processes(msg_list) {
     message_feed_top_notices.update_top_of_narrow_notices(msg_list);
 }
 
-export function deactivate(message_feed_previously_hidden = false, is_actively_scrolling = false) {
+export function deactivate(message_feed_previously_hidden = false) {
     // NOTE: Never call this function independently,
     // always use browser_history.go_to_location("#all_messages") to
     // activate All message narrow.
@@ -994,7 +995,7 @@ export function deactivate(message_feed_previously_hidden = false, is_actively_s
     }
     blueslip.debug("Unnarrowed");
 
-    if (is_actively_scrolling) {
+    if (message_scroll_state.actively_scrolling) {
         // There is no way to intercept in-flight scroll events, and they will
         // cause you to end up in the wrong place if you are actively scrolling
         // on an unnarrow. Wait a bit and try again once the scrolling is likely over.

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -972,7 +972,7 @@ function handle_post_narrow_deactivate_processes(msg_list) {
     message_feed_top_notices.update_top_of_narrow_notices(msg_list);
 }
 
-export function deactivate(message_feed_previously_hidden = false) {
+export function deactivate() {
     // NOTE: Never call this function independently,
     // always use browser_history.go_to_location("#all_messages") to
     // activate All message narrow.
@@ -990,14 +990,22 @@ export function deactivate(message_feed_previously_hidden = false) {
      */
     search.clear_search_form();
 
-    // If we're already looking at the All messages view, exit without
-    // doing any work.
-    if (
-        narrow_state.filter() === undefined &&
-        !message_feed_previously_hidden &&
-        has_visited_all_messages
-    ) {
+    const coming_from_recent_view = recent_view_util.is_visible();
+    const coming_from_inbox = inbox_util.is_visible();
+
+    if (coming_from_recent_view) {
+        recent_view_ui.hide();
+    } else if (coming_from_inbox) {
+        inbox_ui.hide();
+    } else if (narrow_state.filter() === undefined && has_visited_all_messages) {
+        // If we're already looking at the All messages view, exit without
+        // doing any work.
         return;
+    } else {
+        // We must instead be switching from another message view.
+        // Save the scroll position in that message list, so that
+        // we can restore it if/when we later navigate back to that view.
+        message_lists.save_pre_narrow_offset_for_reload();
     }
 
     has_visited_all_messages = true;

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -58,6 +58,7 @@ import * as util from "./util";
 import * as widgetize from "./widgetize";
 
 const LARGER_THAN_MAX_MESSAGE_ID = 10000000000000000;
+export let has_visited_all_messages = false;
 
 export function reset_ui_state() {
     // Resets the state of various visual UI elements that are
@@ -988,11 +989,19 @@ export function deactivate(message_feed_previously_hidden = false) {
       message_lists.home in it.
      */
     search.clear_search_form();
-    // Both All messages and Recent Conversations have `undefined` filter.
-    // Return if already in the All message narrow.
-    if (narrow_state.filter() === undefined && !message_feed_previously_hidden) {
+
+    // If we're already looking at the All messages view, exit without
+    // doing any work.
+    if (
+        narrow_state.filter() === undefined &&
+        !message_feed_previously_hidden &&
+        has_visited_all_messages
+    ) {
         return;
     }
+
+    has_visited_all_messages = true;
+
     blueslip.debug("Unnarrowed");
 
     if (message_scroll_state.actively_scrolling) {

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -60,6 +60,13 @@ run_test("narrowing", () => {
     assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
     assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
     assert.ok($(".top_left_inbox").hasClass("active-filter"));
+
+    left_sidebar_navigation_area.highlight_all_messages_view();
+    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
+    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
+    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
 });
 
 run_test("update_count_in_dom", () => {


### PR DESCRIPTION
This fixes [a code path](https://github.com/zulip/zulip/pull/27643#discussion_r1389691913) for highlighting the All messages navigation item on a reload, which left all users--whether All messages was their home view or not--without a proper highlight when reloading from `/#all_messages`.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20views.20section.20collapsible.20feedback/near/1678805)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before (All messages loses highlight after reload) | After |
| --- | --- |
| ![reload-all-messages-before](https://github.com/zulip/zulip/assets/170719/45f0aba8-1ef4-4e7f-a4a7-684a71e88911) | ![reload-all-messages-after](https://github.com/zulip/zulip/assets/170719/378ebc61-edd0-4463-90a4-ac3940ea54ea) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>