### PR TITLE
send_email: Remove `List-Unsubscribe-Post` from remote-server emails.

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -198,7 +198,8 @@ def build_email(
     # have not implemented.
     if "unsubscribe_link" in context:
         extra_headers["List-Unsubscribe"] = f"<{context['unsubscribe_link']}>"
-        extra_headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+        if not context.get("remote_server_email", False):
+            extra_headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
 
     reply_to = None
     if reply_to_email is not None:


### PR DESCRIPTION
For remote servers, we cannot advertise `List-Unsubscribe=One-Click`, which is specified in RFC 8058[^1] to mean that the `List-Unsubscribe` URL supports a POST request with no arguments to unsubscribe.  Because we show an interstitial and confirmation page, as this is not just a mailing list which is disabled if you click the link, it does not support the mail system performing the unsubscribe for the user.

Remove the inaccurate header for remote servers.

[^1]: https://datatracker.ietf.org/doc/html/rfc8058

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
