### PR TITLE
support: Add forms for attached remote realms.

### DIFF
--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -486,6 +486,7 @@ def remote_servers_support(
     context["get_discount"] = get_customer_discount_for_support_view
     context["get_plan_type_name"] = get_plan_type_string
     context["get_org_type_display_name"] = get_org_type_display_name
+    context["SPONSORED_PLAN_TYPE"] = RemoteZulipServer.PLAN_TYPE_COMMUNITY
 
     return render(
         request,

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -53,6 +53,7 @@ if settings.ZILENCER_ENABLED:
 if settings.BILLING_ENABLED:
     from corporate.lib.stripe import (
         RealmBillingSession,
+        RemoteRealmBillingSession,
         RemoteServerBillingSession,
         SupportType,
         SupportViewRequest,
@@ -391,6 +392,7 @@ def remote_servers_support(
     request: HttpRequest,
     query: Optional[str] = REQ("q", default=None),
     remote_server_id: Optional[int] = REQ(default=None, converter=to_non_negative_int),
+    remote_realm_id: Optional[int] = REQ(default=None, converter=to_non_negative_int),
     discount: Optional[Decimal] = REQ(default=None, converter=to_decimal),
     sponsorship_pending: Optional[bool] = REQ(default=None, json_validator=check_bool),
     approve_sponsorship: bool = REQ(default=False, json_validator=check_bool),
@@ -410,16 +412,22 @@ def remote_servers_support(
     acting_user = request.user
     assert isinstance(acting_user, UserProfile)
     if settings.BILLING_ENABLED and request.method == "POST":
-        # We check that request.POST only has two keys in it: The
-        # remote_server_id and a field to change.
+        # We check that request.POST only has two keys in it:
+        # either the remote_server_id or a remote_realm_id,
+        # and a field to change.
         keys = set(request.POST.keys())
         if "csrfmiddlewaretoken" in keys:
             keys.remove("csrfmiddlewaretoken")
         if len(keys) != 2:
             raise JsonableError(_("Invalid parameters"))
 
-        assert remote_server_id is not None
-        remote_server = RemoteZulipServer.objects.get(id=remote_server_id)
+        if remote_realm_id is not None:
+            remote_realm_support_request = True
+            remote_realm = RemoteRealm.objects.get(id=remote_realm_id)
+        else:
+            assert remote_server_id is not None
+            remote_realm_support_request = False
+            remote_server = RemoteZulipServer.objects.get(id=remote_server_id)
 
         support_view_request = None
 
@@ -446,10 +454,14 @@ def remote_servers_support(
                 plan_modification=modify_plan,
             )
         if support_view_request is not None:
-            billing_session = RemoteServerBillingSession(
-                support_staff=acting_user, remote_server=remote_server
-            )
-            success_message = billing_session.process_support_view_request(support_view_request)
+            if remote_realm_support_request:
+                success_message = RemoteRealmBillingSession(
+                    support_staff=acting_user, remote_realm=remote_realm
+                ).process_support_view_request(support_view_request)
+            else:
+                success_message = RemoteServerBillingSession(
+                    support_staff=acting_user, remote_server=remote_server
+                ).process_support_view_request(support_view_request)
             context["success_message"] = success_message
 
     email_to_search = None
@@ -464,14 +476,23 @@ def remote_servers_support(
         email_to_search=email_to_search, hostname_to_search=hostname_to_search
     )
     remote_server_to_max_monthly_messages: Dict[int, Union[int, str]] = dict()
-    plan_data: Dict[int, PlanData] = {}
+    server_plan_data: Dict[int, PlanData] = {}
+    realm_plan_data: Dict[int, PlanData] = {}
     remote_realms: Dict[int, List[RemoteRealm]] = {}
     for remote_server in remote_servers:
+        # Get remote realms attached to remote server
         remote_realms_for_server = list(remote_server.remoterealm_set.all())
         remote_realms[remote_server.id] = remote_realms_for_server
-        billing_session = RemoteServerBillingSession(remote_server=remote_server)
-        remote_server_plan_data = get_current_plan_data_for_support_view(billing_session)
-        plan_data[remote_server.id] = remote_server_plan_data
+        # Get plan data for remote realms
+        for remote_realm in remote_realms[remote_server.id]:
+            realm_billing_session = RemoteRealmBillingSession(remote_realm=remote_realm)
+            remote_realm_plan_data = get_current_plan_data_for_support_view(realm_billing_session)
+            realm_plan_data[remote_realm.id] = remote_realm_plan_data
+        # Get plan data for remote server
+        server_billing_session = RemoteServerBillingSession(remote_server=remote_server)
+        remote_server_plan_data = get_current_plan_data_for_support_view(server_billing_session)
+        server_plan_data[remote_server.id] = remote_server_plan_data
+        # Get max monthly messages
         try:
             remote_server_to_max_monthly_messages[remote_server.id] = compute_max_monthly_messages(
                 remote_server
@@ -480,9 +501,10 @@ def remote_servers_support(
             remote_server_to_max_monthly_messages[remote_server.id] = "Recent data missing"
 
     context["remote_servers"] = remote_servers
-    context["remote_realms"] = remote_realms
+    context["remote_servers_plan_data"] = server_plan_data
     context["remote_server_to_max_monthly_messages"] = remote_server_to_max_monthly_messages
-    context["plan_data"] = plan_data
+    context["remote_realms"] = remote_realms
+    context["remote_realms_plan_data"] = realm_plan_data
     context["get_discount"] = get_customer_discount_for_support_view
     context["get_plan_type_name"] = get_plan_type_string
     context["get_org_type_display_name"] = get_org_type_display_name

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -20,6 +20,7 @@ class PlanData:
     licenses: Optional[int] = None
     licenses_used: Optional[int] = None
     is_legacy_plan: bool = False
+    has_fixed_price: bool = False
     warning: Optional[str] = None
 
 
@@ -65,5 +66,6 @@ def get_current_plan_data_for_support_view(billing_session: BillingSession) -> P
         plan_data.is_legacy_plan = (
             plan_data.current_plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
         )
+        plan_data.has_fixed_price = plan_data.current_plan.fixed_price is not None
 
     return plan_data

--- a/templates/analytics/current_plan_forms_support.html
+++ b/templates/analytics/current_plan_forms_support.html
@@ -1,0 +1,23 @@
+<form method="POST" class="remote-form">
+    <b>Billing collection method</b><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <select name="billing_modality" class="billing-modality-select" required>
+        <option value="charge_automatically" {% if current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
+        <option value="send_invoice" {% if not current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
+    </select>
+    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+</form>
+
+<form method="POST" class="remote-form">
+    <b>Modify current plan</b><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <select name="modify_plan" class="modify-plan-method-select" required>
+        <option disabled value="" selected>-- select --</option>
+        <option value="downgrade_at_billing_cycle_end">Downgrade at the end of current billing cycle</option>
+        <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
+        <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
+    </select>
+    <button type="submit" class="btn btn-default support-submit-button">Modify</button>
+</form>

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -27,4 +27,11 @@
         {% include 'analytics/current_plan_details.html' %}
     {% endwith %}
 </div>
+
+{% with %}
+    {% set current_plan = plan_data[remote_server.id].current_plan %}
+    {% set remote_id = remote_realm.id %}
+    {% set remote_type = "remote_realm_id" %}
+    {% include 'analytics/current_plan_forms_support.html' %}
+{% endwith %}
 {% endif %}

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -4,4 +4,18 @@
     <b>Remote server hostname:</b> {{ remote_realm.host }}<br />
     <b>Date created</b>: {{ remote_realm.realm_date_created.strftime('%d %B %Y') }}<br />
     <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
+    {% if remote_realm.plan_type == SPONSORED_PLAN_TYPE %}
+        <h4>On 100% sponsored Zulip Community plan.</h4>
+    {% endif %}
 </div>
+
+{% if remote_realm.plan_type != SPONSORED_PLAN_TYPE %}
+{% with %}
+    {% set customer = plan_data[remote_realm.id].customer %}
+    {% set remote_id = remote_realm.id %}
+    {% set remote_type = "remote_realm_id" %}
+    {% set has_fixed_price = plan_data[remote_server.id].has_fixed_price %}
+    {% set get_discount = get_discount %}
+    {% include 'analytics/sponsorship_forms_support.html' %}
+{% endwith %}
+{% endif %}

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -19,3 +19,12 @@
     {% include 'analytics/sponsorship_forms_support.html' %}
 {% endwith %}
 {% endif %}
+
+{% if plan_data[remote_realm.id].current_plan %}
+<div class="remote-realm-information">
+    {% with %}
+        {% set plan_data = plan_data[remote_realm.id] %}
+        {% include 'analytics/current_plan_details.html' %}
+    {% endwith %}
+</div>
+{% endif %}

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -63,10 +63,10 @@
                 {% endwith %}
             {% endif %}
 
-            {% if plan_data[remote_server.id].current_plan %}
+            {% if remote_servers_plan_data[remote_server.id].current_plan %}
             <div class="remote-server-information">
                 {% with %}
-                    {% set plan_data = plan_data[remote_server.id] %}
+                    {% set plan_data = remote_servers_plan_data[remote_server.id] %}
                     {% include 'analytics/current_plan_details.html' %}
                 {% endwith %}
             </div>
@@ -76,8 +76,8 @@
                 {{ csrf_input }}
                 <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
                 <select name="billing_modality" class="billing-modality-select" required>
-                    <option value="charge_automatically" {% if plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
-                    <option value="send_invoice" {% if not plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
+                    <option value="charge_automatically" {% if remote_servers_plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
+                    <option value="send_invoice" {% if not remote_servers_plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
                 </select>
                 <button type="submit" class="btn btn-default support-submit-button">Update</button>
             </form>
@@ -99,7 +99,11 @@
             {% for remote_realm in remote_realms[remote_server.id] %}
             <hr />
             <div>
-                {% include "analytics/remote_realm_details.html" %}
+                {% with %}
+                    {% set plan_data = remote_realms_plan_data %}
+                    {% set get_discount = get_discount %}
+                    {% include "analytics/remote_realm_details.html" %}
+                {% endwith %}
             </div>
             {% endfor %}
         </div>

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -47,12 +47,12 @@
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
                 <b>Has remote realm(s)</b>: {{ remote_realms[remote_server.id] != [] }}
-                {% if remote_server.plan_type == 100 %}
+                {% if remote_server.plan_type == SPONSORED_PLAN_TYPE %}
                     <h4>On 100% sponsored Zulip Community plan.</h4>
                 {% endif %}
             </div>
 
-            {% if remote_server.plan_type != 100 %}
+            {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
             <form method="POST" class="remote-server-form">
                 <b>Sponsorship pending</b>:<br />
                 {{ csrf_input }}
@@ -76,12 +76,12 @@
             </form>
             {% endif %}
 
-            {% if remote_server.plan_type != 100 %}
+            {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
             <form method="POST" class="remote-server-form">
                 <b>Discount</b>:<br />
                 {{ csrf_input }}
                 <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                {% if plan_data[remote_server.id].current_plan and plan_data[remote_server.id].current_plan.fixed_price %}
+                {% if plan_data[remote_server.id].has_fixed_price %}
                 <input type="number" name="discount" value="{{ get_discount(plan_data[remote_server.id].customer) }}" disabled />
                 <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
                 {% else %}

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -53,42 +53,14 @@
             </div>
 
             {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
-            <form method="POST" class="remote-server-form">
-                <b>Sponsorship pending</b>:<br />
-                {{ csrf_input }}
-                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                <select name="sponsorship_pending">
-                    <option value="true" {% if plan_data[remote_server.id].customer and plan_data[remote_server.id].customer.sponsorship_pending %}selected{% endif %}>Yes</option>
-                    <option value="false" {% if not plan_data[remote_server.id].customer or not plan_data[remote_server.id].customer.sponsorship_pending %}selected{% endif %}>No</option>
-                </select>
-                <button type="submit" class="btn btn-default support-submit-button">Update</button>
-            </form>
-            {% endif %}
-
-            {% if plan_data[remote_server.id].customer and plan_data[remote_server.id].customer.sponsorship_pending %}
-            <form method="POST" class="">
-                {{ csrf_input }}
-                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                <input type="hidden" name="approve_sponsorship" value="true" />
-                <button class="btn btn-default sea-green small approve-sponsorship-button">
-                    Approve full sponsorship
-                </button>
-            </form>
-            {% endif %}
-
-            {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
-            <form method="POST" class="remote-server-form">
-                <b>Discount</b>:<br />
-                {{ csrf_input }}
-                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                {% if plan_data[remote_server.id].has_fixed_price %}
-                <input type="number" name="discount" value="{{ get_discount(plan_data[remote_server.id].customer) }}" disabled />
-                <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
-                {% else %}
-                <input type="number" name="discount" value="{{ get_discount(plan_data[remote_server.id].customer) }}" required />
-                <button type="submit" class="btn btn-default support-submit-button">Update</button>
-                {% endif %}
-            </form>
+                {% with %}
+                    {% set customer = remote_servers_plan_data[remote_server.id].customer %}
+                    {% set remote_id = remote_server.id %}
+                    {% set remote_type = "remote_server_id" %}
+                    {% set has_fixed_price = remote_servers_plan_data[remote_server.id].has_fixed_price %}
+                    {% set get_discount = get_discount %}
+                    {% include 'analytics/sponsorship_forms_support.html' %}
+                {% endwith %}
             {% endif %}
 
             {% if plan_data[remote_server.id].current_plan %}
@@ -99,7 +71,7 @@
                 {% endwith %}
             </div>
 
-            <form method="POST" class="remote-server-form">
+            <form method="POST" class="remote-form">
                 <b>Billing collection method</b><br />
                 {{ csrf_input }}
                 <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
@@ -110,7 +82,7 @@
                 <button type="submit" class="btn btn-default support-submit-button">Update</button>
             </form>
 
-            <form method="POST" class="remote-server-form">
+            <form method="POST" class="remote-form">
                 <b>Modify current plan</b><br />
                 {{ csrf_input }}
                 <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -71,29 +71,12 @@
                 {% endwith %}
             </div>
 
-            <form method="POST" class="remote-form">
-                <b>Billing collection method</b><br />
-                {{ csrf_input }}
-                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                <select name="billing_modality" class="billing-modality-select" required>
-                    <option value="charge_automatically" {% if remote_servers_plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
-                    <option value="send_invoice" {% if not remote_servers_plan_data[remote_server.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
-                </select>
-                <button type="submit" class="btn btn-default support-submit-button">Update</button>
-            </form>
-
-            <form method="POST" class="remote-form">
-                <b>Modify current plan</b><br />
-                {{ csrf_input }}
-                <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
-                <select name="modify_plan" class="modify-plan-method-select" required>
-                    <option disabled value="" selected>-- select --</option>
-                    <option value="downgrade_at_billing_cycle_end">Downgrade at the end of current billing cycle</option>
-                    <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
-                    <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
-                </select>
-                <button type="submit" class="btn btn-default support-submit-button">Modify</button>
-            </form>
+            {% with %}
+                {% set current_plan = remote_servers_plan_data[remote_server.id].current_plan %}
+                {% set remote_id = remote_server.id %}
+                {% set remote_type = "remote_server_id" %}
+                {% include 'analytics/current_plan_forms_support.html' %}
+            {% endwith %}
             {% endif %}
 
             {% for remote_realm in remote_realms[remote_server.id] %}

--- a/templates/analytics/sponsorship_forms_support.html
+++ b/templates/analytics/sponsorship_forms_support.html
@@ -1,0 +1,34 @@
+<form method="POST" class="remote-form">
+    <b>Sponsorship pending</b>:<br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <select name="sponsorship_pending">
+        <option value="true" {% if customer and customer.sponsorship_pending %}selected{% endif %}>Yes</option>
+        <option value="false" {% if not customer or not customer.sponsorship_pending %}selected{% endif %}>No</option>
+    </select>
+    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+</form>
+
+{% if customer and customer.sponsorship_pending %}
+<form method="POST" class="">
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <input type="hidden" name="approve_sponsorship" value="true" />
+    <button class="btn btn-default sea-green small approve-sponsorship-button">
+        Approve full sponsorship
+    </button>
+</form>
+{% endif %}
+
+<form method="POST" class="remote-form">
+    <b>Discount</b>:<br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    {% if has_fixed_price %}
+    <input type="number" name="discount" value="{{ get_discount(customer) }}" disabled />
+    <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
+    {% else %}
+    <input type="number" name="discount" value="{{ get_discount(customer) }}" required />
+    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    {% endif %}
+</form>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -158,7 +158,7 @@ tr.admin td:first-child {
     padding-bottom: 15px;
 }
 
-.remote-server-form {
+.remote-form {
     margin-bottom: 10px;
 }
 


### PR DESCRIPTION
Updates the remote server support view so that any remote realms attached to a remote server have the same forms/actions for support admin (e.g. sponsorship requests, discounts, modifying current plan actions).

**Screenshots and screen captures:**

<details>
<summary>business remote realm example</summary>

![Screenshot from 2023-12-11 17-58-43](https://github.com/zulip/zulip/assets/63245456/6fb34465-1a9c-45ba-aa95-57b49950f810)
</details>
<details>
<summary>Sponsorship requested & sponsored remote realms</summary>

*Are we planning that 100% sponsored remote realms/servers will also have a current plan? Or is this just an error with how we're generating that in populate_billing_realms?*

![Screenshot from 2023-12-11 17-59-10](https://github.com/zulip/zulip/assets/63245456/3cea138a-f2e9-4e25-bc2f-a733382c73c3)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
