### PR TITLE
typehead: Remove examples from slash command typehead.

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -454,13 +454,13 @@ export const dev_only_slash_commands = [
 
 export const slash_commands = [
     {
-        text: $t({defaultMessage: "/me is excited (Display action text)"}),
+        text: $t({defaultMessage: "/me (Display action text)"}),
         name: "me",
         aliases: "",
         placeholder: $t({defaultMessage: "is …"}),
     },
     {
-        text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),
+        text: $t({defaultMessage: "/poll (Create a poll)"}),
         name: "poll",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -193,7 +193,7 @@ const emoji_list = [...emojis_by_name.values()].map((emoji_dict) => ({
 const me_slash = {
     name: "me",
     aliases: "",
-    text: "translated: /me is excited (Display action text)",
+    text: "translated: /me (Display action text)",
     placeholder: "translated: is …",
 };
 
@@ -1570,11 +1570,11 @@ test("content_highlighter", ({override_rewire}) => {
     fake_this = {completing: "slash"};
     let th_render_slash_command_called = false;
     const me_slash = {
-        text: "/me is excited (Display action text)",
+        text: "/me (Display action text)",
     };
     override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
         assert.deepEqual(item, {
-            primary: "/me is excited (Display action text)",
+            primary: "/me (Display action text)",
         });
         th_render_slash_command_called = true;
     });


### PR DESCRIPTION
This removes examples from the typehead texts for the slash-commands. They typeheads are:
"/poll (Create a poll)" instead of "/poll Where should we go for lunch today? (Create a poll)"
"/me (Display action text)" instead of "/me is excited (Display action text)"



<!-- Describe your pull request here.-->
## Screenshots of before and after:
| Before | After |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/96174096/112fc3e0-f89b-49a3-bc7a-68d951fc539f) | ![image](https://github.com/zulip/zulip/assets/96174096/f1bddd66-b805-4425-b295-a15f7b1359e0) |

Fixes: zulip/zulip#27391

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
