### PR TITLE
message feed: Correct recipient-bar icon alignment.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1804,7 +1804,6 @@ td.pointer {
         cursor: pointer;
 
         i {
-            font-size: 17px;
             display: block;
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1793,6 +1793,13 @@ td.pointer {
     flex-grow: 1;
     align-items: center;
 
+    .external-topic-link {
+        /* Vertically center the external link
+           icon inside its containing anchor. */
+        display: flex;
+        align-items: center;
+    }
+
     .change_visibility_policy {
         cursor: pointer;
 

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -37,7 +37,7 @@
 
             {{! exterior links (e.g. to a trac ticket) }}
             {{#each topic_links}}
-                <a href="{{this.url}}" target="_blank" rel="noopener noreferrer" class="no-underline">
+                <a href="{{this.url}}" target="_blank" rel="noopener noreferrer" class="external-topic-link no-underline">
                     <i class="fa fa-external-link-square recipient_bar_icon" data-tippy-content="Open {{this.text}}" aria-label="{{t 'External link' }}"></i>
                 </a>
             {{/each}}


### PR DESCRIPTION
This PR corrects a misaligned link icon, which was most obvious in Chrome but also presented itself in Firefox. See screenshots below.

Additionally, this drops the size on the visiblity policy icons (mute, default, follow) so that they are 15px like the others on the row.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/icon.20alignment.20in.20topic.20header.20bar/near/1683623)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Chrome, before | Chrome, after |
| --- | --- |
| ![chrome-before](https://github.com/zulip/zulip/assets/170719/b87bcc6e-e7e6-458a-8d36-86a6a480fb99) | ![chrome-after](https://github.com/zulip/zulip/assets/170719/c19f0587-8396-4011-8175-bc8ffa4ba4ad) |

| Firefox, before | Firefox, after |
| --- | --- |
| ![firefox-before](https://github.com/zulip/zulip/assets/170719/975c5009-fc4b-4faf-ad90-a0815288aa68) | ![firefox-after](https://github.com/zulip/zulip/assets/170719/9a5cd829-02d1-4ab9-808f-4860684f375a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>