### PR TITLE
compose: Fix multiple warning banners for same private stream mention.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -27,6 +27,15 @@ import * as stream_data from "./stream_data";
 
 const compose_clear_box_hooks = [];
 const compose_cancel_hooks = [];
+let displayed_banner_list = [];
+
+export function banner_not_already_displayed(item) {
+    if (displayed_banner_list.includes(item)) {
+        return false;
+    }
+    displayed_banner_list.push(item);
+    return true;
+}
 
 export function register_compose_box_clear_hook(hook) {
     compose_clear_box_hooks.push(hook);
@@ -59,6 +68,7 @@ function hide_box() {
 }
 
 function show_compose_box(msg_type, opts) {
+    displayed_banner_list = [];
     compose_recipient.update_compose_for_message_type(msg_type, opts);
     $("#compose").css({visibility: "visible"});
     // When changing this, edit the 42px in _maybe_autoscroll

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -5,6 +5,7 @@ import * as typeahead from "../shared/src/typeahead";
 import render_topic_typeahead_hint from "../templates/topic_typeahead_hint.hbs";
 
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
+import {banner_not_already_displayed} from "./compose_actions";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
@@ -926,7 +927,9 @@ export function content_typeahead_selected(item, event) {
             } else {
                 beginning += "** ";
             }
-            compose_validate.warn_if_private_stream_is_linked(item, $textbox);
+            if (banner_not_already_displayed(item)) {
+                compose_validate.warn_if_private_stream_is_linked(item, $textbox);
+            }
             break;
         case "syntax": {
             // Isolate the end index of the triple backticks/tildes, including


### PR DESCRIPTION
Previously, each time a private stream is mentioned in the compose box, a warning is displayed. Hence for multiple mentions, multiple warning banners are displayed.

This is fixed by maintaining a list of already displayed banners, which is emptied each time the compose box is opened, and a new method, banner_not_already_displayed, which checks out if a private stream banner is already displayed or not, and display the warning accordingly.

Fixes: #26914

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![brave_MBZuM4qxp0](https://github.com/zulip/zulip/assets/97049524/30bebc83-0ab8-4f84-80d9-760e51d5ce14)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
