### PR TITLE
filters : removal of All filter from recent conversations

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -790,14 +790,18 @@ function show_selected_filters() {
     }
 }
 
-export function update_filters_view() {
-    const rendered_filters = render_recent_view_filters({
+function get_recent_view_filters_params() {
+    return {
         filter_participated: filters.has("participated"),
         filter_unread: filters.has("unread"),
         filter_muted: filters.has("include_muted"),
         filter_pm: filters.has("include_private"),
         is_spectator: page_params.is_spectator,
-    });
+    };
+}
+
+export function update_filters_view() {
+    const rendered_filters = render_recent_view_filters(get_recent_view_filters_params());
     $("#recent_filters_group").html(rendered_filters);
     show_selected_filters();
 
@@ -949,12 +953,8 @@ export function complete_rerender() {
     }
 
     const rendered_body = render_recent_view_body({
-        filter_participated: filters.has("participated"),
-        filter_unread: filters.has("unread"),
-        filter_muted: filters.has("include_muted"),
-        filter_pm: filters.has("include_private"),
         search_val: $("#recent_view_search").val() || "",
-        is_spectator: page_params.is_spectator,
+        ...get_recent_view_filters_params(),
     });
     $("#recent_view_table").html(rendered_body);
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -769,11 +769,7 @@ export function set_filter(filter) {
         `[data-filter="${CSS.escape(filter)}"]`,
     );
 
-    // If user clicks `All`, we clear all filters.
-    if (filter === "all" && filters.size !== 0) {
-        filters = new Set();
-        // If the button was already selected, remove the filter.
-    } else if ($filter_elem.hasClass("btn-recent-selected")) {
+    if ($filter_elem.hasClass("btn-recent-selected")) {
         filters.delete(filter);
         // If the button was not selected, we add the filter.
     } else {
@@ -786,18 +782,11 @@ export function set_filter(filter) {
 function show_selected_filters() {
     // Add `btn-selected-filter` to the buttons to show
     // which filters are applied.
-    if (filters.size === 0) {
+    for (const filter of filters) {
         $("#recent_view_filter_buttons")
-            .find('[data-filter="all"]')
+            .find(`[data-filter="${CSS.escape(filter)}"]`)
             .addClass("btn-recent-selected")
             .attr("aria-checked", "true");
-    } else {
-        for (const filter of filters) {
-            $("#recent_view_filter_buttons")
-                .find(`[data-filter="${CSS.escape(filter)}"]`)
-                .addClass("btn-recent-selected")
-                .attr("aria-checked", "true");
-        }
     }
 }
 

--- a/web/templates/recent_view_filters.hbs
+++ b/web/templates/recent_view_filters.hbs
@@ -1,4 +1,3 @@
-<button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
 <button data-filter="include_private" type="button" class="btn btn-default btn-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="true">
     {{#if filter_pm}}
     <i class="fa fa-check-square-o"></i>

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -420,7 +420,7 @@ function stub_out_filter_buttons() {
     //
     //       See show_selected_filters() and set_filter() in the
     //       implementation.
-    for (const filter of ["all", "unread", "muted", "participated", "include_private"]) {
+    for (const filter of ["unread", "muted", "participated", "include_private"]) {
         const $stub = $.create(`filter-${filter}-stub`);
         const selector = `[data-filter="${filter}"]`;
         $("#recent_view_filter_buttons").set_find_results(selector, $stub);
@@ -499,11 +499,10 @@ test("test_filter_is_spectator", ({mock_template}) => {
     rt.clear_for_tests();
     stub_out_filter_buttons();
     recent_view_util.set_visible(true);
-    rt.set_filter("all");
     rt.process_messages([messages[0]]);
 });
 
-test("test_filter_all", ({mock_template}) => {
+test("test_no_filter", ({mock_template}) => {
     // Just tests inplace rerender of a message
     // in All topics filter.
     page_params.is_spectator = false;
@@ -534,7 +533,6 @@ test("test_filter_all", ({mock_template}) => {
     rt.clear_for_tests();
     stub_out_filter_buttons();
     recent_view_util.set_visible(true);
-    rt.set_filter("all");
     rt.process_messages([messages[0]]);
     assert.equal(
         rt.filters_should_hide_topic({last_msg_id: 1, participated: true, type: "stream"}),
@@ -794,9 +792,6 @@ test("test_filter_unread", ({mock_template}) => {
     $("#recent_view_filter_buttons").removeClass("btn-recent-selected");
     // reselect "unread" filter
     rt.set_filter("unread");
-
-    // Now clicking "all" filter should have no change to expected data.
-    rt.set_filter("all");
 });
 
 test("test_filter_participated", ({mock_template}) => {
@@ -921,16 +916,12 @@ test("test_filter_participated", ({mock_template}) => {
     ];
 
     rt.process_messages([messages[4]]);
-
-    expected_filter_participated = false;
-    rt.set_filter("all");
 });
 
 test("test_update_unread_count", () => {
     recent_view_util.set_visible(false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    rt.set_filter("all");
     rt.process_messages(messages);
 
     // update a message
@@ -950,7 +941,6 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     stub_out_filter_buttons();
     recent_view_util.set_visible(true);
     rt.set_default_focus();
-    rt.set_filter("all");
     rt.process_messages(messages);
     let all_topics = rt_data.get_conversations();
 
@@ -1078,7 +1068,6 @@ test("test_reify_local_echo_message", ({mock_template}) => {
     rt.clear_for_tests();
     stub_out_filter_buttons();
     recent_view_util.set_visible(true);
-    rt.set_filter("all");
     rt.process_messages(messages);
 
     rt_data.process_message({
@@ -1127,7 +1116,6 @@ test("test_delete_messages", ({override}) => {
     recent_view_util.set_visible(false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    rt.set_filter("all");
     rt.process_messages(messages);
 
     // messages[0] was removed.
@@ -1169,7 +1157,6 @@ test("test_topic_edit", ({override}) => {
     // NOTE: This test should always run in the end as it modified the messages data.
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    rt.set_filter("all");
     rt.process_messages(messages);
 
     let all_topics = rt_data.get_conversations();


### PR DESCRIPTION
Earlier All filter button is included in recent conversations which is used to shown all conversations and clears remaining filters whose functionality is confusing

This PR Removes "All" filter and corresponding js along with modified tests to enables control filters individually

Fixes #27588

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**
<img width="885" alt="Screenshot 2023-11-07 at 10 53 44 PM" src="https://github.com/zulip/zulip/assets/88829894/15d2524e-0423-4ffd-b21c-37340b9fe6ec">
**After:**
<img width="883" alt="Screenshot 2023-11-07 at 11 07 24 PM" src="https://github.com/zulip/zulip/assets/88829894/7662d645-14d5-4f6e-b734-74982705180b">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
