### PR TITLE
portico: Disable self-hosted tab for logged-in cloud users.

### DIFF
--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -149,12 +149,21 @@
                 </div>
             </div>
 
+            {% if user_is_authenticated and not is_self_hosted_realm %}
+            <div class="self-hosted-plan-title inactive-pricing-tab">
+                <h2>Self-hosted</h2>
+                <p>
+                    <a href="https://zulip.com/plans/#self-hosted">View self-hosted plans and pricing</a>.
+                </p>
+            </div>
+            {% else %}
             <div id="self-hosted" class="self-hosted-plan-title pricing-tab">
                 <h2>Self-hosted</h2>
                 <p>
                     Retain full control over your data.<br />100% open-source software.
                 </p>
             </div>
+            {% endif %}
 
             <div class="pricing-pane-scroll-container self-hosted-scroll">
                 <div class="self-hosted-plan-pricing pricing-pane">


### PR DESCRIPTION
**Screenshots and screen captures:**

| Cloud, logged in | Self-hosted, logged in (no change)|
| --- | --- |
| ![Screen Shot 2023-12-12 at 10 12 12](https://github.com/zulip/zulip/assets/170719/4419dd86-54bc-4c9a-9f5a-0834fcc1b271) | ![Screen Shot 2023-12-12 at 10 06 57](https://github.com/zulip/zulip/assets/170719/80cb24ec-69ee-4276-a105-b347ffc3bf39) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

