### PR TITLE
notifications: Revert API changes for push_notifications_enabled.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,13 +20,6 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
-**Feature level 231**
-
-* [`GET /server_settings`](/api/get-server-settings): Renamed
-`push_notifications_enabled` to `push_notifications_configured`
- as it doesn't actually check if push notifications are working,
- just whether there is configuration for them.
-
 **Feature level 230**
 
 * [`GET /events`](/api/get-events): Added `has_trigger` field in

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 231
+API_FEATURE_LEVEL = 230
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15624,13 +15624,10 @@ paths:
                           This will be `""` if unavailable.
 
                           **Changes**: New in Zulip 5.0 (feature level 88).
-                      push_notifications_configured:
+                      push_notifications_enabled:
                         type: boolean
                         description: |
                           Whether mobile/push notifications are configured.
-
-                          **Changes**: In Zulip 8.0 (feature level 231), renamed
-                          `push_notifications_enabled` to `push_notifications_configured`.
                       is_incompatible:
                         type: boolean
                         description: |
@@ -15701,7 +15698,7 @@ paths:
                           },
                         "zulip_version": "5.0-dev-1650-gc3fd37755f",
                         "zulip_merge_base": "5.0-dev-1646-gea6b21cd8c",
-                        "push_notifications_configured": false,
+                        "push_notifications_enabled": false,
                         "msg": "",
                         "is_incompatible": false,
                         "email_auth_enabled": true,

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5248,7 +5248,7 @@ class FetchAuthBackends(ZulipTestCase):
                     ("zulip_version", check_string),
                     ("zulip_merge_base", check_string),
                     ("zulip_feature_level", check_int),
-                    ("push_notifications_configured", check_bool),
+                    ("push_notifications_enabled", check_bool),
                     ("realm_web_public_access_enabled", check_bool),
                     ("msg", check_string),
                     ("result", check_string),

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -1109,7 +1109,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
         zulip_version=ZULIP_VERSION,
         zulip_merge_base=ZULIP_MERGE_BASE,
         zulip_feature_level=API_FEATURE_LEVEL,
-        push_notifications_configured=push_notifications_configured(),
+        push_notifications_enabled=push_notifications_configured(),
         is_incompatible=check_server_incompatibility(request),
     )
     context = zulip_default_context(request)


### PR DESCRIPTION
This PR reverts the API changes in 56ec1c2.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
