### PR TITLE
tornado: Support clearing a handler more than once.

### DIFF
--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -37,7 +37,8 @@ def allocate_handler_id(handler: "AsyncDjangoHandler") -> int:
 
 
 def clear_handler_by_id(handler_id: int) -> None:
-    del handlers[handler_id]
+    if handler_id in handlers:
+        del handlers[handler_id]
 
 
 def handler_stats_string() -> str:


### PR DESCRIPTION
4af00f61a8c4b779365a5e7b8746716b7f32e837 claimed that `on_finish` and `on_connection_close` were mutually exclusive.  In cases where a `DELETE` is called on the queue while a longpoll is in progress, this can cause _both_ to happen:

- The `DELETE` pushes a `cleanup_queue` event, which triggers `finish_handler` to begin pushing out an empty event response to the longpoll connection.

- In the midst of that, in an `await`, the longpoll connection drops, and `on_connection_close` clears the handler.

- The `await` resumes, calls `finish`, and attempts to clear the handler.

The easiest solution is to make `clear_handler_by_id` tolerant to multiple attempts to clear it.  Since these processes run in parallel, it means that parts may have a `handler_id` but `get_handler_by_id` may error in attempting to look it up.  We have not observed this in testing, and I cannot currently prove it is impossible.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
