### PR TITLE
billing: Make changes to the free trial flows

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -511,6 +511,7 @@ class UpgradePageContext(TypedDict):
     email: str
     exempt_from_license_number_check: bool
     free_trial_days: Optional[int]
+    free_trial_end_date: Optional[str]
     is_demo_organization: bool
     manual_license_management: bool
     min_invoiced_licenses: int
@@ -1311,13 +1312,23 @@ class BillingSession(ABC):
         seat_count = self.current_count_for_billed_licenses()
         signed_seat_count, salt = sign_string(str(seat_count))
         tier = initial_upgrade_request.tier
+
+        free_trial_days = settings.FREE_TRIAL_DAYS
+        free_trial_end_date = None
+        if free_trial_days is not None:
+            _, _, free_trial_end, _ = compute_plan_parameters(
+                CustomerPlan.STANDARD, False, CustomerPlan.ANNUAL, None, True
+            )
+            free_trial_end_date = f"{free_trial_end:%B} {free_trial_end.day}, {free_trial_end.year}"
+
         context: UpgradePageContext = {
             "customer_name": customer_specific_context["customer_name"],
             "default_invoice_days_until_due": DEFAULT_INVOICE_DAYS_UNTIL_DUE,
             "discount_percent": format_discount_percentage(percent_off),
             "email": customer_specific_context["email"],
             "exempt_from_license_number_check": exempt_from_license_number_check,
-            "free_trial_days": settings.FREE_TRIAL_DAYS,
+            "free_trial_days": free_trial_days,
+            "free_trial_end_date": free_trial_end_date,
             "is_demo_organization": customer_specific_context["is_demo_organization"],
             "manual_license_management": initial_upgrade_request.manual_license_management,
             "min_invoiced_licenses": max(seat_count, MIN_INVOICED_LICENSES),

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -999,7 +999,11 @@ class BillingSession(ABC):
         assert last_ledger_renewal is not None
         last_renewal = last_ledger_renewal.event_time
 
-        if plan.is_free_trial() or plan.status == CustomerPlan.SWITCH_NOW_FROM_STANDARD_TO_PLUS:
+        if plan.status in (
+            CustomerPlan.FREE_TRIAL,
+            CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
+            CustomerPlan.SWITCH_NOW_FROM_STANDARD_TO_PLUS,
+        ):
             assert plan.next_invoice_date is not None
             next_billing_cycle = plan.next_invoice_date
         else:
@@ -1015,7 +1019,7 @@ class BillingSession(ABC):
                     licenses=licenses_at_next_renewal,
                     licenses_at_next_renewal=licenses_at_next_renewal,
                 )
-            if plan.is_free_trial():
+            if plan.is_free_trial() and plan.status != CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL:
                 plan.invoiced_through = last_ledger_entry
                 plan.billing_cycle_anchor = next_billing_cycle.replace(microsecond=0)
                 plan.status = CustomerPlan.ACTIVE
@@ -1167,6 +1171,9 @@ class BillingSession(ABC):
                 )
                 return plus_plan, plus_plan_ledger_entry
 
+            if plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL:
+                self.downgrade_now_without_creating_additional_invoices(plan)
+
             if plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE:
                 self.process_downgrade(plan)
             return None, None
@@ -1185,6 +1192,9 @@ class BillingSession(ABC):
                     plan = new_plan
                 assert plan is not None  # for mypy
                 downgrade_at_end_of_cycle = plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE
+                downgrade_at_end_of_free_trial = (
+                    plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL
+                )
                 switch_to_annual_at_end_of_cycle = (
                     plan.status == CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE
                 )
@@ -1197,7 +1207,7 @@ class BillingSession(ABC):
                 seat_count = self.current_count_for_billed_licenses()
 
                 # Should do this in JavaScript, using the user's time zone
-                if plan.is_free_trial():
+                if plan.is_free_trial() or downgrade_at_end_of_free_trial:
                     assert plan.next_invoice_date is not None
                     renewal_date = "{dt:%B} {dt.day}, {dt.year}".format(dt=plan.next_invoice_date)
                 else:
@@ -1247,6 +1257,7 @@ class BillingSession(ABC):
                     "has_active_plan": True,
                     "free_trial": plan.is_free_trial(),
                     "downgrade_at_end_of_cycle": downgrade_at_end_of_cycle,
+                    "downgrade_at_end_of_free_trial": downgrade_at_end_of_free_trial,
                     "automanage_licenses": plan.automanage_licenses,
                     "switch_to_annual_at_end_of_cycle": switch_to_annual_at_end_of_cycle,
                     "switch_to_monthly_at_end_of_cycle": switch_to_monthly_at_end_of_cycle,
@@ -1402,8 +1413,15 @@ class BillingSession(ABC):
                 assert plan.fixed_price is None
                 do_change_plan_status(plan, status)
             elif status == CustomerPlan.ENDED:
+                # Not used right now on billing page but kept in case we need it.
                 assert plan.is_free_trial()
                 self.downgrade_now_without_creating_additional_invoices(plan=plan)
+            elif status == CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL:
+                assert plan.is_free_trial()
+                do_change_plan_status(plan, status)
+            elif status == CustomerPlan.FREE_TRIAL:
+                assert plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL
+                do_change_plan_status(plan, status)
             return
 
         licenses = update_plan_request.licenses

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1380,6 +1380,7 @@ class BillingSession(ABC):
                 assert plan.status < CustomerPlan.LIVE_STATUS_THRESHOLD
                 do_change_plan_status(plan, status)
             elif status == CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE:
+                assert not plan.is_free_trial()
                 assert plan.status < CustomerPlan.LIVE_STATUS_THRESHOLD
                 self.downgrade_at_the_end_of_billing_cycle(plan=plan)
             elif status == CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE:
@@ -1387,6 +1388,8 @@ class BillingSession(ABC):
                 assert plan.status < CustomerPlan.LIVE_STATUS_THRESHOLD
                 # Customer needs to switch to an active plan first to avoid unexpected behavior.
                 assert plan.status != CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE
+                # Switching billing frequency for free trial should happen instantly.
+                assert not plan.is_free_trial()
                 assert plan.fixed_price is None
                 do_change_plan_status(plan, status)
             elif status == CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE:
@@ -1394,6 +1397,8 @@ class BillingSession(ABC):
                 assert plan.status < CustomerPlan.LIVE_STATUS_THRESHOLD
                 # Customer needs to switch to an active plan first to avoid unexpected behavior.
                 assert plan.status != CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE
+                # Switching billing frequency for free trial should happen instantly.
+                assert not plan.is_free_trial()
                 assert plan.fixed_price is None
                 do_change_plan_status(plan, status)
             elif status == CustomerPlan.ENDED:

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -290,6 +290,8 @@ class CustomerPlan(models.Model):
             self.ACTIVE: "Active",
             self.DOWNGRADE_AT_END_OF_CYCLE: "Scheduled for downgrade at end of cycle",
             self.FREE_TRIAL: "Free trial",
+            self.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE: "Scheduled for switch to annual at end of cycle",
+            self.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE: "Scheduled for switch to monthly at end of cycle",
             self.ENDED: "Ended",
             self.NEVER_STARTED: "Never started",
         }[self.status]

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -267,6 +267,7 @@ class CustomerPlan(models.Model):
     SWITCH_TO_ANNUAL_AT_END_OF_CYCLE = 4
     SWITCH_NOW_FROM_STANDARD_TO_PLUS = 5
     SWITCH_TO_MONTHLY_AT_END_OF_CYCLE = 6
+    DOWNGRADE_AT_END_OF_FREE_TRIAL = 7
     # "Live" plans should have a value < LIVE_STATUS_THRESHOLD.
     # There should be at most one live plan per customer.
     LIVE_STATUS_THRESHOLD = 10
@@ -292,6 +293,7 @@ class CustomerPlan(models.Model):
             self.FREE_TRIAL: "Free trial",
             self.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE: "Scheduled for switch to annual at end of cycle",
             self.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE: "Scheduled for switch to monthly at end of cycle",
+            self.DOWNGRADE_AT_END_OF_FREE_TRIAL: "Scheduled for downgrade at end of free trial",
             self.ENDED: "Ended",
             self.NEVER_STARTED: "Never started",
         }[self.status]
@@ -302,7 +304,10 @@ class CustomerPlan(models.Model):
         return ledger_entry.licenses
 
     def licenses_at_next_renewal(self) -> Optional[int]:
-        if self.status == CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE:
+        if self.status in (
+            CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE,
+            CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
+        ):
             return None
         ledger_entry = LicenseLedger.objects.filter(plan=self).order_by("id").last()
         assert ledger_entry is not None

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1031,7 +1031,7 @@ class StripeTest(StripeTestCase):
             free_trial_end_date = self.now + timedelta(days=60)
 
             self.assert_in_success_response(
-                ["You won't be charged", "Free Trial", "60 day"], response
+                ["You won't be charged", "Free Trial", "60-day"], response
             )
             self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())
@@ -1249,7 +1249,7 @@ class StripeTest(StripeTestCase):
             response = self.client_get("/upgrade/")
 
             self.assert_in_success_response(
-                ["You won't be charged", "Free Trial", "60 day"], response
+                ["You won't be charged", "Free Trial", "60-day"], response
             )
             self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2837,7 +2837,7 @@ class StripeTest(StripeTestCase):
         self.assertIsNone(plan.next_invoice_date)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
 
-    def test_downgrade_free_trial(self) -> None:
+    def test_end_free_trial(self) -> None:
         user = self.example_user("hamlet")
 
         free_trial_end_date = self.now + timedelta(days=60)
@@ -2884,6 +2884,172 @@ class StripeTest(StripeTestCase):
             with patch("corporate.lib.stripe.invoice_plan") as mocked:
                 invoice_plans_as_needed(self.next_year)
             mocked.assert_not_called()
+
+    def test_downgrade_at_end_of_free_trial(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        free_trial_end_date = self.now + timedelta(days=60)
+        with self.settings(FREE_TRIAL_DAYS=60):
+            with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, False, True)
+            plan = get_current_plan_by_realm(user.realm)
+            assert plan is not None
+            self.assertEqual(plan.next_invoice_date, free_trial_end_date)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
+            self.assertEqual(plan.status, CustomerPlan.FREE_TRIAL)
+            self.assertEqual(plan.licenses(), self.seat_count)
+            self.assertEqual(plan.licenses_at_next_renewal(), self.seat_count)
+
+            # Schedule downgrade
+            with self.assertLogs("corporate.stripe", "INFO") as m:
+                with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                    response = self.client_patch(
+                        "/json/billing/plan",
+                        {"status": CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL},
+                    )
+                    stripe_customer_id = Customer.objects.get(realm=user.realm).id
+                    new_plan = get_current_plan_by_realm(user.realm)
+                    assert new_plan is not None
+                    expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
+                    self.assertEqual(m.output[0], expected_log)
+                    self.assert_json_success(response)
+            plan.refresh_from_db()
+            self.assertEqual(plan.next_invoice_date, free_trial_end_date)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
+            self.assertEqual(plan.status, CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL)
+            self.assertEqual(plan.licenses(), self.seat_count)
+            self.assertEqual(plan.licenses_at_next_renewal(), None)
+
+            with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                mock_customer = Mock(email=user.delivery_email)
+                mock_customer.invoice_settings.default_payment_method = Mock(
+                    spec=stripe.PaymentMethod, type=Mock()
+                )
+                with patch("corporate.lib.stripe.stripe_get_customer", return_value=mock_customer):
+                    response = self.client_get("/billing/")
+                    self.assert_in_success_response(
+                        [
+                            "Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of the free trial",
+                            "<strong>March 2, 2012</strong>",
+                        ],
+                        response,
+                    )
+
+            # Verify that we still write LicenseLedger rows during the remaining
+            # part of the cycle
+            with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
+                update_license_ledger_if_needed(user.realm, self.now)
+            self.assertEqual(
+                LicenseLedger.objects.order_by("-id")
+                .values_list("licenses", "licenses_at_next_renewal")
+                .first(),
+                (20, 20),
+            )
+
+            # Verify that we don't invoice them for the additional users during free trial.
+            from stripe import Invoice
+
+            Invoice.create = lambda **args: None  # type: ignore[assignment] # cleaner than mocking
+            Invoice.finalize_invoice = lambda *args: None  # type: ignore[assignment] # cleaner than mocking
+            with patch("stripe.InvoiceItem.create") as mocked:
+                invoice_plans_as_needed(self.next_month)
+            mocked.assert_not_called()
+
+            # Check that we downgrade properly if the cycle is over
+            with patch("corporate.lib.stripe.get_latest_seat_count", return_value=30):
+                update_license_ledger_if_needed(user.realm, free_trial_end_date)
+            plan = CustomerPlan.objects.first()
+            assert plan is not None
+            self.assertIsNone(plan.next_invoice_date)
+            self.assertEqual(plan.status, CustomerPlan.ENDED)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
+            self.assertEqual(
+                LicenseLedger.objects.order_by("-id")
+                .values_list("licenses", "licenses_at_next_renewal")
+                .first(),
+                (20, 20),
+            )
+
+            # Verify that we don't write LicenseLedger rows once we've downgraded
+            with patch("corporate.lib.stripe.get_latest_seat_count", return_value=40):
+                update_license_ledger_if_needed(user.realm, self.next_year)
+            self.assertEqual(
+                LicenseLedger.objects.order_by("-id")
+                .values_list("licenses", "licenses_at_next_renewal")
+                .first(),
+                (20, 20),
+            )
+
+            self.login_user(user)
+            response = self.client_get("/billing/")
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual("/plans/", response["Location"])
+
+            # The extra users added in the final month are not charged
+            with patch("corporate.lib.stripe.invoice_plan") as mocked:
+                invoice_plans_as_needed(self.next_month)
+            mocked.assert_not_called()
+
+            # The plan is not renewed after an year
+            with patch("corporate.lib.stripe.invoice_plan") as mocked:
+                invoice_plans_as_needed(self.next_year)
+            mocked.assert_not_called()
+
+    def test_cancel_downgrade_at_end_of_free_trial(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        free_trial_end_date = self.now + timedelta(days=60)
+        with self.settings(FREE_TRIAL_DAYS=60):
+            with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                self.local_upgrade(self.seat_count, True, CustomerPlan.ANNUAL, False, True)
+            plan = get_current_plan_by_realm(user.realm)
+            assert plan is not None
+            self.assertEqual(plan.next_invoice_date, free_trial_end_date)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
+            self.assertEqual(plan.status, CustomerPlan.FREE_TRIAL)
+            self.assertEqual(plan.licenses(), self.seat_count)
+            self.assertEqual(plan.licenses_at_next_renewal(), self.seat_count)
+
+            # Schedule downgrade
+            with self.assertLogs("corporate.stripe", "INFO") as m:
+                with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                    response = self.client_patch(
+                        "/json/billing/plan",
+                        {"status": CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL},
+                    )
+                    stripe_customer_id = Customer.objects.get(realm=user.realm).id
+                    new_plan = get_current_plan_by_realm(user.realm)
+                    assert new_plan is not None
+                    expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
+                    self.assertEqual(m.output[0], expected_log)
+                    self.assert_json_success(response)
+            plan.refresh_from_db()
+            self.assertEqual(plan.next_invoice_date, free_trial_end_date)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
+            self.assertEqual(plan.status, CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL)
+            self.assertEqual(plan.licenses(), self.seat_count)
+            self.assertEqual(plan.licenses_at_next_renewal(), None)
+
+            # Cancel downgrade
+            with self.assertLogs("corporate.stripe", "INFO") as m:
+                with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
+                    response = self.client_patch(
+                        "/json/billing/plan", {"status": CustomerPlan.FREE_TRIAL}
+                    )
+                    stripe_customer_id = Customer.objects.get(realm=user.realm).id
+                    new_plan = get_current_plan_by_realm(user.realm)
+                    assert new_plan is not None
+                    expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.FREE_TRIAL}"
+                    self.assertEqual(m.output[0], expected_log)
+                    self.assert_json_success(response)
+            plan.refresh_from_db()
+            self.assertEqual(plan.next_invoice_date, free_trial_end_date)
+            self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
+            self.assertEqual(plan.status, CustomerPlan.FREE_TRIAL)
+            self.assertEqual(plan.licenses(), self.seat_count)
+            self.assertEqual(plan.licenses_at_next_renewal(), self.seat_count)
 
     def test_reupgrade_by_billing_admin_after_downgrade(self) -> None:
         user = self.example_user("hamlet")

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -136,6 +136,8 @@ def update_plan(
                 CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE,
                 CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE,
                 CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE,
+                CustomerPlan.FREE_TRIAL,
+                CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
                 CustomerPlan.ENDED,
             ]
         ),

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -259,13 +259,13 @@
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <header class="modal__header">
                 <h1 class="modal__title dialog_heading">
-                    Confirm end free trial
+                    Downgrade {{ org_name }} to Zulip Cloud Free?
                 </h1>
                 <button class="modal__close" aria-label="{{ _('Close modal') }}" data-micromodal-close></button>
             </header>
             <main class="modal__content">
                 <p>
-                    Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of the free trial
+                    Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of your free trial
                     ({{ renewal_date }}). You will lose access to unlimited search history and
                     <a href="/plans/">other features</a>
                     of your current plan. Are you sure you want to continue?

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -27,7 +27,7 @@
                 <div class="input-box billing-page-field no-validation">
                     <label for="org-current-plan" class="inline-block label-title">Your plan</label>
                     <div id="org-current-plan" class="not-editable-realm-field">
-                        {% if free_trial %}
+                        {% if free_trial or downgrade_at_end_of_free_trial %}
                         {{ plan_name }} <i>(free trial)</i>
                         {% else %}
                         {{ plan_name }}
@@ -41,7 +41,7 @@
                   {%if switch_to_monthly_at_end_of_cycle %}data-switch-to-monthly-eoc="true"{% endif %}
                   {%if switch_to_annual_at_end_of_cycle %}data-switch-to-annual-eoc="true"{% endif %}>
                     <label for="org-billing-frequency">Billing frequency</label>
-                    {% if free_trial or downgrade_at_end_of_cycle %}
+                    {% if free_trial or downgrade_at_end_of_free_trial or downgrade_at_end_of_cycle %}
                     <div class="not-editable-realm-field">
                         {{ billing_frequency }}
                     </div>
@@ -149,6 +149,10 @@
                             Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of the current billing
                             period (<strong>{{ renewal_date }}</strong>). You will lose access to unlimited search history and
                             <a href="/plans/">other features</a> of your current plan.
+                            {% elif downgrade_at_end_of_free_trial %}
+                            Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of the free trial
+                            (<strong>{{ renewal_date }}</strong>). You will lose access to unlimited search history and
+                            <a href="/plans/">other features</a> of your current plan.
                             {% else %}
                             {% if charge_automatically %}
                             Your plan will automatically renew on <strong>{{ renewal_date }}</strong>.
@@ -186,17 +190,23 @@
                 </div>
                 <div id="planchange-error" class="alert alert-danger"></div>
                 <div id="planchange-input-section">
-                    {% if free_trial %}
+                    {% if free_trial and not downgrade_at_end_of_free_trial %}
                         <div class="end-free-trial plan-toggle-action input-box billing-page-field no-validation" id="end-free-trial">
                             <button class="end-free-trial-button plan-toggle-action-button">
-                                <span class="billing-button-text">End free trial</span>
+                                <span class="billing-button-text">Cancel plan</span>
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
                         </div>
-                    {% elif downgrade_at_end_of_cycle %}
+                    {% elif downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial %}
                         <div class="reactivate-current-plan plan-toggle-action input-box billing-page-field no-validation" id="reactivate-subscription">
                             <button class="reactivate-current-plan-button plan-toggle-action-button">
-                                <span class="billing-button-text">Reactivate subscription</span>
+                                <span class="billing-button-text">
+                                    {% if downgrade_at_end_of_free_trial %}
+                                    Cancel downgrade
+                                    {% else %}
+                                    Reactivate subscription
+                                    {% endif %}
+                                </span>
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
                         </div>
@@ -211,7 +221,9 @@
                 </div>
                 <form id="planchange-form">
                     {% if free_trial %}
-                    <input name="status" type="hidden" value="{{ CustomerPlan.ENDED }}" />
+                    <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL }}" />
+                    {% elif downgrade_at_end_of_free_trial %}
+                    <input name="status" type="hidden" value="{{ CustomerPlan.FREE_TRIAL }}" />
                     {% elif downgrade_at_end_of_cycle %}
                     <input name="status" type="hidden" value="{{ CustomerPlan.ACTIVE }}" />
                     {% else %}
@@ -253,13 +265,16 @@
             </header>
             <main class="modal__content">
                 <p>
-                    Are you sure you want to end free trial and downgrade plan to <strong>Zulip Free</strong>?
+                    Your organization will be downgraded to <strong>Zulip Cloud Free</strong> at the end of the free trial
+                    ({{ renewal_date }}). You will lose access to unlimited search history and
+                    <a href="/plans/">other features</a>
+                    of your current plan. Are you sure you want to continue?
                 </p>
             </main>
             <footer class="modal__footer">
                 <button class="modal__btn dialog_exit_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Cancel') }}</button>
                 <button class="modal__btn dialog_submit_button">
-                    <span>{{ _('Confirm') }}</span>
+                    <span>{{ _('Downgrade') }}</span>
                 </button>
             </footer>
         </div>

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -218,7 +218,6 @@
                     <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE }}" />
                     {% endif %}
                 </form>
-                <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE }}" />
             </div>
         </div>
         <hr />

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -142,9 +142,6 @@
                     </button>
                 </div>
                 {% endif %}
-                <div id="cardchange-success" class="alert alert-success billing-page-success">
-                    Redirecting to Stripe checkout page for updating Card details.
-                </div>
                 <div class="input-box billing-page-field no-validation">
                     <div class="next-payment-info not-editable-realm-field">
                         {% if renewal_amount %}

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -9,11 +9,11 @@
 <div id="upgrade-page" class="register-account flex full-page">
     <div class="center-block new-style">
         <div class="pitch">
-            <h1>Upgrade {{ customer_name }} to
+            <h1>
                 {% if free_trial_days %}
-                    Zulip Cloud Standard free trial
+                Start free trial of Zulip Cloud Standard
                 {% else %}
-                    {{ plan }}
+                Upgrade {{ customer_name }} to {{ plan }}
                 {% endif %}
             </h1>
         </div>
@@ -28,11 +28,9 @@
 
                     <div id="free-trial-top-banner" class="input-box upgrade-page-field">
                         {% if free_trial_days %}
-                        <div id="free-trial-alert-message" class="alert alert-info">
-                            Upgrade now to start your {{ free_trial_days }} day free trial
-                            of Zulip Cloud Standard!
-                        </div>
                         <div class="not-editable-realm-field">
+                            Start your {{ free_trial_days }}-day free trial, with no upfront payment.
+                            <br /><br />
                             You won't be charged during the free trial. You can also downgrade to
                             Zulip Cloud Free, our forever free plan, at any time.
                         </div>
@@ -71,9 +69,9 @@
                     <div class="input-box upgrade-page-field no-validation">
                         <label for="due-today" class="inline-block label-title">Due
                             {% if free_trial_days %}
-                                after free trial
+                            on {{ free_trial_end_date }}
                             {% else %}
-                                today
+                            today
                             {% endif %}
                         </label>
                         <div id="due-today" class="not-editable-realm-field">
@@ -160,7 +158,7 @@
                         <button id="org-upgrade-button{% if is_demo_organization %} permanent-disabled{% endif %}" {% if not payment_method %}disabled{% endif %}>
                             <span id="org-upgrade-button-text">
                                 {% if free_trial_days %}
-                                    Start {{ free_trial_days }} day free trial
+                                    Start {{ free_trial_days }}-day free trial
                                 {% else %}
                                     Purchase Zulip Cloud Standard
                                 {% endif %}

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -11,7 +11,7 @@
         <div class="pitch">
             <h1>
                 {% if free_trial_days %}
-                Start free trial of Zulip Cloud Standard
+                Start free trial of {{ plan }}
                 {% else %}
                 Upgrade {{ customer_name }} to {{ plan }}
                 {% endif %}
@@ -29,10 +29,9 @@
                     <div id="free-trial-top-banner" class="input-box upgrade-page-field">
                         {% if free_trial_days %}
                         <div class="not-editable-realm-field">
-                            Start your {{ free_trial_days }}-day free trial, with no upfront payment.
-                            <br /><br />
-                            You won't be charged during the free trial. You can also downgrade to
-                            Zulip Cloud Free, our forever free plan, at any time.
+                             Add a credit card to start your <b>{{ free_trial_days }}-day free trial</b> of
+                             {{ plan }}. You card will not be charged if you
+                             cancel in the first {{ free_trial_days }} days.
                         </div>
                         {% endif %}
 
@@ -95,36 +94,20 @@
                     {% if not manual_license_management %}
                     <div id="license-automatic-section" class="input-box upgrade-page-field license-management-section">
                         <p class="not-editable-realm-field">
-                            {% if free_trial_days %}
-                            After the Free Trial, you&rsquo;ll be charged
-                            <b>$<span class="due-today-price"></span></b> for <b>{{ seat_count }}</b>
-                            users (or more if you later add more users).<br />
-
-                            We'll automatically charge you for additional licenses as users
-                            are added, and remove licenses not in use at the end of each billing
-                            period.
-                            {% else %}
                             Your subscription will renew automatically. Your bill will vary based on the number
                             of active users in your organization. You can also
                             <a href="/upgrade/?manual_license_management=true">purchase a fixed number of licenses</a> instead. See
                             <a target="_blank" href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
-                            {% endif %}
                         </p>
                         <input type="hidden" name="licenses" id="automatic_license_count" value="{{ seat_count }}" />
                     </div>
                     {% else %}
                     <div id="license-manual-section" class="input-box upgrade-page-field">
                         <p class="not-editable-realm-field">
-                            {% if free_trial_days %}
-                            Enter the number of users you would like to pay for after the Free Trial.<br />
-                            You'll need to manually add licenses to add or invite
-                            additional users.
-                            {% else %}
                             Your subscription will renew automatically. You will be able to manage the number of licenses on
                             your organization's billing page. You can also
                             <a href="/upgrade/">choose automatic license management</a> instead. See
                             <a href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
-                            {% endif %}
                         </p>
                     </div>
                     {% endif %}

--- a/web/src/billing/billing.ts
+++ b/web/src/billing/billing.ts
@@ -206,7 +206,7 @@ export function initialize(): void {
     $("#confirm-end-free-trial .dialog_submit_button").on("click", (e) => {
         helpers.create_ajax_request("/json/billing/plan", "planchange", [], "PATCH", () =>
             window.location.replace(
-                "/billing/?success_message=" + encodeURIComponent("Successfully ended trial!"),
+                "/billing/?success_message=" + encodeURIComponent("Your plan will be canceled at the end of the trial. Your card will not be charged."),
             ),
         );
         e.preventDefault();

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -37,9 +37,6 @@ export function create_ajax_request(
     const form_error = `#${CSS.escape(form_name)}-error`;
     const form_loading = `#${CSS.escape(form_name)}-loading`;
 
-    const zulip_limited_section = "#zulip-limited-section";
-    const free_trial_alert_message = "#free-trial-alert-message";
-
     loading.make_indicator($(form_loading_indicator), {
         text: "Processing ...",
         abs_positioned: true,
@@ -47,8 +44,6 @@ export function create_ajax_request(
     $(form_input_section).hide();
     $(form_error).hide();
     $(form_loading).show();
-    $(zulip_limited_section).hide();
-    $(free_trial_alert_message).hide();
 
     const data: FormDataObject = {};
 
@@ -82,8 +77,6 @@ export function create_ajax_request(
                 $(form_error).show().text(xhr.responseJSON.msg);
             }
             $(form_input_section).show();
-            $(zulip_limited_section).show();
-            $(free_trial_alert_message).show();
             error_callback(xhr);
         },
     });

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -551,9 +551,7 @@ input[name="licenses"] {
     text-align: center;
 }
 
-#confirm-licenses-modal-decrease,
-#confirm-licenses-modal-increase,
-#confirm-cancel-subscription-modal {
+.micromodal {
     .modal__title {
         font-weight: 600;
     }

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -561,6 +561,10 @@ input[name="licenses"] {
     }
 }
 
+#upgrade-page-details #free-trial-top-banner {
+    margin-top: 10px;
+}
+
 #billing-page-details .billing-frequency-message.not-editable-realm-field,
 #free-trial-top-banner .not-editable-realm-field,
 #upgrade-page-details .license-management-section .not-editable-realm-field {


### PR DESCRIPTION
Based on [#27889](https://github.com/zulip/zulip/pull/27889).

Known to-do's:

- [x] Add on the latest changes from #27889 (billing frequency dropdown).
- [x] Squash commits as needed.
- [x] When there is a free trial, we should remove the billing frequency dropdown from the /upgrade page, and default to monthly billing frequency. Customers can change the billing frequency on the billing page before the first charge.
- [x] We should add a confirmation banner for the upgrade; we can use the same one as without a free trial:

<img width="741" alt="Screenshot 2023-11-27 at 12 12 59 AM" src="https://github.com/zulip/zulip/assets/2090066/3aa4d4ed-2bab-4b64-ab77-db99142a219f">

## Unrelated to free trials

A couple of minor issues I spotted while doing manual testing:

- [x] (unrelated to free trials) You can get this error by upgrading, going back to /upgrade from /billing, and trying to upgrade again. We should not add the last sentence about fixing the issue or using a different card in this case.
<img width="488" alt="Screenshot 2023-11-27 at 12 07 28 AM" src="https://github.com/zulip/zulip/assets/2090066/be1e364e-1f9c-49ea-a43f-e33b08321f79">

- [x] Let's make this field less wide, as it is on other forms. (This is on the /upgrade page.)

<img width="516" alt="Screenshot 2023-11-26 at 11 58 33 PM" src="https://github.com/zulip/zulip/assets/2090066/d70e095e-b5d0-4ae4-abeb-8c3cb5ea0e83">

