### PR TITLE
stream edit toggler: Update `select_tab` when changing hash."

### DIFF
--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -16,6 +16,7 @@ export function setup_subscriptions_stream_hash(
 ): void {
     const hash = hash_util.stream_edit_url(sub, right_side_tab);
     browser_history.update(hash);
+    select_tab = right_side_tab;
 }
 
 export function setup_toggler(): void {


### PR DESCRIPTION
Followup to #27637.

This fixes a bug in #26717 (not merged yet) where the hash would flash to #personal before #subscribers. Sometimes `setup_toggler` is called after the hash change, and it needs to know which tab to show.

Ideally in the future we'd clean up this code so that the hash changing function isn't called multiple times.

