### PR TITLE
compose: Fix issues with the new poll button.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -87,6 +87,7 @@ function clear_box() {
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     compose_banner.clear_uploads();
+    $(".compose_control_button_container:has(.add-poll)").removeClass("disabled-on-hover");
 }
 
 export function autosize_message_content() {
@@ -263,6 +264,7 @@ export function start(msg_type, opts) {
     // different stream/topic, we want to keep the text in the compose box
     if (opts.content !== undefined) {
         compose_state.message_content(opts.content);
+        $(".compose_control_button_container:has(.add-poll)").addClass("disabled-on-hover");
     }
 
     compose_state.set_message_type(msg_type);

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -10,7 +10,7 @@ import * as compose_validate from "./compose_validate";
 import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import * as popover_menus from "./popover_menus";
-import {EXTRA_LONG_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs";
+import {EXTRA_LONG_HOVER_DELAY, INSTANT_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs";
 import {parse_html} from "./ui_util";
 import {user_settings} from "./user_settings";
 
@@ -56,6 +56,16 @@ export function initialize() {
         // This ensures that the upload files tooltip
         // doesn't hide behind the left sidebar.
         appendTo: () => document.body,
+        // If the button is `.disabled-on-hover`, then we want to show the
+        // tooltip instantly, to make it clear to the user that the button
+        // is disabled, and why.
+        onTrigger(instance, event) {
+            if (event.currentTarget.classList.contains("disabled-on-hover")) {
+                instance.setProps({delay: INSTANT_HOVER_DELAY});
+            } else {
+                instance.setProps({delay: LONG_HOVER_DELAY});
+            }
+        },
     });
 
     delegate("body", {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -28,7 +28,7 @@ function get_tooltip_content(reference: Element): string | Element | DocumentFra
 // transition, while the "long" version is intended for elements where
 // we want to avoid distracting the user with the tooltip
 // unnecessarily.
-const INSTANT_HOVER_DELAY: [number, number] = [100, 20];
+export const INSTANT_HOVER_DELAY: [number, number] = [100, 20];
 // INTERACTIVE_HOVER_DELAY is for elements like the emoji reactions, where
 // the tooltip includes useful information (who reacted?), but that
 // needs a short delay for users who are just tapping a reaction


### PR DESCRIPTION
compose: Show tooltip instantly for a `.disabled-on-hover` button.

We have some delay for tooltips for all compose buttons, but we would like to show the tooltip instantly for buttons that are disabled on hover, to emphasize that the button is disabled, and why.

compose: Fix bug where poll button was disabled on opening compose box.

On opening the compose box right after closing it with some text in it, the poll button would wrongly be disabled.

This is now fixed by ensuring to reset the button state on opening the compose box.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
