### PR TITLE
Unset `is_web_public` field on attachments when deactivating stream.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -201,10 +201,13 @@ def do_unarchive_stream(
     ).only("id")
     cache_delete_many(to_dict_cache_key_id(message.id) for message in messages)
 
-    # Unset the is_web_public cache on attachments, since the stream is now private.
-    Attachment.objects.filter(messages__recipient_id=stream.recipient_id).update(is_web_public=None)
+    # Unset the is_web_public and is_realm_public cache on attachments,
+    # since the stream is now private.
+    Attachment.objects.filter(messages__recipient_id=stream.recipient_id).update(
+        is_web_public=None, is_realm_public=None
+    )
     ArchivedAttachment.objects.filter(messages__recipient_id=stream.recipient_id).update(
-        is_web_public=None
+        is_web_public=None, is_realm_public=None
     )
 
     RealmAuditLog.objects.create(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to unset `is_realm_public` field when unarchiving streams.
- Second commit is to unset `is_web_public` field when deactivating streams.

Fixes: <!-- Issue link, or clear description.--> #27634

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
