### PR TITLE
requirements: Remove direct requirement on Twisted

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,9 +8,6 @@
 # moto s3 mock
 moto[s3]
 
-# Needed for running tools/run-dev
-Twisted
-
 # Needed for documentation links test
 Scrapy
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2886,9 +2886,7 @@ twilio==8.10.3 \
 twisted==22.10.0 \
     --hash=sha256:32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31 \
     --hash=sha256:86c55f712cc5ab6f6d64e02503352464f0400f66d4f079096d744080afcccbd0
-    # via
-    #   -r requirements/dev.in
-    #   scrapy
+    # via scrapy
 typeguard==2.13.3 \
     --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \
     --hash=sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1


### PR DESCRIPTION
It’s still used indirectly via Scrapy, but we haven’t used it directly since commit 09e17fbe17fecb3b83ef80a0e04248e7387f328f (#2002).

Skipping a `PROVISION_VERSION` bump because this has no real effect.