### PR TITLE
Left-Sidebar: Empty unread counts now hidden by visibiliy:hidden

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -156,7 +156,7 @@ li.show-more-topics {
         }
 
         .unread_count {
-            display: none;
+            visibility: hidden;
         }
     }
 
@@ -574,7 +574,7 @@ li.active-sub-filter {
         }
 
         &.top_left_starred_messages .unread_count {
-            display: none;
+            visibility: hidden;
         }
     }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -193,7 +193,7 @@ $user_status_emoji_width: 24px;
     }
 
     .unread_count {
-        display: none;
+        visibility: hidden;
         margin-top: 2.5px;
     }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Hiding empty counts currently uses "display: none," but this clashes with using "display: flex" to center the text in the unread count vertically. To avoid problems, I've changed "display: none" to "visibility: hidden" instead for empty or zero counts.
Fixes part of #27567<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| ----- | ----- |
| ![image](https://github.com/zulip/zulip/assets/91622060/4dc5268f-38e8-4b5d-a788-3b0b12edc177) | ![image](https://github.com/zulip/zulip/assets/91622060/8e55eb44-4861-4d07-a155-2d2417f0e9d8) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
