### PR TITLE
message_edit: Tune message-edit buttons and layout.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -69,12 +69,6 @@
         }
     }
 
-    .dialog_exit_button {
-        background-color: hsl(211deg 29% 14%);
-        color: hsl(0deg 0% 100%);
-        border: 1px solid hsl(0deg 0% 0% / 60%);
-    }
-
     .modal__content.simplebar-scrollable-y + .modal__footer {
         border-top: 1px solid hsl(0deg 0% 100% / 20%);
     }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -470,6 +470,14 @@ $time_column_min_width: 42px; /* + padding */
         display: unset !important;
         cursor: default;
     }
+
+    /* Message-editing styles */
+    .message-edit-buttons-and-timer {
+        margin-top: 5px;
+        display: flex;
+        gap: 5px;
+        align-items: baseline;
+    }
 }
 
 .recipient_row {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -476,7 +476,52 @@ $time_column_min_width: 42px; /* + padding */
         margin-top: 5px;
         display: flex;
         gap: 5px;
-        align-items: baseline;
+        /* Allow items to occupy full height.
+           This is especially important for
+           buttons that are flex items. */
+        align-items: stretch;
+    }
+
+    .message-actions-button {
+        box-sizing: border-box;
+        height: 28px;
+        padding: 6px 10px;
+        border-radius: 4px;
+        border: 0;
+        margin-bottom: 0;
+        line-height: 1;
+    }
+
+    .message_edit_save {
+        /* Match Save button's basic colors to
+           the compose box Send button. */
+        color: var(--color-compose-send-button-icon-color);
+        background-color: var(--color-compose-send-button-background);
+
+        &:hover {
+            background-color: var(
+                --color-compose-send-button-background-interactive
+            );
+        }
+
+        &:disabled {
+            /* Replicate the `.new-style` disabled values,
+               without any color shifts. */
+            cursor: not-allowed;
+            filter: saturate(0);
+            opacity: 0.5;
+        }
+    }
+
+    .message_edit_cancel,
+    .message_edit_close {
+        color: var(--color-exit-button-text);
+        background: var(--color-exit-button-background);
+        border: 1px solid var(--color-exit-button-border);
+
+        &:hover {
+            background: var(--color-exit-button-background-interactive);
+        }
     }
 }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -128,11 +128,12 @@
 }
 
 .dialog_exit_button {
-    background: hsl(0deg 0% 100%);
-    border: 1px solid hsl(300deg 2% 11% / 30%);
+    color: var(--color-exit-button-text);
+    background: var(--color-exit-button-background);
+    border: 1px solid var(--color-exit-button-border);
 
     &:hover {
-        background: hsl(0deg 0% 97%);
+        background: var(--color-exit-button-background-interactive);
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -381,6 +381,14 @@ body {
     --color-fill-hover-copy-icon: hsl(200deg 100% 40%);
     --color-fill-user-invite-copy-icon: hsl(0deg 0% 46.7%);
     --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z' fill='%23333333'/%3E%3C/svg%3E%0A");
+
+    /* Button colors on modals and message editing. */
+    /* Exit buttons are sometimes Cancel, but sometimes
+       other "Nah, forget it" actions. */
+    --color-exit-button-text: hsl(0deg 0% 0%);
+    --color-exit-button-border: hsl(300deg 2% 11% / 30%);
+    --color-exit-button-background: hsl(0deg 0% 100%);
+    --color-exit-button-background-interactive: hsl(0deg 0% 97%);
 }
 
 %dark-theme {
@@ -586,6 +594,12 @@ body {
     );
     --color-fill-user-invite-copy-icon: hsl(236deg 33% 90%);
     --icon-chevron-down: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.52977 5.52973C3.78947 5.27004 4.21053 5.27004 4.47023 5.52973L8 9.05951L11.5298 5.52973C11.7895 5.27004 12.2105 5.27004 12.4702 5.52973C12.7299 5.78943 12.7299 6.21049 12.4702 6.47019L8.47023 10.4702C8.21053 10.7299 7.78947 10.7299 7.52977 10.4702L3.52977 6.47019C3.27008 6.21049 3.27008 5.78943 3.52977 5.52973Z' fill='%23FFFFFFBF'/%3E%3C/svg%3E%0A");
+
+    /* Button colors on modals and message editing. */
+    --color-exit-button-text: hsl(0deg 0% 100%);
+    --color-exit-button-border: hsl(0deg 0% 0% / 60%);
+    --color-exit-button-background: hsl(211deg 29% 14%);
+    --color-exit-button-background-interactive: hsl(211deg 29% 17%);
 }
 
 @media screen {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2011,6 +2011,9 @@ div.focused-message-list {
 
 .message-edit-timer {
     display: none;
+    /* Center vertically relative to
+       buttons. */
+    align-self: center;
     /* Use flexbox to position to far right of
        the Save and Cancel buttons. */
     margin-left: auto;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1996,14 +1996,15 @@ div.focused-message-list {
 }
 
 .message-edit-timer {
-    float: right;
     display: none;
-    margin-top: 5px;
+    /* Use flexbox to position to far right of
+       the Save and Cancel buttons. */
+    margin-left: auto;
 }
 
 .message-edit-feature-group {
-    display: inline-flex;
-    margin: 0 auto -5px 10px;
+    display: flex;
+    margin: 0;
     align-items: baseline;
 }
 

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -17,23 +17,25 @@
             <div class="message-edit-feature-group">
                 {{> compose_control_buttons }}
             </div>
-            <div class="message-edit-buttons-and-timer">
-                <div class="message_edit_save_container"
-                  data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
-                    <button type="button" class="button small rounded sea-green message_edit_save">
-                        <img class="loader" alt="" src="" />
-                        <span>{{t "Save" }}</span>
-                    </button>
-                </div>
-                <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
-                <div class="message-edit-timer">
-                    <span class="message_edit_countdown_timer
-                      tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
-                </div>
-            </div>
-            {{else}}
-            <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}
+            <div class="message-edit-buttons-and-timer">
+                {{#if is_editable}}
+                    <div class="message_edit_save_container"
+                      data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
+                        <button type="button" class="message-actions-button message_edit_save">
+                            <img class="loader" alt="" src="" />
+                            <span>{{t "Save" }}</span>
+                        </button>
+                    </div>
+                    <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
+                    <div class="message-edit-timer">
+                        <span class="message_edit_countdown_timer
+                          tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
+                    </div>
+                {{else}}
+                    <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
+                {{/if}}
+            </div>
         </div>
     </div>
 </form>

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -14,27 +14,25 @@
         <div class="message_edit_spinner"></div>
         <div class="controls edit-controls">
             {{#if is_editable}}
-                <div class="btn-wrapper inline-block message_edit_save_container"
+            <div class="message-edit-feature-group">
+                {{> compose_control_buttons }}
+            </div>
+            <div class="message-edit-buttons-and-timer">
+                <div class="message_edit_save_container"
                   data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
                     <button type="button" class="button small rounded sea-green message_edit_save">
                         <img class="loader" alt="" src="" />
                         <span>{{t "Save" }}</span>
                     </button>
                 </div>
-                <div class="btn-wrapper inline-block">
-                    <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
+                <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
+                <div class="message-edit-timer">
+                    <span class="message_edit_countdown_timer
+                      tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
                 </div>
-                <div class="message-edit-feature-group">
-                    {{> compose_control_buttons }}
-                </div>
-            {{else}}
-                <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
-            {{/if}}
-            {{#if is_editable}}
-            <div class="message-edit-timer">
-                <span class="message_edit_countdown_timer
-                  tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
             </div>
+            {{else}}
+            <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
This PR places the message-edit buttons on their own line along with the editing timer, leaving the format buttons to their own line above.

Note that there's nothing fancy about how the lines of buttons are created: they're each just flex containers, each behaving as a block with regard to the other.

There are also some Frankensteined button styles in effect here; they draw on colors and styles from the modal buttons (e.g., on the Delete message modal), as well as the color and dimensions of the new send button to try and suggest a parallel between sending a message and editing and saving it later.

CZO discussion: None public yet; will update this.

**Screenshots and screen captures:**

| Source View, Before | Source View, After |
| --- | --- |
| ![source-view-light-before](https://github.com/zulip/zulip/assets/170719/6cffd831-038b-43d9-9c2e-910dc2ca2af0) | ![source-view-light-after](https://github.com/zulip/zulip/assets/170719/039ee737-f2fe-4731-a8a6-f55d287ffc5c) |
| ![source-view-dark-before](https://github.com/zulip/zulip/assets/170719/7b24d881-b6d1-46ce-8f3a-0519a45fc0ef) | ![source-view-dark-after](https://github.com/zulip/zulip/assets/170719/f0d7dd52-9f41-463c-9aa8-f5b4ca8fad19) |

| Editing, Before | Editing, After |
| --- | --- |
| ![message-edit-light-before](https://github.com/zulip/zulip/assets/170719/62583481-5887-46af-9131-e8f9c95b506d) | ![message-edit-light-after](https://github.com/zulip/zulip/assets/170719/d42417ac-f02c-404d-bbb2-db2cc72161f3) |
| ![message-edit-dark-before](https://github.com/zulip/zulip/assets/170719/a825b61f-7b3e-4842-ba66-993d8bdb93d6) | ![message-edit-dark-after](https://github.com/zulip/zulip/assets/170719/75982ffe-965f-4d06-8eff-e512e5c16c06) |

| Time's Up, Light | Time's Up, Dark |
| --- | --- |
| ![times-up-light-mode](https://github.com/zulip/zulip/assets/170719/96988ab2-9f2b-4a62-b318-9e9ac0326259) | ![times-up-dark-mode](https://github.com/zulip/zulip/assets/170719/b16b7ca0-b114-41ce-ab35-90401ac0e316) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
