### PR TITLE
context_processors: Add common context to be used in corporate pages.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -87,6 +87,24 @@ def is_isolated_page(request: HttpRequest) -> bool:
     return request.GET.get("nav") == "no"
 
 
+def zulip_default_corporate_context(request: HttpRequest) -> Dict[str, Any]:
+    from corporate.lib.decorator import is_self_hosting_management_subdomain
+
+    # Check if view function is in corporate app.
+    if (
+        request.resolver_match is not None
+        and not request.resolver_match.func.__module__.startswith("corporate")
+    ):
+        return {
+            "is_self_hosting_management_page": False,
+        }
+
+    # Add common context variables that are only used on the corporate site.
+    return {
+        "is_self_hosting_management_page": is_self_hosting_management_subdomain(request),
+    }
+
+
 def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
     """Context available to all Zulip Jinja2 templates that have a request
     passed in.  Designed to provide the long list of variables at the

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -592,6 +592,11 @@ base_template_engine_settings: Dict[str, Any] = {
     },
 }
 
+if CORPORATE_ENABLED:
+    base_template_engine_settings["OPTIONS"]["context_processors"].append(
+        "zerver.context_processors.zulip_default_corporate_context"
+    )
+
 default_template_engine_settings = deepcopy(base_template_engine_settings)
 default_template_engine_settings.update(
     NAME="Jinja2",


### PR DESCRIPTION
Context is only available for functions inside corporate app.
