### PR TITLE
top_navbar:  Remove subscriber count; improve icons and alignment.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -669,10 +669,10 @@ export class Filter {
                 context.icon = "envelope";
                 break;
             case "is-starred":
-                context.icon = "star";
+                context.zulip_icon = "star-filled";
                 break;
             case "is-mentioned":
-                context.icon = "at";
+                context.zulip_icon = "at-sign";
                 break;
             case "dm":
                 context.icon = "envelope";

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -10,14 +10,6 @@ import * as recent_view_util from "./recent_view_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
 
-function get_formatted_sub_count(sub_count) {
-    if (sub_count >= 1000) {
-        // parseInt() is used to floor the value of division to an integer
-        sub_count = Number.parseInt(sub_count / 1000, 10) + "k";
-    }
-    return sub_count;
-}
-
 function make_message_view_header(filter) {
     const message_view_header = {};
     if (recent_view_util.is_visible()) {
@@ -56,7 +48,6 @@ function make_message_view_header(filter) {
         message_view_header.rendered_narrow_description = current_stream.rendered_description;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
         message_view_header.sub_count = sub_count;
-        message_view_header.formatted_sub_count = get_formatted_sub_count(sub_count);
         // the "title" is passed as a variable and doesn't get translated (nor should it)
         message_view_header.sub_count_tooltip_text = $t(
             {defaultMessage: "This stream has {count} subscribers."},

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -15,7 +15,7 @@ function make_message_view_header(filter) {
     if (recent_view_util.is_visible()) {
         return {
             title: $t({defaultMessage: "Recent conversations"}),
-            icon: "clock-o",
+            zulip_icon: "clock",
         };
     }
     if (inbox_util.is_visible()) {
@@ -27,7 +27,7 @@ function make_message_view_header(filter) {
     if (filter === undefined) {
         return {
             title: $t({defaultMessage: "All messages"}),
-            icon: "align-left",
+            zulip_icon: "all-messages",
         };
     }
     message_view_header.title = filter.get_title();

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -612,13 +612,6 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
-    #message_view_header .sub_count {
-        &::before,
-        &::after {
-            color: hsl(0deg 0% 100% / 50%);
-        }
-    }
-
     & div.overlay,
     #subscription_overlay
         #stream-creation

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2272,11 +2272,7 @@ div.focused-message-list {
     height: var(--header-height);
     width: 100%;
     line-height: var(--header-height);
-    font-size: 16px;
     display: flex;
-    align-content: flex-start;
-    flex-wrap: nowrap;
-    margin: 0;
     white-space: nowrap;
     cursor: default;
 
@@ -2286,21 +2282,15 @@ div.focused-message-list {
 
     .message-header-stream-settings-button,
     & > span {
-        white-space: nowrap;
-        list-style-type: none;
-        display: inline-block;
-        vertical-align: top;
-        position: relative;
         font-weight: 600;
         font-size: 16px;
-        line-height: 16px;
         margin: 0 -4px 0 0;
-        padding: 12px 6px;
+        padding: 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
 
         @media (width < $sm_min) {
-            padding: 7px 3.5px; /* based on having ~41.66% decrease */
+            padding: 0 3.5px; /* based on having ~41.66% decrease */
         }
 
         & i {
@@ -2335,8 +2325,6 @@ div.focused-message-list {
 
         .zulip-icon {
             font-size: 14px;
-            position: relative;
-            top: 1px;
         }
     }
 
@@ -2348,23 +2336,11 @@ div.focused-message-list {
            is chosen such that the narrow description shrinks to close
            before the stream name must begin to shrink */
         flex-shrink: 100;
-        white-space: nowrap;
-        padding: 12px 0;
         padding-left: 10px;
         background: none;
         font-size: 14px;
         color: inherit;
         font-weight: 400;
-        line-height: 20px;
-
-        @media (width < $sm_min) {
-            padding: 7px 0;
-            padding-left: 10px;
-        }
-
-        & > a {
-            padding: 12px 0;
-        }
     }
 
     /* The very last element in the navbar is the search icon, the second

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2273,6 +2273,7 @@ div.focused-message-list {
     width: 100%;
     line-height: var(--header-height);
     display: flex;
+    align-items: baseline;
     white-space: nowrap;
     cursor: default;
 
@@ -2292,9 +2293,19 @@ div.focused-message-list {
         text-decoration: none;
         /* Don't yield any space needed for the stream name. */
         flex-shrink: 0;
+        /* Create a flex container for the icon and
+           stream name. */
+        display: flex;
+        /* We want to use baseline alignment so that the
+           stream name and narrow description sit on
+           the same invisible line. */
+        align-items: baseline;
 
         .zulip-icon {
             font-size: 14px;
+            /* Pull the icon out of baseline alignment,
+               and center with stream name. */
+            align-self: center;
         }
 
         @media (width < $sm_min) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2312,12 +2312,21 @@ div.focused-message-list {
             font-size: 16px;
         }
 
+        .fa-envelope {
+            /* The squatter envelope icon appears
+               better vertically centered when aligned
+               to the baseline of the adjacent DM partners. */
+            align-self: baseline;
+        }
+
         @media (width < $sm_min) {
             padding: 0 3.5px; /* based on having ~41.66% decrease */
         }
 
         & i {
-            margin: 0 3px 0 5px;
+            margin: 0 6px 0 5px;
+            /* Align all icons to center. */
+            align-self: center;
         }
 
         .fa {
@@ -2330,12 +2339,6 @@ div.focused-message-list {
                 font-size: 1.2rem;
                 margin: 0 2px 0 5px;
             }
-        }
-
-        .zulip-icon-inbox,
-        .zulip-icon-star-filled {
-            position: relative;
-            top: 2px;
         }
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2285,8 +2285,7 @@ div.focused-message-list {
     .navbar_title {
         font-weight: 600;
         font-size: 16px;
-        margin: 0 -4px 0 0;
-        padding: 0 6px;
+        padding: 0 2px 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
         color: inherit;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2284,7 +2284,6 @@ div.focused-message-list {
         display: none;
     }
 
-    .sub_count,
     .message-header-stream-settings-button,
     & > span {
         white-space: nowrap;
@@ -2331,8 +2330,6 @@ div.focused-message-list {
         text-overflow: clip;
         color: inherit;
         text-decoration: none;
-        /* The first ~3px of padding here overlaps with the left padding from sub_count for some reason. */
-        padding-right: calc(3px + 10px);
         /* Don't yield any space needed for the stream name. */
         flex-shrink: 0;
 
@@ -2340,61 +2337,6 @@ div.focused-message-list {
             font-size: 14px;
             position: relative;
             top: 1px;
-        }
-    }
-
-    .divider {
-        color: hsl(0deg 0% 88%);
-        font-size: 20px;
-        margin: 0 3px;
-    }
-
-    .sub_count,
-    .narrow_description {
-        background: none;
-        font-size: 14px;
-        color: inherit;
-        font-weight: 400;
-        line-height: 20px;
-    }
-
-    .sub_count {
-        padding-left: 10px;
-        margin-left: 1px;
-        padding-right: 10px;
-        margin-right: 1px;
-        overflow: visible;
-
-        .fa.fa-user-o {
-            margin-left: 0;
-        }
-
-        &::before,
-        &::after {
-            content: "|";
-            position: absolute;
-            top: 25%;
-            height: 50%;
-            color: hsl(0deg 0% 88%);
-            font-size: 20px;
-
-            @media (width < $sm_min) {
-                top: 10%;
-            }
-        }
-
-        &::before {
-            left: -3px;
-
-            @media (width < $sm_min) {
-                /* this ensures the before "|" doesn't overlap
-                   with the stream name text on small narrows */
-                left: 0;
-            }
-        }
-
-        &::after {
-            right: -3px;
         }
     }
 
@@ -2409,6 +2351,11 @@ div.focused-message-list {
         white-space: nowrap;
         padding: 12px 0;
         padding-left: 10px;
+        background: none;
+        font-size: 14px;
+        color: inherit;
+        font-weight: 400;
+        line-height: 20px;
 
         @media (width < $sm_min) {
             padding: 7px 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2280,14 +2280,22 @@ div.focused-message-list {
         display: none;
     }
 
-    .message-header-stream-settings-button,
-    & > span {
+    .message-header-stream-settings-button {
         font-weight: 600;
         font-size: 16px;
         margin: 0 -4px 0 0;
         padding: 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
+        text-overflow: clip;
+        color: inherit;
+        text-decoration: none;
+        /* Don't yield any space needed for the stream name. */
+        flex-shrink: 0;
+
+        .zulip-icon {
+            font-size: 14px;
+        }
 
         @media (width < $sm_min) {
             padding: 0 3.5px; /* based on having ~41.66% decrease */
@@ -2316,18 +2324,6 @@ div.focused-message-list {
         }
     }
 
-    .message-header-stream-settings-button {
-        text-overflow: clip;
-        color: inherit;
-        text-decoration: none;
-        /* Don't yield any space needed for the stream name. */
-        flex-shrink: 0;
-
-        .zulip-icon {
-            font-size: 14px;
-        }
-    }
-
     .narrow_description {
         /* the actual value of flex shrink does not matter, it is the
            ratio of this value to other flex items that determines the
@@ -2336,11 +2332,14 @@ div.focused-message-list {
            is chosen such that the narrow description shrinks to close
            before the stream name must begin to shrink */
         flex-shrink: 100;
-        padding-left: 10px;
         background: none;
         font-size: 14px;
         color: inherit;
         font-weight: 400;
+        padding: 0 6px;
+        padding-left: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     /* The very last element in the navbar is the search icon, the second

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2281,14 +2281,14 @@ div.focused-message-list {
         display: none;
     }
 
-    .message-header-stream-settings-button {
+    .message-header-stream-settings-button,
+    .navbar_title {
         font-weight: 600;
         font-size: 16px;
         margin: 0 -4px 0 0;
         padding: 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
-        text-overflow: clip;
         color: inherit;
         text-decoration: none;
         /* Don't yield any space needed for the stream name. */
@@ -2306,6 +2306,10 @@ div.focused-message-list {
             /* Pull the icon out of baseline alignment,
                and center with stream name. */
             align-self: center;
+        }
+
+        .zulip-icon-inbox {
+            font-size: 16px;
         }
 
         @media (width < $sm_min) {
@@ -2335,6 +2339,11 @@ div.focused-message-list {
         }
     }
 
+    .message-header-navbar-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
     .narrow_description {
         /* the actual value of flex shrink does not matter, it is the
            ratio of this value to other flex items that determines the
@@ -2356,10 +2365,13 @@ div.focused-message-list {
     /* The very last element in the navbar is the search icon, the second
        last element is either the narrow description (for stream narrows) or
        the "title" (for other narrows). The flex-grow property ensures these
-       elements take up the entirety of the white space. */
+       elements take up the entirety of the white space, while flex-shrink
+       accommodates narrower viewports. Setting flex-basis 0 enables an
+       ellipsis to be displayed, as the 0 takes the place of the max-content
+       default that would otherwise run titles under the search box. */
     .navbar_title,
     .narrow_description {
-        flex-grow: 1;
+        flex: 1 1 0;
         margin: 0;
         /* Calculate right margin so that text can truncate
            and not collide with the search section. */

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -2,10 +2,6 @@
 <a class="message-header-stream-settings-button" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
-<div class="divider only-visible-for-spectators">|</div>
-<a class="sub_count no-style tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{sub_count_tooltip_text}}" data-tippy-placement="bottom" href="{{stream_settings_link}}">
-    <i class="fa fa-user-o"></i>{{formatted_sub_count}}
-</a>
 <span class="narrow_description rendered_markdown">
     {{#if rendered_narrow_description}}
     {{rendered_markdown rendered_narrow_description}}

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -3,4 +3,4 @@
 {{else if icon}}
 <i class="fa fa-{{icon}}" aria-hidden="true"></i>
 {{/if}}
-{{title}}
+<span class="message-header-navbar-title">{{title}}</span>

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1594,7 +1594,7 @@ test("navbar_helpers", () => {
         {
             operator: is_starred,
             is_common_narrow: true,
-            icon: "star",
+            zulip_icon: "star-filled",
             title: "translated: Starred messages",
             redirect_url_with_search: "/#narrow/is/starred",
         },
@@ -1622,7 +1622,7 @@ test("navbar_helpers", () => {
         {
             operator: is_mentioned,
             is_common_narrow: true,
-            icon: "at",
+            zulip_icon: "at-sign",
             title: "translated: Mentions",
             redirect_url_with_search: "/#narrow/is/mentioned",
         },


### PR DESCRIPTION
This PR carries forward work begun in #27409 for dropping the subscription count from the top navbar.

In addition to that work, this PR:

* Modernizes the layout for all icon-title combinations in the top navbar
* Gets ALL titles on the same invisible line (the Inbox one previously drooped a bit lower than the others)
* Precisely aligns the stream name with its description on a shared baseline
* Places the same icons as are in use in the left sidebar, as many of those align better than their FA counterparts
* Makes the whole title area more robust (partially by structuring the title as a first-rate DOM element, where it had previously been a text node), and removes and otherwise cleans up a bunch of brittle CSS that was formerly used for adjusting to a narrower header height. That's now all just accomplished c/o flexbox.

**NOTE**: Because this PR eliminates the always-visible subscriber count, it should probably be deployed in tandem with #27666. I don't think there should be any merge conflicts there, either.

Fixes: #27361 
Fixes much of: #27359

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/message_view_header.20padding.20misalignment/near/1683120)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Streams, before | Streams, after |
| --- | --- |
| ![logged-out-before](https://github.com/zulip/zulip/assets/170719/a172ad08-b337-43f7-b92e-9f93fe715be5) | ![logged-out-after](https://github.com/zulip/zulip/assets/170719/5b8bea31-7339-4b7b-818b-996d649c292d) |
| ![private-before](https://github.com/zulip/zulip/assets/170719/3f0df45f-b125-4825-b669-fd7c96c7ac7a) | ![private-after](https://github.com/zulip/zulip/assets/170719/65b20f03-fbf0-4f8b-b7c6-7fbce4cca8c6) |
| ![stream-before](https://github.com/zulip/zulip/assets/170719/a1a4117c-02bc-4991-8533-75ac94717e92) | ![stream-after](https://github.com/zulip/zulip/assets/170719/a6f9e82b-f7d1-400a-9add-a5520e6233b5) |

| DMs, before | DMs, after |
| --- | --- |
| ![dm-group-before](https://github.com/zulip/zulip/assets/170719/dd5b8d6f-22d0-48d5-99b6-15697acfb235) | ![dm-group-after](https://github.com/zulip/zulip/assets/170719/cf6116c9-1403-4b56-8893-dc8876482608) |

| Home views, before | Home views, after |
| --- | --- |
| ![inbox-before](https://github.com/zulip/zulip/assets/170719/a1e5a132-e360-49df-86d5-64838ea67f23) | ![inbox-after](https://github.com/zulip/zulip/assets/170719/a42d3373-ceea-46f7-accf-d16ed3610219) |
| ![recent-before](https://github.com/zulip/zulip/assets/170719/31c9a015-9f53-4a4e-81e2-7d916951debf) | ![recent-after-new-icon](https://github.com/zulip/zulip/assets/170719/fb28c750-53b5-4507-a257-e6a9abcece3e) |
| ![all-before](https://github.com/zulip/zulip/assets/170719/a8752f88-45d4-4fcc-a6e8-bba950479a81) | ![all-after](https://github.com/zulip/zulip/assets/170719/3a87b86f-1f92-4c02-a5ff-a942e0b72edc) |

| Sidebar narrows, before | Sidebar narrows, after |
| --- | --- |
| ![starred-before](https://github.com/zulip/zulip/assets/170719/cfa25efc-0844-44f7-92da-0bcabc6d70c6) | ![starred-after](https://github.com/zulip/zulip/assets/170719/45de47ea-8c62-4fec-ab59-0db55a93fd47) |
| ![mentions-before](https://github.com/zulip/zulip/assets/170719/f878fffc-62cb-4fc3-a8bc-c37e1ad5764e) | ![mentions-after](https://github.com/zulip/zulip/assets/170719/29f8f4c0-99be-4178-9f1b-5c18fa5f3b8a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>