### PR TITLE
stream_settings: Fix stream settings dropdown of user profile.

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -307,8 +307,11 @@ export function get_custom_profile_field_data(user, field, field_types) {
 }
 
 export function hide_user_profile() {
-    user_streams_list_widget = undefined;
     modals.close_if_open("user-profile-modal");
+}
+
+function on_user_profile_hide() {
+    user_streams_list_widget = undefined;
 }
 
 function show_manage_user_tab(target) {
@@ -386,7 +389,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     }
 
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
-    modals.open("user-profile-modal", {autoremove: true});
+    modals.open("user-profile-modal", {autoremove: true, on_hide: on_user_profile_hide});
     $(".tabcontent").hide();
 
     let default_tab = 0;

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -122,7 +122,8 @@ function render_user_profile_subscribe_widget() {
             placement: "bottom-start",
         },
     };
-    user_profile_subscribe_widget = new dropdown_widget.DropdownWidget(opts);
+    user_profile_subscribe_widget =
+        user_profile_subscribe_widget || new dropdown_widget.DropdownWidget(opts);
     user_profile_subscribe_widget.setup();
 }
 
@@ -145,6 +146,15 @@ function reset_subscribe_widget() {
     $("#user_profile_subscribe_widget .dropdown_widget_value").text(
         $t({defaultMessage: "Select a stream"}),
     );
+    //  There are two cases when the subscribe widget is reset: when the user_profile
+    //  is setup (the object is null), or after subscribing of a user in the dropdown.
+    //
+    //  After subscribing a user, we want the current_value of dropdown to be reset
+    //  to null after the subscribe widget is reloaded. This is to avoid  an error
+    //  of not finding the current_value of the user_profile in the options.
+    if (user_profile_subscribe_widget) {
+        user_profile_subscribe_widget.current_value = null;
+    }
 }
 
 export function get_user_unsub_streams() {
@@ -312,6 +322,7 @@ export function hide_user_profile() {
 
 function on_user_profile_hide() {
     user_streams_list_widget = undefined;
+    user_profile_subscribe_widget = undefined;
 }
 
 function show_manage_user_tab(target) {


### PR DESCRIPTION
Previously, when the user modal is opened, and a stream is selected from the streams tab, and then, when a new tab is selected and you navigate back to this streams tab and try to pick a new stream, it wouldn't allow you to do so.

This is because, previously once a stream is picked, and you go out of the tab and come back, then the
previous object of the subscribe widget was invalidated and a new object was created. However, the options still corresponded to the old object. Hence, the error.

This is fixed by checking out if a stream widget object exists, before creating a new one. Before the user profile modal is rendered, the object is initialized to undefined to avoid using of old object in new modal.

Fixes: #27422

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![brave_yb1XHlUMzf](https://github.com/zulip/zulip/assets/97049524/df7fea3e-909e-4773-92ae-7907529fbe63)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
