### PR TITLE
shortcut : made Shift + M  work in Recent conversations and Inbox

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -936,6 +936,22 @@ export function process_hotkey(e, hotkey) {
         case "all_messages":
             browser_history.go_to_location("#all_messages");
             return true;
+        case "toggle_topic_visibility_policy": {
+            if (recent_view_ui.is_in_focus() && recent_view_ui.is_table_focused()) {
+                const recent_msg = recent_view_ui.get_focused_row_message();
+                user_topics_ui.toggle_topic_visibility_policy(recent_msg);
+                return true;
+            }
+            if (
+                inbox_ui.is_in_focus() &&
+                inbox_ui.is_list_focused() &&
+                !inbox_ui.is_focus_row_a_header()
+            ) {
+                const indox_message = inbox_ui.get_focused_row_message();
+                user_topics_ui.toggle_topic_visibility_policy(indox_message.message);
+                return true;
+            }
+        }
     }
 
     // Shortcuts that are useful with an empty message feed, like opening compose.

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -676,7 +676,7 @@ function focus_inbox_search() {
     focus_current_id();
 }
 
-function is_list_focused() {
+export function is_list_focused() {
     return ![INBOX_SEARCH_ID, INBOX_FILTERS_DROPDOWN_ID].includes(current_focus_id);
 }
 
@@ -728,6 +728,14 @@ function update_closed_compose_text($row, is_header_row) {
         };
     }
     compose_closed_ui.update_reply_recipient_label(message);
+}
+export function is_focus_row_a_header() {
+    const $all_rows = get_all_rows();
+    const $focused_row = $($all_rows.get(row_focus));
+    if (is_row_a_header($focused_row)) {
+        return true;
+    }
+    return false;
 }
 
 export function get_focused_row_message() {

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -210,7 +210,7 @@ function get_min_load_count(already_rendered_count, load_count) {
     return load_count;
 }
 
-function is_table_focused() {
+export function is_table_focused() {
     return $current_focus_elem === "table";
 }
 


### PR DESCRIPTION
Earlier Shift + M  shortcut is working only in messages to mute/unmute topic in messages part

 This PR enables shortcut `Shift + M` work in recent conversations and
 Inbox by using existing function `toggle_topic_visibility_policy` and
 passing focused row message of recent_view_ui to mute/umute selected
 topic in recent_view_ui and the same process for inbox_ui

The function `toggle_topic_visibility_policy` in the both cases is called based on certain conditions to avoid shortcut work on remaining parts of page which results in error

A new function `is_focus_row_a_header` is introduced to check whether the focused row is header or not in indox_ui it is used to determine to use the shortcut when the focus row is a topic

Fixes #27741

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
