### PR TITLE
compose_actions: Hide compose box when navigating to inbox/recent view.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -336,6 +336,24 @@ export function cancel() {
     $(document).trigger("compose_canceled.zulip");
 }
 
+export function on_show_navigation_view() {
+    /* This function dictates the behavior of the compose box
+     * when navigating to a view, as opposed to a narrow. */
+
+    // Leave the compose box closed if it was already closed.
+    if (!compose_state.composing()) {
+        return;
+    }
+
+    // Leave the compose box open if there is content or if the recipient was edited.
+    if (compose_state.has_message_content() || compose_state.is_recipient_edited_manually()) {
+        return;
+    }
+
+    // Otherwise, close the compose box.
+    cancel();
+}
+
 export function on_topic_narrow() {
     if (!compose_state.composing()) {
         // If our compose box is closed, then just

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import * as compose_actions from "./compose_actions";
 import * as compose_recipient from "./compose_recipient";
 import * as dropdown_widget from "./dropdown_widget";
 import {$t} from "./i18n";
@@ -87,6 +88,7 @@ export function show(opts) {
     compose_recipient.handle_middle_pane_transition();
     search.clear_search_form();
     opts.complete_rerender();
+    compose_actions.on_show_navigation_view();
 
     // Misc.
     if (opts.is_recent_view) {


### PR DESCRIPTION
Currently, given that the compose box is already open, it stays open when the user navigates to the inbox/recent view, even when there are no modifications to the message or recipients.

This PR adds conditions to close the compose box when navigating to the inbox/recent view, except when we can reasonably infer that it was the intended action.

<!-- Describe your pull request here.-->

Fixes: [Issue reported at CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20box.20tooltips.20lag.20.2327158/near/1697754)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Navigating between recent/inbox view with different compose states
### **Before**

[before-compose-actions-fix.webm](https://github.com/zulip/zulip/assets/82862779/dddcc09a-6894-43e6-a0cd-bcf1d9fd7a4c)

### **After**

[after-compose-actions-fix.webm](https://github.com/zulip/zulip/assets/82862779/3b6881de-1c22-417c-932e-eaf50cd14fee) 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
