### PR TITLE
stripe: Add 'do_initial_upgrade' method to the 'BillingSession' class.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1448,10 +1448,7 @@ class StripeTest(StripeTestCase):
         new_seat_count = 23
         # Change the seat count while the user is going through the upgrade flow
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=new_seat_count):
-            with patch(
-                "corporate.views.upgrade.get_latest_seat_count", return_value=self.seat_count
-            ):
-                self.upgrade()
+            self.upgrade()
         customer = Customer.objects.first()
         assert customer is not None
         stripe_customer_id: str = assert_is_not_none(customer.stripe_customer_id)
@@ -1714,8 +1711,7 @@ class StripeTest(StripeTestCase):
 
         # Try again, with a valid card, after they added a few users
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=23):
-            with patch("corporate.views.upgrade.get_latest_seat_count", return_value=23):
-                response = self.upgrade()
+            response = self.upgrade()
         [second_payment_intent, _] = PaymentIntent.objects.all().order_by("-id")
         assert second_payment_intent.stripe_payment_intent_id is not None
         response_dict = self.assert_json_success(response)

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -1,33 +1,23 @@
 import logging
-from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from django import forms
 from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
-from django.urls import reverse
 
 from corporate.lib.stripe import (
-    DEFAULT_INVOICE_DAYS_UNTIL_DUE,
-    MIN_INVOICED_LICENSES,
     VALID_BILLING_MODALITY_VALUES,
     VALID_BILLING_SCHEDULE_VALUES,
     VALID_LICENSE_MANAGEMENT_VALUES,
     BillingError,
+    InitialUpgradeRequest,
     RealmBillingSession,
     UpgradeRequest,
-    get_latest_seat_count,
-    sign_string,
 )
 from corporate.lib.support import get_support_url
-from corporate.models import (
-    ZulipSponsorshipRequest,
-    get_current_plan_by_customer,
-    get_customer_by_realm,
-)
-from corporate.views.billing_page import billing_home
+from corporate.models import ZulipSponsorshipRequest
 from zerver.actions.users import do_change_is_billing_admin
 from zerver.decorator import require_organization_member, zulip_login_required
 from zerver.lib.request import REQ, has_request_variables
@@ -101,50 +91,15 @@ def initial_upgrade(
     if not settings.BILLING_ENABLED or user.is_guest:
         return render(request, "404.html", status=404)
 
-    customer = get_customer_by_realm(user.realm)
-    if (
-        customer is not None and customer.sponsorship_pending
-    ) or user.realm.plan_type == user.realm.PLAN_TYPE_STANDARD_FREE:
-        return HttpResponseRedirect(reverse("sponsorship_request"))
-
-    billing_page_url = reverse(billing_home)
-    if customer is not None and (get_current_plan_by_customer(customer) is not None or onboarding):
-        if onboarding:
-            billing_page_url = f"{billing_page_url}?onboarding=true"
-        return HttpResponseRedirect(billing_page_url)
-
-    percent_off = Decimal(0)
-    if customer is not None and customer.default_discount is not None:
-        percent_off = customer.default_discount
-
-    exempt_from_license_number_check = (
-        customer is not None and customer.exempt_from_license_number_check
+    initial_upgrade_request = InitialUpgradeRequest(
+        onboarding=onboarding,
+        manual_license_management=manual_license_management,
     )
+    billing_session = RealmBillingSession(user)
+    redirect_url, context = billing_session.do_initial_upgrade(initial_upgrade_request)
 
-    seat_count = get_latest_seat_count(user.realm)
-    signed_seat_count, salt = sign_string(str(seat_count))
-    context: Dict[str, Any] = {
-        "realm": user.realm,
-        "email": user.delivery_email,
-        "seat_count": seat_count,
-        "signed_seat_count": signed_seat_count,
-        "salt": salt,
-        "min_invoiced_licenses": max(seat_count, MIN_INVOICED_LICENSES),
-        "default_invoice_days_until_due": DEFAULT_INVOICE_DAYS_UNTIL_DUE,
-        "exempt_from_license_number_check": exempt_from_license_number_check,
-        "plan": "Zulip Cloud Standard",
-        "free_trial_days": settings.FREE_TRIAL_DAYS,
-        "onboarding": onboarding,
-        "page_params": {
-            "seat_count": seat_count,
-            "annual_price": 8000,
-            "monthly_price": 800,
-            "percent_off": float(percent_off),
-            "demo_organization_scheduled_deletion_date": user.realm.demo_organization_scheduled_deletion_date,
-        },
-        "is_demo_organization": user.realm.demo_organization_scheduled_deletion_date is not None,
-        "manual_license_management": manual_license_management,
-    }
+    if redirect_url:
+        return HttpResponseRedirect(redirect_url)
 
     response = render(request, "corporate/upgrade.html", context=context)
     return response


### PR DESCRIPTION
This PR moves a major portion of the `initial_upgrade` view to a new shared `BillingSession.do_initial_upgrade` method.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
