### PR TITLE
fix : Add space before 'AM'/'PM' in login time display

### DIFF
--- a/templates/zerver/emails/notify_new_login.html
+++ b/templates/zerver/emails/notify_new_login.html
@@ -19,7 +19,7 @@
             {% trans user_email=macros.email_tag(user_email) %}Email: {{ user_email }}{% endtrans %}
         </li>
         <li>
-            {% trans %}Time: {{ login_time }}{% endtrans %}
+            {% trans %}Time: {{ login_time|replace:"AM" :" AM"|replace:"PM" :" PM" }} {% endtrans %}
         </li>
         <li>
             {% trans %}Device: {{ device_browser }} on {{ device_os }}.{% endtrans %}


### PR DESCRIPTION
Modified the template to include a space before 'AM'/'PM' in the login time format to improve readability.

Fixes: #27727

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ✓] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
