### PR TITLE
help: Document updated setting to restrict wildcard mentions.

### DIFF
--- a/help/restrict-wildcard-mentions.md
+++ b/help/restrict-wildcard-mentions.md
@@ -2,27 +2,24 @@
 
 {!admin-only.md!}
 
-Organization administrators can set a policy for which users are
-allowed to use [wildcard
-mentions](/help/dm-mention-alert-notifications#wildcard-mentions) in
-large streams (defined for this purpose as streams with more than 15
-subscribers).
-
-Zulip allows anyone to use wildcard mentions in streams with at most
-15 subscribers. The default allows only organization administrators to
-use wildcard mentions in large streams.
-
-Users permitted to use wildcard mentions by the organization's policy
-are warned that wildcard mentions will result in all subscribers
-receiving email and mobile push notifications.
+Organization administrators can configure who is allowed to use [wildcard
+mentions](/help/dm-mention-alert-notifications#wildcard-mentions) that affect a
+large number of users. In particular, an organization can restrict who is
+allowed to use `@all` (and, equivalently, `@everyone` and `@stream`) in streams
+with more than 15 subscribers, and `@topic` in topics with more than 15
+participants.
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, configure
-   **Who can use @all/@everyone mentions in large streams**.
+1. Under **Stream permissions**, configure **Who can notify a large number of
+   users with a wildcard mention**.
 
 {!save-changes.md!}
 
 {end_tabs}
+
+## Related articles
+
+* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)


### PR DESCRIPTION
Also drop extraneous details.
- We don't normally document defaults, to avoid having to update documentation if they are changed or become context-dependent.
- I don't think it's important to document warning banners.

I was also careful to not say that it depends on how many people will actually be notified (which the previous version did), since my understanding is that it's based on just the number of subscribers/participants, now how those users' personal notification settings are configured.

<img width="822" alt="Screenshot 2023-11-23 at 1 53 12 PM" src="https://github.com/zulip/zulip/assets/2090066/303a6693-23e4-4d1c-9fbc-fc706c7e7564">
