### PR TITLE
typeahead: Fix '@topic' not present when stream wildcard suggested.

### DIFF
--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -398,15 +398,16 @@ export function sort_recipients({
         }
     }
 
-    // We suggest only the first matching wildcard mention,
-    // irrespective of how many equivalent wildcard mentions match.
+    // We suggest only the first matching stream wildcard mention,
+    // irrespective of how many equivalent stream wildcard mentions match.
     const recipients = [];
-    let wildcard_mention_included = false;
+    let stream_wildcard_mention_included = false;
     for (const item of items) {
-        if (!item.is_broadcast || !wildcard_mention_included) {
+        const topic_wildcard_mention = item.email === "topic";
+        if (!item.is_broadcast || topic_wildcard_mention || !stream_wildcard_mention_included) {
             recipients.push(item);
-            if (item.is_broadcast) {
-                wildcard_mention_included = true;
+            if (item.is_broadcast && !topic_wildcard_mention) {
+                stream_wildcard_mention_included = true;
             }
         }
     }

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1753,8 +1753,8 @@ test("typeahead_results", () => {
     // Verify we're not matching on a terms that only appear in the description.
     assert_mentions_matches("characters of", []);
 
-    // Verify we suggest only the first matching wildcard mention,
-    // irrespective of how many equivalent wildcard mentions match.
+    // Verify we suggest only the first matching stream wildcard mention,
+    // irrespective of how many equivalent stream wildcard mentions match.
     const mention_everyone = ct.broadcast_mentions()[1];
     // Here, we suggest only "everyone" instead of both the matching
     // "everyone" and "stream" wildcard mentions.
@@ -1770,6 +1770,12 @@ test("typeahead_results", () => {
         hamletcharacters,
         call_center,
     ]);
+
+    // Verify we suggest both 'the first matching stream wildcard' and
+    // 'topic wildcard' mentions. Not only one matching wildcard mention.
+    const mention_topic = ct.broadcast_mentions()[3];
+    // Here, we suggest both "everyone" and "topic".
+    assert_mentions_matches("o", [othello, mention_everyone, mention_topic, cordelia]);
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/26371#issuecomment-1808537189

> why @topic doesn't appear at the top of the typeahead for just typing @? I think we probably want it to appear there next to @-all.

---

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>Using @</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/bc45b880-0f9b-4d7e-8a86-cbcb31d0ef58">
</img>
</details> 

<details><summary>Using @t</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/f9dbec24-3a5e-42e4-9654-e0acd944b932">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
