### PR TITLE
support: Use shared template for current plan details in support views.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -198,7 +198,7 @@ class TestSupportEndpoint(ZulipTestCase):
                     '<option value="deactivated" >Deactivated</option>',
                     'scrub-realm-button">',
                     'data-string-id="lear"',
-                    "<b>Name</b>: Zulip Cloud Standard",
+                    "<b>Plan name</b>: Zulip Cloud Standard",
                     "<b>Status</b>: Active",
                     "<b>Billing schedule</b>: Annual",
                     "<b>Licenses</b>: 2/10 (Manual)",

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -18,6 +18,7 @@ class PlanData:
     current_plan: Optional["CustomerPlan"] = None
     licenses: Optional[int] = None
     licenses_used: Optional[int] = None
+    is_legacy_plan: bool = False
 
 
 def get_support_url(realm: Realm) -> str:
@@ -55,5 +56,9 @@ def get_current_plan_data_for_support_view(billing_session: BillingSession) -> P
                 plan_data.current_plan = new_plan  # nocoverage
             plan_data.licenses = last_ledger_entry.licenses
             plan_data.licenses_used = billing_session.current_count_for_billed_licenses()
+        assert plan_data.current_plan is not None  # for mypy
+        plan_data.is_legacy_plan = (
+            plan_data.current_plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
+        )
 
     return plan_data

--- a/templates/analytics/current_plan_details.html
+++ b/templates/analytics/current_plan_details.html
@@ -1,0 +1,15 @@
+<h4>📅 Current plan information:</h4>
+<b>Plan name</b>: {{ plan_data.current_plan.name }}<br />
+<b>Status</b>: {{ plan_data.current_plan.get_plan_status_as_text() }}<br />
+{% if plan_data.is_legacy_plan %}
+    <b>End date</b>: {{ plan_data.current_plan.end_date.strftime('%d %B %Y') }}<br />
+{% else %}
+    <b>Billing schedule</b>: {% if plan_data.current_plan.billing_schedule == plan_data.current_plan.BILLING_SCHEDULE_ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
+    <b>Licenses</b>: {{ plan_data.licenses_used }}/{{ plan_data.licenses }} ({% if plan_data.current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
+    {% if plan_data.current_plan.price_per_license %}
+        <b>Price per license</b>: ${{ plan_data.current_plan.price_per_license/100 }}<br />
+    {% elif plan_data.current_plan.fixed_price %}
+        <b>Fixed price</b>: ${{ plan_data.current_plan.fixed_price/100 }}<br />
+    {% endif %}
+    <b>Next invoice date</b>: {{ plan_data.current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
+{% endif %}

--- a/templates/analytics/current_plan_details.html
+++ b/templates/analytics/current_plan_details.html
@@ -1,4 +1,10 @@
 <h4>📅 Current plan information:</h4>
+{% if plan_data.warning %}
+<div class="current-plan-data-missing">
+    {{ plan_data.warning }}
+    <br />
+</div>
+{% endif %}
 <b>Plan name</b>: {{ plan_data.current_plan.name }}<br />
 <b>Status</b>: {{ plan_data.current_plan.get_plan_status_as_text() }}<br />
 {% if plan_data.is_legacy_plan %}

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -108,19 +108,13 @@
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
     {% endif %}
 </form>
+
 {% if plan_data[realm.id].current_plan %}
 <div class="current-plan-details">
-    <h3>📅 Current plan</h3>
-    <b>Name</b>: {{ plan_data[realm.id].current_plan.name }}<br />
-    <b>Status</b>: {{plan_data[realm.id].current_plan.get_plan_status_as_text()}}<br />
-    <b>Billing schedule</b>: {% if plan_data[realm.id].current_plan.billing_schedule == plan_data[realm.id].current_plan.BILLING_SCHEDULE_ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
-    <b>Licenses</b>: {{ plan_data[realm.id].licenses_used }}/{{ plan_data[realm.id].licenses }} ({% if plan_data[realm.id].current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
-    {% if plan_data[realm.id].current_plan.price_per_license %}
-    <b>Price per license</b>: ${{ plan_data[realm.id].current_plan.price_per_license/100 }}<br />
-    {% else %}
-    <b>Fixed price</b>: ${{ plan_data[realm.id].current_plan.fixed_price/100 }}<br />
-    {% endif %}
-    <b>Next invoice date</b>: {{ plan_data[realm.id].current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
+    {% with %}
+        {% set plan_data = plan_data[realm.id] %}
+        {% include 'analytics/current_plan_details.html' %}
+    {% endwith %}
 </div>
 
 <form method="POST" class="billing-modality-form">

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -93,21 +93,10 @@
 
             {% if plan_data[remote_server.id].current_plan %}
             <div class="remote-server-information">
-                <h4>📅 Current plan information:</h4>
-                <b>Plan name</b>: {{ plan_data[remote_server.id].current_plan.name }}<br />
-                <b>Status</b>: {{plan_data[remote_server.id].current_plan.get_plan_status_as_text()}}<br />
-                {% if plan_data[remote_server.id].current_plan.tier != 101 %}
-                <b>Billing schedule</b>: {% if plan_data[remote_server.id].current_plan.billing_schedule == plan_data[remote_server.id].current_plan.BILLING_SCHEDULE_ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
-                <b>Licenses</b>: {{ plan_data[remote_server.id].licenses_used }}/{{ plan_data[remote_server.id].licenses }} ({% if plan_data[remote_server.id].current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
-                {% if plan_data[remote_server.id].current_plan.price_per_license %}
-                <b>Price per license</b>: ${{ plan_data[remote_server.id].current_plan.price_per_license/100 }}<br />
-                {% elif plan_data[remote_server.id].current_plan.fixed_price %}
-                <b>Fixed price</b>: ${{ plan_data[remote_server.id].current_plan.fixed_price/100 }}<br />
-                {% endif %}
-                <b>Next invoice date</b>: {{ plan_data[remote_server.id].current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
-                {% else %}
-                <b>End date</b>: {{ plan_data[remote_server.id].current_plan.end_date.strftime('%d %B %Y') }}<br />
-                {% endif %}
+                {% with %}
+                    {% set plan_data = plan_data[remote_server.id] %}
+                    {% include 'analytics/current_plan_details.html' %}
+                {% endwith %}
             </div>
 
             <form method="POST" class="remote-server-form">

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -189,7 +189,7 @@ tr.admin td:first-child {
 
 .current-plan-details {
     position: relative;
-    top: -15px;
+    top: -45px;
 }
 
 .approve-sponsorship-form {

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -85,6 +85,7 @@ tr.admin td:first-child {
     color: hsl(120deg 100% 33%);
 }
 
+.current-plan-data-missing,
 .bad {
     font-weight: bold;
     color: hsl(0deg 100% 39%);


### PR DESCRIPTION
Updates the support and remote support views to use a shared template for the current plan details section.

**Notes**:
- Per https://github.com/zulip/zulip/pull/28047#discussion_r1415936156, uses a boolean value to check for the one plan tier that we expect to not have any licenses information.
- Handles, in the 2nd commit, when the remote support view doesn't have current data for the number of licenses used.

**Screenshots and screen captures:**

<details>
<summary>Support view for realm after changes - smaller header for the current plan section</summary>

![Screenshot from 2023-12-06 18-21-07](https://github.com/zulip/zulip/assets/63245456/4d7a524c-6c25-4b58-b9a8-035ebcbb7f30)
</details>
<details>
<summary>Legacy tier remote support view - without and with missing current licenses data</summary>
 
![Screenshot from 2023-12-06 18-20-55](https://github.com/zulip/zulip/assets/63245456/8f13f1bc-50a3-478c-9aac-c45bcbbf0087)
![Screenshot from 2023-12-06 18-20-34](https://github.com/zulip/zulip/assets/63245456/8cb49ddd-c1d5-45f1-9f15-de5088835829)
</details>
<details>
<summary>Business tier remote support view - without and with missing current licenses data</summary>

![Screenshot from 2023-12-06 18-19-11](https://github.com/zulip/zulip/assets/63245456/703c6603-1c42-475b-819b-7cf2b26481b5)
![Screenshot from 2023-12-06 18-18-37](https://github.com/zulip/zulip/assets/63245456/1c136d11-3f52-4cfc-a75b-2e3a54fb456a)
</summary>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
