### PR TITLE
inbox: Fix search icon position on narrow widths.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -55,10 +55,14 @@
 
         #inbox-filters {
             .zulip-icon-search-inbox {
-                position: absolute;
-                top: 23px;
-                /* 5px (dropdown right margin) + 7.5px (= (30px left padding - 15px icon width) / 2)  = 12.5px */
-                left: calc(var(--width-inbox-filters-dropdown) + 12.5px);
+                position: relative;
+                /* We need to position the icon relative to the filters dropdown since its width is variable.
+                   To avoid icon from taking width since it is no longer absolute/fixed positioned, we set its width to 0. */
+                width: 0;
+                /* (30px filters height - 15px icon height) / 2)  = 7.5px */
+                top: 7.5px;
+                /* (30px left padding - 15px icon width) / 2)  = 7.5px */
+                left: 7.5px;
                 color: var(--color-icons-inbox);
                 opacity: 0.4;
             }

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -1,11 +1,11 @@
 <div id="inbox-main" class="no-select">
     <div class="search_group" id="inbox-filters" role="group">
         {{> ../dropdown_widget widget_name="inbox-filter"}}
+        <i class="zulip-icon zulip-icon-search-inbox"></i>
         <input type="text" id="{{INBOX_SEARCH_ID}}" value="{{search_val}}" autocomplete="off" placeholder="{{t 'Filter' }}" />
         <button id="inbox-clear-search">
             <i class="zulip-icon zulip-icon-close-small"></i>
         </button>
-        <i class="zulip-icon zulip-icon-search-inbox"></i>
     </div>
     <div id="inbox-empty-with-search" class="inbox-empty-text empty-list-message">
         {{t "No conversations match your filters."}}


### PR DESCRIPTION
Due to filters dropdown's variable width, the search icon was incorrectly positioned, we fix it by positioning it relative to the filter dropdown.

| before | after |
| --- | --- |
| <img width="361" alt="Screenshot 2023-11-11 at 7 18 19 AM" src="https://github.com/zulip/zulip/assets/25124304/c08fd568-4c0a-4785-9a7a-45d6e567f3c2"> | <img width="361" alt="Screenshot 2023-11-11 at 7 18 01 AM" src="https://github.com/zulip/zulip/assets/25124304/24229e26-a50f-4b4e-ad59-e8b476b2dd05"> |
