### PR TITLE
zilencer: Have push/notify endpoint return deleted registrations.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1190,10 +1190,10 @@ def handle_remove_push_notification(user_profile_id: int, message_ids: List[int]
     apns_payload = get_remove_payload_apns(user_profile, truncated_message_ids)
 
     android_devices = list(
-        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM)
+        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM).order_by("id")
     )
     apple_devices = list(
-        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS)
+        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS).order_by("id")
     )
     if uses_notification_bouncer():
         send_notifications_to_bouncer(
@@ -1356,11 +1356,11 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     logger.info("Sending push notifications to mobile clients for user %s", user_profile_id)
 
     android_devices = list(
-        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM)
+        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM).order_by("id")
     )
 
     apple_devices = list(
-        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS)
+        PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS).order_by("id")
     )
     if uses_notification_bouncer():
         total_android_devices, total_apple_devices = send_notifications_to_bouncer(

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -589,6 +589,11 @@ def send_notifications_to_bouncer(
     android_devices: Sequence[DeviceToken],
     apple_devices: Sequence[DeviceToken],
 ) -> Tuple[int, int]:
+    if not android_devices and not apple_devices:
+        # Avoid making a useless API request to the bouncer if there
+        # are no mobile devices registered for this user.
+        return 0, 0
+
     post_data = {
         "user_uuid": str(user_profile.uuid),
         # user_uuid is the intended future format, but we also need to send user_id

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2393,8 +2393,16 @@ class HandlePushNotificationTest(PushNotificationTest):
                 {"apns": True},
                 {"gcm": True},
                 {},
-                list(PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM)),
-                list(PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS)),
+                list(
+                    PushDeviceToken.objects.filter(
+                        user=user_profile, kind=PushDeviceToken.GCM
+                    ).order_by("id")
+                ),
+                list(
+                    PushDeviceToken.objects.filter(
+                        user=user_profile, kind=PushDeviceToken.APNS
+                    ).order_by("id")
+                ),
             )
             self.assertEqual(
                 mock_logging_info.output,
@@ -2508,8 +2516,16 @@ class HandlePushNotificationTest(PushNotificationTest):
                     "zulip_message_id": message.id,
                 },
                 {"priority": "normal"},
-                list(PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.GCM)),
-                list(PushDeviceToken.objects.filter(user=user_profile, kind=PushDeviceToken.APNS)),
+                list(
+                    PushDeviceToken.objects.filter(
+                        user=user_profile, kind=PushDeviceToken.GCM
+                    ).order_by("id")
+                ),
+                list(
+                    PushDeviceToken.objects.filter(
+                        user=user_profile, kind=PushDeviceToken.APNS
+                    ).order_by("id")
+                ),
             )
             user_message = UserMessage.objects.get(user_profile=self.user_profile, message=message)
             self.assertEqual(user_message.flags.active_mobile_push_notification, False)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -3561,6 +3561,18 @@ class TestGetGCMPayload(PushNotificationTest):
 
 
 class TestSendNotificationsToBouncer(PushNotificationTest):
+    def test_send_notifications_to_bouncer_when_no_devices(self) -> None:
+        user = self.example_user("hamlet")
+
+        with mock.patch("zerver.lib.remote_server.send_to_push_bouncer") as mock_send:
+            total_android_devices, total_apple_devices = send_notifications_to_bouncer(
+                user, {"apns": True}, {"gcm": True}, {}, android_devices=[], apple_devices=[]
+            )
+
+        self.assertEqual(total_android_devices, 0)
+        self.assertEqual(total_apple_devices, 0)
+        mock_send.assert_not_called()
+
     @mock.patch("zerver.lib.remote_server.send_to_push_bouncer")
     def test_send_notifications_to_bouncer(self, mock_send: mock.MagicMock) -> None:
         user = self.example_user("hamlet")


### PR DESCRIPTION
This lets the self-hosted server clean them up too.

Addresses a part of #27483 (https://github.com/zulip/zulip/issues/27483#issuecomment-1791089638 specifically), but needs a couple of extra things mentioned there to close the issue. 
