### PR TITLE
 Add "copy" buttons to bot settings #19884

### DIFF
--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -390,6 +390,34 @@ export function set_up() {
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
 
+    $("#active_bots_list").on("click", ".button-copy-email", function() {
+        const $email_button = $(this); // Reference to the clicked button
+        const email = $email_button.attr("email");
+    
+        const clipboardInstance = new ClipboardJS($email_button[0], {
+            text() {
+                return email;
+            }
+        });
+    
+        clipboardInstance.on("success", (e) => {
+            // eslint-disable-next-line no-console
+            console.log("Email copied: " + e.text);
+            // Optionally show a message or perform other actions after successful copy
+        });
+    
+        clipboardInstance.on("error", (e) => {
+            // eslint-disable-next-line no-console
+            console.error("Failed to copy email: " + e.action);
+            // Optionally handle errors if the copy fails
+        });
+    
+        // Manually trigger the click event to copy the email
+        clipboardInstance.onClick({
+            currentTarget: $email_button[0]
+        });
+    });
+
     $("#active_bots_list").on("click", "button.regenerate_bot_api_key", (e) => {
         const bot_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         channel.post({
@@ -438,6 +466,34 @@ export function set_up() {
         integration_url_modal.show_generate_integration_url_modal(api_key);
     });
 
+    $("#active_bots_list").on("click", ".button-copy-api-key", function() {
+        const $api_key_button = $(this); // Reference to the clicked button
+        const api_key = $api_key_button.attr("data-api-key");
+    
+        const clipboardInstance = new ClipboardJS($api_key_button[0], {
+            text() {
+                return api_key;
+            }
+        });
+    
+        clipboardInstance.on("success", (e) => {
+            // eslint-disable-next-line no-alert
+            alert("API Key copied: " + e.text);
+            // Optionally show a message or perform other actions after successful copy
+        });
+    
+        clipboardInstance.on("error", (e) => {
+            // eslint-disable-next-line no-alert
+            alert("Failed to copy API Key: " + e.action);
+            // Optionally handle errors if the copy fails
+        });
+    
+        // Manually trigger the click event to copy the API key
+        clipboardInstance.onClick({
+            currentTarget: $api_key_button[0]
+        });
+    });
+
     const clipboard = new ClipboardJS("#copy_zuliprc", {
         text(trigger) {
             const $bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
@@ -447,6 +503,8 @@ export function set_up() {
             return data;
         },
     });
+
+    $("active_bots_list").on("click", "button.open-generate-integration-url")
 
     // Show a tippy tooltip when the bot zuliprc is copied
     clipboard.on("success", (e) => {

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -37,7 +37,12 @@
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
             <div class="value">{{email}}</div>
-        </div>
+            <div>
+                <button class="button-copy-email">
+                       <i class="fa fa-clipboard" aria-hidden="true">
+                    </i></button>
+
+        </div></div>
         {{#if is_active}}
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
@@ -47,6 +52,9 @@
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>
+                <button class="button-copy-api-key">
+                       <i class="fa fa-clipboard" aria-hidden="true">
+                    </i></button>
             </div>
             <div class="api_key_error text-error"></div>
         </div>


### PR DESCRIPTION
 Add "copy" buttons to bot settings 

Added copy buttons to the following:

- To copy email from bot settings
- To copy Api key from bot settings