### PR TITLE
hotkey: Fix `N` and `Shift + N` behaviour for muted streams.

### DIFF
--- a/web/src/topic_generator.js
+++ b/web/src/topic_generator.js
@@ -67,13 +67,23 @@ export function get_next_topic(curr_stream, curr_topic, only_followed_topics) {
             // currently narrowed to it.
             return true;
         }
-        return false;
+        // We can use N to go to next unread unmuted/followed topic in a muted stream .
+        const stream_id = stream_data.get_stream_id(stream_name);
+        const topics = stream_topic_history.get_recent_topic_names(stream_id);
+        return topics.some((topic) => user_topics.is_topic_unmuted_or_followed(stream_id, topic));
     });
 
     function get_unmuted_topics(stream_name) {
         const stream_id = stream_data.get_stream_id(stream_name);
         let topics = stream_topic_history.get_recent_topic_names(stream_id);
-        topics = topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
+
+        if (stream_data.is_stream_muted_by_name(stream_name)) {
+            topics = topics.filter((topic) =>
+                user_topics.is_topic_unmuted_or_followed(stream_id, topic),
+            );
+        } else {
+            topics = topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
+        }
         return topics;
     }
 

--- a/web/src/topic_generator.js
+++ b/web/src/topic_generator.js
@@ -56,6 +56,12 @@ export function get_next_topic(curr_stream, curr_topic, only_followed_topics) {
         if (!stream_data.is_stream_muted_by_name(stream_name)) {
             return true;
         }
+        if (only_followed_topics) {
+            // We can use Shift + N to go to unread followed topic in muted stream.
+            const stream_id = stream_data.get_stream_id(stream_name);
+            const topics = stream_topic_history.get_recent_topic_names(stream_id);
+            return topics.some((topic) => user_topics.is_topic_followed(stream_id, topic));
+        }
         if (stream_name === curr_stream) {
             // We can use n within a muted stream if we are
             // currently narrowed to it.

--- a/web/src/topic_generator.js
+++ b/web/src/topic_generator.js
@@ -1,3 +1,6 @@
+import _ from "lodash";
+
+import * as narrow_state from "./narrow_state";
 import * as pm_conversations from "./pm_conversations";
 import * as stream_data from "./stream_data";
 import * as stream_list_sort from "./stream_list_sort";
@@ -75,16 +78,28 @@ export function get_next_topic(curr_stream, curr_topic, only_followed_topics) {
 
     function get_unmuted_topics(stream_name) {
         const stream_id = stream_data.get_stream_id(stream_name);
-        let topics = stream_topic_history.get_recent_topic_names(stream_id);
+        const topics = stream_topic_history.get_recent_topic_names(stream_id);
 
-        if (stream_data.is_stream_muted_by_name(stream_name)) {
-            topics = topics.filter((topic) =>
+        if (
+            narrow_state.active() &&
+            narrow_state.stream_id() === stream_id &&
+            _.isEqual(narrow_state.filter().sorted_term_types(), ["stream", "topic"]) &&
+            !user_topics.is_topic_unmuted_or_followed(stream_id, narrow_state.topic())
+        ) {
+            // Here we're using N within a muted stream starting from
+            // a muted topic; advance to the next not-explicitly-muted
+            // unread topic in the stream, to allow using N within
+            // muted streams. We'll jump back into the normal mode if
+            // we land in a followed/unmuted topic, but that's OK.
+
+            /* istanbul ignore next */
+            return topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
+        } else if (stream_data.is_stream_muted_by_name(stream_name)) {
+            return topics.filter((topic) =>
                 user_topics.is_topic_unmuted_or_followed(stream_id, topic),
             );
-        } else {
-            topics = topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
         }
-        return topics;
+        return topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
     }
 
     function get_followed_topics(stream_name) {

--- a/web/tests/topic_generator.test.js
+++ b/web/tests/topic_generator.test.js
@@ -121,6 +121,14 @@ run_test("topics", ({override}) => {
         topic: "followed",
     });
 
+    // Shift + N takes the user to next unread followed topic,
+    // even if the stream is muted.
+    next_item = tg.get_next_topic("announce", "whatever", true);
+    assert.deepEqual(next_item, {
+        stream: "muted",
+        topic: "followed",
+    });
+
     next_item = tg.get_next_topic("muted", "whatever", true);
     assert.deepEqual(next_item, {
         stream: "muted",


### PR DESCRIPTION
[CZO issue report](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20Shift.2BN.20in.20muted.20stream/near/1690781)

* The Shift+N shortcut is not working to go to a followed topic in a muted stream
*  Go to followed or unmuted topics using N if they are in muted streams




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
