### PR TITLE
gear_menu_popover: Various fixes and improvements related to dropdown menu width and org info.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1389,6 +1389,9 @@ ul {
             font-weight: 600;
             line-height: 22px;
             padding: 0 10px;
+            /* We set white-space to normal for the menu items
+               where we want to explicitly wrap. */
+            white-space: normal;
         }
 
         .org-plan,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1339,7 +1339,7 @@ ul {
 
         & li {
             display: flex;
-            justify-content: center;
+            justify-content: flex-start;
             font-size: 15px;
             font-style: normal;
             font-weight: 400;
@@ -1353,7 +1353,6 @@ ul {
             .navbar-dropdown-menu-link {
                 padding: 2px 10px;
                 flex-grow: 1;
-                text-align: center;
                 text-decoration: none;
 
                 &:hover {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1208,15 +1208,22 @@ ul {
     border: solid 1px var(--color-border-dropdown-menu);
     background-color: var(--color-background-dropdown-menu);
     max-height: 85vh;
-    min-width: 230px;
     overflow-x: hidden;
     user-select: none;
     border-radius: 6px;
     box-shadow: var(--box-shadow-navbar-dropdown-menu);
 
     .simplebar-content {
+        min-width: var(--popover-menu-min-width);
+        /*  This is necessary to set the dropdown menu width equal to
+            the width of the longest menu item, thus letting the menu
+            items control the width of the menu. */
+        width: min-content;
+    }
+
+    .navbar-dropdown-menu-inner-list-item {
         /*  This is necessary to keep long menu items on a single line. */
-        min-width: max-content;
+        white-space: nowrap;
     }
 
     .text-item,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1394,7 +1394,6 @@ ul {
             white-space: normal;
         }
 
-        .org-plan,
         .org-upgrade {
             font-size: 14px;
         }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1344,7 +1344,7 @@ ul {
             }
 
             .navbar-dropdown-menu-link {
-                padding: 2px 0;
+                padding: 2px 10px;
                 flex-grow: 1;
                 text-align: center;
                 text-decoration: none;
@@ -1369,6 +1369,7 @@ ul {
 
         .org-url {
             margin-bottom: 7px;
+            padding: 0 10px;
         }
 
         .org-name,
@@ -1380,6 +1381,7 @@ ul {
             font-size: 17px;
             font-weight: 600;
             line-height: 22px;
+            padding: 0 10px;
         }
 
         .org-plan,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -104,6 +104,9 @@ body {
     --right-sidebar-width: 250px;
     --left-sidebar-header-icon-width: 15px;
 
+    /* Tippy popover related values */
+    --popover-menu-min-width: 230px;
+
     /*
     Message box elements and values.
     */


### PR DESCRIPTION
This PR adds the following changes:

- **Fix padding of items in org info section.**
Add padding to org info items to avoid collision on text with the menu boundary
- **Let menu items control the width of dropdown menus.**
We set the width of the navbar dropdowns to be equal to the longest menu item, via the min-content intrinsic sizing.
- **Add text wrapping to long org names.**
Some organizations may have long names that could blow up the gear menu width, in those cases we want to prevent it by wrapping the org name.
- **Fix font size of org plan.**
As per the intended design, the font size of the org plan should be equal to the font size of other similar links such as org version.
- **Align org info menu items to the left.**
This maintains consistency across the whole gear menu.

<!-- Describe your pull request here.-->

CZO: [Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/Padding.20in.20Org.20Info.20section.20of.20the.20gear.20menu/near/1686235)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Description | Before | After |
|--------|--------|--------|
| Left Align Org Info | ![centre-aligned](https://github.com/zulip/zulip/assets/82862779/72ca435a-f113-4019-8a54-8dd42363de42) | ![left-aligned](https://github.com/zulip/zulip/assets/82862779/e11beca0-0c37-4e14-9e22-eaacaa2a4b58) |
| Let Org Name wrap into multiple lines | ![long-org-name-no-multiline](https://github.com/zulip/zulip/assets/82862779/976a61f1-0f34-43e9-9059-d4de2eb92a7d) | ![multi-line-org-name](https://github.com/zulip/zulip/assets/82862779/c886c268-48e2-4094-884e-e2d82e040d15) |
| Add padding to Org info links | ![padding-error-org-info](https://github.com/zulip/zulip/assets/82862779/bf8f3e19-ce05-4ecf-a477-73bfd7bb8775) | ![fix-padding-org-info](https://github.com/zulip/zulip/assets/82862779/15276127-a35c-4dd9-ae94-761c6e3175a5) |
| Fix size of Org Plan (Zulip Cloud Free) | ![error-org-plan-size](https://github.com/zulip/zulip/assets/82862779/1c265e9a-cf9a-457f-bf21-e21fc3994191) | ![fix-org-plan-size](https://github.com/zulip/zulip/assets/82862779/caabebae-b553-45db-a2a6-bbbf4c352e7a) |
| Differences in Russian Language - menu length is controlled by menu items | ![before-pr-russian](https://github.com/zulip/zulip/assets/82862779/efbc0e3f-2f4a-4bb7-959e-8acfe427d2f4) | ![after-pr-russian](https://github.com/zulip/zulip/assets/82862779/1ca2d3a8-6a91-407f-a26e-8669f6e1c2bb) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
