### PR TITLE
WIP: Push notifications enabled migration to have current information about bouncer registration state

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 231**
+
+* [`GET /server_settings`](/api/get-server-settings): Renamed
+`push_notifications_enabled` to `push_notifications_configured`
+ as it doesn't actually check if push notifications are working,
+ just whether there is configuration for them.
+
 **Feature level 230**
 
 * [`GET /events`](/api/get-events): Added `has_trigger` field in

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -39,7 +39,7 @@ from zerver.lib.muted_users import get_user_mutes
 from zerver.lib.narrow import check_narrow_for_events, read_stop_words
 from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.presence import get_presence_for_user, get_presences_for_realm
-from zerver.lib.push_notifications import push_notifications_enabled
+from zerver.lib.push_notifications import push_notifications_configured
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.realm_logo import get_realm_logo_source, get_realm_logo_url
 from zerver.lib.scheduled_messages import get_undelivered_scheduled_messages
@@ -346,7 +346,7 @@ def fetch_initial_state_data(
         ] = settings.EVENT_QUEUE_LONGPOLL_TIMEOUT_SECONDS
 
         # TODO: Should these have the realm prefix replaced with server_?
-        state["realm_push_notifications_enabled"] = push_notifications_enabled()
+        state["realm_push_notifications_enabled"] = push_notifications_configured()
         state["realm_default_external_accounts"] = get_default_external_accounts()
 
         server_default_jitsi_server_url = (

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -146,7 +146,7 @@ class APNsContext:
     loop: asyncio.AbstractEventLoop
 
 
-def apns_enabled() -> bool:
+def has_apns_credentials() -> bool:
     return settings.APNS_TOKEN_KEY_FILE is not None or settings.APNS_CERT_FILE is not None
 
 
@@ -156,7 +156,7 @@ def get_apns_context() -> Optional[APNsContext]:
     # import time.
     import aioapns
 
-    if not apns_enabled():  # nocoverage
+    if not has_apns_credentials():  # nocoverage
         return None
 
     # NB if called concurrently, this will make excess connections.
@@ -374,7 +374,7 @@ else:
     gcm_client = None
 
 
-def gcm_enabled() -> bool:  # nocoverage
+def has_gcm_credentials() -> bool:  # nocoverage
     return gcm_client is not None
 
 
@@ -722,12 +722,12 @@ def push_notifications_configured() -> bool:
         # works -- e.g., that we have ever successfully sent to the bouncer --
         # but this is a good start.
         return True
-    if settings.DEVELOPMENT and (apns_enabled() or gcm_enabled()):  # nocoverage
+    if settings.DEVELOPMENT and (has_apns_credentials() or has_gcm_credentials()):  # nocoverage
         # Since much of the notifications logic is platform-specific, the mobile
         # developers often work on just one platform at a time, so we should
         # only require one to be configured.
         return True
-    elif apns_enabled() and gcm_enabled():  # nocoverage
+    elif has_apns_credentials() and has_gcm_credentials():  # nocoverage
         # We have the needed configuration to send through APNs and GCM directly
         # (i.e., we are the bouncer, presumably.)  Again, assume it actually works.
         return True

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -710,7 +710,7 @@ def clear_push_device_tokens(user_profile_id: int) -> None:
 #
 
 
-def push_notifications_enabled() -> bool:
+def push_notifications_configured() -> bool:
     """True just if this server has configured a way to send push notifications."""
     if (
         uses_notification_bouncer()
@@ -735,7 +735,7 @@ def push_notifications_enabled() -> bool:
 
 
 def initialize_push_notifications() -> None:
-    if not push_notifications_enabled():
+    if not push_notifications_configured():
         if settings.DEVELOPMENT and not settings.TEST_SUITE:  # nocoverage
             # Avoid unnecessary spam on development environment startup
             return
@@ -1037,7 +1037,7 @@ def handle_remove_push_notification(user_profile_id: int, message_ids: List[int]
     mobile app, when the message is read on the server, to remove the
     message from the notification.
     """
-    if not push_notifications_enabled():
+    if not push_notifications_configured():
         return
 
     user_profile = get_user_profile_by_id(user_profile_id)
@@ -1116,7 +1116,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     missed_message is the event received by the
     zerver.worker.queue_processors.PushNotificationWorker.consume function.
     """
-    if not push_notifications_enabled():
+    if not push_notifications_configured():
         return
     user_profile = get_user_profile_by_id(user_profile_id)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15624,10 +15624,13 @@ paths:
                           This will be `""` if unavailable.
 
                           **Changes**: New in Zulip 5.0 (feature level 88).
-                      push_notifications_enabled:
+                      push_notifications_configured:
                         type: boolean
                         description: |
-                          Whether mobile/push notifications are enabled.
+                          Whether mobile/push notifications are configured.
+
+                          **Changes**: In Zulip 8.0 (feature level 231), renamed
+                          `push_notifications_enabled` to `push_notifications_configured`.
                       is_incompatible:
                         type: boolean
                         description: |
@@ -15698,7 +15701,7 @@ paths:
                           },
                         "zulip_version": "5.0-dev-1650-gc3fd37755f",
                         "zulip_merge_base": "5.0-dev-1646-gea6b21cd8c",
-                        "push_notifications_enabled": false,
+                        "push_notifications_configured": false,
                         "msg": "",
                         "is_incompatible": false,
                         "email_auth_enabled": true,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5248,7 +5248,7 @@ class FetchAuthBackends(ZulipTestCase):
                     ("zulip_version", check_string),
                     ("zulip_merge_base", check_string),
                     ("zulip_feature_level", check_int),
-                    ("push_notifications_enabled", check_bool),
+                    ("push_notifications_configured", check_bool),
                     ("realm_web_public_access_enabled", check_bool),
                     ("msg", check_string),
                     ("result", check_string),

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -620,7 +620,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         # push notifications or message notification emails.
         self.assert_length(info["queue_messages"], 0)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_clear_notification_when_mention_removed(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:
@@ -640,7 +640,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 0)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_clear_notification_when_group_mention_removed(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:
@@ -663,7 +663,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.assertEqual(get_apns_badge_count(group_mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(group_mentioned_user), 0)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_not_clear_notification_when_mention_removed_but_stream_notified(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -171,8 +171,8 @@ class UnreadCountTests(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
-        ) as mock_push_notifications_enabled:
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
+        ) as mock_push_notifications_configured:
             self.unread_msg_ids = [
                 self.send_personal_message(
                     self.example_user("iago"), self.example_user("hamlet"), "hello"
@@ -181,7 +181,7 @@ class UnreadCountTests(ZulipTestCase):
                     self.example_user("iago"), self.example_user("hamlet"), "hello2"
                 ),
             ]
-            mock_push_notifications_enabled.assert_called()
+            mock_push_notifications_configured.assert_called()
 
     # Sending a new message results in unread UserMessages being created
     # for users other than sender.
@@ -580,7 +580,7 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
             .values_list("message_id", flat=True)
         )
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_track_active_mobile_push_notifications(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1779,7 +1779,7 @@ class HandlePushNotificationTest(PushNotificationTest):
             with self.assertRaises(PushNotificationBouncerRetryLaterError):
                 handle_push_notification(self.user_profile.id, missed_message)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_read_message(self, mock_push_notifications: mock.MagicMock) -> None:
         user_profile = self.example_user("hamlet")
         message = self.get_message(
@@ -1845,7 +1845,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         with mock.patch(
             "zerver.lib.push_notifications.uses_notification_bouncer"
         ) as mock_check, mock.patch("logging.error") as mock_logging_error, mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications:
             handle_push_notification(user_profile.id, missed_message)
             mock_push_notifications.assert_called_once()
@@ -1877,7 +1877,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         with mock.patch(
             "zerver.lib.push_notifications.uses_notification_bouncer"
         ) as mock_check, self.assertLogs(level="INFO") as mock_logging_info, mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications:
             handle_push_notification(user_profile.id, missed_message)
             mock_push_notifications.assert_called_once()
@@ -1970,7 +1970,7 @@ class HandlePushNotificationTest(PushNotificationTest):
             "zerver.lib.push_notifications.send_android_push_notification",
             return_value=len(android_devices) - 1,
         ) as mock_send_android, mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications:
             handle_push_notification(self.user_profile.id, missed_message)
             user_identity = UserPushIdentityCompat(user_id=self.user_profile.id)
@@ -2057,7 +2057,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
 
         with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications, mock.patch(
             # Simulate the send...push_notification functions returning a number of successes
             # lesser than the number of devices, so that we can verify correct CountStat counting.
@@ -2124,7 +2124,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {"message_id": message_id}
         with self.assertLogs("zerver.lib.push_notifications", level="ERROR") as logger, mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications:
             handle_push_notification(self.user_profile.id, missed_message)
             self.assertEqual(
@@ -2146,7 +2146,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.subscribe(sender, "public_stream")
         message_id = self.send_stream_message(sender, "public_stream", "test")
         with mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications, mock.patch(
             "zerver.lib.push_notifications.send_android_push_notification", return_value=1
         ) as mock_send_android, mock.patch(
@@ -2204,7 +2204,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         ) as mock_send_android, mock.patch(
             "zerver.lib.push_notifications.logger.error"
         ) as mock_logger, mock.patch(
-            "zerver.lib.push_notifications.push_notifications_enabled", return_value=True
+            "zerver.lib.push_notifications.push_notifications_configured", return_value=True
         ) as mock_push_notifications:
             handle_push_notification(self.user_profile.id, missed_message)
             mock_logger.assert_not_called()
@@ -2213,7 +2213,7 @@ class HandlePushNotificationTest(PushNotificationTest):
             mock_send_android.assert_called_with(user_identity, android_devices, {"gcm": True}, {})
             mock_push_notifications.assert_called_once()
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_user_push_soft_reactivate_soft_deactivated_user(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:
@@ -2337,7 +2337,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.expect_to_stay_long_term_idle(self.user_profile, send_group_mention)
 
     @mock.patch("zerver.lib.push_notifications.logger.info")
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_user_push_notification_already_active(
         self, mock_push_notifications: mock.MagicMock, mock_info: mock.MagicMock
     ) -> None:
@@ -2512,7 +2512,7 @@ class TestAPNs(PushNotificationTest):
         )
         self.assertEqual(modernize_apns_payload(payload), payload)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_apns_badge_count(self, mock_push_notifications: mock.MagicMock) -> None:
         user_profile = self.example_user("othello")
         # Test APNs badge count for personal messages.
@@ -2580,7 +2580,7 @@ class TestGetAPNsPayload(PushNotificationTest):
         }
         self.assertDictEqual(payload, expected)
 
-    @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)
+    @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_get_message_payload_apns_huddle_message(
         self, mock_push_notifications: mock.MagicMock
     ) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -57,7 +57,7 @@ from zerver.lib.exceptions import (
     UserDeactivatedError,
 )
 from zerver.lib.mobile_auth_otp import otp_encrypt_api_key
-from zerver.lib.push_notifications import push_notifications_enabled
+from zerver.lib.push_notifications import push_notifications_configured
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
@@ -1109,7 +1109,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
         zulip_version=ZULIP_VERSION,
         zulip_merge_base=ZULIP_MERGE_BASE,
         zulip_feature_level=API_FEATURE_LEVEL,
-        push_notifications_enabled=push_notifications_enabled(),
+        push_notifications_configured=push_notifications_configured(),
         is_incompatible=check_server_incompatibility(request),
     )
     context = zulip_default_context(request)


### PR DESCRIPTION
Prototype of the API detailed in https://chat.zulip.org/#narrow/stream/378-api-design/topic/register.3A.20Be.20more.20informative.20about.20push-bouncer.20setup/near/1686802.
