### PR TITLE
input : Error message disappears when user inputs

### DIFF
--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -89,6 +89,10 @@ export function enable_subscriber_management({sub, $parent_container}) {
         get_potential_subscribers,
     });
 
+    $pill_container.find(".input").on("input", () => {
+        $parent_container.find(".stream_subscription_request_result").empty();
+    });
+
     const user_ids = peer_data.get_subscribers(stream_id);
     const user_can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -91,13 +91,13 @@ function update_add_members_elements(group) {
     const $button_element = $add_members_container.find('button[name="add_member"]').expectOne();
 
     if (settings_data.can_edit_user_group(group.id)) {
-        $input_element.prop("disabled", false);
+        $input_element.prop("contenteditable", true);
         $button_element.prop("disabled", false);
         $button_element.css("pointer-events", "");
         $add_members_container[0]._tippy?.destroy();
         $add_members_container.removeClass("add_members_disabled");
     } else {
-        $input_element.prop("disabled", true);
+        $input_element.prop("contenteditable", false);
         $button_element.prop("disabled", true);
         $add_members_container.addClass("add_members_disabled");
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -290,8 +290,6 @@ export function show_settings_for(group) {
     $edit_container.show();
     show_membership_settings(group);
     user_group_components.setup_permissions_dropdown(group, false);
-
-    $edit_container.find("button").prop("disabled", !settings_data.can_edit_user_group(group.id));
 }
 
 export function setup_group_settings(group) {

--- a/web/src/user_group_edit_members.js
+++ b/web/src/user_group_edit_members.js
@@ -106,6 +106,10 @@ export function enable_member_management({group, $parent_container}) {
         get_potential_subscribers: get_potential_members,
     });
 
+    $pill_container.find(".input").on("input", () => {
+        $parent_container.find(".user_group_subscription_request_result").empty();
+    });
+
     member_list_widget = make_list_widget({
         $parent_container,
         name: "user_group_members",


### PR DESCRIPTION
Previously, when wrong username is entered in the Stream Membership input to subscribe a user then "No User to Subscribe" error is thrown but the error is expected to fade away it remains until successful user is added and the same goes for succesfull messages too

This PR uses the `stream_subscription_req_result_elem` div which is responsible for showing both error and successful messages and makes the `innerHTML` to empty when user inputs into the input box which result in removal of message

Fixes : #27438

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Screenshots**

**Before:**
<img width="555" alt="Screenshot 2023-11-14 at 3 02 07 PM" src="https://github.com/zulip/zulip/assets/88829894/d31eadb3-f0e2-493d-bcaa-4ffcae584c98">

**After**
<img width="587" alt="Screenshot 2023-11-14 at 3 03 54 PM" src="https://github.com/zulip/zulip/assets/88829894/2f851d0a-88d7-43b7-8205-faed3c8ca8c1">

**screen captures**

**Before:**

https://github.com/zulip/zulip/assets/88829894/0ccf3962-9936-4f35-8fbb-77245419eb9d

**After:**

https://github.com/zulip/zulip/assets/88829894/66e64ca4-c6ff-4bac-90ab-1bfd783200ed
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
