### PR TITLE
remote_activity: Add 'guest users' and 'non guest users' count column.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -1,9 +1,73 @@
+from datetime import timedelta
 from unittest import mock
 
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import Client, UserActivity, UserProfile
+from zilencer.models import RemoteRealmAuditLog, get_remote_server_guest_and_non_guest_count
+
+event_time = timezone_now() - timedelta(days=3)
+data_list = [
+    {
+        "server_id": 1,
+        "realm_id": 1,
+        "event_type": RemoteRealmAuditLog.USER_CREATED,
+        "event_time": event_time,
+        "extra_data": {
+            RemoteRealmAuditLog.ROLE_COUNT: {
+                RemoteRealmAuditLog.ROLE_COUNT_HUMANS: {
+                    UserProfile.ROLE_REALM_ADMINISTRATOR: 10,
+                    UserProfile.ROLE_REALM_OWNER: 10,
+                    UserProfile.ROLE_MODERATOR: 10,
+                    UserProfile.ROLE_MEMBER: 10,
+                    UserProfile.ROLE_GUEST: 10,
+                }
+            }
+        },
+    },
+    {
+        "server_id": 1,
+        "realm_id": 1,
+        "event_type": RemoteRealmAuditLog.USER_ROLE_CHANGED,
+        "event_time": event_time,
+        "extra_data": {
+            RemoteRealmAuditLog.ROLE_COUNT: {
+                RemoteRealmAuditLog.ROLE_COUNT_HUMANS: {
+                    UserProfile.ROLE_REALM_ADMINISTRATOR: 20,
+                    UserProfile.ROLE_REALM_OWNER: 0,
+                    UserProfile.ROLE_MODERATOR: 0,
+                    UserProfile.ROLE_MEMBER: 20,
+                    UserProfile.ROLE_GUEST: 10,
+                }
+            }
+        },
+    },
+    {
+        "server_id": 1,
+        "realm_id": 2,
+        "event_type": RemoteRealmAuditLog.USER_CREATED,
+        "event_time": event_time,
+        "extra_data": {
+            RemoteRealmAuditLog.ROLE_COUNT: {
+                RemoteRealmAuditLog.ROLE_COUNT_HUMANS: {
+                    UserProfile.ROLE_REALM_ADMINISTRATOR: 10,
+                    UserProfile.ROLE_REALM_OWNER: 10,
+                    UserProfile.ROLE_MODERATOR: 0,
+                    UserProfile.ROLE_MEMBER: 10,
+                    UserProfile.ROLE_GUEST: 5,
+                }
+            }
+        },
+    },
+    {
+        "server_id": 1,
+        "realm_id": 2,
+        "event_type": RemoteRealmAuditLog.USER_CREATED,
+        "event_time": event_time,
+        "extra_data": {},
+    },
+]
 
 
 class ActivityTest(ZulipTestCase):
@@ -35,7 +99,8 @@ class ActivityTest(ZulipTestCase):
             result = self.client_get("/activity")
             self.assertEqual(result.status_code, 200)
 
-        with self.assert_database_query_count(4):
+        RemoteRealmAuditLog.objects.bulk_create([RemoteRealmAuditLog(**data) for data in data_list])
+        with self.assert_database_query_count(6):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 
@@ -51,3 +116,12 @@ class ActivityTest(ZulipTestCase):
         with self.assert_database_query_count(5):
             result = self.client_get(f"/user_activity/{iago.id}/")
             self.assertEqual(result.status_code, 200)
+
+    def test_get_remote_server_guest_and_non_guest_count(self) -> None:
+        RemoteRealmAuditLog.objects.bulk_create([RemoteRealmAuditLog(**data) for data in data_list])
+
+        remote_server_counts = get_remote_server_guest_and_non_guest_count(
+            server_id=1, event_time=timezone_now()
+        )
+        self.assertEqual(remote_server_counts.non_guest_user_count, 70)
+        self.assertEqual(remote_server_counts.guest_user_count, 15)

--- a/analytics/views/remote_activity.py
+++ b/analytics/views/remote_activity.py
@@ -11,6 +11,7 @@ from analytics.views.activity_common import (
     remote_installation_support_link,
 )
 from zerver.decorator import require_server_admin
+from zilencer.models import get_remote_server_guest_and_non_guest_count
 
 
 @require_server_admin
@@ -73,6 +74,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         "Mobile users",
         "Last update time",
         "Mobile pushes forwarded",
+        "Non guest users",
+        "Guest users",
         "Links",
     ]
 
@@ -83,6 +86,9 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         stats = remote_installation_stats_link(row[0])
         support = remote_installation_support_link(row[1])
         links = stats + " " + support
+        remote_server_counts = get_remote_server_guest_and_non_guest_count(row[0])
+        row.append(remote_server_counts.non_guest_user_count)
+        row.append(remote_server_counts.guest_user_count)
         row.append(links)
     for i, col in enumerate(cols):
         if col == "Last update time":


### PR DESCRIPTION
This PR adds two columns named 'Guest users' and 'Non guest users' to represent count of such users.

We query 'RemoteRealmAuditLog' to get the data.

**Steps for manual testing**
* Uncomment the bottom two lines of zproject/dev_settings.py to use localhost as a push notifications bouncer.
* start server: `./tools/run-dev`
* Run manage.py register_server and register your server (as the local server) with itself (as the bouncer).
* Restart server
* In `update_remote_realm_data_for_server` add `ignore_conflicts=True` 
```
    try:
        RemoteRealm.objects.bulk_create(new_remote_realms, ignore_conflicts=True)
```
Reason: This is an existing bug in main. So, I'd fix that separately.

* In `update_analytics_counts.py` change (60*10) to (5) -- reduced delay to 5 second
* Run management command `manage.py update_analytics_counts`
* visit `/activity/remote` (login as iago -- is_staff=True needed)

**Screenshots and screen captures:**

<details><summary>Remote Servers Data</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/de27a0d5-c870-4985-aa71-eda9ca5d4250">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
