### PR TITLE
stripe: Move `setup_upgrade_checkout_session_and...` to BillingSession.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1984,7 +1984,7 @@ class StripeTest(StripeTestCase):
                 stripe_session.id = "stripe_session_id"
                 stripe_session.url = "stripe_session_url"
                 with patch(
-                    "corporate.views.upgrade.setup_upgrade_checkout_session_and_payment_intent",
+                    "corporate.lib.stripe.BillingSession.setup_upgrade_checkout_session_and_payment_intent",
                     return_value=stripe_session,
                 ):
                     response = self.upgrade(
@@ -2039,7 +2039,7 @@ class StripeTest(StripeTestCase):
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
         with patch(
-            "corporate.views.upgrade.setup_upgrade_checkout_session_and_payment_intent",
+            "corporate.lib.stripe.BillingSession.setup_upgrade_checkout_session_and_payment_intent",
             side_effect=Exception,
         ), self.assertLogs("corporate.stripe", "WARNING") as m:
             response = self.upgrade(talk_to_stripe=False)


### PR DESCRIPTION
Moves the `setup_upgrade_checkout_session_and_payment_intent` function to the 'BillingSession' abstract class.

This refactoring will help in minimising duplicate code while supporting both realm and remote_server customers.





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
