### PR TITLE
bililng: Fix incorrect price per license on billing page.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -68,6 +68,20 @@ STRIPE_API_VERSION = "2020-08-27"
 stripe.api_version = STRIPE_API_VERSION
 
 
+# This function imitates the behavior of the format_money in billing/helpers.ts
+def format_money(cents: float) -> str:
+    # allow for small floating point errors
+    cents = math.ceil(cents - 0.001)
+    if cents % 100 == 0:
+        precision = 0
+    else:
+        precision = 2
+
+    dollars = cents / 100
+    # Format the number as a string with the correct number of decimal places
+    return f"{dollars:.{precision}f}"
+
+
 def get_latest_seat_count(realm: Realm) -> int:
     return get_seat_count(realm, extra_non_guests_count=0, extra_guests_count=0)
 

--- a/corporate/tests/stripe_fixtures/free_trial_upgrade_by_card--Customer.retrieve.4.json
+++ b/corporate/tests/stripe_fixtures/free_trial_upgrade_by_card--Customer.retrieve.4.json
@@ -1,0 +1,79 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1010000001,
+  "currency": null,
+  "default_currency": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip (Zulip Dev)",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "cus_NORMALIZED0001",
+  "invoice_prefix": "NORMA01",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 11,
+        "exp_year": 2024,
+        "fingerprint": "NORMALIZED000001",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1010000002,
+      "customer": "cus_NORMALIZED0001",
+      "id": "pm_1OAbdVDEQaroqDjsOzvEMpeM",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "realm_id": "1",
+    "realm_str": "zulip"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -14,6 +14,7 @@ from corporate.lib.stripe import (
     do_change_plan_status,
     downgrade_at_the_end_of_billing_cycle,
     downgrade_now_without_creating_additional_invoices,
+    format_money,
     get_latest_seat_count,
     make_end_of_cycle_updates_if_needed,
     renewal_amount,
@@ -194,15 +195,13 @@ def billing_home(
             )
 
             billing_frequency = CustomerPlan.BILLING_SCHEDULES[plan.billing_schedule]
-            price_per_license_int = plan.price_per_license
-            if price_per_license_int is not None and billing_frequency == "Annual":
-                price_per_license_int = int(price_per_license_int / 12)
 
-            price_per_license = (
-                cents_to_dollar_string(price_per_license_int)
-                if price_per_license_int is not None
-                else None
-            )
+            if plan.price_per_license is None:
+                price_per_license = ""
+            elif billing_frequency == "Annual":
+                price_per_license = format_money(plan.price_per_license / 12)
+            else:
+                price_per_license = format_money(plan.price_per_license)
 
             context.update(
                 plan_name=plan.name,

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -89,6 +89,7 @@ export function create_ajax_request(
     });
 }
 
+// This function imitates the behavior of the format_money in views/billing_page.py
 export function format_money(cents: number): string {
     // allow for small floating point errors
     cents = Math.ceil(cents - 0.001);


### PR DESCRIPTION
There is a discrepancy between price per license shown on billing and upgrade page for annual billing frequency due to difference in methods used to calculate the amount.

To fix it, we use the same method on both the pages.

| before | after |
| --- | --- |
| <img width="1134" alt="Screenshot 2023-11-14 at 7 17 23 AM" src="https://github.com/zulip/zulip/assets/25124304/bd7692f2-7c3a-4b09-8d2f-9edafb8434ad"> | <img width="1136" alt="Screenshot 2023-11-14 at 7 53 41 AM" src="https://github.com/zulip/zulip/assets/25124304/3a41e3aa-ba9f-4ad8-a626-456c9ba705bc"> |
