### PR TITLE
decorator: Add wrapper to directly pass remote_realm to view_func.

### DIFF
--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -1,14 +1,21 @@
 from functools import wraps
-from typing import Callable, TypeVar
+from typing import Callable
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from typing_extensions import Concatenate, ParamSpec
 
+from corporate.lib.remote_billing_util import get_remote_realm_from_session
 from zerver.lib.subdomains import get_subdomain
+from zilencer.models import RemoteRealm
 
 ParamT = ParamSpec("ParamT")
+
+
+def is_self_hosting_management_subdomain(request: HttpRequest) -> bool:  # nocoverage
+    subdomain = get_subdomain(request)
+    return settings.DEVELOPMENT and subdomain == settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN
 
 
 def self_hosting_management_endpoint(
@@ -18,9 +25,36 @@ def self_hosting_management_endpoint(
     def _wrapped_view_func(
         request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
     ) -> HttpResponse:
-        subdomain = get_subdomain(request)
-        if not settings.DEVELOPMENT or subdomain != settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN:
+        if not is_self_hosting_management_subdomain(request):
             return render(request, "404.html", status=404)
         return view_func(request, *args, **kwargs)
+
+    return _wrapped_view_func
+
+
+def authenticated_remote_realm_management_endpoint(
+    view_func: Callable[Concatenate[HttpRequest, RemoteRealm, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, RemoteRealm, ParamT], HttpResponse]:  # nocoverage
+    @wraps(view_func)
+    def _wrapped_view_func(
+        request: HttpRequest,
+        remote_realm: RemoteRealm,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
+    ) -> HttpResponse:
+        if not is_self_hosting_management_subdomain(request):
+            return render(request, "404.html", status=404)
+
+        realm_uuid = kwargs.get("realm_uuid")
+        server_uuid = kwargs.get("server_uuid")
+        if realm_uuid is not None and not isinstance(realm_uuid, str):
+            raise TypeError("realm_uuid must be a string or None")
+        if server_uuid is not None and not isinstance(server_uuid, str):
+            raise TypeError("server_uuid must be a string or None")
+        remote_realm = get_remote_realm_from_session(
+            request, realm_uuid=realm_uuid, server_uuid=server_uuid
+        )
+        return view_func(request, remote_realm, *args, **kwargs)
 
     return _wrapped_view_func

--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -1,0 +1,26 @@
+from functools import wraps
+from typing import Callable, TypeVar
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from typing_extensions import Concatenate, ParamSpec
+
+from zerver.lib.subdomains import get_subdomain
+
+ParamT = ParamSpec("ParamT")
+
+
+def self_hosting_management_endpoint(
+    view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, ParamT], HttpResponse]:  # nocoverage
+    @wraps(view_func)
+    def _wrapped_view_func(
+        request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
+    ) -> HttpResponse:
+        subdomain = get_subdomain(request)
+        if not settings.DEVELOPMENT or subdomain != settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN:
+            return render(request, "404.html", status=404)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view_func

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -10,11 +10,11 @@ from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from pydantic import Json
 
+from corporate.lib.decorator import self_hosting_management_endpoint
 from corporate.lib.remote_billing_util import (
     RemoteBillingIdentityDict,
     get_identity_dict_from_session,
 )
-from zerver.decorator import self_hosting_management_endpoint
 from zerver.lib.exceptions import JsonableError, MissingRemoteRealmError
 from zerver.lib.remote_server import RealmDataForAnalytics, UserDataForRemoteBilling
 from zerver.lib.response import json_success

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -8,8 +8,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from pydantic import Json
 
-from corporate.lib.decorator import self_hosting_management_endpoint
-from corporate.lib.remote_billing_util import get_remote_realm_from_session
+from corporate.lib.decorator import authenticated_remote_realm_management_endpoint
 from corporate.lib.stripe import (
     VALID_BILLING_MODALITY_VALUES,
     VALID_BILLING_SCHEDULE_VALUES,
@@ -30,6 +29,7 @@ from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.lib.validator import check_bool, check_int, check_string_in
 from zerver.models import UserProfile, get_org_type_display_name
+from zilencer.models import RemoteRealm
 
 billing_logger = logging.getLogger("corporate.stripe")
 
@@ -107,15 +107,15 @@ def upgrade_page(
     return response
 
 
-@self_hosting_management_endpoint
+@authenticated_remote_realm_management_endpoint
 @typed_endpoint
 def remote_realm_upgrade_page(
     request: HttpRequest,
+    remote_realm: RemoteRealm,
     *,
     realm_uuid: PathOnly[str],
     manual_license_management: Json[bool] = False,
 ) -> HttpResponse:  # nocoverage
-    remote_realm = get_remote_realm_from_session(request, realm_uuid)
     initial_upgrade_request = InitialUpgradeRequest(
         manual_license_management=manual_license_management,
         tier=CustomerPlan.STANDARD,

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -8,6 +8,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from pydantic import Json
 
+from corporate.lib.decorator import self_hosting_management_endpoint
 from corporate.lib.remote_billing_util import get_remote_realm_from_session
 from corporate.lib.stripe import (
     VALID_BILLING_MODALITY_VALUES,
@@ -22,11 +23,7 @@ from corporate.lib.stripe import (
 from corporate.lib.support import get_support_url
 from corporate.models import CustomerPlan, ZulipSponsorshipRequest
 from zerver.actions.users import do_change_is_billing_admin
-from zerver.decorator import (
-    require_organization_member,
-    self_hosting_management_endpoint,
-    zulip_login_required,
-)
+from zerver.decorator import require_organization_member, zulip_login_required
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -65,7 +65,6 @@ from zerver.models import UserProfile, get_client, get_user_profile_by_api_key
 
 if TYPE_CHECKING:
     from django.http.request import _ImmutableQueryDict
-from django.shortcuts import render
 
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")
 webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.unsupported")
@@ -73,21 +72,6 @@ webhook_anomalous_payloads_logger = logging.getLogger("zulip.zerver.webhooks.ano
 
 ParamT = ParamSpec("ParamT")
 ReturnT = TypeVar("ReturnT")
-
-
-def self_hosting_management_endpoint(
-    view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponse]
-) -> Callable[Concatenate[HttpRequest, ParamT], HttpResponse]:  # nocoverage
-    @wraps(view_func)
-    def _wrapped_view_func(
-        request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
-    ) -> HttpResponse:
-        subdomain = get_subdomain(request)
-        if not settings.DEVELOPMENT or subdomain != settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN:
-            return render(request, "404.html", status=404)
-        return view_func(request, *args, **kwargs)
-
-    return _wrapped_view_func
 
 
 def update_user_activity(


### PR DESCRIPTION
Discussion: https://github.com/zulip/zulip/pull/27868#discussion_r1403598674

Added just the `authenticated_remote_realm_management_endpoint` wrapper, we can add `authenticated_remote_server_management_endpoint` while making progress on billing pages otherwise it will just be unused right now.