### PR TITLE
left_sidebar: Set shared right margin on DM section.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -238,8 +238,14 @@ li.show-more-topics {
 }
 
 .direct-messages-container {
+    #private_messages_section {
+        /* Properly offset all the grid rows
+           in the DM section. */
+        margin-right: 12px;
+    }
+
     #private_messages_section_header {
-        grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 12px;
+        grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
         grid-template-rows: 24px;
         /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
            value and the styles dependent on it so that this kind of


### PR DESCRIPTION
This corrects a regression in the DM section header introduced by #27638, which caused the highlighted header to extend beyond the other DM rows (thanks @amanagr for catching). 

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20views.20section.20collapsible.20feedback/near/1680162)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="400" alt="dm-header-row-before" src="https://github.com/zulip/zulip/assets/170719/bb2a3092-3439-4093-94c8-e6a486ac690e"> | <img width="400" alt="dm-header-row-after" src="https://github.com/zulip/zulip/assets/170719/24165d2b-6ad3-4d3c-bcf3-bbd80289047a"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>