### PR TITLE
docs: Update Spanish translation for "Narrow to".

### DIFF
--- a/docs/translating/spanish.md
+++ b/docs/translating/spanish.md
@@ -64,8 +64,11 @@ Zulip friendly and usable.
 ## Frases
 
 - Subscribe/Unsubscribe to a stream - **Suscribir a/Desuscribir de un canal**
-- Narrow to - **Filtrar solo**: this is _filter only_, because there's no other
-  word that's common enough in Spanish for _to narrow_ except for "filtrar".
+- Narrow to - **Buscar solo**: this translates to _search only_. We use this
+  term because there's no other word that's common enough in Spanish for
+  _to narrow_ except for "filtrar", but this word can be incorrectly
+  interpreted as _filter out_. We should stick to a term that we can use
+  unambiguously and consistently for all instances of _Narrow to_.
 - Mute/Unmute - **Silenciar/No silenciar**
 - Deactivate/Reactivate - **Desactivar/Reactivar**
 - Search - **Buscar**


### PR DESCRIPTION
The word "Filtrar" is ambiguous in this context since it can be interpreted as "filter out" which is the opposite of what we want here. "Buscar solo" is a better phrase that we can use unambiguously and consistently for all instances of "Narrow to".

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/4728e827-ff8b-4e65-84c8-178c01e2531d)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
