### PR TITLE
register_server: Update the prompt.

### DIFF
--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -67,19 +67,29 @@ class Command(ZulipBaseCommand):
         if options["rotate_key"]:
             request["new_org_key"] = get_random_string(64)
 
-        self._log_params(request)
+        print(
+            "This command registers your server for the Mobile Push Notifications Service.\n"
+            "Doing so will share basic metadata with the service's maintainers:\n\n"
+            f"* This server's configured hostname: {request['hostname']}\n"
+            f"* This server's configured contact email address: {request['contact_email']}\n"
+            "* Metadata about each organization hosted by the server; see:\n\n"
+            "    <https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata>\n\n"
+            "Use of this service is governed by the Zulip Terms of Service:\n\n"
+            "    <https://zulip.com/policies/terms>\n"
+        )
 
         if not options["agree_to_terms_of_service"] and not options["rotate_key"]:
-            print(
-                "To register, you must agree to the Zulipchat Terms of Service: "
-                "https://zulip.com/policies/terms"
+            tos_prompt = input(
+                "Do you want to agree to the Zulip Terms of Service and proceed? [Y/n] "
             )
-            tos_prompt = input("Do you agree to the Terms of Service? [Y/n] ")
             print("")
             if not (
                 tos_prompt.lower() == "y" or tos_prompt.lower() == "" or tos_prompt.lower() == "yes"
             ):
-                raise CommandError("Aborting, since Terms of Service have not been accepted.")
+                # Exit without registering; no need to print anything
+                # special, as the "n" reply to the query is clear
+                # enough about what happened.
+                return
 
         response = self._request_push_notification_bouncer_url(
             "/api/v1/remotes/server/register", request
@@ -87,13 +97,9 @@ class Command(ZulipBaseCommand):
 
         if response.json()["created"]:
             print(
-                "You've successfully registered for the Mobile Push Notification Service!\n"
-                "To finish setup for sending push notifications:"
+                "Your server is now registered for the Mobile Push Notification Service!\n"
+                "Return to the documentation for next steps."
             )
-            print(
-                "- Restart the server, using /home/zulip/deployments/current/scripts/restart-server"
-            )
-            print("- Return to the documentation to learn how to test push notifications")
         else:
             if options["rotate_key"]:
                 print(f"Success! Updating {SECRETS_FILENAME} with the new key...")
@@ -132,11 +138,3 @@ class Command(ZulipBaseCommand):
             raise CommandError("Error: " + content_dict["msg"])
 
         return response
-
-    def _log_params(self, params: Dict[str, Any]) -> None:
-        print("The following data will be submitted to the push notification service:")
-        for key, value in sorted(params.items()):
-            if key == "zulip_org_key":
-                value = value[0:8] + "..."
-            print(f"  {key}: {value}")
-        print("")


### PR DESCRIPTION
Includes a proposed way of having an extra prompt + the --submit-realms-data arg for skipping the prompt (analogical to --agree_to_terms_of_service), to have a reasonable user experience with this command.

Example from terminal:
```
./manage.py register_server
The following data will be submitted to the push notification service:
  contact_email: desdemona+admin@zulip.com
  hostname: zulipdev.com:9991
  zulip_org_id: xxx
  zulip_org_key: xxxxxxxxxx

To register, you must agree to the Zulipchat Terms of Service: https://zulip.com/policies/terms
Do you agree to the Terms of Service? [Y/n] 

You've successfully registered for the Mobile Push Notification Service!
Now initial realms data needs to be submitted.
Proceed? [Y/n] 

Successfully submitted realms data.
To finish setup for sending push notifications:
- Restart the server, using /home/zulip/deployments/current/scripts/restart-server
- Return to the documentation to learn how to test push notifications
```