### PR TITLE
Consistently use time_machine, and lint against mocking timezone_now

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -130,7 +130,7 @@ class AnalyticsTestCase(ZulipTestCase):
         for key, value in defaults.items():
             kwargs[key] = kwargs.get(key, value)
         kwargs["delivery_email"] = kwargs["email"]
-        with mock.patch("zerver.lib.create_user.timezone_now", return_value=kwargs["date_joined"]):
+        with time_machine.travel(kwargs["date_joined"], tick=False):
             pass_kwargs: Dict[str, Any] = {}
             if kwargs["is_bot"]:
                 pass_kwargs["bot_type"] = UserProfile.DEFAULT_BOT

--- a/tools/semgrep-py.yml
+++ b/tools/semgrep-py.yml
@@ -282,3 +282,16 @@ rules:
       Specify timedelta with named arguments.
     languages: [python]
     severity: ERROR
+
+  - id: time-machine
+    languages: [python]
+    patterns:
+      - pattern-either:
+          - pattern: patch("$FUNCTION", return_value=$TIME)
+          - pattern: mock.patch("$FUNCTION", return_value=$TIME)
+      - metavariable-regex:
+          metavariable: $FUNCTION
+          regex: .*timezone_now
+    fix: time_machine.travel($TIME, tick=False)
+    severity: ERROR
+    message: "Use the time_machine package, rather than mocking timezone_now"

--- a/tools/semgrep-py.yml
+++ b/tools/semgrep-py.yml
@@ -266,3 +266,19 @@ rules:
     message: "Replace functools.partial with returns.curry.partial for type safety"
     languages: [python]
     severity: ERROR
+
+  - id: timedelta-positional-argument
+    patterns:
+      - pattern: timedelta(...)
+      - pattern-not: timedelta(0)
+      - pattern-not: timedelta(..., days=..., ...)
+      - pattern-not: timedelta(..., seconds=..., ...)
+      - pattern-not: timedelta(..., microseconds=..., ...)
+      - pattern-not: timedelta(..., milliseconds=..., ...)
+      - pattern-not: timedelta(..., minutes=..., ...)
+      - pattern-not: timedelta(..., hours=..., ...)
+      - pattern-not: timedelta(..., weeks=..., ...)
+    message: |
+      Specify timedelta with named arguments.
+    languages: [python]
+    severity: ERROR

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1709,7 +1709,7 @@ Output:
 
         def set_age(user_name: str, age: int) -> None:
             user = self.example_user(user_name)
-            user.date_joined = timezone_now() - timedelta(age)
+            user.date_joined = timezone_now() - timedelta(days=age)
             user.save()
 
         do_set_realm_property(realm, "waiting_period_threshold", 1000, acting_user=None)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -32,6 +32,7 @@ import ldap
 import orjson
 import requests
 import responses
+import time_machine
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -1931,7 +1932,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         result = self.social_auth_test(
             account_data_dict, expect_choose_email_screen=True, subdomain=subdomain, is_signup=True
         )
-        with mock.patch("zerver.models.timezone_now", return_value=now):
+        with time_machine.travel(now, tick=False):
             self.stage_two_of_registration(
                 result, realm, subdomain, email, name, name, self.BACKEND_CLASS.full_name_validated
             )

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -3,6 +3,7 @@ import time
 from typing import List, Set
 from unittest import mock
 
+import time_machine
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
@@ -451,7 +452,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         tuesday = self.tuesday()
         cutoff = tuesday - datetime.timedelta(days=5)
 
-        with mock.patch("zerver.lib.digest.timezone_now", return_value=tuesday):
+        with time_machine.travel(tuesday, tick=False):
             with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
                 enqueue_emails(cutoff)
         queue_mock.assert_not_called()
@@ -463,7 +464,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         not_tuesday = datetime.datetime(year=2016, month=1, day=6, tzinfo=datetime.timezone.utc)
         cutoff = not_tuesday - datetime.timedelta(days=5)
 
-        with mock.patch("zerver.lib.digest.timezone_now", return_value=not_tuesday):
+        with time_machine.travel(not_tuesday, tick=False):
             with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
                 enqueue_emails(cutoff)
         queue_mock.assert_not_called()

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -1,7 +1,7 @@
 import datetime
 from email.headerregistry import Address
-from unittest import mock
 
+import time_machine
 from django.conf import settings
 from django.core import mail
 from django.utils.html import escape
@@ -79,7 +79,7 @@ class EmailChangeTestCase(ZulipTestCase):
             realm=user_profile.realm,
         )
         date_sent = now() - datetime.timedelta(days=2)
-        with mock.patch("confirmation.models.timezone_now", return_value=date_sent):
+        with time_machine.travel(date_sent, tick=False):
             url = create_confirmation_link(obj, Confirmation.EMAIL_CHANGE)
 
         response = self.client_get(url)

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import mock
 
 import orjson
+import time_machine
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.users import do_change_can_create_users, do_change_user_role
@@ -491,10 +492,7 @@ class TestMocking(ZulipTestCase):
             seconds=MESSAGE_CONTENT_EDIT_LIMIT + 100
         )  # There's a buffer time applied to the limit, hence the extra 100s.
 
-        with mock.patch(
-            "zerver.actions.message_edit.timezone_now",
-            return_value=time_beyond_edit_limit,
-        ):
+        with time_machine.travel(time_beyond_edit_limit, tick=False):
             result = self.client_patch(
                 f"/json/messages/{sent_message_id}", {"content": "I actually want pizza."}
             )

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import dateutil.parser
 import orjson
+import time_machine
 
 from zerver.data_import.gitter import do_convert_data, get_usermentions
 from zerver.lib.import_realm import do_import_realm
@@ -33,9 +34,8 @@ class GitterImporter(ZulipTestCase):
         with open(gitter_file) as f:
             gitter_data = orjson.loads(f.read())
         sent_datetime = dateutil.parser.parse(gitter_data[1]["sent"])
-        with self.assertLogs(level="INFO"), mock.patch(
-            "zerver.data_import.import_util.timezone_now",
-            return_value=sent_datetime + timedelta(days=1),
+        with self.assertLogs(level="INFO"), time_machine.travel(
+            (sent_datetime + timedelta(days=1)), tick=False
         ):
             do_convert_data(gitter_file, output_dir)
 

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict
 from unittest.mock import patch
 
 import orjson
+import time_machine
 from django.conf import settings
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
@@ -1020,17 +1021,17 @@ class HomeTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         now = LAST_SERVER_UPGRADE_TIME.replace(tzinfo=datetime.timezone.utc)
-        with patch("zerver.lib.compatibility.timezone_now", return_value=now + timedelta(days=10)):
+        with time_machine.travel((now + timedelta(days=10)), tick=False):
             self.assertEqual(is_outdated_server(iago), False)
             self.assertEqual(is_outdated_server(hamlet), False)
             self.assertEqual(is_outdated_server(None), False)
 
-        with patch("zerver.lib.compatibility.timezone_now", return_value=now + timedelta(days=397)):
+        with time_machine.travel((now + timedelta(days=397)), tick=False):
             self.assertEqual(is_outdated_server(iago), True)
             self.assertEqual(is_outdated_server(hamlet), True)
             self.assertEqual(is_outdated_server(None), True)
 
-        with patch("zerver.lib.compatibility.timezone_now", return_value=now + timedelta(days=380)):
+        with time_machine.travel((now + timedelta(days=380)), tick=False):
             self.assertEqual(is_outdated_server(iago), True)
             self.assertEqual(is_outdated_server(hamlet), False)
             self.assertEqual(is_outdated_server(None), False)

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1439,7 +1439,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             email=email, referred_by=inviter, realm=realm
         )
         date_sent = timezone_now() - datetime.timedelta(weeks=3)
-        with patch("confirmation.models.timezone_now", return_value=date_sent):
+        with time_machine.travel(date_sent, tick=False):
             url = create_confirmation_link(prereg_user, Confirmation.USER_REGISTRATION)
 
         key = url.split("/")[-1]
@@ -1782,10 +1782,7 @@ class InvitationsTestCase(InviteUserBase):
             invite_expires_in_minutes=invite_expires_in_minutes,
         )
 
-        with patch(
-            "confirmation.models.timezone_now",
-            return_value=timezone_now() - datetime.timedelta(days=3),
-        ):
+        with time_machine.travel((timezone_now() - datetime.timedelta(days=3)), tick=False):
             do_invite_users(
                 user_profile,
                 ["TestTwo@zulip.com"],
@@ -1828,10 +1825,7 @@ class InvitationsTestCase(InviteUserBase):
             get_stream(stream_name, user_profile.realm) for stream_name in ["Denmark", "Scotland"]
         ]
 
-        with patch(
-            "confirmation.models.timezone_now",
-            return_value=timezone_now() - datetime.timedelta(days=1000),
-        ):
+        with time_machine.travel((timezone_now() - datetime.timedelta(days=1000)), tick=False):
             # Testing the invitation with expiry date set to "None" exists
             # after a large amount of days.
             do_invite_users(
@@ -2291,7 +2285,7 @@ class MultiuseInviteTest(ZulipTestCase):
         if date_sent is None:
             date_sent = timezone_now()
         validity_in_minutes = 2 * 24 * 60
-        with patch("confirmation.models.timezone_now", return_value=date_sent):
+        with time_machine.travel(date_sent, tick=False):
             return create_confirmation_link(
                 invite, Confirmation.MULTIUSE_INVITE, validity_in_minutes=validity_in_minutes
             )

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from unittest import mock
 
+import time_machine
+
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.cache import cache_get, get_muting_users_cache_key
 from zerver.lib.muted_users import get_mute_object, get_muting_users, get_user_mutes
@@ -19,7 +21,7 @@ class MutedUsersTests(ZulipTestCase):
         self.assertEqual(muted_users, [])
         mute_time = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-        with mock.patch("zerver.views.muted_users.timezone_now", return_value=mute_time):
+        with time_machine.travel(mute_time, tick=False):
             url = f"/api/v1/users/me/muted_users/{cordelia.id}"
             result = self.api_post(hamlet, url)
             self.assert_json_success(result)
@@ -85,7 +87,7 @@ class MutedUsersTests(ZulipTestCase):
         if deactivate_user:
             do_deactivate_user(cordelia, acting_user=None)
 
-        with mock.patch("zerver.views.muted_users.timezone_now", return_value=mute_time):
+        with time_machine.travel(mute_time, tick=False):
             url = f"/api/v1/users/me/muted_users/{cordelia.id}"
             result = self.api_post(hamlet, url)
             self.assert_json_success(result)
@@ -139,12 +141,12 @@ class MutedUsersTests(ZulipTestCase):
         if deactivate_user:
             do_deactivate_user(cordelia, acting_user=None)
 
-        with mock.patch("zerver.views.muted_users.timezone_now", return_value=mute_time):
+        with time_machine.travel(mute_time, tick=False):
             url = f"/api/v1/users/me/muted_users/{cordelia.id}"
             result = self.api_post(hamlet, url)
             self.assert_json_success(result)
 
-        with mock.patch("zerver.actions.muted_users.timezone_now", return_value=mute_time):
+        with time_machine.travel(mute_time, tick=False):
             # To test that `RealmAuditLog` entry has correct `event_time`.
             url = f"/api/v1/users/me/muted_users/{cordelia.id}"
             result = self.api_delete(hamlet, url)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -1,8 +1,8 @@
 import datetime
 import sys
 from typing import Sequence
-from unittest import mock
 
+import time_machine
 from django.conf import settings
 from django.core import mail
 from django.test import override_settings
@@ -55,7 +55,7 @@ class SendLoginEmailTest(ZulipTestCase):
             user_tz = zoneinfo.ZoneInfo(user.timezone)
             mock_time = datetime.datetime(year=2018, month=1, day=1, tzinfo=datetime.timezone.utc)
             reference_time = mock_time.astimezone(user_tz).strftime("%A, %B %d, %Y at %I:%M %p %Z")
-            with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
+            with time_machine.travel(mock_time, tick=False):
                 self.client_post(
                     "/accounts/login/", info=login_info, HTTP_USER_AGENT=firefox_windows
                 )
@@ -71,7 +71,7 @@ class SendLoginEmailTest(ZulipTestCase):
             self.logout()  # We just logged in, we'd be redirected without this
             user.twenty_four_hour_time = True
             user.save()
-            with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
+            with time_machine.travel(mock_time, tick=False):
                 self.client_post(
                     "/accounts/login/", info=login_info, HTTP_USER_AGENT=firefox_windows
                 )
@@ -116,13 +116,13 @@ class SendLoginEmailTest(ZulipTestCase):
 
         do_change_user_setting(user, "enable_login_emails", False, acting_user=None)
         self.assertFalse(user.enable_login_emails)
-        with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
+        with time_machine.travel(mock_time, tick=False):
             self.login_user(user)
         self.assert_length(mail.outbox, 0)
 
         do_change_user_setting(user, "enable_login_emails", True, acting_user=None)
         self.assertTrue(user.enable_login_emails)
-        with mock.patch("zerver.signals.timezone_now", return_value=mock_time):
+        with time_machine.travel(mock_time, tick=False):
             self.login_user(user)
         self.assert_length(mail.outbox, 1)
 

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -648,7 +648,8 @@ class UserPresenceAggregationTests(ZulipTestCase):
 
         with mock.patch(
             "zerver.views.presence.timezone_now",
-            return_value=validate_time + datetime.timedelta(settings.OFFLINE_THRESHOLD_SECS + 1),
+            return_value=validate_time
+            + datetime.timedelta(seconds=settings.OFFLINE_THRESHOLD_SECS + 1),
         ):
             # After settings.OFFLINE_THRESHOLD_SECS + 1 this generated, recent presence data
             # will count as offline.

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -172,7 +172,7 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
         )
         self._change_messages_date_sent(
             msg_ids,
-            timezone_now() - timedelta(ZULIP_REALM_DAYS + 1),
+            timezone_now() - timedelta(days=ZULIP_REALM_DAYS + 1),
         )
 
         return msg_ids
@@ -240,7 +240,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         )
         self._change_messages_date_sent(
             expired_zulip_msg_ids,
-            timezone_now() - timedelta(ZULIP_REALM_DAYS + 1),
+            timezone_now() - timedelta(days=ZULIP_REALM_DAYS + 1),
         )
 
         expired_msg_ids = expired_mit_msg_ids + expired_zulip_msg_ids
@@ -273,7 +273,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         )
         self._change_messages_date_sent(
             zulip_msg_ids,
-            timezone_now() - timedelta(ZULIP_REALM_DAYS + 1),
+            timezone_now() - timedelta(days=ZULIP_REALM_DAYS + 1),
         )
 
         # Only MIT has a retention policy:
@@ -323,7 +323,9 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         msg_ids += [self._send_personal_message_to_cross_realm_bot() for i in range(1, 7)]
         usermsg_ids = self._get_usermessage_ids(msg_ids)
         # Make the message expired in the Zulip realm.:
-        self._change_messages_date_sent(msg_ids, timezone_now() - timedelta(ZULIP_REALM_DAYS + 1))
+        self._change_messages_date_sent(
+            msg_ids, timezone_now() - timedelta(days=ZULIP_REALM_DAYS + 1)
+        )
 
         archive_messages()
         self._verify_archive_data(msg_ids, usermsg_ids)
@@ -376,7 +378,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         # Make the message expired in the recipient's realm:
         self._change_messages_date_sent(
             [expired_crossrealm_msg_id],
-            timezone_now() - timedelta(ZULIP_REALM_DAYS + 1),
+            timezone_now() - timedelta(days=ZULIP_REALM_DAYS + 1),
         )
 
         expired_msg_ids = [*expired_mit_msg_ids, *expired_zulip_msg_ids, expired_crossrealm_msg_id]

--- a/zerver/tests/test_sessions.py
+++ b/zerver/tests/test_sessions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Any, Callable
-from unittest import mock
 
+import time_machine
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -134,15 +134,13 @@ class TestExpirableSessionVars(ZulipTestCase):
 
     def test_set_and_get_basic(self) -> None:
         start_time = timezone_now()
-        with mock.patch("zerver.lib.sessions.timezone_now", return_value=start_time):
+        with time_machine.travel(start_time, tick=False):
             set_expirable_session_var(
                 self.session, "test_set_and_get_basic", "some_value", expiry_seconds=10
             )
             value = get_expirable_session_var(self.session, "test_set_and_get_basic")
             self.assertEqual(value, "some_value")
-        with mock.patch(
-            "zerver.lib.sessions.timezone_now", return_value=start_time + timedelta(seconds=11)
-        ):
+        with time_machine.travel((start_time + timedelta(seconds=11)), tick=False):
             value = get_expirable_session_var(self.session, "test_set_and_get_basic")
             self.assertEqual(value, None)
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional
 from unittest import mock
 
 import orjson
+import time_machine
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
@@ -1189,9 +1190,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
 
         current_time = timezone_now()
-        with mock.patch(
-            "zerver.actions.user_groups.timezone_now", return_value=current_time + timedelta(days=3)
-        ):
+        with time_machine.travel((current_time + timedelta(days=3)), tick=False):
             promote_new_full_members()
 
         self.assertTrue(


### PR DESCRIPTION
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
