### PR TITLE
watchdog: Handle exception in `callback`.

### DIFF
--- a/web/src/watchdog.ts
+++ b/web/src/watchdog.ts
@@ -1,3 +1,5 @@
+import * as blueslip from "./blueslip";
+
 const unsuspend_callbacks: (() => void)[] = [];
 let watchdog_time = Date.now();
 
@@ -35,7 +37,17 @@ export function check_for_unsuspend(): void {
         // Our app's JS wasn't running, which probably means the machine was
         // asleep.
         for (const callback of unsuspend_callbacks) {
-            callback();
+            try {
+                callback();
+            } catch (error) {
+                blueslip.error(
+                    `Error while executing callback '${
+                        callback.name || "Anonymous function"
+                    }' from unsuspend_callbacks.`,
+                    undefined,
+                    error,
+                );
+            }
         }
     }
     watchdog_time = new_time;


### PR DESCRIPTION
Earlier, in the `check_for_unsuspend` function, we didn't handle the exception, if any, during callback execution, resulting in `watchdog_time` not always being updated.

This PR handles the exception using the try/catch block.

Fixes: #27723

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
