### PR TITLE
support: Add plan information to remote activity page.

### DIFF
--- a/corporate/lib/analytics.py
+++ b/corporate/lib/analytics.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 from django.utils.timezone import now as timezone_now
 
-from corporate.lib.stripe import renewal_amount
+from corporate.lib.stripe import RealmBillingSession
 from corporate.models import Customer, CustomerPlan
 from zerver.lib.utils import assert_is_not_none
 
@@ -31,7 +31,9 @@ def estimate_annual_recurring_revenue_by_realm() -> Dict[str, int]:  # nocoverag
         if plan.customer.realm is not None:
             # TODO: figure out what to do for plans that don't automatically
             # renew, but which probably will renew
-            renewal_cents = renewal_amount(plan, timezone_now())
+            renewal_cents = RealmBillingSession(
+                realm=plan.customer.realm
+            ).get_customer_plan_renewal_amount(plan, timezone_now())
             if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
                 renewal_cents *= 12
             # TODO: Decimal stuff

--- a/templates/analytics/remote_activity_key.html
+++ b/templates/analytics/remote_activity_key.html
@@ -2,6 +2,7 @@
 <ul>
     <li><strong>Zulip version</strong> - as of last update time</li>
     <li><strong>Mobile pushes forwarded</strong> - last 7 days, including today's current count</li>
+    <li><strong>ARR</strong> (annual recurring revenue) - the number of users they are paying for * annual price/user</li>
     <li><strong>Links</strong>
         <ul>
             <li><strong><i class="fa fa-pie-chart"></i></strong> - remote server's stats page</li>


### PR DESCRIPTION
Adds two columns to the chart for remote servers on the remote activity support page:
- Whether the server (or attached realms) has a customer plan with an "Active" status.
- The annual revenue for that customer plan.

**Notes**:
- The 4 additional queries in the activity test for the remote active page are:
  - the new query to get the customer plans
  - 2 queries on the LicenseLedger table via the first two lines of `make_end_of_cycle_updates_if_needed`
  - an additional query on `get_remote_server_guest_and_non_guest_count` as I added a realm without an active plan for test coverage.

**Screenshots and screen captures:**

<details>
<summary>Remote activity - updated</summary>

![Screenshot from 2023-12-12 19-53-43](https://github.com/zulip/zulip/assets/63245456/421c76ae-472f-4d1d-99fd-8fba6d0d8da0)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
