### PR TITLE
stripe: Refactoring related to current license count.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1888,7 +1888,7 @@ class BillingSession(ABC):
                 self.current_count_for_billed_licenses(),
                 plan.customer.exempt_from_license_number_check,
             )
-            update_license_ledger_for_manual_plan(plan, timezone_now(), licenses=licenses)
+            self.update_license_ledger_for_manual_plan(plan, timezone_now(), licenses=licenses)
             return
 
         licenses_at_next_renewal = update_plan_request.licenses_at_next_renewal
@@ -1911,7 +1911,7 @@ class BillingSession(ABC):
                 self.current_count_for_billed_licenses(),
                 plan.customer.exempt_from_license_number_check,
             )
-            update_license_ledger_for_manual_plan(
+            self.update_license_ledger_for_manual_plan(
                 plan, timezone_now(), licenses_at_next_renewal=licenses_at_next_renewal
             )
             return
@@ -2280,6 +2280,35 @@ class BillingSession(ABC):
                 success_message = self.do_change_plan_to_new_tier(new_plan_tier)
 
         return success_message
+
+    def update_license_ledger_for_manual_plan(
+        self,
+        plan: CustomerPlan,
+        event_time: datetime,
+        licenses: Optional[int] = None,
+        licenses_at_next_renewal: Optional[int] = None,
+    ) -> None:
+        if licenses is not None:
+            if not plan.customer.exempt_from_license_number_check:
+                assert self.current_count_for_billed_licenses() <= licenses
+            assert licenses > plan.licenses()
+            LicenseLedger.objects.create(
+                plan=plan,
+                event_time=event_time,
+                licenses=licenses,
+                licenses_at_next_renewal=licenses,
+            )
+        elif licenses_at_next_renewal is not None:
+            if not plan.customer.exempt_from_license_number_check:
+                assert self.current_count_for_billed_licenses() <= licenses_at_next_renewal
+            LicenseLedger.objects.create(
+                plan=plan,
+                event_time=event_time,
+                licenses=plan.licenses(),
+                licenses_at_next_renewal=licenses_at_next_renewal,
+            )
+        else:
+            raise AssertionError("Pass licenses or licenses_at_next_renewal")
 
 
 class RealmBillingSession(BillingSession):
@@ -3343,34 +3372,6 @@ def do_deactivate_remote_server(remote_server: RemoteZulipServer) -> None:
         server=remote_server,
         event_time=timezone_now(),
     )
-
-
-def update_license_ledger_for_manual_plan(
-    plan: CustomerPlan,
-    event_time: datetime,
-    licenses: Optional[int] = None,
-    licenses_at_next_renewal: Optional[int] = None,
-) -> None:
-    if licenses is not None:
-        assert plan.customer.realm is not None
-        if not plan.customer.exempt_from_license_number_check:
-            assert get_latest_seat_count(plan.customer.realm) <= licenses
-        assert licenses > plan.licenses()
-        LicenseLedger.objects.create(
-            plan=plan, event_time=event_time, licenses=licenses, licenses_at_next_renewal=licenses
-        )
-    elif licenses_at_next_renewal is not None:
-        assert plan.customer.realm is not None
-        if not plan.customer.exempt_from_license_number_check:
-            assert get_latest_seat_count(plan.customer.realm) <= licenses_at_next_renewal
-        LicenseLedger.objects.create(
-            plan=plan,
-            event_time=event_time,
-            licenses=plan.licenses(),
-            licenses_at_next_renewal=licenses_at_next_renewal,
-        )
-    else:
-        raise AssertionError("Pass licenses or licenses_at_next_renewal")
 
 
 def update_license_ledger_for_automanaged_plan(

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -55,7 +55,7 @@ from zerver.models import (
 from zerver.tornado.django_api import send_event_on_commit
 
 if settings.BILLING_ENABLED:
-    from corporate.lib.stripe import update_license_ledger_if_needed
+    from corporate.lib.stripe import RealmBillingSession
 
 
 MAX_NUM_ONBOARDING_MESSAGES = 1000
@@ -514,7 +514,8 @@ def do_create_user(
             event_time,
         )
         if settings.BILLING_ENABLED:
-            update_license_ledger_if_needed(user_profile.realm, event_time)
+            billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+            billing_session.update_license_ledger_if_needed(event_time)
 
         system_user_group = get_system_user_group_for_user(user_profile)
         UserGroupMembership.objects.create(user_profile=user_profile, user_group=system_user_group)
@@ -624,7 +625,8 @@ def do_activate_mirror_dummy_user(
             event_time,
         )
         if settings.BILLING_ENABLED:
-            update_license_ledger_if_needed(user_profile.realm, event_time)
+            billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+            billing_session.update_license_ledger_if_needed(event_time)
 
     notify_created_user(user_profile, [])
 
@@ -676,7 +678,8 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserP
         event_time,
     )
     if settings.BILLING_ENABLED:
-        update_license_ledger_if_needed(user_profile.realm, event_time)
+        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+        billing_session.update_license_ledger_if_needed(event_time)
 
     event = dict(
         type="realm_user", op="update", person=dict(user_id=user_profile.id, is_active=True)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -51,7 +51,7 @@ from zerver.models import (
 from zerver.tornado.django_api import send_event, send_event_on_commit
 
 if settings.BILLING_ENABLED:
-    from corporate.lib.stripe import update_license_ledger_if_needed
+    from corporate.lib.stripe import RealmBillingSession
 
 
 def do_delete_user(user_profile: UserProfile, *, acting_user: Optional[UserProfile]) -> None:
@@ -364,7 +364,8 @@ def do_deactivate_user(
             increment=-1,
         )
         if settings.BILLING_ENABLED:
-            update_license_ledger_if_needed(user_profile.realm, event_time)
+            billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+            billing_session.update_license_ledger_if_needed(event_time)
 
         transaction.on_commit(lambda: delete_user_sessions(user_profile))
 


### PR DESCRIPTION
* First commit: Moves the `update_license_ledger_for_manual_plan` function to the `BillingSession` abstract class.
* Second commit: Moves `update_license_ledger_if_needed` and `update_license_ledger_for_automanaged_plan` to `BillingSession`.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
