### PR TITLE
remote_server: Immediately send analytics on user count change.

### DIFF
--- a/analytics/management/commands/update_analytics_counts.py
+++ b/analytics/management/commands/update_analytics_counts.py
@@ -106,4 +106,4 @@ class Command(BaseCommand):
             logger.info("Sleeping %d seconds before reporting...", delay)
             time.sleep(delay)
 
-            send_analytics_to_push_bouncer()
+            send_analytics_to_push_bouncer(consider_usage_statistics=True)

--- a/analytics/management/commands/update_analytics_counts.py
+++ b/analytics/management/commands/update_analytics_counts.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 
 from analytics.lib.counts import ALL_COUNT_STATS, logger, process_count_stat
 from scripts.lib.zulip_tools import ENDC, WARNING
-from zerver.lib.remote_server import send_analytics_to_push_bouncer
+from zerver.lib.remote_server import send_server_data_to_push_bouncer
 from zerver.lib.timestamp import floor_to_hour
 from zerver.models import Realm
 
@@ -106,4 +106,4 @@ class Command(BaseCommand):
             logger.info("Sleeping %d seconds before reporting...", delay)
             time.sleep(delay)
 
-            send_analytics_to_push_bouncer(consider_usage_statistics=True)
+            send_server_data_to_push_bouncer(consider_usage_statistics=True)

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -15,7 +15,7 @@ from corporate.lib.remote_billing_util import (
     RemoteBillingIdentityDict,
     RemoteBillingUserDict,
 )
-from zerver.lib.remote_server import send_realms_only_to_push_bouncer
+from zerver.lib.remote_server import send_analytics_to_push_bouncer
 from zerver.lib.test_classes import BouncerTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import UserProfile
@@ -163,7 +163,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona)
 
@@ -193,14 +193,14 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         # and successfully completing the flow - transparently to the user.
         self.assertFalse(RemoteRealm.objects.filter(uuid=realm.uuid).exists())
 
-        # send_realms_only_to_push_bouncer will be called within the endpoint's
+        # send_analytics_to_push_bouncer will be called within the endpoint's
         # error handling to register realms with the bouncer. We mock.patch it
         # to be able to assert that it was called - but also use side_effect
         # to maintain the original behavior of the function, instead of
         # replacing it with a Mock.
         with mock.patch(
-            "zerver.views.push_notifications.send_realms_only_to_push_bouncer",
-            side_effect=send_realms_only_to_push_bouncer,
+            "zerver.views.push_notifications.send_analytics_to_push_bouncer",
+            side_effect=send_analytics_to_push_bouncer,
         ) as m:
             result = self.execute_remote_billing_authentication_flow(desdemona)
 
@@ -219,7 +219,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         desdemona = self.example_user("desdemona")
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(
             desdemona,
@@ -235,7 +235,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         desdemona = self.example_user("desdemona")
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         with self.settings(TERMS_OF_SERVICE_VERSION="1.0"):
             result = self.execute_remote_billing_authentication_flow(
@@ -280,7 +280,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         with time_machine.travel(now, tick=False):
             result = self.execute_remote_billing_authentication_flow(desdemona)
@@ -336,7 +336,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         # Straight-up access without authing at all:
         result = self.client_get(f"/realm/{realm.uuid!s}/plans/", subdomain="selfhosting")
@@ -388,7 +388,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona, "sponsorship")
 
@@ -408,7 +408,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona, "upgrade")
 

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -15,7 +15,7 @@ from corporate.lib.remote_billing_util import (
     RemoteBillingIdentityDict,
     RemoteBillingUserDict,
 )
-from zerver.lib.remote_server import send_analytics_to_push_bouncer
+from zerver.lib.remote_server import send_server_data_to_push_bouncer
 from zerver.lib.test_classes import BouncerTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import UserProfile
@@ -163,7 +163,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona)
 
@@ -193,14 +193,14 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         # and successfully completing the flow - transparently to the user.
         self.assertFalse(RemoteRealm.objects.filter(uuid=realm.uuid).exists())
 
-        # send_analytics_to_push_bouncer will be called within the endpoint's
+        # send_server_data_to_push_bouncer will be called within the endpoint's
         # error handling to register realms with the bouncer. We mock.patch it
         # to be able to assert that it was called - but also use side_effect
         # to maintain the original behavior of the function, instead of
         # replacing it with a Mock.
         with mock.patch(
-            "zerver.views.push_notifications.send_analytics_to_push_bouncer",
-            side_effect=send_analytics_to_push_bouncer,
+            "zerver.views.push_notifications.send_server_data_to_push_bouncer",
+            side_effect=send_server_data_to_push_bouncer,
         ) as m:
             result = self.execute_remote_billing_authentication_flow(desdemona)
 
@@ -219,7 +219,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         desdemona = self.example_user("desdemona")
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(
             desdemona,
@@ -235,7 +235,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         desdemona = self.example_user("desdemona")
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         with self.settings(TERMS_OF_SERVICE_VERSION="1.0"):
             result = self.execute_remote_billing_authentication_flow(
@@ -280,7 +280,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         with time_machine.travel(now, tick=False):
             result = self.execute_remote_billing_authentication_flow(desdemona)
@@ -336,7 +336,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         # Straight-up access without authing at all:
         result = self.client_get(f"/realm/{realm.uuid!s}/plans/", subdomain="selfhosting")
@@ -388,7 +388,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona, "sponsorship")
 
@@ -408,7 +408,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
         realm = desdemona.realm
 
         self.add_mock_response()
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         result = self.execute_remote_billing_authentication_flow(desdemona, "upgrade")
 

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -15,7 +15,7 @@ from zerver.actions.realm_settings import (
 )
 from zerver.lib.bulk_create import create_users
 from zerver.lib.push_notifications import sends_notifications_directly
-from zerver.lib.remote_server import enqueue_register_realm_with_push_bouncer_if_needed
+from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
 from zerver.lib.streams import ensure_stream, get_signups_stream
 from zerver.lib.user_groups import (
@@ -270,7 +270,7 @@ def do_create_realm(
             ]
         )
 
-    enqueue_register_realm_with_push_bouncer_if_needed(realm)
+        maybe_enqueue_audit_log_upload(realm)
 
     # Create stream once Realm object has been saved
     notifications_stream = ensure_stream(

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -21,6 +21,7 @@ from zerver.lib.default_streams import get_slim_realm_default_streams
 from zerver.lib.email_notifications import enqueue_welcome_emails, send_account_registered_email
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import silent_mention_syntax_for_user
+from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.send_email import clear_scheduled_invitation_emails
 from zerver.lib.stream_subscription import bulk_get_subscriber_peer_info
 from zerver.lib.user_counts import realm_user_count, realm_user_count_by_role
@@ -495,6 +496,7 @@ def do_create_user(
                 RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
             },
         )
+        maybe_enqueue_audit_log_upload(user_profile.realm)
 
         if realm_creation:
             # If this user just created a realm, make sure they are
@@ -619,6 +621,7 @@ def do_activate_mirror_dummy_user(
                 RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
             },
         )
+        maybe_enqueue_audit_log_upload(user_profile.realm)
         do_increment_logging_stat(
             user_profile.realm,
             COUNT_STATS["active_users_log:is_bot:day"],
@@ -652,6 +655,7 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: Optional[UserP
             RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
         },
     )
+    maybe_enqueue_audit_log_upload(user_profile.realm)
 
     bot_owner_changed = False
     if (

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -336,6 +336,7 @@ def do_set_realm_user_default_setting(
     send_event(realm, event, active_user_ids(realm.id))
 
 
+@transaction.atomic
 def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
     """
     Deactivate this realm. Do NOT deactivate the users -- we need to be able to
@@ -379,7 +380,7 @@ def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> 
     # deactivated). So the purpose of sending this is to flush all
     # active longpoll connections for the realm.
     event = dict(type="realm", op="deactivated", realm_id=realm.id)
-    send_event(realm, event, active_user_ids(realm.id))
+    send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 
 def do_reactivate_realm(realm: Realm) -> None:

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import QuerySet
 from django.utils.timezone import now as timezone_now
 
 from confirmation.models import Confirmation, create_confirmation_link, generate_key
@@ -15,7 +14,7 @@ from zerver.actions.user_settings import do_delete_avatar_image
 from zerver.lib.message import parse_message_time_limit_setting, update_first_visible_message_id
 from zerver.lib.retention import move_messages_to_archive
 from zerver.lib.send_email import FromAddress, send_email_to_admins
-from zerver.lib.sessions import delete_user_sessions
+from zerver.lib.sessions import delete_realm_user_sessions
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.upload import delete_message_attachments
 from zerver.lib.user_counts import realm_user_count_by_role
@@ -42,10 +41,6 @@ from zerver.tornado.django_api import send_event, send_event_on_commit
 
 if settings.BILLING_ENABLED:
     from corporate.lib.stripe import RealmBillingSession
-
-
-def active_humans_in_realm(realm: Realm) -> QuerySet[UserProfile]:
-    return UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False)
 
 
 @transaction.atomic(savepoint=False)
@@ -370,11 +365,12 @@ def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> 
     )
 
     ScheduledEmail.objects.filter(realm=realm).delete()
-    for user in active_humans_in_realm(realm):
-        # Don't deactivate the users, but do delete their sessions so they get
-        # bumped to the login screen, where they'll get a realm deactivation
-        # notice when they try to log in.
-        delete_user_sessions(user)
+
+    # Don't deactivate the users, as that would lose a lot of state if
+    # the realm needs to be reactivated, but do delete their sessions
+    # so they get bumped to the login screen, where they'll get a
+    # realm deactivation notice when they try to log in.
+    delete_realm_user_sessions(realm)
 
     # This event will only ever be received by clients with an active
     # longpoll connection, because by this point clients will be

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -365,6 +365,10 @@ def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> 
         },
     )
 
+    from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
+
+    maybe_enqueue_audit_log_upload(realm)
+
     ScheduledEmail.objects.filter(realm=realm).delete()
 
     # Don't deactivate the users, as that would lose a lot of state if
@@ -405,6 +409,10 @@ def do_reactivate_realm(realm: Realm) -> None:
                 RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(realm),
             },
         )
+
+        from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
+
+        maybe_enqueue_audit_log_upload(realm)
 
 
 def do_add_deactivated_redirect(realm: Realm, redirect_url: str) -> None:

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -17,6 +17,7 @@ from zerver.lib.avatar import avatar_url_from_dict
 from zerver.lib.bot_config import ConfigError, get_bot_config, get_bot_configs, set_bot_config
 from zerver.lib.cache import bot_dict_fields
 from zerver.lib.create_user import create_user
+from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.send_email import clear_scheduled_emails
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.stream_subscription import bulk_get_subscriber_peer_info
@@ -356,6 +357,7 @@ def do_deactivate_user(
                 RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
             },
         )
+        maybe_enqueue_audit_log_upload(user_profile.realm)
         do_increment_logging_stat(
             user_profile.realm,
             COUNT_STATS["active_users_log:is_bot:day"],
@@ -475,6 +477,7 @@ def do_change_user_role(
             RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
         },
     )
+    maybe_enqueue_audit_log_upload(user_profile.realm)
     event = dict(
         type="realm_user", op="update", person=dict(user_id=user_profile.id, role=user_profile.role)
     )

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -28,7 +28,7 @@ from zerver.lib.markdown import markdown_convert
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import get_last_message_id
 from zerver.lib.push_notifications import sends_notifications_directly
-from zerver.lib.remote_server import enqueue_register_realm_with_push_bouncer_if_needed
+from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
 from zerver.lib.streams import render_stream_description
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -1422,7 +1422,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
     # Ask the push notifications service if this realm can send
     # notifications, if we're using it. Needs to happen after the
     # Realm object is reactivated.
-    enqueue_register_realm_with_push_bouncer_if_needed(realm)
+    maybe_enqueue_audit_log_upload(realm)
 
     return realm
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -44,8 +44,8 @@ from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.message import access_message, huddle_users
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.remote_server import (
-    send_analytics_to_push_bouncer,
     send_json_to_push_bouncer,
+    send_server_data_to_push_bouncer,
     send_to_push_bouncer,
 )
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
@@ -784,7 +784,7 @@ def initialize_push_notifications() -> None:
         # If we're using the notification bouncer, check if we can
         # actually send push notifications, and update our
         # understanding of that state for each realm accordingly.
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
         return
 
     logger.warning(  # nocoverage

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -312,7 +312,7 @@ def get_realms_info_for_push_bouncer(realm_id: Optional[int] = None) -> List[Rea
     return realm_info_list
 
 
-def send_analytics_to_push_bouncer(consider_usage_statistics: bool = True) -> None:
+def send_server_data_to_push_bouncer(consider_usage_statistics: bool = True) -> None:
     logger = logging.getLogger("zulip.analytics")
     # first, check what's latest
     try:

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -21,7 +21,7 @@ from zerver.lib.exceptions import (
     RemoteRealmServerMismatchError,
 )
 from zerver.lib.outgoing_http import OutgoingSession
-from zerver.lib.queue import queue_json_publish
+from zerver.lib.queue import queue_event_on_commit
 from zerver.models import OrgTypeEnum, Realm, RealmAuditLog
 
 
@@ -409,4 +409,4 @@ def enqueue_register_realm_with_push_bouncer_if_needed(realm: Realm) -> None:
         # We do this in a queue worker to avoid messing with the realm
         # creation process due to network issues or latency.
         event = {"type": "register_realm_with_push_bouncer", "realm_id": realm.id}
-        queue_json_publish("deferred_work", event)
+        queue_event_on_commit("deferred_work", event)

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -401,7 +401,7 @@ def send_analytics_to_push_bouncer(consider_usage_statistics: bool = True) -> No
     logger.info("Reported %d records", record_count)
 
 
-def enqueue_register_realm_with_push_bouncer_if_needed(realm: Realm) -> None:
+def maybe_enqueue_audit_log_upload(realm: Realm) -> None:
     from zerver.lib.push_notifications import uses_notification_bouncer
 
     if uses_notification_bouncer():

--- a/zerver/lib/sessions.py
+++ b/zerver/lib/sessions.py
@@ -49,7 +49,7 @@ def delete_user_sessions(user_profile: UserProfile) -> None:
 
 
 def delete_realm_user_sessions(realm: Realm) -> None:
-    realm_user_ids = list(UserProfile.objects.filter(realm=realm).values_list("id", flat=True))
+    realm_user_ids = set(UserProfile.objects.filter(realm=realm).values_list("id", flat=True))
     for session in Session.objects.all():
         if get_session_user_id(session) in realm_user_ids:
             delete_session(session)

--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -10,7 +10,7 @@ from requests.models import Response
 from typing_extensions import override
 
 from zerver.lib.management import ZulipBaseCommand, check_config
-from zerver.lib.remote_server import PushBouncerSession
+from zerver.lib.remote_server import PushBouncerSession, send_server_data_to_push_bouncer
 
 if settings.DEVELOPMENT:
     SECRETS_FILENAME = "zproject/dev-secrets.conf"
@@ -94,6 +94,10 @@ class Command(ZulipBaseCommand):
         response = self._request_push_notification_bouncer_url(
             "/api/v1/remotes/server/register", request
         )
+
+        # Makes sure that we have a current state of user count when first
+        # logging in after the RemoteRealm flow.
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         if response.json()["created"]:
             print(

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4856,7 +4856,7 @@ class AbstractRealmAuditLog(models.Model):
 
     # This value is for RemoteRealmAuditLog entries tracking changes to the
     # RemoteRealm model resulting from modified realm information sent to us
-    # via send_analytics_to_push_bouncer.
+    # via send_server_data_to_push_bouncer.
     REMOTE_REALM_VALUE_UPDATED = 20001
 
     event_type = models.PositiveSmallIntegerField()

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1413,7 +1413,8 @@ class RealmImportExportTest(ExportFile):
 
             m.side_effect = mock_send_to_push_bouncer_response
 
-            new_realm = do_import_realm(get_output_dir(), "test-zulip")
+            with self.captureOnCommitCallbacks(execute=True):
+                new_realm = do_import_realm(get_output_dir(), "test-zulip")
 
         self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
         calls_args_for_assert = m.call_args_list[1][0]

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -66,7 +66,7 @@ from zerver.lib.remote_server import (
     PushNotificationBouncerServerError,
     build_analytics_data,
     get_realms_info_for_push_bouncer,
-    send_analytics_to_push_bouncer,
+    send_server_data_to_push_bouncer,
     send_to_push_bouncer,
 )
 from zerver.lib.response import json_response_from_error
@@ -1033,7 +1033,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             "zulip.analytics", level="WARNING"
         ) as mock_warning:
             resp.add(responses.GET, ANALYTICS_STATUS_URL, body=ConnectionError())
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
             self.assertIn(
                 "WARNING:zulip.analytics:ConnectionError while trying to connect to push notification bouncer\nTraceback ",
                 mock_warning.output[0],
@@ -1046,7 +1046,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         assert remote_server is not None
         assert remote_server.last_version is None
 
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         self.assertTrue(responses.assert_call_count(ANALYTICS_STATUS_URL, 1))
 
         audit_log = RealmAuditLog.objects.all().order_by("id").last()
@@ -1121,16 +1121,16 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         with self.settings(SUBMIT_USAGE_STATISTICS=False):
             # With this setting off, we don't send RealmCounts and InstallationCounts.
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
         check_counts(2, 2, 0, 0, 1)
 
         with self.settings(SUBMIT_USAGE_STATISTICS=True):
             # With 'SUBMIT_USAGE_STATISTICS=True' but 'consider_usage_statistics=False',
             # we don't send RealmCount and InstallationCounts.
-            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
         check_counts(3, 3, 0, 0, 1)
 
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(4, 4, 1, 1, 1)
 
         self.assertEqual(
@@ -1205,7 +1205,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         # Deactivation is synced.
         do_deactivate_realm(zephyr_realm, acting_user=None)
 
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(5, 5, 1, 1, 7)
 
         zephyr_remote_realm = RemoteRealm.objects.get(uuid=zephyr_realm.uuid)
@@ -1282,7 +1282,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         )
 
         # Test having no new rows
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(6, 6, 1, 1, 7)
 
         # Test only having new RealmCount rows
@@ -1298,14 +1298,14 @@ class AnalyticsBouncerTest(BouncerTestCase):
             end_time=end_time + timedelta(days=2),
             value=9,
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(7, 7, 3, 1, 7)
 
         # Test only having new InstallationCount rows
         InstallationCount.objects.create(
             property=realm_stat.property, end_time=end_time + timedelta(days=1), value=6
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(8, 8, 3, 2, 7)
 
         # Test only having new RealmAuditLog rows
@@ -1317,7 +1317,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             event_time=end_time,
             extra_data={"data": "foo"},
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(9, 9, 3, 2, 7)
         # Synced event
         RealmAuditLog.objects.create(
@@ -1329,7 +1329,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user.realm),
             },
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         check_counts(10, 10, 3, 2, 8)
 
         # Now create an InstallationCount with a property that's not supposed
@@ -1343,7 +1343,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             value=5,
         )
         with self.assertLogs("zulip.analytics", level="WARNING") as warn_log:
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
         self.assertEqual(
             warn_log.output,
             ["WARNING:zulip.analytics:Invalid property mobile_pushes_received::day"],
@@ -1379,7 +1379,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             id=F("id") + InstallationCount.objects.latest("id").id
         )
         with self.assertLogs(level="WARNING") as warn_log:
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
         self.assertEqual(
             warn_log.output,
             [
@@ -1501,7 +1501,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         self.assertEqual(remote_realm_audit_log.remote_id, realm_audit_log.id)
         self.assertEqual(remote_realm_audit_log.remote_realm, None)
 
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
 
         remote_realm_count.refresh_from_db()
         remote_installation_count.refresh_from_db()
@@ -1533,7 +1533,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             event_time=end_time,
             extra_data={"data": "foo"},
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
 
         # Make sure new data was created, so that we're actually testing what we think.
         self.assertEqual(RemoteRealmCount.objects.count(), current_remote_realm_count_amount + 1)
@@ -1565,7 +1565,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         self.assertEqual(RemoteRealmCount.objects.count(), 0)
         with self.assertLogs("zulip.analytics", level="WARNING") as m:
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
         self.assertEqual(m.output, ["WARNING:zulip.analytics:Invalid property invalid count stat"])
         self.assertEqual(RemoteRealmCount.objects.count(), 0)
 
@@ -1607,7 +1607,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         with transaction.atomic(), self.assertLogs("zulip.analytics", level="WARNING") as m:
             # The usual atomic() wrapper to avoid IntegrityError breaking the test's
             # transaction.
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
         self.assertEqual(m.output, ["WARNING:zulip.analytics:Duplicate registration detected."])
 
     # Servers on Zulip 2.0.6 and earlier only send realm_counts and installation_counts data,
@@ -1658,7 +1658,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             extra_data=orjson.dumps({"foo": "bar"}).decode(),
         )
 
-        # send_analytics_to_push_bouncer calls send_to_push_bouncer twice.
+        # send_server_data_to_push_bouncer calls send_to_push_bouncer twice.
         # We need to distinguish the first and second calls.
         first_call = True
 
@@ -1678,7 +1678,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         with mock.patch(
             "zerver.lib.remote_server.send_to_push_bouncer", side_effect=check_for_unwanted_data
         ):
-            send_analytics_to_push_bouncer()
+            send_server_data_to_push_bouncer()
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
     @responses.activate
@@ -1694,7 +1694,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             event_time=self.TIME_ZERO,
             extra_data=orjson.dumps({RealmAuditLog.ROLE_COUNT: user_count}).decode(),
         )
-        send_analytics_to_push_bouncer()
+        send_server_data_to_push_bouncer()
         remote_log_entry = RemoteRealmAuditLog.objects.order_by("id").last()
         assert remote_log_entry is not None
         self.assertEqual(str(remote_log_entry.server.uuid), self.server_uuid)
@@ -1749,7 +1749,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 "zerver.lib.remote_server.send_to_push_bouncer",
                 side_effect=transform_realmauditlog_extra_data,
             ):
-                send_analytics_to_push_bouncer()
+                send_server_data_to_push_bouncer()
 
             if skip_audit_log_check:
                 return
@@ -1792,7 +1792,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         with mock.patch(
             "zilencer.views.RemoteRealmBillingSession.get_customer", return_value=None
         ) as m:
-            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
             m.assert_called()
             realms = Realm.objects.all()
             for realm in realms:
@@ -1804,7 +1804,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             "zilencer.views.RemoteRealmBillingSession.get_customer", return_value=dummy_customer
         ):
             with mock.patch("zilencer.views.get_current_plan_by_customer", return_value=None) as m:
-                send_analytics_to_push_bouncer(consider_usage_statistics=False)
+                send_server_data_to_push_bouncer(consider_usage_statistics=False)
                 m.assert_called()
                 realms = Realm.objects.all()
                 for realm in realms:
@@ -1824,7 +1824,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                     "zilencer.views.RemoteRealmBillingSession.get_next_billing_cycle",
                     return_value=dummy_date,
                 ) as m, self.assertLogs("zulip.analytics", level="INFO") as info_log:
-                    send_analytics_to_push_bouncer(consider_usage_statistics=False)
+                    send_server_data_to_push_bouncer(consider_usage_statistics=False)
                     m.assert_called()
                     realms = Realm.objects.all()
                     for realm in realms:
@@ -1854,7 +1854,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
             m.side_effect = mock_send_to_push_bouncer_response
 
-            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
             realms = Realm.objects.all()
             for realm in realms:
@@ -1864,7 +1864,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 exception_log.output[0],
             )
 
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         self.assertEqual(
             list(

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -24,7 +24,7 @@ from typing_extensions import override
 from analytics.lib.counts import CountStat, LoggingCountStat
 from analytics.models import InstallationCount, RealmCount
 from corporate.models import CustomerPlan
-from version import API_FEATURE_LEVEL, ZULIP_VERSION
+from version import ZULIP_VERSION
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_flags import do_mark_stream_messages_as_read, do_update_message_flags
 from zerver.actions.realm_settings import (
@@ -67,7 +67,6 @@ from zerver.lib.remote_server import (
     build_analytics_data,
     get_realms_info_for_push_bouncer,
     send_analytics_to_push_bouncer,
-    send_realms_only_to_push_bouncer,
     send_to_push_bouncer,
 )
 from zerver.lib.response import json_response_from_error
@@ -780,29 +779,28 @@ class PushBouncerNotificationTest(BouncerTestCase):
         with mock.patch(
             "zerver.lib.push_notifications.uses_notification_bouncer", return_value=True
         ):
-            realms_response = {realm.uuid: {"can_push": True, "expected_end_timestamp": None}}
-            with mock.patch(
-                "zerver.lib.push_notifications.send_realms_only_to_push_bouncer",
-                return_value=realms_response,
-            ):
+            with mock.patch("zerver.lib.remote_server.send_to_push_bouncer") as m:
+                post_response = {
+                    "realms": {realm.uuid: {"can_push": True, "expected_end_timestamp": None}}
+                }
+                get_response = {
+                    "last_realm_count_id": 0,
+                    "last_installation_count_id": 0,
+                    "last_realmauditlog_id": 0,
+                }
+
+                def mock_send_to_push_bouncer_response(method: str, *args: Any) -> Dict[str, Any]:
+                    if method == "POST":
+                        return post_response
+                    return get_response
+
+                m.side_effect = mock_send_to_push_bouncer_response
+
                 initialize_push_notifications()
 
                 realm = get_realm("zulip")
                 self.assertTrue(realm.push_notifications_enabled)
                 self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
-
-            with mock.patch(
-                "zerver.lib.push_notifications.send_realms_only_to_push_bouncer",
-                side_effect=Exception,
-            ), self.assertLogs("zerver.lib.push_notifications", level="ERROR") as exception_log:
-                initialize_push_notifications()
-
-                realm = get_realm("zulip")
-                self.assertFalse(realm.push_notifications_enabled)
-                self.assertIn(
-                    "ERROR:zerver.lib.push_notifications:Exception while sending realms only data to push bouncer",
-                    exception_log.output[0],
-                )
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
     @responses.activate
@@ -1044,16 +1042,16 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         self.add_mock_response()
         # Send any existing data over, so that we can start the test with a "clean" slate
-        audit_log = RealmAuditLog.objects.all().order_by("id").last()
-        assert audit_log is not None
-        audit_log_max_id = audit_log.id
-
         remote_server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
         assert remote_server is not None
         assert remote_server.last_version is None
 
         send_analytics_to_push_bouncer()
         self.assertTrue(responses.assert_call_count(ANALYTICS_STATUS_URL, 1))
+
+        audit_log = RealmAuditLog.objects.all().order_by("id").last()
+        assert audit_log is not None
+        audit_log_max_id = audit_log.id
 
         remote_server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
         assert remote_server.last_version == ZULIP_VERSION
@@ -1126,8 +1124,14 @@ class AnalyticsBouncerTest(BouncerTestCase):
             send_analytics_to_push_bouncer()
         check_counts(2, 2, 0, 0, 1)
 
+        with self.settings(SUBMIT_USAGE_STATISTICS=True):
+            # With 'SUBMIT_USAGE_STATISTICS=True' but 'consider_usage_statistics=False',
+            # we don't send RealmCount and InstallationCounts.
+            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        check_counts(3, 3, 0, 0, 1)
+
         send_analytics_to_push_bouncer()
-        check_counts(3, 3, 1, 1, 1)
+        check_counts(4, 4, 1, 1, 1)
 
         self.assertEqual(
             list(
@@ -1202,7 +1206,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         do_deactivate_realm(zephyr_realm, acting_user=None)
 
         send_analytics_to_push_bouncer()
-        check_counts(4, 4, 1, 1, 7)
+        check_counts(5, 5, 1, 1, 7)
 
         zephyr_remote_realm = RemoteRealm.objects.get(uuid=zephyr_realm.uuid)
         self.assertEqual(zephyr_remote_realm.host, zephyr_realm.host)
@@ -1279,7 +1283,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         # Test having no new rows
         send_analytics_to_push_bouncer()
-        check_counts(5, 5, 1, 1, 7)
+        check_counts(6, 6, 1, 1, 7)
 
         # Test only having new RealmCount rows
         RealmCount.objects.create(
@@ -1295,14 +1299,14 @@ class AnalyticsBouncerTest(BouncerTestCase):
             value=9,
         )
         send_analytics_to_push_bouncer()
-        check_counts(6, 6, 3, 1, 7)
+        check_counts(7, 7, 3, 1, 7)
 
         # Test only having new InstallationCount rows
         InstallationCount.objects.create(
             property=realm_stat.property, end_time=end_time + timedelta(days=1), value=6
         )
         send_analytics_to_push_bouncer()
-        check_counts(7, 7, 3, 2, 7)
+        check_counts(8, 8, 3, 2, 7)
 
         # Test only having new RealmAuditLog rows
         # Non-synced event
@@ -1314,7 +1318,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             extra_data={"data": "foo"},
         )
         send_analytics_to_push_bouncer()
-        check_counts(8, 8, 3, 2, 7)
+        check_counts(9, 9, 3, 2, 7)
         # Synced event
         RealmAuditLog.objects.create(
             realm=user.realm,
@@ -1326,7 +1330,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             },
         )
         send_analytics_to_push_bouncer()
-        check_counts(9, 9, 3, 2, 8)
+        check_counts(10, 10, 3, 2, 8)
 
         # Now create an InstallationCount with a property that's not supposed
         # to be tracked by the remote server - since the bouncer itself tracks
@@ -1346,7 +1350,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         )
         # The analytics endpoint call counts increase by 1, but the actual RemoteCounts remain unchanged,
         # since syncing the data failed.
-        check_counts(10, 10, 3, 2, 8)
+        check_counts(11, 11, 3, 2, 8)
         forbidden_installation_count.delete()
 
         (realm_count_data, installation_count_data, realmauditlog_data) = build_analytics_data(
@@ -1384,7 +1388,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             ],
         )
         # Only the request counts go up -- all of the other rows' duplicates are dropped
-        check_counts(11, 11, 3, 2, 8)
+        check_counts(12, 12, 3, 2, 8)
 
         # Test that only valid org_type values are accepted - integers defined in OrgTypeEnum.
         realms_data = get_realms_info_for_push_bouncer()
@@ -1782,28 +1786,30 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
     @responses.activate
-    def test_send_realms_only_to_push_bouncer(self) -> None:
+    def test_realm_properties_after_send_analytics(self) -> None:
         self.add_mock_response()
 
         with mock.patch(
             "zilencer.views.RemoteRealmBillingSession.get_customer", return_value=None
         ) as m:
-            realms = send_realms_only_to_push_bouncer()
+            send_analytics_to_push_bouncer(consider_usage_statistics=False)
             m.assert_called()
-            for data in realms.values():
-                self.assertEqual(data["can_push"], True)
-                self.assertEqual(data["expected_end_timestamp"], None)
+            realms = Realm.objects.all()
+            for realm in realms:
+                self.assertEqual(realm.push_notifications_enabled, True)
+                self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
 
         dummy_customer = mock.MagicMock()
         with mock.patch(
             "zilencer.views.RemoteRealmBillingSession.get_customer", return_value=dummy_customer
         ):
             with mock.patch("zilencer.views.get_current_plan_by_customer", return_value=None) as m:
-                realms = send_realms_only_to_push_bouncer()
+                send_analytics_to_push_bouncer(consider_usage_statistics=False)
                 m.assert_called()
-                for data in realms.values():
-                    self.assertEqual(data["can_push"], True)
-                    self.assertEqual(data["expected_end_timestamp"], None)
+                realms = Realm.objects.all()
+                for realm in realms:
+                    self.assertEqual(realm.push_notifications_enabled, True)
+                    self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
 
         dummy_customer_plan = mock.MagicMock()
         dummy_customer_plan.status = CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE
@@ -1817,16 +1823,48 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 with mock.patch(
                     "zilencer.views.RemoteRealmBillingSession.get_next_billing_cycle",
                     return_value=dummy_date,
-                ) as m:
-                    realms = send_realms_only_to_push_bouncer()
+                ) as m, self.assertLogs("zulip.analytics", level="INFO") as info_log:
+                    send_analytics_to_push_bouncer(consider_usage_statistics=False)
                     m.assert_called()
-                    for data in realms.values():
-                        self.assertEqual(data["can_push"], True)
+                    realms = Realm.objects.all()
+                    for realm in realms:
+                        self.assertEqual(realm.push_notifications_enabled, True)
                         self.assertEqual(
-                            data["expected_end_timestamp"], datetime_to_timestamp(dummy_date)
+                            realm.push_notifications_enabled_end_timestamp,
+                            dummy_date,
                         )
+                    self.assertIn(
+                        "INFO:zulip.analytics:Reported 0 records",
+                        info_log.output[0],
+                    )
 
-        send_realms_only_to_push_bouncer()
+        with mock.patch("zerver.lib.remote_server.send_to_push_bouncer") as m, self.assertLogs(
+            "zulip.analytics", level="ERROR"
+        ) as exception_log:
+            get_response = {
+                "last_realm_count_id": 0,
+                "last_installation_count_id": 0,
+                "last_realmauditlog_id": 0,
+            }
+
+            def mock_send_to_push_bouncer_response(method: str, *args: Any) -> Dict[str, int]:
+                if method == "POST":
+                    raise Exception
+                return get_response
+
+            m.side_effect = mock_send_to_push_bouncer_response
+
+            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+
+            realms = Realm.objects.all()
+            for realm in realms:
+                self.assertFalse(realm.push_notifications_enabled)
+            self.assertIn(
+                "ERROR:zulip.analytics:Exception asking push bouncer if notifications will work.",
+                exception_log.output[0],
+            )
+
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         self.assertEqual(
             list(
@@ -1854,38 +1892,6 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 }
                 for realm in Realm.objects.order_by("id")
             ],
-        )
-
-        # Use a mock to assert exactly the data that gets sent.
-        dummy_send_realms_only_response = {
-            "result": "success",
-            "msg": "",
-            "realms": {
-                "f9535515-84d0-489e-80d5-9ae97c3c7ec1": {
-                    "can_push": True,
-                    "expected_end_timestamp": None,
-                },
-            },
-        }
-        with mock.patch(
-            "zerver.lib.remote_server.send_to_push_bouncer",
-            return_value=dummy_send_realms_only_response,
-        ) as mock_send_to_push_bouncer:
-            send_realms_only_to_push_bouncer()
-
-        post_data = {
-            "realm_counts": "[]",
-            "installation_counts": "[]",
-            "realms": orjson.dumps(
-                [dict(realm_data) for realm_data in get_realms_info_for_push_bouncer()]
-            ).decode(),
-            "version": orjson.dumps(ZULIP_VERSION).decode(),
-            "api_feature_level": orjson.dumps(API_FEATURE_LEVEL).decode(),
-        }
-        mock_send_to_push_bouncer.assert_called_with(
-            "POST",
-            "server/analytics",
-            post_data,
         )
 
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1089,18 +1089,30 @@ class RealmTest(ZulipTestCase):
         }
         with mock.patch(
             "zerver.lib.remote_server.send_to_push_bouncer",
-            return_value=dummy_send_realms_only_response,
         ) as m:
+            get_response = {
+                "last_realm_count_id": 0,
+                "last_installation_count_id": 0,
+                "last_realmauditlog_id": 0,
+            }
+
+            def mock_send_to_push_bouncer_response(method: str, *args: Any) -> Dict[str, Any]:
+                if method == "GET":
+                    return get_response
+                return dummy_send_realms_only_response
+
+            m.side_effect = mock_send_to_push_bouncer_response
+
             realm = do_create_realm("realm_string_id", "realm name")
 
         self.assertEqual(realm.string_id, "realm_string_id")
-        self.assertEqual(m.call_count, 1)
+        self.assertEqual(m.call_count, 2)
 
-        calls_args_for_assert = m.call_args_list[0][0]
+        calls_args_for_assert = m.call_args_list[1][0]
         self.assertEqual(calls_args_for_assert[0], "POST")
         self.assertEqual(calls_args_for_assert[1], "server/analytics")
         self.assertIn(
-            realm.id, [realm["id"] for realm in json.loads(m.call_args_list[0][0][2]["realms"])]
+            realm.id, [realm["id"] for realm in json.loads(m.call_args_list[1][0][2]["realms"])]
         )
 
     def test_changing_waiting_period_updates_system_groups(self) -> None:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1103,7 +1103,8 @@ class RealmTest(ZulipTestCase):
 
             m.side_effect = mock_send_to_push_bouncer_response
 
-            realm = do_create_realm("realm_string_id", "realm name")
+            with self.captureOnCommitCallbacks(execute=True):
+                realm = do_create_realm("realm_string_id", "realm name")
 
         self.assertEqual(realm.string_id, "realm_string_id")
         self.assertEqual(m.call_count, 2)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1085,12 +1085,7 @@ class RealmTest(ZulipTestCase):
         dummy_send_realms_only_response = {
             "result": "success",
             "msg": "",
-            "realms": {
-                "dummy-uuid": {
-                    "can_push": True,
-                    "expected_end_timestamp": None,
-                },
-            },
+            "realms": {},
         }
         with mock.patch(
             "zerver.lib.remote_server.send_to_push_bouncer",

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -24,7 +24,7 @@ from zerver.lib.push_notifications import (
 from zerver.lib.remote_server import (
     UserDataForRemoteBilling,
     get_realms_info_for_push_bouncer,
-    send_analytics_to_push_bouncer,
+    send_server_data_to_push_bouncer,
     send_to_push_bouncer,
 )
 from zerver.lib.request import REQ, has_request_variables
@@ -162,7 +162,7 @@ def self_hosting_auth_redirect(
         result = send_to_push_bouncer("POST", "server/billing", post_data)
     except MissingRemoteRealmError:
         # Upload realm info and re-try. It should work now.
-        send_analytics_to_push_bouncer(consider_usage_statistics=False)
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
         result = send_to_push_bouncer("POST", "server/billing", post_data)
     except RemoteRealmServerMismatchError:
         return render(request, "zilencer/remote_realm_server_mismatch_error.html", status=403)

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -24,7 +24,7 @@ from zerver.lib.push_notifications import (
 from zerver.lib.remote_server import (
     UserDataForRemoteBilling,
     get_realms_info_for_push_bouncer,
-    send_realms_only_to_push_bouncer,
+    send_analytics_to_push_bouncer,
     send_to_push_bouncer,
 )
 from zerver.lib.request import REQ, has_request_variables
@@ -162,7 +162,7 @@ def self_hosting_auth_redirect(
         result = send_to_push_bouncer("POST", "server/billing", post_data)
     except MissingRemoteRealmError:
         # Upload realm info and re-try. It should work now.
-        send_realms_only_to_push_bouncer()
+        send_analytics_to_push_bouncer(consider_usage_statistics=False)
         result = send_to_push_bouncer("POST", "server/billing", post_data)
     except RemoteRealmServerMismatchError:
         return render(request, "zilencer/remote_realm_server_mismatch_error.html", status=403)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1170,12 +1170,10 @@ class DeferredWorker(QueueProcessingWorker):
             )
             user_profile = get_user_profile_by_id(event["user_profile_id"])
             reactivate_user_if_soft_deactivated(user_profile)
-        elif event["type"] == "register_realm_with_push_bouncer":
+        elif event["type"] == "push_bouncer_update_for_realm":
             # In the future we may use the realm_id to send only that single realm's info.
             realm_id = event["realm_id"]
-            logger.info(
-                "Running send_analytics_to_push_bouncer, requested due to realm %s", realm_id
-            )
+            logger.info("Updating push bouncer with metadata on behalf of realm %s", realm_id)
             send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         end = time.time()

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -80,7 +80,7 @@ from zerver.lib.pysa import mark_sanitized
 from zerver.lib.queue import SimpleQueueClient, retry_event
 from zerver.lib.remote_server import (
     PushNotificationBouncerRetryLaterError,
-    send_analytics_to_push_bouncer,
+    send_server_data_to_push_bouncer,
 )
 from zerver.lib.send_email import (
     EmailNotDeliveredError,
@@ -1174,7 +1174,7 @@ class DeferredWorker(QueueProcessingWorker):
             # In the future we may use the realm_id to send only that single realm's info.
             realm_id = event["realm_id"]
             logger.info("Updating push bouncer with metadata on behalf of realm %s", realm_id)
-            send_analytics_to_push_bouncer(consider_usage_statistics=False)
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
 
         end = time.time()
         logger.info(

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -80,7 +80,7 @@ from zerver.lib.pysa import mark_sanitized
 from zerver.lib.queue import SimpleQueueClient, retry_event
 from zerver.lib.remote_server import (
     PushNotificationBouncerRetryLaterError,
-    send_realms_only_to_push_bouncer,
+    send_analytics_to_push_bouncer,
 )
 from zerver.lib.send_email import (
     EmailNotDeliveredError,
@@ -1174,9 +1174,9 @@ class DeferredWorker(QueueProcessingWorker):
             # In the future we may use the realm_id to send only that single realm's info.
             realm_id = event["realm_id"]
             logger.info(
-                "Running send_realms_only_to_push_bouncer, requested due to realm %s", realm_id
+                "Running send_analytics_to_push_bouncer, requested due to realm %s", realm_id
             )
-            send_realms_only_to_push_bouncer()
+            send_analytics_to_push_bouncer(consider_usage_statistics=False)
 
         end = time.time()
         logger.info(


### PR DESCRIPTION
Actions that change the number of user counts adds a deferred_work queue processor job immediately update the billing service about your change.

This helps to avoid having users see stale state for how many users they have when trying to pay.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
