### PR TITLE
stripe: Move `process_initial_upgrade` to BillingSession.

### DIFF
--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -18,7 +18,6 @@ from corporate.lib.stripe import (
     ensure_customer_does_not_have_active_plan,
     get_latest_seat_count,
     is_free_trial_offer_enabled,
-    process_initial_upgrade,
     sign_string,
     unsign_string,
     validate_licenses,
@@ -119,8 +118,8 @@ def upgrade(
         billing_schedule = {"annual": CustomerPlan.ANNUAL, "monthly": CustomerPlan.MONTHLY}[
             schedule
         ]
+        billing_session = RealmBillingSession(user)
         if charge_automatically:
-            billing_session = RealmBillingSession(user)
             stripe_checkout_session = (
                 billing_session.setup_upgrade_checkout_session_and_payment_intent(
                     CustomerPlan.STANDARD,
@@ -140,8 +139,7 @@ def upgrade(
                 },
             )
         else:
-            process_initial_upgrade(
-                user,
+            billing_session.process_initial_upgrade(
                 CustomerPlan.STANDARD,
                 licenses,
                 automanage_licenses,


### PR DESCRIPTION
Moves the `process_initial_upgrade` function to the `BillingSession` abstract class.

This refactoring will help in minimizing duplicate code while supporting both realm and remote_server customers.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
