### PR TITLE
support: Fix remote realm details.

### DIFF
--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -481,7 +481,9 @@ def remote_servers_support(
     remote_realms: Dict[int, List[RemoteRealm]] = {}
     for remote_server in remote_servers:
         # Get remote realms attached to remote server
-        remote_realms_for_server = list(remote_server.remoterealm_set.all())
+        remote_realms_for_server = list(
+            remote_server.remoterealm_set.exclude(is_system_bot_realm=True)
+        )
         remote_realms[remote_server.id] = remote_realms_for_server
         # Get plan data for remote realms
         for remote_realm in remote_realms[remote_server.id]:

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -14,7 +14,7 @@
     {% set customer = plan_data[remote_realm.id].customer %}
     {% set remote_id = remote_realm.id %}
     {% set remote_type = "remote_realm_id" %}
-    {% set has_fixed_price = plan_data[remote_server.id].has_fixed_price %}
+    {% set has_fixed_price = plan_data[remote_realm.id].has_fixed_price %}
     {% set get_discount = get_discount %}
     {% include 'analytics/sponsorship_forms_support.html' %}
 {% endwith %}
@@ -29,7 +29,7 @@
 </div>
 
 {% with %}
-    {% set current_plan = plan_data[remote_server.id].current_plan %}
+    {% set current_plan = plan_data[remote_realm.id].current_plan %}
     {% set remote_id = remote_realm.id %}
     {% set remote_type = "remote_realm_id" %}
     {% include 'analytics/current_plan_forms_support.html' %}


### PR DESCRIPTION
**Notes**:
- Corrects two references in `remote_realm_details.html` to be remote_realm (instead of remote_server).
- Excludes the system bot realm from the remote realms listed in the support view for a remote server.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
