### PR TITLE
analytics: Adjust width and margin CSS for activity pages.

### DIFF
--- a/templates/analytics/activity.html
+++ b/templates/analytics/activity.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-
+<div class="activity-page">
     <a class="show-all" href="/activity">Home</a>
     <br />
     <h4>{{ title }} {% if realm_stats_link %}{{ realm_stats_link }}{% endif %}</h4>
@@ -28,5 +28,5 @@
         </div>
         {% endfor %}
     </div>
-
+</div>
 {% endblock %}

--- a/templates/analytics/activity_details_template.html
+++ b/templates/analytics/activity_details_template.html
@@ -9,14 +9,14 @@
 
 
 {% block content %}
-
+<div class="activity-page">
     {% if not is_home %}
     <a class="show-all" href="/activity">Home</a>
     <br />
     {% endif %}
 
-    <div class="container">
+    <div>
         {{ data|safe }}
     </div>
-
+</div>
 {% endblock %}

--- a/templates/analytics/ad_hoc_query.html
+++ b/templates/analytics/ad_hoc_query.html
@@ -1,9 +1,9 @@
 <h3>{{ data.title }}</h3>
 
 {{ data.rows|length}} rows
-<table class="table sortable table-striped table-bordered analytics_table">
+<table class="table sortable table-striped table-bordered analytics-table">
 
-    <thead class="activity_head">
+    <thead class="activity-head">
         <tr>
             {% for col in data.cols %}
             <th>{{ col }}</th>

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -31,7 +31,7 @@
 
 <table class="table summary-table sortable table-striped table-bordered">
 
-    <thead class="activity_head">
+    <thead class="activity-head">
         <tr>
             <th>Realm</th>
             <th>Created (green if ≤12wk)</th>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -1,4 +1,8 @@
-.activity_head {
+.activity-page {
+    margin: 10px;
+}
+
+.activity-head {
     background-color: hsl(208deg 100% 97%);
 }
 
@@ -15,13 +19,13 @@
 }
 
 .summary-table,
-.analytics_table {
+.analytics-table {
     border: 1px solid hsl(0deg 0% 87%);
     border-collapse: separate;
     border-left: 0;
     border-radius: 4px;
     border-spacing: 0;
-    width: 100%;
+    margin: 0 10px;
 
     & th,
     td {
@@ -36,6 +40,7 @@
     th {
         vertical-align: bottom;
         padding: 8px;
+        max-width: fit-content;
     }
 
     td {
@@ -67,11 +72,6 @@
     thead tr:first-child th {
         border-top: 0;
     }
-}
-
-.summary-table {
-    width: auto;
-    margin: 0 auto;
 }
 
 tr.admin td:first-child {


### PR DESCRIPTION
**Notes**:
- Removes use of bootstrap "container" class from analytics activity pages. Note it is still used in the support view pages.
- Adds "activity-page" class to give a slight margin to the page content on activity pages in general. This pushes the "Home" link and other content away from the edge of the browser.
- Renames "analytics_table" class to "analytics-table" and "activity_head" class to "activity-head". This makes it easier to grep for these CSS classes.
- Stops setting `width` on the installation and activity tables and instead gives a small 10px right/left margin to the tables. As a result, the tables are no longer centered on the page, but since width is no longer being set by the bootstrap "container" class, this should help with overflow issues.
- Sets the max-width on the installation and activity tables for `<th>` element to be `fit-content`.

**Screenshots and screen captures:**

<details>
<summary>Realm activity page - on history tab since that has data in dev environment</summary>

![Screenshot from 2023-11-29 20-22-10](https://github.com/zulip/zulip/assets/63245456/89bf1d2a-e3ed-4a50-bbb5-0b9d119ce725)
</details>
<details>
<summary>Remote servers activity page - with long example</summary>

![Screenshot from 2023-11-29 20-20-53](https://github.com/zulip/zulip/assets/63245456/e583a8b2-1c24-4c70-aff0-d9697b2e2fde)
</details>
<details>
<summary>Installation activity page</summary>

![Screenshot from 2023-11-29 20-20-35](https://github.com/zulip/zulip/assets/63245456/09f8a288-d68f-4c27-9be8-f045c9ff1be9)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
