### PR TITLE
tooltips: Fix tippy design where default tippy was used.

### DIFF
--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -16,7 +16,7 @@
                     </div>
                 </span>
                 <span class="recipient_bar_controls"></span>
-                <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
+                <div class="recipient_row_date restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="last-modified-tooltip-template">{{time_stamp}}</div>
             </div>
         </div>
         {{else}}
@@ -26,7 +26,7 @@
                     <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
                     <span class="private_message_header_name">{{t "You and {recipients}" }}</span>
                 </div>
-                <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
+                <div class="recipient_row_date restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="last-modified-tooltip-template">{{ time_stamp }}</div>
             </div>
         </div>
         {{/if}}

--- a/web/templates/settings/admin_emoji_list.hbs
+++ b/web/templates/settings/admin_emoji_list.hbs
@@ -18,7 +18,7 @@
         {{/if}}
     </td>
     <td>
-        <button class="button rounded small delete btn-danger" {{#unless can_delete_emoji}}disabled="disabled"{{/unless}} data-emoji-name="{{name}}">
+        <button class="button rounded small delete btn-danger tippy-zulip-delayed-tooltip" {{#unless can_delete_emoji}}disabled="disabled"{{/unless}} data-tippy-content="{{t 'Delete emoji' }}" data-emoji-name="{{name}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>

--- a/web/templates/settings/admin_linkifier_list.hbs
+++ b/web/templates/settings/admin_linkifier_list.hbs
@@ -14,10 +14,10 @@
     </td>
     {{#if ../can_modify}}
     <td class="no-select actions">
-        <button class="button small edit btn-warning" data-linkifier-id="{{id}}" title="{{t 'Edit' }}" aria-label="{{t 'Edit' }}">
+        <button class="button small edit btn-warning tippy-zulip-delayed-tooltip" data-linkifier-id="{{id}}" data-tippy-content="{{t 'Edit' }}" aria-label="{{t 'Edit' }}">
             <i class="fa fa-pencil"></i>
         </button>
-        <button class="button small delete btn-danger" data-linkifier-id="{{id}}" title="{{t 'Delete' }}" aria-label="{{t 'Delete' }}">
+        <button class="button small delete btn-danger tippy-zulip-delayed-tooltip" data-linkifier-id="{{id}}" aria-label="{{t 'Delete' }}" data-tippy-content="{{t 'Delete' }}" >
             <i class="fa fa-trash-o"></i>
         </button>
     </td>

--- a/web/templates/settings/alert_word_settings_item.hbs
+++ b/web/templates/settings/alert_word_settings_item.hbs
@@ -7,7 +7,7 @@
         </div>
     </td>
     <td>
-        <button type="submit" class="button rounded small delete btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+        <button type="submit" class="button rounded small delete btn-danger remove-alert-word tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete alert word' }}" data-word="{{word}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -15,7 +15,7 @@
         </div>
         <div>
             <span>{{t 'Download config of all active outgoing webhook bots in Zulip Botserver format.' }}</span>
-            <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn" title="{{t 'Download botserverrc' }}">
+            <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download Botserver' }}">
                 <i class="fa fa-download sea-green" aria-hidden="true"></i>
             </a>
         </div>

--- a/web/templates/settings/default_stream_choice.hbs
+++ b/web/templates/settings/default_stream_choice.hbs
@@ -1,6 +1,6 @@
 <div class="choice-row" data-value="{{value}}">
     {{> ../dropdown_widget widget_name=stream_dropdown_widget_name default_text=(t 'Select stream')}}
-    <button type="button" class="button rounded small delete-choice" title="{{t 'Delete' }}">
+    <button type="button" class="button rounded small delete-choice tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -51,7 +51,7 @@
         </div>
         <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green w-200 block" id="id_org_profile_preview">
             {{t 'Preview organization profile' }}
-            <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview organization profile' }}"></i>
+            <i class="fa fa-external-link"></i>
         </a>
 
         <div class="subsection-header">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -63,7 +63,7 @@
             </div>
             <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
-                <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview profile' }}"></i>
+                <i class="fa fa-external-link"></i>
             </button>
         </div>
     </div>

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -1,7 +1,7 @@
 {{#with attachment}}
 <tr class="uploaded_file_row" id="{{name}}" data-attachment-id="{{id}}">
     <td>
-        <a type="submit" href="/user_uploads/{{path_id}}" target="_blank" rel="noopener noreferrer" title="{{t 'View file' }}">
+        <a type="submit" href="/user_uploads/{{path_id}}" class="tippy-zulip-tooltip" target="_blank" rel="noopener noreferrer" data-tippy-content="{{t 'View file' }}">
             {{ name }}
         </a>
     </td>
@@ -20,17 +20,18 @@
     <td class="upload-size" >{{ size_str }}</td>
     <td class="actions">
         <span class="edit-attachment-buttons">
-            <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'Download file' }}" id="download_attachment" download>
-                <i class="fa fa-download sea-green" aria-hidden="true"></i>
+            <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" id="download_attachment" download>
+                <i class="fa fa-download sea-green tippy-zulip-delayed-tooltip" aria-hidden="true" data-tippy-content="{{t 'Download file' }}"></i>
             </a>
         </span>
         <span class="edit-attachment-buttons">
             <button type="submit"
               class="button small no-style remove-attachment"
-              title="{{t 'Delete file' }}" data-attachment="{{id}}">
-                <i class="fa fa-trash-o" aria-hidden="true"></i>
+              data-attachment="{{id}}">
+                <i class="fa fa-trash-o tippy-zulip-delayed-tooltip" aria-hidden="true" data-tippy-content="{{t 'Delete file' }}"></i>
             </button>
         </span>
+
     </td>
 </tr>
 {{/with}}

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -39,7 +39,7 @@
                   invite_only=invite_only
                   is_web_public=is_web_public }}
                 <div class="stream-name">
-                    <span class="sub-stream-name" title="{{name}}">{{name}}</span>
+                    <span class="sub-stream-name">{{name}}</span>
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
                 <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -204,6 +204,9 @@
     {{t 'View stream' }}
     {{tooltip_hotkey_hints "Shift" "V"}}
 </template>
+<template id="last-modified-tooltip-template">
+    {{t "Last modified"}}
+</template>
 <template id="mobile-push-notification-tooltip-template">
     {{t 'Mobile push notifications are not enabled on this server.' }}
 </template>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes #27817.

In several places an old design of tooltips were used. To create a more uniform UI, I have changed replaced several old tooltips to the tippy more commonly used. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before      | After |
| ----------- | ----------- |
|  <img width="456" alt="Screenshot 2023-11-27 at 11 07 57" src="https://github.com/zulip/zulip/assets/64125524/6ca3b9f4-099c-4138-9c80-763ee66794ea">| ![default_stream_settings](https://github.com/zulip/zulip/assets/64125524/a54dbaeb-d301-438e-877e-8ea63cb3ac1a)|
| <img width="753" alt="Screenshot 2023-11-27 at 11 06 58" src="https://github.com/zulip/zulip/assets/64125524/adde2eca-4c6a-4ed5-a1f3-6290816b59ff">  |![alert_word_settings](https://github.com/zulip/zulip/assets/64125524/9961cffa-f353-4790-acb3-2325ed7a384c)|
| <img width="810" alt="Screenshot 2023-11-27 at 11 08 26" src="https://github.com/zulip/zulip/assets/64125524/ea5d46b6-6e15-4790-a2ce-e6f135e2afbe">      | ![drafts_last_modified](https://github.com/zulip/zulip/assets/64125524/70f98e26-581c-4c23-9685-07f5a988f52b) |
| <img width="663" alt="Screenshot 2023-11-27 at 11 09 25" src="https://github.com/zulip/zulip/assets/64125524/31f1cf2d-32c8-4d34-9bf1-5e398fe6a026">      | ![preview_organization_profile](https://github.com/zulip/zulip/assets/64125524/3d1034fd-7a3e-4c5b-b657-b30bc45ee1e4)|
| <img width="282" alt="Screenshot 2023-11-27 at 11 09 49" src="https://github.com/zulip/zulip/assets/64125524/2d8b3239-d99a-419f-8751-c163df56195a">      | ![preview_profile_settings](https://github.com/zulip/zulip/assets/64125524/e51cdc67-49fa-45cf-896a-d3bab554f1c4)|
| <img width="732" alt="Screenshot 2023-11-27 at 11 17 45" src="https://github.com/zulip/zulip/assets/64125524/cb82e751-ab6e-47f4-adf3-83f5ade249ad">      | ![download_botserver](https://github.com/zulip/zulip/assets/64125524/19d55df4-0ecc-4001-959a-ee93dc6cabd3) |
| <img width="699" alt="Screenshot 2023-11-27 at 11 11 20" src="https://github.com/zulip/zulip/assets/64125524/1a34a83f-0cb5-42ca-99ab-ca3fc7abcf70">      | ![settings_custom_emoji](https://github.com/zulip/zulip/assets/64125524/35db2527-d83c-4ba3-bfc6-782afb5ec221)|
| <img width="732" alt="Screenshot 2023-11-27 at 11 12 08" src="https://github.com/zulip/zulip/assets/64125524/27663a7d-de74-4e18-90bc-7f60c592101e"> |![upload_file](https://github.com/zulip/zulip/assets/64125524/276038ee-c871-4a04-b131-9ad533869676) |
| <img width="699" alt="Screenshot 2023-11-27 at 11 10 28" src="https://github.com/zulip/zulip/assets/64125524/c8ffb4a5-17ae-431f-9c64-f0275f4e26f2"> | ![settings_linkfiers](https://github.com/zulip/zulip/assets/64125524/081a58c5-7e1a-46b5-895c-524318271e02)|
| <img width="538" alt="Screenshot 2023-11-27 at 09 29 45" src="https://github.com/zulip/zulip/assets/64125524/fe478b9f-5c92-4ad1-a8f5-cc3f9811d2df"> |![general_streams](https://github.com/zulip/zulip/assets/64125524/c6e7eb65-baef-43d1-bf32-f04fbb0c629b)|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
