### PR TITLE
settings: Simplify testing push bouncer.

### DIFF
--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -208,10 +208,5 @@ SCIM_CONFIG: Dict[str, SCIMConfigDict] = {
 }
 
 SELF_HOSTING_MANAGEMENT_SUBDOMAIN = "selfhosting"
-
-# You can uncomment these lines to use the development environment
-# server as a dummy push bouncer for itself, to test functionalities
-# such as register_server or update_analytics_counts management commands
-# or others involving new bouncer-side logic.
-# DEVELOPMENT_DISABLE_PUSH_BOUNCER_DOMAIN_CHECK = True
-# PUSH_NOTIFICATION_BOUNCER_URL = "http://localhost:9991"
+DEVELOPMENT_DISABLE_PUSH_BOUNCER_DOMAIN_CHECK = True
+PUSH_NOTIFICATION_BOUNCER_URL = f"http://push.{EXTERNAL_HOST}"

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -204,6 +204,7 @@ BIG_BLUE_BUTTON_URL = "https://bbb.example.com/bigbluebutton/"
 # Explicitly set this to True within tests that must have this on.
 TWO_FACTOR_AUTHENTICATION_ENABLED = False
 PUSH_NOTIFICATION_BOUNCER_URL: Optional[str] = None
+DEVELOPMENT_DISABLE_PUSH_BOUNCER_DOMAIN_CHECK = False
 
 # Logging the emails while running the tests adds them
 # to /emails page.


### PR DESCRIPTION
We already override PUSH_NOTIFICATION_BOUNCER_URL in test_extra_settings.py, so making this change should have as its only impact making it a bit easier to test the push notifications bouncer manually in a development environment.

I submitted a related PR to the mobile app documentation for testing the push notifications software against a production server motivated by this.
