### PR TITLE
scheduled_message: Fix editing msg scheduled to inaccessible stream.

### DIFF
--- a/web/src/scheduled_messages_feed_ui.js
+++ b/web/src/scheduled_messages_feed_ui.js
@@ -33,6 +33,9 @@ function get_scheduled_messages_matching_narrow() {
                 return true;
             }
         } else if (scheduled_message.type === "stream") {
+            if (narrow_state.stream_sub() === undefined) {
+                return false;
+            }
             const narrow_dict = {
                 stream_id: narrow_state.stream_sub().stream_id,
                 topic: narrow_state.topic(),

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -8,7 +8,7 @@ import {$t} from "./i18n";
 import * as narrow from "./narrow";
 import * as people from "./people";
 import * as scheduled_messages from "./scheduled_messages";
-import * as sub_store from "./sub_store";
+import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 
 export function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
@@ -39,7 +39,7 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
         compose_args = {
             type: "stream",
             stream_id: scheduled_msg.to,
-            stream: sub_store.maybe_get_stream_name(scheduled_msg.to),
+            stream: stream_data.get_stream_name_from_id(scheduled_msg.to),
             topic: scheduled_msg.topic,
             content: scheduled_msg.content,
         };


### PR DESCRIPTION
We now pass empty string as stream name instead of undefined when passing the narrow
operands to make sure we show an invalid narrow instead of error. We do same thing for drafts.

We also need to add a check to make sure narrow_state.stream_sub is defined before accessing
stream_id field in the code to filter scheduled messages for a narrow.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before
![inaccessible-stream-scheduled-before](https://github.com/zulip/zulip/assets/35494118/fc7c05ba-fb8d-46e0-9c1b-760f4edb52fa)

After
![inaccessible-stream-scheduled](https://github.com/zulip/zulip/assets/35494118/327ca94b-e14c-4302-9e26-b814ab1eba21)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
