### PR TITLE
message_feed_ui: Fix focus when clicking on message feed buttons.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -295,7 +295,6 @@ export function initialize() {
     $("body").on("click", ".move_message_button", function (e) {
         const $row = message_lists.current.get_row(rows.id($(this).closest(".message_row")));
         const message_id = rows.id($row);
-        message_lists.current.select_id(message_id);
         const message = message_lists.current.get(message_id);
         stream_popover.build_move_topic_to_stream_popover(
             message.stream_id,

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -11,7 +11,6 @@ import * as blueslip from "./blueslip";
 import * as compose_ui from "./compose_ui";
 import * as emoji from "./emoji";
 import * as keydown_util from "./keydown_util";
-import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
@@ -283,7 +282,7 @@ function filter_emojis() {
 }
 
 function toggle_reaction(emoji_name, event) {
-    const message_id = message_lists.current.selected_id();
+    const message_id = current_message_id;
     const message = message_store.get(message_id);
     if (!message) {
         blueslip.error("reactions: Bad message id", {message_id});
@@ -641,9 +640,6 @@ function get_default_emoji_popover_options() {
             ],
         },
         onCreate(instance) {
-            if (current_message_id) {
-                message_lists.current.select_id(current_message_id);
-            }
             emoji_popover_instance = instance;
             const $popover = $(instance.popper);
             $popover.addClass("emoji-popover-root");

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -508,7 +508,6 @@ export function get_user_card_popover_manage_menu_items() {
 // user is the user whose profile to show
 // message is the message containing it, which should be selected
 function toggle_user_card_popover_for_message(element, user, message, on_mount) {
-    message_lists.current.select_id(message.id);
     const $elt = $(element);
     if (!message_user_card.is_open()) {
         if (user === undefined) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the focus on messages when clicking message feed buttons that open popovers. The focus no longer changes when following buttons are clicked on the message-box:

- "Add emoji"
- "Move message"
- "User avatar or name"

Fixes: #27820
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2023-11-23 184045](https://github.com/zulip/zulip/assets/119798962/054a0def-37b8-432c-953c-7b885a44ea71)
![Screenshot 2023-11-23 184554](https://github.com/zulip/zulip/assets/119798962/e034ff04-9367-4c28-86ae-fb1d4ca2a054)
![Screenshot 2023-11-23 184104](https://github.com/zulip/zulip/assets/119798962/a36e6bad-c6d9-4150-81eb-94a0c0407c34)

<details>


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
