### PR TITLE
compose box: Improve structures, clickable areas, and load spinner.

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -704,7 +704,7 @@ export function format_text($textarea, type, inserted_content) {
 export function hide_compose_spinner() {
     compose_spinner_visible = false;
     $(".compose-submit-button .loader").hide();
-    $(".compose-submit-button span").show();
+    $(".compose-submit-button .zulip-icon-send").show();
     $(".compose-submit-button").removeClass("disable-btn");
 }
 
@@ -712,7 +712,7 @@ export function show_compose_spinner() {
     compose_spinner_visible = true;
     // Always use white spinner.
     loading.show_button_spinner($(".compose-submit-button .loader"), true);
-    $(".compose-submit-button span").hide();
+    $(".compose-submit-button .zulip-icon-send").hide();
     $(".compose-submit-button").addClass("disable-btn");
 }
 

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -461,7 +461,7 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: "#send_later",
+        target: ".send-control-button",
         delay: LONG_HOVER_DELAY,
         placement: "top",
         appendTo: () => document.body,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1252,9 +1252,12 @@ textarea.new_message_textarea,
     height: 28px;
     /* Make the vdots appear to extend from
        beneath the send button when an
-       interactive background is present. */
+       interactive background is present.
+       Compensatory padding for this negative
+       margin is handled on the vdots icon
+       below, so as to make for a maximum
+       clickable vdots area. */
     margin-left: -4px;
-    padding: 0 0 0 4px;
     border-radius: 0 4px 4px 0;
     /* Flex items respect z-index values;
        this is needed to keep the vdots
@@ -1277,14 +1280,14 @@ textarea.new_message_textarea,
     @media (width < $sm_min) {
         /* Drop to a square, rounded button. */
         width: 30px;
-        padding: 0;
         margin-left: 0;
         border-radius: 4px;
     }
 
     .zulip-icon {
-        padding: 5px 3px;
+        padding: 5px 0 5px 4px;
         font-size: 17px;
+        flex-grow: 1;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1204,14 +1204,14 @@ textarea.new_message_textarea,
 
 /* Class for send-area buttons, such as
    Drafts and the send-adjacent vdots */
-.message-control-button {
+.send-control-button {
     border: 0;
     outline: 0;
     padding: 0;
     margin: 0;
     border-radius: 4px;
-    color: var(--color-compose-message-control-button);
-    background-color: var(--color-compose-message-control-button-background);
+    color: var(--color-compose-send-control-button);
+    background-color: var(--color-compose-send-control-button-background);
     font-weight: 450;
 
     &:active {
@@ -1230,11 +1230,9 @@ textarea.new_message_textarea,
     &:hover {
         /* We need to use !important here, regrettably, to keep the default
            dark-mode hover colors from showing. */
-        color: var(
-            --color-compose-message-control-button-interactive
-        ) !important;
+        color: var(--color-compose-send-control-button-interactive) !important;
         background-color: var(
-            --color-compose-message-control-button-background-interactive
+            --color-compose-send-control-button-background-interactive
         );
         text-decoration: none;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -227,13 +227,13 @@ body {
     --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
     --color-compose-send-button-focus-border: hsl(232deg 20% 10%);
     --color-compose-send-button-focus-shadow: hsl(230deg 100% 20%);
-    --color-compose-message-control-button: hsl(240deg 30% 50% / 80%);
-    --color-compose-message-control-button-background: transparent;
-    --color-compose-message-control-button-interactive: hsl(240deg 30% 50%);
-    --color-compose-message-control-button-background-interactive: hsl(
+    --color-compose-send-control-button: hsl(240deg 30% 50% / 80%);
+    --color-compose-send-control-button-background: transparent;
+    --color-compose-send-control-button-interactive: hsl(240deg 30% 50%);
+    --color-compose-send-control-button-background-interactive: hsl(
         240deg 100% 30% / 5%
     );
-    --color-compose-message-control-button-focus-shadow: var(
+    --color-compose-send-control-button-focus-shadow: var(
         --color-compose-send-button-focus-shadow
     );
     --color-compose-collapsed-reply-button-area-background: hsl(0deg 0% 100%);
@@ -443,15 +443,15 @@ body {
 
     /* Compose box colors */
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);
-    --color-compose-message-control-button: hsl(240deg 30% 70%);
-    --color-compose-message-control-button-background: transparent;
-    --color-compose-message-control-button-interactive: var(
-        --color-compose-message-control-button
+    --color-compose-send-control-button: hsl(240deg 30% 70%);
+    --color-compose-send-control-button-background: transparent;
+    --color-compose-send-control-button-interactive: var(
+        --color-compose-send-control-button
     );
-    --color-compose-message-control-button-background-interactive: hsl(
+    --color-compose-send-control-button-background-interactive: hsl(
         235deg 100% 70% / 11%
     );
-    --color-compose-message-control-button-focus-shadow: var(
+    --color-compose-send-control-button-focus-shadow: var(
         --color-compose-send-button-focus-shadow
     );
     --color-compose-collapsed-reply-button-area-background: hsl(

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -85,7 +85,7 @@
                             <div class="drag"></div>
 
                             <div id="message-send-controls-container">
-                                <a id="compose-drafts-button" role="button" class="compose_control_button message-control-button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
+                                <a id="compose-drafts-button" role="button" class="compose_control_button send-control-button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
                                     {{t 'Drafts' }}
                                 </a>
                                 <span id="compose-limit-indicator"></span>
@@ -94,7 +94,7 @@
                                         <img class="loader" alt="" src="" />
                                         <i class="zulip-icon zulip-icon-send"></i>
                                     </button>
-                                    <button class="message-control-button send-related-action-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send options' }}">
+                                    <button class="send-control-button send-related-action-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send options' }}">
                                         <i class="zulip-icon zulip-icon-more-vertical"></i>
                                     </button>
                                 </div>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -85,7 +85,7 @@
                             <div class="drag"></div>
 
                             <div id="message-send-controls-container">
-                                <a id="compose-drafts-button" role="button" class="compose_control_button send-control-button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
+                                <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
                                     {{t 'Drafts' }}
                                 </a>
                                 <span id="compose-limit-indicator"></span>


### PR DESCRIPTION
This PR introduces a few fixes to the new Send area UI. In particular:

* It introduces a new `send-control-button` class [to avoid confusion](https://github.com/zulip/zulip/pull/27535#discussion_r1391677223) with `message-control-buttons` references outside the compose area
* It uses that class to unify the tooltip behavior on the Send and vdots buttons
* It ensures that all of the hovered area around vdots is clickable, for opening the send options menu
* It fixes the position of the loading spinner, which appears in place of the Send button icon

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/new.20Send.20button.20styles/near/1681175)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Fixed load spinner:
![fixed-load-spinner](https://github.com/zulip/zulip/assets/170719/17ce2f43-9209-42a1-a7f6-1b54cdefc9d8)

Fixed clickable areas:
![fixed-clickable-area](https://github.com/zulip/zulip/assets/170719/3a3f9d2d-9a85-4092-9b25-9ca0bbe5ef50)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
