### PR TITLE
migrations: Fix revert migration to not lose all preferences.

### DIFF
--- a/zerver/migrations/0490_renumber_options_desktop_icon_count_display.py
+++ b/zerver/migrations/0490_renumber_options_desktop_icon_count_display.py
@@ -40,18 +40,18 @@ def reverse_code(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> No
     UserProfile = apps.get_model("zerver", "UserProfile")
 
     UserProfile.objects.filter(
-        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_NONE
-    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_NONE)
+        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION
+    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION)
     RealmUserDefault.objects.filter(
-        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_NONE
-    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_NONE)
+        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION
+    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION)
 
     UserProfile.objects.filter(
-        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION
-    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION)
+        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_NONE
+    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_NONE)
     RealmUserDefault.objects.filter(
-        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION
-    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_DM_MENTION)
+        desktop_icon_count_display=NEW_DESKTOP_ICON_COUNT_DISPLAY_NONE
+    ).update(desktop_icon_count_display=OLD_DESKTOP_ICON_COUNT_DISPLAY_NONE)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Renumbering 4 -> 3, and then 3 -> 2 leads to everyone having their preferences set to 2.  Swap the order, so that we renumber 3 -> 2, then 4 -> 3.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
