### PR TITLE
left_sidebar: Avoid closing sidebar in narrow views when interacting …

### DIFF
--- a/web/src/sidebar_ui.js
+++ b/web/src/sidebar_ui.js
@@ -112,8 +112,11 @@ export function initialize() {
                 !$elt.closest(".no-auto-hide-left-sidebar-overlay").length
             ) {
                 const $left_column = $(".app-main .column-left");
+                const $popover = $(".tippy-box");
                 const click_outside_left_sidebar = !$elt.closest($left_column).length;
-                if (click_outside_left_sidebar) {
+                const click_outside_popover = !$elt.closest($popover).length;
+
+                if (click_outside_left_sidebar && click_outside_popover) {
                     hide_streamlist_sidebar();
                 }
             }


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/27625

As described, previously the behavior was that ANY click outside the left sidebar, including on any of its popover menus, closes the sidebar, in such a narrow view, with the exception of the color picker option in the stream menus. 

Now it wont close when interacting with the popovers (both topic and stream), but still closes if pressing anywhere outside of the popover or the left sidebar. Instead of making the popover a part of the sidebar, as described in [CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/narrow.20left.20sidebar.20closing/near/1678316), I have instead added a check in sidebar_ui to only hide streamlist sidebar when clicking outside of the sidebar AND popover, what do you think about that solution?

When fixing this issue, I found another issue/bug: if pressing anywhere on the tippy-box (but not on any of the links on the popover), the left sidebar will close but the popover will still be there, see image. I believe this solution fixes that as well 

**Screenshots and screen captures:**

*Issue with popover not closing, as described above, that is now solved*
<img width="718" alt="Skärmavbild 2023-11-29 kl  11 56 56" src="https://github.com/zulip/zulip/assets/36896949/536c1426-c45a-4107-ba7b-725b06f088b7">
<img width="652" alt="Skärmavbild 2023-11-29 kl  11 56 50" src="https://github.com/zulip/zulip/assets/36896949/f730e44d-3991-414d-a9ff-aa68674b6aa7">


<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
