### PR TITLE
zulip-icons: Use WOFF2 format for icon font

### DIFF
--- a/web/images/icons/zulip-icons.font.js
+++ b/web/images/icons/zulip-icons.font.js
@@ -12,4 +12,5 @@ module.exports = {
     baseSelector: ".zulip-icon",
     cssTemplate: "./template.hbs",
     ligature: false,
+    types: ["woff2"], // https://github.com/jeerbl/webfonts-loader/pull/219
 };


### PR DESCRIPTION
We’re currently generating the icon font in five formats: Embedded OpenType, WOFF, WOFF2, TrueType, and SVG. But they’re [misordered](https://github.com/jeerbl/webfonts-loader/pull/219) by webfonts-loader such that modern browsers always select the WOFF version. WOFF2 is [supported](https://caniuse.com/woff2) by all modern browsers, so just use that exclusively.

(The [EOT](https://caniuse.com/eot) and [SVG font](https://caniuse.com/svg-fonts) formats are obsolete and no longer supported.)