### PR TITLE
refactor: Rename `is_search` to `is_keyword_search` for clarity.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -448,7 +448,7 @@ export class Filter {
         });
     }
 
-    is_search() {
+    is_keyword_search() {
         return this.has_operator("search");
     }
 
@@ -803,7 +803,7 @@ export class Filter {
         // Since there can be multiple operators, each block should
         // just return false here.
 
-        if (this.is_search()) {
+        if (this.is_keyword_search()) {
             // The semantics for matching keywords are implemented
             // by database plugins, and we don't have JS code for
             // that, plus search queries tend to go too far back in

--- a/web/src/message_feed_top_notices.js
+++ b/web/src/message_feed_top_notices.js
@@ -48,7 +48,7 @@ export function update_top_of_narrow_notices(msg_list) {
         }
         // Potentially display the notice that lets users know
         // that not all messages were searched.  One could
-        // imagine including `filter.is_search()` in these
+        // imagine including `filter.is_keyword_search()` in these
         // conditions, but there's a very legitimate use case
         // for moderation of searching for all messages sent
         // by a potential spammer user.

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -181,8 +181,8 @@ export class MessageList {
         return this.data.nth_most_recent_id(n);
     }
 
-    is_search() {
-        return this.data.is_search();
+    is_keyword_search() {
+        return this.data.is_keyword_search();
     }
 
     can_mark_messages_read() {

--- a/web/src/message_list_data.js
+++ b/web/src/message_list_data.js
@@ -202,8 +202,8 @@ export class MessageListData {
         this._selected_id = this.closest_id(this._selected_id);
     }
 
-    is_search() {
-        return this.filter.is_search();
+    is_keyword_search() {
+        return this.filter.is_keyword_search();
     }
     can_mark_messages_read() {
         return this.filter.can_mark_messages_read();

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -866,7 +866,7 @@ export class MessageListView {
 
             $rendered_groups = this._render_group({
                 message_groups: message_actions.prepend_groups,
-                use_match_properties: this.list.is_search(),
+                use_match_properties: this.list.is_keyword_search(),
                 table_name: this.table_name,
             });
 
@@ -893,7 +893,7 @@ export class MessageListView {
 
                 $rendered_groups = this._render_group({
                     message_groups: [message_group],
-                    use_match_properties: this.list.is_search(),
+                    use_match_properties: this.list.is_keyword_search(),
                     table_name: this.table_name,
                 });
 
@@ -930,7 +930,7 @@ export class MessageListView {
 
             $rendered_groups = this._render_group({
                 message_groups: message_actions.append_groups,
-                use_match_properties: this.list.is_search(),
+                use_match_properties: this.list.is_keyword_search(),
                 table_name: this.table_name,
             });
 

--- a/web/src/narrow_state.js
+++ b/web/src/narrow_state.js
@@ -348,7 +348,7 @@ export function narrowed_to_topic() {
 }
 
 export function narrowed_to_search() {
-    return current_filter !== undefined && current_filter.is_search();
+    return current_filter !== undefined && current_filter.is_keyword_search();
 }
 
 export function narrowed_to_starred() {

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -200,7 +200,7 @@ export function clear_search_form() {
 // to set the initial text and to see if the user has changed it.
 function get_initial_search_string() {
     let search_string = narrow_state.search_string();
-    if (search_string !== "" && !narrow_state.filter().is_search()) {
+    if (search_string !== "" && !narrow_state.filter().is_keyword_search()) {
         // saves the user a keystroke for quick searches
         search_string = search_string + " ";
     }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -96,7 +96,7 @@ test("basics", () => {
     assert.ok(!filter.has_operand("stream", "exclude_stream"));
     assert.ok(!filter.has_operand("stream", "nada"));
 
-    assert.ok(!filter.is_search());
+    assert.ok(!filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());
@@ -113,7 +113,7 @@ test("basics", () => {
     ];
     filter = new Filter(operators);
 
-    assert.ok(filter.is_search());
+    assert.ok(filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());
@@ -131,7 +131,7 @@ test("basics", () => {
     ];
     filter = new Filter(operators);
 
-    assert.ok(!filter.is_search());
+    assert.ok(!filter.is_keyword_search());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());
@@ -320,7 +320,7 @@ test("basics", () => {
     ];
     filter = new Filter(operators);
 
-    assert.ok(!filter.is_search());
+    assert.ok(!filter.is_keyword_search());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.contains_only_private_messages());

--- a/web/tests/message_list_data.test.js
+++ b/web/tests/message_list_data.test.js
@@ -42,7 +42,7 @@ run_test("basics", () => {
         filter: new Filter(),
     });
 
-    assert.equal(mld.is_search(), false);
+    assert.equal(mld.is_keyword_search(), false);
     assert.ok(mld.can_mark_messages_read());
     mld.add_anywhere(make_msgs([35, 25, 15, 45]));
 

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -319,7 +319,7 @@ run_test("initiate_search", () => {
     // this implicitly expects the code to used the chained
     // function calls, which is something to keep in mind if
     // this test ever fails unexpectedly.
-    narrow_state.filter = () => ({is_search: () => false});
+    narrow_state.filter = () => ({is_keyword_search: () => false});
     let typeahead_forced_open = false;
     let is_searchbox_text_selected = false;
     $("#search_query").typeahead = (lookup) => {


### PR DESCRIPTION
For more clarity, the 3 related functions `is_search` in `filter.js`, `message_list.js` and `message_list_data.js` are all renamed to `is_keyword_search`.

Fixes: [issue brought up here](https://github.com/zulip/zulip/pull/27509#discussion_r1389955254)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
