### PR TITLE
left_sidebar: Keep all DM container rows to same right margin.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -238,11 +238,9 @@ li.show-more-topics {
 }
 
 .direct-messages-container {
-    #private_messages_section {
-        /* Properly offset all the grid rows
-           in the DM section. */
-        margin-right: 12px;
-    }
+    /* Properly offset all the grid rows
+       in the DM section. */
+    margin-right: 12px;
 
     #private_messages_section_header {
         grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;


### PR DESCRIPTION
This goes up a selector level with the fix from #27679, which only partially fixed the issue of rows in the DM area extending too far right when the All DMs narrow was active.