### PR TITLE
keyboard_shortcut: Add feedback for N/P shortcut after no more message.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -815,6 +815,12 @@ export function narrow_to_next_topic(opts = {}) {
     }
 
     if (!next_narrow) {
+        feedback_widget.show({
+            populate($container) {
+                $container.text($t({defaultMessage: "You have no more unread topics."}));
+            },
+            title_text: $t({defaultMessage: "You're done!"}),
+        });
         return;
     }
 
@@ -832,6 +838,12 @@ export function narrow_to_next_pm_string(opts = {}) {
     const next_direct_message = topic_generator.get_next_unread_pm_string(current_direct_message);
 
     if (!next_direct_message) {
+        feedback_widget.show({
+            populate($container) {
+                $container.text($t({defaultMessage: "You have no more unread direct messages."}));
+            },
+            title_text: $t({defaultMessage: "You're done!"}),
+        });
         return;
     }
 


### PR DESCRIPTION
Earlier navigating to the next unread topic or DM with N / P and reaching last unread topic or dm, nothing happened when shortcut was pressed again.

This commit changes the behaviour when shortcut reaches the last topic or dm and pressed again. Now it notifies the user that there are no more unread messages.

Fixes zulip#27862.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-11-24 20-44-13](https://github.com/zulip/zulip/assets/33497322/65f0ce71-2d90-4864-8e62-a6d164db5131)
![Screenshot from 2023-11-24 20-44-20](https://github.com/zulip/zulip/assets/33497322/13846abb-c6d6-452a-9aee-0836a771ae69)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
