### PR TITLE
emails: Adjust wording in server log in link email.

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -80,9 +80,9 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
                 user.delivery_email,
                 url_pattern=(
                     f"{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}"
-                    r"(\S+)>"
+                    r"(\S+)"
                 ),
-                email_body_contains="Click the link below to complete the login process",
+                email_body_contains="This link will expire in 2 hours",
             )
             if return_without_clicking_confirmation_link:
                 return result

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -82,7 +82,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
                     f"{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}"
                     r"(\S+)"
                 ),
-                email_body_contains="This link will expire in 2 hours",
+                email_body_contains="This link will expire in 24 hours",
             )
             if return_without_clicking_confirmation_link:
                 return result
@@ -501,7 +501,7 @@ class LegacyServerLoginTest(BouncerTestCase):
             url_pattern=(
                 f"{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}" + r"(\S+)"
             ),
-            email_body_contains="This link will expire in 2 hours",
+            email_body_contains="This link will expire in 24 hours",
         )
         if return_without_clicking_confirmation_link:
             return result

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -499,9 +499,9 @@ class LegacyServerLoginTest(BouncerTestCase):
         confirmation_url = self.get_confirmation_url_from_outbox(
             email,
             url_pattern=(
-                f"{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}" + r"(\S+)>"
+                f"{settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN}.{settings.EXTERNAL_HOST}" + r"(\S+)"
             ),
-            email_body_contains="Click the link below to complete the login process",
+            email_body_contains="This link will expire in 2 hours",
         )
         if return_without_clicking_confirmation_link:
             return result

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -313,9 +313,10 @@ def remote_realm_billing_confirm_email(
     )
 
     context = {
-        "remote_server_hostname": remote_server.hostname,
         "remote_realm_host": remote_realm.host,
         "confirmation_url": url,
+        "billing_help_link": "https://zulip.com/help/self-hosted-billing",
+        "billing_contact_email": "sales@zulip.com",
     }
     send_email(
         "zerver/emails/remote_realm_billing_confirm_login",

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -58,6 +58,9 @@ VALID_NEXT_PAGES = [None, "sponsorship", "upgrade", "billing", "plans"]
 VALID_NEXT_PAGES_TYPE = Literal[None, "sponsorship", "upgrade", "billing", "plans"]
 
 REMOTE_BILLING_SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS = 2 * 60 * 60
+# We use units of hours here so that we can pass this through to the
+# email template that tells the recipient how long these will last.
+LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS = 24
 
 
 @csrf_exempt
@@ -307,9 +310,7 @@ def remote_realm_billing_confirm_email(
     url = create_remote_billing_confirmation_link(
         obj,
         Confirmation.REMOTE_REALM_BILLING_LEGACY_LOGIN,
-        # Use the same expiration time as for the signed access token,
-        # since this is similarly transient in nature.
-        validity_in_minutes=int(REMOTE_BILLING_SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS / 60),
+        validity_in_minutes=LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS * 60,
     )
 
     context = {
@@ -317,6 +318,7 @@ def remote_realm_billing_confirm_email(
         "confirmation_url": url,
         "billing_help_link": "https://zulip.com/help/self-hosted-billing",
         "billing_contact_email": "sales@zulip.com",
+        "validity_in_hours": LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS,
     }
     send_email(
         "zerver/emails/remote_realm_billing_confirm_login",
@@ -519,9 +521,7 @@ def remote_billing_legacy_server_confirm_login(
     url = create_remote_billing_confirmation_link(
         obj,
         Confirmation.REMOTE_SERVER_BILLING_LEGACY_LOGIN,
-        # Use the same expiration time as for the signed access token,
-        # since this is similarly transient in nature.
-        validity_in_minutes=int(REMOTE_BILLING_SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS / 60),
+        validity_in_minutes=LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS * 60,
     )
 
     context = {
@@ -529,6 +529,7 @@ def remote_billing_legacy_server_confirm_login(
         "confirmation_url": url,
         "billing_help_link": "https://zulip.com/help/self-hosted-billing",
         "billing_contact_email": "sales@zulip.com",
+        "validity_in_hours": LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS,
     }
     send_email(
         "zerver/emails/remote_billing_legacy_server_confirm_login",

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -525,8 +525,9 @@ def remote_billing_legacy_server_confirm_login(
 
     context = {
         "remote_server_hostname": remote_server.hostname,
-        "remote_server_uuid": str(remote_server.uuid),
         "confirmation_url": url,
+        "billing_help_link": "https://zulip.com/help/self-hosted-billing",
+        "billing_contact_email": "sales@zulip.com",
     }
     send_email(
         "zerver/emails/remote_billing_legacy_server_confirm_login",

--- a/help/self-hosted-billing.md
+++ b/help/self-hosted-billing.md
@@ -1,0 +1,24 @@
+# Self-hosted Zulip billing
+
+This page describes how to manage your self-hosted plan, and answers some common
+questions about plans and billing for self-hosted organizations. Please refer to
+[Self-hosted Zulip plans and pricing](https://zulip.com/plans/#self-hosted) for plan
+details.  If you have any questions not answered here, please don't hesitate to
+reach out at [sales@zulip.com](mailto:sales@zulip.com).
+
+Zulip is 100% open-source. Organizations that do not require support with their
+installation can always use Zulip for free with no limitations.
+
+You can self-manage your Zulip installation without signing up for a plan. Get
+started with the [installation
+guide](https://zulip.readthedocs.io/en/stable/production/install.html).
+
+To inquire about an Enterprise plan, contact
+[sales@zulip.com](mailto:sales@zulip.com).
+
+## Related articles
+
+* [Trying out Zulip](/help/trying-out-zulip)
+* [Zulip Cloud or self-hosting?](/help/zulip-cloud-or-self-hosting)
+* [Migrating from other chat tools](/help/migrating-from-other-chat-tools)
+* [Contact support](/help/contact-support)

--- a/templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+++ b/templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
@@ -9,7 +9,13 @@
     {% trans %}Either you, or someone on your behalf, has requested a log in link to manage the Zulip plan for <b>{{ remote_server_hostname }}</b>.{% endtrans %}
 </p>
 <p>
-    {{ _("Click the button below to log in. This link will expire in 2 hours.") }}
+    {% trans %}
+    Click the button below to log in.
+    {% endtrans %}
+
+    {% trans %}
+    This link will expire in {{ validity_in_hours }} hours.
+    {% endtrans %}
 </p>
 <p>
     <a class="button" href="{{ confirmation_url }}">{{ _("Log in") }}</a>

--- a/templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+++ b/templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
@@ -6,17 +6,15 @@
 
 {% block content %}
 <p>
-    {{ _("You have initiated login to the Zulip server billing management system for the following server:") }}
-    <ul>
-        <li>{% trans %}Hostname: {{ remote_server_hostname }}{% endtrans %}</li>
-        <li>{% trans %}zulip_org_id: {{ remote_server_uuid }}{% endtrans %}</li>
-    </ul>
+    {% trans %}Either you, or someone on your behalf, has requested a log in link to manage the Zulip plan for <b>{{ remote_server_hostname }}</b>.{% endtrans %}
 </p>
 <p>
-    {{ _("Click the button below to complete the login process.") }}
-    <a class="button" href="{{ confirmation_url }}">{{ _("Confirm login") }}</a>
+    {{ _("Click the button below to log in. This link will expire in 2 hours.") }}
 </p>
 <p>
-    {{macros.contact_us_zulip_cloud(support_email)}}
+    <a class="button" href="{{ confirmation_url }}">{{ _("Log in") }}</a>
+</p>
+<p>
+    {% trans billing_contact_email=macros.email_tag(billing_contact_email) %}Questions? <a href="{{ billing_help_link }}">Learn more</a> or contact {{ billing_contact_email }}.{% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
+++ b/templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
@@ -1,1 +1,1 @@
-{% trans %}Confirm login to Zulip server billing management{% endtrans %}
+{% trans %}Log in to Zulip plan management{% endtrans %}

--- a/templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+++ b/templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
@@ -1,9 +1,8 @@
-{{ _("You have initiated login to the Zulip server billing management system for the following server:") }}
-* {% trans %}Hostname: {{ remote_server_hostname }}{% endtrans %}
+{% trans %}Either you, or someone on your behalf, has requested a log in link to manage the Zulip plan for {{ remote_server_hostname }}.{% endtrans %}
 
-* {% trans %}zulip_org_id: {{ remote_server_uuid }}{% endtrans %}
 
-{{ _("Click the link below to complete the login process;") }}
-    <{{ confirmation_url }}>
+{{ _("Click the link below to log in. This link will expire in 2 hours.") }}
 
-{% trans %}Do you have questions or feedback to share? Contact us at {{ support_email }} — we'd love to help!{% endtrans %}
+{{ _("Log in") }}: {{ confirmation_url }}
+
+{% trans %}Questions? Learn more at {{ billing_help_link }} or contact {{ billing_contact_email }}.{% endtrans %}

--- a/templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+++ b/templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
@@ -1,7 +1,7 @@
 {% trans %}Either you, or someone on your behalf, has requested a log in link to manage the Zulip plan for {{ remote_server_hostname }}.{% endtrans %}
 
 
-{{ _("Click the link below to log in. This link will expire in 2 hours.") }}
+{% trans %}Click the link below to log in.{% endtrans %} {% trans %}This link will expire in {{ validity_in_hours }} hours.{% endtrans %}
 
 {{ _("Log in") }}: {{ confirmation_url }}
 

--- a/templates/zerver/emails/remote_realm_billing_confirm_login.html
+++ b/templates/zerver/emails/remote_realm_billing_confirm_login.html
@@ -6,7 +6,13 @@
 
 {% block content %}
 <p>
-    {% trans %}Click the button below to log in to Zulip plan management for <b>{{ remote_realm_host }}</b>. This link will expire in 2 hours.{% endtrans %}
+    {% trans %}
+    Click the button below to log in to Zulip plan management for <b>{{ remote_realm_host }}</b>.
+    {% endtrans %}
+
+    {% trans %}
+    This link will expire in {{ validity_in_hours }} hours.
+    {% endtrans %}
 </p>
 <p>
     <a class="button" href="{{ confirmation_url }}">{{ _("Log in") }}</a>

--- a/templates/zerver/emails/remote_realm_billing_confirm_login.html
+++ b/templates/zerver/emails/remote_realm_billing_confirm_login.html
@@ -6,17 +6,12 @@
 
 {% block content %}
 <p>
-    {{ _("You have initiated login to the Zulip plan management system for the following organization:") }}
-    <ul>
-        <li>{% trans %}Organization host: {{ remote_realm_host }}{% endtrans %}</li>
-        <li>{% trans %}Server host: {{ remote_server_hostname }}{% endtrans %}</li>
-    </ul>
+    {% trans %}Click the button below to log in to Zulip plan management for <b>{{ remote_realm_host }}</b>. This link will expire in 2 hours.{% endtrans %}
 </p>
 <p>
-    {{ _("Click the button below to complete the login process.") }}
-    <a class="button" href="{{ confirmation_url }}">{{ _("Confirm login") }}</a>
+    <a class="button" href="{{ confirmation_url }}">{{ _("Log in") }}</a>
 </p>
 <p>
-    {{macros.contact_us_zulip_cloud(support_email)}}
+    {% trans billing_contact_email=macros.email_tag(billing_contact_email) %}Questions? <a href="{{ billing_help_link }}">Learn more</a> or contact {{ billing_contact_email }}.{% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
+++ b/templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
@@ -1,1 +1,1 @@
-{% trans %}Confirm login to Zulip plan management{% endtrans %}
+{% trans %}Log in to Zulip plan management{% endtrans %}

--- a/templates/zerver/emails/remote_realm_billing_confirm_login.txt
+++ b/templates/zerver/emails/remote_realm_billing_confirm_login.txt
@@ -1,4 +1,4 @@
-{% trans %}Click the link below to log in to Zulip plan management for {{ remote_realm_host }}. This link will expire in 2 hours.{% endtrans %}
+{% trans %}Click the link below to log in to Zulip plan management for {{remote_realm_host}}.{% endtrans %} {% trans %}This link will expire in {{ validity_in_hours }} hours.{% endtrans %}
 
 
 {{ _("Log in") }}: {{ confirmation_url }}

--- a/templates/zerver/emails/remote_realm_billing_confirm_login.txt
+++ b/templates/zerver/emails/remote_realm_billing_confirm_login.txt
@@ -1,9 +1,6 @@
-{{ _("You have initiated login to the Zulip plan management system for the following organization:") }}
-* {% trans %}Organization host: {{ remote_realm_host }}{% endtrans %}
+{% trans %}Click the link below to log in to Zulip plan management for {{ remote_realm_host }}. This link will expire in 2 hours.{% endtrans %}
 
-* {% trans %}Server host: {{ remote_server_hostname }}{% endtrans %}
 
-{{ _("Click the link below to complete the login process;") }}
-    <{{ confirmation_url }}>
+{{ _("Log in") }}: {{ confirmation_url }}
 
-{% trans %}Do you have questions or feedback to share? Contact us at {{ support_email }} — we'd love to help!{% endtrans %}
+{% trans %}Questions? Learn more at {{ billing_help_link }} or contact {{ billing_contact_email }}.{% endtrans %}


### PR DESCRIPTION
Also adds a basic help page to link to (not linked from the left sidebar yet).

Someone should take an engineering cleanup pass on this:

- There are probably emails/urls that should be put in variables somewhere.
- I'm not sure I got all the translation tags quite right.