### PR TITLE
compose: Remove gaps between formatting buttons, and make all same size.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -28,48 +28,14 @@ kbd {
     user-select: none;
 }
 
-@media (width < $mc_min) {
-    .hide-mc {
-        display: none !important;
-    }
-
-    .show-mc {
-        display: block !important;
-    }
-}
-
-@media (width < $md_min) {
-    .hide-md {
-        display: none !important;
-    }
-
-    .show-md {
-        display: flex !important;
-    }
-}
-
 @media (width < $sm_min) {
     .hide-sm {
         display: none !important;
     }
 
-    .show-sm {
-        display: block !important;
-    }
-
     #settings_page .save-button-controls {
         display: block;
         margin: 10px 0 0;
-    }
-}
-
-@media (width < $lg_min) {
-    .hide-lg {
-        display: none !important;
-    }
-
-    .show-lg {
-        display: block !important;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -969,28 +969,28 @@ textarea.new_message_textarea,
 .compose-control-buttons-container {
     margin-right: auto;
     display: flex;
-    gap: 4px;
     align-items: center;
 
     /* We use the selector in this manner to maintain specificity. */
     .compose_control_button_container .compose_gif_icon {
         font-size: 22px;
-
-        /* Remove top and bottom padding. This is necessary
-         * because `compose_gif_icon` is no longer a flex item.  */
-        padding: 0 5px;
     }
 
     .compose_control_button {
-        padding: 5px;
+        height: 27px;
+        width: 27px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         opacity: 0.7;
         color: inherit;
         text-decoration: none;
         font-size: 17px;
-        text-align: center;
+        border-radius: 4px;
 
         &:hover {
             opacity: 1;
+            background-color: hsl(0deg 0% 100% / 10%);
         }
     }
 
@@ -1037,7 +1037,6 @@ textarea.new_message_textarea,
     .hide-lg {
         display: flex;
         align-items: center;
-        gap: 4px;
         padding: 0;
         margin: 0;
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1015,16 +1015,35 @@ textarea.new_message_textarea,
 
         .compose_control_menu {
             opacity: 1;
+            display: none;
+
+            /* The media queries below handle the hiding and showing of the
+            vdot menu icon, so that it is hidden when all compose buttons fit
+            in the main row below the compose box. So, these are opposite of
+            the media queries for .show_popover_buttons. */
+
+            @media (((width < $mc_min) and (width >= $md_min)) or (width < $sm_min)) {
+                display: flex;
+            }
+
+            &.show-lg {
+                @media (width < $lg_min) {
+                    display: flex;
+                }
+            }
         }
     }
 
-    .hide-sm,
     .hide-lg {
         display: flex;
         align-items: center;
         gap: 4px;
         padding: 0;
         margin: 0;
+
+        @media (width < $lg_min) {
+            display: none;
+        }
     }
 
     .divider {
@@ -1045,6 +1064,23 @@ textarea.new_message_textarea,
     .compose_help_button {
         font-size: 20px;
         line-height: 17px;
+    }
+
+    .show_popover_buttons {
+        display: flex;
+        align-items: center;
+        padding: 0;
+        margin: 0;
+
+        /* We use this class for the div containing those compose buttons,
+        which we hide and show in a popover instead when they no longer fit
+        in a single row (and related divider elements). The media queries
+        below handle the hiding and showing of the buttons from the main row
+        of compose buttons below the compose box. */
+
+        @media (((width < $mc_min) and (width >= $md_min)) or (width < $sm_min)) {
+            display: none;
+        }
     }
 }
 

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -22,11 +22,11 @@
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}} preview_mode_disabled" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
     </div>
-    <div class="divider hide-sm show-md hide-mc">|</div>
-    <div class="{{#if message_id}}hide-lg{{else}}hide-sm show-md hide-mc{{/if}}">
+    <div class="divider show_popover_buttons">|</div>
+    <div class="{{#if message_id}}hide-lg{{else}}show_popover_buttons{{/if}}">
         {{> popovers/compose_control_buttons/compose_control_buttons_in_popover}}
     </div>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>
-        <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{else}}show-sm hide-md show-mc{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
+        <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
     </div>
 </div>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -5,8 +5,12 @@
         <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0></a>
     </div>
     {{/if}}
-    <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
-    <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
+    <div class="compose_control_button_container" data-tippy-content="{{t 'Preview' }}">
+        <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0></a>
+    </div>
+    <div class="compose_control_button_container" data-tippy-content="{{t 'Write' }}">
+        <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;"></a>
+    </div>
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add voice call' }}">
         <a role="button" class="compose_control_button fa fa-phone audio_link" aria-label="{{t 'Add voice call' }}" tabindex=0></a>
     </div>

--- a/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
+++ b/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
@@ -4,6 +4,6 @@
     <a role="button" data-format-type="bulleted" class="compose_control_button fa fa-list-ul formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
     <a role="button" data-format-type="numbered" class="compose_control_button fa fa-list-ol formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
     <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Link' }}"></a>
-    <div class="divider hide-sm show-md hide-mc">|</div>
+    <div class="divider show_popover_buttons">|</div>
 </div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>


### PR DESCRIPTION
Fixes: [issue brought up here on CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20compose.20formatting.20buttons/near/1684084)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/00c604f6-fb97-48b6-a1c4-7c1d417b7bd5)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
