### PR TITLE
portico: Update strings for RemoteRealm login flow.

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -66,7 +66,7 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
             # When logging in for the first time some extra steps are needed
             # to confirm and verify the email address.
             self.assertEqual(result.status_code, 200)
-            self.assert_in_success_response(["Enter log in email"], result)
+            self.assert_in_success_response(["Enter email"], result)
             self.assert_in_success_response([user.realm.host], result)
             self.assert_in_success_response(
                 [f'action="/remote-billing-login/{signed_access_token}/confirm/"'], result
@@ -80,7 +80,11 @@ class RemoteBillingAuthenticationTest(BouncerTestCase):
                 )
             self.assertEqual(result.status_code, 200)
             self.assert_in_success_response(
-                ["We have sent a log in link", "link will expire in", user.delivery_email],
+                [
+                    "To finish logging in, check your email account (",
+                    ") for a confirmation email from Zulip.",
+                    user.delivery_email,
+                ],
                 result,
             )
             confirmation_url = self.get_confirmation_url_from_outbox(

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -511,7 +511,7 @@ class LegacyServerLoginTest(BouncerTestCase):
             )
         self.assertEqual(result.status_code, 200)
         self.assert_in_success_response(
-            ["We have sent a log in link", "link will expire in", email],
+            ["We have sent", "a log in", "link will expire in", email],
             result,
         )
 

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -548,7 +548,7 @@ def remote_billing_legacy_server_confirm_login(
     return render(
         request,
         "corporate/remote_billing_email_confirmation_sent.html",
-        context={"email": email},
+        context={"email": email, "remote_server_hostname": remote_server.hostname},
     )
 
 

--- a/templates/corporate/remote_billing_confirm_email_form.html
+++ b/templates/corporate/remote_billing_confirm_email_form.html
@@ -2,14 +2,22 @@
 {% set entrypoint = "upgrade" %}
 
 {% block title %}
+{% if remote_server_hostname %}
 <title>Enter log in email | Zulip</title>
+{% else %}
+<title>Enter email | Zulip</title>
+{% endif %}
 {% endblock %}
 
 {% block portico_content %}
 <div class="register-account flex full-page" id="remote-billing-confirm-email">
     <div class="center-block new-style">
         <div class="pitch">
+            {% if remote_server_hostname %}
             <h1>Enter log in email</h1>
+            {% else %}
+            <h1>Enter email</h1>
+            {% endif %}
         </div>
         <div class="white-box">
             <form id="remote-billing-confirm-email-form" method="post" action="{{ action_url }}">
@@ -22,7 +30,7 @@
                         {% if remote_server_hostname %}
                             Enter the email address of the person who is logging in to manage plans and billing for this server (yourself or someone else). They will receive an email from Zulip with a log in link.
                         {% else %}
-                            Enter the email address where you want to receive an email from Zulip with a log in link.
+                            Enter the email address you want to use for Zulip plan management. You will receive a one-time confirmation email.
                         {% endif %}
                     </div>
                 </div>

--- a/templates/corporate/remote_billing_email_confirmation_sent.html
+++ b/templates/corporate/remote_billing_email_confirmation_sent.html
@@ -2,7 +2,11 @@
 {% set entrypoint = "upgrade" %}
 
 {% block title %}
+{% if remote_server_hostname %}
 <title>Log in link sent | Zulip</title>
+{% else %}
+<title>Confirm your email address | Zulip</title>
+{% endif %}
 {% endblock %}
 
 {% block portico_content %}
@@ -11,11 +15,19 @@
         <div class="inline-block">
 
             <div class="get-started">
+                {% if remote_server_hostname %}
                 <h1>Log in link sent</h1>
+                {% else %}
+                <h1>Confirm your email address</h1>
+                {% endif %}
             </div>
 
             <div class="white-box">
+                {% if remote_server_hostname %}
                 <p>We have sent a log in link for Zulip plan management to <span class="user_email semi-bold">{{ email }}</span>. This link will expire in 2 hours.</p>
+                {% else %}
+                <p>To finish logging in, check your email account (<span class="user_email semi-bold">{{ email }}</span>) for a confirmation email from Zulip.</p>
+                {% endif %}
 
                 {% include 'zerver/dev_env_email_access_details.html' %}
             </div>

--- a/templates/corporate/remote_billing_email_confirmation_sent.html
+++ b/templates/corporate/remote_billing_email_confirmation_sent.html
@@ -24,7 +24,7 @@
 
             <div class="white-box">
                 {% if remote_server_hostname %}
-                <p>We have sent a log in link for Zulip plan management to <span class="user_email semi-bold">{{ email }}</span>. This link will expire in 2 hours.</p>
+                <p>We have sent <span class="user_email semi-bold">{{ email }}</span> a log in link for Zulip plan management. This link will expire in 24 hours.</p>
                 {% else %}
                 <p>To finish logging in, check your email account (<span class="user_email semi-bold">{{ email }}</span>) for a confirmation email from Zulip.</p>
                 {% endif %}


### PR DESCRIPTION
These updates are only for RemoteRealms; legacy self-managed logins should be unaffected.

**Screenshots and screen captures:**

| Remote realm login | Remote realm confirm |
| --- | --- |
| <img width="1181" alt="Screenshot 2023-12-12 at 1 38 37 PM" src="https://github.com/zulip/zulip/assets/170719/7373c69f-dfa9-414f-8ad4-148388d63cda"> | <img width="1181" alt="Screenshot 2023-12-12 at 1 39 27 PM" src="https://github.com/zulip/zulip/assets/170719/63469730-2698-4dab-b6ef-e2509ca4e174"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>