### PR TITLE
push_notifications: Fix handling of 500s from bouncer.

### DIFF
--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -20,8 +20,8 @@ from zerver.models import OrgTypeEnum, Realm, RealmAuditLog
 
 
 class PushBouncerSession(OutgoingSession):
-    def __init__(self) -> None:
-        super().__init__(role="push_bouncer", timeout=30)
+    def __init__(self, timeout: int = 15) -> None:
+        super().__init__(role="push_bouncer", timeout=timeout)
 
 
 class PushNotificationBouncerError(Exception):
@@ -98,9 +98,23 @@ def send_to_push_bouncer(
     headers = {"User-agent": f"ZulipServer/{ZULIP_VERSION}"}
     headers.update(extra_headers)
 
+    if endpoint == "server/analytics":
+        # Uploading audit log and/or analytics data can require the
+        # bouncer to do a significant chunk of work in a few
+        # situations; since this occurs in background jobs, set a long
+        # timeout.
+        session = PushBouncerSession(timeout=90)
+    else:
+        session = PushBouncerSession()
+
     try:
-        res = PushBouncerSession().request(
-            method, url, data=post_data, auth=api_auth, verify=True, headers=headers
+        res = session.request(
+            method,
+            url,
+            data=post_data,
+            auth=api_auth,
+            verify=True,
+            headers=headers,
         )
     except (
         requests.exceptions.Timeout,

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -32,6 +32,10 @@ class PushNotificationBouncerRetryLaterError(JsonableError):
     http_status_code = 502
 
 
+class PushNotificationBouncerServerError(PushNotificationBouncerRetryLaterError):
+    http_status_code = 502
+
+
 class RealmDataForAnalytics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -114,7 +118,7 @@ def send_to_push_bouncer(
         # to the callers that the attempt failed and they can retry.
         error_msg = "Received 500 from push notification bouncer"
         logging.warning(error_msg)
-        raise PushNotificationBouncerRetryLaterError(error_msg)
+        raise PushNotificationBouncerServerError(error_msg)
     elif res.status_code >= 400:
         # If JSON parsing errors, just let that exception happen
         result_dict = orjson.loads(res.content)


### PR DESCRIPTION
The comments explain the context, but we shouldn't mark our access to push notifications as disabled incorrectly here.

We have some existing nocoverage markers in this code that probably should be fixed in a separate PR that also moves this code to be reusable.