### PR TITLE
recent_view: Show checkbox icon for unread filter.

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -821,6 +821,7 @@ function show_selected_filters() {
 
 function get_recent_view_filters_params() {
     return {
+        filter_unread: filters.has("unread"),
         filter_participated: filters.has("participated"),
         filter_muted: filters.has("include_muted"),
         filter_pm: filters.has("include_private"),

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -448,6 +448,7 @@ test("test_recent_view_show", ({mock_template}) => {
     // and are not to be tested here.
     page_params.is_spectator = false;
     const expected = {
+        filter_unread: false,
         filter_participated: false,
         filter_muted: false,
         filter_pm: false,
@@ -478,6 +479,7 @@ test("test_recent_view_show", ({mock_template}) => {
 test("test_filter_is_spectator", ({mock_template}) => {
     page_params.is_spectator = true;
     const expected = {
+        filter_unread: false,
         filter_participated: false,
         filter_muted: false,
         filter_pm: false,
@@ -510,6 +512,7 @@ test("test_no_filter", ({mock_template}) => {
     // in All topics filter.
     page_params.is_spectator = false;
     const expected = {
+        filter_unread: false,
         filter_participated: false,
         filter_muted: false,
         filter_pm: false,
@@ -632,6 +635,7 @@ test("test_no_filter", ({mock_template}) => {
 test("test_filter_pm", ({mock_template}) => {
     page_params.is_spectator = false;
     const expected = {
+        filter_unread: false,
         filter_participated: false,
         filter_muted: false,
         filter_pm: true,
@@ -680,6 +684,7 @@ test("test_filter_participated", ({mock_template}) => {
     page_params.is_spectator = false;
     mock_template("recent_view_table.hbs", false, (data) => {
         assert.deepEqual(data, {
+            filter_unread: false,
             filter_participated: expected_filter_participated,
             filter_muted: false,
             filter_pm: false,


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Recent.20conversations.20unread.20filter

I accidentally removed the filter_unread parameter passed to the template.

<img width="937" alt="Screenshot 2023-11-27 at 6 52 27 PM" src="https://github.com/zulip/zulip/assets/25124304/fb9cce02-b8f9-46e5-80d1-fc7e92df5561">
