### PR TITLE
markdown: Stop attempting to expand/collapse re2 regex.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1821,25 +1821,7 @@ def prepare_linkifier_pattern(source: str) -> str:
     # We use an extended definition of 'whitespace' which is
     # equivalent to \p{White_Space} -- since \s in re2 only matches
     # ASCII spaces, and re2 does not support \p{White_Space}.
-    regex = rf"""
-        (?P<{BEFORE_CAPTURE_GROUP}>
-            ^  |
-            \s | {next_line} | \pZ |
-            ['"\(,:<]
-        )
-        (?P<{OUTER_CAPTURE_GROUP}>
-            {source}
-        )
-        (?P<{AFTER_CAPTURE_GROUP}>
-            $ |
-            [^\pL\pN]
-        )
-    """
-    # Strip out the spaces and newlines added to make the above
-    # legible -- re2 does not have the equivalent of the /x modifier
-    # that does this automatically.  Note that we are careful to not
-    # strip _whitespace_, which would strip the literal \u0085 out.
-    return regex.replace(" ", "").replace("\n", "")
+    return rf"""(?P<{BEFORE_CAPTURE_GROUP}>^|\s|{next_line}|\pZ|['"\(,:<])(?P<{OUTER_CAPTURE_GROUP}>{source})(?P<{AFTER_CAPTURE_GROUP}>$|[^\pL\pN])"""
 
 
 # Given a regular expression pattern, linkifies groups that match it

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1366,6 +1366,25 @@ class MarkdownTest(ZulipTestCase):
             [{"url": "https://example.com/A%20Test/%25%25%ba/123", "text": "url-123"}],
         )
 
+        # Test spaces in the linkifier pattern
+        RealmFilter(
+            realm=realm,
+            pattern=r"community guidelines",
+            url_template="https://zulip.com/development-community/#community-norms",
+        ).save()
+        converted = markdown_convert("community guidelines", message_realm=realm, message=msg)
+        self.assertEqual(
+            converted.rendered_content,
+            '<p><a href="https://zulip.com/development-community/#community-norms">community guidelines</a></p>',
+        )
+        converted = markdown_convert(
+            "please observe community guidelines here", message_realm=realm, message=msg
+        )
+        self.assertEqual(
+            converted.rendered_content,
+            '<p>please observe <a href="https://zulip.com/development-community/#community-norms">community guidelines</a> here</p>',
+        )
+
     def test_multiple_matching_realm_patterns(self) -> None:
         realm = get_realm("zulip")
         self.check_add_linkifiers(


### PR DESCRIPTION
549dd8a4c4a4 changed the regex that we build to contain whitespace for readability, and strip that back out before returning it. Unfortunately, this also serves to strip out whitespace in the source linkifier, causing it to not match expected strings.

Revert 549dd8a4c4a4.

Fixes: #27854.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
