### PR TITLE
left_sidebar: Remove tabindex from correct home-view element.

### DIFF
--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -189,8 +189,8 @@ export function highlight_all_messages_view() {
 function handle_home_view_order(home_view) {
     // Remove class and tabindex from current home view
     const $current_home_view = $(".selected-home-view");
-    $current_home_view.removeAttr("tabindex");
     $current_home_view.removeClass("selected-home-view");
+    $current_home_view.find("a").removeAttr("tabindex");
 
     const $all_messages_rows = $(".top_left_all_messages");
     const $recent_views_rows = $(".top_left_recent_view");


### PR DESCRIPTION
This corrects a small oversight from #27501, where the tabindex on a previous home view wasn't removed from the correct element. This also reorders the class and tabindex removal to match the comment above.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>