### PR TITLE
tornado: Handle the handler having been cleared by connection close.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -197,8 +197,9 @@ class ClientDescriptor:
     def add_event(self, event: Mapping[str, Any]) -> None:
         if self.current_handler_id is not None:
             handler = get_handler_by_id(self.current_handler_id)
-            assert handler._request is not None
-            async_request_timer_restart(handler._request)
+            if handler is not None:
+                assert handler._request is not None
+                async_request_timer_restart(handler._request)
 
         self.event_queue.push(event)
         self.finish_current_handler()


### PR DESCRIPTION
As premonitioned in c741c527d7cc56d7a4999257b7332ce2441bf63b, it is indeed possible for `get_handler_by_id` to error out by cause the handler has been unset elsewhere.

Protect the callsites of `get_handler_by_id` to be able to gracefully handle when the handler has already done away.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
