### PR TITLE
Improve documentation for followed topics

### DIFF
--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -1,10 +1,24 @@
 # Follow a topic
 
-Zulip lets you follow topics you are interested in. You can configure how you
-get notified about new messages for topics you follow.
+Zulip lets you follow topics you are interested in. You can follow or unfollow
+any topic. You can also configure Zulip to automatically follow topics you start
+or participate in.
 
-In muted streams, topics you follow are automatically treated as
-[unmuted](/help/mute-a-topic).
+It's easy to prioritize catching up on followed topics. You can:
+
+- Configure how you get notified about new messages for topics you follow.
+
+- Use the <kbd>Shift</kbd> + <kbd>N</kbd> keyboard shortcut to go to the next
+  unread followed topic.
+
+- Filter the [**inbox**](/help/inbox) view to only show followed topics.
+
+- See which topics are followed in the **left sidebar** and [**recent
+  conversations**](/help/recent-conversations).
+
+You can use followed topics for a variety of workflows:
+
+{!followed-topic-workflows.md!}
 
 ## Follow or unfollow a topic
 
@@ -13,6 +27,32 @@ In muted streams, topics you follow are automatically treated as
 {tab|desktop-web}
 
 {!configure-topic-notifications-desktop-web.md!}
+
+{end_tabs}
+
+## Catch up on followed topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!go-to-inbox.md!}
+
+1. Filter the view to the topics you follow by selecting **Followed topics** in
+   the dropdown in the upper left.
+
+1. Click on a conversation you're interested in to view it. You can also use
+   the arrow keys to select a conversation, and press <kbd>Enter</kbd>.
+
+2. Return to **Inbox** when done to select the next conversation. You can use
+   the **back** button in your browser or the desktop app, <kbd>Shift</kbd> +
+   <kbd>I</kbd>, or <kbd>Esc</kbd> if **Inbox** is configured as you [home
+   view](/help/configure-home-view).
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Shift</kbd> + <kbd>N</kbd> to go to the next unread
+    followed topic from any location.
 
 {end_tabs}
 
@@ -36,6 +76,7 @@ In muted streams, topics you follow are automatically treated as
 
 ## Related articles
 
+* [Reading strategies](/help/reading-strategies)
 * [Topic notifications](/help/topic-notifications)
 * [Stream notifications](/help/stream-notifications)
 * [Mute or unmute a topic](/help/mute-a-topic)

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -14,10 +14,13 @@ regularly clear all unread messages in your subscribed streams.
     The arrow keys and vim navigation keys (<kbd>J</kbd>, <kbd>K</kbd>,
     <kbd>L</kbd>, <kbd>H</kbd>) can be used to move between elements.
 
-## Include muted conversations
+## Filter conversations
 
-In the web app, you can control whether **Inbox** includes muted
-conversations.
+### Filter by topic state
+
+In the web app, you can control whether the **Inbox** includes all topics, just
+[unmuted](/help/mute-a-topic) topics, or only topics you
+[follow](/help/follow-a-topic).
 
 {start_tabs}
 
@@ -25,11 +28,12 @@ conversations.
 
 {!go-to-inbox.md!}
 
-1. Toggle **Include muted** next to the filter box at the top.
+1. Select **All topics**, **Unmuted topics**, or **Followed topics** in
+   the dropdown in the upper left.
 
 {end_tabs}
 
-## Filter conversations
+### Filter by keyword
 
 {start_tabs}
 

--- a/help/include/followed-topic-workflows.md
+++ b/help/include/followed-topic-workflows.md
@@ -1,0 +1,20 @@
+- [Catch up](/help/follow-a-topic#catch-up-on-followed-topics) on
+  followed topics at the start of the day, and whenever you want to
+  spend a few minutes checking on where your attention is needed.
+
+- No more stressing about missing a reply to your message in streams
+  you don't regularly read. You can [automatically
+  follow](/help/follow-a-topic#automatically-follow-topics) topics you
+  start or participate in.
+
+- You can also [mute](/help/mute-a-stream) the streams you don't
+  regularly read, and [automatically follow or
+  unmute](/help/follow-a-topic#automatically-follow-topics) topics you
+  start or participate in. In muted streams, topics you follow are
+  automatically treated as [unmuted](/help/mute-a-topic), so it will
+  be easy to see when someone responds to your message.
+
+- If you like, follow just the topics where you prompt attention is
+  needed, and [enable desktop and mobile
+  notifications](/help/follow-a-topic#configure-notifications-for-followed-topics)
+  for followed topics.

--- a/help/include/view-starred-messages.md
+++ b/help/include/view-starred-messages.md
@@ -1,6 +1,6 @@
 {start_tabs}
 
-{tab|desktop}
+{tab|desktop-web}
 
 1. Click on <i class="zulip-icon zulip-icon-star-filled"></i> **Starred messages**
    (or <i class="zulip-icon zulip-icon-star-filled"></i> if the **views**

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -34,6 +34,15 @@ in Zulip.
 
 {!reading-conversations.md!}
 
+### Following, muting and unmuting conversations
+
+You can improve your workflow for catching up on messages by taking advantage of
+[following topics](/help/follow-a-topic), as well as muting and unmuting
+[streams](/help/mute-a-stream) and [topics](/help/mute-a-topic). Some example
+workflows:
+
+{!followed-topic-workflows.md!}
+
 ## Combined views
 
 ### All messages


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes part of #27510, but I'd like to keep it open for now.

1. Updates Inbox view documentation for #27552.

Because the dropdown is unlabeled, I think it's worth listing out the options.

<details>
<summary>
Screenshot
</summary>

Current: https://chat.zulip.org/help/inbox#include-muted-conversations

<img width="944" alt="Screenshot 2023-11-10 at 11 57 29 AM" src="https://github.com/zulip/zulip/assets/2090066/2a755282-35d4-4a08-b045-bd479295d49f">

</details>


2. Adds instructions for going though your followed topics.
<details>
<summary>
Screenshot
</summary>

Current page (this section is new): https://chat.zulip.org/help/follow-a-topic
![Screenshot 2023-11-10 at 1 16 19 PM](https://github.com/zulip/zulip/assets/2090066/ceadb5df-9272-4138-a503-6a725c296c7a)

</details>

3. Documents some workflows with followed topics on https://chat.zulip.org/help/follow-a-topic and https://chat.zulip.org/help/reading-strategies.

<details>
<summary>
Screenshots
</summary>

![Screenshot 2023-11-10 at 1 16 10 PM](https://github.com/zulip/zulip/assets/2090066/598f7ac1-a1bd-4015-8803-c20478d30dcf)

![Screenshot 2023-11-10 at 1 16 37 PM](https://github.com/zulip/zulip/assets/2090066/bae95d0e-186c-4bd2-853c-8b83a842d8f8)

</details>


