### PR TITLE
emoji: Use individual emoji images instead of a sprite sheet.

### DIFF
--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -76,11 +76,11 @@ EMOJI_POS_INFO_TEMPLATE = """\
 }}
 """
 
-EMOJI_POS_INFO_OVERRIDE_TEMPLATE = """\
+EMOJI_OVERRIDE_TEMPLATE = """\
 .emoji-{codepoint} {{
-    background-image: url(~emoji-datasource-google/img/google/sheets-256/64.png) !important;
-    background-size: {background_size} !important;
-    background-position: {pos_x} {pos_y};
+    background-image: url(../../../static/generated/emoji/images-google-64/{codepoint}.png) !important;
+    background-position: 0% 0% !important;
+    background-size: contain !important;
 }}
 """
 
@@ -238,19 +238,14 @@ def generate_sprite_css_files(
     # fallback to Google Modern for any emoji not covered by Google Classic.
     if emojiset == "google-blob":
         extra_emoji_positions = ""
-        n = get_square_size(fallback_emoji_data)
-        background_size = percent(n)
         covered_emoji_codes = [
             get_emoji_code(emoji) for emoji in emoji_data if emoji["has_img_google"]
         ]
         for emoji in fallback_emoji_data:
             code = get_emoji_code(emoji)
             if emoji["has_img_google"] and code not in covered_emoji_codes:
-                extra_emoji_positions += EMOJI_POS_INFO_OVERRIDE_TEMPLATE.format(
+                extra_emoji_positions += EMOJI_OVERRIDE_TEMPLATE.format(
                     codepoint=code,
-                    pos_x=percent(emoji["sheet_x"] / (n - 1)),
-                    pos_y=percent(emoji["sheet_y"] / (n - 1)),
-                    background_size=background_size,
                 )
         with open(SPRITE_CSS_PATH, "a") as f:
             f.write(extra_emoji_positions)
@@ -270,11 +265,8 @@ def generate_sprite_css_files(
         for emoji in emoji_data:
             code = get_emoji_code(emoji)
             if emoji["has_img_google"] and code not in twitter_covered_emoji_codes:
-                extra_emoji_positions += EMOJI_POS_INFO_OVERRIDE_TEMPLATE.format(
+                extra_emoji_positions += EMOJI_OVERRIDE_TEMPLATE.format(
                     codepoint=code,
-                    pos_x=percent(emoji["sheet_x"] / (n - 1)),
-                    pos_y=percent(emoji["sheet_y"] / (n - 1)),
-                    background_size=background_size,
                 )
         with open(SPRITE_CSS_PATH, "a") as f:
             f.write(extra_emoji_positions)


### PR DESCRIPTION
CZO conversation:
https://chat.zulip.org/#narrow/stream/107-kandra/topic/emoji.20changes.20in.208.2E0/near/1690617

google blob:

<img width="469" alt="image" src="https://github.com/zulip/zulip/assets/5634097/a1aa3e7b-f679-45b2-a6e8-9d91293927b9">

google modern:

<img width="438" alt="image" src="https://github.com/zulip/zulip/assets/5634097/f9d1c385-5a63-4e64-885b-b578cd028457">


twitter:

<img width="449" alt="image" src="https://github.com/zulip/zulip/assets/5634097/3193569e-7e31-4e9c-965a-cf9cb261ea92">
