### PR TITLE
topic_mentions: Fix the incorrect large @-mention notification warning.

### DIFF
--- a/web/e2e-tests/mention.test.ts
+++ b/web/e2e-tests/mention.test.ts
@@ -26,8 +26,8 @@ async function test_mention(page: Page): Promise<void> {
         zulip_test.get_subscriber_count(zulip_test.get_sub("Verona").stream_id),
     );
     const threshold = await page.evaluate(() => {
-        zulip_test.set_wildcard_mention_large_stream_threshold(5);
-        return zulip_test.wildcard_mention_large_stream_threshold;
+        zulip_test.set_stream_wildcard_mention_large_stream_threshold(5);
+        return zulip_test.stream_wildcard_mention_large_stream_threshold;
     });
     assert.ok(stream_size > threshold);
     await page.click("#compose-send-button");

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -75,8 +75,8 @@ function clear_box() {
 
     // TODO: Better encapsulate at-mention warnings.
     compose_validate.clear_topic_resolved_warning();
-    compose_validate.clear_wildcard_warnings($("#compose_banners"));
-    compose_validate.set_user_acknowledged_wildcard_flag(false);
+    compose_validate.clear_stream_wildcard_warnings($("#compose_banners"));
+    compose_validate.set_user_acknowledged_stream_wildcard_flag(false);
 
     compose_state.set_recipient_edited_manually(false);
     clear_textarea();

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -108,8 +108,8 @@ export function initialize() {
             event.preventDefault();
             const {$banner_container, is_edit_input} = get_input_info(event);
             const $row = $(event.target).closest(".message_row");
-            compose_validate.clear_wildcard_warnings($banner_container);
-            compose_validate.set_user_acknowledged_wildcard_flag(true);
+            compose_validate.clear_stream_wildcard_warnings($banner_container);
+            compose_validate.set_user_acknowledged_stream_wildcard_flag(true);
             if (is_edit_input) {
                 message_edit.save_message_row_edit($row);
             } else if (event.target.dataset.validationTrigger === "schedule") {
@@ -118,7 +118,7 @@ export function initialize() {
                 // We need to set this flag to true here because `open_send_later_menu` validates the message and sets
                 // the user acknowledged wildcard flag back to 'false' and we don't want that to happen because then it
                 // would again show the wildcard warning banner when we actually send the message from 'send-later' modal.
-                compose_validate.set_user_acknowledged_wildcard_flag(true);
+                compose_validate.set_user_acknowledged_stream_wildcard_flag(true);
             } else {
                 compose.finish();
             }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -958,14 +958,13 @@ export function save_message_row_edit($row) {
         changed = old_content !== new_content;
     }
 
-    const already_has_wildcard_mention =
-        message.stream_wildcard_mentioned || message.topic_wildcard_mentioned;
-    if (!already_has_wildcard_mention) {
-        const wildcard_mention = util.find_wildcard_mentions(new_content);
+    const already_has_stream_wildcard_mention = message.stream_wildcard_mentioned;
+    if (!already_has_stream_wildcard_mention) {
+        const stream_wildcard_mention = util.find_stream_wildcard_mentions(new_content);
         const is_stream_message_mentions_valid = compose_validate.validate_stream_message_mentions({
             stream_id,
             $banner_container,
-            wildcard_mention,
+            stream_wildcard_mention,
         });
 
         if (!is_stream_message_mentions_valid) {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -192,8 +192,8 @@ export class CachedValue<T> {
     }
 }
 
-export function find_wildcard_mentions(message_content: string): string | null {
-    const mention = message_content.match(/(^|\s)(@\*{2}(all|everyone|stream|topic)\*{2})($|\s)/);
+export function find_stream_wildcard_mentions(message_content: string): string | null {
+    const mention = message_content.match(/(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/);
     if (mention === null) {
         return null;
     }

--- a/web/src/zulip_test.js
+++ b/web/src/zulip_test.js
@@ -3,8 +3,8 @@
 // Puppeteer tests.  It should not be used in the code itself.
 
 export {
-    set_wildcard_mention_large_stream_threshold,
-    wildcard_mention_large_stream_threshold,
+    set_stream_wildcard_mention_large_stream_threshold,
+    stream_wildcard_mention_large_stream_threshold,
 } from "./compose_validate";
 export {private_message_recipient} from "./compose_state";
 export {current as current_msg_list} from "./message_lists";

--- a/web/templates/compose_banner/stream_wildcard_warning.hbs
+++ b/web/templates/compose_banner/stream_wildcard_warning.hbs
@@ -1,0 +1,7 @@
+{{#> compose_banner }}
+    <p class="banner_message">
+        {{#tr}}
+        Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{stream_name}? If not, please edit your message to remove the <strong>@{stream_wildcard_mention}</strong> mention.
+        {{/tr}}
+    </p>
+{{/compose_banner}}

--- a/web/templates/compose_banner/wildcard_warning.hbs
+++ b/web/templates/compose_banner/wildcard_warning.hbs
@@ -1,7 +1,0 @@
-{{#> compose_banner }}
-    <p class="banner_message">
-        {{#tr}}
-        Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{stream_name}? If not, please edit your message to remove the <strong>@{wildcard_mention}</strong> mention.
-        {{/tr}}
-    </p>
-{{/compose_banner}}

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -413,18 +413,22 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
         assert.equal(stream_id, 101);
         return 16;
     });
-    let wildcard_warning_rendered = false;
+    let stream_wildcard_warning_rendered = false;
     $("#compose_banner_area .wildcard_warning").length = 0;
-    mock_template("compose_banner/wildcard_warning.hbs", false, (data) => {
-        wildcard_warning_rendered = true;
+    mock_template("compose_banner/stream_wildcard_warning.hbs", false, (data) => {
+        stream_wildcard_warning_rendered = true;
         assert.equal(data.subscriber_count, 16);
     });
 
-    override_rewire(compose_validate, "wildcard_mention_allowed_in_large_stream", () => true);
+    override_rewire(
+        compose_validate,
+        "stream_wildcard_mention_allowed_in_large_stream",
+        () => true,
+    );
     compose_state.message_content("Hey @**all**");
     assert.ok(!compose_validate.validate());
     assert.equal($("#compose-send-button").prop("disabled"), false);
-    assert.ok(wildcard_warning_rendered);
+    assert.ok(stream_wildcard_warning_rendered);
 
     let wildcards_not_allowed_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
@@ -433,12 +437,16 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
             data.banner_text,
             $t({
                 defaultMessage:
-                    "You do not have permission to use wildcard mentions in this stream.",
+                    "You do not have permission to use stream wildcard mentions in this stream.",
             }),
         );
         wildcards_not_allowed_rendered = true;
     });
-    override_rewire(compose_validate, "wildcard_mention_allowed_in_large_stream", () => false);
+    override_rewire(
+        compose_validate,
+        "stream_wildcard_mention_allowed_in_large_stream",
+        () => false,
+    );
     assert.ok(!compose_validate.validate());
     assert.ok(wildcards_not_allowed_rendered);
 });

--- a/web/tests/example1.test.js
+++ b/web/tests/example1.test.js
@@ -25,8 +25,8 @@ const util = zrequire("util");
 // The most basic unit tests load up code, call functions,
 // and assert truths:
 
-assert.ok(!util.find_wildcard_mentions("boring text"));
-assert.ok(util.find_wildcard_mentions("mention @**everyone**"));
+assert.ok(!util.find_stream_wildcard_mentions("boring text"));
+assert.ok(util.find_stream_wildcard_mentions("mention @**everyone**"));
 
 // Let's test with people.js next.  We'll show this technique:
 //  * get a false value

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -204,46 +204,33 @@ run_test("wildcard_mentions_regexp", () => {
         "some_email@**stream**.com",
     ];
 
-    const messages_without_topic_mentions = [
-        "some text before @topic some text after",
-        "@topic",
-        "`@topic`",
-        "some_email@topic.com",
-        "`@**topic**`",
-        "some_email@**topic**.com",
-    ];
-
     let i;
     for (i = 0; i < messages_with_all_mentions.length; i += 1) {
-        assert.ok(util.find_wildcard_mentions(messages_with_all_mentions[i]));
+        assert.ok(util.find_stream_wildcard_mentions(messages_with_all_mentions[i]));
     }
 
     for (i = 0; i < messages_with_everyone_mentions.length; i += 1) {
-        assert.ok(util.find_wildcard_mentions(messages_with_everyone_mentions[i]));
+        assert.ok(util.find_stream_wildcard_mentions(messages_with_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_with_stream_mentions.length; i += 1) {
-        assert.ok(util.find_wildcard_mentions(messages_with_stream_mentions[i]));
+        assert.ok(util.find_stream_wildcard_mentions(messages_with_stream_mentions[i]));
     }
 
     for (i = 0; i < messages_with_topic_mentions.length; i += 1) {
-        assert.ok(util.find_wildcard_mentions(messages_with_topic_mentions[i]));
+        assert.ok(!util.find_stream_wildcard_mentions(messages_with_topic_mentions[i]));
     }
 
     for (i = 0; i < messages_without_all_mentions.length; i += 1) {
-        assert.ok(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
+        assert.ok(!util.find_stream_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_everyone_mentions.length; i += 1) {
-        assert.ok(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
+        assert.ok(!util.find_stream_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_stream_mentions.length; i += 1) {
-        assert.ok(!util.find_wildcard_mentions(messages_without_stream_mentions[i]));
-    }
-
-    for (i = 0; i < messages_without_topic_mentions.length; i += 1) {
-        assert.ok(!util.find_wildcard_mentions(messages_without_topic_mentions[i]));
+        assert.ok(!util.find_stream_wildcard_mentions(messages_without_stream_mentions[i]));
     }
 });
 


### PR DESCRIPTION
Earlier, a 'large @-mention notification' warning that pops up for stream wildcard mentions was shown for topic wildcard mentions too, which is incorrect.

This PR fixes the incorrect behavior. We no longer show the banner for @-topic mentions.

We don't need a banner for @-topic mentions, as those are much less likely to be used without thinking about it and would rarely be spammy for a lot of people.

Fixes #27767.

---

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[no-warning.webm](https://github.com/zulip/zulip/assets/56781761/1835281b-244d-4025-9db3-25317d74f0e6)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
