### PR TITLE
css: Set tippy-arrow color same as background in light theme.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1194,7 +1194,7 @@ textarea.new_message_textarea,
     & ul {
         list-style: none;
         margin: 0;
-        background: hsl(0deg 0% 100%);
+        background-color: var(--color-background-popover);
     }
 
     .typeahead-header {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -130,38 +130,6 @@
                 color: hsl(200deg 79% 66%);
             }
         }
-
-        &[data-placement^="top"] {
-            > .tippy-arrow {
-                &::before {
-                    border-top-color: hsl(235deg 18% 7%);
-                }
-            }
-        }
-
-        &[data-placement^="bottom"] {
-            > .tippy-arrow {
-                &::before {
-                    border-bottom-color: hsl(235deg 18% 7%);
-                }
-            }
-        }
-
-        &[data-placement^="left"] {
-            > .tippy-arrow {
-                &::before {
-                    border-left-color: hsl(235deg 18% 7%);
-                }
-            }
-        }
-
-        &[data-placement^="right"] {
-            > .tippy-arrow {
-                &::before {
-                    border-right-color: hsl(235deg 18% 7%);
-                }
-            }
-        }
     }
 
     .tippy-box:not([data-theme]) {
@@ -644,11 +612,6 @@
             box-shadow: 0 0 30px hsl(213deg 31% 0%);
             background-color: var(--color-background);
         }
-    }
-
-    .tippy-box[data-theme~="light-border"],
-    .dropdown-menu ul,
-        background-color: hsl(212deg 32% 14%);
     }
 
     /* Undo default dropdown background color for dark mode. */

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -648,7 +648,6 @@
 
     .tippy-box[data-theme~="light-border"],
     .dropdown-menu ul,
-    .dropdown .dropdown-menu {
         background-color: hsl(212deg 32% 14%);
     }
 
@@ -661,7 +660,6 @@
         color: inherit;
     }
 
-    .dropdown .dropdown-menu li.divider,
     .popover hr,
     hr {
         color: hsl(212deg 28% 18%);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -4,6 +4,8 @@
   popovers. (Tippy tooltips are defined in tooltips.css).
 */
 .tippy-box[data-theme="light-border"] {
+    background-color: var(--color-background-popover);
+
     .sp-input {
         /* Override incorrect color for text in dark theme. */
         color: var(--color-text-default) !important;
@@ -27,6 +29,38 @@
         /* Override bootstrap defaults */
         .nav-list > li > a {
             padding: 3px 15px;
+        }
+    }
+
+    &[data-placement^="top"] {
+        > .tippy-arrow {
+            &::before {
+                border-top-color: var(--color-background-popover);
+            }
+        }
+    }
+
+    &[data-placement^="bottom"] {
+        > .tippy-arrow {
+            &::before {
+                border-bottom-color: var(--color-background-popover);
+            }
+        }
+    }
+
+    &[data-placement^="left"] {
+        > .tippy-arrow {
+            &::before {
+                border-left-color: var(--color-background-popover);
+            }
+        }
+    }
+
+    &[data-placement^="right"] {
+        > .tippy-arrow {
+            &::before {
+                border-right-color: var(--color-background-popover);
+            }
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -226,6 +226,7 @@ body {
     --color-background-tab-picker-selected-tab: hsl(0deg 0% 100%);
     --color-outline-tab-picker-tab-option: hsl(0deg 0% 0% / 30%);
     --color-background-tab-picker-tab-option-hover: hsl(0deg 0% 100% / 60%);
+    --color-background-popover: hsl(0deg 0% 100%);
 
     /* Compose box colors */
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
@@ -507,6 +508,7 @@ body {
     --color-compose-embedded-button-background-hover: hsl(
         235deg 100% 70% / 11%
     );
+    --color-background-popover: hsl(212deg 32% 14%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20arrow.20on.20popovers.20in.20dark.20theme

<img width="456" alt="Screenshot 2023-11-22 at 1 24 24 PM" src="https://github.com/zulip/zulip/assets/25124304/733f01a3-fc17-4444-a91a-00d5e569e45a">
