### PR TITLE
realm_inline_image_preview: Use it to toggle video previews too.

### DIFF
--- a/help/allow-image-link-previews.md
+++ b/help/allow-image-link-previews.md
@@ -15,7 +15,7 @@ prevent images from being used to track Zulip users.
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, toggle **Show previews of uploaded and linked images**.
+1. Under **Other settings**, toggle **Show previews of uploaded and linked images and videos**.
 
 1. Under **Other settings**, toggle **Show previews of linked websites**.
 

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -30,7 +30,9 @@ const admin_settings_label = {
     realm_mandatory_topics: $t({defaultMessage: "Require topics in stream messages"}),
     realm_notifications_stream: $t({defaultMessage: "New stream announcements"}),
     realm_signup_notifications_stream: $t({defaultMessage: "New user announcements"}),
-    realm_inline_image_preview: $t({defaultMessage: "Show previews of uploaded and linked images"}),
+    realm_inline_image_preview: $t({
+        defaultMessage: "Show previews of uploaded and linked images and videos",
+    }),
     realm_inline_url_embed_preview: $t({defaultMessage: "Show previews of linked websites"}),
     realm_send_welcome_emails: $t({defaultMessage: "Send emails introducing Zulip to new users"}),
     realm_message_content_allowed_in_email_notifications: $t({

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1195,6 +1195,9 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 return insertion_index
 
     def is_video(self, url: str) -> bool:
+        if not self.zmd.image_preview_enabled:
+            return False
+
         url_type = mimetypes.guess_type(url)[0]
         # Support only video formats (containers) that are supported cross-browser and cross-device. As per
         # https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#index_of_media_container_formats_file_types


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/setting.20for.20whether.20previews.20are.20displayed

This setting now also works to decide whether to show previews of uploaded or linked videos.

![image](https://github.com/zulip/zulip/assets/25124304/34582e3c-69e3-4d11-a2f9-4ca7714a1e00)

First message with preview enabled second with preview disabled.
<img width="676" alt="image" src="https://github.com/zulip/zulip/assets/25124304/ebe51d90-efb5-4e01-8cf7-2381d2cd2419">

