### PR TITLE
changed populate db to follow relam set up in production

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -342,7 +342,6 @@ class Command(BaseCommand):
                 enable_read_receipts=True,
                 enable_spectator_access=True,
             )
-
             RealmDomain.objects.create(realm=zulip_realm, domain="zulip.com")
             assert zulip_realm.notifications_stream is not None
             zulip_realm.notifications_stream.name = "Verona"

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -20,6 +20,7 @@ from typing_extensions import override
 
 from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
 from zerver.actions.create_realm import do_create_realm
+from zerver.actions.create_user import do_create_user
 from zerver.actions.custom_profile_fields import (
     do_update_user_custom_profile_data_if_changed,
     try_add_realm_custom_profile_field,
@@ -33,12 +34,13 @@ from zerver.actions.streams import bulk_add_subscriptions
 from zerver.actions.user_groups import create_user_group_in_database
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.users import do_change_user_role
-from zerver.actions.create_user import do_create_user
-from zerver.actions.create_realm import do_create_realm
 from zerver.lib.bulk_create import bulk_create_streams
 from zerver.lib.generate_test_data import create_test_data, generate_topics
-from zerver.lib.onboarding import create_if_missing_realm_internal_bots
-from zerver.lib.onboarding import send_initial_direct_message, send_initial_realm_messages
+from zerver.lib.onboarding import (
+    create_if_missing_realm_internal_bots,
+    send_initial_direct_message,
+    send_initial_realm_messages,
+)
 from zerver.lib.push_notifications import logger as push_notifications_logger
 from zerver.lib.remote_server import get_realms_info_for_push_bouncer
 from zerver.lib.server_initialization import create_internal_realm, create_users
@@ -355,11 +357,12 @@ class Command(BaseCommand):
             )
             realm_user_default.save()
 
-            if UserProfile.objects.filter(realm = zulip_realm).exists():
-                user = do_create_user('iago1@zulip.com', 'password', zulip_realm, 'Iago', acting_user=None)
+            if UserProfile.objects.filter(realm=zulip_realm).exists():
+                user = do_create_user(
+                    "iago1@zulip.com", "password", zulip_realm, "Iago", acting_user=None
+                )
                 send_initial_direct_message(user)
                 send_initial_realm_messages(zulip_realm)
-            
             if options["test_suite"]:
                 mit_realm = do_create_realm(
                     string_id="zephyr",
@@ -369,12 +372,12 @@ class Command(BaseCommand):
                     plan_type=Realm.PLAN_TYPE_SELF_HOSTED,
                     org_type=Realm.ORG_TYPES["business"]["id"],
                 )
-            
-                if UserProfile.objects.filter(realm = mit_realm).exists():
-                    user = do_create_user('iago2@zulip.com', 'password', mit_realm, 'Iago2', acting_user=None)
+                if UserProfile.objects.filter(realm=mit_realm).exists():
+                    user = do_create_user(
+                        "iago2@zulip.com", "password", mit_realm, "Iago2", acting_user=None
+                    )
                     send_initial_direct_message(user)
                     send_initial_realm_messages(mit_realm)
-
                 RealmDomain.objects.create(realm=mit_realm, domain="mit.edu")
                 lear_realm = do_create_realm(
                     string_id="lear",
@@ -385,11 +388,12 @@ class Command(BaseCommand):
                     org_type=Realm.ORG_TYPES["business"]["id"],
                 )
 
-                if UserProfile.objects.filter(realm = lear_realm).exists():
-                    user = do_create_user('iago3@zulip.com', 'password', lear_realm, 'Iago3', acting_user=None)
+                if UserProfile.objects.filter(realm=lear_realm).exists():
+                    user = do_create_user(
+                        "iago3@zulip.com", "password", lear_realm, "Iago3", acting_user=None
+                    )
                     send_initial_direct_message(user)
                     send_initial_realm_messages(lear_realm)
-
                 # Default to allowing all members to send mentions in
                 # large streams for the test suite to keep
                 # mention-related tests simple.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #6020 
Changes to initialize streams and initial messages to be production-like following pseudocode. setup_initial_streams(realm), setup_initial_private_stream(user) are deprecated functions that are replaced now

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
