### PR TITLE
[WIP] remote_billing: Add flow for legacy servers.

### DIFF
--- a/corporate/lib/remote_billing_util.py
+++ b/corporate/lib/remote_billing_util.py
@@ -18,6 +18,12 @@ class RemoteBillingIdentityDict(TypedDict):
     remote_realm_uuid: str
 
 
+class LegacyServerIdentityDict(TypedDict):
+    # Currently this has only one field. We can extend this
+    # to add more information as appropriate.
+    remote_server_uuid: str
+
+
 def get_identity_dict_from_session(
     request: HttpRequest,
     realm_uuid: Optional[str],

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -16,6 +16,7 @@ from corporate.views.portico import (
     team_view,
 )
 from corporate.views.remote_billing_page import (
+    remote_billing_legacy_server_login,
     remote_billing_page_realm,
     remote_billing_page_server,
     remote_billing_plans_realm,
@@ -169,4 +170,9 @@ urlpatterns += [
     path("realm/<realm_uuid>/billing", remote_billing_page_realm, name="remote_billing_page_realm"),
     path("server/<server_uuid>/", remote_billing_page_server, name="remote_billing_page_server"),
     path("realm/<realm_uuid>/upgrade", remote_realm_upgrade_page, name="remote_realm_upgrade_page"),
+    path(
+        "serverlogin/",
+        remote_billing_legacy_server_login,
+        name="remote_billing_legacy_server_login",
+    ),
 ]

--- a/templates/corporate/legacy_server_login.html
+++ b/templates/corporate/legacy_server_login.html
@@ -1,0 +1,45 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "upgrade" %}
+
+{% set PAGE_TITLE = "Zulip server billing management" %}
+
+{% block portico_content %}
+
+<div class="register-account flex full-page server-login-page">
+    <div class="center-block new-style">
+        <div class="pitch">
+            <h1>Zulip server billing management</h1>
+        </div>
+        <div class="white-box">
+            {% if error_message %}
+            <div id="server-login-error" class="alert alert-danger">{{ error_message }}</div>
+            {% endif %}
+            <div id="server-login-input-section">
+                <form id="server-login-form" method="post" action="/serverlogin/">
+                    {{ csrf_input }}
+                    <div class="input-box server-login-form-field">
+                        <label for="username" class="inline-block label-title">
+                            server_org_id
+                            <a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html" target="_blank">
+                                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                            </a>
+                        </label>
+                        <input id="username" name="server_org_id" class="required" type="text"/>
+                    </div>
+                    <div class="input-box server-login-form-field">
+                        <label for="password" class="inline-block label-title">server_org_key</label>
+                        <input id="password" name="server_org_secret" class="required" type="password"/>
+                    </div>
+                    <div class="upgrade-button-container">
+                        <button type="submit" id="server-login-button" class="stripe-button-el invoice-button">
+                            <span class="server-login-button-text">Login</span>
+                            <img class="loader server-login-button-loader" src="{{ static('images/loading/loader-white.svg') }}" alt="" />
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/web/src/billing/legacy_server_login.ts
+++ b/web/src/billing/legacy_server_login.ts
@@ -1,0 +1,29 @@
+import $ from "jquery";
+
+export function initialize(): void {
+    $("#server-login-form").validate({
+        errorClass: "text-error",
+        wrapper: "div",
+        submitHandler(form) {
+            $("#server-login-form").find(".loader").css("display", "inline-block");
+            $("#server-login-button .server-login-button-text").hide();
+
+            form.submit();
+        },
+        invalidHandler() {
+            // this removes all previous errors that were put on screen
+            // by the server.
+            $("#server-login-form .alert.alert-error").remove();
+        },
+        showErrors(error_map) {
+            if (error_map.password) {
+                $("#server-login-form .alert.alert-error").remove();
+            }
+            this.defaultShowErrors!();
+        },
+    });
+}
+
+$(() => {
+    initialize();
+});

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -656,3 +656,16 @@ input[name="licenses"] {
     opacity: 0.8;
     font-weight: 400;
 }
+
+.server-login-button-loader {
+    display: none;
+    vertical-align: top;
+    position: relative;
+    height: 30px;
+    margin-top: -10px;
+    top: 5px;
+}
+
+#server-login-error {
+    text-align: center;
+}

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -26,6 +26,8 @@
         "./src/portico/tippyjs",
         "./src/billing/helpers",
         "./src/billing/upgrade",
+        "jquery-validation",
+        "./src/billing/legacy_server_login",
         "./styles/portico/billing.css"
     ],
     "billing-event-status": [


### PR DESCRIPTION
Missing tests, but they should be  easy once we agree this is roughly the way this is supposed to work.

Adds a flow for legacy servers that don't have `RemoteRealm` registrations.  At the end redirects to the dummy page that shows basic info, just like in #27575

The form's mechanism is mostly inspired by our login for at `/login/` 

Here's a screencast showing how it works, including an error. This is very crude and basic and we may want to open a follow-up issue for styling this properly?

[Screencast from 2023-11-29 21-35-15.webm](https://github.com/zulip/zulip/assets/45007152/1f8b837f-c3de-4caa-ba75-b096047f8f54)
