### PR TITLE
nagios: Use a better index on UserActivity for zephyr alerting.

### DIFF
--- a/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
+++ b/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
@@ -9,7 +9,7 @@ Django ORM.
 import datetime
 import os
 import sys
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 sys.path.append("/home/zulip/deployments/current")
 from scripts.lib.setup_path import setup_path
@@ -17,6 +17,7 @@ from scripts.lib.setup_path import setup_path
 setup_path()
 
 import django
+from django.db.models import QuerySet
 from django.utils.timezone import now as timezone_now
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
@@ -25,9 +26,9 @@ sys.path.append("/home/zulip/deployments/current/zerver")
 
 django.setup()
 
-from typing import AbstractSet, Any, Dict
+from typing import Dict
 
-from zerver.models import UserActivity
+from zerver.models import UserActivity, get_client
 
 states: Dict[str, int] = {
     "OK": 0,
@@ -40,15 +41,26 @@ state_file_path = "/var/lib/nagios_state/check_user_zephyr_mirror_liveness"
 now = timezone_now()
 
 
-def report(state: str, short_msg: str, too_old: AbstractSet[Any] = set()) -> NoReturn:
+def report(
+    state: str, short_msg: str, all_users: Optional[QuerySet[UserActivity]] = None
+) -> NoReturn:
     too_old_data = ""
-    if too_old:
+    if all_users is not None:
+        recently_inactive_users = (
+            all_users.filter(last_visit__lt=now - datetime.timedelta(minutes=10))
+            .distinct("user_profile_id")
+            .difference(
+                all_users.filter(last_visit__lt=now - datetime.timedelta(minutes=60)).distinct(
+                    "user_profile_id"
+                )
+            )
+        )
         too_old_data = "\nLast call to get_message for recently out of date mirrors:\n" + "\n".join(
             "{:>16}: {}".format(
                 user.user_profile.email,
                 user.last_visit.strftime("%Y-%m-%d %H:%M %Z"),
             )
-            for user in too_old
+            for user in recently_inactive_users
         )
 
     with open(state_file_path + ".tmp", "w") as f:
@@ -58,18 +70,35 @@ def report(state: str, short_msg: str, too_old: AbstractSet[Any] = set()) -> NoR
     sys.exit(states[state])
 
 
+zephyr_client = get_client("zephyr_mirror")
 all_users = UserActivity.objects.filter(
-    query__in=["get_events", "/api/v1/events"], client__name="zephyr_mirror"
+    # We need to use the client_id so we can use the partial index we
+    # have created, which builds in both the query and the client_id.
+    # The partial index is:
+    # CREATE INDEX CONCURRENTLY zerver_useractivity_zehpyr_liveness
+    #     ON zerver_useractivity(last_visit)
+    #  WHERE client_id = 1005
+    #    AND query IN ('get_events', '/api/v1/events');
+    query__in=["get_events", "/api/v1/events"],
+    client_id=zephyr_client.id,
 )
-new_inactive_users = [
-    user for user in all_users if user.last_visit < now - datetime.timedelta(minutes=10)
-]
-old_inactive_users = [
-    user for user in new_inactive_users if user.last_visit < now - datetime.timedelta(minutes=60)
-]
-recently_inactive_users = set(new_inactive_users) - set(old_inactive_users)
+new_inactive_users = (
+    all_users.filter(last_visit__lt=now - datetime.timedelta(minutes=10))
+    .values("user_profile_id")
+    .distinct("user_profile_id")
+    .count()
+)
 
-if (len(recently_inactive_users) / float(len(old_inactive_users))) > 0.25:
-    report("CRITICAL", "Many mirrors recently became inactive", recently_inactive_users)
+old_inactive_users = (
+    all_users.filter(last_visit__lt=now - datetime.timedelta(minutes=60))
+    .values("user_profile_id")
+    .distinct("user_profile_id")
+    .count()
+)
+
+recently_inactive_users = new_inactive_users - old_inactive_users
+
+if recently_inactive_users / float(old_inactive_users) > 0.25:
+    report("CRITICAL", "Many mirrors recently became inactive", all_users)
 else:
     report("OK", "Most mirrors that were recently active continue to be active")


### PR DESCRIPTION
Limiting only by client_name and query leads to a very poorly-indexed lookup on `query` which throws out nearly all of its rows:

```
Nested Loop  (cost=50885.64..60522.96 rows=821 width=8)
  ->  Index Scan using zerver_client_name_key on zerver_client  (cost=0.28..2.49 rows=1 width=4)
        Index Cond: ((name)::text = 'zephyr_mirror'::text)
  ->  Bitmap Heap Scan on zerver_useractivity  (cost=50885.37..60429.95 rows=9052 width=12)
        Recheck Cond: ((client_id = zerver_client.id) AND ((query)::text = ANY ('{get_events,/api/v1/events}'::text[])))
        ->  BitmapAnd  (cost=50885.37..50885.37 rows=9052 width=0)
              ->  Bitmap Index Scan on zerver_useractivity_2bfe9d72  (cost=0.00..16631.82 rows=..large.. width=0)
                    Index Cond: (client_id = zerver_client.id)
              ->  Bitmap Index Scan on zerver_useractivity_1b1cc7f0  (cost=0.00..34103.95 rows=..large.. width=0)
                    Index Cond: ((query)::text = ANY ('{get_events,/api/v1/events}'::text[]))
```

A partial index on the client and query list is extremely effective here in reducing PostgreSQL's workload; however, we cannot easily write it as a migration, since it depends on the value of the ID of the `zephyr_mirror` client.

Since this is only relevant for Zulip Cloud, we manually create the index:

```sql
CREATE INDEX CONCURRENTLY zerver_useractivity_zehpyr_liveness
    ON zerver_useractivity(last_visit)
 WHERE client_id = 1005
   AND query IN ('get_events', '/api/v1/events');
```

We rewrite the query to do the time limit, distinct, and count in SQL, instead of Python, and make use of this index.  This turns a 20-second query into two 10ms queries.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
