### PR TITLE
cache: Drop the huddle cache.

### DIFF
--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -24,7 +24,7 @@ from zerver.lib.cache import (
 from zerver.lib.safe_session_cached_db import SessionStore
 from zerver.lib.sessions import session_engine
 from zerver.lib.users import get_all_api_keys
-from zerver.models import Client, Huddle, UserProfile, get_client_cache_key, huddle_hash_cache_key
+from zerver.models import Client, UserProfile, get_client_cache_key
 
 
 def user_cache_items(
@@ -41,10 +41,6 @@ def user_cache_items(
 
 def client_cache_items(items_for_remote_cache: Dict[str, Tuple[Client]], client: Client) -> None:
     items_for_remote_cache[get_client_cache_key(client.name)] = (client,)
-
-
-def huddle_cache_items(items_for_remote_cache: Dict[str, Tuple[Huddle]], huddle: Huddle) -> None:
-    items_for_remote_cache[huddle_hash_cache_key(huddle.huddle_hash)] = (huddle,)
 
 
 def session_cache_items(
@@ -95,12 +91,6 @@ cache_fillers: Dict[
     "client": (
         lambda: Client.objects.all(),
         client_cache_items,
-        3600 * 24 * 7,
-        10000,
-    ),
-    "huddle": (
-        lambda: Huddle.objects.select_related("recipient").all(),
-        huddle_cache_items,
         3600 * 24 * 7,
         10000,
     ),

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4291,10 +4291,6 @@ def get_huddle_hash(id_list: List[int]) -> str:
     return hashlib.sha1(hash_key.encode()).hexdigest()
 
 
-def huddle_hash_cache_key(huddle_hash: str) -> str:
-    return f"huddle_by_hash:{huddle_hash}"
-
-
 def get_or_create_huddle(id_list: List[int]) -> Huddle:
     """
     Takes a list of user IDs and returns the Huddle object for the
@@ -4302,13 +4298,6 @@ def get_or_create_huddle(id_list: List[int]) -> Huddle:
     yet exist, it will be transparently created.
     """
     huddle_hash = get_huddle_hash(id_list)
-    return get_or_create_huddle_backend(huddle_hash, id_list)
-
-
-@cache_with_key(
-    lambda huddle_hash, id_list: huddle_hash_cache_key(huddle_hash), timeout=3600 * 24 * 7
-)
-def get_or_create_huddle_backend(huddle_hash: str, id_list: List[int]) -> Huddle:
     with transaction.atomic():
         (huddle, created) = Huddle.objects.get_or_create(huddle_hash=huddle_hash)
         if created:


### PR DESCRIPTION
This cache was only used in one place, which is infrequently called (only when sending messages, or searching explicitly for a list of users) and the overhead of maintaining the cache is not worth trying to avoid the well-indexed lookup of the huddle.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
