### PR TITLE
stripe: Refactor `event_status` and `sponsorship_request` views.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -79,11 +79,6 @@ CARD_CAPITALIZATION = {
     "visa": "Visa",
 }
 
-PAID_PLANS = [
-    Realm.PLAN_TYPE_STANDARD,
-    Realm.PLAN_TYPE_PLUS,
-]
-
 # The version of Stripe API the billing system supports.
 STRIPE_API_VERSION = "2020-08-27"
 
@@ -210,10 +205,6 @@ def check_upgrade_parameters(
         seat_count,
         exempt_from_license_number_check,
     )
-
-
-def is_realm_on_paid_plan(realm: Realm) -> bool:
-    return realm.plan_type in PAID_PLANS
 
 
 # Be extremely careful changing this function. Historical billing periods
@@ -1636,6 +1627,11 @@ class RealmBillingSession(BillingSession):
             assert realm is not None  # for mypy
             self.realm = realm
 
+    PAID_PLANS = [
+        Realm.PLAN_TYPE_STANDARD,
+        Realm.PLAN_TYPE_PLUS,
+    ]
+
     @override
     @property
     def billing_session_url(self) -> str:
@@ -1861,7 +1857,7 @@ class RealmBillingSession(BillingSession):
 
     @override
     def on_paid_plan(self) -> bool:
-        return is_realm_on_paid_plan(self.realm)
+        return self.realm.plan_type in self.PAID_PLANS
 
     @override
     def add_sponsorship_info_to_context(self, context: Dict[str, Any]) -> None:

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -5,41 +5,15 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 
-from corporate.lib.stripe import RealmBillingSession, UpdatePlanRequest
-from corporate.models import CustomerPlan, get_current_plan_by_customer, get_customer_by_realm
+from corporate.lib.stripe import RealmBillingSession, UpdatePlanRequest, is_realm_on_paid_plan
+from corporate.models import CustomerPlan, get_customer_by_realm
 from zerver.decorator import require_billing_access, zulip_login_required
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import check_int, check_int_in, check_string
-from zerver.models import Realm, UserProfile
+from zerver.models import UserProfile
 
 billing_logger = logging.getLogger("corporate.stripe")
-
-PAID_PLANS = [
-    Realm.PLAN_TYPE_STANDARD,
-    Realm.PLAN_TYPE_PLUS,
-]
-
-
-def is_realm_on_paid_plan(realm: Realm) -> bool:
-    return realm.plan_type in PAID_PLANS
-
-
-def add_sponsorship_info_to_context(context: Dict[str, Any], user_profile: UserProfile) -> None:
-    def key_helper(d: Any) -> int:
-        return d[1]["display_order"]
-
-    context.update(
-        realm_org_type=user_profile.realm.org_type,
-        sorted_org_types=sorted(
-            (
-                [org_type_name, org_type]
-                for (org_type_name, org_type) in Realm.ORG_TYPES.items()
-                if not org_type.get("hidden")
-            ),
-            key=key_helper,
-        ),
-    )
 
 
 @zulip_login_required
@@ -47,30 +21,12 @@ def add_sponsorship_info_to_context(context: Dict[str, Any], user_profile: UserP
 def sponsorship_request(request: HttpRequest) -> HttpResponse:
     user = request.user
     assert user.is_authenticated
-    context: Dict[str, Any] = {}
 
-    customer = get_customer_by_realm(user.realm)
-    if customer is not None and customer.sponsorship_pending:
-        if is_realm_on_paid_plan(user.realm):
-            return HttpResponseRedirect(reverse("billing_home"))
+    billing_session = RealmBillingSession(user)
+    context = billing_session.get_sponsorship_request_context()
+    if context is None:
+        return HttpResponseRedirect(reverse("billing_home"))
 
-        context["is_sponsorship_pending"] = True
-
-    if user.realm.plan_type == user.realm.PLAN_TYPE_STANDARD_FREE:
-        context["is_sponsored"] = True
-
-    if customer is not None:
-        plan = get_current_plan_by_customer(customer)
-        if plan is not None:
-            context["plan_name"] = plan.name
-            context["free_trial"] = plan.is_free_trial()
-        # We don't create CustomerPlan objects for fully sponsored realms via support page.
-        elif user.realm.plan_type == Realm.PLAN_TYPE_STANDARD_FREE:
-            context["plan_name"] = "Zulip Cloud Standard"
-        else:
-            context["plan_name"] = "Zulip Cloud Free"
-
-    add_sponsorship_info_to_context(context, user)
     return render(request, "corporate/sponsorship.html", context=context)
 
 

--- a/corporate/views/event_status.py
+++ b/corporate/views/event_status.py
@@ -3,11 +3,9 @@ from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
-from django.utils.translation import gettext as _
 
-from corporate.models import PaymentIntent, Session, get_customer_by_realm
+from corporate.lib.stripe import EventStatusRequest, RealmBillingSession
 from zerver.decorator import require_organization_member, zulip_login_required
-from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
@@ -23,30 +21,12 @@ def event_status(
     stripe_session_id: Optional[str] = REQ(default=None),
     stripe_payment_intent_id: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
-    customer = get_customer_by_realm(user.realm)
-    if customer is None:
-        raise JsonableError(_("No customer for this organization!"))
-
-    if stripe_session_id is not None:
-        try:
-            session = Session.objects.get(stripe_session_id=stripe_session_id, customer=customer)
-        except Session.DoesNotExist:
-            raise JsonableError(_("Session not found"))
-
-        if session.type == Session.CARD_UPDATE_FROM_BILLING_PAGE and not user.has_billing_access:
-            raise JsonableError(_("Must be a billing administrator or an organization owner"))
-        return json_success(request, data={"session": session.to_dict()})
-
-    if stripe_payment_intent_id is not None:
-        payment_intent = PaymentIntent.objects.filter(
-            stripe_payment_intent_id=stripe_payment_intent_id,
-            customer=customer,
-        ).last()
-
-        if payment_intent is None:
-            raise JsonableError(_("Payment intent not found"))
-        return json_success(request, data={"payment_intent": payment_intent.to_dict()})
-    raise JsonableError(_("Pass stripe_session_id or stripe_payment_intent_id"))
+    event_status_request = EventStatusRequest(
+        stripe_session_id=stripe_session_id, stripe_payment_intent_id=stripe_payment_intent_id
+    )
+    billing_session = RealmBillingSession(user)
+    data = billing_session.get_event_status(event_status_request)
+    return json_success(request, data)
 
 
 @zulip_login_required


### PR DESCRIPTION
This PR refactors `event_status` view and adds `BillingSession.get_event_status` method.

This refactoring will help in minimizing duplicate code while supporting both realm and remote_server customers.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
