### PR TITLE
help: Document "(guest)" indicator setting.

### DIFF
--- a/help/change-a-users-role.md
+++ b/help/change-a-users-role.md
@@ -2,9 +2,9 @@
 
 {!admin-only.md!}
 
-Users join as [owners, administrators, moderators, members, or
-guests](/help/roles-and-permissions), depending on how they were
-invited.
+Users join as [owners, administrators, moderators, members
+](/help/roles-and-permissions), or [guests](/help/guest-users),
+depending on how they were invited.
 
 An organization owner can change the role of any user.  An
 organization administrator can change the role of most users, but
@@ -47,3 +47,4 @@ organization](/help/deactivate-your-organization) instead).
 * [Change a user's name](/help/change-a-users-name)
 * [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
 * [Manage a user](/help/manage-a-user)
+* [Guest users](/help/guest-users)

--- a/help/guest-users.md
+++ b/help/guest-users.md
@@ -28,6 +28,20 @@ can:
 Zulip Cloud plans have [special discounted
 pricing](/help/zulip-cloud-billing#temporary-users-and-guests) for guest users.
 
+## Configure guest indicator
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|organization-permissions}
+
+1. Under **Guests**, toggle **Display “(guest)” after names of guest users**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
 ## Related articles
 
 * [Roles and permissions](/help/roles-and-permissions)

--- a/help/roles-and-permissions.md
+++ b/help/roles-and-permissions.md
@@ -20,9 +20,9 @@ There are several possible roles in a Zulip organization.
   who do not have those restrictions are called **full members**.
 
 * **Guest**: Can only view or access streams they've been added to.
-  Guest users interact with public streams as though they were private
-  streams with shared history.  Cannot create new streams or invite
-  other users.
+  [Guest users](/help/guest-users) interact with public streams as
+  though they were private streams with shared history.  Cannot
+  create new streams or invite other users.
 
 * **Billing administrator**: The user who upgrades the organization to
   a paid plan is, in addition to their normal role, a billing
@@ -46,3 +46,4 @@ this means "organization owners and administrators" can do that thing.
 * [Stream permissions](/help/stream-permissions)
 * [Inviting new users](/help/invite-new-users)
 * [Zulip Cloud billing](/help/zulip-cloud-billing)
+* [Guest users](/help/guest-users)

--- a/help/stream-permissions.md
+++ b/help/stream-permissions.md
@@ -5,8 +5,9 @@ determine who receives a message. Zulip supports a few types of streams:
 
 * **Public** (<i class="zulip-icon zulip-icon-hashtag"></i>):
   Members can join and view the complete message history.
-  Public streams are visible to guest users only if they are
-  subscribed (exactly like private streams with shared history).
+  Public streams are visible to [guest users](/help/guest-users)
+  only if they are subscribed (exactly like private streams with
+  shared history).
 
 * **Private** (<i class="zulip-icon zulip-icon-lock"></i>):
   New subscribers must be added by an existing subscriber. Only subscribers

--- a/help/zulip-cloud-billing.md
+++ b/help/zulip-cloud-billing.md
@@ -49,10 +49,9 @@ up their license for reuse.
 
 ### How are guest accounts billed? Is there special pricing?
 
-For an organization with N other users, 5*N [guest
-users](/help/roles-and-permissions) are included at no extra charge. After that,
-you will be charged at 1/5 of your regular per-user pricing for each additional
-guest.
+For an organization with N other users, 5*N [guest users](/help/guest-users)
+are included at no extra charge. After that, you will be charged at 1/5 of
+your regular per-user pricing for each additional guest.
 
 ## Related articles
 


### PR DESCRIPTION
This is a follow-up PR (see #27917) to document the new  setting that configures the `(guest)` indicator, and add links to the guest users page from relevant docs.

**Screenshots and screen captures:**
- https://chat.zulip.org/help/guest-users
![image](https://github.com/zulip/zulip/assets/2343554/0f53b9ce-3f38-4c8c-9188-a4dfb792146b)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>