### PR TITLE
portico-header: Dropped find accounts link for smaller windows.

### DIFF
--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -45,7 +45,7 @@
             {% endif %}
 
             {% if not is_self_hosting_management_page and not find_team_link_disabled %}
-            <a href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
+            <a class= "find-accounts-link" href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
             <a href="{{ root_domain_url }}/new/">{{ _('New organization') }}</a>
             {% endif %}
         </div>

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1173,6 +1173,10 @@ input.new-organization-button {
             }
         }
     }
+
+    .top-links .find-accounts-link {
+        display: none;
+    }
 }
 
 @media (width <= 500px) {


### PR DESCRIPTION
Fixes #27477

<!-- Describe your pull request here.-->
Dropped the Find accounts link for shorter screem in the header of help-center/api-center/policy-page as discussed in the [here](https://chat.zulip.org/#narrow/stream/101-design/topic/Documentation.20website.20in.20mobile.20browser)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Earlier



![Screenshot (68)](https://github.com/zulip/zulip/assets/126336384/890394c7-72ac-4b6d-bba1-f8cc35196ddf)

![Screenshot (69)](https://github.com/zulip/zulip/assets/126336384/16435924-dfe7-48c6-b869-38acd5caeab0)
![Screenshot (71)](https://github.com/zulip/zulip/assets/126336384/17935292-5571-40e6-aadf-1f2f582db55d)


### Fixed:

**For wider screen:**

![Screenshot (63)](https://github.com/zulip/zulip/assets/126336384/509ee19a-3c59-4281-b914-e10a1be04b67)

**For smaller screen:**

![Screenshot (64)](https://github.com/zulip/zulip/assets/126336384/87e4603f-ba9d-4c71-a2da-433e67f95bf6)

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
