### PR TITLE
compose: Fix bug where extra line breaks were pasted between blocks.

### DIFF
--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -337,6 +337,7 @@ export function paste_handler_converter(paste_html) {
         emDelimiter: "*",
         codeBlockStyle: "fenced",
         headingStyle: "atx",
+        br: "",
     });
     turndownService.addRule("style", {
         filter: "style",

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -97,6 +97,11 @@ run_test("paste_handler_converter", () => {
         "* bulleted\n* nested\n  * nested level 1\n  * nested level 1 continue\n    * nested level 2\n    * nested level 2 continue",
     );
 
+    // 2 paragraphs with line break/s in between
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><p>paragraph 1</p><br><p>paragraph 2</p>';
+    assert.equal(copy_and_paste.paste_handler_converter(input), "paragraph 1\n\nparagraph 2");
+
     // Pasting from external sources
     // Pasting list from GitHub
     input =


### PR DESCRIPTION
Due to the way turndown pads every block element with 2 new lines, and makes `br` double space by default, we would get 3 blank lines pasted when there's just 1 line break between 2 paragraphs.

Now we set `br` to an empty string, and since turndown collapses sequences of multiple new lines to `\n\n` (1 blank line), so any 2 block elements will now always have 1 blank line between them, irrespective of if and how many line breaks there are between them in the copied HTML.

Fixes: [issue brought up in this CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/extra.20line.20breaks.20when.20pasting/near/1682915)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
