### PR TITLE
email_notification: Fix bad rendering of math formulas.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -248,6 +248,20 @@ def build_message_list(
         relative_to_full_url(fragment, user.realm.uri)
         fix_emojis(fragment, user.emojiset)
         fix_spoilers_in_html(fragment, user.default_language)
+
+        # Selecting the <span> elements with class 'katex'
+        katex_spans = fragment.xpath("//span[@class='katex']")
+
+        # Iterate through 'katex_spans' and replace with a new <span> having LaTeX text.
+        for katex_span in katex_spans:
+            latex_text = katex_span.xpath(".//annotation[@encoding='application/x-tex']")[0].text
+            # We store 'tail' to insert them back as the replace operation removes it.
+            tail = katex_span.tail
+            latex_span = lxml.html.Element("span")
+            latex_span.text = f"$${latex_text}$$"
+            katex_span.getparent().replace(katex_span, latex_span)
+            latex_span.tail = tail
+
         html = lxml.html.tostring(fragment, encoding="unicode")
         if sender:
             plain, html = prepend_sender_to_message(plain, html, sender)

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1593,6 +1593,20 @@ class TestMessageNotificationEmails(ZulipTestCase):
         )
         self.assertEqual(actual_output, expected_output)
 
+    def test_latex_math_formulas_in_email(self) -> None:
+        msg_id = self.send_stream_message(
+            self.example_user("iago"), "Denmark", "Equation: $$d^* = +\\infty$$ is correct."
+        )
+        verify_body_include = ["Equation: <span>$$d^* = +\\infty$$</span> is correct"]
+        email_subject = "#Denmark > test"
+        self._test_cases(
+            msg_id,
+            verify_body_include,
+            email_subject,
+            verify_html_body=True,
+            trigger=NotificationTriggers.STREAM_EMAIL,
+        )
+
     def test_empty_backticks_in_missed_message(self) -> None:
         msg_id = self.send_personal_message(
             self.example_user("othello"),


### PR DESCRIPTION
Fixes the email notification part of #25289.

> When I receive a message with latex math, the notification (in all of email, android, and desktop) includes the math three times in a row (once as unicode, once as latex, again as unicode). This seems to happen every time.


Earlier, for the emails having latex math like `$$d^* = +\infty$$`, the bad rendering led to the math being included multiple times in the email body.

This was due to displaying KaTeX HTML without the CSS.

This PR fixes the incorrect behavior by replacing the KaTeX with the raw LaTex source.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/56781761/dbfedadb-44f7-456e-9ddb-57ff1af72ae1) |  ![image](https://github.com/zulip/zulip/assets/56781761/cda37986-99c5-4d63-99b9-a990ed8b843e) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
