### PR TITLE
analytics: Regenerate partial indexes due to Django bug.

### DIFF
--- a/analytics/migrations/0017_regenerate_partial_indexes.py
+++ b/analytics/migrations/0017_regenerate_partial_indexes.py
@@ -1,0 +1,114 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analytics", "0016_unique_constraint_when_subgroup_null"),
+    ]
+
+    # If the server was installed between 7.0 and 7.4 (or main between
+    # 2c20028aa451 and 7807bff52635), it contains indexes which (when
+    # running 7.5 or 7807bff52635 or higher) are never used, because
+    # they contain an improper cast
+    # (https://code.djangoproject.com/ticket/34840).
+    #
+    # We regenerate the indexes here, by dropping and re-creating
+    # them, so that we know that they are properly formed.
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="installationcount",
+            name="unique_installation_count",
+        ),
+        migrations.AddConstraint(
+            model_name="installationcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=False),
+                fields=("property", "subgroup", "end_time"),
+                name="unique_installation_count",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="installationcount",
+            name="unique_installation_count_null_subgroup",
+        ),
+        migrations.AddConstraint(
+            model_name="installationcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=True),
+                fields=("property", "end_time"),
+                name="unique_installation_count_null_subgroup",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="realmcount",
+            name="unique_realm_count",
+        ),
+        migrations.AddConstraint(
+            model_name="realmcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=False),
+                fields=("realm", "property", "subgroup", "end_time"),
+                name="unique_realm_count",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="realmcount",
+            name="unique_realm_count_null_subgroup",
+        ),
+        migrations.AddConstraint(
+            model_name="realmcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=True),
+                fields=("realm", "property", "end_time"),
+                name="unique_realm_count_null_subgroup",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="streamcount",
+            name="unique_stream_count",
+        ),
+        migrations.AddConstraint(
+            model_name="streamcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=False),
+                fields=("stream", "property", "subgroup", "end_time"),
+                name="unique_stream_count",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="streamcount",
+            name="unique_stream_count_null_subgroup",
+        ),
+        migrations.AddConstraint(
+            model_name="streamcount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=True),
+                fields=("stream", "property", "end_time"),
+                name="unique_stream_count_null_subgroup",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="usercount",
+            name="unique_user_count",
+        ),
+        migrations.AddConstraint(
+            model_name="usercount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=False),
+                fields=("user", "property", "subgroup", "end_time"),
+                name="unique_user_count",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="usercount",
+            name="unique_user_count_null_subgroup",
+        ),
+        migrations.AddConstraint(
+            model_name="usercount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(subgroup__isnull=True),
+                fields=("user", "property", "end_time"),
+                name="unique_user_count_null_subgroup",
+            ),
+        ),
+    ]


### PR DESCRIPTION
Due to a bug[^1] in Django 4.2, fixed in 4.2.6, queries using `__isnull` added an unnecessary cast.  This cast was _also_ used in `WHERE` clauses for partial indexes.  This means that partial indexes created before Zulip was using Django 4.2 (i.e. before Zulip Server 7.0 or 2c20028aa451) will not be used when the server is using Django 4.2.0 through 4.2.5 -- and, conversely, that indexes created while Zulip had those versions of Django (i.e. Zulip Server 7.0 through 7.4 or 7807bff52635) will not be used later.

We re-create the indexes, to ensure that users that installed Zulip after Zulip Server 7.0 / 2c20028aa451 and before Zulip Server 7.5 / 7807bff52635 have indexes which can be used by current Django.  This is useless work for some installations, but most analytics tables are not large enough for this to take significant time.

[^1]: https://code.djangoproject.com/ticket/34840

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
