### PR TITLE
stream_traffic: Use the realm_id to get a much better-indexed query.

### DIFF
--- a/zerver/lib/stream_traffic.py
+++ b/zerver/lib/stream_traffic.py
@@ -9,18 +9,21 @@ from analytics.models import StreamCount
 from zerver.models import Realm
 
 
-def get_streams_traffic(
-    stream_ids: Set[int], realm: Optional[Realm] = None
-) -> Optional[Dict[int, int]]:
-    if realm is not None and realm.is_zephyr_mirror_realm:
+def get_streams_traffic(stream_ids: Set[int], realm: Realm) -> Optional[Dict[int, int]]:
+    if realm.is_zephyr_mirror_realm:
         # We do not need traffic data for streams in zephyr mirroring realm.
         return None
 
     stat = COUNT_STATS["messages_in_stream:is_bot:day"]
     traffic_from = timezone_now() - datetime.timedelta(days=28)
 
-    query = StreamCount.objects.filter(property=stat.property, end_time__gt=traffic_from)
-    query = query.filter(stream_id__in=stream_ids)
+    query = StreamCount.objects.filter(
+        # The realm_id is important, as it makes this significantly better-indexed
+        realm_id=realm.id,
+        stream_id__in=stream_ids,
+        property=stat.property,
+        end_time__gt=traffic_from,
+    )
 
     traffic_list = query.values("stream_id").annotate(value=Sum("value"))
     traffic_dict = {}

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -370,7 +370,7 @@ class TestRealmAuditLog(ZulipTestCase):
         stream = self.make_stream(stream_name, realm)
         stream_ids = {stream.id}
 
-        result = get_streams_traffic(stream_ids)
+        result = get_streams_traffic(stream_ids, realm)
         self.assertEqual(result, {})
 
         StreamCount.objects.create(
@@ -381,7 +381,7 @@ class TestRealmAuditLog(ZulipTestCase):
             value=999,
         )
 
-        result = get_streams_traffic(stream_ids)
+        result = get_streams_traffic(stream_ids, realm)
         self.assertEqual(result, {stream.id: 999})
 
     def test_subscriptions(self) -> None:


### PR DESCRIPTION
This reduces the query time by an order of magnitude, since it is able to switch from a raw `stream_id` index to an index over all of `realm_id, property, end_time`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
