### PR TITLE
compose_ui: Fall back to comma join when `Intl.ListFormat` is missing

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -252,15 +252,16 @@ export function compute_placeholder_text(opts) {
     // For direct messages
     if (opts.private_message_recipient) {
         const recipient_list = opts.private_message_recipient.split(",");
-        const recipient_names = new Intl.ListFormat(user_settings.default_language).format(
-            recipient_list.map((recipient) => {
-                const user = people.get_by_email(recipient);
-                if (people.should_add_guest_user_indicator(user.user_id)) {
-                    return $t({defaultMessage: "{name} (guest)"}, {name: user.full_name});
-                }
-                return user.full_name;
-            }),
-        );
+        const recipient_parts = recipient_list.map((recipient) => {
+            const user = people.get_by_email(recipient);
+            if (people.should_add_guest_user_indicator(user.user_id)) {
+                return $t({defaultMessage: "{name} (guest)"}, {name: user.full_name});
+            }
+            return user.full_name;
+        });
+        const recipient_names = Intl.ListFormat
+            ? new Intl.ListFormat(user_settings.default_language).format(recipient_parts)
+            : recipient_parts.join(", ");
 
         if (recipient_list.length === 1) {
             // If it's a single user, display status text if available


### PR DESCRIPTION
Tested on Safari 13.1 on macOS 10.15.