### PR TITLE
hotkey: Fix emoji popover not triggered in a narrow width range.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1057,13 +1057,17 @@ export function process_hotkey(e, hotkey) {
         // ':': open reactions to message
         case "toggle_reactions_popover": {
             const $row = message_lists.current.selected_row();
-            emoji_picker.toggle_emoji_popover(
-                msg.sent_by_me
-                    ? $row.find(".message-actions-menu-button")[0]
-                    : $row.find(".emoji-message-control-button-container")[0],
-                msg.id,
-                {placement: "bottom"},
-            );
+            const $emoji_icon = $row.find(".emoji-message-control-button-container");
+            let emoji_picker_reference;
+            if ($emoji_icon.is(":visible")) {
+                emoji_picker_reference = $emoji_icon[0];
+            } else {
+                emoji_picker_reference = $row.find(".message-actions-menu-button")[0];
+            }
+
+            emoji_picker.toggle_emoji_popover(emoji_picker_reference, msg.id, {
+                placement: "bottom",
+            });
             return true;
         }
         case "thumbs_up_emoji": {

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -108,6 +108,7 @@ message_lists.current = {
     selected_row() {
         const $row = $.create("selected-row-stub");
         $row.set_find_results(".message-actions-menu-button", []);
+        $row.set_find_results(".emoji-message-control-button-container", {is: () => false});
         return $row;
     },
     selected_message() {


### PR DESCRIPTION
We don't show emoji icon on message on width range even if the logged in user is not the sender, which causes popover to not be displayed since the reference is not visible.

To avoid such case in future, we just check if the emoji icon is visible and if not fallback to the ellipsis icon for reference.

<img width="427" alt="Screenshot 2023-11-22 at 9 36 02 AM" src="https://github.com/zulip/zulip/assets/25124304/73913d3d-2f12-4201-a2cc-936320b4503e">


discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20emoji.20reaction.20shortcut.20broken.20in.20narrow-ish.20windows