### PR TITLE
upgrade: Simplify free trial upgrade page.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1031,7 +1031,7 @@ class StripeTest(StripeTestCase):
             free_trial_end_date = self.now + timedelta(days=60)
 
             self.assert_in_success_response(
-                ["You card will not be charged", "free trial", "60-day"], response
+                ["Your card will not be charged", "free trial", "60-day"], response
             )
             self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())
@@ -1249,7 +1249,7 @@ class StripeTest(StripeTestCase):
             response = self.client_get("/upgrade/")
 
             self.assert_in_success_response(
-                ["You card will not be charged", "free trial", "60-day"], response
+                ["Your card will not be charged", "free trial", "60-day"], response
             )
             self.assertNotEqual(user.realm.plan_type, Realm.PLAN_TYPE_STANDARD)
             self.assertFalse(Customer.objects.filter(realm=user.realm).exists())

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -30,7 +30,7 @@
                         {% if free_trial_days %}
                         <div class="not-editable-realm-field">
                             Add a credit card to start your <b>{{ free_trial_days }}-day free trial</b> of
-                            {{ plan }}. You card will not be charged if you
+                            {{ plan }}. Your card will not be charged if you
                             cancel in the first {{ free_trial_days }} days.
                         </div>
                         {% endif %}
@@ -92,10 +92,15 @@
                             <i class="billing-page-discount">(includes {{ discount_percent }}% discount)</i>
                             {% endif %}
                             <h1>$<span class="due-today-price"></span></h1>
+                            {% if free_trial_days %}
+                            <i>Your actual bill will depend on the number of
+                            active users in your organization.</i>
+                            {% endif %}
                         </div>
                     </div>
 
-                    {% if not manual_license_management %}
+                    {% if free_trial_days %}
+                    {% elif not manual_license_management %}
                     <div id="license-automatic-section" class="input-box upgrade-page-field license-management-section">
                         <p class="not-editable-realm-field">
                             Your subscription will renew automatically. Your bill will vary based on the number
@@ -106,7 +111,7 @@
                         <input type="hidden" name="licenses" id="automatic_license_count" value="{{ seat_count }}" />
                     </div>
                     {% else %}
-                    <div id="license-manual-section" class="input-box upgrade-page-field">
+                    <div id="license-manual-section" class="input-box upgrade-page-field license-management-section">
                         <p class="not-editable-realm-field">
                             Your subscription will renew automatically. You will be able to manage the number of licenses on
                             your organization's billing page. You can also

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1792,7 +1792,7 @@ class RealmCreationTest(ZulipTestCase):
         self.assertEqual(result["Location"], "http://custom-test.testserver/upgrade/")
 
         result = self.client_get(result["Location"], subdomain=string_id)
-        self.assert_in_success_response(["You card will not be charged", "free trial"], result)
+        self.assert_in_success_response(["Your card will not be charged", "free trial"], result)
 
         realm = get_realm(string_id)
         self.assertEqual(realm.string_id, string_id)


### PR DESCRIPTION
This PR simplifies the /upgrade page when there's a free trial. The intent is not to change anything about the upgrade page otherwise.

Known to-do's:

- [x] I couldn't figure out how to make the "Your actual bill..." note appear right under the price. @amanagr could you please fix it up?
- [x] I also haven't tested this page with the free trial turned off, so making sure that still looks good would be great.

<img width="686" alt="Screenshot 2023-11-27 at 2 55 49 PM" src="https://github.com/zulip/zulip/assets/2090066/343779d1-2335-49eb-a040-b8753aeb7610">

