### PR TITLE
help: Document setting to automatically follow topics when mentioned.

### DIFF
--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -4,7 +4,8 @@ Zulip lets you follow topics you are interested in. You can follow or unfollow
 any topic. You can also configure Zulip to automatically follow topics you start
 or participate in. Participating in a topic means sending a message,
 [reacting](/help/emoji-reactions) with an emoji, or participating in a
-[poll](/help/create-a-poll).
+[poll](/help/create-a-poll). You can also automatically follow topics where you
+are [mentioned](/help/mention-a-user-or-group).
 
 It's easy to prioritize catching up on followed topics. You can:
 

--- a/help/include/automatically-follow-topics.md
+++ b/help/include/automatically-follow-topics.md
@@ -1,3 +1,5 @@
+### Follow topics you start or participate in
+
 {start_tabs}
 
 {tab|desktop-web}
@@ -6,5 +8,29 @@
 
 1. Under **Topic notifications**, select the desired option from the
    **Automatically follow topics** dropdown.
+
+{end_tabs}
+
+### Follow topics where you are mentioned
+
+You can automatically follow topics where you are personally
+[mentioned](/help/mention-a-user-or-group). If this setting is enabled:
+
+- You will automatically follow topics where you are personally mentioned, but
+  group mentions and wildcard mentions (**@all**, **@topic**, etc.) will not
+  affect topic status.
+- You will automatically follow topics in [muted streams](/help/mute-a-stream)
+  when you are mentioned.
+- Mentions will *not* cause you to automatically follow topics you have
+  explicitly [muted](/help/mute-a-topic).
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|notifications}
+
+1. Under **Topic notifications**, toggle **Automatically follow topics where I'm
+   mentioned**.
 
 {end_tabs}


### PR DESCRIPTION
Current:
- https://zulip.com/help/follow-a-topic#automatically-follow-topics
- https://zulip.com/help/topic-notifications#automatically-follow-topics

Updated:

![Screenshot 2023-12-11 at 11 07 16 PM](https://github.com/zulip/zulip/assets/2090066/e230b218-eacd-4e3e-8649-677f2f566932)
![Screenshot 2023-12-11 at 11 04 06 PM](https://github.com/zulip/zulip/assets/2090066/85f35048-bef2-4cbb-a3a3-5ec5547799ac)
