### PR TITLE
help: Update documentation on followed topics in recent conversations.

### DIFF
--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -8,15 +8,17 @@ or participate in. Participating in a topic means sending a message,
 
 It's easy to prioritize catching up on followed topics. You can:
 
-- Configure how you get notified about new messages for topics you follow.
+- [Configure](/help/follow-a-topic#configure-notifications-for-followed-topics)
+  how you get notified about new messages for topics you follow.
 
-- Use the <kbd>Shift</kbd> + <kbd>N</kbd> keyboard shortcut to go to the next
-  unread followed topic.
+- Use the <kbd>Shift</kbd> + <kbd>N</kbd> [keyboard
+  shortcut](/help/keyboard-shortcuts) to go to the next unread followed topic.
 
-- Filter the [**inbox**](/help/inbox) view to only show followed topics.
+- Filter the [**inbox**](/help/inbox) and [**recent
+  conversations**](/help/recent-conversations) views to only show followed
+  topics.
 
-- See which topics you are following in the **left sidebar** and [**recent
-  conversations**](/help/recent-conversations).
+- See which topics you are following in the **left sidebar**.
 
 You can use followed topics for a variety of workflows:
 


### PR DESCRIPTION
Notes:

- This PR documents that recent conversations has a "followed" filter now.
- Also adds a few links.
- We don't list specific filters on the recent conversations page, since we plan to revamp them. So don't have to update anything there.
- I kept the section recommending using Inbox for catching up on followed topics as-is.


Current: https://zulip.com/help/follow-a-topic

Updated:


<img width="541" alt="Screenshot 2023-12-03 at 12 17 46 PM" src="https://github.com/zulip/zulip/assets/2090066/700f0adc-579e-4cc0-aee4-0af0d9e6c1a6">
