### PR TITLE
help: Document compose box UI changes.

### DIFF
--- a/help/include/compose-and-send-message.md
+++ b/help/include/compose-and-send-message.md
@@ -2,6 +2,6 @@
    can [preview your message](/help/preview-your-message-before-sending) before
    sending.
 
-1. Click **Send**, or use a [keyboard
-   shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
+   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
    to send your message.

--- a/help/include/replying-to-messages.md
+++ b/help/include/replying-to-messages.md
@@ -8,10 +8,9 @@ To reply to an existing thread:
    can [preview your message](/help/preview-your-message-before-sending) before
    sending.
 
-1. Click **Send**, or use a [keyboard
-   shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
+   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
    to send your message.
-
 
 !!! tip ""
     You can also reply by clicking on a message, or using the <kbd>R</kbd> or

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -81,8 +81,9 @@ Zulip so that the <kbd>Enter</kbd> key sends your message.
 
 {!start-composing.md!}
 
-1. Click **<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to send** in the bottom right
-   corner of the compose box, just below the **Send** button.
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
+   in the bottom right corner of the compose box, next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
 
 1. Select **<kbd>Enter</kbd> to send**.
 
@@ -94,8 +95,9 @@ Zulip so that the <kbd>Enter</kbd> key sends your message.
 
 {!start-composing.md!}
 
-1. Click **<kbd>Enter</kbd> to send** in the bottom right
-   corner of the compose box, just below the **Send** button.
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
+   in the bottom right corner of the compose box, next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
 
 1. Select **<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to send**.
 

--- a/help/schedule-a-message.md
+++ b/help/schedule-a-message.md
@@ -15,7 +15,8 @@ can schedule a message for next morning to avoid disturbing others.
 1. Write a message.
 
 1. Click on the **ellipsis** (<i class="zulip-icon
-   zulip-icon-more-vertical"></i>) next to the **Send** button.
+   zulip-icon-more-vertical"></i>) next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
 
 1. Click **Schedule message**.
 
@@ -42,7 +43,8 @@ can schedule a message for next morning to avoid disturbing others.
 1. *(optional)* Edit the message.
 
 1. Click the **ellipsis** (<i class="zulip-icon
-   zulip-icon-more-vertical"></i>) next to the **Send** button.
+   zulip-icon-more-vertical"></i>) next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
 
 1. Select the previously scheduled time, or click **Schedule message** to pick a
    new time.
@@ -67,7 +69,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 1. *(optional)* Edit the message.
 
-1. Click **Send**.
+1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button.
 
 !!! keyboard_tip ""
 
@@ -104,8 +106,9 @@ can schedule a message for next morning to avoid disturbing others.
 
 !!! tip ""
 
-    You can also view scheduled messages by clicking on the **ellipsis** (<i class="zulip-icon
-    zulip-icon-more-vertical"></i>) next to the **Send** button in the compose
+    You can also view scheduled messages by clicking on the **ellipsis**
+    (<i class="zulip-icon zulip-icon-more-vertical"></i>) next to the **Send**
+    (<i class="zulip-icon zulip-icon-send"></i>) button in the compose
     box, and selecting **View scheduled messages**.
 
 {end_tabs}


### PR DESCRIPTION
Updates relevant articles to reflect the changes to the send button and compose box menu.

Fixes #27848.

**Screenshots and screen captures:**

- https://zulip.com/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message
![image](https://github.com/zulip/zulip/assets/2343554/9901aaa7-e882-4ba0-94b7-0a757b2f77f6)

- https://zulip.com/help/schedule-a-message
![image](https://github.com/zulip/zulip/assets/2343554/76fa2b65-e250-4215-8429-6c0b37a480a9)
![image](https://github.com/zulip/zulip/assets/2343554/055670ee-d4e3-4d35-99cb-2a42be748de1)

- https://zulip.com/help/getting-started-with-zulip#responding-to-an-existing-thread
![image](https://github.com/zulip/zulip/assets/2343554/1641c143-31fb-423f-88d9-cbecb2e381ec)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
