### PR TITLE
hotkey: Give feedback when no unreads left in followed topics.

### DIFF
--- a/web/src/feedback_widget.ts
+++ b/web/src/feedback_widget.ts
@@ -152,7 +152,11 @@ export function show(opts: FeedbackWidgetOptions): void {
 
     meta.$container = $("#feedback_container");
 
-    const html = render_feedback_container({});
+    let has_undo_button = true;
+    if (opts.on_undo === undefined) {
+        has_undo_button = false;
+    }
+    const html = render_feedback_container({has_undo_button});
     meta.$container.html(html);
 
     set_up_handlers();

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -12,9 +12,11 @@ import * as compose_fade from "./compose_fade";
 import * as compose_recipient from "./compose_recipient";
 import * as compose_state from "./compose_state";
 import * as condense from "./condense";
+import * as feedback_widget from "./feedback_widget";
 import {Filter} from "./filter";
 import * as hash_parser from "./hash_parser";
 import * as hash_util from "./hash_util";
+import {$t} from "./i18n";
 import * as inbox_ui from "./inbox_ui";
 import * as inbox_util from "./inbox_util";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area";
@@ -775,6 +777,18 @@ export function narrow_to_next_topic(opts = {}) {
         curr_info.topic,
         opts.only_followed_topics,
     );
+
+    if (!next_narrow && opts.only_followed_topics) {
+        feedback_widget.show({
+            populate($container) {
+                $container.text(
+                    $t({defaultMessage: "You have no unread messages in followed topics."}),
+                );
+            },
+            title_text: $t({defaultMessage: "You're done!"}),
+        });
+        return;
+    }
 
     if (!next_narrow) {
         return;

--- a/web/templates/feedback_container.hbs
+++ b/web/templates/feedback_container.hbs
@@ -1,7 +1,9 @@
 <div class="float-header">
     <h3 class="light no-margin small-line-height float-left feedback_title"></h3>
     <div class="exit-me float-right">&#215;</div>
-    <button class="button small rounded float-right feedback_undo" type="button" name="button"></button>
+    {{#if has_undo_button}}
+        <button class="button small rounded float-right feedback_undo" type="button" name="button"></button>
+    {{/if}}
     <div class="float-clear"></div>
 </div>
 <p class="n-margin feedback_content"></p>


### PR DESCRIPTION
When navigating to the next unread followed topic using the Shift+N hotkey, we notify the user using `feedback_widget` when there are no more unread messages in followed topics.

Fixes: #27604




**Screenshots and screen captures:**

[no-more-unread.webm](https://github.com/zulip/zulip/assets/56781761/f88ab472-07f4-4987-8118-f4ca9e895462)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
