### PR TITLE
remote_billing: Implement a redirection flow for unauthed users.

### DIFF
--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -110,7 +110,7 @@ def authenticated_remote_realm_management_endpoint(
     return _wrapped_view_func
 
 
-def get_next_page_param_from_request_path(request: HttpRequest) -> Optional[str]:  # nocoverage
+def get_next_page_param_from_request_path(request: HttpRequest) -> Optional[str]:
     # Our endpoint URLs in this subsystem end with something like
     # /sponsorship or /plans etc.
     # Therefore we can use this nice property to figure out easily what

--- a/corporate/lib/remote_billing_util.py
+++ b/corporate/lib/remote_billing_util.py
@@ -137,7 +137,7 @@ def get_remote_server_from_session(
     )
 
     if identity_dict is None:
-        raise JsonableError(_("User not authenticated"))
+        raise RemoteBillingAuthenticationError
 
     remote_server_uuid = identity_dict["remote_server_uuid"]
     try:

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -55,6 +55,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
             remote_server_uuid=str(self.server.uuid),
             remote_realm_uuid=str(user.realm.uuid),
             authenticated_at=datetime_to_timestamp(now),
+            uri_scheme="http://",
             next_page=next_page,
         )
         self.assertEqual(
@@ -152,13 +153,81 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         self.assert_in_success_response([desdemona.delivery_email], result)
 
         # Now go there again, simulating doing this after the session has expired.
-        # We should be denied access.
+        # We should be denied access and redirected to re-auth.
         with time_machine.travel(
             now + datetime.timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 1),
             tick=False,
         ):
             result = self.client_get(final_url, subdomain="selfhosting")
-        self.assert_json_error(result, "User not authenticated")
+
+            self.assertEqual(result.status_code, 302)
+            self.assertEqual(
+                result["Location"],
+                f"http://{desdemona.realm.host}/self-hosted-billing/?next_page=plans",
+            )
+
+            # Opening this re-auth URL in result["Location"] is same as re-doing the auth
+            # flow via execute_remote_billing_authentication_flow with next_page="plans".
+            # So let's test that and assert that we end up successfully re-authed on the /plans
+            # page.
+            result = self.execute_remote_billing_authentication_flow(desdemona, next_page="plans")
+            self.assertEqual(result["Location"], f"/realm/{realm.uuid!s}/plans")
+            result = self.client_get(result["Location"], subdomain="selfhosting")
+            self.assert_in_success_response(["Your remote user info:"], result)
+            self.assert_in_success_response([desdemona.delivery_email], result)
+
+    @responses.activate
+    def test_remote_billing_unauthed_access(self) -> None:
+        now = timezone_now()
+        self.login("desdemona")
+        desdemona = self.example_user("desdemona")
+        realm = desdemona.realm
+
+        self.add_mock_response()
+        send_realms_only_to_push_bouncer()
+
+        # Straight-up access without authing at all:
+        result = self.client_get(f"/realm/{realm.uuid!s}/plans", subdomain="selfhosting")
+        self.assert_json_error(result, "User not authenticated", 401)
+
+        result = self.execute_remote_billing_authentication_flow(desdemona)
+        self.assertEqual(result["Location"], f"/realm/{realm.uuid!s}/plans")
+
+        final_url = result["Location"]
+
+        # Sanity check - access is granted after authing:
+        result = self.client_get(final_url, subdomain="selfhosting")
+        self.assertEqual(result.status_code, 200)
+
+        # Now mess with the identity dict in the session in unlikely ways so that it should
+        # not grant access.
+        # First delete the RemoteRealm entry for this session.
+        RemoteRealm.objects.filter(uuid=realm.uuid).delete()
+
+        with self.assertLogs("django.request", "ERROR") as m, self.assertRaises(AssertionError):
+            self.client_get(final_url, subdomain="selfhosting")
+        self.assertIn(
+            "The remote realm is missing despite being in the RemoteBillingIdentityDict",
+            m.output[0],
+        )
+
+        # Try the case where the identity dict is simultaneously expired.
+        with time_machine.travel(
+            now + datetime.timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 30),
+            tick=False,
+        ):
+            with self.assertLogs("django.request", "ERROR") as m, self.assertRaises(AssertionError):
+                self.client_get(final_url, subdomain="selfhosting")
+        # The django.request log should be a traceback, mentioning the relevant
+        # exceptions that occurred.
+        self.assertIn(
+            "RemoteBillingIdentityExpiredError",
+            m.output[0],
+        )
+        self.assertIn(
+            "AssertionError",
+            m.output[0],
+        )
 
     @responses.activate
     def test_remote_billing_authentication_flow_to_sponsorship_page(self) -> None:

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 
 from django.conf import settings
 from django.core import signing
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.crypto import constant_time_compare
@@ -242,6 +242,10 @@ def remote_billing_legacy_server_login(
             "corporate/legacy_server_login.html",
             context={"error_message": False},
         )
+
+    # The form must be submitted via POST.
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
 
     try:
         remote_server = get_remote_server_by_uuid(server_org_id)

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -14,6 +14,7 @@ from pydantic import Json
 
 from corporate.lib.decorator import (
     authenticated_remote_realm_management_endpoint,
+    authenticated_remote_server_management_endpoint,
     self_hosting_management_endpoint,
 )
 from corporate.lib.remote_billing_util import (
@@ -23,12 +24,12 @@ from corporate.lib.remote_billing_util import (
     RemoteBillingUserDict,
     get_identity_dict_from_session,
 )
-from corporate.lib.stripe import RemoteRealmBillingSession
+from corporate.lib.stripe import RemoteRealmBillingSession, RemoteServerBillingSession
 from zerver.lib.exceptions import JsonableError, MissingRemoteRealmError
 from zerver.lib.remote_server import RealmDataForAnalytics, UserDataForRemoteBilling
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
+from zerver.lib.typed_endpoint import typed_endpoint
 from zilencer.models import RemoteRealm, RemoteZulipServer, get_remote_server_by_uuid
 
 billing_logger = logging.getLogger("corporate.stripe")
@@ -208,9 +209,11 @@ def remote_realm_plans_page(
     return remote_billing_plans_common(request, realm_uuid=realm_uuid, server_uuid=None)
 
 
-@self_hosting_management_endpoint
-@typed_endpoint
-def remote_server_plans_page(request: HttpRequest, *, server_uuid: PathOnly[str]) -> HttpResponse:
+@authenticated_remote_server_management_endpoint
+def remote_server_plans_page(
+    request: HttpRequest, billing_session: RemoteServerBillingSession
+) -> HttpResponse:
+    server_uuid = str(billing_session.remote_server.uuid)
     return remote_billing_plans_common(request, server_uuid=server_uuid, realm_uuid=None)
 
 

--- a/templates/corporate/legacy_server_login.html
+++ b/templates/corporate/legacy_server_login.html
@@ -17,6 +17,9 @@
             <div id="server-login-input-section">
                 <form id="server-login-form" method="post" action="/serverlogin/">
                     {{ csrf_input }}
+                    {% if next_page %}
+                    <input type="hidden" name="next_page" value="{{ next_page }}" />
+                    {% endif %}
                     <div class="input-box server-login-form-field">
                         <label for="username" class="inline-block label-title">
                             server_org_id

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -49,6 +49,7 @@ class ErrorCode(Enum):
     MISSING_REMOTE_REALM = auto()
     TOPIC_WILDCARD_MENTION_NOT_ALLOWED = auto()
     STREAM_WILDCARD_MENTION_NOT_ALLOWED = auto()
+    REMOTE_BILLING_UNAUTHENTICATED_USER = auto()
 
 
 class JsonableError(Exception):
@@ -443,6 +444,22 @@ class MissingAuthenticationError(JsonableError):
 
     # No msg_format is defined since this exception is caught and
     # converted into json_unauthorized in Zulip's middleware.
+
+
+class RemoteBillingAuthenticationError(JsonableError):
+    # We want this as a distinct class from MissingAuthenticationError,
+    # as we don't want the json_unauthorized conversion mechanism to apply
+    # to this.
+    code = ErrorCode.REMOTE_BILLING_UNAUTHENTICATED_USER
+    http_status_code = 401
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("User not authenticated")
 
 
 class InvalidSubdomainError(JsonableError):

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -148,6 +148,11 @@ def self_hosting_auth_redirect(
     post_data = {
         "user": user_info.model_dump_json(),
         "realm": realm_info.model_dump_json(),
+        # The uri_scheme is necessary for the bouncer to know the correct URL
+        # to redirect the user to for re-authing in case the session expires.
+        # Otherwise, the bouncer would know only the realm.host but be missing
+        # the knowledge of whether to use http or https.
+        "uri_scheme": settings.EXTERNAL_URI_SCHEME,
     }
     if next_page is not None:
         post_data["next_page"] = next_page


### PR DESCRIPTION
Edit: the PR message below is outdated, it's from the original approach to this for just the RemoteRealm flow. See the message on `remote_billing: Add redirect flow for users with expired session` and `remote_billing: Add redirects to login for unauthed user in legacy flow` for descriptions of their mechanism

------
Implements a nice redirect flow to give a good UX for users attempting to access a remote billing page without a valid session e.g. `/realm/some-uuid/sponsorship` unauthed - perhaps through their browser history or just their session expired while they were doing things in this billing system.

The logic has two pieces:
1. `get_remote_realm_from_session`, if the user doesn't have a valid identity_dict will raise `MissingAuthenticationError`.
2. The decorator `authenticated_remote_realm_management_endpoint` catches that exception and uses some general logic, described in more detail in the comments in the code, to figure out the right URL to redirect them to. Something like: `https://theirserver.example.com/self-hosted-billing/?next_page=...` where the `next_page` param is determined based on parsing `request.path` to see what kind of endpoint they're trying to access.

Remaining TODOs before this commit can reasonably be merged:
- [] Tests, because this logic can be fragile.
- [] Apply the `authenticated_remote_realm_management_endpoint decorator` to the little endpoints like `remote_billing_page_realm` in `corporate/views/remote_billing_page.py`.

If this mechanism looks good, we'll want to replicate it for the legacy server flow as well.

Here's a screencast showing this working - I try to access a remote realm's /sponsorship page without a session, and I get smoothly redirected to re-auth:
[Screencast from 2023-12-01 02-32-30.webm](https://github.com/zulip/zulip/assets/45007152/7ca619ad-53c9-4043-8f2d-fd0cde59a4d3)
![image](https://github.com/zulip/zulip/assets/45007152/1fd4b53d-0689-405d-8829-46550916ef3e)


Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
