### PR TITLE
support: Filter remote realm data query for customer realm None.

### DIFF
--- a/corporate/lib/analytics.py
+++ b/corporate/lib/analytics.py
@@ -56,7 +56,7 @@ def estimate_annual_recurring_revenue_by_realm() -> Dict[str, int]:  # nocoverag
 def get_plan_data_by_remote_server() -> Dict[int, RemoteActivityPlanData]:  # nocoverage
     remote_server_plan_data: Dict[int, RemoteActivityPlanData] = {}
     for plan in CustomerPlan.objects.filter(
-        status__lt=CustomerPlan.LIVE_STATUS_THRESHOLD
+        status__lt=CustomerPlan.LIVE_STATUS_THRESHOLD, customer__realm__isnull=True
     ).select_related("customer__remote_server", "customer__remote_realm"):
         renewal_cents = 0
         server_id = None


### PR DESCRIPTION
Quick follow-up to #28171. Updates query of CustomerPlan objects to filter for `customer__realm__isnull=True`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
