### PR TITLE
realm: Allow setting notification settings to unsubscribed private streams.

### DIFF
--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -494,6 +494,15 @@ class RealmTest(ZulipTestCase):
         assert realm.notifications_stream is not None
         self.assertEqual(realm.notifications_stream.id, new_notif_stream_id)
 
+        # Test that admin can set the setting to an unsubscribed private stream as well.
+        new_notif_stream_id = self.make_stream("private_stream", invite_only=True).id
+        req = dict(notifications_stream_id=orjson.dumps(new_notif_stream_id).decode())
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_success(result)
+        realm = get_realm("zulip")
+        assert realm.notifications_stream is not None
+        self.assertEqual(realm.notifications_stream.id, new_notif_stream_id)
+
         invalid_notif_stream_id = 1234
         req = dict(notifications_stream_id=orjson.dumps(invalid_notif_stream_id).decode())
         result = self.client_patch("/json/realm", req)
@@ -553,6 +562,18 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.signup_notifications_stream, None)
 
         new_signup_notifications_stream_id = Stream.objects.get(name="Denmark").id
+        req = dict(
+            signup_notifications_stream_id=orjson.dumps(new_signup_notifications_stream_id).decode()
+        )
+
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_success(result)
+        realm = get_realm("zulip")
+        assert realm.signup_notifications_stream is not None
+        self.assertEqual(realm.signup_notifications_stream.id, new_signup_notifications_stream_id)
+
+        # Test that admin can set the setting to an unsubscribed private stream as well.
+        new_signup_notifications_stream_id = self.make_stream("private_stream", invite_only=True).id
         req = dict(
             signup_notifications_stream_id=orjson.dumps(new_signup_notifications_stream_id).decode()
         )

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -383,7 +383,7 @@ def update_realm(
         new_notifications_stream = None
         if notifications_stream_id >= 0:
             (new_notifications_stream, sub) = access_stream_by_id(
-                user_profile, notifications_stream_id
+                user_profile, notifications_stream_id, allow_realm_admin=True
             )
         do_set_realm_notifications_stream(
             realm, new_notifications_stream, notifications_stream_id, acting_user=user_profile
@@ -397,7 +397,7 @@ def update_realm(
         new_signup_notifications_stream = None
         if signup_notifications_stream_id >= 0:
             (new_signup_notifications_stream, sub) = access_stream_by_id(
-                user_profile, signup_notifications_stream_id
+                user_profile, signup_notifications_stream_id, allow_realm_admin=True
             )
         do_set_realm_signup_notifications_stream(
             realm,


### PR DESCRIPTION
We previously did not allow setting `signup_notifications_stream` and `notifications_stream`
settings to private streams that admin is not subscribed to, even when admins have access
to metadata of all the streams in the realm and can see them in the dropdown options as well.

This commit fixes it to allow admins to set these settings to private streams that the admin is not subscribed to.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20private.20stream.20for.20announcements

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Peek 2023-11-22 22-46](https://github.com/zulip/zulip/assets/35494118/99f4e798-f021-4a98-bba8-d80862434b79)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
