### PR TITLE
left_sidebar: Respect unread display settings on STREAMS header.

### DIFF
--- a/web/src/sidebar_ui.js
+++ b/web/src/sidebar_ui.js
@@ -144,6 +144,7 @@ export function initialize_left_sidebar() {
             user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code,
         is_recent_view_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code,
+        hide_unread_counts: settings_data.should_mask_unread_count(),
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -594,6 +594,12 @@ export function update_dom_with_unread_counts(counts) {
 }
 
 export function update_dom_unread_counts_visibility() {
+    const $streams_header = $("#streams_header");
+    if (settings_data.should_mask_unread_count()) {
+        $streams_header.addClass("hide_unread_counts");
+    } else {
+        $streams_header.removeClass("hide_unread_counts");
+    }
     for (const stream of stream_sidebar.rows.values()) {
         const $subscription_block = stream.get_li().find(".subscription_block");
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -613,7 +613,7 @@ div.overlay {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background-color: hsl(0deg 0% 80%);
+    background-color: var(--color-masked-unread-marker);
     display: none;
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1268,6 +1268,38 @@ li.topic-list-item {
             padding: 0;
         }
     }
+
+    &.hide_unread_counts {
+        .unread_count,
+        .unread_count.hide,
+        .masked_unread_count {
+            display: none;
+        }
+
+        /* When an empty unread count is hidden,
+           hide the masked unread count, too. */
+        .unread_count.hide + .masked_unread_count {
+            display: none;
+        }
+
+        .masked_unread_count {
+            display: block;
+            /* Hold space enough so single-digit
+               unreads don't shift on hover. */
+            margin: 0 3px;
+        }
+
+        &:hover {
+            .unread_count {
+                display: block;
+            }
+
+            .hide,
+            .masked_unread_count {
+                display: none;
+            }
+        }
+    }
 }
 
 .streams_subheader {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -195,6 +195,7 @@ body {
     --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
+    --color-masked-unread-marker: hsl(0deg 0% 80%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
     --color-background-modal: hsl(0deg 0% 98%);
     --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
@@ -444,6 +445,7 @@ body {
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
+    --color-masked-unread-marker: hsl(0deg 0% 30%);
     --color-background-modal: hsl(212deg 28% 18%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -157,7 +157,7 @@
         </div>
 
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide">
+            <div id="streams_header" class="zoom-in-hide {{#if hide_unread_counts}}hide_unread_counts{{/if}}">
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
@@ -165,6 +165,7 @@
                         <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                     </span>
                     <span class="unread_count"></span>
+                    <span class="masked_unread_count"></span>
                 </div>
 
                 <div class="input-append notdisplayed stream_search_section">


### PR DESCRIPTION
In addition to displaying a hoverable unread dot on STREAMS based on the user preference to do so, this PR introduces a subtle dark-mode color for masked unread dots. Previously, the shade used in light mode was also used in dark mode, where it appeared considerably more intense.

Fixes: #27762

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/unread.20dot.20color.20on.20Streams/near/1691388) (dot color)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="295" alt="masked-unread-light-before" src="https://github.com/zulip/zulip/assets/170719/6822ac27-6e7f-401f-aded-54b150614235"> | <img width="295" alt="masked-unread-light-after" src="https://github.com/zulip/zulip/assets/170719/e86659da-068f-4ddb-a7b2-cce1298f276d"> |
| <img width="295" alt="masked-unread-dark-before" src="https://github.com/zulip/zulip/assets/170719/d263f44f-908b-455d-b9df-5eadc1798df8"> | <img width="295" alt="masked-unread-dark-after" src="https://github.com/zulip/zulip/assets/170719/e7053986-1d8f-4371-b9e1-6007c07ed1d2"> |

Hover and cleared unreads behavior:

![masked-unread-hover-behavior](https://github.com/zulip/zulip/assets/170719/b17efb8c-ee36-48c0-a69f-3f8ecd3e4574)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>