### PR TITLE
typing: Limit typing notifications in large streams.

### DIFF
--- a/help/typing-notifications.md
+++ b/help/typing-notifications.md
@@ -2,8 +2,10 @@
 
 The Zulip web app displays typing notifications in [conversation
 views](/help/reading-conversations) and [**All direct
-messages**](/help/direct-messages#access-all-dms). The mobile app displays
-typing notifications in direct message conversations.
+messages**](/help/direct-messages#access-all-dms). Typing
+notifications are not shown in streams with more than 100
+subscribers. The mobile app displays typing notifications in direct
+message conversations.
 
 Typing notifications are only sent while one is actively editing text in
 the compose box. They disappear if typing is paused for several seconds,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -587,3 +587,8 @@ TYPING_STOPPED_WAIT_PERIOD_MILLISECONDS = 5000
 # How often a client should send start notifications to the server to
 # indicate that the user is still interacting with the compose UI.
 TYPING_STARTED_WAIT_PERIOD_MILLISECONDS = 10000
+
+# The maximum number of subscribers for a stream to have typing
+# notifications enabled. Default is set to avoid excessive Tornado
+# load in large organizations.
+MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS = 100


### PR DESCRIPTION
#27706 

Changes:
* Test added
* removed the equality sign in `if total_subscriptions > settings.MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS:` as the doc says "Typing notifications are not shown in streams with more than 100 subscribers."

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
