### PR TITLE
corporate: Add billing support email constant.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -86,6 +86,8 @@ log_to_file(logging.getLogger("stripe"), BILLING_LOG_PATH)
 ParamT = ParamSpec("ParamT")
 ReturnT = TypeVar("ReturnT")
 
+BILLING_SUPPORT_EMAIL = "sales@zulip.com"
+
 MIN_INVOICED_LICENSES = 30
 MAX_INVOICED_LICENSES = 1000
 DEFAULT_INVOICE_DAYS_UNTIL_DUE = 30
@@ -2464,7 +2466,7 @@ class BillingSession(ABC):
         }
         send_email(
             "zerver/emails/sponsorship_request",
-            to_emails=[FromAddress.SUPPORT],
+            to_emails=[BILLING_SUPPORT_EMAIL],
             # Sent to the server's support team, so this email is not user-facing.
             from_name="Zulip sponsorship request",
             from_address=FromAddress.tokenized_no_reply_address(),
@@ -3230,7 +3232,7 @@ class RemoteRealmBillingSession(BillingSession):
             send_email(
                 "zerver/emails/sponsorship_approved_community_plan",
                 to_emails=billing_emails,
-                from_address="sales@zulip.com",
+                from_address=BILLING_SUPPORT_EMAIL,
                 context={
                     "billing_entity": self.billing_entity_display_name,
                     "plans_link": "https://zulip.com/plans/#self-hosted",
@@ -3629,7 +3631,7 @@ class RemoteServerBillingSession(BillingSession):
         send_email(
             "zerver/emails/sponsorship_approved_community_plan",
             to_emails=billing_emails,
-            from_address="sales@zulip.com",
+            from_address=BILLING_SUPPORT_EMAIL,
             context={
                 "billing_entity": self.billing_entity_display_name,
                 "plans_link": "https://zulip.com/plans/#self-hosted",

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1848,7 +1848,7 @@ class StripeTest(StripeTestCase):
 
         for message in outbox:
             self.assert_length(message.to, 1)
-            self.assertEqual(message.to[0], "desdemona+admin@zulip.com")
+            self.assertEqual(message.to[0], "sales@zulip.com")
             self.assertEqual(message.subject, "Sponsorship request (Open-source project) for zulip")
             self.assertEqual(message.reply_to, ["hamlet@zulip.com"])
             self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -30,7 +30,11 @@ from corporate.lib.remote_billing_util import (
     RemoteBillingUserDict,
     get_remote_server_and_user_from_session,
 )
-from corporate.lib.stripe import RemoteRealmBillingSession, RemoteServerBillingSession
+from corporate.lib.stripe import (
+    BILLING_SUPPORT_EMAIL,
+    RemoteRealmBillingSession,
+    RemoteServerBillingSession,
+)
 from zerver.lib.exceptions import (
     JsonableError,
     MissingRemoteRealmError,
@@ -334,7 +338,7 @@ def remote_realm_billing_confirm_email(
         "remote_realm_host": remote_realm.host,
         "confirmation_url": url,
         "billing_help_link": "https://zulip.com/help/self-hosted-billing",
-        "billing_contact_email": "sales@zulip.com",
+        "billing_contact_email": BILLING_SUPPORT_EMAIL,
         "validity_in_hours": LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS,
     }
     send_email(
@@ -551,7 +555,7 @@ def remote_billing_legacy_server_confirm_login(
         "remote_server_hostname": remote_server.hostname,
         "confirmation_url": url,
         "billing_help_link": "https://zulip.com/help/self-hosted-billing",
-        "billing_contact_email": "sales@zulip.com",
+        "billing_contact_email": BILLING_SUPPORT_EMAIL,
         "validity_in_hours": LOGIN_CONFIRMATION_EMAIL_DURATION_HOURS,
     }
     send_email(


### PR DESCRIPTION
Adds `BILLING_SUPPORT_EMAIL` to `stripe.py` so that it can be consistently used in billing code.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
