### PR TITLE
analytics: Add mobile pushes forwarded column to remote activity page.

### DIFF
--- a/analytics/views/remote_activity.py
+++ b/analytics/views/remote_activity.py
@@ -69,9 +69,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         "Analytics users",
         "Mobile users",
         "Last update time",
-        "7 day count of mobile pushes forwarded (includes today's current count)",
-        "Analytics",
-        "Support",
+        "Mobile pushes forwarded",
+        "Links",
     ]
 
     rows = get_query_data(query)
@@ -79,14 +78,12 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     totals_columns = [4, 5]
     for row in rows:
         stats = remote_installation_stats_link(row[0])
-        row.append(stats)
+        support = remote_installation_support_link(row[1])
+        links = stats + " " + support
+        row.append(links)
     for i, col in enumerate(cols):
         if col == "Last update time":
             fix_rows(rows, i, format_date_for_activity_reports)
-        if col == "Hostname":
-            for row in rows:
-                support = remote_installation_support_link(row[i])
-                row.append(support)
         if i == 0:
             total_row.append("Total")
         elif i in totals_columns:

--- a/templates/analytics/ad_hoc_query.html
+++ b/templates/analytics/ad_hoc_query.html
@@ -1,5 +1,9 @@
 <h3>{{ data.title }}</h3>
 
+{% if data.title == "Remote servers" %}
+{% include "analytics/remote_activity_key.html" %}
+{% endif %}
+
 {{ data.rows|length}} rows
 <table class="table sortable table-striped table-bordered analytics_table">
 

--- a/templates/analytics/remote_activity_key.html
+++ b/templates/analytics/remote_activity_key.html
@@ -1,0 +1,11 @@
+<h4>Chart key:</h4>
+<ul>
+    <li><strong>Zulip version</strong> - as of last update time</li>
+    <li><strong>Mobile pushes forwarded</strong> - last 7 days, including today's current count</li>
+    <li><strong>Links</strong>
+        <ul>
+            <li><strong><i class="fa fa-pie-chart"></i></strong> - remote server's stats page</li>
+            <li><strong><i class="fa fa-gear"></i></strong> - remote server's support page</li>
+        </ul>
+    </li>
+</ul>


### PR DESCRIPTION
**1st commit**:
- Adds a column to the remote servers activity page for a 7-day count of forwarded mobile push notifications from
`RemoteInstallationCount` for each server, which will be `None` if there is no data for the remote server with that ID.
- This expands the current query for the new data since we're already getting data on all remote servers here.
- Manually tested by adding a remote server and countstat via `populate_analytics_db.py` and rebuilding the dev database (`tools/rebuild-dev-database`) with those changes and comparing the query data to the database via `./manage.py dbshell`.

<details>
<summary>populate_analytics_db for testing</summary>

replace FixtureData and insert_fixture_data function with below:

```python
        import uuid

        from zilencer.models import RemoteInstallationCount, RemoteZulipServer

        remote_server = RemoteZulipServer.objects.create(
            hostname="zulip-remote.example.com",
            contact_email="admin@zulip-remote.example.com",
            plan_type=1,
            uuid=uuid.uuid4(),
            last_version="7.0",
        )

        FixtureData: TypeAlias = Mapping[Union[str, int, None], List[int]]

        def insert_fixture_data(
            stat: CountStat,
            fixture_data: FixtureData,
            table: Type[BaseCount],
        ) -> None:
            end_times = time_range(
                last_end_time, last_end_time, stat.frequency, len(next(iter(fixture_data.values())))
            )
            if table == InstallationCount:
                id_args: Dict[str, Any] = {}
            if table == RealmCount:
                id_args = {"realm": realm}
            if table == UserCount:
                id_args = {"realm": realm, "user": shylock}
            if table == StreamCount:
                id_args = {"stream": stream, "realm": realm}
            if table == RemoteInstallationCount:
                id_args = {"server": remote_server}

            for subgroup, values in fixture_data.items():
                table._default_manager.bulk_create(
                    table(
                        property=stat.property,
                        subgroup=subgroup,
                        end_time=end_time,
                        value=value,
                        **id_args,
                    )
                    for end_time, value in zip(end_times, values)
                    if value != 0
                )

        stat = COUNT_STATS["mobile_pushes_forwarded::day"]
        remote_server_data: FixtureData = {
            None: self.generate_fixture_data(stat, 1.5, 1, 3, 0.6, 8),
        }
        insert_fixture_data(stat, remote_server_data, RemoteInstallationCount)
        FillState.objects.create(
            property=stat.property, end_time=last_end_time, state=FillState.DONE
        )
```

</details>

**2nd commit**:
- Adds a chart key to the top of the remote activity page. And, combines the support and stats links for a remote server into one column.
- Added the chart key as a separate template that's conditionally added to a shared template. This will let us quickly iterate on adding more information to this particular page.
- This is a separate commit so as not to delay merging first commit due to these changes.

**Screenshots and screen captures:**

<details>
<summary>Updated remote servers activity page</summary>

![Screenshot from 2023-11-29 15-58-18](https://github.com/zulip/zulip/assets/63245456/b6e38f0b-31e7-43b3-b13f-771948be671e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
