### PR TITLE
populate_db: Clean up existing RemoteRealm, RemoteZulipServer objects.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -390,6 +390,7 @@ class Command(BaseCommand):
                 api_key=settings.ZULIP_ORG_KEY,
                 hostname=settings.EXTERNAL_HOST,
                 last_updated=timezone_now(),
+                contact_email="remotezulipserver@zulip.com",
             )
             update_remote_realm_data_for_server(server, get_realms_info_for_push_bouncer())
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -73,7 +73,7 @@ from zerver.models import (
     get_user_by_delivery_email,
     get_user_profile_by_id,
 )
-from zilencer.models import RemoteZulipServer
+from zilencer.models import RemoteRealm, RemoteZulipServer
 from zilencer.views import update_remote_realm_data_for_server
 
 settings.USING_TORNADO = False
@@ -128,6 +128,8 @@ def clear_database() -> None:
         UserMessage,
         Client,
         DefaultStream,
+        RemoteRealm,
+        RemoteZulipServer,
     ]:
         model.objects.all().delete()
     Session.objects.all().delete()


### PR DESCRIPTION
As of c9b060232005e34d31e87a35c6a96582f1f88af8 and 8b55d60f9e0365e47dadd4d82b7946e9c8f53149 we create a default registration for the dev env "RemoteZulipServer" (and also RemoteRealms for the dev realms) in populate_db. However these models weren't listed in clear_database, meaning the state wasn't properly cleaned up at the start of the command.

Most important, this would manifest in getting:
```
django.db.utils.IntegrityError: duplicate key value violates unique
constraint "zilencer_remotezulipserver_uuid_key"
DETAIL:  Key (uuid)=(......) already exists
```

if you re-run populate_db.

