### PR TITLE
invite: Change setup tips banner from warning to info and remove redundant code.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -14,6 +14,7 @@ export function set_scroll_to_message_banner_message_id(val: number | null): voi
 export const WARNING = "warning";
 export const ERROR = "error";
 export const SUCCESS = "success";
+export const INFO = "info";
 
 const MESSAGE_SENT_CLASSNAMES = {
     sent_scroll_to_view: "sent_scroll_to_view",

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -442,8 +442,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         const invite_tips_data = generate_invite_tips_data();
 
         const context = {
-            banner_type: compose_banner.WARNING,
-            classname: "setup_tips_warning",
+            banner_type: compose_banner.INFO,
+            classname: "setup_tips_banner",
             banner_html: "",
             ...invite_tips_data,
         };

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -444,7 +444,6 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         const context = {
             banner_type: compose_banner.INFO,
             classname: "setup_tips_banner",
-            banner_html: "",
             ...invite_tips_data,
         };
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR contains the following changes,
1. Change banner type from `warning` to `info`.
2. Rename "setup_tips_warning" classname to "setup_tips_banner". (part of the same commit as `1`)
3. Remove redundant param "banner_html" which was introduced in eecb611789aa61ee84c6ffc8d2f5bafb333da4c7

CZO: [link](https://chat.zulip.org/#narrow/stream/101-design/topic/setup.20tips.20in.20user.20invite.20modal/near/1687490)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/82862779/feda13c3-ef18-49d3-afb6-a84536af9cbf)
![image](https://github.com/zulip/zulip/assets/82862779/57ccf77e-88d9-4002-a3b4-62ca0457a56c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
