### PR TITLE
widgets: Support markdown in widgets.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -32,11 +32,25 @@
         position: relative;
         vertical-align: top;
 
+        .task,
+        .task_desc,
+        .description {
+            display: inline-block;
+        }
+
+        .task_complete,
+        .task_desc_complete,
+        .description_complete {
+            display: inline-block;
+            text-decoration: line-through;
+        }
+
         & input[type="checkbox"] {
             ~ span {
                 height: 12px;
                 width: 12px;
                 border: 2px solid hsl(156deg 28% 70%);
+                top: 2px;
 
                 border-radius: 4px;
                 filter: brightness(1);

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -84,6 +84,7 @@
     & li {
         list-style: none;
         margin: 2px 2px 6px 0;
+        display: flex;
     }
 
     & ul {
@@ -122,6 +123,8 @@
     .poll-option {
         font-weight: 400;
         font-size: 14px;
+        padding-top: 3px;
+        display: inline;
     }
 
     /* For the box-shadow to be visible on the left */
@@ -131,7 +134,6 @@
 
     & span.poll-option {
         font-weight: 600;
-        padding-top: 28px;
     }
 
     .poll-vote {
@@ -166,8 +168,13 @@
     .poll-names {
         color: hsl(0deg 0% 45%);
         padding-left: 4px;
-        padding-top: 28px;
+        padding-top: 3px;
         font-size: 14px;
+        display: inline;
+    }
+
+    .poll-option p {
+        display: inline;
     }
 }
 

--- a/web/templates/widgets/poll_widget_results.hbs
+++ b/web/templates/widgets/poll_widget_results.hbs
@@ -3,9 +3,11 @@
         <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
             {{ count }}
         </button>
-        <span class="poll-option">{{ option }}</span>
-        {{#if names}}
-        <span class="poll-names">({{ names }})</span>
-        {{/if}}
+        <span class="poll-option">
+            {{rendered_markdown option }}
+            {{#if names}}
+                <span class="poll-names">({{ names }})</span>
+            {{/if}}
+        </span>
     </li>
 {{/each}}

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -8,9 +8,9 @@
             </div>
             <div>
                 {{#if completed}}
-                <strike><strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}</strike>
+                <strike><strong class="task_complete">{{rendered_markdown task }}</strong>{{#if desc }}<span class="task_desc_complete">: </span><span class="description_complete">{{rendered_markdown desc }}</span>{{/if}}</strike>
                 {{else}}
-                <strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}
+                <strong class="task">{{rendered_markdown task }}</strong>{{#if desc }}<span class="task_desc">: </span><span class="description">{{rendered_markdown desc }}</span>{{/if}}
                 {{/if}}
             </div>
         </label>

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -259,7 +259,7 @@ test("marked_shared", () => {
     for (const test of tests) {
         // Ignore tests if specified
         /* istanbul ignore if */
-        if (test.ignore === true) {
+        if (test.ignore === true || test.markdown === "Inline") {
             continue;
         }
 

--- a/web/tests/poll_widget.test.js
+++ b/web/tests/poll_widget.test.js
@@ -243,6 +243,8 @@ run_test("activate another person poll", ({mock_template}) => {
     const $poll_question_header = set_widget_find_result(".poll-question-header");
     const $poll_question_container = set_widget_find_result(".poll-question-bar");
     const $poll_option_container = set_widget_find_result(".poll-option-bar");
+    set_widget_find_result("ul.poll-widget time");
+    $("ul.poll-widget time").each = function () {};
 
     const $poll_vote_button = set_widget_find_result("button.poll-vote");
     const $poll_please_wait = set_widget_find_result(".poll-please-wait");
@@ -350,6 +352,8 @@ run_test("activate own poll", ({mock_template}) => {
     set_widget_find_result("button.poll-option");
     const $poll_option_input = set_widget_find_result("input.poll-option");
     const $widget_option_container = set_widget_find_result("ul.poll-widget");
+    set_widget_find_result("ul.poll-widget time");
+    $("ul.poll-widget time").each = function () {};
 
     const $poll_question_submit = set_widget_find_result("button.poll-question-check");
     const $poll_edit_question = set_widget_find_result(".poll-edit-question");

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -2,6 +2,7 @@ import json
 import re
 from typing import Any, Optional, Tuple
 
+from zerver.lib.markdown import markdown_convert_inline
 from zerver.lib.message import SendMessageRequest
 from zerver.models import Message, SubMessage
 
@@ -35,7 +36,7 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
             # before adding an option.
             option = re.sub(r"(\s*[-*]?\s*)", "", line.strip(), count=1)
             if len(option) > 0:
-                options.append(option)
+                options.append(markdown_convert_inline(option).rendered_content)
         extra_data = {
             "question": question,
             "options": options,

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -14,10 +14,24 @@
       "text_content": "Hamlet said:\ndef speak(self):\n    x = 1\n"
     },
     {
+      "name": "inline_markdown_codeblock_hilite_python",
+      "input": "Hamlet said:\n~~~~.python \ndef speak(self):\n    x = 1\n~~~~",
+      "markdown": "Inline",
+      "expected_output": "<p>Hamlet said:<br>~~~~.python <br>def speak(self):<br>    x = 1<br>~~~~</p>",
+      "text_content": "Hamlet said:~~~~.python def speak(self):    x = 1~~~~"
+    },
+    {
       "name": "codeblock_hilite_invented_language",
       "input": "``` inventedlanguage\ndef speak(self):\n    x = 1\n```",
       "expected_output": "<div class=\"codehilite\" data-code-language=\"inventedlanguage\"><pre><span></span><code>def speak(self):\n    x = 1\n</code></pre></div>",
       "text_content": "def speak(self):\n    x = 1\n"
+    },
+    {
+      "name": "inline_markdown_codeblock_hilite_invented_language",
+      "input": "``` inventedlanguage\ndef speak(self):\n    x = 1\n```",
+      "markdown": "Inline",
+      "expected_output": "<p>``` inventedlanguage<br>def speak(self):<br>    x = 1<br>```</p>",
+      "text_content": "``` inventedlanguagedef speak(self):    x = 1```"
     },
     {
       "name": "codeblock_canonicalize_lang_alias",
@@ -30,6 +44,13 @@
       "name": "ampampamp",
       "input": "& &amp; &amp;amp;\n~~~~\n& &amp; &amp;amp;\n~~~~\n    & &amp; &amp;amp;",
       "expected_output": "<p>&amp; &amp; &amp;amp;</p>\n<div class=\"codehilite\"><pre><span></span><code>&amp; &amp;amp; &amp;amp;amp;\n</code></pre></div>\n<div class=\"codehilite\"><pre><span></span><code>&amp; &amp;amp; &amp;amp;amp;\n</code></pre></div>"
+    },
+    {
+      "name": "inline_markdown_ampampamp",
+      "input": "& &amp; &amp;amp;\n~~~~\n& &amp; &amp;amp;\n~~~~\n    & &amp; &amp;amp;",
+      "markdown": "Inline",
+      "expected_output": "<p>&amp; &amp; &amp;amp;<br>~~~~<br>&amp; &amp; &amp;amp;<br>~~~~<br>    &amp; &amp; &amp;amp;</p>",
+      "text_content": "& & &amp;~~~~& & &amp;~~~~    & & &amp;"
     },
     {
       "name": "basic_paragraph",
@@ -46,6 +67,12 @@
     {
       "name": "normal_text_test",
       "input": "it's lunch time",
+      "expected_output": "<p>it's lunch time</p>"
+    },
+    {
+      "name": "inline_markdown_normal_text_test",
+      "input": "it's lunch time",
+      "markdown": "Inline",
       "expected_output": "<p>it's lunch time</p>"
     },
     {
@@ -71,6 +98,13 @@
       "input": "\n```\nfenced code\n```\n\n```inline code```\n",
       "expected_output": "<div class=\"codehilite\"><pre><span></span><code>fenced code\n</code></pre></div>\n<p><code>inline code</code></p>",
       "text_content": "fenced code\n\ninline code"
+    },
+    {
+      "name": "inline_markdown_codeblock_backticks",
+      "input": "\n```\nfenced code\n```\n\n```inline code```\n",
+      "markdown": "Inline",
+      "expected_output": "<p>```<br>fenced code<br>```</p><p>```inline code```<br></p>",
+      "text_content": "```fenced code``````inline code```"
     },
     {
       "name": "hanging_multi_codeblock",
@@ -175,6 +209,12 @@
       "expected_output": "<h1>Hello world</h1>"
     },
     {
+      "name": "inline_markdown_hashheading_enabled",
+      "input": "# Hello world",
+      "markdown": "Inline",
+      "expected_output": "<p># Hello world</p>"
+    },
+    {
       "name": "hashheading_needs_spaces",
       "input": "#Hello world",
       "expected_output": "<p>#Hello world</p>"
@@ -209,6 +249,13 @@
       "input": "Some text with a list:\n\n* One item\n* Two items\n* Three items",
       "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",
       "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
+    },
+    {
+      "name": "inline_markdown_ulist_standard_1",
+      "input": "Some text with a list:\n\n* One item\n* Two items\n* Three items",
+      "markdown": "Inline",
+      "expected_output": "<p>Some text with a list:</p><p>* One item<br>* Two items<br>* Three items</p>",
+      "text_content": "Some text with a list:* One item* Two items* Three items"
     },
     {
       "name": "ulist_standard_2",
@@ -303,6 +350,13 @@
       "text_content": "I like software hardware"
     },
     {
+      "name": "inline_markdown_strikthrough_basic",
+      "input": "I like ~~software~~ hardware",
+      "markdown": "Inline",
+      "expected_output": "<p>I like <del>software</del> hardware</p>",
+      "text_content": "I like software hardware"
+    },
+    {
       "name": "strikthrough_multiword_with_no_space_in_between",
       "input": "I ~~like software~~ love hardware",
       "expected_output": "<p>I <del>like software</del> love hardware</p>",
@@ -332,6 +386,13 @@
       "text_content": "foo"
     },
     {
+      "name": "inline_markdown_emphasis_text",
+      "input": "*foo*",
+      "markdown": "Inline",
+      "expected_output": "<p><em>foo</em></p>",
+      "text_content": "foo"
+    },
+    {
       "name": "emphasis_code",
       "input": "const char *x = (char *)y",
       "expected_output": "<p>const char *x = (char *)y</p>"
@@ -355,6 +416,13 @@
     {
       "name": "star_strong",
       "input": "**foo**",
+      "expected_output": "<p><strong>foo</strong></p>",
+      "text_content": "foo"
+    },
+    {
+      "name": "inline_markdown_star_strong",
+      "input": "**foo**",
+      "markdown": "Inline",
       "expected_output": "<p><strong>foo</strong></p>",
       "text_content": "foo"
     },
@@ -411,6 +479,14 @@
       "expected_output": "<p>Google logo today: <a href=\"https://www.google.com/images/srpr/logo4w.png\">https://www.google.com/images/srpr/logo4w.png</a><br>\nKinda boring</p>\n<div class=\"message_inline_image\"><a href=\"https://www.google.com/images/srpr/logo4w.png\"><img data-src-fullsize=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=full\" src=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=thumbnail\"></a></div>",
       "backend_only_rendering": true,
       "text_content": "Google logo today: https:\/\/www.google.com\/images\/srpr\/logo4w.png\nKinda boring\n"
+    },
+    {
+      "name": "inline_markdown_inline_image",
+      "input": "Google logo today: https://www.google.com/images/srpr/logo4w.png Kinda boring",
+      "markdown": "Inline",
+      "expected_output": "<p>Google logo today: <a href=\"https://www.google.com/images/srpr/logo4w.png\">https://www.google.com/images/srpr/logo4w.png</a> Kinda boring</p>",
+      "backend_only_rendering": true,
+      "text_content": "Google logo today: https:\/\/www.google.com\/images\/srpr\/logo4w.png Kinda boring"
     },
     {
       "name": "blockquote_inline_image",
@@ -472,6 +548,14 @@
       "text_content": "Google link\n"
     },
     {
+      "name": "inline_markdown_only_named_inline_video",
+      "input": "[Google link](https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_480_1_5MG.mp4)",
+      "markdown": "Inline",
+      "expected_output": "<p><a href=\"https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_480_1_5MG.mp4\">Google link</a></p>",
+      "backend_only_rendering": true,
+      "text_content": "Google link"
+    },
+    {
       "name": "link_with_text",
       "input": "[hello](https://github.com)",
       "expected_output": "<p><a href=\"https://github.com\">hello</a></p>"
@@ -479,6 +563,12 @@
     {
       "name": "link_without_text",
       "input": "[](https://github.com)",
+      "expected_output": "<p><a href=\"https://github.com\">https://github.com</a></p>"
+    },
+    {
+      "name": "inline_markdown_link_without_text",
+      "input": "[](https://github.com)",
+      "markdown": "Inline",
       "expected_output": "<p><a href=\"https://github.com\">https://github.com</a></p>"
     },
     {
@@ -599,6 +689,12 @@
     {
       "name": "random_emoji_2",
       "input": ":poop:",
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>"
+    },
+    {
+      "name": "inline_markdown_random_emoji_2",
+      "input": ":poop:",
+      "markdown": "Inline",
       "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>"
     },
     {
@@ -812,6 +908,14 @@
       "text_content": "Jun 5th 2017, 10:30PM"
     },
     {
+      "name": "inline_markdown_timestamp_backend_markdown_only",
+      "input": "<time:Jun 5th 2017, 10:30PM>",
+      "markdown": "Inline",
+      "expected_output": "<p><time datetime=\"2017-06-05T22:30:00Z\">Jun 5th 2017, 10:30PM</time></p>",
+      "marked_expected_output": "<p><span>Jun 5th 2017, 10:30PM</span></p>",
+      "text_content": "Jun 5th 2017, 10:30PM"
+    },
+    {
       "name": "timestamp_backend_markdown_and_marked",
       "input": "<time:31 Dec 2017>",
       "expected_output": "<p><time datetime=\"2017-12-31T00:00:00Z\">31 Dec 2017</time></p>",
@@ -965,6 +1069,13 @@
       "text_content": "(…)\noutside spoiler"
     },
     {
+      "name": "inline_markdown_spoilers_empty_header",
+      "input": "```spoiler\ncontent\n```\noutside spoiler\n",
+      "markdown": "Inline",
+      "expected_output": "<p>```spoiler<br>content<br>```<br>outside spoiler<br></p>",
+      "text_content": "```spoilercontent```outside spoiler"
+    },
+    {
       "name": "spoilers_script_tags",
       "input": "```spoiler <script>alert(1)</script>\n<script>alert(1)</script>\n```",
       "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n</div></div>",
@@ -1017,6 +1128,12 @@
         "input": "[call me](tel:+14155551234) [or maybe not](sms:+14155551234)",
         "expected_output": "<p><a href=\"tel:+14155551234\">call me</a> <a href=\"sms:+14155551234\">or maybe not</a></p>"
     },
+    {
+      "name": "inline_markdown_telephone_sms_link",
+      "input": "[call me](tel:+14155551234) [or maybe not](sms:+14155551234)",
+      "markdown": "Inline",
+      "expected_output": "<p><a href=\"tel:+14155551234\">call me</a> <a href=\"sms:+14155551234\">or maybe not</a></p>"
+  },
     {
       "name": "codeblock_hilite_shebang_feature_no_path_1",
       "input": "```\n#!python\nprint(\"Hello World\")\n```",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -37,6 +37,7 @@ from zerver.lib.markdown import (
     get_tweet_id,
     image_preview_enabled,
     markdown_convert,
+    markdown_convert_inline,
     maybe_update_markdown_engines,
     possible_linked_stream_names,
     render_message_markdown,
@@ -200,6 +201,13 @@ class FencedBlockPreprocessorTest(ZulipTestCase):
 
 def markdown_convert_wrapper(content: str) -> str:
     return markdown_convert(
+        content=content,
+        message_realm=get_realm("zulip"),
+    ).rendered_content
+
+
+def markdown_convert_inline_wrapper(content: str) -> str:
+    return markdown_convert_inline(
         content=content,
         message_realm=get_realm("zulip"),
     ).rendered_content
@@ -456,12 +464,13 @@ class MarkdownTest(ZulipTestCase):
         for name, test in format_tests.items():
             with self.subTest(markdown_test_case=name):
                 # Check that there aren't any unexpected keys as those are often typos
-                self.assert_length(set(test.keys()) - valid_keys, 0)
+                if not test.get("markdown", False):
+                    self.assert_length(set(test.keys()) - valid_keys, 0)
                 # Ignore tests if specified
                 if test.get("ignore", False):
                     continue  # nocoverage
 
-                if test.get("translate_emoticons", False):
+                if test.get("translate_emoticons", False) and not test.get("markdown", False):
                     # Create a userprofile and send message with it.
                     user_profile = self.example_user("othello")
                     do_change_user_setting(
@@ -475,7 +484,11 @@ class MarkdownTest(ZulipTestCase):
                     rendering_result = render_message_markdown(msg, test["input"])
                     converted = rendering_result.rendered_content
                 else:
-                    converted = markdown_convert_wrapper(test["input"])
+                    if test.get("markdown", False):
+                        converted = markdown_convert_inline_wrapper(test["input"])
+
+                    else:
+                        converted = markdown_convert_wrapper(test["input"])
 
                 self.assertEqual(converted, test["expected_output"])
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1552,13 +1552,14 @@ class TestMessageNotificationEmails(ZulipTestCase):
             if "spoiler" in test["name"]:
                 test_fixtures[test["name"]] = test
         for test_name in test_fixtures:
-            fragment = lxml.html.fromstring(test_fixtures[test_name]["expected_output"])
-            fix_spoilers_in_html(fragment, "en")
-            output_data = lxml.html.tostring(fragment, encoding="unicode")
-            assert "spoiler-header" not in output_data
-            assert "spoiler-content" not in output_data
-            assert "spoiler-block" in output_data
-            assert "spoiler-title" in output_data
+            if not test_fixtures[test_name].get("markdown", False):
+                fragment = lxml.html.fromstring(test_fixtures[test_name]["expected_output"])
+                fix_spoilers_in_html(fragment, "en")
+                output_data = lxml.html.tostring(fragment, encoding="unicode")
+                assert "spoiler-header" not in output_data
+                assert "spoiler-content" not in output_data
+                assert "spoiler-block" in output_data
+                assert "spoiler-title" in output_data
 
     def test_spoilers_in_text_emails(self) -> None:
         content = "@**King Hamlet**\n\n```spoiler header text\nsecret-text\n```"

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -343,10 +343,7 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_error('{"type": "bogus"}', "Unknown type for todo data: bogus")
 
         assert_error('{"type": "new_task"}', "key is missing")
-        assert_error(
-            '{"type": "new_task", "key": 7, "task": 7, "desc": "", "completed": false}',
-            'data["task"] is not a string',
-        )
+
         assert_error(
             '{"type": "new_task", "key": -1, "task": "eat", "desc": "", "completed": false}',
             'data["key"] is too small',
@@ -365,6 +362,7 @@ class WidgetContentTestCase(ZulipTestCase):
             self.assert_json_success(result)
 
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
+        assert_success(dict(type="new_task", key=8, task="beat", desc="yes", completed=False))
         assert_success(dict(type="strike", key="5,9"))
 
     def test_get_widget_type(self) -> None:

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -196,7 +196,7 @@ class WidgetContentTestCase(ZulipTestCase):
         expected_submessage_content = dict(
             widget_type="poll",
             extra_data=dict(
-                options=["Red", "Green", "Blue", "Yellow"],
+                options=["<p>Red</p>", "<p>Green</p>", "<p>Blue</p>", "<p>Yellow</p>"],
                 question="What is your favorite color?",
             ),
         )
@@ -295,7 +295,6 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_error('{"type": "question", "question": 7}', "not a string")
 
         assert_error('{"type": "new_option"}', "key is missing")
-        assert_error('{"type": "new_option", "idx": 7, "option": 999}', "not a string")
         assert_error('{"type": "new_option", "idx": -1, "option": "pizza"}', "too small")
         assert_error('{"type": "new_option", "idx": 1001, "option": "pizza"}', "too large")
         assert_error('{"type": "new_option", "idx": "bogus", "option": "maybe"}', "not an int")

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -37,13 +37,24 @@ def process_submessage(
 
     try:
         widget_data = orjson.loads(content)
-        if (
-            isinstance(widget_data, dict)
-            and widget_data.get("type") == "new_option"
-            and widget_data.get("option")
-        ):
-            rendered_content = markdown_convert_inline(str(widget_data["option"])).rendered_content
-            widget_data["option"] = rendered_content
+        if isinstance(widget_data, dict):
+            if widget_data.get("type") == "new_option" and widget_data.get("option"):
+                rendered_content = markdown_convert_inline(
+                    str(widget_data["option"])
+                ).rendered_content
+                widget_data["option"] = rendered_content
+                content = json.dumps(widget_data)
+
+            elif widget_data.get("type") == "new_task" and widget_data.get("task"):
+                rendered_task = markdown_convert_inline(str(widget_data["task"])).rendered_content
+                if widget_data.get("desc"):
+                    rendered_desc = markdown_convert_inline(
+                        str(widget_data["desc"])
+                    ).rendered_content
+                    rendered_desc = rendered_desc.replace("<p>", "<p>&nbsp;")
+                    widget_data["desc"] = rendered_desc
+                widget_data["task"] = rendered_task
+
             content = json.dumps(widget_data)
 
     except orjson.JSONDecodeError:

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -1,3 +1,5 @@
+import json
+
 import orjson
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -6,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from zerver.actions.submessage import do_add_submessage, verify_submessage_sender
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.markdown import markdown_convert_inline
 from zerver.lib.message import access_message
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
@@ -34,6 +37,15 @@ def process_submessage(
 
     try:
         widget_data = orjson.loads(content)
+        if (
+            isinstance(widget_data, dict)
+            and widget_data.get("type") == "new_option"
+            and widget_data.get("option")
+        ):
+            rendered_content = markdown_convert_inline(str(widget_data["option"])).rendered_content
+            widget_data["option"] = rendered_content
+            content = json.dumps(widget_data)
+
     except orjson.JSONDecodeError:
         raise JsonableError(_("Invalid json for submessage"))
 


### PR DESCRIPTION
Previously, markdown was not supported in widgets like polls and todo. This is fixed by adding an inline only backend processor ZulipInlineMarkdown, and using it to render the poll options or tasks and descriptions of todo before adding them to the database.

- Commt 1 (`fbb12bc`): Add `ZulipInlineMarkdown` processor to render inline only patterns.
- Commit 2 (`e4ceba6`): Support inline markdown in polls.
- Commit 3 (`1197b5f`): Support inline markdown in todo widgets.  

Fixes: #21917

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Support.20links.20in.20Polls/near/1674037)

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="548" alt="image" src="https://github.com/zulip/zulip/assets/97049524/c0770cb6-630c-46db-be62-43f29d3381ac">

<img width="544" alt="image" src="https://github.com/zulip/zulip/assets/97049524/66084967-cb55-4036-82c6-715f17bbbfbf">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
