### PR TITLE
corporate: Clean up some sponsorship related billing code.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3145,10 +3145,6 @@ def is_realm_on_free_trial(realm: Realm) -> bool:
     return plan is not None and plan.is_free_trial()
 
 
-def is_sponsored_realm(realm: Realm) -> bool:
-    return realm.plan_type == Realm.PLAN_TYPE_STANDARD_FREE
-
-
 def do_change_plan_status(plan: CustomerPlan, status: int) -> None:
     plan.status = status
     plan.save(update_fields=["status"])

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -67,7 +67,6 @@ from corporate.lib.stripe import (
     invoice_plans_as_needed,
     is_free_trial_offer_enabled,
     is_realm_on_free_trial,
-    is_sponsored_realm,
     next_month,
     sign_string,
     stripe_customer_has_credit_card_as_default_payment_method,
@@ -4557,14 +4556,6 @@ class BillingHelpersTest(ZulipTestCase):
         plan.status = CustomerPlan.FREE_TRIAL
         plan.save(update_fields=["status"])
         self.assertTrue(is_realm_on_free_trial(realm))
-
-    def test_is_sponsored_realm(self) -> None:
-        realm = get_realm("zulip")
-        self.assertFalse(is_sponsored_realm(realm))
-
-        realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
-        realm.save()
-        self.assertTrue(is_sponsored_realm(realm))
 
     def test_change_remote_server_plan_type(self) -> None:
         server_uuid = str(uuid.uuid4())


### PR DESCRIPTION
**Notes**
- The first commit changes `is_sponsored_or_pending` in `BillingSession` to be implemented on the abstract class vs the child classes. This logic is used when getting the initial upgrade page context and should do the same checks for all classes.
- The second commit removes the now unused `is_realm_sponsored` as it's been replaced by the `is_sponsored` method on the `RealmBillingSession` class.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
