### PR TITLE
left_sidebar: Present consistent header tooltips.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -215,7 +215,7 @@ export function initialize() {
 
     delegate("body", {
         target: [
-            "#streams_header .left-sidebar-title",
+            "#streams_header .streams-tooltip-target",
             "#userlist-title",
             "#user_filter_icon",
             "#scroll-to-bottom-button-clickable-area",

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -421,7 +421,7 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: "#pm_tooltip_container",
+        target: ".dm-tooltip-target",
         onShow(instance) {
             if ($(".direct-messages-container").hasClass("zoom-in")) {
                 return false;

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -434,7 +434,7 @@ export function initialize() {
             }
             return true;
         },
-        delay: LONG_HOVER_DELAY,
+        delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });
 
@@ -456,7 +456,7 @@ export function initialize() {
             }
             return true;
         },
-        delay: LONG_HOVER_DELAY,
+        delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });
 

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -421,6 +421,24 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".views-tooltip-target",
+        onShow(instance) {
+            if ($("#toggle-top-left-navigation-area-icon").hasClass("fa-caret-down")) {
+                instance.setContent(
+                    $t({
+                        defaultMessage: "Collapse views",
+                    }),
+                );
+            } else {
+                instance.setContent($t({defaultMessage: "Expand views"}));
+            }
+            return true;
+        },
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+    });
+
+    delegate("body", {
         target: ".dm-tooltip-target",
         onShow(instance) {
             if ($(".direct-messages-container").hasClass("zoom-in")) {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,9 +1,9 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="showing-expanded-navigation hidden-for-spectators">
-            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down" aria-hidden="true"></i>
+            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down views-tooltip-target" aria-hidden="true"></i>
             {{~!-- squash whitespace --~}}
-            <h4 class="left-sidebar-title">{{t 'VIEWS' }}</h4>
+            <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
                 <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
                     <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -136,8 +136,8 @@
     <div id="private_messages_sticky_header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
-                <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-                <h4 id="pm_tooltip_container" class="left-sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
+                <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+                <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <span class="unread_count"></span>
                 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -158,7 +158,7 @@
 
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide">
-                <h4 class="left-sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
+                <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 </div>


### PR DESCRIPTION
This PR improves the presentation and consistency of tooltips on the left sidebar's headers. Specifically, it:

1. Adds an expand/collapse tooltip to the Views header to make that header consistent with the tooltip on the DMs header
2. It introduces `<span>` elements to keep the tooltip centered on the heading text, rather than the heading's area in the grid (which can be much wider than the text itself); this fixes a regression introduced in #27638
3. It adds an `EXTRA_LONG_HOVER_DELAY` to the expand/collapse tooltips on the Views and DMs headers so as not to distract users familiar with the UI
4. For Views and DMs rows, it adds the expand/collapse tooltip to the arrows as well; while there isn't a contiguous area with the arrow and the heading text following the grid-row rewrites, the extra-long hover delay makes that less obvious for users dragging their mouse from the arrow to the text, or vice-versa.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/tooltips.20on.20Direct.20Messages.20heading/near/1678507)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
(Note that, because it advertises a keyboard shortcut, the Streams tooltip still pops up more quickly than the expand/collapse tooltips. Also, the tooltip on the Views header has been shortened to "Expand views" and "Collapse views" since this screenshot was captured.)

![left-sidebar-header-tooltips](https://github.com/zulip/zulip/assets/170719/cd70935c-1bea-44ce-a318-8f87616c99de)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
