### PR TITLE
sponsorship: Don't hard-code "Cloud Standard" plan name in messages.

### DIFF
--- a/templates/corporate/sponsorship.html
+++ b/templates/corporate/sponsorship.html
@@ -165,6 +165,8 @@
             </div>
         </div>
     </div>
+    <!-- This is for our TypeScript code to extract the plan name to use in strings. -->
+    <div id="sponsorship-plan-name-hidden-info" data-plan-name="{{ sponsorship_plan_name }}" style="display: none;"></div>
 </div>
 {% endif %}
 

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -99,16 +99,17 @@ export function format_money(cents: number): string {
 }
 
 export function update_discount_details(organization_type: string): void {
-    let discount_notice =
-        "Your organization may be eligible for a discount on Zulip Cloud Standard. Organizations whose members are not employees are generally eligible.";
+    const plan_name_element = document.querySelector("#sponsorship-plan-name-hidden-info");
+    const plan_name = plan_name_element?.getAttribute("data-plan-name") || "Zulip Cloud Standard";
+
+    let discount_notice = `Your organization may be eligible for a discount on the ${plan_name} plan. Organizations whose members are not employees are generally eligible.`;
     const discount_details: DiscountDetails = {
-        opensource: "Zulip Cloud Standard is free for open-source projects.",
-        research: "Zulip Cloud Standard is free for academic research.",
-        nonprofit: "Zulip Cloud Standard is discounted 85%+ for registered non-profits.",
-        event: "Zulip Cloud Standard is free for academic conferences and most non-profit events.",
-        education: "Zulip Cloud Standard is discounted 85% for education.",
-        education_nonprofit:
-            "Zulip Cloud Standard is discounted 90% for education non-profits with online purchase.",
+        opensource: `${plan_name} plan is free for open-source projects.`,
+        research: `${plan_name} plan is free for academic research.`,
+        nonprofit: `${plan_name} plan is discounted 85%+ for registered non-profits.`,
+        event: `${plan_name} plan is free for academic conferences and most non-profit events.`,
+        education: `${plan_name} plan is discounted 85% for education.`,
+        education_nonprofit: `${plan_name} plan is discounted 90% for education non-profits with online purchase.`,
     };
 
     try {


### PR DESCRIPTION
The name was hard-coded in strings. We should instead grab the sponsorship_plan_name and use that, to ensure it's correct in the context in which the code is running.

Though honestly I don't if this is quite right with the `Community` name, Maybe we just shouldn't be showing these strings in remote billing at all.
![image](https://github.com/zulip/zulip/assets/45007152/c8bc3362-c044-4e04-96db-af7b635a4c9d)
