### PR TITLE
people: Remove final use of date-fns-tz

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "css-loader": "^6.2.0",
     "css-minimizer-webpack-plugin": "^5.0.0",
     "date-fns": "^2.16.1",
-    "date-fns-tz": "^2.0.0",
     "email-addresses": "^5.0.0",
     "emoji-datasource-google": "^15.0.1",
     "emoji-datasource-google-blob": "npm:emoji-datasource-google@^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,6 @@ dependencies:
   date-fns:
     specifier: ^2.16.1
     version: 2.30.0
-  date-fns-tz:
-    specifier: ^2.0.0
-    version: 2.0.0(date-fns@2.30.0)
   email-addresses:
     specifier: ^5.0.0
     version: 5.0.0
@@ -5081,14 +5078,6 @@ packages:
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
     dev: true
-
-  /date-fns-tz@2.0.0(date-fns@2.30.0):
-    resolution: {integrity: sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==}
-    peerDependencies:
-      date-fns: '>=2.0.0'
-    dependencies:
-      date-fns: 2.30.0
-    dev: false
 
   /date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 227
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (253, 1)
+PROVISION_VERSION = (254, 0)

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -1,4 +1,4 @@
-import {format, isSameDay} from "date-fns";
+import {isSameDay} from "date-fns";
 import $ from "jquery";
 
 import render_message_edit_history from "../templates/message_edit_history.hbs";
@@ -16,6 +16,7 @@ import * as spectators from "./spectators";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
+import {user_settings} from "./user_settings";
 
 export function fetch_and_render_message_history(message) {
     channel.get({
@@ -26,12 +27,15 @@ export function fetch_and_render_message_history(message) {
             let prev_time = null;
             let prev_stream_item = null;
 
+            const date_time_format = new Intl.DateTimeFormat(user_settings.default_language, {
+                dateStyle: "long",
+            });
             for (const [index, msg] of data.message_history.entries()) {
                 // Format times and dates nicely for display
                 const time = new Date(msg.timestamp * 1000);
                 const item = {
                     timestamp: timerender.stringify_time(time),
-                    display_date: format(time, "MMMM d, yyyy"),
+                    display_date: date_time_format.format(time),
                     show_date_row: prev_time === null || !isSameDay(time, prev_time),
                 };
 

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1,5 +1,4 @@
 import md5 from "blueimp-md5";
-import {format, utcToZonedTime} from "date-fns-tz";
 import assert from "minimalistic-assert";
 
 import * as typeahead from "../shared/src/typeahead";
@@ -12,8 +11,9 @@ import * as muted_users from "./muted_users";
 import {page_params} from "./page_params";
 import * as reload_state from "./reload_state";
 import * as settings_config from "./settings_config";
-import * as settings_data from "./settings_data";
+import * as timerender from "./timerender";
 import type {DisplayRecipientUser, Message, MessageWithBooleans} from "./types";
+import {user_settings} from "./user_settings";
 import * as util from "./util";
 
 export type ProfileData = {
@@ -364,26 +364,17 @@ export function emails_to_full_names_string(emails: string[]): string {
         .join(", ");
 }
 
-export function get_user_time_preferences(
-    user_id: number,
-): settings_data.TimePreferences | undefined {
+export function get_user_time(user_id: number): string | undefined {
     const user_timezone = get_by_user_id(user_id)!.timezone;
     if (user_timezone) {
-        return settings_data.get_time_preferences(user_timezone);
-    }
-    return undefined;
-}
-
-export function get_user_time(user_id: number): string | undefined {
-    const user_pref = get_user_time_preferences(user_id);
-    if (user_pref) {
-        const current_date = utcToZonedTime(new Date(), user_pref.timezone);
-        // This could happen if the timezone is invalid.
-        if (Number.isNaN(current_date.getTime())) {
-            blueslip.error("Got invalid date for timezone", {timezone: user_pref.timezone});
-            return undefined;
+        try {
+            return new Date().toLocaleTimeString(user_settings.default_language, {
+                ...timerender.get_format_options_for_type("time"),
+                timeZone: user_timezone,
+            });
+        } catch (error) {
+            blueslip.error(`Error formatting time in ${user_timezone}`, undefined, error);
         }
-        return format(current_date, user_pref.format, {timeZone: user_pref.timezone});
     }
     return undefined;
 }

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -19,24 +19,6 @@ export function initialize(current_user_join_date: Date): void {
     about page_params and settings_config details.
 */
 
-export type TimePreferences = {
-    timezone: string;
-    format: string;
-};
-
-export function get_time_preferences(user_timezone: string): TimePreferences {
-    if (user_settings.twenty_four_hour_time) {
-        return {
-            timezone: user_timezone,
-            format: "H:mm",
-        };
-    }
-    return {
-        timezone: user_timezone,
-        format: "h:mm a",
-    };
-}
-
 export function user_can_change_name(): boolean {
     if (page_params.is_admin) {
         return true;

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -112,7 +112,7 @@ export function get_localized_date_or_time_for_format(
 // Exported for tests only.
 export function get_tz_with_UTC_offset(time: number | Date): string {
     const tz_offset = format(time, "xxx");
-    let timezone = new Intl.DateTimeFormat(undefined, {timeZoneName: "short"})
+    let timezone = new Intl.DateTimeFormat(user_settings.default_language, {timeZoneName: "short"})
         .formatToParts(time)
         .find(({type}) => type === "timeZoneName")?.value;
 

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -43,7 +43,7 @@ type DateOrTimeFormat = DateFormat | TimeFormat | DateWithTimeFormat;
 // for any formats that display the name for a month/weekday, but
 // possibly in more subtle ways for languages with different
 // punctuation schemes for date and times.
-function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTimeFormatOptions {
+export function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTimeFormatOptions {
     const is_twenty_four_hour_time = user_settings.twenty_four_hour_time;
 
     const time_format_options: Intl.DateTimeFormatOptions = is_twenty_four_hour_time

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -2,7 +2,6 @@ import {
     differenceInCalendarDays,
     differenceInHours,
     differenceInMinutes,
-    format,
     formatISO,
     isEqual,
     isValid,
@@ -111,7 +110,6 @@ export function get_localized_date_or_time_for_format(
 
 // Exported for tests only.
 export function get_tz_with_UTC_offset(time: number | Date): string {
-    const tz_offset = format(time, "xxx");
     let timezone = new Intl.DateTimeFormat(user_settings.default_language, {timeZoneName: "short"})
         .formatToParts(time)
         .find(({type}) => type === "timeZoneName")?.value;
@@ -125,7 +123,12 @@ export function get_tz_with_UTC_offset(time: number | Date): string {
     // show that along with (UTC+x:y)
     timezone = /GMT[+-][\d:]*/.test(timezone ?? "") ? "" : timezone;
 
-    const tz_UTC_offset = `(UTC${tz_offset})`;
+    const tz_offset = new Intl.DateTimeFormat(user_settings.default_language, {
+        timeZoneName: "longOffset",
+    })
+        .formatToParts(time)
+        .find(({type}) => type === "timeZoneName")!.value;
+    const tz_UTC_offset = `(${tz_offset.replace(/^GMT/, "UTC")})`;
 
     if (timezone) {
         return timezone + " " + tz_UTC_offset;

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -94,17 +94,6 @@ function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTimeForma
     }
 }
 
-function get_user_locale(): string {
-    const user_default_language = user_settings.default_language;
-    let locale = "";
-    try {
-        locale = Intl.DateTimeFormat.supportedLocalesOf(user_default_language)[0];
-    } catch {
-        locale = "default";
-    }
-    return locale;
-}
-
 // Common function for all date/time rendering in the project. Handles
 // localization using the user's configured locale and the
 // twenty_four_hour_time setting.
@@ -114,8 +103,10 @@ export function get_localized_date_or_time_for_format(
     date: Date | number,
     format: DateOrTimeFormat,
 ): string {
-    const locale = get_user_locale();
-    return new Intl.DateTimeFormat(locale, get_format_options_for_type(format)).format(date);
+    return new Intl.DateTimeFormat(
+        user_settings.default_language,
+        get_format_options_for_type(format),
+    ).format(date);
 }
 
 // Exported for tests only.
@@ -467,8 +458,7 @@ export function get_full_datetime_clarification(
     time: Date,
     time_format: TimeFormat = "time_sec",
 ): string {
-    const locale = get_user_locale();
-    const date_string = time.toLocaleDateString(locale);
+    const date_string = time.toLocaleDateString(user_settings.default_language);
     let time_string = get_localized_date_or_time_for_format(time, time_format);
 
     const tz_offset_str = get_tz_with_UTC_offset(time);

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -586,25 +586,11 @@ test_people("bot_custom_profile_data", () => {
 test_people("user_timezone", () => {
     MockDate.set(parseISO("20130208T080910").getTime());
 
-    const expected_pref = {
-        timezone: "America/Los_Angeles",
-        format: "H:mm",
-    };
-
     user_settings.twenty_four_hour_time = true;
-    assert.deepEqual(people.get_user_time_preferences(me.user_id), expected_pref);
-
-    expected_pref.format = "h:mm a";
-    user_settings.twenty_four_hour_time = false;
-    assert.deepEqual(people.get_user_time_preferences(me.user_id), expected_pref);
-
-    user_settings.twenty_four_hour_time = true;
-    assert.equal(people.get_user_time(me.user_id), "0:09");
+    assert.equal(people.get_user_time(me.user_id), "00:09");
 
     user_settings.twenty_four_hour_time = false;
     assert.equal(people.get_user_time(me.user_id), "12:09 AM");
-
-    assert.deepEqual(people.get_user_time_preferences(unknown_user.user_id), undefined);
 });
 
 test_people("utcToZonedTime", ({override}) => {
@@ -612,10 +598,10 @@ test_people("utcToZonedTime", ({override}) => {
     user_settings.twenty_four_hour_time = true;
 
     assert.deepEqual(people.get_user_time(unknown_user.user_id), undefined);
-    assert.equal(people.get_user_time(me.user_id), "0:09");
+    assert.equal(people.get_user_time(me.user_id), "00:09");
 
     override(people.get_by_user_id(me.user_id), "timezone", "Eriador/Rivendell");
-    blueslip.expect("error", "Got invalid date for timezone");
+    blueslip.expect("error", "Error formatting time in Eriador/Rivendell");
     people.get_user_time(me.user_id);
 });
 

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -39,7 +39,7 @@ run_test("get_localized_date_or_time_for_format returns default date with incorr
     const date = date_2019;
     const expectedDate = "Friday, April 12, 2019";
 
-    user_settings.default_language = "invalidLanguageCode";
+    user_settings.default_language = "invalid";
     const actualDate = timerender.get_localized_date_or_time_for_format(
         date,
         "weekday_dayofyear_year",


### PR DESCRIPTION
`date-fns-tz` does not handle daylight saving time correctly, and can be replaced with modern browser APIs.