### PR TITLE
lightbox_view: Fix media title update on change in title.

### DIFF
--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -479,7 +479,14 @@ export function parse_media_data(media) {
     if (is_compose_preview_media) {
         sender_full_name = people.my_full_name();
     } else {
-        const $message = $parent.closest("[zid]");
+        //  To obtain the message corresponding to the media we are parsing, we
+        //  we choose a selector that selects the closest element to parent
+        //  whose id starts with 'zfilt'.
+        //
+        //  We refrain from using a selector which chooses the closest element
+        //  with 'zid' since both the message and non-message elements contain
+        //  zid. However, their id starts with 'zhome' rather.
+        const $message = $parent.closest("[id^='zfilt']");
         const zid = rows.id($message);
         const message = message_store.get(zid);
         if (message === undefined) {

--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -314,6 +314,10 @@ function display_video(payload) {
     $(".media-actions .open").attr("href", payload.url);
 }
 
+function get_asset_map_key_for_media($preview_src, $media) {
+    return [$preview_src, $media.parent().attr("aria-label") || $media.parent().attr("href")];
+}
+
 export function build_open_media_function(on_close) {
     if (on_close === undefined) {
         on_close = function () {
@@ -327,7 +331,7 @@ export function build_open_media_function(on_close) {
         // if the asset_map already contains the metadata required to display the
         // asset, just recall that metadata.
         let $preview_src = $media.attr("src");
-        let payload = asset_map.get($preview_src);
+        let payload = asset_map.get(get_asset_map_key_for_media($preview_src, $media));
         if (payload === undefined) {
             if ($preview_src.endsWith("&size=full")) {
                 // while fetching an image for canvas, `src` attribute supplies
@@ -341,7 +345,7 @@ export function build_open_media_function(on_close) {
                 // `data-thumbnail-src` attribute that we add to the
                 // canvas elements.
                 $preview_src = $preview_src.slice(0, -"full".length) + "thumbnail";
-                payload = asset_map.get($preview_src);
+                payload = asset_map.get(get_asset_map_key_for_media($preview_src, $media));
             }
             if (payload === undefined) {
                 payload = parse_media_data($media);
@@ -428,9 +432,9 @@ export function parse_media_data(media) {
     const $media = $(media);
     const preview_src = $media.attr("src");
 
-    if (asset_map.has(preview_src)) {
+    if (asset_map.has(get_asset_map_key_for_media(preview_src, $media))) {
         // check if media's data is already present in asset_map.
-        return asset_map.get(preview_src);
+        return asset_map.get(get_asset_map_key_for_media(preview_src, $media));
     }
 
     // if wrapped in the .youtube-video class, it will be length = 1, and therefore
@@ -504,7 +508,7 @@ export function parse_media_data(media) {
         url: util.is_valid_url(url) ? url : "",
     };
 
-    asset_map.set(preview_src, payload);
+    asset_map.set(get_asset_map_key_for_media(preview_src, $media), payload);
     return payload;
 }
 


### PR DESCRIPTION
The metadata of the media is stored in Map for the session with the preview_src as keys, and hence, when title is changed the preview_src being same, the title change is not reflected inside lightbox view.

This is fixed by modifing the asset_map (cache map) keys from preview_src to an array of preview_src, and the media title and using get_asset_map_key_for_media() to get the keys.

The filter for obtaining the closest zid element of media is also updated from [zid] to a more precise one to include only the zid containing media.

Fixes #21311

Update over previous PR #27469

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
