### PR TITLE
dropdown_widget: Allow showing custom text if value is not in options.

### DIFF
--- a/web/src/dropdown_widget.js
+++ b/web/src/dropdown_widget.js
@@ -43,8 +43,8 @@ export class DropdownWidget {
         // NOTE: Any value other than `null` will be rendered when class is initialized.
         default_id = null,
         unique_id_type = null,
-        // Show disabled state if the default_id is not in `get_options()`.
-        show_disabled_if_current_value_not_in_options = false,
+        // Text to show if the current value is not in `get_options()`.
+        text_if_current_value_not_in_options = null,
         hide_search_box = false,
     }) {
         this.widget_name = widget_name;
@@ -67,8 +67,7 @@ export class DropdownWidget {
         this.current_value = default_id;
         this.unique_id_type = unique_id_type;
         this.$events_container = $events_container;
-        this.show_disabled_if_current_value_not_in_options =
-            show_disabled_if_current_value_not_in_options;
+        this.text_if_current_value_not_in_options = text_if_current_value_not_in_options;
         this.hide_search_box = hide_search_box;
     }
 
@@ -295,11 +294,12 @@ export class DropdownWidget {
         }
 
         const all_options = this.get_options();
-        let option = all_options.find((option) => option.unique_id === this.current_value);
+        const option = all_options.find((option) => option.unique_id === this.current_value);
 
-        // Show disabled if cannot find current option.
-        if (!option && this.show_disabled_if_current_value_not_in_options) {
-            option = all_options.find((option) => option.is_setting_disabled === true);
+        // If provided, show custom text if cannot find current option.
+        if (!option && this.text_if_current_value_not_in_options) {
+            $(this.widget_value_selector).text(this.text_if_current_value_not_in_options);
+            return;
         }
 
         if (!option) {

--- a/web/src/dropdown_widget.js
+++ b/web/src/dropdown_widget.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import * as tippy from "tippy.js";
 
+import render_dropdown_current_value_not_in_options from "../templates/dropdown_current_value_not_in_options.hbs";
 import render_dropdown_disabled_state from "../templates/dropdown_disabled_state.hbs";
 import render_dropdown_list from "../templates/dropdown_list.hbs";
 import render_dropdown_list_container from "../templates/dropdown_list_container.hbs";
@@ -298,7 +299,11 @@ export class DropdownWidget {
 
         // If provided, show custom text if cannot find current option.
         if (!option && this.text_if_current_value_not_in_options) {
-            $(this.widget_value_selector).text(this.text_if_current_value_not_in_options);
+            $(this.widget_value_selector).html(
+                render_dropdown_current_value_not_in_options({
+                    name: this.text_if_current_value_not_in_options,
+                }),
+            );
             return;
         }
 

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -626,7 +626,7 @@ export function init_dropdown_widgets() {
         const disabled_option = {
             is_setting_disabled: true,
             unique_id: DISABLED_STATE_ID,
-            name: $t({defaultMessage: "Cannot view stream"}),
+            name: $t({defaultMessage: "Disabled"}),
         };
 
         options.unshift(disabled_option);
@@ -649,7 +649,7 @@ export function init_dropdown_widgets() {
         },
         default_id: page_params.realm_notifications_stream_id,
         unique_id_type: dropdown_widget.DATA_TYPES.NUMBER,
-        show_disabled_if_current_value_not_in_options: true,
+        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view stream"}),
     });
     settings_components.set_notifications_stream_widget(notifications_stream_widget);
     notifications_stream_widget.setup();
@@ -670,7 +670,7 @@ export function init_dropdown_widgets() {
         },
         default_id: page_params.realm_signup_notifications_stream_id,
         unique_id_type: dropdown_widget.DATA_TYPES.NUMBER,
-        show_disabled_if_current_value_not_in_options: true,
+        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view stream"}),
     });
     settings_components.set_signup_notifications_stream_widget(signup_notifications_stream_widget);
     signup_notifications_stream_widget.setup();

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1123,6 +1123,7 @@ div.overlay {
     }
 }
 
+.dropdown-current-value-not-in-options,
 .setting-disabled-option {
     color: hsl(38deg 46% 54%);
 

--- a/web/templates/dropdown_current_value_not_in_options.hbs
+++ b/web/templates/dropdown_current_value_not_in_options.hbs
@@ -1,0 +1,1 @@
+<span class="dropdown-current-value-not-in-options">{{name}}</span>


### PR DESCRIPTION
If the current value is not in the calculated options, `text_if_current_value_not_in_options` can be provided to the widget to show custom text in that case.

Used by stream / user announcement settings if user doesn't have access to information about the currently selected stream.

| Owner with stream access |
| --- |
| <img width="456" alt="Screenshot 2023-11-22 at 3 22 34 PM" src="https://github.com/zulip/zulip/assets/25124304/c1c8bf83-eb48-4127-a165-a5202395b9b8"> |

| Admin not subscribed to the stream but has stream data |
| --- |
| <img width="456" alt="Screenshot 2023-11-22 at 3 21 53 PM" src="https://github.com/zulip/zulip/assets/25124304/88e0fa64-16f2-4b41-a44b-06d43d7b3a4b"> |

| Normal user with not subscribed to the stream |
| --- |
| <img width="456" alt="Screenshot 2023-11-22 at 3 22 16 PM" src="https://github.com/zulip/zulip/assets/25124304/8b8b10e9-631b-4e96-9056-837638261ebc"> |

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/incorrect.20.22Cannot.20view.20stream.22.20for.20new.20user.20announcements
