### PR TITLE
push-notifications: Update payload for realm name and event string.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 234**
+
+* Mobile push notifications now include a `realm_name` field.
+* [`POST /mobile_push/test_notification`](/api/test-notify) now sends
+  a test notification with `test` rather than `test-by-device-token`
+  in the `event` field.
+
 **Feature level 233**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 233
+API_FEATURE_LEVEL = 234
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -908,6 +908,7 @@ def get_base_payload(user_profile: UserProfile) -> Dict[str, Any]:
     data["server"] = settings.EXTERNAL_HOST
     data["realm_id"] = user_profile.realm.id
     data["realm_uri"] = user_profile.realm.uri
+    data["realm_name"] = user_profile.realm.name
     data["user_id"] = user_profile.id
 
     return data
@@ -1398,7 +1399,7 @@ def send_test_push_notification_directly_to_devices(
     remote: Optional["RemoteZulipServer"] = None,
 ) -> None:
     payload = copy.deepcopy(base_payload)
-    payload["event"] = "test-by-device-token"
+    payload["event"] = "test"
 
     apple_devices = [device for device in devices if device.kind == PushDeviceToken.APNS]
     android_devices = [device for device in devices if device.kind == PushDeviceToken.GCM]
@@ -1408,10 +1409,13 @@ def send_test_push_notification_directly_to_devices(
     android_payload = copy.deepcopy(payload)
 
     realm_uri = base_payload["realm_uri"]
+    realm_name = base_payload["realm_name"]
     apns_data = {
         "alert": {
             "title": _("Test notification"),
-            "body": _("This is a test notification from {realm_uri}.").format(realm_uri=realm_uri),
+            "body": _("This is a test notification from {realm_name} ({realm_uri}).").format(
+                realm_name=realm_name, realm_uri=realm_uri
+            ),
         },
         "sound": "default",
         "custom": {"zulip": apple_payload},

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9503,7 +9503,13 @@ paths:
         This endpoint allows a user to trigger a test push notification to their
         selected mobile device, or all their mobile devices.
 
-        **Changes**: New in Zulip 8.0 (feature level 217).
+        **Changes**: Starting with Zulip 8.0 (feature level 234), test
+        notifications sent via this endpoint use `test` rather than
+        `test-by-device-token` in the `event` field. (All mobile push
+        notifications also now include a `realm_name` field as well as
+        of this feature level).
+
+        New in Zulip 8.0 (feature level 217).
       parameters:
         - name: token
           in: query

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -196,9 +196,10 @@ class SendTestPushNotificationEndpointTest(BouncerTestCase):
         expected_android_payload = {
             "server": "testserver",
             "realm_id": user.realm_id,
+            "realm_name": "Zulip Dev",
             "realm_uri": "http://zulip.testserver",
             "user_id": user.id,
-            "event": "test-by-device-token",
+            "event": "test",
             "time": datetime_to_timestamp(time_now),
         }
         expected_gcm_options = {"priority": "high"}
@@ -219,16 +220,17 @@ class SendTestPushNotificationEndpointTest(BouncerTestCase):
         expected_apple_payload = {
             "alert": {
                 "title": "Test notification",
-                "body": "This is a test notification from http://zulip.testserver.",
+                "body": "This is a test notification from Zulip Dev (http://zulip.testserver).",
             },
             "sound": "default",
             "custom": {
                 "zulip": {
                     "server": "testserver",
                     "realm_id": user.realm_id,
+                    "realm_name": "Zulip Dev",
                     "realm_uri": "http://zulip.testserver",
                     "user_id": user.id,
-                    "event": "test-by-device-token",
+                    "event": "test",
                 }
             },
         }
@@ -301,9 +303,10 @@ class SendTestPushNotificationEndpointTest(BouncerTestCase):
         expected_payload = {
             "server": "testserver",
             "realm_id": user.realm_id,
+            "realm_name": "Zulip Dev",
             "realm_uri": "http://zulip.testserver",
             "user_id": user.id,
-            "event": "test-by-device-token",
+            "event": "test",
             "time": datetime_to_timestamp(time_now),
         }
         expected_gcm_options = {"priority": "high"}
@@ -2389,6 +2392,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                         "zulip": {
                             "server": "testserver",
                             "realm_id": self.sender.realm.id,
+                            "realm_name": self.sender.realm.name,
                             "realm_uri": "http://zulip.testserver",
                             "user_id": self.user_profile.id,
                             "event": "remove",
@@ -2399,6 +2403,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 {
                     "server": "testserver",
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": "http://zulip.testserver",
                     "user_id": self.user_profile.id,
                     "event": "remove",
@@ -2452,6 +2457,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 {
                     "server": "testserver",
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": "http://zulip.testserver",
                     "user_id": self.user_profile.id,
                     "event": "remove",
@@ -2469,6 +2475,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                         "zulip": {
                             "server": "testserver",
                             "realm_id": self.sender.realm.id,
+                            "realm_name": self.sender.realm.name,
                             "realm_uri": "http://zulip.testserver",
                             "user_id": self.user_profile.id,
                             "event": "remove",
@@ -2948,6 +2955,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "sender_id": self.sender.id,
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -2991,6 +2999,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "sender_id": self.sender.id,
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3023,6 +3032,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "topic": message.topic_name(),
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": self.sender.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3061,6 +3071,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "topic": message.topic_name(),
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3098,6 +3109,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "topic": message.topic_name(),
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "mentioned_user_group_id": user_group.id,
@@ -3136,6 +3148,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "topic": message.topic_name(),
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3197,6 +3210,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "sender_id": self.sender.id,
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": self.sender.realm.id,
+                    "realm_name": self.sender.realm.name,
                     "realm_uri": self.sender.realm.uri,
                     "user_id": user_profile.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3246,6 +3260,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                     "topic": message.topic_name(),
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": hamlet.realm.id,
+                    "realm_name": hamlet.realm.name,
                     "realm_uri": hamlet.realm.uri,
                     "user_id": polonius.id,
                     "time": datetime_to_timestamp(message.date_sent),
@@ -3284,6 +3299,7 @@ class TestGetGCMPayload(PushNotificationTest):
             "content_truncated": truncate_content,
             "server": settings.EXTERNAL_HOST,
             "realm_id": hamlet.realm.id,
+            "realm_name": hamlet.realm.name,
             "realm_uri": hamlet.realm.uri,
             "sender_id": hamlet.id,
             "sender_email": hamlet.email,
@@ -3342,6 +3358,7 @@ class TestGetGCMPayload(PushNotificationTest):
                 "content_truncated": False,
                 "server": settings.EXTERNAL_HOST,
                 "realm_id": hamlet.realm.id,
+                "realm_name": hamlet.realm.name,
                 "realm_uri": hamlet.realm.uri,
                 "sender_id": hamlet.id,
                 "sender_email": hamlet.email,
@@ -3374,6 +3391,7 @@ class TestGetGCMPayload(PushNotificationTest):
                 "content_truncated": False,
                 "server": settings.EXTERNAL_HOST,
                 "realm_id": hamlet.realm.id,
+                "realm_name": hamlet.realm.name,
                 "realm_uri": hamlet.realm.uri,
                 "sender_id": hamlet.id,
                 "sender_email": hamlet.email,
@@ -3423,6 +3441,7 @@ class TestGetGCMPayload(PushNotificationTest):
                 "content_truncated": False,
                 "server": settings.EXTERNAL_HOST,
                 "realm_id": hamlet.realm.id,
+                "realm_name": hamlet.realm.name,
                 "realm_uri": hamlet.realm.uri,
                 "sender_id": hamlet.id,
                 "sender_email": f"user{hamlet.id}@zulip.testserver",


### PR DESCRIPTION
Adds `user.realm.string_id` as the realm name to the base payload for notifications. Uses this realm name in the body of the alert in the `apns_data`.

Changes the event string from "test-by-device-token" to "test".

See [relevant conversation on CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/.2323997.20Endpoint.20for.20test.20notification/near/1696957).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
