### PR TITLE
message_view_header: Update tooltip when user is not logged in.

### DIFF
--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -11,8 +11,8 @@ import * as recent_view_util from "./recent_view_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
 
-function make_message_view_header(filter) {
-    const message_view_header = {};
+function get_message_view_header_context(filter) {
+    const context = {};
     if (recent_view_util.is_visible()) {
         return {
             title: $t({defaultMessage: "Recent conversations"}),
@@ -31,30 +31,30 @@ function make_message_view_header(filter) {
             zulip_icon: "all-messages",
         };
     }
-    message_view_header.title = filter.get_title();
-    message_view_header.is_spectator = page_params.is_spectator;
-    filter.add_icon_data(message_view_header);
+    context.title = filter.get_title();
+    context.is_spectator = page_params.is_spectator;
+    filter.add_icon_data(context);
     if (filter.has_operator("stream") && !filter._sub) {
-        message_view_header.sub_count = "0";
-        message_view_header.formatted_sub_count = "0";
-        message_view_header.rendered_narrow_description = $t({
+        context.sub_count = "0";
+        context.formatted_sub_count = "0";
+        context.rendered_narrow_description = $t({
             defaultMessage: "This stream does not exist or is private.",
         });
-        return message_view_header;
+        return context;
     }
     if (filter._sub) {
         // We can now be certain that the narrow
         // involves a stream which exists and
         // the current user can access.
         const current_stream = filter._sub;
-        message_view_header.rendered_narrow_description = current_stream.rendered_description;
+        context.rendered_narrow_description = current_stream.rendered_description;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
-        message_view_header.sub_count = sub_count;
-        message_view_header.stream = current_stream;
-        message_view_header.stream_settings_link =
+        context.sub_count = sub_count;
+        context.stream = current_stream;
+        context.stream_settings_link =
             "#streams/" + current_stream.stream_id + "/" + current_stream.name;
     }
-    return message_view_header;
+    return context;
 }
 
 export function colorize_message_view_header() {
@@ -66,12 +66,12 @@ export function colorize_message_view_header() {
     $("#message_view_header a.stream i").css("color", filter._sub.color);
 }
 
-function append_and_display_title_area(message_view_header_data) {
+function append_and_display_title_area(context) {
     const $message_view_header_elem = $("#message_view_header");
     $message_view_header_elem.empty();
-    const rendered = render_message_view_header(message_view_header_data);
+    const rendered = render_message_view_header(context);
     $message_view_header_elem.append(rendered);
-    if (message_view_header_data.stream_settings_link) {
+    if (context.stream_settings_link) {
         colorize_message_view_header();
     }
     $message_view_header_elem.removeClass("notdisplayed");
@@ -89,8 +89,8 @@ function build_message_view_header(filter) {
         search.open_search_bar_and_close_narrow_description();
         $("#search_query").val(narrow_state.search_string());
     } else {
-        const message_view_header_data = make_message_view_header(filter);
-        append_and_display_title_area(message_view_header_data);
+        const context = get_message_view_header_context(filter);
+        append_and_display_title_area(context);
         search.close_search_bar_and_open_narrow_description();
     }
 }

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -5,6 +5,7 @@ import render_message_view_header from "../templates/message_view_header.hbs";
 import {$t} from "./i18n";
 import * as inbox_util from "./inbox_util";
 import * as narrow_state from "./narrow_state";
+import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as recent_view_util from "./recent_view_util";
 import * as rendered_markdown from "./rendered_markdown";
@@ -31,6 +32,7 @@ function make_message_view_header(filter) {
         };
     }
     message_view_header.title = filter.get_title();
+    message_view_header.is_spectator = page_params.is_spectator;
     filter.add_icon_data(message_view_header);
     if (filter.has_operator("stream") && !filter._sub) {
         message_view_header.sub_count = "0";

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -5,9 +5,11 @@
 <template id="stream-details-tooltip-template">
     <div>
         <div>{{t "Go to stream settings" }}</div>
+        {{#unless is_spectator}}
         <div class="tooltip-inner-content italic">
             {{t "This stream has {sub_count, plural, =0 {no subscribers} one {# subscriber} other {# subscribers}}." }}
         </div>
+        {{/unless}}
     </div>
 </template>
 <span class="narrow_description rendered_markdown">


### PR DESCRIPTION
This PR encompasses the following changes:
1. Hide the subscriber count on the message view header tooltip for spectators, since this information is not available to such users.
2. Rename the variables `message_view_header` and `message_view_header_data` with `context`. We also rename the function `make_message_view_header` with `get_message_view_header_context`.

Fixes: We used to show "_This stream has no subscribers_" to the guest user, when it reality the subscriber count was unavailable.

CZO discussion: [Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20weird.20stream.20tooltip.20for.20logged.20out.20users/near/1691644)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Tooltip for a spectator
![image](https://github.com/zulip/zulip/assets/82862779/2e63d227-b22e-42c7-94b1-d7491187cff7)

- Tooltip for a logged-in user
![image](https://github.com/zulip/zulip/assets/82862779/6181a07d-4cbc-43cf-8715-8c2c977ded1d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
