### PR TITLE
Add support for overriding development environment settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /zproject/apns-dev.pem
 /zproject/apns-dev-key.p8
 /zproject/dev-secrets.conf
+/zproject/custom_dev_settings.py
 /tools/conf.ini
 /tools/custom_provision
 /tools/droplets/conf.ini

--- a/docs/subsystems/settings.md
+++ b/docs/subsystems/settings.md
@@ -110,6 +110,14 @@ additionally:
   You can see a full list with `git grep development_only=True`, or
   add additional settings of this form if needed.
 
+- If you need to override a setting in your development environment,
+  you can do so by creating a `zproject/custom_dev_settings.py`
+  setting the values you'd like to override (the test suites ignore
+  this file). This optional file is processed just after
+  `dev_settings.py` in `configured_settings.py`, so
+  `zproject/computed_settings.py` will correctly use your custom
+  settings when calculating any computed settings that depend on them.
+
 - `zproject/test_settings.py` imports everything from
   `zproject/settings.py` and `zproject/test_extra_settings.py`.
 

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -101,8 +101,6 @@ else:
 
 
 # This is overridden in test_settings.py for the test suites
-TEST_SUITE = False
-# This is overridden in test_settings.py for the test suites
 PUPPETEER_TESTS = False
 # This is overridden in test_settings.py for the test suites
 RUNNING_OPENAPI_CURL_TEST = False

--- a/zproject/configured_settings.py
+++ b/zproject/configured_settings.py
@@ -2,6 +2,8 @@
 # DEFAULT VALUES FOR SETTINGS
 ########################################################################
 
+import os
+
 # For any settings that are not set in the site-specific configuration file
 # (/etc/zulip/settings.py in production, or dev_settings.py or test_settings.py
 # in dev and test), we want to initialize them to sane defaults.
@@ -10,6 +12,8 @@ from .default_settings import *  # noqa: F403 isort: skip
 # Import variables like secrets from the prod_settings file
 # Import prod_settings after determining the deployment/machine type
 from .config import PRODUCTION
+
+TEST_SUITE = os.getenv("ZULIP_TEST_SUITE") == "true"
 
 if PRODUCTION:  # nocoverage
     from .prod_settings import *  # noqa: F403 isort: skip

--- a/zproject/configured_settings.py
+++ b/zproject/configured_settings.py
@@ -23,5 +23,21 @@ else:
     from .prod_settings_template import *  # noqa: F403 isort: skip
     from .dev_settings import *  # noqa: F403 isort: skip
 
+    # Support for local overrides to dev_settings.py is implemented here.
+    #
+    # We're careful to avoid those overrides applying to automated tests.
+    if not TEST_SUITE:  # nocoverage
+        import contextlib
+
+        with contextlib.suppress(ImportError):
+            from zproject.custom_dev_settings import *  # type: ignore[import, unused-ignore] # noqa: F403
+
+            # Print that we've got settings changes, so you know if you're testing non-base code.
+            #
+            # TODO: Figure out how to make this not be printed several
+            # times, and maybe print the actual keys that are
+            # overridden.
+            print("Using custom settings from zproject/custom_dev_settings.py.")
+
 # Do not add any code after these wildcard imports!  Add it to
 # computed_settings instead.

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -7,6 +7,9 @@ from zproject.settings_types import SCIMConfigDict
 
 ZULIP_ADMINISTRATOR = "desdemona+admin@zulip.com"
 
+# Initiatize TEST_SUITE early, so other code can rely on the setting.
+TEST_SUITE = os.getenv("ZULIP_TEST_SUITE") == "true"
+
 # We want LOCAL_UPLOADS_DIR to be an absolute path so that code can
 # chdir without having problems accessing it.  Unfortunately, this
 # means we need a duplicate definition of DEPLOY_ROOT with the one in

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -82,7 +82,6 @@ AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch(
     "ou=users,dc=zulip,dc=com", ldap.SCOPE_ONELEVEL, "(mail=%(email)s)"
 )
 
-TEST_SUITE = True
 RATE_LIMITING = False
 RATE_LIMITING_AUTHENTICATE = False
 # Don't use RabbitMQ from the test suite -- the user_profile_ids for

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -16,6 +16,7 @@ import os
 # it can be set there, at the right place in the settings.py flow.
 # Ick.
 os.environ["EXTERNAL_HOST"] = os.getenv("TEST_EXTERNAL_HOST", "testserver")
+os.environ["ZULIP_TEST_SUITE"] = "true"
 
 from .settings import *  # noqa: F403 isort: skip
 from .test_extra_settings import *  # noqa: F403 isort: skip


### PR DESCRIPTION
Extracted from #28017; see https://github.com/zulip/zulip/pull/28017/commits/3f40f4598ca84e52d4355959204ada188bbfa075#r1413157005 for context.