### PR TITLE
stream_settings: Add stream "reset to default notifications" button.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -289,6 +289,25 @@ export function update_muting_rendering(sub) {
     $edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
 }
 
+function stream_notification_reset(e) {
+    const sub = get_sub_for_target(e.target);
+    const data = [{stream_id: sub.stream_id, property: "is_muted", value: false}];
+    for (const [per_stream_setting_name, global_setting_name] of Object.entries(
+        settings_config.generalize_stream_notification_setting,
+    )) {
+        data.push({
+            stream_id: sub.stream_id,
+            property: per_stream_setting_name,
+            value: user_settings[global_setting_name],
+        });
+    }
+
+    stream_settings_api.bulk_set_stream_property(
+        data,
+        $(`#stream_change_property_status${CSS.escape(sub.stream_id)}`),
+    );
+}
+
 function stream_is_muted_changed(e) {
     const sub = get_sub_for_target(e.target);
     if (!sub) {
@@ -536,6 +555,12 @@ export function initialize() {
             },
         });
     });
+
+    $("#streams_overlay_container").on(
+        "click",
+        ".subsection-parent .reset-stream-notifications-button",
+        stream_notification_reset,
+    );
 
     $("#streams_overlay_container").on(
         "change",

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -125,6 +125,9 @@
                 <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
                 <p>{{t "In muted streams, stream notification settings apply only to unmuted topics." }}</p>
                 <div class="subsection-parent">
+                    <div class="input-group">
+                        <button class="button small rounded reset-stream-notifications-button" type="button">{{t "Reset to default notifications" }}</button>
+                    </div>
                     {{#each notification_settings}}
                         <div class="input-group">
                             {{> stream_settings_checkbox


### PR DESCRIPTION
This commit introduces a "reset to default notifications" button to the personal panel in stream settings. On clicking, it unmutes the stream and reset all notifications configurations to default.

Fixes zulip#27624.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 20-01-24 03:48:52 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/148f085a-d045-4e55-a911-183bcd211db6)


**Reset notification button preview:**

![Screenshot from 2024-01-20 03-05-30](https://github.com/zulip/zulip/assets/33497322/81f65730-b680-4243-bac7-d7bbfe7e3273)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
