### PR TITLE
help: Document how to change font size with zoom.

### DIFF
--- a/help/font-size.md
+++ b/help/font-size.md
@@ -1,0 +1,19 @@
+# Font size
+
+You can adjust the font size in Zulip by zooming in or out in your browser, or
+in the Zulip desktop app. Zooming in to 110% or 125% works well on many screens.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Use <kbd>Ctrl</kbd> + <kbd>+</kbd> to zoom in, <kbd>Ctrl</kbd> + <kbd>-</kbd>
+    to zoom out, or <kbd>Ctrl</kbd> + <kbd>0</kbd> to reset to default zoom.
+
+!!! tip ""
+
+    In the Zulip desktop app and most browsers, you can also open the **View**
+    menu in the top menu bar, and click **Zoom In**, **Zoom Out**, or **Actual
+    Size**.
+
+{end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -46,6 +46,7 @@
 
 ## Preferences
 * [Dark theme](/help/dark-theme)
+* [Font size](/help/font-size)
 * [Change your language](/help/change-your-language)
 * [Change your time zone](/help/change-your-timezone)
 * [Change the time format](/help/change-the-time-format)


### PR DESCRIPTION
I documented the keyboard as the primary method, as it's generally the most handy, and consistent across browsers.

<img width="1146" alt="Screenshot 2023-11-17 at 10 34 03 AM" src="https://github.com/zulip/zulip/assets/2090066/8b0de40c-e541-4360-a753-37f0548660c0">

Thanks @alexmv for the suggestion on a thread a couple of months ago. :)