### PR TITLE
Bunch of bug fixes where stream id had to be passed into `compose_actions.start` instead of stream name.

### DIFF
--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -38,6 +38,7 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
     if (scheduled_msg.type === "stream") {
         compose_args = {
             type: "stream",
+            stream_id: scheduled_msg.to,
             stream: sub_store.maybe_get_stream_name(scheduled_msg.to),
             topic: scheduled_msg.topic,
             content: scheduled_msg.content,


### PR DESCRIPTION
reload: Fix bug where stream input is unexpectedly cleared on reload.

Earlier, we preserved the stream name across reloads, and to restore the compose state, passed that to `compose_actions.start`, which since c3fe96a, considers the stream id, and not its name.

This caused a bug where on server initiated reload, the stream input would not retain its value and be unexpectedly cleared.

This is fixed by preserving the stream id across reloads, instead of its name, and passing that to `compose_actions.start` instead.

compose: Pass in `stream_id` to compose when editing scheduled message.

Earlier, we only passed in the stream name which isn't considered in `compose_actions.start` when populating the recipient.

There was no visible bug since we first narrow to the correct stream and then call `compose_actions.start`, but this was brittle since it would not work if we open the compose box before narrowing.

left-sidebar: Fix "New topic" button in stream popover.

Now we pass in the stream's id to `compose_actions.start()` (not its name), so that the compose box opens with the correct stream selected.

Fixes: [Issues described here](https://chat.zulip.org/#narrow/stream/9-issues/topic/Left.20sidebar.20topic.20menu.20new.20topic.20bug)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
