### PR TITLE
Allow upgrade access to remote realms.

### DIFF
--- a/corporate/lib/remote_billing_util.py
+++ b/corporate/lib/remote_billing_util.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Optional, TypedDict
+
+from django.http import HttpRequest
+from django.utils.translation import gettext as _
+
+billing_logger = logging.getLogger("corporate.stripe")
+
+
+class RemoteBillingIdentityDict(TypedDict):
+    user_uuid: str
+    user_email: str
+    user_full_name: str
+    remote_server_uuid: str
+    remote_realm_uuid: str
+
+
+def get_identity_dict_from_session(
+    request: HttpRequest,
+    realm_uuid: Optional[str],
+    server_uuid: Optional[str],
+) -> Optional[RemoteBillingIdentityDict]:
+    authed_uuid = realm_uuid or server_uuid
+    assert authed_uuid is not None
+
+    identity_dicts = request.session.get("remote_billing_identities")
+    if identity_dicts is not None:
+        return identity_dicts.get(authed_uuid)
+
+    return None

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -556,7 +556,7 @@ class BillingSession(ABC):
         pass
 
     @abstractmethod
-    def update_context_initial_upgrade(self, context: Dict[str, Any]) -> None:
+    def get_upgrade_page_session_type_specific_context(self, context: Dict[str, Any]) -> None:
         pass
 
     @catch_stripe_errors
@@ -1282,7 +1282,7 @@ class BillingSession(ABC):
                 # Show "Update card" button if user has already added a card.
                 context["payment_method"] = payment_method
 
-        self.update_context_initial_upgrade(context)
+        self.get_upgrade_page_session_type_specific_context(context)
 
         return None, context
 
@@ -1634,7 +1634,7 @@ class RealmBillingSession(BillingSession):
         return False
 
     @override
-    def update_context_initial_upgrade(self, context: Dict[str, Any]) -> None:
+    def get_upgrade_page_session_type_specific_context(self, context: Dict[str, Any]) -> None:
         assert self.user is not None
         data = {
             "customer_name": self.realm.name,
@@ -1985,7 +1985,7 @@ class RemoteServerBillingSession(BillingSession):  # nocoverage
         return False
 
     @override
-    def update_context_initial_upgrade(self, context: Dict[str, Any]) -> None:
+    def get_upgrade_page_session_type_specific_context(self, context: Dict[str, Any]) -> None:
         # TBD
         pass
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1847,6 +1847,14 @@ class RemoteRealmBillingSession(BillingSession):  # nocoverage
         pass
 
     @override
+    def is_sponsored_or_pending(self, customer: Optional[Customer]) -> bool:
+        if (
+            customer is not None and customer.sponsorship_pending
+        ) or self.remote_realm.plan_type == self.remote_realm.PLAN_TYPE_COMMUNITY:
+            return True
+        return False
+
+    @override
     def get_upgrade_page_session_type_specific_context(
         self,
     ) -> UpgradePageSessionTypeSpecificContext:

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1256,21 +1256,21 @@ class BillingSession(ABC):
         signed_seat_count, salt = sign_string(str(seat_count))
         tier = initial_upgrade_request.tier
         context: Dict[str, Any] = {
-            "seat_count": seat_count,
-            "signed_seat_count": signed_seat_count,
-            "salt": salt,
-            "min_invoiced_licenses": max(seat_count, MIN_INVOICED_LICENSES),
             "default_invoice_days_until_due": DEFAULT_INVOICE_DAYS_UNTIL_DUE,
+            "discount_percent": format_discount_percentage(percent_off),
             "exempt_from_license_number_check": exempt_from_license_number_check,
-            "plan": "Zulip Cloud Standard",
             "free_trial_days": settings.FREE_TRIAL_DAYS,
+            "manual_license_management": initial_upgrade_request.manual_license_management,
+            "min_invoiced_licenses": max(seat_count, MIN_INVOICED_LICENSES),
             "page_params": {
-                "seat_count": seat_count,
                 "annual_price": get_price_per_license(tier, CustomerPlan.ANNUAL, percent_off),
                 "monthly_price": get_price_per_license(tier, CustomerPlan.MONTHLY, percent_off),
+                "seat_count": seat_count,
             },
-            "manual_license_management": initial_upgrade_request.manual_license_management,
-            "discount_percent": format_discount_percentage(percent_off),
+            "plan": "Zulip Cloud Standard",
+            "salt": salt,
+            "seat_count": seat_count,
+            "signed_seat_count": signed_seat_count,
         }
 
         # Check if user was successful in adding a card and we are rendering the page again.

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -100,7 +100,7 @@ def format_money(cents: float) -> str:
 
 
 def format_discount_percentage(discount: Optional[Decimal]) -> Optional[str]:
-    if type(discount) is not Decimal:
+    if type(discount) is not Decimal or discount == Decimal(0):
         return None
 
     # Even though it looks like /activity/support only finds integers valid,

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1637,7 +1637,7 @@ class RealmBillingSession(BillingSession):
     def update_context_initial_upgrade(self, context: Dict[str, Any]) -> None:
         assert self.user is not None
         data = {
-            "realm": self.realm,
+            "customer_name": self.realm.name,
             "email": self.user.delivery_email,
             "is_demo_organization": self.realm.demo_organization_scheduled_deletion_date
             is not None,

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1273,7 +1273,7 @@ class BillingSession(ABC):
         customer = self.get_customer()
 
         if self.is_sponsored_or_pending(customer):
-            return reverse("sponsorship_request"), None
+            return f"{self.billing_session_url}/sponsorship", None
 
         billing_page_url = reverse("billing_home")
         if customer is not None and (get_current_plan_by_customer(customer) is not None):
@@ -1702,7 +1702,7 @@ class RemoteRealmBillingSession(BillingSession):  # nocoverage
     @override
     @property
     def billing_session_url(self) -> str:
-        return "TBD"
+        return f"{settings.EXTERNAL_URI_SCHEME}{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}/realm/{self.remote_realm.uuid}"
 
     @override
     def get_customer(self) -> Optional[Customer]:

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2384,7 +2384,7 @@ def downgrade_small_realms_behind_on_payments_as_needed() -> None:
             billing_session.downgrade_now_without_creating_additional_invoices()
             void_all_open_invoices(realm)
             context: Dict[str, Union[str, Realm]] = {
-                "upgrade_url": f"{realm.uri}{reverse('initial_upgrade')}",
+                "upgrade_url": f"{realm.uri}{reverse('upgrade_page')}",
                 "realm": realm,
             }
             send_email_to_billing_admins_and_realm_owners(

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1839,7 +1839,7 @@ class StripeTest(StripeTestCase):
 
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], "/sponsorship/")
+        self.assertEqual(response["Location"], "http://zulip.testserver/sponsorship")
 
         response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
@@ -1943,7 +1943,7 @@ class StripeTest(StripeTestCase):
         user.realm.save()
         response = self.client_get("/upgrade/")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], "/sponsorship/")
+        self.assertEqual(response["Location"], "http://zulip.testserver/sponsorship")
 
         # Avoid contacting stripe as we only want to check redirects here.
         with patch(

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -27,7 +27,7 @@ from corporate.views.session import (
     start_card_update_stripe_session_for_realm_upgrade,
 )
 from corporate.views.support import support_request
-from corporate.views.upgrade import initial_upgrade, sponsorship, upgrade
+from corporate.views.upgrade import sponsorship, upgrade, upgrade_page
 from corporate.views.webhook import stripe_webhook
 from zerver.lib.rest import rest_path
 from zerver.lib.url_redirects import LANDING_PAGE_REDIRECTS
@@ -40,7 +40,7 @@ i18n_urlpatterns: Any = [
     # Billing
     path("billing/", billing_home, name="billing_home"),
     path("sponsorship/", sponsorship_request, name="sponsorship_request"),
-    path("upgrade/", initial_upgrade, name="initial_upgrade"),
+    path("upgrade/", upgrade_page, name="upgrade_page"),
     path("support/", support_request),
     path("billing/event_status/", event_status_page, name="event_status_page"),
     path("stripe/webhook/", stripe_webhook, name="stripe_webhook"),

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -27,7 +27,7 @@ from corporate.views.session import (
     start_card_update_stripe_session_for_realm_upgrade,
 )
 from corporate.views.support import support_request
-from corporate.views.upgrade import sponsorship, upgrade, upgrade_page
+from corporate.views.upgrade import remote_realm_upgrade_page, sponsorship, upgrade, upgrade_page
 from corporate.views.webhook import stripe_webhook
 from zerver.lib.rest import rest_path
 from zerver.lib.url_redirects import LANDING_PAGE_REDIRECTS
@@ -168,4 +168,5 @@ urlpatterns += [
     ),
     path("realm/<realm_uuid>/billing", remote_billing_page_realm, name="remote_billing_page_realm"),
     path("server/<server_uuid>/", remote_billing_page_server, name="remote_billing_page_server"),
+    path("realm/<realm_uuid>/upgrade", remote_realm_upgrade_page, name="remote_realm_upgrade_page"),
 ]

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -105,14 +105,14 @@ def billing_home(
         return HttpResponseRedirect(reverse("plans"))
 
     if customer is None:
-        from corporate.views.upgrade import initial_upgrade
+        from corporate.views.upgrade import upgrade_page
 
-        return HttpResponseRedirect(reverse(initial_upgrade))
+        return HttpResponseRedirect(reverse(upgrade_page))
 
     if not CustomerPlan.objects.filter(customer=customer).exists():
-        from corporate.views.upgrade import initial_upgrade
+        from corporate.views.upgrade import upgrade_page
 
-        return HttpResponseRedirect(reverse(initial_upgrade))
+        return HttpResponseRedirect(reverse(upgrade_page))
 
     billing_session = RealmBillingSession(user=None, realm=user.realm)
     main_context = billing_session.get_billing_page_context()

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -78,7 +78,7 @@ def upgrade(
 
 @zulip_login_required
 @has_request_variables
-def initial_upgrade(
+def upgrade_page(
     request: HttpRequest,
     manual_license_management: bool = REQ(default=False, json_validator=check_bool),
 ) -> HttpResponse:

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -9,7 +9,7 @@
 <div id="upgrade-page" class="register-account flex full-page">
     <div class="center-block new-style">
         <div class="pitch">
-            <h1>Upgrade {{ realm.name }} to
+            <h1>Upgrade {{ customer_name }} to
                 {% if free_trial_days %}
                     Zulip Cloud Standard free trial
                 {% else %}

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -57,6 +57,7 @@ not_yet_fully_covered = [
     # TODO: This is a work in progress and therefore without
     # tests yet.
     "corporate/views/remote_billing_page.py",
+    "corporate/lib/remote_billing_util.py",
     # Major lib files should have 100% coverage
     "zerver/actions/presence.py",
     "zerver/lib/addressee.py",

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -394,7 +394,7 @@ def login_or_register_remote_user(request: HttpRequest, result: ExternalAuthResu
         from corporate.lib.stripe import is_free_trial_offer_enabled
 
         if is_free_trial_offer_enabled():
-            redirect_to = reverse("initial_upgrade")
+            redirect_to = reverse("upgrade_page")
 
     redirect_to = get_safe_redirect_to(redirect_to, user_profile.realm.uri)
     return HttpResponseRedirect(redirect_to)


### PR DESCRIPTION
Completes the first and second task of `#16`.

changed dev_settings:

```
DEVELOPMENT_DISABLE_PUSH_BOUNCER_DOMAIN_CHECK = True
PUSH_NOTIFICATION_BOUNCER_URL = "http://aman.zulipdev.org:9991"
```

and ran `./manage.py register_server` for it to work as recommened in #27575

The actual upgrade flow doesn't work here. 