### PR TITLE
Use noop in test files.

### DIFF
--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -3,14 +3,14 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
 
 const $window_stub = $.create("window-stub");
 set_global("to_$", () => $window_stub);
-$(window).idle = () => {};
+$(window).idle = noop;
 
 const _document = {
     hasFocus() {
@@ -212,7 +212,7 @@ test("huddle_data.process_loaded_messages", () => {
 });
 
 test("presence_list_full_update", ({override, mock_template}) => {
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
     mock_template("presence_rows.hbs", false, (data) => {
         assert.equal(data.presence_rows.length, 7);
         assert.equal(data.presence_rows[0].user_id, me.user_id);
@@ -275,17 +275,17 @@ test("direct_message_update_dom_counts", () => {
 test("handlers", ({override, override_rewire, mock_template}) => {
     let filter_key_handlers;
 
-    mock_template("presence_rows.hbs", false, () => {});
+    mock_template("presence_rows.hbs", false, noop);
 
     override(keydown_util, "handle", (opts) => {
         filter_key_handlers = opts.handlers;
     });
-    override(scroll_util, "scroll_element_into_container", () => {});
-    override(padded_widget, "update_padding", () => {});
-    override(popovers, "hide_all", () => {});
-    override(sidebar_ui, "hide_all", () => {});
-    override(sidebar_ui, "show_userlist_sidebar", () => {});
-    override(resize, "resize_sidebars", () => {});
+    override(scroll_util, "scroll_element_into_container", noop);
+    override(padded_widget, "update_padding", noop);
+    override(popovers, "hide_all", noop);
+    override(sidebar_ui, "hide_all", noop);
+    override(sidebar_ui, "show_userlist_sidebar", noop);
+    override(resize, "resize_sidebars", noop);
 
     // This is kind of weak coverage; we are mostly making sure that
     // keys and clicks got mapped to functions that don't crash.
@@ -306,12 +306,12 @@ test("handlers", ({override, override_rewire, mock_template}) => {
             all_user_ids: [me.user_id, alice.user_id, fred.user_id],
         });
 
-        buddy_list.start_scroll_handler = () => {};
-        override_rewire(util, "call_function_periodically", () => {});
-        override_rewire(activity, "send_presence_to_server", () => {});
+        buddy_list.start_scroll_handler = noop;
+        override_rewire(util, "call_function_periodically", noop);
+        override_rewire(activity, "send_presence_to_server", noop);
         activity_ui.initialize({narrow_by_email});
 
-        $("#buddy-list-users-matching-view").empty = () => {};
+        $("#buddy-list-users-matching-view").empty = noop;
 
         $me_li = $.create("me stub");
         $alice_li = $.create("alice stub");
@@ -435,13 +435,13 @@ test("first/prev/next", ({override, mock_template}) => {
         }
     });
 
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
 
     assert.equal(buddy_list.first_key(), undefined);
     assert.equal(buddy_list.prev_key(alice.user_id), undefined);
     assert.equal(buddy_list.next_key(alice.user_id), undefined);
 
-    override(buddy_list.$container, "append", () => {});
+    override(buddy_list.$container, "append", noop);
 
     activity_ui.redraw_user(alice.user_id);
     activity_ui.redraw_user(fred.user_id);
@@ -503,7 +503,7 @@ test("insert_one_user_into_empty_list", ({override, mock_template}) => {
         return html;
     });
 
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
 
     let appended_html;
     override(buddy_list.$container, "append", (html) => {
@@ -522,7 +522,7 @@ test("insert_alice_then_fred", ({override, mock_template}) => {
     override(buddy_list.$container, "append", (html) => {
         appended_html = html;
     });
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
 
     activity_ui.redraw_user(alice.user_id);
     assert.ok(appended_html.indexOf('data-user-id="1"') > 0);
@@ -540,7 +540,7 @@ test("insert_fred_then_alice_then_rename", ({override, mock_template}) => {
     override(buddy_list.$container, "append", (html) => {
         appended_html = html;
     });
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
 
     activity_ui.redraw_user(fred.user_id);
     assert.ok(appended_html.indexOf('data-user-id="2"') > 0);
@@ -609,7 +609,7 @@ test("redraw_muted_user", () => {
 });
 
 test("update_presence_info", ({override}) => {
-    override(pm_list, "update_private_messages", () => {});
+    override(pm_list, "update_private_messages", noop);
 
     page_params.realm_presence_disabled = false;
     page_params.server_presence_ping_interval_seconds = 60;
@@ -661,10 +661,10 @@ test("update_presence_info", ({override}) => {
 });
 
 test("initialize", ({override, mock_template}) => {
-    mock_template("presence_rows.hbs", false, () => {});
-    override(padded_widget, "update_padding", () => {});
-    override(pm_list, "update_private_messages", () => {});
-    override(watchdog, "check_for_unsuspend", () => {});
+    mock_template("presence_rows.hbs", false, noop);
+    override(padded_widget, "update_padding", noop);
+    override(pm_list, "update_private_messages", noop);
+    override(watchdog, "check_for_unsuspend", noop);
 
     let payload;
     override(channel, "post", (arg) => {
@@ -678,7 +678,7 @@ test("initialize", ({override, mock_template}) => {
     function clear() {
         $.clear_all_elements();
         buddy_list.$container = $("#buddy-list-users-matching-view");
-        buddy_list.$container.append = () => {};
+        buddy_list.$container.append = noop;
         clear_buddy_list();
         page_params.presences = {};
     }
@@ -750,7 +750,7 @@ test("initialize", ({override, mock_template}) => {
 });
 
 test("electron_bridge", ({override_rewire}) => {
-    override_rewire(activity, "send_presence_to_server", () => {});
+    override_rewire(activity, "send_presence_to_server", noop);
 
     function with_bridge_idle(bridge_idle, f) {
         with_overrides(({override}) => {

--- a/web/tests/alert_words_ui.test.js
+++ b/web/tests/alert_words_ui.test.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {$t} = require("./lib/i18n");
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const channel = mock_esm("../src/channel");
@@ -15,7 +15,6 @@ const alert_words_ui = zrequire("alert_words_ui");
 alert_words.initialize({
     alert_words: ["foo", "bar"],
 });
-const noop = () => {};
 
 run_test("rerender_alert_words_ui", ({mock_template}) => {
     let list_widget_create_called = false;
@@ -45,7 +44,7 @@ run_test("rerender_alert_words_ui", ({mock_template}) => {
 });
 
 run_test("remove_alert_word", ({override_rewire}) => {
-    override_rewire(alert_words_ui, "rerender_alert_words_ui", () => {});
+    override_rewire(alert_words_ui, "rerender_alert_words_ui", noop);
     alert_words_ui.set_up_alert_words();
 
     const $word_list = $("#alert-words-table");
@@ -95,7 +94,7 @@ run_test("remove_alert_word", ({override_rewire}) => {
 });
 
 run_test("close_status_message", ({override_rewire}) => {
-    override_rewire(alert_words_ui, "rerender_alert_words_ui", () => {});
+    override_rewire(alert_words_ui, "rerender_alert_words_ui", noop);
     alert_words_ui.set_up_alert_words();
 
     const $alert_word_settings = $("#alert-word-settings");

--- a/web/tests/buddy_list.test.js
+++ b/web/tests/buddy_list.test.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
@@ -69,7 +69,7 @@ run_test("basics", ({override}) => {
     });
 
     override(message_viewport, "height", () => 550);
-    override(padded_widget, "update_padding", () => {});
+    override(padded_widget, "update_padding", noop);
 
     let appended;
     $("#buddy-list-users-matching-view").append = (html) => {

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -3,10 +3,8 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-
-const noop = () => {};
 
 mock_esm("tippy.js", {
     default(arg) {
@@ -224,7 +222,7 @@ run_test("adjust_mac_tooltip_keys mac random", ({override}) => {
 run_test("show password", () => {
     const password_selector = "#id_password ~ .password_visibility_toggle";
 
-    $(password_selector)[0] = () => {};
+    $(password_selector)[0] = noop;
 
     function set_attribute(type) {
         $("#id_password").attr("type", type);

--- a/web/tests/components.test.js
+++ b/web/tests/components.test.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {$t} = require("./lib/i18n");
 const {mock_jquery, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 
 let env;
@@ -165,8 +165,6 @@ mock_jquery((sel) => {
 });
 
 const components = zrequire("components");
-
-const noop = () => {};
 
 const LEFT_KEY = {key: "ArrowLeft", preventDefault: noop, stopPropagation: noop};
 const RIGHT_KEY = {key: "ArrowRight", preventDefault: noop, stopPropagation: noop};

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -8,13 +8,11 @@ const {mock_stream_header_colorblock} = require("./lib/compose");
 const {mock_banners} = require("./lib/compose_banner");
 const {$t} = require("./lib/i18n");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
 
 const settings_config = zrequire("settings_config");
-
-const noop = () => {};
 
 set_global("document", {
     querySelector() {},
@@ -29,8 +27,8 @@ set_global(
 
 const fake_now = 555;
 
-const autosize = () => {};
-autosize.update = () => {};
+const autosize = noop;
+autosize.update = noop;
 mock_esm("autosize", {default: autosize});
 
 const channel = mock_esm("../src/channel");
@@ -125,8 +123,8 @@ function test_ui(label, f) {
 function initialize_handlers({override}) {
     override(page_params, "realm_available_video_chat_providers", {disabled: {id: 0}});
     override(page_params, "realm_video_chat_provider", 0);
-    override(upload, "feature_check", () => {});
-    override(resize, "watch_manual_resize", () => {});
+    override(upload, "feature_check", noop);
+    override(resize, "watch_manual_resize", noop);
     compose_setup.initialize();
 }
 
@@ -237,8 +235,8 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         override(compose_pm_pill, "get_emails", () => "alice@example.com");
 
         const server_message_id = 127;
-        override(markdown, "apply_markdown", () => {});
-        override(markdown, "add_topic_links", () => {});
+        override(markdown, "apply_markdown", noop);
+        override(markdown, "add_topic_links", noop);
 
         override_rewire(echo, "try_deliver_locally", (message_request) => {
             const local_id_float = 123.04;
@@ -336,7 +334,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         $(".compose-submit-button .loader").show();
         $("textarea#compose-textarea").off("select");
         echo_error_msg_checked = false;
-        override_rewire(echo, "try_deliver_locally", () => {});
+        override_rewire(echo, "try_deliver_locally", noop);
 
         override(sent_messages, "get_new_local_id", () => "loc-55");
 
@@ -360,7 +358,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
     $("textarea#compose-textarea").toggleClass = noop;
     mock_stream_header_colorblock();
-    override_rewire(compose_banner, "clear_message_sent_banners", () => {});
+    override_rewire(compose_banner, "clear_message_sent_banners", noop);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;
     override(loading, "show_button_spinner", ($spinner) => {
@@ -411,7 +409,7 @@ test_ui("finish", ({override, override_rewire}) => {
     mock_banners();
     mock_stream_header_colorblock();
 
-    override_rewire(compose_banner, "clear_message_sent_banners", () => {});
+    override_rewire(compose_banner, "clear_message_sent_banners", noop);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;
     override(loading, "show_button_spinner", ($spinner) => {
@@ -500,7 +498,7 @@ test_ui("initialize", ({override}) => {
             uppy_cancel_all_called = true;
         },
     });
-    override(upload, "feature_check", () => {});
+    override(upload, "feature_check", noop);
 
     compose_setup.initialize();
 
@@ -607,7 +605,7 @@ test_ui("on_events", ({override, override_rewire}) => {
 
     initialize_handlers({override});
 
-    override(rendered_markdown, "update_elements", () => {});
+    override(rendered_markdown, "update_elements", noop);
 
     (function test_attach_files_compose_clicked() {
         const handler = $("#compose").get_on_handler("click", ".compose_upload_file");

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -5,20 +5,18 @@ const {strict: assert} = require("assert");
 const {mock_stream_header_colorblock} = require("./lib/compose");
 const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
 const settings_config = zrequire("settings_config");
 
-const noop = () => {};
-
 set_global("document", {
     to_$: () => $("document-stub"),
 });
 
-const autosize = () => {};
-autosize.update = () => {};
+const autosize = noop;
+autosize.update = noop;
 mock_esm("autosize", {default: autosize});
 
 const channel = mock_esm("../src/channel");
@@ -98,8 +96,8 @@ function override_private_message_recipient({override}) {
 function test(label, f) {
     run_test(label, (helpers) => {
         // We don't test the css calls; we just skip over them.
-        $("#compose").css = () => {};
-        $(".new_message_textarea").css = () => {};
+        $("#compose").css = noop;
+        $(".new_message_textarea").css = noop;
 
         people.init();
         compose_state.set_message_type(false);
@@ -116,14 +114,14 @@ test("initial_state", () => {
 test("start", ({override, override_rewire, mock_template}) => {
     mock_banners();
     override_private_message_recipient({override});
-    override_rewire(compose_actions, "autosize_message_content", () => {});
-    override_rewire(compose_actions, "expand_compose_box", () => {});
-    override_rewire(compose_actions, "complete_starting_tasks", () => {});
-    override_rewire(compose_actions, "blur_compose_inputs", () => {});
-    override_rewire(compose_actions, "clear_textarea", () => {});
-    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
-    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", () => {});
-    mock_template("inline_decorated_stream_name.hbs", false, () => {});
+    override_rewire(compose_actions, "autosize_message_content", noop);
+    override_rewire(compose_actions, "expand_compose_box", noop);
+    override_rewire(compose_actions, "complete_starting_tasks", noop);
+    override_rewire(compose_actions, "blur_compose_inputs", noop);
+    override_rewire(compose_actions, "clear_textarea", noop);
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
+    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    mock_template("inline_decorated_stream_name.hbs", false, noop);
     mock_stream_header_colorblock();
 
     let compose_defaults;
@@ -244,12 +242,12 @@ test("start", ({override, override_rewire, mock_template}) => {
 
 test("respond_to_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
-    override_rewire(compose_actions, "complete_starting_tasks", () => {});
-    override_rewire(compose_actions, "clear_textarea", () => {});
+    override_rewire(compose_actions, "complete_starting_tasks", noop);
+    override_rewire(compose_actions, "clear_textarea", noop);
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     override_private_message_recipient({override});
-    mock_template("inline_decorated_stream_name.hbs", false, () => {});
+    mock_template("inline_decorated_stream_name.hbs", false, noop);
     mock_stream_header_colorblock();
 
     // Test direct message
@@ -300,12 +298,12 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     mock_banners();
     mock_stream_header_colorblock();
     compose_state.set_message_type("stream");
-    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
-    override_rewire(compose_actions, "complete_starting_tasks", () => {});
-    override_rewire(compose_actions, "clear_textarea", () => {});
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
+    override_rewire(compose_actions, "complete_starting_tasks", noop);
+    override_rewire(compose_actions, "clear_textarea", noop);
     override_private_message_recipient({override});
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
-    mock_template("inline_decorated_stream_name.hbs", false, () => {});
+    mock_template("inline_decorated_stream_name.hbs", false, noop);
 
     const denmark = {
         subscribed: true,
@@ -368,8 +366,8 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     };
     people.add_active_user(steve);
 
-    override_rewire(compose_actions, "complete_starting_tasks", () => {});
-    override_rewire(compose_actions, "clear_textarea", () => {});
+    override_rewire(compose_actions, "complete_starting_tasks", noop);
+    override_rewire(compose_actions, "clear_textarea", noop);
     override_private_message_recipient({override});
 
     let selected_message;

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -4,10 +4,9 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
-const noop = () => {};
 // Mocking and stubbing things
 set_global("document", "document-stub");
 const message_lists = mock_esm("../src/message_lists");

--- a/web/tests/compose_state.test.js
+++ b/web/tests/compose_state.test.js
@@ -4,15 +4,13 @@ const {strict: assert} = require("assert");
 
 const {mock_stream_header_colorblock} = require("./lib/compose");
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 
 const compose_state = zrequire("compose_state");
 const stream_data = zrequire("stream_data");
-
-const noop = () => {};
 
 run_test("private_message_recipient", ({override}) => {
     let emails;

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -4,16 +4,14 @@ const {strict: assert} = require("assert");
 
 const {$t} = require("./lib/i18n");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
-const noop = () => {};
-
 set_global("navigator", {});
 
-const autosize = () => {};
-autosize.update = () => {};
+const autosize = noop;
+autosize.update = noop;
 mock_esm("autosize", {default: autosize});
 
 mock_esm("../src/message_lists", {

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {mock_banners} = require("./lib/compose_banner");
 const {$t} = require("./lib/i18n");
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
@@ -164,13 +164,13 @@ test_ui("validate", ({mock_template}) => {
         $("#private_message_recipient")[0] = {};
         $("#private_message_recipient").set_parent($pm_pill_container);
         $pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
-        $("#private_message_recipient").before = () => {};
+        $("#private_message_recipient").before = noop;
 
         compose_pm_pill.initialize({
             on_pill_create_or_remove: compose_recipient.update_placeholder_text,
         });
 
-        $("#zephyr-mirror-error").is = () => {};
+        $("#zephyr-mirror-error").is = noop;
 
         mock_template("input_pill.hbs", false, () => "<div>pill-html</div>");
 

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const events = require("./lib/events");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
@@ -70,7 +70,7 @@ function test(label, f) {
 test("videos", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
 
-    override(upload, "feature_check", () => {});
+    override(upload, "feature_check", noop);
 
     stub_out_video_calls();
 
@@ -247,7 +247,7 @@ test("videos", ({override}) => {
 });
 
 test("test_video_chat_button_toggle disabled", ({override}) => {
-    override(upload, "feature_check", () => {});
+    override(upload, "feature_check", noop);
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose_setup.initialize();
@@ -255,7 +255,7 @@ test("test_video_chat_button_toggle disabled", ({override}) => {
 });
 
 test("test_video_chat_button_toggle no url", ({override}) => {
-    override(upload, "feature_check", () => {});
+    override(upload, "feature_check", noop);
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
@@ -264,7 +264,7 @@ test("test_video_chat_button_toggle no url", ({override}) => {
 });
 
 test("test_video_chat_button_toggle enabled", ({override}) => {
-    override(upload, "feature_check", () => {});
+    override(upload, "feature_check", noop);
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.realm_jitsi_server_url = "https://meet.jit.si";

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -5,11 +5,9 @@ const {strict: assert} = require("assert");
 const {mock_stream_header_colorblock} = require("./lib/compose");
 const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 let autosize_called;
 
@@ -487,7 +485,7 @@ test("content_typeahead_selected", ({override}) => {
     // mention
     fake_this.completing = "mention";
 
-    override(compose_validate, "warn_if_mentioning_unsubscribed_user", () => {});
+    override(compose_validate, "warn_if_mentioning_unsubscribed_user", noop);
     override(
         compose_validate,
         "convert_mentions_to_silent_in_direct_messages",
@@ -755,7 +753,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         assert.equal(typeof data.has_image, "boolean");
         return html;
     });
-    override(stream_topic_history_util, "get_server_history", () => {});
+    override(stream_topic_history_util, "get_server_history", noop);
 
     let topic_typeahead_called = false;
     $("input#stream_message_recipient_topic").typeahead = (options) => {
@@ -1307,7 +1305,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
         assert.equal(stream_id, sweden_stream.stream_id);
         return sweden_topics_to_show;
     });
-    override(stream_topic_history_util, "get_server_history", () => {});
+    override(stream_topic_history_util, "get_server_history", noop);
 
     const begin_typehead_this = {
         options: {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -5,12 +5,10 @@ const {strict: assert} = require("assert");
 const events = require("./lib/events");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params, realm_user_settings_defaults, user_settings} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 const event_fixtures = events.fixtures;
 const test_message = events.test_message;
@@ -593,7 +591,7 @@ run_test("realm_bot add", ({override}) => {
     const event = event_fixtures.realm_bot__add;
     const bot_stub = make_stub();
     override(bot_data, "add", bot_stub.f);
-    override(settings_bots, "render_bots", () => {});
+    override(settings_bots, "render_bots", noop);
     dispatch(event);
 
     assert.equal(bot_stub.num_calls, 1);
@@ -605,7 +603,7 @@ run_test("realm_bot delete", ({override}) => {
     const event = event_fixtures.realm_bot__delete;
     const bot_stub = make_stub();
     override(bot_data, "del", bot_stub.f);
-    override(settings_bots, "render_bots", () => {});
+    override(settings_bots, "render_bots", noop);
 
     dispatch(event);
     assert.equal(bot_stub.num_calls, 1);
@@ -617,7 +615,7 @@ run_test("realm_bot update", ({override}) => {
     const event = event_fixtures.realm_bot__update;
     const bot_stub = make_stub();
     override(bot_data, "update", bot_stub.f);
-    override(settings_bots, "render_bots", () => {});
+    override(settings_bots, "render_bots", noop);
 
     dispatch(event);
 
@@ -834,7 +832,7 @@ run_test("stream_typing", ({override}) => {
 });
 
 run_test("user_settings", ({override}) => {
-    settings_display.set_default_language_name = () => {};
+    settings_display.set_default_language_name = noop;
     let event = event_fixtures.user_settings__default_language;
     user_settings.default_language = "en";
     override(settings_display, "update_page", noop);

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const events = require("./lib/events");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const {page_params} = require("./lib/zpage_params");
 
@@ -29,8 +29,6 @@ const people = zrequire("people");
 const server_events_dispatch = zrequire("server_events_dispatch");
 const stream_data = zrequire("stream_data");
 const sub_store = zrequire("sub_store");
-
-const noop = () => {};
 
 people.add_active_user(test_user);
 
@@ -137,7 +135,7 @@ test("add error handling", () => {
 });
 
 test("peer event error handling (bad stream_ids/user_ids)", ({override}) => {
-    override(stream_events, "process_subscriber_update", () => {});
+    override(stream_events, "process_subscriber_update", noop);
 
     const add_event = {
         type: "subscription",
@@ -260,7 +258,7 @@ test("stream delete (special streams)", ({override}) => {
 });
 
 test("stream delete (stream is selected in compose)", ({override, override_rewire}) => {
-    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
 
     const event = event_fixtures.stream__delete;
 

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {mock_stream_header_colorblock} = require("./lib/compose");
 const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire, with_overrides} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {user_settings} = require("./lib/zpage_params");
 
@@ -24,8 +24,6 @@ const aaron = {
     full_name: "Aaron",
 };
 people.add_active_user(aaron);
-
-const noop = () => {};
 
 const setTimeout_delay = 3000;
 set_global("setTimeout", (f, delay) => {
@@ -88,7 +86,7 @@ const short_msg = {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        $("#draft_overlay").css = () => {};
+        $("#draft_overlay").css = noop;
         window.localStorage.clear();
         f(helpers);
     });
@@ -609,7 +607,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     $.clear_all_elements();
     $.create("#drafts_table .overlay-message-row", {children: []});
-    $("#draft_overlay").css = () => {};
+    $("#draft_overlay").css = noop;
 
     override_rewire(sub_store, "get", (stream_id) => {
         assert.ok([30, 40].includes(stream_id));

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -6,7 +6,7 @@ const MockDate = require("mockdate");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const {page_params} = require("./lib/zpage_params");
 
 const compose_notifications = mock_esm("../src/compose_notifications");
@@ -34,7 +34,6 @@ const message_store = mock_esm("../src/message_store", {
     set_message_booleans() {},
 });
 
-const noop = () => {};
 message_lists.current = {
     view: {
         rerender_messages: noop,
@@ -307,8 +306,8 @@ run_test("insert_local_message direct message", ({override}) => {
 run_test("test reify_message_id", ({override}) => {
     const local_id_float = 103.01;
 
-    override(markdown, "apply_markdown", () => {});
-    override(markdown, "add_topic_links", () => {});
+    override(markdown, "apply_markdown", noop);
+    override(markdown, "add_topic_links", noop);
 
     const message_request = {
         type: "stream",
@@ -318,7 +317,7 @@ run_test("test reify_message_id", ({override}) => {
         sender_id: 123,
         draft_id: 100,
     };
-    echo.insert_local_message(message_request, local_id_float, () => {});
+    echo.insert_local_message(message_request, local_id_float, noop);
 
     let message_store_reify_called = false;
     let notifications_reify_called = false;

--- a/web/tests/example4.test.js
+++ b/web/tests/example4.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 
 /*
 
@@ -84,7 +84,7 @@ run_test("add users with event", ({override}) => {
 
     // We need to override a stub here before dispatching the event.
     // Keep reading to see how overriding works!
-    override(settings_users, "redraw_bots_list", () => {});
+    override(settings_users, "redraw_bots_list", noop);
     // Let's simulate dispatching our event!
     server_events_dispatch.dispatch_normal_event(event);
 
@@ -132,11 +132,11 @@ run_test("update user with event", ({override}) => {
     // verify that they run. Fortunately, the run_test()
     // wrapper will tell us if we override a method that
     // doesn't get called!
-    override(activity_ui, "redraw", () => {});
-    override(message_live_update, "update_user_full_name", () => {});
-    override(pm_list, "update_private_messages", () => {});
-    override(settings_users, "update_user_data", () => {});
-    override(settings_users, "update_bot_data", () => {});
+    override(activity_ui, "redraw", noop);
+    override(message_live_update, "update_user_full_name", noop);
+    override(pm_list, "update_private_messages", noop);
+    override(settings_users, "update_user_data", noop);
+    override(settings_users, "update_bot_data", noop);
 
     // Dispatch the realm_user/update event, which will update
     // data structures and have other side effects that are

--- a/web/tests/example5.test.js
+++ b/web/tests/example5.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 
 /*
    Our test from an earlier example verifies that the update events
@@ -85,7 +85,7 @@ function test_helper({override}) {
 run_test("insert_message", ({override}) => {
     message_store.clear_for_testing();
 
-    override(pm_list, "update_private_messages", () => {});
+    override(pm_list, "update_private_messages", noop);
 
     const helper = test_helper({override});
 

--- a/web/tests/example6.test.js
+++ b/web/tests/example6.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 
 /*
     The previous example was a bit extreme.  Generally we just
@@ -43,8 +43,8 @@ run_test("explore make_stub", ({override}) => {
     // effects get in the way.  We have to override them to do
     // the simple test here.
 
-    override(app, "notify_server_of_deposit", () => {});
-    override(app, "pop_up_fancy_confirmation_screen", () => {});
+    override(app, "notify_server_of_deposit", noop);
+    override(app, "pop_up_fancy_confirmation_screen", noop);
     deposit_paycheck(10);
     assert.equal(balance, 50);
 

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 /*
@@ -106,11 +106,11 @@ run_test("unread_ops", ({override}) => {
     override(message_lists.current, "all_messages", () => test_messages);
 
     // Ignore these interactions for now:
-    override(message_lists.current.view, "show_message_as_read", () => {});
-    override(message_lists.home.view, "show_message_as_read", () => {});
-    override(desktop_notifications, "close_notification", () => {});
-    override(unread_ui, "update_unread_counts", () => {});
-    override(unread_ui, "notify_messages_remain_unread", () => {});
+    override(message_lists.current.view, "show_message_as_read", noop);
+    override(message_lists.home.view, "show_message_as_read", noop);
+    override(desktop_notifications, "close_notification", noop);
+    override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "notify_messages_remain_unread", noop);
 
     // Set up a way to capture the options passed in to channel.post.
     let channel_post_opts;

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
@@ -11,7 +11,6 @@ set_global("document", {});
 class ClipboardEvent {}
 set_global("ClipboardEvent", ClipboardEvent);
 
-const noop = () => {};
 const example_img_link = "http://example.com/example.png";
 
 mock_esm("../src/ui_util", {
@@ -114,7 +113,7 @@ function set_up() {
     const $pill_input = $.create("pill_input");
 
     $pill_input[0] = {};
-    $pill_input.before = () => {};
+    $pill_input.before = noop;
 
     const create_item_from_text = (text) => items[text];
 
@@ -503,7 +502,7 @@ run_test("exit button on pill", ({mock_template}) => {
 
     const pills = widget._get_pills_for_testing();
     for (const pill of pills) {
-        pill.$element.remove = () => {};
+        pill.$element.remove = noop;
     }
 
     let next_pill_focused = false;
@@ -613,7 +612,7 @@ run_test("appendValue/clear", ({mock_template}) => {
         get_text_from_item: /* istanbul ignore next */ (s) => s.display_value,
     };
 
-    $pill_input.before = () => {};
+    $pill_input.before = noop;
     $pill_input[0] = {};
 
     const widget = input_pill.create(config);

--- a/web/tests/lib/compose.js
+++ b/web/tests/lib/compose.js
@@ -1,11 +1,12 @@
 "use strict";
 
+const {noop} = require("./test");
 const $ = require("./zjquery");
 
 exports.mock_stream_header_colorblock = () => {
     const $stream_selection_dropdown = $("#compose_select_recipient_widget_wrapper");
     const $stream_header_colorblock = $(".stream_header_colorblock");
-    $("#compose_select_recipient_widget_wrapper .stream_header_colorblock").css = () => {};
+    $("#compose_select_recipient_widget_wrapper .stream_header_colorblock").css = noop;
     $stream_selection_dropdown.set_find_results(
         ".stream_header_colorblock",
         $stream_header_colorblock,

--- a/web/tests/lib/compose_banner.js
+++ b/web/tests/lib/compose_banner.js
@@ -2,6 +2,7 @@
 
 const compose_banner = require("../../src/compose_banner");
 
+const {noop} = require("./test");
 const $ = require("./zjquery");
 
 exports.mock_banners = () => {
@@ -13,16 +14,16 @@ exports.mock_banners = () => {
                 .split(" ")
                 .map((classname) => CSS.escape(classname))
                 .join(".")}`,
-        ).remove = () => {};
+        ).remove = noop;
     }
-    $("#compose_banners .warning").remove = () => {};
-    $("#compose_banners .error").remove = () => {};
-    $("#compose_banners .upload_banner").remove = () => {};
+    $("#compose_banners .warning").remove = noop;
+    $("#compose_banners .error").remove = noop;
+    $("#compose_banners .upload_banner").remove = noop;
 
     const $stub = $.create("stub_to_remove");
     const $cb = $("#compose_banners");
 
-    $stub.remove = () => {};
+    $stub.remove = noop;
     $stub.length = 0;
 
     $cb.closest = () => [];

--- a/web/tests/lib/test.js
+++ b/web/tests/lib/test.js
@@ -17,6 +17,8 @@ exports.set_verbose = (value) => {
     verbose = value;
 };
 
+exports.noop = () => {};
+
 exports.suite = [];
 
 async function execute_test(label, f, opts) {

--- a/web/tests/lib/zjquery.js
+++ b/web/tests/lib/zjquery.js
@@ -194,7 +194,7 @@ function make_zjquery() {
                 over that aspect of the module for the purpose
                 of testing, see if you can wrap the code
                 that extends $.fn and use override() to
-                replace the wrapper with () => {}.
+                replace the wrapper with tests.lib.noop.
             `);
         },
     });

--- a/web/tests/list_cursor.test.js
+++ b/web/tests/list_cursor.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
@@ -71,7 +71,7 @@ run_test("single item list", ({override}) => {
     };
 
     override(conf.list, "find_li", () => $li_stub);
-    override(cursor, "adjust_scroll", () => {});
+    override(cursor, "adjust_scroll", noop);
 
     cursor.go_to(valid_key);
 
@@ -91,7 +91,7 @@ run_test("multiple item list", ({override}) => {
         prev_key: (key) => (key > 1 ? key - 1 : undefined),
     });
     const cursor = new ListCursor(conf);
-    override(cursor, "adjust_scroll", () => {});
+    override(cursor, "adjust_scroll", noop);
 
     function li(key) {
         return $.create(`item-${key}`, {children: ["stub"]});

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, mock_jquery, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
@@ -45,8 +45,8 @@ const ListWidget = zrequire("list_widget");
 
 function make_container() {
     const $container = {};
-    $container.empty = () => {};
-    $container.data = () => {};
+    $container.empty = noop;
+    $container.data = noop;
 
     // Make our append function just set a field we can
     // check in our tests.

--- a/web/tests/message_fetch.test.js
+++ b/web/tests/message_fetch.test.js
@@ -5,13 +5,11 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
 set_global("document", "document-stub");
-
-const noop = () => {};
 
 function MessageListView() {
     return {
@@ -365,7 +363,7 @@ run_test("loading_newer", () => {
         });
 
         msg_list = simulate_narrow();
-        msg_list.append_to_view = () => {};
+        msg_list.append_to_view = noop;
         // Instead of using 444 as page_param.pointer, we
         // should have a message with that id in the message_list.
         msg_list.append(message_range(444, 445), false);

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -5,12 +5,10 @@ const {strict: assert} = require("assert");
 const _ = require("lodash");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 set_global("document", "document-stub");
-
-const noop = () => {};
 
 // timerender calls setInterval when imported
 mock_esm("../src/timerender", {
@@ -445,8 +443,8 @@ test("merge_message_groups", () => {
 
         const view = new MessageListView(list, table_name, true);
         view._message_groups = message_groups;
-        view.list.unsubscribed_bookend_content = () => {};
-        view.list.subscribed_bookend_content = () => {};
+        view.list.unsubscribed_bookend_content = noop;
+        view.list.subscribed_bookend_content = noop;
         return view;
     }
 

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -3,11 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const {page_params} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 mock_esm("../src/stream_topic_history", {
     add_message: noop,

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 mock_esm("../src/resize", {
@@ -98,7 +98,7 @@ function test_helper({override}) {
     stub(compose_closed_ui, "update_buttons_for_stream_views");
     stub(compose_closed_ui, "update_buttons_for_private");
     // We don't test the css calls; we just skip over them.
-    $("#mark_read_on_scroll_state_banner").toggleClass = () => {};
+    $("#mark_read_on_scroll_state_banner").toggleClass = noop;
 
     return {
         assert_events(expected_events) {

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -4,7 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
@@ -309,8 +309,8 @@ test("sending", ({override, override_rewire}) => {
 
     let emoji_name = "smile"; // should be a current reaction
 
-    override_rewire(reactions, "add_reaction", () => {});
-    override_rewire(reactions, "remove_reaction", () => {});
+    override_rewire(reactions, "add_reaction", noop);
+    override_rewire(reactions, "remove_reaction", noop);
 
     {
         const stub = make_stub();
@@ -397,7 +397,7 @@ test("prevent_simultaneous_requests_updating_reaction", ({override, override_rew
         assert.equal(message_id, message.id);
         return message;
     });
-    override_rewire(reactions, "add_reaction", () => {});
+    override_rewire(reactions, "add_reaction", noop);
     const stub = make_stub();
     channel.post = stub.f;
 
@@ -485,8 +485,8 @@ test("update_vote_text_on_message", ({override_rewire}) => {
 
     user_settings.display_emoji_reaction_users = true;
 
-    override_rewire(reactions, "find_reaction", () => {});
-    override_rewire(reactions, "set_reaction_vote_text", () => {});
+    override_rewire(reactions, "find_reaction", noop);
+    override_rewire(reactions, "set_reaction_vote_text", noop);
 
     reactions.update_vote_text_on_message(message);
 
@@ -1168,7 +1168,7 @@ test("view.remove_reaction (last person)", () => {
 });
 
 test("error_handling", ({override, override_rewire}) => {
-    override(message_store, "get", () => {});
+    override(message_store, "get", noop);
 
     blueslip.expect("error", "reactions: Bad message id");
 
@@ -1208,7 +1208,7 @@ test("remove last user", ({override}) => {
     const message = {...sample_message};
 
     override(message_store, "get", () => message);
-    override(reactions.view, "remove_reaction", () => {});
+    override(reactions.view, "remove_reaction", noop);
 
     function assert_names(names) {
         assert.deepEqual(
@@ -1241,7 +1241,7 @@ test("local_reaction_id", () => {
 });
 
 test("process_reaction_click", ({override}) => {
-    override(reactions.view, "remove_reaction", () => {});
+    override(reactions.view, "remove_reaction", noop);
 
     const message = {...sample_message};
     override(message_store, "get", () => message);

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -3,11 +3,10 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
-const noop = () => {};
 const test_url = () => "https://www.example.com";
 
 // We assign this in our test() wrapper.
@@ -435,7 +434,7 @@ function stub_out_filter_buttons() {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        $(".header").css = () => {};
+        $(".header").css = noop;
         page_params.development_environment = true;
 
         messages = sample_messages.map((message) => ({...message}));
@@ -462,11 +461,11 @@ test("test_recent_view_show", ({mock_template}) => {
         return "<recent_view table stub>";
     });
 
-    mock_template("recent_view_row.hbs", false, () => {});
+    mock_template("recent_view_row.hbs", false, noop);
 
     stub_out_filter_buttons();
     // We don't test the css calls; we just skip over them.
-    $("#mark_read_on_scroll_state_banner").toggleClass = () => {};
+    $("#mark_read_on_scroll_state_banner").toggleClass = noop;
 
     rt.clear_for_tests();
     rt.process_messages(messages);
@@ -817,7 +816,7 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     override_rewire(rt, "inplace_rerender", noop);
     rt.clear_for_tests();
 
-    mock_template("recent_view_table.hbs", false, () => {});
+    mock_template("recent_view_table.hbs", false, noop);
     mock_template("recent_view_row.hbs", true, (_data, html) => {
         assert.ok(html.startsWith('<tr id="recent_conversation'));
     });
@@ -946,8 +945,8 @@ test("basic assertions", ({mock_template, override_rewire}) => {
 });
 
 test("test_reify_local_echo_message", ({mock_template}) => {
-    mock_template("recent_view_table.hbs", false, () => {});
-    mock_template("recent_view_row.hbs", false, () => {});
+    mock_template("recent_view_table.hbs", false, noop);
+    mock_template("recent_view_row.hbs", false, noop);
 
     rt.clear_for_tests();
     stub_out_filter_buttons();

--- a/web/tests/reload.test.js
+++ b/web/tests/reload.test.js
@@ -3,10 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
+const {run_test, noop} = require("./lib/test");
+
 // override file-level function call in reload.js
-window.addEventListener = () => {};
+window.addEventListener = noop;
 const reload = zrequire("reload");
-const {run_test} = require("./lib/test");
 
 run_test("old_metadata_string_is_stale", () => {
     assert.ok(reload.is_stale_refresh_token("1663886962834", "1663883954033"), true);

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_cjs, mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
@@ -586,7 +586,7 @@ run_test("code playground none", ({override, mock_template}) => {
         return undefined;
     });
 
-    override(copied_tooltip, "show_copied_confirmation", () => {});
+    override(copied_tooltip, "show_copied_confirmation", noop);
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, false);
     assert.deepEqual(prepends, [$copy_code]);
@@ -602,7 +602,7 @@ run_test("code playground single", ({override, mock_template}) => {
         return [{name: "Some Javascript Playground"}];
     });
 
-    override(copied_tooltip, "show_copied_confirmation", () => {});
+    override(copied_tooltip, "show_copied_confirmation", noop);
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);
@@ -622,7 +622,7 @@ run_test("code playground multiple", ({override, mock_template}) => {
         return ["whatever", "whatever"];
     });
 
-    override(copied_tooltip, "show_copied_confirmation", () => {});
+    override(copied_tooltip, "show_copied_confirmation", noop);
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const narrow_state = mock_esm("../src/narrow_state");
@@ -294,7 +294,7 @@ run_test("initialize", ({override_rewire, mock_template}) => {
 
     assert.ok(!is_blurred);
 
-    override_rewire(search, "exit_search", () => {});
+    override_rewire(search, "exit_search", noop);
     ev.key = "Enter";
     $search_query_box.is = () => true;
     $searchbox_form.trigger(ev);

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const {page_params} = require("./lib/zpage_params");
 
 const narrow_state = mock_esm("../src/narrow_state");
@@ -459,7 +459,7 @@ test("has_suggestions", ({override, mock_template}) => {
     let query = "h";
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
-    override(narrow_state, "stream_name", () => {});
+    override(narrow_state, "stream_name", noop);
 
     let suggestions = get_suggestions(query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
@@ -518,7 +518,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
-    override(narrow_state, "stream_name", () => {});
+    override(narrow_state, "stream_name", noop);
 
     let query = "i";
     let suggestions = get_suggestions(query);
@@ -599,7 +599,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 test("sent_by_me_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    override(narrow_state, "stream_name", () => {});
+    override(narrow_state, "stream_name", noop);
 
     let query = "";
     let suggestions = get_suggestions(query);
@@ -675,7 +675,7 @@ test("topic_suggestions", ({override, mock_template}) => {
     let suggestions;
     let expected;
 
-    override(stream_topic_history_util, "get_server_history", () => {});
+    override(stream_topic_history_util, "get_server_history", noop);
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     override(narrow_state, "stream_name", () => "office");
 
@@ -800,7 +800,7 @@ test("whitespace_glitch", ({override, mock_template}) => {
 
     const query = "stream:office "; // note trailing space
 
-    override(stream_topic_history_util, "get_server_history", () => {});
+    override(stream_topic_history_util, "get_server_history", noop);
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
     const suggestions = get_suggestions(query);
@@ -816,7 +816,7 @@ test("stream_completion", ({override, mock_template}) => {
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
-    override(narrow_state, "stream_name", () => {});
+    override(narrow_state, "stream_name", noop);
 
     let query = "stream:of";
     let suggestions = get_suggestions(query);
@@ -839,7 +839,7 @@ test("people_suggestions", ({override, mock_template}) => {
 
     let query = "te";
 
-    override(narrow_state, "stream_name", () => {});
+    override(narrow_state, "stream_name", noop);
 
     const ted = {
         email: "ted@zulip.com",

--- a/web/tests/server_events.test.js
+++ b/web/tests/server_events.test.js
@@ -3,11 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const {page_params} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 set_global("addEventListener", noop);
 

--- a/web/tests/settings_muted_users.test.js
+++ b/web/tests/settings_muted_users.test.js
@@ -3,10 +3,8 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-
-const noop = () => {};
 
 const channel = mock_esm("../src/channel");
 const list_widget = mock_esm("../src/list_widget", {

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -4,12 +4,10 @@ const {strict: assert} = require("assert");
 
 const {$t} = require("./lib/i18n");
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 const realm_icon = mock_esm("../src/realm_icon");
 
@@ -30,7 +28,7 @@ const dropdown_widget = zrequire("dropdown_widget");
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        $("#realm-icon-upload-widget .upload-spinner-background").css = () => {};
+        $("#realm-icon-upload-widget .upload-spinner-background").css = noop;
         page_params.is_admin = false;
         page_params.realm_domains = [
             {domain: "example.com", allow_subdomains: true},

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
@@ -63,15 +63,15 @@ function test_populate(opts, template_data) {
 
     $table[0] = "stub";
 
-    $rows.remove = () => {};
-    $form.remove = () => {};
+    $rows.remove = noop;
+    $form.remove = noop;
 
     let num_appends = 0;
     $table.append = () => {
         num_appends += 1;
     };
 
-    loading.destroy_indicator = () => {};
+    loading.destroy_indicator = noop;
 
     settings_profile_fields.do_populate_profile_fields(fields_data);
 
@@ -83,7 +83,7 @@ run_test("populate_profile_fields", ({mock_template}) => {
     page_params.custom_profile_fields = {};
     page_params.realm_default_external_accounts = JSON.stringify({});
 
-    $("#admin_profile_fields_table .display_in_profile_summary_false").toggleClass = () => {};
+    $("#admin_profile_fields_table .display_in_profile_summary_false").toggleClass = noop;
 
     const template_data = [];
     mock_template("settings/admin_profile_field_list.hbs", false, (data) => {

--- a/web/tests/settings_realm_domains.test.js
+++ b/web/tests/settings_realm_domains.test.js
@@ -3,11 +3,10 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const channel = mock_esm("../src/channel");
-const noop = () => {};
 mock_esm("../src/ui_report", {
     success(msg, elem) {
         elem.val(msg);

--- a/web/tests/settings_user_topics.test.js
+++ b/web/tests/settings_user_topics.test.js
@@ -3,10 +3,8 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-
-const noop = () => {};
 
 const list_widget = mock_esm("../src/list_widget", {
     generic_sort_functions: noop,

--- a/web/tests/spoilers.test.js
+++ b/web/tests/spoilers.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const spoilers = zrequire("spoilers");
@@ -22,7 +22,7 @@ const get_spoiler_elem = (title) => {
     const $block = $.create(`block-${title}`);
     const $header = $.create(`header-${title}`);
     const $content = $.create(`content-${title}`);
-    $content.remove = () => {};
+    $content.remove = noop;
     $header.text(title);
     $block.set_find_results(".spoiler-header", $header);
     $block.set_find_results(".spoiler-content", $content);

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -4,11 +4,9 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-
-const noop = () => {};
 
 const color_data = mock_esm("../src/color_data");
 const compose_fade = mock_esm("../src/compose_fade");

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
 
@@ -15,7 +15,6 @@ page_params.realm_users = [];
 // We use this with override.
 let num_unread_for_stream;
 let stream_has_any_unread_mentions;
-const noop = () => {};
 
 mock_esm("../src/narrow_state", {
     active: () => false,

--- a/web/tests/stream_search.test.js
+++ b/web/tests/stream_search.test.js
@@ -3,13 +3,11 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.
-
-const noop = () => {};
 
 mock_esm("../src/resize", {
     resize_page_components: noop,

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 
 const channel = mock_esm("../src/channel");
 const message_util = mock_esm("../src/message_util");
@@ -320,11 +320,11 @@ test("server_history_end_to_end", () => {
         get_error_callback = opts.error;
     };
 
-    stream_topic_history_util.get_server_history(stream_id, () => {});
+    stream_topic_history_util.get_server_history(stream_id, noop);
 
     // Another call. Early return because a request is already in progress
     // for stream_id = 99. This function call adds coverage.
-    stream_topic_history_util.get_server_history(stream_id, () => {});
+    stream_topic_history_util.get_server_history(stream_id, noop);
     assert.ok(stream_topic_history.is_request_pending_for(stream_id));
 
     get_error_callback();

--- a/web/tests/transmit.test.js
+++ b/web/tests/transmit.test.js
@@ -3,11 +3,9 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const {page_params} = require("./lib/zpage_params");
-
-const noop = () => {};
 
 const channel = mock_esm("../src/channel");
 const reload = mock_esm("../src/reload");

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
@@ -181,7 +181,7 @@ test("get_item", () => {
 });
 
 test("show_error_message", ({mock_template}) => {
-    $("#compose_banners .upload_banner .moving_bar").css = () => {};
+    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
 
     let banner_shown = false;
@@ -206,8 +206,8 @@ test("show_error_message", ({mock_template}) => {
 });
 
 test("upload_files", async ({mock_template, override_rewire}) => {
-    $("#compose_banners .upload_banner").remove = () => {};
-    $("#compose_banners .upload_banner .moving_bar").css = () => {};
+    $("#compose_banners .upload_banner").remove = noop;
+    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
 
     let files = [
@@ -502,9 +502,9 @@ test("copy_paste", ({override, override_rewire}) => {
 });
 
 test("uppy_events", ({override_rewire, mock_template}) => {
-    $("#compose_banners .upload_banner .moving_bar").css = () => {};
+    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
-    override_rewire(compose_ui, "smart_insert_inline", () => {});
+    override_rewire(compose_ui, "smart_insert_inline", noop);
 
     const callbacks = {};
     let state = {};

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
@@ -210,7 +210,7 @@ run_test("updates", () => {
     assert.equal(user_id, isaac.user_id);
     assert.equal(person.avatar_url, avatar_url);
 
-    $("#personal-menu .header-button-avatar").css = () => {};
+    $("#personal-menu .header-button-avatar").css = noop;
 
     user_events.update_person({user_id: me.user_id, avatar_url: "http://gravatar.com/789456"});
     person = people.get_by_email(me.email);
@@ -275,7 +275,7 @@ run_test("updates", () => {
     user_events.update_person({user_id: isaac.user_id, is_active: true});
     assert.ok(people.is_person_active(isaac.user_id));
 
-    stream_events.remove_deactivated_user_from_all_streams = () => {};
+    stream_events.remove_deactivated_user_from_all_streams = noop;
 
     let bot_data_updated = false;
     settings_users.update_bot_data = (user_id) => {

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
@@ -79,8 +79,8 @@ function set_input_val(val) {
 test("clear_search", ({override}) => {
     override(presence, "get_status", () => "active");
     override(presence, "get_user_ids", () => all_user_ids);
-    override(popovers, "hide_all", () => {});
-    override(resize, "resize_sidebars", () => {});
+    override(popovers, "hide_all", noop);
+    override(resize, "resize_sidebars", noop);
 
     // Empty because no users match this search string.
     override(fake_buddy_list, "populate", (user_ids) => {
@@ -102,8 +102,8 @@ test("clear_search", ({override}) => {
 test("escape_search", ({override}) => {
     page_params.realm_presence_disabled = true;
 
-    override(resize, "resize_sidebars", () => {});
-    override(popovers, "hide_all", () => {});
+    override(resize, "resize_sidebars", noop);
+    override(popovers, "hide_all", noop);
 
     set_input_val("somevalue");
     activity_ui.escape_search();
@@ -116,9 +116,9 @@ test("escape_search", ({override}) => {
 });
 
 test("blur search right", ({override}) => {
-    override(sidebar_ui, "show_userlist_sidebar", () => {});
-    override(popovers, "hide_all", () => {});
-    override(resize, "resize_sidebars", () => {});
+    override(sidebar_ui, "show_userlist_sidebar", noop);
+    override(popovers, "hide_all", noop);
+    override(resize, "resize_sidebars", noop);
 
     $(".user-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
@@ -132,9 +132,9 @@ test("blur search right", ({override}) => {
 });
 
 test("blur search left", ({override}) => {
-    override(sidebar_ui, "show_streamlist_sidebar", () => {});
-    override(popovers, "hide_all", () => {});
-    override(resize, "resize_sidebars", () => {});
+    override(sidebar_ui, "show_streamlist_sidebar", noop);
+    override(popovers, "hide_all", noop);
+    override(resize, "resize_sidebars", noop);
 
     $(".user-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
@@ -204,9 +204,9 @@ test("filter_user_ids", ({override}) => {
 test("click on user header to toggle display", ({override}) => {
     const $user_filter = $(".user-list-filter");
 
-    override(popovers, "hide_all", () => {});
-    override(sidebar_ui, "show_userlist_sidebar", () => {});
-    override(resize, "resize_sidebars", () => {});
+    override(popovers, "hide_all", noop);
+    override(sidebar_ui, "show_userlist_sidebar", noop);
+    override(resize, "resize_sidebars", noop);
 
     page_params.realm_presence_disabled = true;
 


### PR DESCRIPTION
Some files already were using `noop` in place of `() => {}`. It's both clearer what it means and is easier to type. This updates all test files to fully use `noop`, and adds a shared import from the test lib file.

[Brief CZO conversation about this](https://chat.zulip.org/#narrow/stream/6-frontend/topic/noop)