### PR TITLE
compose: Add banner to go to conversation when composing in search view.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -290,6 +290,10 @@ export function start(msg_type, opts) {
 
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
+    // Show a warning if the user is in a search narrow when replying to a message
+    if (opts.is_reply) {
+        compose_validate.warn_if_in_search_view();
+    }
 
     compose_recipient.check_posting_policy_for_compose_box();
 

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -37,6 +37,7 @@ export const CLASSNAMES = {
     wildcard_warning: "wildcard_warning",
     private_stream_warning: "private_stream_warning",
     unscheduled_message: "unscheduled_message",
+    search_view: "search_view",
     // errors
     wildcards_not_allowed: "wildcards_not_allowed",
     subscription_error: "subscription_error",
@@ -120,6 +121,10 @@ export function clear_unmute_topic_notifications(): void {
             .map((classname) => CSS.escape(classname))
             .join(".")}`,
     ).remove();
+}
+
+export function clear_search_view_banner(): void {
+    $(`#compose_banners .${CSS.escape(CLASSNAMES.search_view)}`).remove();
 }
 
 export function clear_all(): void {

--- a/web/src/compose_reply.js
+++ b/web/src/compose_reply.js
@@ -114,6 +114,7 @@ export function respond_to_message(opts) {
         topic,
         private_message_recipient: pm_recipient,
         trigger: opts.trigger,
+        is_reply: true,
     });
 }
 

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -257,6 +257,15 @@ export function initialize() {
         },
     );
 
+    $("body").on(
+        "click",
+        `.${CSS.escape(compose_banner.CLASSNAMES.search_view)} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            narrow.to_compose_target();
+        },
+    );
+
     for (const classname of Object.values(compose_banner.CLASSNAMES)) {
         const classname_selector = `.${CSS.escape(classname)}`;
         $("body").on("click", `${classname_selector} .main-view-banner-close-button`, (event) => {

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -15,6 +15,7 @@ import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import {$t} from "./i18n";
 import * as message_store from "./message_store";
+import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
@@ -281,6 +282,23 @@ export function warn_if_topic_resolved(topic_changed) {
         compose_state.set_recipient_viewed_topic_resolved_banner(true);
     } else {
         clear_topic_resolved_warning();
+    }
+}
+
+export function warn_if_in_search_view() {
+    if (narrow_state.filter() && !narrow_state.filter().supports_collapsing_recipients()) {
+        const context = {
+            banner_type: compose_banner.WARNING,
+            banner_text: $t({
+                defaultMessage:
+                    "This conversation may have additional messages not shown in this view.",
+            }),
+            button_text: $t({defaultMessage: "Go to conversation"}),
+            classname: compose_banner.CLASSNAMES.search_view,
+        };
+
+        const new_row = render_compose_banner(context);
+        compose_banner.append_compose_banner_to_banner_list(new_row, $("#compose_banners"));
     }
 }
 

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -934,7 +934,6 @@ export function by_recipient(target_id, opts) {
     }
 }
 
-// Called by the narrow_to_compose_target hotkey.
 export function to_compose_target() {
     if (!compose_state.composing()) {
         return;
@@ -943,6 +942,8 @@ export function to_compose_target() {
     const opts = {
         trigger: "narrow_to_compose_target",
     };
+
+    compose_banner.clear_search_view_banner();
 
     if (compose_state.get_message_type() === "stream") {
         const stream_id = compose_state.stream_id();

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -39,6 +39,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
 const hash_util = mock_esm("../src/hash_util");
 const narrow_state = mock_esm("../src/narrow_state", {
     set_compose_defaults: noop,
+    filter: noop,
 });
 
 mock_esm("../src/reload_state", {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -21,6 +21,9 @@ const settings_config = zrequire("settings_config");
 const recent_view_util = zrequire("recent_view_util");
 const inbox_util = zrequire("inbox_util");
 
+mock_esm("../src/compose_banner", {
+    clear_search_view_banner() {},
+});
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 mock_esm("../src/spectators", {
     login_to_access() {},


### PR DESCRIPTION
When a user is composing a message while in a search view, we now warn them that the full conversation is not visible and urge them to go to the conversation they are composing to, so they can see the complete conversation. On narrowing to that conversation, the banner is removed.

Fixes: #25893.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/ad369474-1376-4346-b868-9978440286aa)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
