### PR TITLE
soft_reactivate: Reactivate if group mention has < 12 members.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -414,9 +414,11 @@ def do_send_missedmessage_events_reply_in_zulip(
     )
 
     mentioned_user_group_name = None
+    mentioned_user_group_members_count = None
     mentioned_user_group = get_mentioned_user_group(missed_messages, user_profile)
     if mentioned_user_group is not None:
         mentioned_user_group_name = mentioned_user_group.name
+        mentioned_user_group_members_count = mentioned_user_group.members_count
 
     triggers = [message["trigger"] for message in missed_messages]
     unique_triggers = set(triggers)
@@ -564,7 +566,7 @@ def do_send_missedmessage_events_reply_in_zulip(
 
     # Soft reactivate the long_term_idle user personally mentioned
     soft_reactivate_if_personal_notification(
-        user_profile, unique_triggers, mentioned_user_group_name
+        user_profile, unique_triggers, mentioned_user_group_members_count
     )
 
     with override_language(user_profile.default_language):

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -25,7 +25,7 @@ from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import FENCE_RE
 from zerver.lib.message import bulk_access_messages
-from zerver.lib.notification_data import get_mentioned_user_group_name
+from zerver.lib.notification_data import get_mentioned_user_group
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress, send_future_email
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
@@ -413,7 +413,11 @@ def do_send_missedmessage_events_reply_in_zulip(
         ),
     )
 
-    mentioned_user_group_name = get_mentioned_user_group_name(missed_messages, user_profile)
+    mentioned_user_group_name = None
+    mentioned_user_group = get_mentioned_user_group(missed_messages, user_profile)
+    if mentioned_user_group is not None:
+        mentioned_user_group_name = mentioned_user_group.name
+
     triggers = [message["trigger"] for message in missed_messages]
     unique_triggers = set(triggers)
 

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Collection, Dict, List, Optional, Set
 
 from zerver.lib.mention import MentionData
-from zerver.lib.user_groups import get_user_group_direct_member_ids
+from zerver.lib.user_groups import get_user_group_member_ids
 from zerver.models import UserGroup, UserProfile, UserTopic
 from zerver.models.scheduled_jobs import NotificationTriggers
 
@@ -344,7 +344,7 @@ def get_mentioned_user_group_name(
     smallest_user_group_name = None
     for user_group_id in mentioned_user_group_ids:
         current_user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        current_user_group_size = len(get_user_group_direct_member_ids(current_user_group))
+        current_user_group_size = len(get_user_group_member_ids(current_user_group))
 
         if current_user_group_size < smallest_user_group_size:
             # If multiple user groups are mentioned, we prefer the

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -313,9 +313,16 @@ def get_user_group_mentions_data(
     return mentioned_user_groups_map
 
 
-def get_mentioned_user_group_name(
+@dataclass
+class MentionedUserGroup:
+    id: int
+    name: str
+    members_count: int
+
+
+def get_mentioned_user_group(
     messages: List[Dict[str, Any]], user_profile: UserProfile
-) -> Optional[str]:
+) -> Optional[MentionedUserGroup]:
     """Returns the user group name to display in the email notification
     if user group(s) are mentioned.
 
@@ -325,7 +332,7 @@ def get_mentioned_user_group_name(
     """
     for message in messages:
         if (
-            message["mentioned_user_group_id"] is None
+            message.get("mentioned_user_group_id") is None
             and message["trigger"] == NotificationTriggers.MENTION
         ):
             # The user has also been personally mentioned, so that gets prioritized.
@@ -335,21 +342,27 @@ def get_mentioned_user_group_name(
     mentioned_user_group_ids = [
         message["mentioned_user_group_id"]
         for message in messages
-        if message["mentioned_user_group_id"] is not None
+        if message.get("mentioned_user_group_id") is not None
     ]
+
+    if len(mentioned_user_group_ids) == 0:
+        return None
 
     # We now want to calculate the name of the smallest user group mentioned among
     # all these messages.
     smallest_user_group_size = math.inf
-    smallest_user_group_name = None
     for user_group_id in mentioned_user_group_ids:
         current_user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        current_user_group_size = len(get_user_group_member_ids(current_user_group))
+        current_mentioned_user_group = MentionedUserGroup(
+            id=current_user_group.id,
+            name=current_user_group.name,
+            members_count=len(get_user_group_member_ids(current_user_group)),
+        )
 
-        if current_user_group_size < smallest_user_group_size:
+        if current_mentioned_user_group.members_count < smallest_user_group_size:
             # If multiple user groups are mentioned, we prefer the
             # user group with the least members.
-            smallest_user_group_size = current_user_group_size
-            smallest_user_group_name = current_user_group.name
+            smallest_user_group_size = current_mentioned_user_group.members_count
+            smallest_mentioned_user_group = current_mentioned_user_group
 
-    return smallest_user_group_name
+    return smallest_mentioned_user_group

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1356,13 +1356,17 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     # message or not.
     mentioned_user_group_id = None
     mentioned_user_group_name = None
+    mentioned_user_group_members_count = None
     mentioned_user_group = get_mentioned_user_group([missed_message], user_profile)
     if mentioned_user_group is not None:
         mentioned_user_group_id = mentioned_user_group.id
         mentioned_user_group_name = mentioned_user_group.name
+        mentioned_user_group_members_count = mentioned_user_group.members_count
 
     # Soft reactivate if pushing to a long_term_idle user that is personally mentioned
-    soft_reactivate_if_personal_notification(user_profile, {trigger}, mentioned_user_group_name)
+    soft_reactivate_if_personal_notification(
+        user_profile, {trigger}, mentioned_user_group_members_count
+    )
 
     if message.is_stream_message():
         # This will almost always be True. The corner case where you

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -14,7 +14,7 @@ from django.test import override_settings
 from django_stubs_ext import StrPromise
 
 from zerver.actions.create_user import do_create_user
-from zerver.actions.user_groups import check_add_user_group
+from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.email_notifications import (
@@ -1615,13 +1615,26 @@ class TestMessageNotificationEmails(ZulipTestCase):
         email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(msg_id, verify_body_include, email_subject, verify_html_body=True)
 
+    @override_settings(MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION=2)
     def test_long_term_idle_user_missed_message(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
-        large_user_group = check_add_user_group(
-            get_realm("zulip"), "large_user_group", [hamlet, othello, cordelia], acting_user=None
+        zulip_realm = get_realm("zulip")
+
+        # user groups having upto 'MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION'
+        # members are small user groups.
+        small_user_group = check_add_user_group(
+            zulip_realm, "small_user_group", [hamlet, othello], acting_user=None
         )
+
+        large_user_group = check_add_user_group(
+            zulip_realm, "large_user_group", [hamlet], acting_user=None
+        )
+        subgroup = check_add_user_group(
+            zulip_realm, "subgroup", [othello, cordelia], acting_user=None
+        )
+        add_subgroups_to_user_group(large_user_group, [subgroup], acting_user=None)
 
         def reset_hamlet_as_soft_deactivated_user() -> None:
             nonlocal hamlet
@@ -1727,8 +1740,25 @@ class TestMessageNotificationEmails(ZulipTestCase):
         reset_hamlet_as_soft_deactivated_user()
         self.expect_to_stay_long_term_idle(hamlet, send_stream_wildcard_mention)
 
-        # Group mention should NOT soft reactivate the user
-        def send_group_mention() -> None:
+        # Small group mention should soft reactivate the user
+        def send_small_group_mention() -> None:
+            mention = "@*small_user_group*"
+            stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
+            handle_missedmessage_emails(
+                hamlet.id,
+                {
+                    stream_mentioned_message_id: MissedMessageData(
+                        trigger=NotificationTriggers.MENTION,
+                        mentioned_user_group_id=small_user_group.id,
+                    ),
+                },
+            )
+
+        reset_hamlet_as_soft_deactivated_user()
+        self.expect_soft_reactivation(hamlet, send_small_group_mention)
+
+        # Large group mention should NOT soft reactivate the user
+        def send_large_group_mention() -> None:
             mention = "@*large_user_group*"
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_missedmessage_emails(
@@ -1742,7 +1772,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
             )
 
         reset_hamlet_as_soft_deactivated_user()
-        self.expect_to_stay_long_term_idle(hamlet, send_group_mention)
+        self.expect_to_stay_long_term_idle(hamlet, send_large_group_mention)
 
     def test_followed_topic_missed_message(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -621,6 +621,10 @@ TYPING_STARTED_WAIT_PERIOD_MILLISECONDS = 30000
 # load in large organizations.
 MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS = 100
 
+# The maximum user-group size value upto which members should
+# be soft-reactivated in the case of user group mention.
+MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION = 11
+
 # Limiting guest access to other users via the
 # can_access_all_users_group setting makes presence queries much more
 # expensive. This can be a significant performance problem for


### PR DESCRIPTION
This PR makes possible to soft reactivate if the user group mentions has less than 12 members.

Fixes part of #27586 

We will do topic wildcard mention part of the issue in a separate PR.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
