### PR TITLE
search: Do nothing for enter on empty search input.

### DIFF
--- a/web/src/search.js
+++ b/web/src/search.js
@@ -129,8 +129,14 @@ export function initialize({on_narrow_search}) {
                 // this codepath is that they first all blur the box to
                 // indicate that they've done what they need to do)
 
+                // If nothing is written in the search bar, we do nothing.
+                const search_string = $search_query_box.val();
+                if (search_string === "") {
+                    return;
+                }
+
                 // Pill is already added during keydown event of input pills.
-                narrow_or_search_for_term($search_query_box.val(), {on_narrow_search});
+                narrow_or_search_for_term(search_string, {on_narrow_search});
                 $search_query_box.trigger("blur");
             }
         });

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -27,7 +27,7 @@ run_test("clear_search_form", () => {
     assert.equal($("#search_query").val(), "");
 });
 
-run_test("initialize", ({override_rewire, mock_template}) => {
+run_test("initialize", ({mock_template}) => {
     const $search_query_box = $("#search_query");
     const $searchbox_form = $("#searchbox_form");
 
@@ -294,11 +294,16 @@ run_test("initialize", ({override_rewire, mock_template}) => {
 
     assert.ok(!is_blurred);
 
-    override_rewire(search, "exit_search", () => {});
+    _setup("as");
     ev.key = "Enter";
     $search_query_box.is = () => true;
     $searchbox_form.trigger(ev);
     assert.ok(is_blurred);
+
+    // We don't blur search for empty string input.
+    _setup("");
+    $searchbox_form.trigger(ev);
+    assert.ok(!is_blurred);
 
     _setup("ver");
     ev.key = "Enter";

--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -369,8 +369,13 @@ import {get_string_diff} from "../../src/util";
         }
         return i[0]
       })
+      if(this.query.length!==0){
 
       items.first().addClass('active')
+    }
+    else{
+      items.first().removeClass('active');
+    }
       this.$menu.html(items)
       return this
     }
@@ -513,7 +518,7 @@ import {get_string_diff} from "../../src/util";
         case 9: // tab
           if (!this.options.tabIsEnter) return
         case 13: // enter
-          if (!this.shown) return
+          if (!this.shown || this.query.length===0) return
           this.select(e)
           break
 


### PR DESCRIPTION
Previously, when the search was empty, the first typeahead suggestion was selected by default, and on clicking enter, it would navigate to that suggestion and close the search.

This PR removes that first typeahead selection and prevents closing of search bar upon pressing enter on empty string input.

Fixes: #27605 Don't do anything on Enter for empty search input 

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![brave_NI2UrNADhv](https://github.com/zulip/zulip/assets/97049524/798930cc-bd97-4375-b0dc-180afa6ecf0d)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
