### PR TITLE
analytics: Add Zulip version and support page links to remote installations page.

### DIFF
--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -48,46 +48,22 @@ def make_table(
     return content
 
 
-def get_page(
-    query: Composable, cols: Sequence[str], title: str, totals_columns: Sequence[int] = []
-) -> Dict[str, str]:
+def fix_rows(
+    rows: List[List[Any]],
+    i: int,
+    fixup_func: Union[Callable[[str], Markup], Callable[[datetime], str]],
+) -> None:
+    for row in rows:
+        row[i] = fixup_func(row[i])
+
+
+def get_query_data(query: Composable) -> List[List[Any]]:
     cursor = connection.cursor()
     cursor.execute(query)
     rows = cursor.fetchall()
     rows = list(map(list, rows))
     cursor.close()
-
-    def fix_rows(
-        i: int, fixup_func: Union[Callable[[str], Markup], Callable[[datetime], str]]
-    ) -> None:
-        for row in rows:
-            row[i] = fixup_func(row[i])
-
-    total_row = []
-    for i, col in enumerate(cols):
-        if col == "Realm":
-            fix_rows(i, realm_activity_link)
-        elif col in ["Last time", "Last visit"]:
-            fix_rows(i, format_date_for_activity_reports)
-        elif col == "Hostname":
-            for row in rows:
-                row[i] = remote_installation_stats_link(row[0], row[i])
-        if len(totals_columns) > 0:
-            if i == 0:
-                total_row.append("Total")
-            elif i in totals_columns:
-                total_row.append(str(sum(row[i] for row in rows if row[i] is not None)))
-            else:
-                total_row.append("")
-    if len(totals_columns) > 0:
-        rows.insert(0, total_row)
-
-    content = make_table(title, cols, rows)
-
-    return dict(
-        content=content,
-        title=title,
-    )
+    return rows
 
 
 def dictfetchall(cursor: CursorWrapper) -> List[Dict[str, Any]]:
@@ -137,13 +113,11 @@ def realm_url_link(realm_str: str) -> Markup:
     return Markup('<a href="{url}"><i class="fa fa-home"></i></a>').format(url=url)
 
 
-def remote_installation_stats_link(server_id: int, hostname: str) -> Markup:
+def remote_installation_stats_link(server_id: int) -> Markup:
     from analytics.views.stats import stats_for_remote_installation
 
     url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
-    return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a> {hostname}').format(
-        url=url, hostname=hostname
-    )
+    return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
 
 
 def remote_installation_support_link(hostname: str) -> Markup:

--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -128,7 +128,7 @@ def realm_support_link(realm_str: str) -> Markup:
     support_url = reverse("support")
     query = urlencode({"q": realm_str})
     url = append_url_query_string(support_url, query)
-    return Markup('<a href="{url}">{realm_str}</a>').format(url=url, realm_str=realm_str)
+    return Markup('<a href="{url}"><i class="fa fa-gear"></i></a>').format(url=url)
 
 
 def realm_url_link(realm_str: str) -> Markup:

--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -146,6 +146,13 @@ def remote_installation_stats_link(server_id: int, hostname: str) -> Markup:
     )
 
 
+def remote_installation_support_link(hostname: str) -> Markup:
+    support_url = reverse("remote_servers_support")
+    query = urlencode({"q": hostname})
+    url = append_url_query_string(support_url, query)
+    return Markup('<a href="{url}"><i class="fa fa-gear"></i></a>').format(url=url)
+
+
 def get_user_activity_summary(records: Collection[UserActivity]) -> Dict[str, Any]:
     #: The type annotation used above is clearly overly permissive.
     #: We should perhaps use TypedDict to clearly lay out the schema

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -13,7 +13,10 @@ from psycopg2.sql import SQL
 from analytics.lib.counts import COUNT_STATS
 from analytics.views.activity_common import (
     dictfetchall,
-    get_page,
+    fix_rows,
+    format_date_for_activity_reports,
+    get_query_data,
+    make_table,
     realm_activity_link,
     realm_stats_link,
     realm_support_link,
@@ -327,14 +330,20 @@ def get_integrations_activity(request: HttpRequest) -> HttpResponse:
         "Last time",
     ]
 
-    integrations_activity = get_page(query, cols, title)
+    rows = get_query_data(query)
+    for i, col in enumerate(cols):
+        if col == "Realm":
+            fix_rows(rows, i, realm_activity_link)
+        elif col == "Last time":
+            fix_rows(rows, i, format_date_for_activity_reports)
 
+    content = make_table(title, cols, rows)
     return render(
         request,
         "analytics/activity_details_template.html",
         context=dict(
-            data=integrations_activity["content"],
-            title=integrations_activity["title"],
+            data=content,
+            title=title,
             is_home=False,
         ),
     )

--- a/analytics/views/remote_activity.py
+++ b/analytics/views/remote_activity.py
@@ -38,6 +38,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             rserver.id,
             rserver.hostname,
             rserver.contact_email,
+            rserver.last_version,
             max_value,
             push_user_count,
             max_end_time
@@ -52,6 +53,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         "ID",
         "Hostname",
         "Contact email",
+        "Zulip version",
         "Analytics users",
         "Mobile users",
         "Last update time",
@@ -61,7 +63,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
 
     rows = get_query_data(query)
     total_row = []
-    totals_columns = [3, 4]
+    totals_columns = [4, 5]
     for row in rows:
         stats = remote_installation_stats_link(row[0])
         row.append(stats)

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -21,7 +21,7 @@
         <ul>
             <li><strong><i class="fa fa-home"></i></strong> - realm's Zulip</li>
             <li><strong><i class="fa fa-pie-chart"></i></strong> - realm's stats page</li>
-            <li><strong>realm</strong> - realm's support page</li>
+            <li><strong><i class="fa fa-gear"></i></strong> - realm's support page</li>
         </ul>
     </li>
     <li><strong>DAU</strong> (daily active users) - users active in last 24hr</li>

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -50,8 +50,9 @@ not_yet_fully_covered = [
     "analytics/lib/fixtures.py",
     # We have 100% coverage on the new stuff; need to refactor old stuff.
     "analytics/views/activity_common.py",
-    "analytics/views/realm_activity.py",
     "analytics/views/installation_activity.py",
+    "analytics/views/realm_activity.py",
+    "analytics/views/remote_activity.py",
     "analytics/views/stats.py",
     "analytics/views/support.py",
     # TODO: This is a work in progress and therefore without


### PR DESCRIPTION
Updates the remote installations analytics page to have a columns for:
- The Zulip version stored on the server (will be `None` if no value is stored).
- The link to the remote server's analytics page (pie chart icon).
- The link to the remote server's support page (gear icon).

Also updates the general installation activity page to show the realm's support page link as a gear icon, instead of the realm's name.

**Screenshots and screen captures:**

<details>
<summary>Updated installation activity page for gear icon</summary>

![Screenshot from 2023-11-28 14-07-38](https://github.com/zulip/zulip/assets/63245456/cd7db615-f39f-46b9-b56b-30c4315f76d8)
</details>
<details>
<summary>Updated remote installations page - hovering on analytics icon</summary>

![Screenshot from 2023-11-28 14-06-43](https://github.com/zulip/zulip/assets/63245456/c799d38d-9c6c-4f6a-ae9d-c7460cea4edb)
</details>
<details>
<summary>Updated remote installations page - hovering on support icon</summary>

![Screenshot from 2023-11-28 14-06-31](https://github.com/zulip/zulip/assets/63245456/56e14393-0249-4c76-a109-560615eee998)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
