### PR TITLE
Rename "Manage streams" -> "Stream settings".

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -446,7 +446,7 @@ Test subscribe/unsubscribe:
 
 - Log in as Hamlet and go to his stream settings.
 - As Cordelia, unsubscribe from "public1" using the checkmark in the
-  streams settings page.
+  stream settings page.
 - Verify that Hamlet sees that Cordelia has unsubscribed (and the
   subscriber count should decrement).
 - As Cordelia, resubscribe to "public1."

--- a/docs/translating/translating.md
+++ b/docs/translating/translating.md
@@ -209,8 +209,8 @@ properly capitalized in a way consistent with how Zulip does
 capitalization in general. This means that:
 
 - The first letter of a sentence or phrase should be capitalized.
-  - Correct: "Manage streams"
-  - Incorrect: "Manage Streams"
+  - Correct: "Stream settings"
+  - Incorrect: "Stream Settings"
 - All proper nouns should be capitalized.
   - Correct: "This is Zulip"
   - Incorrect: "This is zulip"

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -12,7 +12,7 @@ in the Zulip app to add more to your repertoire as needed.
 * [Message actions](#message-actions)
 * [Drafts](#drafts)
 * [Menus](#menus)
-* [Streams settings](#streams-settings-page)
+* [Stream settings](#stream-settings)
 
 ## The basics
 
@@ -213,7 +213,7 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **Toggle message actions menu**: <kbd>I</kbd>
 
-## Streams settings page
+## Stream settings
 
 * **Scroll through streams**: <kbd class="arrow-key">↑</kbd> and
   <kbd class="arrow-key">↓</kbd>

--- a/help/unsubscribe-from-a-stream.md
+++ b/help/unsubscribe-from-a-stream.md
@@ -22,7 +22,7 @@ You can always unsubscribe from any stream in Zulip.
 
 ## Alternate methods to unsubscribe from a stream
 
-### Via manage streams
+### Via subscribed streams
 
 {start_tabs}
 

--- a/web/src/add_stream_options_popover.js
+++ b/web/src/add_stream_options_popover.js
@@ -16,7 +16,7 @@ export function initialize() {
 
             if (!can_create_streams) {
                 // If the user can't create streams, we directly
-                // navigate them to the Manage streams subscribe UI.
+                // navigate them to the Stream settings subscribe UI.
                 window.location.assign("#streams/all");
                 // Returning false from an onShow handler cancels the show.
                 return false;

--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -25,7 +25,7 @@ actually do much of the work.
 Our gear menu has these choices:
 
 =================
-hash:  Manage streams
+hash:  Stream settings
 hash:  Settings
 hash:  Organization settings
 link:  Usage statistics

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -523,7 +523,7 @@ export function setup_page(callback) {
     // so it's too risky a change for now.
     //
     // The history behind setting up the page from scratch every
-    // time we go into "Manage streams" is that we used to have
+    // time we go into "Stream settings" is that we used to have
     // some live-update issues, so being able to re-launch the
     // streams page is kind of a workaround for those bugs, since
     // we will re-populate the widget.
@@ -532,7 +532,7 @@ export function setup_page(callback) {
     // continue the strategy that we re-render everything from scratch.
     // Also, we'll always go back to the "Subscribed" tab.
     function initialize_components() {
-        // Sort by name by default when opening "Manage streams".
+        // Sort by name by default when opening "Stream settings".
         sort_order = "by-stream-name";
         const sort_toggler = components.toggle({
             values: [
@@ -564,7 +564,7 @@ export function setup_page(callback) {
         $("#streams_overlay_container .list-toggler-container").prepend(sort_toggler.get());
 
         // Reset our internal state to reflect that we're initially in
-        // the "Subscribed" tab if we're reopening "Manage streams".
+        // the "Subscribed" tab if we're reopening "Stream settings".
         stream_ui_updates.set_subscribed_only(true);
         toggler = components.toggle({
             child_wants_focus: true,

--- a/web/templates/gear_menu_popover.hbs
+++ b/web/templates/gear_menu_popover.hbs
@@ -56,7 +56,7 @@
             <ul class="navbar-dropdown-menu-inner-list">
                 <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">
                     <a href="#streams/subscribed" class="navigate-link-on-enter navbar-dropdown-menu-link">
-                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i> {{t 'Manage streams' }}
+                        <i class="navbar-dropdown-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i> {{t 'Stream settings' }}
                     </a>
                 </li>
                 <li class="link-item navbar-dropdown-menu-inner-list-item hidden-for-spectators">

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -343,7 +343,7 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Streams settings' }}</th>
+                        <th colspan="2">{{t 'Stream settings' }}</th>
                     </tr>
                 </thead>
                 <tr>

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -19,7 +19,7 @@ gear_info = {
     # key is from REGEXP: `{relative|gear|key}`
     # name is what the item is called in the gear menu: `Select **name**.`
     # link is used for relative links: `Select [name](link).`
-    "manage-streams": ['<i class="fa fa-exchange"></i> Manage streams', "/#streams/subscribed"],
+    "stream-settings": ['<i class="fa fa-exchange"></i> Stream settings', "/#streams/subscribed"],
     "settings": ['<i class="fa fa-wrench"></i> Personal Settings', "/#settings/profile"],
     "organization-settings": [
         '<i class="fa fa-bolt"></i> Organization settings',
@@ -92,7 +92,7 @@ stream_instructions_no_link = """
 1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
    right corner of the web or desktop app.
 
-1. Click **Manage streams**.
+1. Click **Stream settings**.
 """
 
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -429,7 +429,7 @@ class HelpTest(ZulipTestCase):
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
             result = self.client_get("/help/message-a-stream-by-email", subdomain="")
         self.assertEqual(result.status_code, 200)
-        self.assertIn("<strong>Manage streams</strong>", str(result.content))
+        self.assertIn("<strong>Stream settings</strong>", str(result.content))
         self.assertNotIn("/#streams", str(result.content))
 
 


### PR DESCRIPTION
- Renames gear menu label, and updates code comments.
- Renames "Streams settings" label in the keyboard shortcuts reference to "Stream settings" for consistency.
- Updates help center docs to reflect renamed gear menu label.
- Updates contributor docs to reflect renamed gear menu label.

Fixes #27754.

**Screenshots and screen captures:**
- **Gear menu**
![image](https://github.com/zulip/zulip/assets/2343554/175bfb3f-7eea-4f51-b8a1-8a8f4a31d70e)

- https://zulip.com/help/unsubscribe-from-a-stream
![image](https://github.com/zulip/zulip/assets/2343554/9dde2ff0-29ac-44bb-b4e6-8f2bb30f65b1)

- https://chat.zulip.org/#keyboard-shortcuts
![image](https://github.com/zulip/zulip/assets/2343554/1afaf414-56b3-42df-9b09-3dc5bfc99d72)

- https://zulip.com/help/keyboard-shortcuts
![image](https://github.com/zulip/zulip/assets/2343554/1e9d8441-cd41-4f86-8550-0a50a956c488)
![image](https://github.com/zulip/zulip/assets/2343554/a04dd820-f1f2-4fac-9c81-8376d26d7e93)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
