### PR TITLE
stream_settings: Fix going back in stream settings modal.

### DIFF
--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -4,11 +4,10 @@ import * as browser_history from "./browser_history";
 import * as components from "./components";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
-import * as sub_store from "./sub_store";
 import type {StreamSubscription} from "./sub_store";
 
 export let toggler: components.Toggle;
-export let select_tab = "personal";
+export const select_tab = "personal";
 
 export function setup_subscriptions_stream_hash(
     sub: StreamSubscription,
@@ -29,13 +28,6 @@ export function setup_toggler(): void {
         callback(_name, key) {
             $(".stream_section").hide();
             $(`[data-stream-section="${CSS.escape(key)}"]`).show();
-            select_tab = key;
-            const $stream_header = $("#streams_overlay_container .stream_settings_header");
-            const stream_id = Number.parseInt($stream_header.attr("data-stream-id") ?? "", 10);
-            const sub = sub_store.get(stream_id);
-            if (sub) {
-                setup_subscriptions_stream_hash(sub, select_tab);
-            }
         },
     });
 }


### PR DESCRIPTION
Previously, when we try to go back in the stream settings modal, we just cycled between different tabs of the top right corner.

This is because, we were trying to set the browser history hash two times, once through subscription_stream_hash, and second when we setup stream settings (in ```open_edit_panel_for_row``` method of ```stream_edit```), which invokes the setup_toggler, which sets the hash again in its callback. This causes the error.

This is fixed by removing the portion which sets the browser history hash once more in the setup_toggler callback of stream_edit.

<!-- Describe your pull request here.-->

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Alt.2Bleftarrow.20steals.20focus.3F.20.28streams.20settings.29)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![3fB5fHD4u2](https://github.com/zulip/zulip/assets/97049524/3b9c73ca-b4b4-409e-b9f8-fd1fc0f64216)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
