### PR TITLE
remote_server: Handle data of non existent realms.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1909,6 +1909,36 @@ class AnalyticsBouncerTest(BouncerTestCase):
             ],
         )
 
+    @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
+    @responses.activate
+    def test_non_existent_realm_uuid(self) -> None:
+        self.add_mock_response()
+        realm_info = get_realms_info_for_push_bouncer()
+
+        # Hard-delete a realm to test the non existent realm uuid case.
+        realm = Realm.objects.order_by("id").first()
+        assert realm is not None
+        deleted_realm_uuid = realm.uuid
+        realm.delete()
+
+        with mock.patch(
+            "zerver.lib.remote_server.get_realms_info_for_push_bouncer", return_value=realm_info
+        ) as m, self.assertLogs("zulip.analytics", level="WARNING") as analytics_logger:
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
+            m.assert_called()
+            realms = Realm.objects.all()
+            for realm in realms:
+                self.assertEqual(realm.push_notifications_enabled, True)
+                self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
+
+        self.assertEqual(
+            analytics_logger.output,
+            [
+                "WARNING:zulip.analytics:"
+                f"Received unexpected realm UUID from bouncer {deleted_realm_uuid}"
+            ],
+        )
+
 
 class PushNotificationTest(BouncerTestCase):
     @override


### PR DESCRIPTION
This PR adds code to make sure that the push
notification does not crash on receiving data for
a non-existent realm.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
