### PR TITLE
lightbox: Fix broken media list nav when youtube videos are opened first.

### DIFF
--- a/web/src/lightbox.js
+++ b/web/src/lightbox.js
@@ -91,6 +91,10 @@ export class PanZoomControl {
     }
 
     constrainImage(e) {
+        if (!this.isActive()) {
+            return;
+        }
+
         // Instead of using panzoom's built in bounds option which was buggy
         // at the time of this writing, we act on pan/zoom events and move the
         // image back in to view if it is moved beyond the image-preview container.
@@ -154,12 +158,20 @@ export class PanZoomControl {
     }
 
     zoomIn() {
+        if (!this.isActive()) {
+            return;
+        }
+
         const w = $(".image-preview").width();
         const h = $(".image-preview").height();
         this.panzoom.smoothZoom(w / 2, h / 2, Math.SQRT2);
     }
 
     zoomOut() {
+        if (!this.isActive()) {
+            return;
+        }
+
         const w = $(".image-preview").width();
         const h = $(".image-preview").height();
         this.panzoom.smoothZoom(w / 2, h / 2, Math.SQRT1_2);


### PR DESCRIPTION
Previously, when we load for the first time, the ```panzoom``` control is binded by default to the image class.

This causes various problems like when a non image class is opened first in lightbox, and some ```panzoom``` function
is performed on it. Even though no ```panzoom``` object is binded to them, it would rather perform the function with the object binded to image class, causing it to throw errors when no image has been opened yet in the lightbox.

This is fixed by checking if the image class has an ```img``` tag in it before performing any functions of the the ```panzoom``` object using the ```isActive()``` method

[CZO Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Lightbox.20youtube.20previews.20breaking.20the.20media_list.20navigation)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
