### PR TITLE
message_edit: Don't hide spinner on save success.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1040,7 +1040,13 @@ export function save_message_row_edit($row) {
                 delete message.local_edit_timestamp;
                 currently_echoing_messages.delete(message_id);
             }
-            hide_message_edit_spinner($row);
+            // Ordinarily, in a code path like this, we'd make
+            // a call to `hide_message_edit_spinner()`. But in
+            // this instance, we want to avoid a momentary flash
+            // of the Save button text before the edited message
+            // re-renders. Note that any subsequent editing will
+            // create a fresh Save button, without the spinner
+            // class attached.
         },
         error(xhr) {
             if (msg_list === message_lists.current) {


### PR DESCRIPTION
Hiding the spinner confusingly flashes the Save button before the edit view closes. This just prevents that from happening, so that the sign of success is the rendered, edited message.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20.22Save.22.20button.20states/near/1692911)

**Screenshots and screen captures:**

Spinner remains until the message-edit form closes:

![spin-until-close](https://github.com/zulip/zulip/assets/170719/cc13b338-0a1e-4109-9b69-0abb2d8b9f74)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>