### PR TITLE
help: Document that pronouns are now shown in @-mention typeahead.

### DIFF
--- a/help/custom-profile-fields.md
+++ b/help/custom-profile-fields.md
@@ -51,7 +51,9 @@ There are several different types of fields available.
 * **Date picker**: For dates, like "Birthday".
 * **Link**: For links to websites.
 * **External account**: For linking to GitHub, Twitter, etc.
-* **Pronouns**: What pronouns should people use to refer to the user?
+* **Pronouns**: What pronouns should people use to refer to the user? Pronouns
+  are displayed in [user mention](/help/mention-a-user-or-group) autocomplete
+  suggestions.
 * **List of options**: Creates a dropdown with a list of options.
 * **Person picker**: For selecting one or more users, like "Manager" or
     "Direct reports".


### PR DESCRIPTION
Current: https://zulip.com/help/custom-profile-fields#profile-field-types

Updated: 
![Screenshot 2023-11-16 at 2 12 46 PM](https://github.com/zulip/zulip/assets/2090066/1b03ed7a-e3b8-4670-b3b6-174ebcced286)

I decided that the precise detail of what happens if an org has *two* pronoun fields does not need to be documented, since it's a rather odd circumstance.