### PR TITLE
registration: Prevent injecting arbitrary strings via query param.

### DIFF
--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1194,7 +1194,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         zulip_realm.save()
 
         result = self.submit_reg_form_for_user("foo@example.com", "password")
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 400)
         self.assert_in_response(
             "does not allow signups using emails with your email domain", result
         )
@@ -1221,7 +1221,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         zulip_realm.save()
 
         result = self.submit_reg_form_for_user("foo@mailnator.com", "password")
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 400)
         self.assert_in_response("does not allow signups using disposable email addresses.", result)
 
     def test_invite_with_email_containing_plus_before_closing(self) -> None:
@@ -1247,7 +1247,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         zulip_realm.save()
 
         result = self.submit_reg_form_for_user(external_address, "password")
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 400)
         self.assert_in_response('does not allow signups using emails that contain "+".', result)
 
     def test_invalid_email_check_after_confirming_email(self) -> None:
@@ -1263,7 +1263,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         prereg_user.save()
 
         result = self.submit_reg_form_for_user(email, "password")
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 400)
         self.assert_in_response(
             "The email address you are trying to sign up with is not valid", result
         )

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2935,6 +2935,24 @@ class UserSignUpTest(ZulipTestCase):
             form.errors["email"][0],
         )
 
+    def test_signup_confirm_injection(self) -> None:
+        result = self.client_get("/accounts/send_confirm/?email=bogus@example.com")
+        self.assert_in_success_response(
+            [
+                'check your email account (<span class="user_email semi-bold">bogus@example.com</span>)'
+            ],
+            result,
+        )
+
+        result = self.client_get(
+            "/accounts/send_confirm/?email={quote(email)}",
+            {"email": "bogus@example.com for example"},
+        )
+        self.assertEqual(result.status_code, 400)
+        self.assert_in_response(
+            "The email address you are trying to sign up with is not valid", result
+        )
+
     def test_access_signup_page_in_root_domain_without_realm(self) -> None:
         result = self.client_get("/register", subdomain="", follow=True)
         self.assert_in_success_response(["Find your Zulip accounts"], result)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -272,7 +272,10 @@ def registration_helper(
             validators.validate_email(email)
         except ValidationError:
             return TemplateResponse(
-                request, "zerver/invalid_email.html", context={"invalid_email": True}
+                request,
+                "zerver/invalid_email.html",
+                context={"invalid_email": True},
+                status=400,
             )
 
     if realm_creation:
@@ -293,18 +296,21 @@ def registration_helper(
                 request,
                 "zerver/invalid_email.html",
                 context={"realm_name": realm.name, "closed_domain": True},
+                status=400,
             )
         except DisposableEmailError:
             return TemplateResponse(
                 request,
                 "zerver/invalid_email.html",
                 context={"realm_name": realm.name, "disposable_emails_not_allowed": True},
+                status=400,
             )
         except EmailContainsPlusError:
             return TemplateResponse(
                 request,
                 "zerver/invalid_email.html",
                 context={"realm_name": realm.name, "email_contains_plus": True},
+                status=400,
             )
 
         if realm.deactivated:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -914,6 +914,18 @@ def create_realm(request: HttpRequest, creation_key: Optional[str] = None) -> Ht
 
 @has_request_variables
 def signup_send_confirm(request: HttpRequest, email: str = REQ("email")) -> HttpResponse:
+    try:
+        # Because we interpolate the email directly into the template
+        # from the query parameter, do a simple validation that it
+        # looks a at least a bit like an email address.
+        validators.validate_email(email)
+    except ValidationError:
+        return TemplateResponse(
+            request,
+            "zerver/invalid_email.html",
+            context={"invalid_email": True},
+            status=400,
+        )
     return TemplateResponse(
         request,
         "zerver/accounts_send_confirm.html",


### PR DESCRIPTION
While the query parameter is properly excaped when inlined into the
template (and thus is not an XSS), it can still produce content which
misleads the user via carefully-crafted query parameter.

Validate that the parameter looks like an email address.

Thanks to jinjo2 for reporting this, via HackerOne.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
