### PR TITLE
left_sidebar: Add unread count to Streams header.

### DIFF
--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -30,9 +30,11 @@ export function update_dom_with_unread_counts(counts, skip_animations) {
     // mentioned/home views have simple integer counts
     const $mentioned_li = $(".top_left_mentions");
     const $home_view_li = $(".selected-home-view");
+    const $streams_header = $("#streams_header");
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
+    ui_util.update_unread_count_in_dom($streams_header, counts.stream_unread_messages);
 
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -807,6 +807,7 @@ export function get_counts() {
     const streams_with_mentions = unread_topic_counter.get_streams_with_unread_mentions();
     const streams_with_unmuted_mentions = unread_topic_counter.get_streams_with_unmuted_mentions();
     res.home_unread_messages = topic_res.stream_unread_messages;
+    res.stream_unread_messages = topic_res.stream_unread_messages;
     res.stream_count = topic_res.stream_count;
     res.streams_with_mentions = [...streams_with_mentions];
     res.streams_with_unmuted_mentions = [...streams_with_unmuted_mentions];

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1184,27 +1184,23 @@ li.topic-list-item {
     .heading-markers-and-controls {
         grid-area: markers-and-controls;
         height: 100%;
+        display: flex;
+        align-items: center;
+        grid-gap: 5px;
     }
 
     #filter_streams_tooltip {
         display: flex;
         align-items: center;
         justify-content: center;
-        /* Filter streams tooltip is just a block,
-           not a flex or grid item at present,
-           so we fill the row height this way. */
-        height: 100%;
+        width: 15px;
     }
 
-    /* TODO: In the redesign, the streams icons will
-       be grouped and placed to the left of a new
-       unread count on Streams. */
     #add_streams_tooltip {
-        grid-area: ending-anchor-element;
-        align-self: stretch;
         display: flex;
         align-items: center;
         justify-content: center;
+        width: 15px;
     }
 
     .input-append {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -262,13 +262,13 @@ li.show-more-topics {
 
         .heading-markers-and-controls {
             grid-area: markers-and-controls;
+            display: flex;
+            gap: 5px;
+            align-items: center;
         }
 
         #show_all_private_messages {
-            grid-area: ending-anchor-element;
-            /* Make the clickable area large
-               around the icon. */
-            align-self: stretch;
+            width: var(--left-sidebar-header-icon-width);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1193,14 +1193,14 @@ li.topic-list-item {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 15px;
+        width: var(--left-sidebar-header-icon-width);
     }
 
     #add_streams_tooltip {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 15px;
+        width: var(--left-sidebar-header-icon-width);
     }
 
     .input-append {
@@ -1380,9 +1380,5 @@ li.topic-list-item {
         top: 0;
         z-index: 1;
         padding: 3px 0 3px $far_left_gutter_size;
-    }
-
-    #show_all_private_messages {
-        margin-right: 5px !important;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -98,6 +98,7 @@ body {
     --left-sidebar-collapse-widget-gutter: 10px;
     --left-sidebar-width: 270px;
     --right-sidebar-width: 250px;
+    --left-sidebar-header-icon-width: 15px;
 
     /*
     Message box elements and values.

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -161,6 +161,7 @@
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                    <span class="unread_count"></span>
                 </div>
                 <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -139,11 +139,11 @@
                 <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
+                    <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
+                        <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
+                    </a>
                     <span class="unread_count"></span>
                 </div>
-                <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
-                    <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
-                </a>
             </div>
         </div>
         <a class="zoom-out-hide" id="hide-more-direct-messages">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -161,11 +161,12 @@
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                    <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+                        <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
+                    </span>
                     <span class="unread_count"></span>
                 </div>
-                <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
-                    <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
-                </span>
+
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -74,6 +74,7 @@ run_test("update_count_in_dom", () => {
     const counts = {
         mentioned_message_count: 222,
         home_unread_messages: 333,
+        stream_unread_messages: 666,
     };
 
     make_elem($(".top_left_mentions"), "<mentioned-count>");
@@ -86,6 +87,8 @@ run_test("update_count_in_dom", () => {
 
     make_elem($(".top_left_scheduled_messages"), "<scheduled-count>");
 
+    make_elem($("#streams_header"), "<stream-count>");
+
     left_sidebar_navigation_area.update_dom_with_unread_counts(counts, false);
     left_sidebar_navigation_area.update_starred_count(444);
     // Calls left_sidebar_navigation_area.update_scheduled_messages_row
@@ -95,6 +98,7 @@ run_test("update_count_in_dom", () => {
     assert.equal($("<home-count>").text(), "333");
     assert.equal($("<starred-count>").text(), "444");
     assert.equal($("<scheduled-count>").text(), "555");
+    assert.equal($("<stream-count>").text(), "666");
 
     counts.mentioned_message_count = 0;
     scheduled_messages.get_count = () => 0;


### PR DESCRIPTION
In addition to adding a Streams unread count, this shifts the icons on the DM and Streams header rows to the left of the unread count, as called for in the left-sidebar redesign.

Fixes: #27559, #27380

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Unreads with everything expanded:
![expanded-everything-unreads](https://github.com/zulip/zulip/assets/170719/7b25aa08-b737-4dd3-8e0b-e2bafe09185b)

Unreads with condensed views (yay!):
![condensed-views-unreads](https://github.com/zulip/zulip/assets/170719/7e0f71cc-b32c-4e85-88de-d3bad48248b6)

Unreads with condensed views, home view:
![condensed-views-unreads-home-view](https://github.com/zulip/zulip/assets/170719/6dbabfb4-ef2b-4086-8c06-4aecdf5d9048)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
