### PR TITLE
left_sidebar: Adjust STREAMS header grid for spectators.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1302,6 +1302,23 @@ li.topic-list-item {
     }
 }
 
+/* Prepare an adjusted grid for the logged-out state,
+   one that reassigns the vdots space to markers and
+   controls. */
+.spectator-view #streams_header {
+    grid-template-columns: 0 0 minmax(0, 1fr) minmax(30px, max-content) 0 12px;
+
+    /* With markers and controls now sized the same
+       as the ordinary vdots area (but allowed to grow,
+       care of `minmax(30px, max-content)`, should
+       additional logged-out icons be added in the
+       future), let's center the icon in that area,
+       just like vdots would be. */
+    .heading-markers-and-controls {
+        justify-content: center;
+    }
+}
+
 .streams_subheader {
     font-size: 0.8em;
     font-weight: normal;


### PR DESCRIPTION
This PR redefines the STREAMS header grid and centers the lone filter icon in the space ordinarily reserved for vdots, which aren't present for spectators.

[CZO discussion
](https://chat.zulip.org/#narrow/stream/101-design/topic/filter.20location.20on.20Streams.20row.20.28logged.20out.29/near/1691673)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="550" alt="streams-spectator-before" src="https://github.com/zulip/zulip/assets/170719/cce9709b-6b86-41af-a904-d16803f3c6ae"> | <img width="550" alt="streams-spectator-after" src="https://github.com/zulip/zulip/assets/170719/335f59ac-7908-4274-a50e-d543a1f97bd2"> |
| <img width="550" alt="streams-spectator-before-showing-grid" src="https://github.com/zulip/zulip/assets/170719/9fc75dc8-9c5a-40da-8d4a-5add9d270612"> | <img width="550" alt="streams-spectator-after-showing-grid" src="https://github.com/zulip/zulip/assets/170719/d47d17df-16e7-4abf-9e4e-a5779c78d63f"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>