### PR TITLE
Handle long url for `jitsi_server_url` setting.

### DIFF
--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -139,7 +139,7 @@
                                 {{t 'URL' }}
                             </label>
                             <input type="text" id="id_realm_jitsi_server_url_custom_input" autocomplete="off"
-                              name="realm_jitsi_server_url_custom_input" class="realm_jitsi_server_url_custom_input settings_url_input"/>
+                              name="realm_jitsi_server_url_custom_input" class="realm_jitsi_server_url_custom_input settings_url_input" maxlength="200" />
                         </div>
                     </div>
                 </div>

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -389,6 +389,22 @@ def check_url(var_name: str, val: object) -> str:
         raise ValidationError(_("{var_name} is not a URL").format(var_name=var_name))
 
 
+def check_capped_url(max_length: int) -> Validator[str]:
+    def validator(var_name: str, val: object) -> str:
+        # Ensure val is a string and length of the string does not
+        # exceed max_length.
+        s = check_capped_string(max_length)(var_name, val)
+        # Validate as URL.
+        validate = URLValidator()
+        try:
+            validate(s)
+            return s
+        except ValidationError:
+            raise ValidationError(_("{var_name} is not a URL").format(var_name=var_name))
+
+    return validator
+
+
 def check_external_account_url_pattern(var_name: str, val: object) -> str:
     s = check_string(var_name, val)
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1,6 +1,8 @@
 import json
 import os
+import random
 import re
+import string
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Union
 from unittest import mock
@@ -924,6 +926,12 @@ class RealmTest(ZulipTestCase):
         self.assert_json_error(result, "jitsi_server_url is not an allowed_type")
 
         req = dict(jitsi_server_url=orjson.dumps(12).decode())
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_error(result, "jitsi_server_url is not an allowed_type")
+
+        url_string = "".join(random.choices(string.ascii_lowercase, k=180))
+        long_url = "https://jitsi.example.com/" + url_string
+        req = dict(jitsi_server_url=orjson.dumps(long_url).decode())
         result = self.client_patch("/json/realm", req)
         self.assert_json_error(result, "jitsi_server_url is not an allowed_type")
 

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -32,13 +32,13 @@ from zerver.lib.user_groups import access_user_group_for_setting
 from zerver.lib.validator import (
     check_bool,
     check_capped_string,
+    check_capped_url,
     check_dict,
     check_int,
     check_int_in,
     check_string_in,
     check_string_or_int,
     check_union,
-    check_url,
     to_non_negative_int,
 )
 from zerver.models import Realm, RealmReactivationStatus, RealmUserDefault, UserProfile
@@ -52,6 +52,9 @@ def parse_jitsi_server_url(
         return special_values_map[value]
 
     return value
+
+
+JITSI_SERVER_URL_MAX_LENGTH = 200
 
 
 @require_realm_admin
@@ -147,7 +150,10 @@ def update_realm(
     jitsi_server_url_raw: Optional[str] = REQ(
         "jitsi_server_url",
         json_validator=check_union(
-            [check_string_in(list(Realm.JITSI_SERVER_SPECIAL_VALUES_MAP.keys())), check_url]
+            [
+                check_string_in(list(Realm.JITSI_SERVER_SPECIAL_VALUES_MAP.keys())),
+                check_capped_url(JITSI_SERVER_URL_MAX_LENGTH),
+            ]
         ),
         default=None,
     ),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to raise error at API level for long url.
- Second commit is to set max length in input UI.

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
