### PR TITLE
top_navbar: Contain stream, description elements.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2285,6 +2285,17 @@ div.focused-message-list {
     }
 }
 
+.top-navbar-container {
+    /* Calculate right margin so that title and description
+       elements can truncate and not collide with or run underneath
+       with the search section. */
+    margin-right: calc(
+        var(--search-box-width) + var(--navbar-content-righthand-offset)
+    );
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 #message_view_header {
     color: var(--color-text-message-view-header);
     z-index: 2;
@@ -2310,8 +2321,6 @@ div.focused-message-list {
         text-overflow: ellipsis;
         color: inherit;
         text-decoration: none;
-        /* Don't yield any space needed for the stream name. */
-        flex-shrink: 0;
         /* Create a flex container for the icon and
            stream name. */
         display: flex;
@@ -2362,6 +2371,8 @@ div.focused-message-list {
     }
 
     .message-header-navbar-title {
+        /* Allow long navbar titles (e.g., stream names) to collapse. */
+        flex: 0 1 auto;
         overflow: hidden;
         text-overflow: ellipsis;
     }
@@ -2378,7 +2389,6 @@ div.focused-message-list {
         font-size: 14px;
         color: inherit;
         font-weight: 400;
-        padding: 0 6px;
         padding-left: 10px;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -2395,11 +2405,6 @@ div.focused-message-list {
     .narrow_description {
         flex: 1 1 0;
         margin: 0;
-        /* Calculate right margin so that text can truncate
-           and not collide with the search section. */
-        margin-right: calc(
-            var(--search-box-width) + var(--navbar-content-righthand-offset)
-        );
     }
 }
 


### PR DESCRIPTION
This fixes the display of long stream names and stream descriptions in the top navbar, allowing both to take an ellipsis (previously, only descriptions did so correctly) and preventing either from running underneath the search bar and peaking out the other side.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/narrow.20screen.20long.20stream.20name/near/1688951)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![navbar-stream-name-before](https://github.com/zulip/zulip/assets/170719/9ba70b48-c6bd-4374-804a-a551e6502b72) | ![navbar-stream-name-after](https://github.com/zulip/zulip/assets/170719/fb4e94e5-9a6e-4eed-84a3-303b015db3e7) |

Showing responsive behavior:

![collapsing-navbar-streams](https://github.com/zulip/zulip/assets/170719/35e966af-6cba-4d01-b060-518ffbe436de)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
