### PR TITLE
popovers: Add dynamic width, structural changes and other small improvements to stream and topic action popovers.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -134,7 +134,6 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         can_rename_topic,
         is_realm_admin: page_params.is_admin,
         topic_is_resolved: resolved_topic.is_resolved(topic_name),
-        color: sub.color,
         has_starred_messages,
         url,
         visibility_policy,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -63,7 +63,6 @@ $before_unread_count_padding: 3px;
 }
 
 .sidebar-topic-check,
-.topic-name,
 .topic-markers-and-controls {
     cursor: pointer;
 }
@@ -919,6 +918,29 @@ li.top_left_scheduled_messages {
     grid-template-columns:
         25px $topic_resolve_width minmax(0, 1fr) minmax(0, max-content)
         30px 0;
+
+    .topic-name {
+        cursor: pointer;
+        grid-area: row-content;
+        padding: 1px $before_unread_count_padding 1px 0;
+
+        /* TODO: We should figure out how to remove this without changing the spacing */
+        line-height: 1.1;
+
+        /* TODO: Consolidate these styles with conversation partners and stream name
+            once grid rewrite is complete on all sidebar rows.
+
+            Also: note that these styles will be moot for topic names once we allow
+            for multiline topics. If we hold multiline topics to a certain number
+            of lines, we'll likely need a JavaScript-based solution like Clamp.js
+            to display an ellipsis on the final visible line. */
+        white-space: nowrap;
+        /* Both `hidden` and `clip` are shown for the sake
+            of older browsers that do not support `clip`. */
+        overflow-x: hidden;
+        overflow-x: clip;
+        text-overflow: ellipsis;
+    }
 }
 
 .topic-box .zero_count {
@@ -929,28 +951,6 @@ li.top_left_scheduled_messages {
     grid-area: starting-anchor-element;
     font-size: 15px;
     height: 20px;
-}
-
-.topic-name {
-    grid-area: row-content;
-    padding: 1px $before_unread_count_padding 1px 0;
-
-    /* TODO: We should figure out how to remove this without changing the spacing */
-    line-height: 1.1;
-
-    /* TODO: Consolidate these styles with conversation partners and stream name
-       once grid rewrite is complete on all sidebar rows.
-
-       Also: note that these styles will be moot for topic names once we allow
-       for multiline topics. If we hold multiline topics to a certain number
-       of lines, we'll likely need a JavaScript-based solution like Clamp.js
-       to display an ellipsis on the final visible line. */
-    white-space: nowrap;
-    /* Both `hidden` and `clip` are shown for the sake
-       of older browsers that do not support `clip`. */
-    overflow-x: hidden;
-    overflow-x: clip;
-    text-overflow: ellipsis;
 }
 
 .stream-markers-and-controls,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -226,6 +226,12 @@
 }
 
 .streams_popover {
+    width: min-content;
+
+    .stream-menu-item {
+        white-space: nowrap;
+    }
+
     .topic-name {
         text-align: center;
         margin-top: 5px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -236,6 +236,7 @@
         text-align: center;
         margin-top: 5px;
         margin-bottom: 5px;
+        white-space: normal;
     }
 
     .colorpicker-container {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -323,10 +323,6 @@ ul {
             margin-top: 5px;
             margin-bottom: 5px;
             white-space: normal;
-
-            .fa-chevron-right {
-                font-size: 12px;
-            }
         }
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -320,7 +320,6 @@ ul {
         }
 
         .topic-name {
-            text-align: center;
             margin-top: 5px;
             margin-bottom: 5px;
             white-space: normal;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -323,6 +323,7 @@ ul {
             text-align: center;
             margin-top: 5px;
             margin-bottom: 5px;
+            white-space: normal;
 
             .fa-chevron-right {
                 font-size: 12px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -312,6 +312,13 @@ ul {
     }
 
     &.topics_popover {
+        min-width: var(--popover-menu-min-width);
+        width: min-content;
+
+        .topic-menu-item {
+            white-space: nowrap;
+        }
+
         .topic-name {
             text-align: center;
             margin-top: 5px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -232,12 +232,14 @@
         white-space: nowrap;
     }
 
-    .topic-name {
+    .stream-name {
         align-items: baseline;
+        color: var(--color-text-sidebar-popover-menu);
         display: flex;
         gap: 3px;
-        margin-top: 5px;
-        margin-bottom: 5px;
+        font-weight: 700;
+        line-height: 1.1;
+        margin: 6px 0;
         white-space: normal;
     }
 
@@ -286,6 +288,23 @@
     }
 }
 
+.topics_popover {
+    min-width: var(--popover-menu-min-width);
+    width: min-content;
+
+    .topic-menu-item {
+        white-space: nowrap;
+    }
+
+    .topic-name {
+        color: var(--color-text-sidebar-popover-menu);
+        font-weight: 700;
+        line-height: 1.1;
+        margin: 6px 0;
+        white-space: normal;
+    }
+}
+
 ul {
     &.user-card-popover-actions i,
     &.actions_popover i,
@@ -317,21 +336,6 @@ ul {
                 line-height: 1;
                 top: 1px;
             }
-        }
-    }
-
-    &.topics_popover {
-        min-width: var(--popover-menu-min-width);
-        width: min-content;
-
-        .topic-menu-item {
-            white-space: nowrap;
-        }
-
-        .topic-name {
-            margin-top: 5px;
-            margin-bottom: 5px;
-            white-space: normal;
         }
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -233,7 +233,9 @@
     }
 
     .topic-name {
-        text-align: center;
+        align-items: baseline;
+        display: flex;
+        gap: 3px;
         margin-top: 5px;
         margin-bottom: 5px;
         white-space: normal;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -284,6 +284,7 @@ body {
     --color-text-personal-menu-no-status: hsl(0deg 0% 50%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
     --color-text-sidebar-heading: hsl(0deg 0% 43%);
+    --color-text-sidebar-popover-menu: hsl(0deg 0% 20%);
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
@@ -573,6 +574,7 @@ body {
     --color-text-item: hsl(0deg 0% 50%);
     --color-text-personal-menu-no-status: hsl(0deg 0% 100% 35%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 100% 50%);
+    --color-text-sidebar-popover-menu: hsl(236deg 33% 90%);
     /* 75% opacity of --color-text-default against --color-background.
        We use color-mix here to avoid defining a separate, compounding
        `opacity` property, and also to preserve a record of the

--- a/web/templates/stream_sidebar_actions.hbs
+++ b/web/templates/stream_sidebar_actions.hbs
@@ -1,14 +1,14 @@
 {{! Contents of the "stream actions" popup }}
 <ul class="nav nav-list streams_popover" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
     <li class="stream-menu-item">
-        <p class="topic-name">
+        <div class="stream-name">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
                 {{> stream_privacy
                   invite_only=stream.invite_only
                   is_web_public=stream.is_web_public }}
             </span>
-            <b>{{stream.name}}</b>
-        </p>
+            {{stream.name}}
+        </div>
     </li>
 
     <hr />

--- a/web/templates/stream_sidebar_actions.hbs
+++ b/web/templates/stream_sidebar_actions.hbs
@@ -1,6 +1,6 @@
 {{! Contents of the "stream actions" popup }}
 <ul class="nav nav-list streams_popover" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
-    <li>
+    <li class="stream-menu-item">
         <p class="topic-name">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
                 {{> stream_privacy
@@ -14,13 +14,13 @@
     <hr />
 
     {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-    <li>
+    <li class="stream-menu-item">
         <a tabindex="0" class="open_stream_settings">
             <i class="fa fa-cog" aria-hidden="true"></i>
             {{t "Stream settings" }}
         </a>
     </li>
-    <li class="hidden-for-spectators">
+    <li class="stream-menu-item hidden-for-spectators">
         <a tabindex="0" class="pin_to_top">
             <i class="fa fa-thumb-tack stream-pin-icon" aria-hidden="true"></i>
             {{#if stream.pin_to_top}}
@@ -30,13 +30,13 @@
             {{/if}}
         </a>
     </li>
-    <li class="hidden-for-spectators">
+    <li class="stream-menu-item hidden-for-spectators">
         <a tabindex="0" class="mark_stream_as_read">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
-    <li class="hidden-for-spectators">
+    <li class="stream-menu-item hidden-for-spectators">
         <a tabindex="0" class="toggle_stream_muted">
             {{#if stream.is_muted}}
             <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
@@ -47,19 +47,19 @@
             {{/if}}
         </a>
     </li>
-    <li>
+    <li class="stream-menu-item">
         <a tabindex="0" class="popover_new_topic_button">
             <i class="fa fa-plus" aria-hidden="true"></i>
             {{t "New topic" }}
         </a>
     </li>
-    <li class="hidden-for-spectators">
+    <li class="stream-menu-item hidden-for-spectators">
         <a tabindex="0" class="popover_sub_unsub_button" data-name="{{stream.name}}">
             <i class='fa fa-envelope' aria-hidden="true"></i>
             {{t "Unsubscribe" }}
         </a>
     </li>
-    <li class="hidden-for-spectators no-auto-hide-left-sidebar-overlay">
+    <li class="stream-menu-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
         <span class="colorpicker-container"><input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" /></span>
         <a tabindex="0" class="choose_stream_color">
             <i class="fa fa-eyedropper" aria-hidden="true"></i>

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -1,5 +1,5 @@
 <ul class="nav nav-list topics_popover">
-    <li>
+    <li class="topic-menu-item">
         <p class="topic-name">
             <i class="fa fa-chevron-right" aria-hidden="true" style="color: {{color}}"></i>
             <b>{{topic_name}}</b>
@@ -8,7 +8,7 @@
 
     <hr />
 
-    <li class="hidden-for-spectators">
+    <li class="topic-menu-item hidden-for-spectators">
         <div class="tabs-container">
             <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
                 <i class="zulip-icon zulip-icon-mute-new"></i>
@@ -30,7 +30,7 @@
     <hr class="hidden-for-spectators" />
 
     {{#if has_starred_messages}}
-    <li class="hidden-for-spectators">
+    <li class="topic-menu-item hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-unstar-all-in-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
             {{t "Unstar all messages in topic" }}
@@ -38,14 +38,14 @@
     </li>
     {{/if}}
 
-    <li class="hidden-for-spectators">
+    <li class="topic-menu-item hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
 
-    <li>
+    <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-copy-link-to-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}">
             <i class="fa fa-link" aria-hidden="true"></i>
             {{t "Copy link to topic"}}
@@ -55,7 +55,7 @@
     {{#if can_move_topic}}
     <hr />
 
-    <li>
+    <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-move-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-arrows" aria-hidden="true"></i>
             {{t "Move topic"}}
@@ -64,7 +64,7 @@
     {{else if can_rename_topic}}
     <hr />
 
-    <li>
+    <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-rename-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
             {{t "Rename topic"}}
@@ -73,7 +73,7 @@
     {{/if}}
 
     {{#if can_rename_topic}}
-    <li>
+    <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-toggle-resolved" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-check" aria-hidden="true"></i>
             {{# if topic_is_resolved }}
@@ -86,7 +86,7 @@
     {{/if}}
 
     {{#if is_realm_admin}}
-    <li>
+    <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-delete-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-trash" aria-hidden="true"></i>
             {{t "Delete topic"}}

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -1,7 +1,6 @@
 <ul class="nav nav-list topics_popover">
     <li class="topic-menu-item">
         <p class="topic-name">
-            <i class="fa fa-chevron-right" aria-hidden="true" style="color: {{color}}"></i>
             <b>{{topic_name}}</b>
         </p>
     </li>

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -1,8 +1,6 @@
 <ul class="nav nav-list topics_popover">
     <li class="topic-menu-item">
-        <p class="topic-name">
-            <b>{{topic_name}}</b>
-        </p>
+        <div class="topic-name">{{topic_name}}</div>
     </li>
 
     <hr />


### PR DESCRIPTION
**Changes:**
### Topics Action Popover
- Set popover width based the longest menu item. (`min-content` sizing)
- Allow topic name to wrap across multiple lines.
- Left align the topic name.
- Remove the '>' icon.
- Change `<p>` tag to `<div>` and replace `<b>` tag with `font-weight` property.

### Streams Action Popover
- Set popover width based the longest menu item. (`min-content` sizing)
- Allow stream name to wrap across multiple lines.
- Left align the stream name.
- Change `<p>` tag to `<div>` and replace `<b>` tag with `font-weight` property.

### Common
- Restructured popover-related CSS and sensible renaming, to avoid CSS overlapping.

Fixes: #27562.

CZO Discussions: [#design](https://chat.zulip.org/#narrow/stream/101-design/topic/topic.20menu.20with.20long.20topic/near/1671161) and [#frontend](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Setting.20width.20of.20title.20to.20the.20max.20length.20of.20menu.20options.2E/near/1693679)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### **Topic Actions Popover**
| Description | Before | After |
|--------|--------|--------|
| Light Mode | ![topic-popover-before](https://github.com/zulip/zulip/assets/82862779/925ba118-ecc0-4919-bc40-9d1846909340) | ![topic-popover-after](https://github.com/zulip/zulip/assets/82862779/5450c85a-5384-4d5b-9a00-61e34fee6237) |
| Dark Mode | ![topic-popover-before-dark](https://github.com/zulip/zulip/assets/82862779/b29a511e-1e5a-407c-ab94-6d37d3bd0275)| ![topic-popover-after-dark](https://github.com/zulip/zulip/assets/82862779/c8b78fc3-c42d-452c-8451-5ca64eecf879) |
| Long Menu Options (Russian) | ![topic-popover-russian-lang-before](https://github.com/zulip/zulip/assets/82862779/fd1c3956-14d1-4b2d-8ef5-ee05e27509a7) | ![topic-popover-russian-lang](https://github.com/zulip/zulip/assets/82862779/31b6b7e0-e153-4ec5-b5db-3611a3dc38ef) |
| Topic Name that wraps across multiple lines (Japanese) | ![topic-popver-title-that-wraps-multiple-lines-before](https://github.com/zulip/zulip/assets/82862779/f3a6e4d3-58b3-4c45-977e-3bf43cd40b20) | ![topic-popver-title-that-wraps-multiple-lines](https://github.com/zulip/zulip/assets/82862779/db50cd29-0dfd-497c-b2bb-3a047c303a36) |

### **Streams Actions Popover**
| Description | Before | After |
|--------|--------|--------|
| Light Mode | ![streams-popover-light-before](https://github.com/zulip/zulip/assets/82862779/bbc2b603-3ed6-461b-9312-245aa511e4e0) | ![streams-popover-light-after](https://github.com/zulip/zulip/assets/82862779/30a940e7-00fe-4b9b-9747-fdfb265bb4ef) |
| Dark Mode | ![streams-popover-dark-before](https://github.com/zulip/zulip/assets/82862779/709d3270-0f32-4533-a79c-2b2c07b0347a) | ![streams-popover-dark](https://github.com/zulip/zulip/assets/82862779/7c035783-4670-48ac-a3e2-79751bba5278) |
| Long Menu Options (Russian) | ![streams-popover-russian-lang-before](https://github.com/zulip/zulip/assets/82862779/8cf7daa0-0048-4ee6-9ac8-b9bde7a6544a) | ![streams-popover-russian-lang-after](https://github.com/zulip/zulip/assets/82862779/17d71628-dd66-4f98-a07d-54a47cb617e9) |
| Stream Name that wraps across multiple lines | ![streams-popver-title-that-wraps-multiple-lines-before](https://github.com/zulip/zulip/assets/82862779/6f949d5b-0938-4bcd-bbcf-372cb55392f3) | ![streams-popver-title-that-wraps-multiple-lines-after](https://github.com/zulip/zulip/assets/82862779/490d4aa3-388e-473b-abce-93888fcb7cd6) |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
