### PR TITLE
api_docs: Add missing followed topic visibility policy.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -96,6 +96,10 @@ format used by the Zulip server that they are interacting with.
   [`PATCH /settings`](/api/update-settings): Renamed `default_view` and
   `escape_navigates_to_default_view` settings to `web_home_view` and
   `web_escape_navigates_to_home_view` respectively.
+* [`POST /user_topics`](/api/update-user-topic), [`POST
+  register`](/api/register-queue), [`GET /events`](/api/get-events):
+  Added followed as a supported value for visibility policies in
+  `user_topic` objects.
 
 **Feature level 218**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2152,11 +2152,15 @@ paths:
 
                                     - 0 = None. Used to indicate that the user no
                                       longer has a special visibility policy for this topic.
-                                    - 1 = Muted. Used to record muted topics.
+                                    - 1 = Muted. Used to record [muted topics](/help/mute-a-topic).
                                     - 2 = Unmuted. Used to record unmuted topics.
+                                    - 3 = Followed. Used to record [followed topics](/help/follow-a-topic).
 
-                                    **Changes**: In Zulip 7.0 (feature level 170), added unmuted as
+                                    **Changes**: In Zulip 7.0 (feature level 219), added followed as
                                     a visibility policy option.
+
+                                    In Zulip 7.0 (feature level 170), added unmuted as a visibility
+                                    policy option.
                               additionalProperties: false
                               example:
                                 {
@@ -9445,9 +9449,13 @@ paths:
             - 0 = None. Removes the visibility policy previously set for the topic.
             - 1 = Muted. [Mutes the topic](/help/mute-a-topic) in a stream.
             - 2 = Unmuted. [Unmutes the topic](/help/mute-a-topic) in a muted stream.
+            - 3 = Followed. [Follows the topic](/help/follow-a-topic).
 
             In an unmuted stream, a topic visibility policy of unmuted will have the
             same effect as the "None" visibility policy.
+
+            **Changes**: In Zulip 7.0 (feature level 219), added followed as
+            a visibility policy option.
           schema:
             type: integer
             enum:
@@ -12871,9 +12879,13 @@ paths:
 
                                 - 1 = Muted. Used to record [muted topics](/help/mute-a-topic).
                                 - 2 = Unmuted. Used to record [unmuted topics](/help/mute-a-topic).
+                                - 3 = Followed. Used to record [followed topics](/help/follow-a-topic).
 
-                                **Changes**: In Zulip 7.0 (feature level 170), added unmuted as
+                                **Changes**: In Zulip 7.0 (feature level 219), added followed as
                                 a visibility policy option.
+
+                                In Zulip 7.0 (feature level 170), added unmuted as a visibility
+                                policy option.
                       has_zoom_token:
                         type: boolean
                         description: |


### PR DESCRIPTION
While the server implementation has accepted this value for a few months as part of building the feature, following topics was not a fully supported feature of the Zulip server before 3f2ab44f9485da603dc192b1b6a03102d13997d4, just before feature level 219.

So that's probably the correct level to document as the first feature level at which we recommend that clients supporting the followed topics feature process the value.