### PR TITLE
compose box: Suppress tooltips when vdot send popover is open.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -691,11 +691,6 @@ export function initialize() {
         if ($target.is(".compose_mobile_button, .compose_mobile_button *")) {
             return;
         }
-
-        if ($(".enter_sends").has(e.target).length) {
-            e.preventDefault();
-            return;
-        }
     }
 
     $("body").on("click", "#compose-content", handle_compose_click);
@@ -835,7 +830,6 @@ export function initialize() {
                 !$(e.target).closest(".micromodal").length &&
                 !$(e.target).closest("[data-tippy-root]").length &&
                 !$(e.target).closest(".typeahead").length &&
-                !$(e.target).closest(".enter_sends").length &&
                 !$(e.target).closest(".flatpickr-calendar").length &&
                 $(e.target).closest("body").length
             ) {

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -8,6 +8,7 @@ import * as compose_recipient from "./compose_recipient";
 import * as compose_state from "./compose_state";
 import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
+import * as popover_menus from "./popover_menus";
 import {EXTRA_LONG_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs";
 import {parse_html} from "./ui_util";
 import {user_settings} from "./user_settings";
@@ -60,6 +61,13 @@ export function initialize() {
         target: ".send-control-button",
         delay: LONG_HOVER_DELAY,
         placement: "top",
+        onShow() {
+            // Don't show send-area tooltips if the popover is displayed.
+            if (popover_menus.is_scheduled_messages_popover_displayed()) {
+                return false;
+            }
+            return true;
+        },
         appendTo: () => document.body,
     });
 
@@ -72,11 +80,16 @@ export function initialize() {
         trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
+            // Don't show Send button tooltip if the popover is displayed.
+            if (popover_menus.is_scheduled_messages_popover_displayed()) {
+                return false;
+            }
             if (user_settings.enter_sends) {
                 instance.setContent(parse_html($("#send-enter-tooltip-template").html()));
             } else {
                 instance.setContent(parse_html($("#send-ctrl-enter-tooltip-template").html()));
             }
+            return true;
         },
     });
 

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -57,6 +57,13 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".send-control-button",
+        delay: LONG_HOVER_DELAY,
+        placement: "top",
+        appendTo: () => document.body,
+    });
+
+    delegate("body", {
         target: "#compose-send-button",
         delay: EXTRA_LONG_HOVER_DELAY,
         // By default, tippyjs uses a trigger value of "mouseenter focus",

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -83,6 +83,10 @@ export function get_scheduled_messages_popover() {
     return popover_instances.send_later;
 }
 
+export function is_scheduled_messages_popover_displayed() {
+    return popover_instances.send_later?.state.isVisible;
+}
+
 export function get_compose_control_buttons_popover() {
     return popover_instances.compose_control_buttons;
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -23,7 +23,6 @@ export const popover_instances = {
     message_actions: null,
     stream_settings: null,
     compose_mobile_button: null,
-    compose_enter_sends: null,
     topics_menu: null,
     send_later: null,
     change_visibility_policy: null,
@@ -90,10 +89,6 @@ export function get_compose_control_buttons_popover() {
 
 export function get_starred_messages_popover() {
     return popover_instances.starred_messages;
-}
-
-export function is_compose_enter_sends_popover_displayed() {
-    return popover_instances.compose_enter_sends?.state.isVisible;
 }
 
 export function is_personal_menu_popover_displayed() {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -4,7 +4,6 @@ import tippy, {delegate} from "tippy.js";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
 import {$t} from "./i18n";
-import * as popover_menus from "./popover_menus";
 import {user_settings} from "./user_settings";
 
 // For tooltips without data-tippy-content, we use the HTML content of
@@ -240,20 +239,6 @@ export function initialize() {
         onHidden(instance) {
             instance.destroy();
         },
-    });
-
-    delegate("body", {
-        target: [".enter_sends_true", ".enter_sends_false"],
-        delay: LONG_HOVER_DELAY,
-        content: $t({defaultMessage: "Change send shortcut"}),
-        onShow() {
-            // Don't show tooltip if the popover is displayed.
-            if (popover_menus.is_compose_enter_sends_popover_displayed()) {
-                return false;
-            }
-            return true;
-        },
-        appendTo: () => document.body,
     });
 
     delegate("body", {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -446,13 +446,6 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ".send-control-button",
-        delay: LONG_HOVER_DELAY,
-        placement: "top",
-        appendTo: () => document.body,
-    });
-
-    delegate("body", {
         target: ["#stream_creation_form .add_subscribers_disabled"],
         content: $t({
             defaultMessage:

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -935,40 +935,6 @@ textarea.new_message_textarea,
     }
 }
 
-.open_enter_sends_dialog {
-    font-size: 12px;
-    height: 14px;
-    padding-left: 4px;
-    opacity: 0.7;
-    margin-bottom: 5px;
-    position: relative;
-    top: -2px;
-    cursor: pointer;
-
-    @media (width < $mm_min) {
-        font-size: 11px;
-    }
-
-    & kbd {
-        padding: 0 4px;
-    }
-
-    &:hover {
-        opacity: 1;
-    }
-
-    .enter_sends_true,
-    .enter_sends_false {
-        display: none;
-    }
-
-    & i {
-        padding-left: 3px;
-        font-size: 12px;
-        font-weight: 600;
-    }
-}
-
 .drafts-item-in-popover {
     display: none;
     /* Only show the Drafts item in the popover when it's not visible

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -94,7 +94,6 @@
         box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
     }
 
-    .open_enter_sends_dialog,
     .enter_sends_choices {
         color: hsl(236deg 33% 90%);
 


### PR DESCRIPTION
In addition to suppressing the tooltips when the send popover is open, this PR has a prep commit that cleans up a bunch of unreachable stuff from the now-defunct `enter_sends` interface that used to live beneath the Send button.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Send.20tooltip.20with.20popover.20open/near/1681410)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

With tooltips suppressed:

![suppress-tooltips-on-popover](https://github.com/zulip/zulip/assets/170719/113e36a5-b876-4260-97fc-e36e07b03051)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
