### PR TITLE
message_list: Add delay, tooltip suppression to reaction button.

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -150,6 +150,11 @@ export function initialize() {
             }
             const $elem = $(instance.reference);
 
+            if ($elem.hasClass("active-emoji-picker-reference")) {
+                // Don't show the tooltip when the emoji picker is open
+                return false;
+            }
+
             const config = {attributes: false, childList: true, subtree: true};
             const target = $elem.parents(".message-list.focused-message-list").get(0);
             const nodes_to_check_for_removal = [

--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -104,7 +104,7 @@ export function initialize() {
 
     // message reaction tooltip showing who reacted.
     let observer;
-    message_list_tooltip(".message_reaction, .message_reactions .reaction_button", {
+    message_list_tooltip(".message_reaction", {
         delay: INTERACTIVE_HOVER_DELAY,
         placement: "bottom",
         onShow(instance) {
@@ -114,12 +114,10 @@ export function initialize() {
                 return false;
             }
             const $elem = $(instance.reference);
-            if (!instance.reference.classList.contains("reaction_button")) {
-                const local_id = $elem.attr("data-reaction-id");
-                const message_id = rows.get_message_id(instance.reference);
-                const title = reactions.get_reaction_title_data(message_id, local_id);
-                instance.setContent(title);
-            }
+            const local_id = $elem.attr("data-reaction-id");
+            const message_id = rows.get_message_id(instance.reference);
+            const title = reactions.get_reaction_title_data(message_id, local_id);
+            instance.setContent(title);
 
             const config = {attributes: false, childList: true, subtree: true};
             const target = $elem.parents(".message-list.focused-message-list").get(0);
@@ -136,6 +134,34 @@ export function initialize() {
             if (observer) {
                 observer.disconnect();
             }
+        },
+    });
+
+    message_list_tooltip(".message_reactions .reaction_button", {
+        delay: LONG_HOVER_DELAY,
+        placement: "bottom",
+        onShow(instance) {
+            if (!document.body.contains(instance.reference)) {
+                // It is possible for the single reaction necessary for
+                // displaying the reaction button to be removed before
+                // `onShow` is triggered, so we check if the element
+                // exists before proceeding.
+                return false;
+            }
+            const $elem = $(instance.reference);
+
+            const config = {attributes: false, childList: true, subtree: true};
+            const target = $elem.parents(".message-list.focused-message-list").get(0);
+            const nodes_to_check_for_removal = [
+                $elem.parents(".recipient_row").get(0),
+                $elem.parents(".message_reactions").get(0),
+                $elem.get(0),
+            ];
+            hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
+            return true;
+        },
+        onHidden(instance) {
+            instance.destroy();
         },
     });
 


### PR DESCRIPTION
This PR decouples the reaction button Tippy logic from other reaction pills, and introduces a longer delay. Additionally, it suppresses the reaction-button tooltip when the emoji picker is open.

CZO discussion

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![reaction-button-tooltip-before](https://github.com/zulip/zulip/assets/170719/c9f78adb-3cf6-4f05-8eab-c9936e392023) | ![reaction-button-tooltip-after](https://github.com/zulip/zulip/assets/170719/581f6b88-7e08-437f-b56e-81ee3d967df4) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

