### PR TITLE
compose box: Message-preview fixes.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1352,6 +1352,9 @@ textarea.new_message_textarea,
 
 .preview_mode {
     #preview-message-area-container {
+        /* Maintain same top alignment as the
+           compose textarea. */
+        margin-top: 5px;
         /* When in preview mode, we display the
            preview container as a columnar flexbox.
            This containing element is necessary

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1334,11 +1334,10 @@ textarea.new_message_textarea,
 
     #compose-textarea,
     #preview_message_area {
-        /* When in full screen, override any height-
-           related properties set on the textarea itself,
+        /* When in full screen, override max-height
+           properties set on the textarea itself,
            e.g., from manually resizing the textarea. */
         max-height: none !important;
-        height: auto !important;
     }
 
     #preview_message_area {


### PR DESCRIPTION
This PR corrects a layout shift where the preview area appeared closer to the recipient row than the normal text area. It also fixes a regression with previewing long messages in full screen. That was achieved by removing a no-longer-necessary `height` declaration, which is now more properly the province of grid to manage.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/preview.20mode/near/1681809)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![message-preview-before](https://github.com/zulip/zulip/assets/170719/888975f1-028a-45ec-a7a5-9279b023b34c) | ![message-preview-after](https://github.com/zulip/zulip/assets/170719/e66ba7b9-2443-4e22-a28e-efd8449e0f88) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>