### PR TITLE
support: Expand remote servers support view.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -504,7 +504,7 @@ class TestSupportEndpoint(ZulipTestCase):
             )
             m.assert_called_once_with(get_realm("zulip"), 2, acting_user=iago)
             self.assert_in_success_response(
-                ["Plan type of zulip changed from self-hosted to limited"], result
+                ["Plan type of zulip changed from Self-hosted to Limited"], result
             )
 
         with mock.patch("analytics.views.support.do_change_realm_plan_type") as m:
@@ -513,7 +513,7 @@ class TestSupportEndpoint(ZulipTestCase):
             )
             m.assert_called_once_with(get_realm("zulip"), 10, acting_user=iago)
             self.assert_in_success_response(
-                ["Plan type of zulip changed from self-hosted to plus"], result
+                ["Plan type of zulip changed from Self-hosted to Plus"], result
             )
 
     def test_change_org_type(self) -> None:

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -22,7 +22,7 @@ from analytics.views.activity_common import (
     realm_support_link,
     realm_url_link,
 )
-from analytics.views.support import get_plan_name
+from analytics.views.support import get_plan_type_string
 from zerver.decorator import require_server_admin
 from zerver.lib.request import has_request_variables
 from zerver.models import Realm, get_org_type_display_name
@@ -204,7 +204,7 @@ def realm_summary_table() -> str:
         realms_with_default_discount = get_realms_with_default_discount_dict()
 
         for row in rows:
-            row["plan_type_string"] = get_plan_name(row["plan_type"])
+            row["plan_type_string"] = get_plan_type_string(row["plan_type"])
 
             string_id = row["string_id"]
 

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -392,6 +392,9 @@ def remote_servers_support(
     billing_modality: Optional[str] = REQ(
         default=None, str_validator=check_string_in(VALID_BILLING_MODALITY_VALUES)
     ),
+    modify_plan: Optional[str] = REQ(
+        default=None, str_validator=check_string_in(VALID_MODIFY_PLAN_METHODS)
+    ),
 ) -> HttpResponse:
     context: Dict[str, Any] = {}
 
@@ -431,6 +434,11 @@ def remote_servers_support(
             support_view_request = SupportViewRequest(
                 support_type=SupportType.update_billing_modality,
                 billing_modality=billing_modality,
+            )
+        elif modify_plan is not None:
+            support_view_request = SupportViewRequest(
+                support_type=SupportType.modify_plan,
+                plan_modification=modify_plan,
             )
         if support_view_request is not None:
             billing_session = RemoteServerBillingSession(

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -389,6 +389,9 @@ def remote_servers_support(
     discount: Optional[Decimal] = REQ(default=None, converter=to_decimal),
     sponsorship_pending: Optional[bool] = REQ(default=None, json_validator=check_bool),
     approve_sponsorship: bool = REQ(default=False, json_validator=check_bool),
+    billing_modality: Optional[str] = REQ(
+        default=None, str_validator=check_string_in(VALID_BILLING_MODALITY_VALUES)
+    ),
 ) -> HttpResponse:
     context: Dict[str, Any] = {}
 
@@ -423,6 +426,11 @@ def remote_servers_support(
             support_view_request = SupportViewRequest(
                 support_type=SupportType.attach_discount,
                 discount=discount,
+            )
+        elif billing_modality is not None:
+            support_view_request = SupportViewRequest(
+                support_type=SupportType.update_billing_modality,
+                billing_modality=billing_modality,
             )
         if support_view_request is not None:
             billing_session = RemoteServerBillingSession(

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -66,13 +66,17 @@ if settings.BILLING_ENABLED:
     from corporate.models import CustomerPlan
 
 
-def get_plan_name(plan_type: int) -> str:
+def get_plan_type_string(plan_type: int) -> str:
     return {
-        Realm.PLAN_TYPE_SELF_HOSTED: "self-hosted",
-        Realm.PLAN_TYPE_LIMITED: "limited",
-        Realm.PLAN_TYPE_STANDARD: "standard",
-        Realm.PLAN_TYPE_STANDARD_FREE: "open source",
-        Realm.PLAN_TYPE_PLUS: "plus",
+        Realm.PLAN_TYPE_SELF_HOSTED: "Self-hosted",
+        Realm.PLAN_TYPE_LIMITED: "Limited",
+        Realm.PLAN_TYPE_STANDARD: "Standard",
+        Realm.PLAN_TYPE_STANDARD_FREE: "Standard free",
+        Realm.PLAN_TYPE_PLUS: "Plus",
+        RemoteZulipServer.PLAN_TYPE_SELF_HOSTED: "Self-hosted",
+        RemoteZulipServer.PLAN_TYPE_COMMUNITY: "Community",
+        RemoteZulipServer.PLAN_TYPE_BUSINESS: "Business",
+        RemoteZulipServer.PLAN_TYPE_ENTERPRISE: "Enterprise",
     }[plan_type]
 
 
@@ -210,7 +214,7 @@ def support(
         elif plan_type is not None:
             current_plan_type = realm.plan_type
             do_change_realm_plan_type(realm, plan_type, acting_user=acting_user)
-            msg = f"Plan type of {realm.string_id} changed from {get_plan_name(current_plan_type)} to {get_plan_name(plan_type)} "
+            msg = f"Plan type of {realm.string_id} changed from {get_plan_type_string(current_plan_type)} to {get_plan_type_string(plan_type)} "
             context["success_message"] = msg
         elif org_type is not None:
             current_realm_type = realm.org_type
@@ -475,6 +479,7 @@ def remote_servers_support(
     context["remote_server_to_max_monthly_messages"] = remote_server_to_max_monthly_messages
     context["plan_data"] = plan_data
     context["get_discount"] = get_customer_discount_for_support_view
+    context["get_plan_type_name"] = get_plan_type_string
 
     return render(
         request,

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -1,0 +1,7 @@
+<div class="remote-realm-information">
+    <span class="label">remote realm</span>
+    <h3>{{ remote_realm.name }}</h3>
+    <b>Remote server hostname:</b> {{ remote_realm.host }}<br />
+    <b>Date created</b>: {{ remote_realm.realm_date_created.strftime('%d %B %Y') }}<br />
+    <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
+</div>

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -45,6 +45,7 @@
                 <br />
                 <b>Last updated</b>: {{ remote_server.last_updated|timesince }} ago<br />
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
+                <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
                 {% if remote_server.plan_type == 100 %}
                     <h4>On 100% sponsored Zulip Community plan.</h4>
                 {% endif %}

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -88,6 +88,26 @@
                 {% endif %}
             </form>
             {% endif %}
+
+            {% if plan_data[remote_server.id].current_plan %}
+            <div class="remote-server-information">
+                <h4>📅 Current plan information:</h4>
+                <b>Plan name</b>: {{ plan_data[remote_server.id].current_plan.name }}<br />
+                <b>Status</b>: {{plan_data[remote_server.id].current_plan.get_plan_status_as_text()}}<br />
+                {% if plan_data[remote_server.id].current_plan.tier != 101 %}
+                <b>Billing schedule</b>: {% if plan_data[remote_server.id].current_plan.billing_schedule == plan_data[remote_server.id].current_plan.BILLING_SCHEDULE_ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
+                <b>Licenses</b>: {{ plan_data[remote_server.id].licenses_used }}/{{ plan_data[remote_server.id].licenses }} ({% if plan_data[remote_server.id].current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
+                {% if plan_data[remote_server.id].current_plan.price_per_license %}
+                <b>Price per license</b>: ${{ plan_data[remote_server.id].current_plan.price_per_license/100 }}<br />
+                {% elif plan_data[remote_server.id].current_plan.fixed_price %}
+                <b>Fixed price</b>: ${{ plan_data[remote_server.id].current_plan.fixed_price/100 }}<br />
+                {% endif %}
+                <b>Next invoice date</b>: {{ plan_data[remote_server.id].current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
+                {% else %}
+                <b>End date</b>: {{ plan_data[remote_server.id].current_plan.end_date.strftime('%d %B %Y') }}<br />
+                {% endif %}
+            </div>
+            {% endif %}
         </div>
         {% endfor %}
     </div>

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -46,6 +46,7 @@
                 <b>Last updated</b>: {{ remote_server.last_updated|timesince }} ago<br />
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
+                <b>Has remote realm(s)</b>: {{ remote_realms[remote_server.id] != [] }}
                 {% if remote_server.plan_type == 100 %}
                     <h4>On 100% sponsored Zulip Community plan.</h4>
                 {% endif %}
@@ -133,6 +134,13 @@
                 <button type="submit" class="btn btn-default support-submit-button">Modify</button>
             </form>
             {% endif %}
+
+            {% for remote_realm in remote_realms[remote_server.id] %}
+            <hr />
+            <div>
+                {% include "analytics/remote_realm_details.html" %}
+            </div>
+            {% endfor %}
         </div>
         {% endfor %}
     </div>

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -107,6 +107,17 @@
                 <b>End date</b>: {{ plan_data[remote_server.id].current_plan.end_date.strftime('%d %B %Y') }}<br />
                 {% endif %}
             </div>
+
+            <form method="POST" class="remote-server-form">
+                <b>Billing collection method</b><br />
+                {{ csrf_input }}
+                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
+                <select name="billing_modality" class="billing-modality-select" required>
+                    <option value="charge_automatically" {% if plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
+                    <option value="send_invoice" {% if not plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
+                </select>
+                <button type="submit" class="btn btn-default support-submit-button">Update</button>
+            </form>
             {% endif %}
         </div>
         {% endfor %}

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -118,6 +118,19 @@
                 </select>
                 <button type="submit" class="btn btn-default support-submit-button">Update</button>
             </form>
+
+            <form method="POST" class="remote-server-form">
+                <b>Modify current plan</b><br />
+                {{ csrf_input }}
+                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
+                <select name="modify_plan" class="modify-plan-method-select" required>
+                    <option disabled value="" selected>-- select --</option>
+                    <option value="downgrade_at_billing_cycle_end">Downgrade at the end of current billing cycle</option>
+                    <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
+                    <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
+                </select>
+                <button type="submit" class="btn btn-default support-submit-button">Modify</button>
+            </form>
             {% endif %}
         </div>
         {% endfor %}

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -96,6 +96,7 @@ tr.admin td:first-child {
     padding-top: 14px;
     border-radius: 7px;
     box-shadow: 0 10px 7px -6px hsl(0deg 2% 45%);
+    margin-bottom: 10px;
 
     & select {
         height: 30px;

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -152,7 +152,8 @@ tr.admin td:first-child {
     }
 }
 
-.remote-server-information {
+.remote-server-information,
+.remote-realm-information {
     padding-bottom: 15px;
 }
 


### PR DESCRIPTION
Expands the support view for remote servers for:
- Displaying the current `CustomerPlan` information for the remote server.
- Updating the billing modality for the current `CustomerPlan`.
- Modifying the current `CustomerPlan` for various downgrade actions.
- Adds information about the remote server's plan type.
- Adds information about any remote realms attached to the remote server.

**Notes**:
- Updated query for remote servers in the final commit (adds remote realm information) may not be the most efficient way to add this information. Calling a `RemoteRealm` query on the loop over the remote servers also didn't seem like a good option.
- Not sure if it would be better to hide the update billing modality for legacy plans, see 3rd commit.
- CSS changes just add some small margins to help search results not overlapping.

---

**Screenshots and screen captures:**

<details>
<summary>Installation activity page - updated plan type strings</summary>

![Screenshot from 2023-12-05 16-08-11](https://github.com/zulip/zulip/assets/63245456/8f6a733a-36b6-4ee8-9c79-19a29c7f51a8)
</details>
<details>
<summary>Remote servers activity page - no changes from current main</summary>

![Screenshot from 2023-12-05 16-08-26](https://github.com/zulip/zulip/assets/63245456/74ae142b-0de4-416d-a395-d43d180302a2)
</details>
<details>
<summary>Remote server with legacy plan</summary>

![Screenshot from 2023-12-05 16-08-37](https://github.com/zulip/zulip/assets/63245456/b488ad82-0f18-4424-889f-08c991dfdfdb)
</details>
<details>
<summary>Remote server with current plan</summary>

![Screenshot from 2023-12-05 16-08-48](https://github.com/zulip/zulip/assets/63245456/1815fba9-4eb1-4528-9379-60bb9cb37107)
</details>
<details>
<summary>Remote server with current plan and remote realm</summary>

![Screenshot from 2023-12-05 16-08-59](https://github.com/zulip/zulip/assets/63245456/f0f07537-2ab3-45c5-9fd4-3c1a7f3b6aed)
</details>
<details>
<summary>Search results can return multiple remote servers</summary>

![Screenshot from 2023-12-05 16-09-44](https://github.com/zulip/zulip/assets/63245456/56271136-8668-47f8-9908-3e630cfae973)
![Screenshot from 2023-12-05 16-09-16](https://github.com/zulip/zulip/assets/63245456/7c6dc17e-15dc-4b3e-803a-45009c0ab01c)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
