### PR TITLE
Organization settings: Fix tippy design for edit/delete in custom profile fields.

### DIFF
--- a/web/templates/settings/admin_profile_field_list.hbs
+++ b/web/templates/settings/admin_profile_field_list.hbs
@@ -25,10 +25,10 @@
     </td>
     {{#if ../can_modify}}
     <td class="actions">
-        <button class="button rounded small btn-warning open-edit-form-modal" title="{{t 'Edit' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small btn-warning open-edit-form-modal tippy-zulip-tooltip" data-tippy-content="{{t 'Edit' }}"  data-profile-field-id="{{id}}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
-        <button class="button rounded small delete btn-danger" title="{{t 'Delete' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small delete btn-danger tippy-zulip-tooltip" data-tippy-content="{{t 'Delete' }}" data-profile-field-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the issue #27816. 

Explanation:
In the "Organization settings" under the tab "Custom profile fields" the edit and delete buttons have a hover-text displaying "edit" respectivley "delete". Before, it looked like the GIF "old version" below but this PR has updated the design to use the new tippy design, shown in GIF "New version dark mode" and "New version lilght theme".

Fixes: #27816 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Old version - before this PR**
![edit_delete_old_tippy](https://github.com/zulip/zulip/assets/114491379/bd7d64fa-15be-419b-b3ac-e6aa8a3b4e89)

**New version dark theme**
![edit_delete_new_tippy](https://github.com/zulip/zulip/assets/114491379/355e9993-ed19-4ba8-8d0f-d86bd6d1b7ae)


**New version lilght theme**
![light_theme_tippy_edit_delete](https://github.com/zulip/zulip/assets/114491379/4e00e737-9db5-43da-b0d7-70395bd2bb20)

<details>
<summary>Self-review checklist</summary>



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
