### PR TITLE
Fixes #27837. making the height of compose  bars  steady.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -10,6 +10,7 @@
             font-size: 1em;
             padding: 3px 10px;
             vertical-align: middle;
+            line-height: 1;
         }
 
         .compose_mobile_button {
@@ -30,21 +31,14 @@
 
         /* Button-like styling */
         border-radius: 4px;
-        background-color: var(
-            --color-compose-collapsed-reply-button-area-background
-        );
-        border: 1px solid
-            var(--color-compose-collapsed-reply-button-area-border);
+        background-color: var(--color-compose-collapsed-reply-button-area-background);
+        border: 1px solid var(--color-compose-collapsed-reply-button-area-border);
         transition: all 0.2s ease;
 
         &:hover,
         &:focus {
-            background-color: var(
-                --color-compose-collapsed-reply-button-area-background-interactive
-            );
-            border-color: var(
-                --color-compose-collapsed-reply-button-area-border-interactive
-            );
+            background-color: var(--color-compose-collapsed-reply-button-area-background-interactive);
+            border-color: var(--color-compose-collapsed-reply-button-area-border-interactive);
         }
 
         #left_bar_compose_reply_button_big,
@@ -76,16 +70,14 @@
             color: var(--color-compose-embedded-button-text-color);
 
             &:hover {
-                background-color: var(
-                    --color-compose-embedded-button-background-hover
-                );
+                background-color: var(--color-compose-embedded-button-background-hover);
                 color: var(--color-compose-embedded-button-text-color-hover);
             }
         }
     }
 
     .mobile_button_container {
-        @media (width >= $sm_min) {
+        @media (width >=$sm_min) {
             display: none;
         }
     }
@@ -248,7 +240,7 @@
             "message-formatting-controls-container . ";
         gap: 4px 6px;
 
-        @media ((width >= $sm_min) and (width < $mc_min)) {
+        @media ((width >=$sm_min) and (width < $mc_min)) {
             /* Drop to a 62px wide send column. */
             grid-template-columns: minmax(0, 1fr) 62px;
         }
@@ -294,7 +286,8 @@
        button and the textarea. */
     margin-left: 6px;
 
-    @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+    @media (width < $sm_min),
+    ((width >=$sm_min) and (width < $mc_min)) {
         margin-left: 0;
     }
 }
@@ -353,7 +346,7 @@
     width: calc(112px - 23px + 6px);
     justify-content: flex-end;
 
-    @media ((width >= $sm_min) and (width < $mc_min)) {
+    @media ((width >=$sm_min) and (width < $mc_min)) {
         /* Align to compose controls at narrower widths */
         width: calc(62px - 23px + 6px);
     }
@@ -476,6 +469,7 @@
                width of the flex container. */
             margin-left: 10px;
         }
+
         /* Extra margin to ensure the layout is identical when there is no
            close button. */
         &.right_edge {
@@ -520,7 +514,7 @@
         align-items: center;
     }
 
-    .banner_content + .main-view-banner-close-button {
+    .banner_content+.main-view-banner-close-button {
         /* When there's no action button, set the max
            height for the typical height of the box
            when it contains only banner message text.
@@ -803,9 +797,7 @@ textarea.new_message_textarea,
         }
 
         &:hover {
-            background-color: var(
-                --color-compose-embedded-button-background-hover
-            );
+            background-color: var(--color-compose-embedded-button-background-hover);
             color: var(--color-compose-embedded-button-text-color-hover);
         }
 
@@ -853,15 +845,11 @@ textarea.new_message_textarea,
     &:focus-visible {
         border: 1px solid var(--color-compose-send-button-focus-border);
         box-shadow: 0 0 5px var(--color-compose-send-button-focus-shadow);
-        background-color: var(
-            --color-compose-send-button-background-interactive
-        );
+        background-color: var(--color-compose-send-button-background-interactive);
     }
 
     &:hover {
-        background-color: var(
-            --color-compose-send-button-background-interactive
-        );
+        background-color: var(--color-compose-send-button-background-interactive);
     }
 }
 
@@ -883,7 +871,8 @@ textarea.new_message_textarea,
        background */
     z-index: 1;
 
-    @media (width < $sm_min), ((width >= $sm_min) and (width < $mc_min)) {
+    @media (width < $sm_min),
+    ((width >=$sm_min) and (width < $mc_min)) {
         /* Drop to a square button,
            and don't flex any wider. */
         width: 30px;
@@ -942,6 +931,7 @@ textarea.new_message_textarea,
 
 .drafts-item-in-popover {
     display: none;
+
     /* Only show the Drafts item in the popover when it's not visible
        in the compose box. */
     @media (width < $sm_min) {
@@ -1025,7 +1015,7 @@ textarea.new_message_textarea,
             in the main row below the compose box. So, this is the same as
             the media query for .show_popover_buttons. */
 
-            @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
+            @media (((width < $cb1_min) and (width >=$xl_min)) or ((width < $cb2_min) and (width >=$md_min)) or (width < $cb4_min)) {
                 display: flex;
             }
         }
@@ -1062,7 +1052,7 @@ textarea.new_message_textarea,
         single row. The media query below handles the hiding and showing of the
         buttons from the main row of compose buttons below the compose box. */
 
-        @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
+        @media (((width < $cb1_min) and (width >=$xl_min)) or ((width < $cb2_min) and (width >=$md_min)) or (width < $cb4_min)) {
             display: none;
         }
     }
@@ -1077,7 +1067,7 @@ textarea.new_message_textarea,
         compose buttons that we hide, and show in the popover only when the
         screen gets extremely narrow. */
 
-        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
+        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >=$md_min))) {
             display: none;
         }
     }
@@ -1088,7 +1078,7 @@ textarea.new_message_textarea,
         /* This is to show the popover 2 buttons in the popover, only when
         they are hidden in the main row below the compose box. */
 
-        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
+        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >=$md_min))) {
             display: flex;
         }
     }
@@ -1248,9 +1238,7 @@ textarea.new_message_textarea,
         /* We need to use !important here, regrettably, to keep the default
            dark-mode hover colors from showing. */
         color: var(--color-compose-send-control-button-interactive) !important;
-        background-color: var(
-            --color-compose-send-control-button-background-interactive
-        );
+        background-color: var(--color-compose-send-control-button-background-interactive);
         text-decoration: none;
     }
 }
@@ -1290,7 +1278,7 @@ textarea.new_message_textarea,
         border: 2px solid var(--color-outline-focus);
     }
 
-    @media ((width >= $sm_min) and (width < $mc_min)) {
+    @media ((width >=$sm_min) and (width < $mc_min)) {
         width: 32px;
     }
 


### PR DESCRIPTION
Fixes: #27837.
This PR  fixes the issue “Unsteady height of  compose  bar  buttons while scrolling down 
through  the  stream names  having    language  other than English  like  Korean or Chinese”.

<h3>Cause of this  Issue:</h3>
Compose  bar  of  Zulip is a html  button  which is an  inline-element .It  adjust its  height as per  the  height of  elements within  it. Html button  is assigned with a  text box  by  default to  hold the text of the button .Whenever the text having  more than default  size is inserted in to the button[Korean text etc..] it increases  the height of the inner text box  making the button to  adjust its height.

<h3>Quick  solution :</h3>
For this issue  setting  fixed height of  button can  be  a  quick  solution but  it  not generic solution and it  affects the  responsive design of the application.

<h3>Approach for the solution:</h3>
The best approach to solve this problem would be to make the  inner text box of the button in such a way that  whenever the  text is inserted  no matter whether its   font-size  is more or less than the default size   it  is  converted to 1em.

<h3>Solution:</h3>
CSS  line-height  property is  used to set the  distance between the lines  of default  text box  of the button.when its  value is set as  1   (line-height : 1;)  The line-height of the  text box becomes  1*font-size. This  makes  every  incoming text  to be converted  to given font size(1em).

![Screenshot (8)](https://github.com/zulip/zulip/assets/153224120/5c06628a-25e1-4a9c-805a-b5dfa9f9f3e5)


<h3>Before Changes:</h3>
![beforeissue1](https://github.com/zulip/zulip/assets/153224120/f9134d30-5343-4290-a85b-05a82a66af74)

<h3>After Changes:</h3>
![afterissue1](https://github.com/zulip/zulip/assets/153224120/bd9c7326-0f9f-49fa-920c-0ae7547f561f)




