### PR TITLE
puppet: Change /etc/rabbitmq to be owned by rabbitmq.

### DIFF
--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -14,17 +14,32 @@ class zulip::profile::rabbitmq {
     ensure => absent,
   }
 
+
+  group { 'rabbitmq':
+    ensure => present,
+    system => true,
+  }
+  user { 'rabbitmq':
+    ensure  => present,
+    comment => 'RabbitMQ messaging server',
+    gid     => 'rabbitmq',
+    home    => '/var/lib/rabbitmq',
+    shell   => '/usr/sbin/nologin',
+    system  => true,
+    require => Group['rabbitmq'],
+  }
   file { '/etc/rabbitmq':
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-    before => Package['rabbitmq-server'],
+    ensure  => directory,
+    owner   => 'rabbitmq',
+    group   => 'rabbitmq',
+    mode    => '0755',
+    require => User['rabbitmq'],
+    before  => Package['rabbitmq-server'],
   }
   file { '/etc/rabbitmq/rabbitmq.config':
     ensure => file,
-    owner  => 'root',
-    group  => 'root',
+    owner  => 'rabbitmq',
+    group  => 'rabbitmq',
     mode   => '0644',
     source => 'puppet:///modules/zulip/rabbitmq/rabbitmq.config',
     # This config file must be installed before the package, so that
@@ -46,8 +61,8 @@ class zulip::profile::rabbitmq {
   }
   file { '/etc/rabbitmq/rabbitmq-env.conf':
     ensure => file,
-    owner  => 'root',
-    group  => 'root',
+    owner  => 'rabbitmq',
+    group  => 'rabbitmq',
     mode   => '0644',
     source => 'puppet:///modules/zulip/rabbitmq/rabbitmq-env.conf',
     before => Package['rabbitmq-server'],


### PR DESCRIPTION
The Ubuntu and Debian package installation scripts for `rabbitmq-server` install `/etc/rabbitmq` (and its contents) owned by the `rabbitmq` user -- not `root` as Puppet does.  This means that Puppet and `rabbitmq-server` unnecessarily fight over the ownership.

Create the `rabbitmq` user and group, to the same specifications that the Debian package install scripts do, so that we can properly declare the ownership of `/etc/rabbitmq`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
