### PR TITLE
typeahead: Fix bug where typeahead showed momentarily on shift + tab.

### DIFF
--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -525,6 +525,13 @@ import {get_string_diff} from "../../src/util";
           }
           break
 
+        // to stop typeahead from showing up momentarily
+        // when shift + tabbing to the topic field
+        case 16: // shift
+          if (e.currentTarget.id === "stream_message_recipient_topic") {
+            return;
+          }
+
         default:
           var hideOnEmpty = false
           // backspace


### PR DESCRIPTION
Since the keyup event for keys including shift triggers the typeahead, shift tabbing into the topic recipient field would show the typeahead momentarily, which is distracting.

As we need typeahead to trigger on shift for certain use cases in the compose box, but not in the topic recipient field, we now do not trigger typeahead on shift keyup events in the topic recipient field.

Fixes: #24152.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
