### PR TITLE
T27250: Updated placeholder text for linkifiers and custom profile fields

### DIFF
--- a/web/e2e-tests/custom-profile.test.ts
+++ b/web/e2e-tests/custom-profile.test.ts
@@ -27,8 +27,14 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
     await common.wait_for_micromodal_to_close(page);
 
     await page.waitForSelector(
-        'xpath///*[@id="admin_profile_fields_table"]//tr[last()]/td[normalize-space()="Teams"]',
+        'xpath///*[@id="admin_profile_fieldds_table"]//tr[last()]/td[normalize-space()="Teams"]',
     );
+    
+    assert.strictEqual(
+        await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
+        "No custom profile fields configured",
+    );
+    
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
         "Short text",

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers configured.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
         {{#if is_admin}}
-        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
+        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a neew profile field" }}</button>
         {{/if}}
     </div>
     <div class="admin-table-wrapper" data-simplebar>
@@ -19,7 +19,8 @@
                     {{/if}}
                 </tr>
             </thead>
-            <tbody id="admin_profile_fields_table" class="required-text" data-empty="{{t 'No custom profile field configured for this organization.' }}"></tbody>
+            <tbody>No custom profile fields configured</tbody>
+            <tbody id="admin_profile_fields_table" class="required-text" data-empty="{{t 'No custom profile fields configured.' }}" data-search-results-empty="{{t 'No custom profile fields configured.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
         {{#if is_admin}}
-        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a neew profile field" }}</button>
+        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
         {{/if}}
     </div>
     <div class="admin-table-wrapper" data-simplebar>


### PR DESCRIPTION
By rewriting HTML templates for linkifiers and custom profile field configurations, we have updated placeholder text to appear in the absence of data or configurations being set. UI screenshots are shown below. Updates to the language JSON files are necessary for closing this ticket. 

[Fixes: <!-- Issue link, or clear description.-->](https://github.com/zulip/zulip/issues/27250)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1028" alt="Screenshot 2023-12-05 at 6 17 54 PM" src="https://github.com/zulip/zulip/assets/82491744/1da81ed5-56fc-40a4-a7cd-899abd779e45">
<img width="1028" alt="Screenshot 2023-12-05 at 6 18 15 PM" src="https://github.com/zulip/zulip/assets/82491744/fd5a7bc4-bfe7-4c7e-a0f7-e3ff5dd44205">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
