### PR TITLE
Left_sidebar: Rename "All messages" to "Global feed".

### DIFF
--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -266,7 +266,7 @@ Some scenarios to consider:
 
 - Try clicking on any interactive elements, multiple times, in a variety of orders.
 - If the feature affects the **message view**, try it out in different types of
-  narrows: topic, stream, All messages, direct messages.
+  narrows: topic, stream, global feed, direct messages.
 - If the feature affects the **compose box** in the web app, try both ways of
   [resizing the compose box](https://zulip.com/help/resize-the-compose-box).
   Test both stream messages and direct messages.

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -280,7 +280,7 @@ self-explanatory names.
 
 - **ellipsis**: A small vertical three dot icon (technically called
   as ellipsis-v), present in sidebars as a menu icon.
-  It offers contextual options for global filters (All messages
+  It offers contextual options for global filters (Global feed
   and Starred messages), stream filters and topics in left
   sidebar and users in right sidebar. To avoid visual clutter
   ellipsis only appears in the web UI upon hover.

--- a/docs/subsystems/pointer.md
+++ b/docs/subsystems/pointer.md
@@ -54,11 +54,11 @@ streams.)
 ### Unnarrow: previous sequence
 
 When you unnarrow using e.g. the `a` key, you will automatically be
-taken to the same message that was selected in the All messages view before
+taken to the same message that was selected in the Global feed view before
 you narrowed, unless in the narrow you read new messages, in which
 case you will be jumped forward to the first unread and non-muted
-message in the All messages view (or the bottom of the feed if there is
-none). This makes for a nice experience reading threads via the All messages
+message in the Global feed view (or the bottom of the feed if there is
+none). This makes for a nice experience reading threads via the Global feed
 view in sequence.
 
 ### Forced reload: state preservation

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -53,7 +53,7 @@ Try using all the navigation hotkeys:
 Try narrowing from the message view:
 
 - Hotkeys
-  - use a to go to All messages
+  - use a to go to Global feed
   - use s to narrow to a stream (select message first
     and verify in sidebar)
   - use S to narrow to the topic (and verify in sidebar)
@@ -184,7 +184,7 @@ For each of the above types of messages, you will want to cycle
 through the following views for Cordelia (and have Hamlet send new
 messages after each narrow):
 
-- Go to All messages view.
+- Go to Global feed view.
 - Go to All direct messages view.
 - Go to Direct messages w/Hamlet.
 - Go to Direct messages w/Hamlet and Othello.

--- a/help/archive-a-stream.md
+++ b/help/archive-a-stream.md
@@ -4,7 +4,7 @@
 
 Archiving a stream will immediately unsubscribe all users from the stream,
 remove the stream from search and other typeaheads, and remove the stream's
-messages from **All messages**.
+messages from **Global feed**.
 
 Archiving a stream does not delete a stream's messages. Users will still be
 able to find any given message by searching for it. However, links to

--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -27,7 +27,7 @@ preference settings, including the following:
     * [Home view](/help/configure-home-view)
       ([Inbox](/help/inbox) vs.
       [Recent conversations](/help/recent-conversations) vs.
-      [All messages](/help/reading-strategies#all-messages))
+      [Global feed](/help/reading-strategies#global-feed))
 
 * Notification settings:
     * What types of messages [trigger notifications][default-notifications]

--- a/help/global-feed.md
+++ b/help/global-feed.md
@@ -1,12 +1,12 @@
-# All messages
+# Global feed
 
-{!all-messages.md!}
+{!global-feed.md!}
 
 !!! keyboard_tip ""
 
     Use <kbd>S</kbd> (go to stream) or <kbd>Shift</kbd> +
     <kbd>S</kbd> (go to conversation) to zoom in, and <kbd>A</kbd> to
-    get back to **All messages**.
+    get back to **Global feed**.
 
 
 ## Related articles

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -51,7 +51,7 @@ In the web app, you can control whether the **Inbox** includes all topics, just
 
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
-* [All messages](/help/all-messages)
+* [Global feed](/help/global-feed)
 * [Mute or unmute a stream](/help/mute-a-stream)
 * [Mute or unmute a topic](/help/mute-a-topic)
 * [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)

--- a/help/include/global-feed.md
+++ b/help/include/global-feed.md
@@ -1,8 +1,8 @@
-The **All messages** view is a feed of all the unmuted messages you have
+The **Global feed** view is a feed of all the unmuted messages you have
 received, which combines stream messages and direct messages. It's a great way
 to see new messages as they come in.
 
-You can configure **All messages** to be the [home
+You can configure **Global feed** to be the [home
 view](/help/configure-home-view#configure-home-view) for the Zulip web app.
 
 {start_tabs}
@@ -13,7 +13,7 @@ view](/help/configure-home-view#configure-home-view) for the Zulip web app.
 
 {tab|mobile}
 
-1. Tap the **All messages**
+1. Tap the **Global feed**
    (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="help-center-icon"/>)
    tab in the upper left corner of the app.
 

--- a/help/include/go-to-all-messages.md
+++ b/help/include/go-to-all-messages.md
@@ -1,4 +1,4 @@
-1. Click on <i class="zulip-icon zulip-icon-all-messages"></i> **All messages**
+1. Click on <i class="zulip-icon zulip-icon-all-messages"></i> **Global feed**
    (or <i class="zulip-icon zulip-icon-all-messages"></i> if the **views**
    section is collapsed) in the left sidebar,
    or use the <kbd>A</kbd> keyboard shortcut.

--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -8,8 +8,8 @@ Muting has the following effects:
 - Messages in muted topics do not generate notifications (including [alert
   word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
   you are [mentioned](/help/mention-a-user-or-group).
-- Messages in muted topics do not appear in the [**All messages**
-  view](/help/all-messages) or the mobile **Inbox** view.
+- Messages in muted topics do not appear in the [**Global feed**
+  view](/help/global-feed) or the mobile **Inbox** view.
 - Muted topics appear in the [**Recent conversations**
   view](/help/recent-conversations) only if the **Include muted** filter is
   enabled.

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -96,7 +96,7 @@
 * [Reading strategies](/help/reading-strategies)
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
-* [All messages](/help/all-messages)
+* [Global feed](/help/global-feed)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -99,7 +99,7 @@ in the Zulip app to add more to your repertoire as needed.
 * **Cycle between stream views**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
-* **Go to All messages**: <kbd>A</kbd> — Shows all unmuted messages.
+* **Go to Global feed**: <kbd>A</kbd> — Shows all unmuted messages.
 
 * **Go to the conversation you are composing to**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -69,7 +69,7 @@ stream or topic as read**.
 
 {tab|via-left-sidebar}
 
-1. Hover over a stream, topic, or **All messages** in the left sidebar.
+1. Hover over a stream, topic, or **Global feed** in the left sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
 
@@ -100,8 +100,8 @@ stream or topic as read**.
 
 {tab|mobile}
 
-1. Tap a stream, topic, or the **All messages**
-   (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="help-center-icon"/>)
+1. Tap a stream, topic, or the **Global feed**
+   (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="mobile-icon"/>)
    tab.
 
 2. Tap **Mark stream as read**, **Mark topic as read**, or **Mark all as read**

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -45,9 +45,9 @@ workflows:
 
 ## Combined views
 
-### All messages
+### Global feed
 
-{!all-messages.md!}
+{!global-feed.md!}
 
 ### All direct messages
 

--- a/help/recent-conversations.md
+++ b/help/recent-conversations.md
@@ -37,5 +37,5 @@ containing the most recent messages.
 * [Reading conversations](/help/reading-conversations)
 * [Reading strategies](/help/reading-strategies)
 * [Inbox](/help/inbox)
-* [All messages](/help/all-messages)
+* [Global feed](/help/global-feed)
 * [Configure home view](/help/configure-home-view)

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -110,7 +110,7 @@ async function un_narrow(page: Page): Promise<void> {
     await page.waitForSelector(".message-list .message_row", {visible: true});
     // Assert that there is only one message list.
     assert.equal((await page.$$(".message-list")).length, 1);
-    assert.strictEqual(await page.title(), "All messages - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "Global feed - Zulip Dev - Zulip");
 }
 
 async function un_narrow_by_clicking_org_icon(page: Page): Promise<void> {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1000,7 +1000,7 @@ export class Filter {
         if (term_types.length === 1) {
             switch (term_types[0]) {
                 case "in-home":
-                    return $t({defaultMessage: "All messages"});
+                    return $t({defaultMessage: "Global feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted streams"});
                 case "streams-public":

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -117,7 +117,7 @@ export function is_spectator_compatible(hash: string): boolean {
         "keyboard-shortcuts",
         "message-formatting",
         "search-operators",
-        "all_messages",
+        "global_feed",
         "about-zulip",
     ];
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -100,7 +100,7 @@ function show_home_view() {
             recent_view_ui.show();
             break;
         }
-        case "all_messages": {
+        case "global_feed": {
             // Hides inbox/recent views internally if open.
             show_all_message_view();
             break;
@@ -130,7 +130,6 @@ function do_hashchange_normal(from_reload) {
     // Even if the URL bar says #%41%42%43%44, the value here will
     // be #ABCD.
     const hash = window.location.hash.split("/");
-
     switch (hash[0]) {
         case "#narrow": {
             let terms;
@@ -198,8 +197,15 @@ function do_hashchange_normal(from_reload) {
             maybe_hide_recent_view();
             inbox_ui.show();
             break;
-        case "#all_messages":
+        case "#global_feed":
             show_all_message_view();
+            break;
+        case "#all_messages":
+            // Since "#all_messages" was deprecated and replaced by
+            // "#global_feed" current URL hash is replaced by
+            // "#global_feed" after showing the view.
+            show_all_message_view();
+            window.location.replace("#global_feed");
             break;
         case "#keyboard-shortcuts":
         case "#message-formatting":

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -172,7 +172,7 @@ const keypress_mappings = {
     83: {name: "toggle_stream_subscription", message_view_only: true}, // 'S'
     85: {name: "mark_unread", message_view_only: true}, // 'U'
     86: {name: "view_selected_stream", message_view_only: false}, // 'V'
-    97: {name: "all_messages", message_view_only: true}, // 'a'
+    97: {name: "global_feed", message_view_only: true}, // 'a'
     99: {name: "compose", message_view_only: true}, // 'c'
     100: {name: "open_drafts", message_view_only: true}, // 'd'
     101: {name: "edit_message", message_view_only: true}, // 'e'
@@ -972,7 +972,7 @@ export function process_hotkey(e, hotkey) {
         case "open_inbox":
             browser_history.go_to_location("#inbox");
             return true;
-        case "all_messages":
+        case "global_feed":
             browser_history.go_to_location("#all_messages");
             return true;
         case "toggle_topic_visibility_policy":

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -973,7 +973,7 @@ export function process_hotkey(e, hotkey) {
             browser_history.go_to_location("#inbox");
             return true;
         case "global_feed":
-            browser_history.go_to_location("#all_messages");
+            browser_history.go_to_location("#global_feed");
             return true;
         case "toggle_topic_visibility_policy":
             if (recent_view_ui.is_in_focus()) {

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -197,7 +197,7 @@ function handle_home_view_order(home_view: string): void {
     const res = unread.get_counts();
 
     // Add the class and tabindex to the matching home view
-    if (home_view === settings_config.web_home_view_values.all_messages.code) {
+    if (home_view === settings_config.web_home_view_values.global_feed.code) {
         $all_messages_rows.addClass("selected-home-view");
         $all_messages_rows.find("a").attr("tabindex", 0);
     } else if (home_view === settings_config.web_home_view_values.recent_topics.code) {
@@ -214,7 +214,7 @@ function handle_home_view_order(home_view: string): void {
 export function handle_home_view_changed(new_home_view: string): void {
     const $recent_view_sidebar_menu_icon = $(".recent-view-sidebar-menu-icon");
     const $all_messages_sidebar_menu_icon = $(".all-messages-sidebar-menu-icon");
-    if (new_home_view === settings_config.web_home_view_values.all_messages.code) {
+    if (new_home_view === settings_config.web_home_view_values.global_feed.code) {
         $recent_view_sidebar_menu_icon.removeClass("hide");
         $all_messages_sidebar_menu_icon.addClass("hide");
     } else if (new_home_view === settings_config.web_home_view_values.recent_topics.code) {

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -27,7 +27,7 @@ function get_message_view_header_context(filter) {
     }
     if (filter === undefined) {
         return {
-            title: $t({defaultMessage: "All messages"}),
+            title: $t({defaultMessage: "Global feed"}),
             zulip_icon: "all-messages",
         };
     }

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -97,9 +97,9 @@ export const web_home_view_values = {
         code: "recent_topics",
         description: $t({defaultMessage: "Recent conversations"}),
     },
-    all_messages: {
-        code: "all_messages",
-        description: $t({defaultMessage: "All messages"}),
+    global_feed: {
+        code: "global_feed",
+        description: $t({defaultMessage: "Global feed"}),
     },
 };
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -153,7 +153,7 @@ export function initialize_left_sidebar(): void {
         is_inbox_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.inbox.code,
         is_all_messages_home_view:
-            user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code,
+            user_settings.web_home_view === settings_config.web_home_view_values.global_feed.code,
         is_recent_view_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code,
         hide_unread_counts: settings_data.should_mask_unread_count(false),

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -81,7 +81,7 @@
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Global feed' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -22,7 +22,7 @@
                     </a>
                 </li>
                 <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                    <a href="#all_messages" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
+                    <a href="#global_feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                         </span>
@@ -76,7 +76,7 @@
                 </span>
             </li>
             <li class="tippy-views-tooltip top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="all-message-tooltip-template">
-                <a href="#all_messages" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container">
+                <a href="#global_feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>

--- a/web/templates/popovers/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar_all_messages_popover.hbs
@@ -13,7 +13,7 @@
         <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
             <i class="fa fa-home" aria-hidden="true"></i>
             {{#tr}}
-                Make <b>all messages</b> my home view
+                Make <b>global feed</b> my home view
             {{/tr}}
         </a>
     </li>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -93,7 +93,7 @@
 </template>
 <template id="all-message-tooltip-template">
     <div class="views-tooltip-container" data-view-code="all_messages">
-        <div>{{t 'All messages' }}</div>
+        <div>{{t 'Global feed' }}</div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "A"}}

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -955,7 +955,7 @@ run_test("user_settings", ({override}) => {
 
     {
         event = event_fixtures.user_settings__web_home_view_recent_topics;
-        user_settings.web_home_view = "all_messages";
+        user_settings.web_home_view = "global_feed";
         dispatch(event);
         assert.equal(user_settings.web_home_view, "recent_topics");
     }
@@ -964,12 +964,12 @@ run_test("user_settings", ({override}) => {
         event = event_fixtures.user_settings__web_home_view_all_messages;
         user_settings.web_home_view = "recent_topics";
         dispatch(event);
-        assert.equal(user_settings.web_home_view, "all_messages");
+        assert.equal(user_settings.web_home_view, "global_feed");
     }
 
     {
         event = event_fixtures.user_settings__web_home_view_inbox;
-        user_settings.web_home_view = "all_messages";
+        user_settings.web_home_view = "global_feed";
         dispatch(event);
         assert.equal(user_settings.web_home_view, "inbox");
     }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1606,7 +1606,7 @@ test("navbar_helpers", () => {
             terms: in_home,
             is_common_narrow: true,
             icon: "home",
-            title: "translated: All messages",
+            title: "translated: Global feed",
             redirect_url_with_search: "#",
         },
         {

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -189,7 +189,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [message_viewport, "stop_auto_scrolling"],
     ]);
 
-    window.location.hash = "#all_messages";
+    window.location.hash = "#global_feed";
     hide_all_called = false;
 
     helper.clear_events();

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -23,7 +23,7 @@ const $ = require("./lib/zjquery");
 
 // Since all the tests here are based on narrow starting with all_messages.
 // We set our default narrow to all messages here.
-window.location.hash = "#all_messages";
+window.location.hash = "#global_feed";
 
 set_global("navigator", {
     platform: "",

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -1038,7 +1038,7 @@ exports.fixtures = {
         type: "user_settings",
         op: "update",
         property: "web_home_view",
-        value: "all_messages",
+        value: "global_feed",
     },
 
     user_settings__web_home_view_inbox: {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -789,7 +789,7 @@ run_test("narrow_compute_title", () => {
 
     inbox_util.set_visible(false);
     filter = new Filter([{operator: "in", operand: "home"}]);
-    assert.equal(narrow_title.compute_narrow_title(filter), "translated: All messages");
+    assert.equal(narrow_title.compute_narrow_title(filter), "translated: Global feed");
 
     // Search & uncommon narrows
     filter = new Filter([{operator: "search", operand: "potato"}]);

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -156,7 +156,7 @@ recent_instructions = """
 """
 
 all_instructions = """
-1. Click on <i class="fa fa-align-left"></i> **All messages** in the left
+1. Click on <i class="fa fa-align-left"></i> **Global feed** in the left
    sidebar, or use the <kbd>A</kbd> keyboard shortcut.
 """
 
@@ -181,7 +181,7 @@ message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
     "recent": ["Recent conversations", "/#recent", recent_instructions],
-    "all": ["All messages", "/#all_messages", all_instructions],
+    "all": ["Global feed", "/#global_feed", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
     "direct": ["All direct messages", "/#narrow/is/dm", direct_instructions],
     "inbox": ["Inbox", "/#inbox", inbox_instructions],

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -83,6 +83,7 @@ HELP_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
     URLRedirect("/help/view-and-browse-images", "/help/view-images-and-videos"),
     URLRedirect("/help/bots-and-integrations", "/help/bots-overview"),
     URLRedirect("/help/configure-notification-bot", "/help/configure-automated-notices"),
+    URLRedirect("/help/all-messages", "/help/global-feed"),
 ]
 
 LANDING_PAGE_REDIRECTS = [

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10620,12 +10620,12 @@ paths:
 
                     - "recent_topics" - Recent conversations view
                     - "inbox" - Inbox view
-                    - "all_messages" - All messages view
+                    - "global_feed" - Global feed view
 
                     **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                     called `default_view`, which was new in Zulip 4.0 (feature level 42).
                   type: string
-                  example: all_messages
+                  example: global_feed
                 web_escape_navigates_to_home_view:
                   description: |
                     Whether the escape key navigates to the
@@ -13079,7 +13079,7 @@ paths:
 
                               - "recent_topics" - Recent conversations view
                               - "inbox" - Inbox view
-                              - "all_messages" - All messages view
+                              - "global_feed" - Global feed view
 
                               **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -15370,7 +15370,7 @@ paths:
 
                               - "recent_topics" - Recent conversations view
                               - "inbox" - Inbox view
-                              - "all_messages" - All messages view
+                              - "global_feed" - Global feed view
 
                               **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -16492,7 +16492,7 @@ paths:
 
                     - "recent_topics" - Recent conversations view
                     - "inbox" - Inbox view
-                    - "all_messages" - All messages view
+                    - "global_feed" - Global feed view
 
                     **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                     called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -16502,7 +16502,7 @@ paths:
 
                     Unnecessary JSON-encoding of this parameter was removed in Zulip 4.0 (feature level 64).
                   type: string
-                  example: all_messages
+                  example: global_feed
                 web_escape_navigates_to_home_view:
                   description: |
                     Whether the escape key navigates to the
@@ -19434,7 +19434,7 @@ components:
           description: |
             Whether the user has muted the stream. Muted streams do
             not count towards your total unread count and do not show up in
-            `All messages` view (previously known as `Home` view).
+            `Global feed` view (previously known as `All messages` view).
 
             **Changes**: Prior to Zulip 2.1.0, this feature was
             represented by the more confusingly named `in_home_view` (with the

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -769,7 +769,7 @@ class TestRealmAuditLog(ZulipTestCase):
         value: Union[bool, int, str]
         test_values = dict(
             default_language="de",
-            web_home_view="all_messages",
+            web_home_view="global_feed",
             emojiset="twitter",
             notification_sound="ding",
         )

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3509,7 +3509,7 @@ class NormalActionsTest(BaseAction):
             lambda: do_change_user_setting(
                 self.user_profile,
                 "web_home_view",
-                "all_messages",
+                "global_feed",
                 acting_user=self.user_profile,
             ),
             state_change_expected=True,
@@ -3716,7 +3716,7 @@ class RealmPropertyActionTest(BaseAction):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_LEGACY],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_LEGACY],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent_topics", "inbox", "global_feed"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,
@@ -3851,7 +3851,7 @@ class UserDisplayActionTest(BaseAction):
         test_changes: Dict[str, Any] = dict(
             emojiset=["twitter"],
             default_language=["es", "de", "en"],
-            web_home_view=["all_messages", "inbox", "recent_topics"],
+            web_home_view=["global_feed", "inbox", "recent_topics"],
             demote_inactive_streams=[2, 3, 1],
             web_mark_read_on_scroll_policy=[2, 3, 1],
             user_list_style=[1, 2, 3],

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1582,7 +1582,7 @@ class RealmAPITest(ZulipTestCase):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_LEGACY],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_LEGACY],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent_topics", "inbox", "global_feed"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -345,7 +345,7 @@ class ChangeSettingsTest(ZulipTestCase):
     def do_test_change_user_setting(self, setting_name: str) -> None:
         test_changes: Dict[str, Any] = dict(
             default_language="de",
-            web_home_view="all_messages",
+            web_home_view="global_feed",
             emojiset="google",
             timezone="America/Denver",
             demote_inactive_streams=2,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1253,7 +1253,7 @@ class UserProfileTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
 
         do_change_user_setting(cordelia, "default_language", "de", acting_user=None)
-        do_change_user_setting(cordelia, "web_home_view", "all_messages", acting_user=None)
+        do_change_user_setting(cordelia, "web_home_view", "global_feed", acting_user=None)
         do_change_user_setting(cordelia, "emojiset", "twitter", acting_user=None)
         do_change_user_setting(cordelia, "timezone", "America/Phoenix", acting_user=None)
         do_change_user_setting(

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -506,7 +506,7 @@ def realm_reactivation(request: HttpRequest, confirmation_key: str) -> HttpRespo
 
 
 emojiset_choices = {emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()}
-web_home_view_options = ["recent_topics", "inbox", "all_messages"]
+web_home_view_options = ["recent_topics", "inbox", "global_feed"]
 
 
 @require_realm_admin

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -155,7 +155,7 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
 
 
 emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices()}
-web_home_view_options = ["recent_topics", "inbox", "all_messages"]
+web_home_view_options = ["recent_topics", "inbox", "global_feed"]
 
 
 def check_settings_values(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changed "All messages" to "Global feed"  in the Left Sidebar and changed the url to `#global_feed` with a redirect from  `#all_messages` and updated the documentation as  discussed in [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/All.20messages.20view.20label.20and.20icon/near/1668230)

Fixes: #27802.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/91622060/cf7e93a7-5920-40b7-916e-b65d56dcc82a)
![image](https://github.com/zulip/zulip/assets/91622060/99504a2c-64b1-4183-8fa6-03f113240f49)
![Animation8](https://github.com/zulip/zulip/assets/91622060/7665ccd8-dd5d-475c-afaa-8de962e0ffad)

Help Center (Major)

![image](https://github.com/zulip/zulip/assets/91622060/7fb76cb1-e2e9-4b06-aed2-89ea344cdf84)
There are several other changes in about 13 pages in help center documentation which are updated in this pr as well.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
