### PR TITLE
remote_billing: Add endpoint and a helper to make deactivation links.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3828,6 +3828,9 @@ def do_change_remote_server_plan_type(remote_server: RemoteZulipServer, plan_typ
 
 @transaction.atomic
 def do_deactivate_remote_server(remote_server: RemoteZulipServer) -> None:
+    # TODO: This should also ensure that the server doesn't have an active plan,
+    # and deactivate it otherwise. (Like do_deactivate_realm does.)
+
     if remote_server.deactivated:
         billing_logger.warning(
             "Cannot deactivate remote server with ID %d, server has already been deactivated.",

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -8,6 +8,7 @@ from corporate.views.billing_page import (
     billing_page,
     remote_realm_billing_page,
     remote_server_billing_page,
+    remote_server_deactivate_page,
     update_plan,
     update_plan_for_remote_realm,
     update_plan_for_remote_server,
@@ -229,6 +230,11 @@ urlpatterns += [
         "server/<server_uuid>/sponsorship/",
         remote_server_sponsorship_page,
         name="remote_server_sponsorship_page",
+    ),
+    path(
+        "server/<server_uuid>/deactivate/",
+        remote_server_deactivate_page,
+        name="remote_server_deactivate_page",
     ),
     path(
         "serverlogin/",

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -54,8 +54,8 @@ from zilencer.models import (
 billing_logger = logging.getLogger("corporate.stripe")
 
 
-VALID_NEXT_PAGES = [None, "sponsorship", "upgrade", "billing", "plans"]
-VALID_NEXT_PAGES_TYPE = Literal[None, "sponsorship", "upgrade", "billing", "plans"]
+VALID_NEXT_PAGES = [None, "sponsorship", "upgrade", "billing", "plans", "deactivate"]
+VALID_NEXT_PAGES_TYPE = Literal[None, "sponsorship", "upgrade", "billing", "plans", "deactivate"]
 
 REMOTE_BILLING_SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS = 2 * 60 * 60
 # We use units of hours here so that we can pass this through to the
@@ -654,3 +654,19 @@ def remote_billing_legacy_server_from_login_confirmation_link(
         return HttpResponseRedirect(
             reverse("remote_server_billing_page", args=(remote_server_uuid,))
         )
+
+
+def generate_confirmation_link_for_server_deactivation(
+    remote_server: RemoteZulipServer, validity_in_minutes: int
+) -> str:
+    obj = PreregistrationRemoteServerBillingUser.objects.create(
+        email=remote_server.contact_email,
+        remote_server=remote_server,
+        next_page="deactivate",
+    )
+    url = create_remote_billing_confirmation_link(
+        obj,
+        Confirmation.REMOTE_SERVER_BILLING_LEGACY_LOGIN,
+        validity_in_minutes=validity_in_minutes,
+    )
+    return url

--- a/templates/corporate/remote_billing_server_deactivate.html
+++ b/templates/corporate/remote_billing_server_deactivate.html
@@ -1,0 +1,47 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "upgrade" %}
+
+{% block title %}
+<title>{{ _("Deactivate server registration?") }} | Zulip</title>
+{% endblock %}
+
+{% block portico_content %}
+<div id="server-deactivate-page" class="register-account flex full-page">
+    <div class="center-block new-style">
+
+        <div class="pitch">
+            <h1>
+                Deactivate registration for {{ server_hostname }}?
+            </h1>
+        </div>
+        <div class="white-box">
+            <div id="server-deactivate-details">
+                <form id="server-deactivate-form" method="post" action="{{ action_url }}">
+                    {{ csrf_input }}
+                    <p class="not-editable-realm-field">
+                        You are about to deactivate this server's
+                        registration with
+                        the <a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html">Zulip
+                        Mobile Push Notification Service</a>. This
+                        will disable delivery of mobile push
+                        notifications for all organizations hosted
+                        on <b>{{ server_hostname }}</b>.
+                    </p>
+                    <input type="hidden" name="confirmed" value="true" />
+                    <div class="upgrade-button-container">
+                        <button type="submit" id="server-deactivate-button" class="stripe-button-el invoice-button">
+                            <span class="server-deactivate-button-text">Deactivate registration</span>
+                            <img class="loader remote-billing-button-loader" src="{{ static('images/loading/loader-white.svg') }}" alt="" />
+                        </button>
+                    </div>
+                </form>
+                <div class="input-box upgrade-page-field">
+                    <div class="support-link not-editable-realm-field">
+                        Questions? Contact <a href="mailto:support@zulip.com">support@zulip.com</a>.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/corporate/remote_billing_server_deactivated_success.html
+++ b/templates/corporate/remote_billing_server_deactivated_success.html
@@ -1,0 +1,27 @@
+{% extends "zerver/portico_signup.html" %}
+{% set entrypoint = "upgrade" %}
+
+{% block title %}
+<title>Server registration deactivated | Zulip</title>
+{% endblock %}
+
+{% block portico_content %}
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation account-email-confirm-container new-style">
+        <div class="pitch">
+            <h1>
+                Registration deactivated for {{ server_hostname }}
+            </h1>
+        </div>
+        <div class="inline-block">
+            <div class="white-box">
+                <p>Your server's registration has been deactivated.</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block customhead %}
+{{ super() }}
+{% endblock %}

--- a/web/src/billing/deactivate_server.ts
+++ b/web/src/billing/deactivate_server.ts
@@ -1,0 +1,16 @@
+import $ from "jquery";
+
+export function initialize(): void {
+    $("#server-deactivate-form").validate({
+        submitHandler(form) {
+            $("#server-deactivate-form").find(".loader").css("display", "inline-block");
+            $("#server-deactivate-button .server-deactivate-button-text").hide();
+
+            form.submit();
+        },
+    });
+}
+
+$(() => {
+    initialize();
+});

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -28,6 +28,7 @@
         "./src/billing/upgrade",
         "jquery-validation",
         "./src/billing/remote_billing_auth",
+        "./src/billing/deactivate_server",
         "./styles/portico/billing.css"
     ],
     "billing-event-status": [


### PR DESCRIPTION
This is a general link for logging into the billing system on behalf of a server, but it's tied to the .contact_email and takes the user straight to the /deactivate/ page via the next_page mechanism.

The `generate_confirmation_link_for_server_deactivation` can be used to generate and send these in emails to self hosters.

Screencast of using the link:
[Screencast from 2023-12-12 19-08-16.webm](https://github.com/zulip/zulip/assets/45007152/16bd5aa9-8219-4251-ba7e-40f2dffd172d)
