### PR TITLE
message_view_header: Add tooltip to stream name in top navbar.

### DIFF
--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -48,11 +48,7 @@ function make_message_view_header(filter) {
         message_view_header.rendered_narrow_description = current_stream.rendered_description;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
         message_view_header.sub_count = sub_count;
-        // the "title" is passed as a variable and doesn't get translated (nor should it)
-        message_view_header.sub_count_tooltip_text = $t(
-            {defaultMessage: "This stream has {count} subscribers."},
-            {count: message_view_header.sub_count},
-        );
+        message_view_header.stream = current_stream;
         message_view_header.stream_settings_link =
             "#streams/" + current_stream.stream_id + "/" + current_stream.name;
     }

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -1,7 +1,18 @@
 {{#if stream_settings_link}}
-<a class="message-header-stream-settings-button" href="{{stream_settings_link}}">
+<a class="message-header-stream-settings-button tippy-zulip-tooltip" data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
+<template id="stream-details-tooltip-template">
+    <div>
+        <div>
+            {{#tr}}
+                Go to <z-stream></z-stream> settings
+                {{#*inline "z-stream"}}{{> inline_decorated_stream_name stream=stream}}{{/inline}}
+            {{/tr}}
+        </div>
+        <div class="tooltip-inner-content">{{t "{sub_count, plural, =0 {No subscribers} one {# subscriber} other {# subscribers}}" }}</div>
+    </div>
+</template>
 <span class="narrow_description rendered_markdown">
     {{#if rendered_narrow_description}}
     {{rendered_markdown rendered_narrow_description}}


### PR DESCRIPTION
At present, it's not obvious that clicking on the stream name in the top navbar will take the user to stream settings. To make it more apparent, we add a tooltip to the stream name, explicitly indicating its functionality.

We also add a second line to the tooltip thar displays the number of subscribers to the stream and remove the tooltip from the number of subscribers indicator on the top navbar. These changes are in preparation for removing the number of subscribers indicator from the top navbar.

Fixes #27360.

Previous work: #27466

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/stream.20subscribers.20in.20top.20bar/near/1666842)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Stream Name tooltip
![image](https://github.com/zulip/zulip/assets/82862779/8fcb559c-ac8f-4712-a0ef-0761db5f5f41)
- Tooltip removed from number of subscribers indicator
![image](https://github.com/zulip/zulip/assets/82862779/6c7d6d88-b357-4fc0-b62a-fbc8af388798)
- Stream Name tooltip with a large number of subscribers (see number formatting)
![image](https://github.com/zulip/zulip/assets/82862779/991db3f9-40a9-4cb5-a892-30fae0dbbb66)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
