### PR TITLE
search: Remove "All messages" typeahead

### DIFF
--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -500,11 +500,6 @@ function get_special_filter_suggestions(last, operators, suggestions) {
             s.description_html.toLowerCase().startsWith(last_string)
         );
     });
-
-    // Only show home if there's an empty bar
-    if (operators.length === 0 && last_string === "") {
-        suggestions.unshift({search_string: "", description_html: "All messages"});
-    }
     return suggestions;
 }
 

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -95,7 +95,7 @@ test("basic_get_suggestions_for_spectator", () => {
 
     const query = "";
     const suggestions = get_suggestions(query);
-    assert.deepEqual(suggestions.strings, ["", "has:link", "has:image", "has:attachment"]);
+    assert.deepEqual(suggestions.strings, ["has:link", "has:image", "has:attachment"]);
     page_params.is_spectator = false;
 });
 
@@ -419,7 +419,6 @@ test("empty_query_suggestions", () => {
     const suggestions = get_suggestions(query);
 
     const expected = [
-        "",
         "streams:public",
         "is:dm",
         "is:starred",


### PR DESCRIPTION
Previously, the "All messages" typeahead would be shown whenever the search bar had an empty input. This change removes that typeahead completely in favor of using other filters such as -is:muted.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/search.20bar.20UX/near/1662286)

Fixes #27358

<details>
<summary>Self-review checklist</summary>

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
