### PR TITLE
left_sidebar: Make streams header sticky.

### DIFF
--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -31,10 +31,12 @@ export function update_dom_with_unread_counts(counts, skip_animations) {
     const $mentioned_li = $(".top_left_mentions");
     const $home_view_li = $(".selected-home-view");
     const $streams_header = $("#streams_header");
+    const $back_to_streams = $("#topics_header");
 
     ui_util.update_unread_count_in_dom($mentioned_li, counts.mentioned_message_count);
     ui_util.update_unread_count_in_dom($home_view_li, counts.home_unread_messages);
     ui_util.update_unread_count_in_dom($streams_header, counts.stream_unread_messages);
+    ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
 
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1165,6 +1165,8 @@ li.topic-list-item {
     cursor: pointer;
     padding: $sections_vertical_gutter 0 3px calc($far_left_gutter_size + 2px);
     position: sticky;
+    /* Keep sticky within SimpleBar context. */
+    top: 0;
     background-color: var(--color-background);
     /* Ideally, 0px should work here, but maybe simplebar is doing something
        that is creating `0.5px` extra gap in zoomed-in windows. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -773,7 +773,8 @@ li.top_left_scheduled_messages {
 }
 
 #private_messages_section_header,
-#streams_header {
+#streams_header,
+#topics_header {
     display: grid;
     align-items: center;
     /* This extends the general pattern of left sidebar rows, but includes a
@@ -1139,12 +1140,14 @@ li.topic-list-item {
     position: sticky;
     top: 0;
     z-index: 2;
-    margin-right: 10px;
+    grid-template-columns: 0 0 minmax(0, 1fr) max-content 0 42px;
+    grid-template-rows: 24px;
     padding-top: $sections_vertical_gutter;
     color: hsl(0deg 0% 43%);
     background-color: var(--color-background);
 
     .show-all-streams {
+        grid-area: row-content;
         color: inherit;
         text-decoration: none;
         text-transform: uppercase;
@@ -1155,6 +1158,10 @@ li.topic-list-item {
             position: relative;
             top: 1px;
         }
+    }
+
+    .unread_count {
+        grid-area: markers-and-controls;
     }
 }
 
@@ -1336,6 +1343,7 @@ li.topic-list-item {
         background-color: var(--color-background);
     }
 
+    #streams_header,
     #subscribe-to-more-streams,
     .show-more-topics {
         display: none;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3278,16 +3278,8 @@ select.invite-as {
         margin-top: 10px;
     }
 
-    .column-left.expanded {
-        .left-sidebar {
-            #streams_header {
-                padding-right: 10px;
-            }
-        }
-
-        .left-sidebar-navigation-area {
-            margin-top: 10px;
-        }
+    .column-left.expanded .left-sidebar-navigation-area {
+        margin-top: 10px;
     }
 
     .spectator-view {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -175,7 +175,7 @@
                 </div>
             </div>
             <div id="topics_header">
-                <a class="show-all-streams" tabindex="0">{{t 'Back to streams' }}</a>
+                <a class="show-all-streams" tabindex="0">{{t 'Back to streams' }}</a> <span class="unread_count"></span>
             </div>
             <div id="stream-filters-container">
                 <ul id="stream_filters" class="filters"></ul>

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -96,6 +96,8 @@ run_test("update_count_in_dom", () => {
 
     make_elem($("#streams_header"), "<stream-count>");
 
+    make_elem($("#topics_header"), "<topics-count>");
+
     left_sidebar_navigation_area.update_dom_with_unread_counts(counts, false);
     left_sidebar_navigation_area.update_starred_count(444);
     // Calls left_sidebar_navigation_area.update_scheduled_messages_row
@@ -106,6 +108,7 @@ run_test("update_count_in_dom", () => {
     assert.equal($("<starred-count>").text(), "444");
     assert.equal($("<scheduled-count>").text(), "555");
     assert.equal($("<stream-count>").text(), "666");
+    assert.equal($("<topics-count>").text(), "666");
 
     counts.mentioned_message_count = 0;
     scheduled_messages.get_count = () => 0;


### PR DESCRIPTION
Judging by the surrounding CSS, including `position: sticky`, this PR makes the streams header sticky, increasing its utility especially in a collapsed views state.

The streams sticky-header should be a fairly low-risk change, as it's only a single line of CSS, and makes no structural changes to the left sidebar.

Additionally, this presents the 'Back to streams' area as a gridded row, complete with an unread count that will be shown while the ordinary streams header is hidden when zoomed in to a topic. By matching the two row heights and their typographic treatments, the two appear to swap places when zooming in and out.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20views.20section.20collapsible.20feedback/near/1685495)

**Screenshots and screen captures:**

Sticky header behavior:
![sticky-streams-header](https://github.com/zulip/zulip/assets/170719/8d96eb47-2204-4890-aa43-0abffd6ebbe1)

Zoomed in, back-to-streams behavior:
![back-to-streams-with-count](https://github.com/zulip/zulip/assets/170719/86eaa536-d5dd-4371-ac9a-8a192c79841e)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>