### PR TITLE
corporate: Update sponsorship request emails sent to support.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2245,8 +2245,7 @@ class BillingSession(ABC):
         context = {
             "requested_by": user_info["name"],
             "user_role": user_info["role"],
-            # TODO: realm_string_id needs to be replaced by something more generic.
-            "string_id": request_context["realm_string_id"],
+            "billing_entity": self.billing_entity_display_name,
             "support_url": support_url,
             "organization_type": org_type_display_name,
             "website": sponsorship_request.org_website,

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -20,7 +20,7 @@ class PlanData:
     licenses_used: Optional[int] = None
 
 
-def get_support_url(realm: Realm) -> str:
+def get_realm_support_url(realm: Realm) -> str:
     support_realm_uri = get_realm(settings.STAFF_SUBDOMAIN).uri
     support_url = urljoin(
         support_realm_uri,

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -2,7 +2,7 @@ from django import forms
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
-from corporate.lib.support import get_support_url
+from corporate.lib.support import get_realm_support_url
 from zerver.decorator import zulip_login_required
 from zerver.lib.request import has_request_variables
 from zerver.lib.send_email import FromAddress, send_email
@@ -38,7 +38,7 @@ def support_request(request: HttpRequest) -> HttpResponse:
                 "realm_string_id": user.realm.string_id,
                 "request_subject": form.cleaned_data["request_subject"],
                 "request_message": form.cleaned_data["request_message"],
-                "support_url": get_support_url(user.realm),
+                "support_url": get_realm_support_url(user.realm),
                 "user_role": user.get_role_name(),
             }
             # Sent to the server's support team, so this email is not user-facing.

--- a/templates/zerver/emails/sponsorship_request.html
+++ b/templates/zerver/emails/sponsorship_request.html
@@ -19,6 +19,19 @@
 
 <br /><br />
 
+<b>Expected users</b>:
+<br />
+<ul>
+    <li>Total: {{ expected_total_users }}</li>
+    <li>Paid: {{ paid_users_count }}</li>
+</ul>
+
+<b>Description of paid users</b>:
+<br />
+{{ paid_users_description }}
+
+<br /><br />
+
 <b>Requested by</b>: {{ requested_by }} ({{ user_role }})
 
 {% endblock %}

--- a/templates/zerver/emails/sponsorship_request.subject.txt
+++ b/templates/zerver/emails/sponsorship_request.subject.txt
@@ -1,1 +1,1 @@
-Sponsorship request ({{ organization_type }}) for {{ string_id }}
+Sponsorship request ({{ organization_type }}) for {{ billing_entity }}

--- a/templates/zerver/emails/sponsorship_request.txt
+++ b/templates/zerver/emails/sponsorship_request.txt
@@ -7,4 +7,11 @@ Organization type: {{ organization_type }}
 Description:
 {{ description }}
 
+Expected users:
+- Total: {{ expected_total_users }}
+- Paid: {{ paid_users_count }}
+
+Description of paid users:
+{{ paid_users_description }}
+
 Requested by: {{ requested_by }} ({{ user_role }})

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -38,7 +38,7 @@ from zerver.models import (
 from zproject.backends import all_implemented_backend_names
 
 if settings.CORPORATE_ENABLED:
-    from corporate.lib.support import get_support_url
+    from corporate.lib.support import get_realm_support_url
 
 
 def do_change_realm_subdomain(
@@ -310,7 +310,7 @@ def do_create_realm(
         admin_realm = get_realm(settings.SYSTEM_BOT_REALM)
         sender = get_system_bot(settings.NOTIFICATION_BOT, admin_realm.id)
 
-        support_url = get_support_url(realm)
+        support_url = get_realm_support_url(realm)
         organization_type = get_org_type_display_name(realm.org_type)
 
         message = "[{name}]({support_link}) ([{subdomain}]({realm_link})). Organization type: {type}".format(


### PR DESCRIPTION
Makes some updates to the sponsorship request email sent to support.

**Notes**:
- The first commit removes the `string_id` from the context, which is used in the email header, and replaces it with the `BillingSession.billing_entity_display_name`. This is no change for organizations requesting sponsorship on Zulip Cloud.
- The second commit implements `support_url` for all the `BillingSession` child classes. Note the query for the support view for a remote realm is based on the attached remote server.
- The third commit updates the email templates for the new information in the form for sponsorship requests.

**Screenshots and screen captures:**

<details>
<summary>Sponsorship request for regular organization - both text and HTML versions</summary>

![Screenshot from 2023-12-06 18-34-09](https://github.com/zulip/zulip/assets/63245456/810d8535-cbc0-413d-bc52-f53bc4dfc7d3)
![Screenshot from 2023-12-06 18-33-59](https://github.com/zulip/zulip/assets/63245456/ec4a42ff-7e13-4b93-bd7e-7c93b544a095)
</details>
<details>
<summary>Sponsorship request for remote organization - both text and HTML versions</summary>

![Screenshot from 2023-12-06 18-33-44](https://github.com/zulip/zulip/assets/63245456/092425a0-9d60-45e2-afd8-61d4a287445a)
![Screenshot from 2023-12-06 18-33-33](https://github.com/zulip/zulip/assets/63245456/5d3b7176-731f-47ce-96c8-92df3280a8ca)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
