### PR TITLE
realms: Call send_realms_only_to_push_bouncer at realm creation/import.

### DIFF
--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -14,6 +14,7 @@ from zerver.actions.realm_settings import (
     do_deactivate_realm,
 )
 from zerver.lib.bulk_create import create_users
+from zerver.lib.remote_server import enqueue_register_realm_with_push_bouncer_if_needed
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
 from zerver.lib.streams import ensure_stream, get_signups_stream
 from zerver.lib.user_groups import (
@@ -264,6 +265,8 @@ def do_create_realm(
                 for backend_name in all_implemented_backend_names()
             ]
         )
+
+    enqueue_register_realm_with_push_bouncer_if_needed(realm)
 
     # Create stream once Realm object has been saved
     notifications_stream = ensure_stream(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -27,6 +27,7 @@ from zerver.lib.export import DATE_FIELDS, Field, Path, Record, TableData, Table
 from zerver.lib.markdown import markdown_convert
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import get_last_message_id
+from zerver.lib.remote_server import enqueue_register_realm_with_push_bouncer_if_needed
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
 from zerver.lib.streams import render_stream_description
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -1017,6 +1018,8 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
 
         if "zerver_usergroup" not in data:
             set_default_for_realm_permission_group_settings(realm)
+
+    enqueue_register_realm_with_push_bouncer_if_needed(realm)
 
     # Remap the user IDs for notification_bot and friends to their
     # appropriate IDs on this server

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import shutil
 import uuid
@@ -10,6 +11,7 @@ import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Q, QuerySet
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -1387,6 +1389,25 @@ class RealmImportExportTest(ExportFile):
         realm_user_default = RealmUserDefault.objects.get(realm=imported_realm)
         self.assertEqual(realm_user_default.default_language, "en")
         self.assertEqual(realm_user_default.twenty_four_hour_time, False)
+
+    @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
+    def test_import_realm_notify_bouncer(self) -> None:
+        original_realm = Realm.objects.get(string_id="zulip")
+
+        self.export_realm(original_realm)
+
+        with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"), patch(
+            "zerver.lib.remote_server.send_to_push_bouncer"
+        ) as m:
+            new_realm = do_import_realm(get_output_dir(), "test-zulip")
+
+        self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
+        calls_args_for_assert = m.call_args_list[0][0]
+        self.assertEqual(calls_args_for_assert[0], "POST")
+        self.assertEqual(calls_args_for_assert[1], "server/analytics")
+        self.assertIn(
+            new_realm.id, [realm["id"] for realm in json.loads(m.call_args_list[0][0][2]["realms"])]
+        )
 
     def test_import_files_from_local(self) -> None:
         user = self.example_user("hamlet")


### PR DESCRIPTION
Queues up an order to `deferred_work` to call `send_realms_only_to_push_bouncer()` in:
1. `do_create_realm`
2. `do_import_realm`