### PR TITLE
addsubscriberspill : Made error message disappear when user inputs

### DIFF
--- a/web/src/add_subscribers_pill.js
+++ b/web/src/add_subscribers_pill.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 import * as input_pill from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import * as pill_typeahead from "./pill_typeahead";
@@ -61,6 +63,7 @@ export function create({$pill_container, get_potential_subscribers}) {
 
     const $pill_widget_input = $pill_container.find(".input");
     const $pill_widget_button = $pill_container.parent().find(".add-subscriber-button");
+    const $stream_subscription_req_result_elem = $(".stream_subscription_request_result")[0];
     // Disable the add button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 
@@ -70,12 +73,13 @@ export function create({$pill_container, get_potential_subscribers}) {
     );
     // Disable the add button when there is no pending text that can be converted
     // into a pill and the number of existing pills is zero.
-    $pill_widget_input.on("input", () =>
+    $pill_widget_input.on("input", () => {
         $pill_widget_button.prop(
             "disabled",
             !pill_widget.is_pending() && pill_widget.items().length === 0,
-        ),
-    );
+        );
+        $stream_subscription_req_result_elem.innerHTML = "";
+    });
 
     return pill_widget;
 }

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -55,10 +55,14 @@
 
         #inbox-filters {
             .zulip-icon-search-inbox {
-                position: absolute;
-                top: 23px;
-                /* 5px (dropdown right margin) + 7.5px (= (30px left padding - 15px icon width) / 2)  = 12.5px */
-                left: calc(var(--width-inbox-filters-dropdown) + 12.5px);
+                position: relative;
+                /* We need to position the icon relative to the filters dropdown since its width is variable.
+                   To avoid icon from taking width since it is no longer absolute/fixed positioned, we set its width to 0. */
+                width: 0;
+                /* (30px filters height - 15px icon height) / 2)  = 7.5px */
+                top: 7.5px;
+                /* (30px left padding - 15px icon width) / 2)  = 7.5px */
+                left: 7.5px;
                 color: var(--color-icons-inbox);
                 opacity: 0.4;
             }

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -1,11 +1,11 @@
 <div id="inbox-main" class="no-select">
     <div class="search_group" id="inbox-filters" role="group">
         {{> ../dropdown_widget widget_name="inbox-filter"}}
+        <i class="zulip-icon zulip-icon-search-inbox"></i>
         <input type="text" id="{{INBOX_SEARCH_ID}}" value="{{search_val}}" autocomplete="off" placeholder="{{t 'Filter' }}" />
         <button id="inbox-clear-search">
             <i class="zulip-icon zulip-icon-close-small"></i>
         </button>
-        <i class="zulip-icon zulip-icon-search-inbox"></i>
     </div>
     <div id="inbox-empty-with-search" class="inbox-empty-text empty-list-message">
         {{t "No conversations match your filters."}}


### PR DESCRIPTION
Previously, when wrong username is entered in the Stream Membership input to subscribe a user then "No User to Subscribe" error is thrown but the error is expected to fade away it remains until successful user is added and the same goes for succesfull messages too

This PR uses the `stream_subscription_req_result_elem` div which is responsible for showing both error and successful messages and makes the `innerHTML` to empty when user inputs into the input box which result in removal of message

Fixes : #27438

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Before:**

https://github.com/zulip/zulip/assets/88829894/0ccf3962-9936-4f35-8fbb-77245419eb9d

**After:**

https://github.com/zulip/zulip/assets/88829894/66e64ca4-c6ff-4bac-90ab-1bfd783200ed

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
