### PR TITLE
timerender: Avoid dateStyle option missing in Safari < 14.1

### DIFF
--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -28,7 +28,9 @@ export function fetch_and_render_message_history(message) {
             let prev_stream_item = null;
 
             const date_time_format = new Intl.DateTimeFormat(user_settings.default_language, {
-                dateStyle: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
             });
             for (const [index, msg] of data.message_history.entries()) {
                 // Format times and dates nicely for display

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -55,7 +55,12 @@ export function get_format_options_for_type(type: DateOrTimeFormat): Intl.DateTi
           };
 
     const weekday_format_options: Intl.DateTimeFormatOptions = {weekday: "long"};
-    const full_format_options: Intl.DateTimeFormatOptions = {dateStyle: "full"};
+    const full_format_options: Intl.DateTimeFormatOptions = {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    };
 
     const dayofyear_format_options: Intl.DateTimeFormatOptions = {day: "numeric", month: "short"};
     const dayofyear_year_format_options: Intl.DateTimeFormatOptions = {


### PR DESCRIPTION
https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_datetimeformat_options_parameter_options_datestyle_parameter