### PR TITLE
topic edit: Warn when renaming a topic to an existing topic name.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -311,7 +311,7 @@ export function initialize() {
     });
     $("body").on("click", ".topic_edit_save", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
-        message_edit.save_inline_topic_edit($recipient_row);
+        message_edit.try_save_inline_topic_edit($recipient_row);
         e.stopPropagation();
     });
     $("body").on("click", ".topic_edit_cancel", function (e) {

--- a/web/src/confirm_dialog.ts
+++ b/web/src/confirm_dialog.ts
@@ -4,10 +4,9 @@ import {$t_html} from "./i18n";
 
 export function launch(conf: DialogWidgetConfig): void {
     dialog_widget.launch({
-        ...conf,
         close_on_submit: true,
         focus_submit_on_open: true,
         html_submit_button: $t_html({defaultMessage: "Confirm"}),
-        // Used to control button colors in the template.
+        ...conf,
     });
 }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -870,10 +870,8 @@ export function save_inline_topic_edit($row) {
     show_topic_edit_spinner($row);
 
     if (message.locally_echoed) {
-        if (topic_changed) {
-            message = echo.edit_locally(message, {new_topic});
-            $row = message_lists.current.get_row(message_id);
-        }
+        message = echo.edit_locally(message, {new_topic});
+        $row = message_lists.current.get_row(message_id);
         end_inline_topic_edit($row);
         return;
     }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -923,7 +923,6 @@ export function save_inline_topic_edit($row) {
             }
             loading.destroy_indicator($spinner);
             if (msg_list === message_lists.current) {
-                message_id = rows.id_for_recipient_row($row);
                 const message = channel.xhr_error_message(
                     $t({defaultMessage: "Error saving edit"}),
                     xhr,

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 import * as resolved_topic from "../shared/src/resolved_topic";
 import render_wildcard_mention_not_allowed_error from "../templates/compose_banner/wildcard_mention_not_allowed_error.hbs";
 import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
+import render_confirm_merge_topics_with_rename from "../templates/confirm_dialog/confirm_merge_topics_with_rename.hbs";
 import render_confirm_moving_messages_modal from "../templates/confirm_dialog/confirm_moving_messages.hbs";
 import render_message_edit_form from "../templates/message_edit_form.hbs";
 import render_resolve_topic_time_limit_error_modal from "../templates/resolve_topic_time_limit_error_modal.hbs";
@@ -38,6 +39,7 @@ import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
+import * as stream_topic_history from "./stream_topic_history";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
@@ -383,7 +385,7 @@ function handle_inline_topic_edit_keydown(e) {
             return;
         }
         const $row = $(e.target).closest(".recipient_row");
-        save_inline_topic_edit($row);
+        try_save_inline_topic_edit($row);
         e.stopPropagation();
         e.preventDefault();
     } else if (e.key === "Escape") {
@@ -851,10 +853,9 @@ export function end_message_edit(message_id) {
     }
 }
 
-export function save_inline_topic_edit($row) {
-    const msg_list = message_lists.current;
-    let message_id = rows.id_for_recipient_row($row);
-    let message = message_lists.current.get(message_id);
+export function try_save_inline_topic_edit($row) {
+    const message_id = rows.id_for_recipient_row($row);
+    const message = message_lists.current.get(message_id);
 
     const old_topic = message.topic;
     const new_topic = $row.find(".inline_topic_edit").val();
@@ -867,11 +868,30 @@ export function save_inline_topic_edit($row) {
         return;
     }
 
+    const $message_header = $row.find(".message_header").expectOne();
+    const stream_id = Number.parseInt($message_header.attr("data-stream-id"), 10);
+    const stream_topics = stream_topic_history.get_recent_topic_names(stream_id);
+    if (stream_topics.includes(new_topic)) {
+        confirm_dialog.launch({
+            html_heading: $t_html({defaultMessage: "Merge with another topic?"}),
+            html_body: render_confirm_merge_topics_with_rename({
+                topic_name: new_topic,
+            }),
+            focus_submit_on_open: false,
+            on_click: () => do_save_inline_topic_edit($row, message, new_topic),
+        });
+    } else {
+        do_save_inline_topic_edit($row, message, new_topic);
+    }
+}
+
+export function do_save_inline_topic_edit($row, message, new_topic) {
+    const msg_list = message_lists.current;
     show_topic_edit_spinner($row);
 
     if (message.locally_echoed) {
         message = echo.edit_locally(message, {new_topic});
-        $row = message_lists.current.get_row(message_id);
+        $row = message_lists.current.get_row(message.id);
         end_inline_topic_edit($row);
         return;
     }

--- a/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
+++ b/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
@@ -1,0 +1,6 @@
+<p>
+    {{#tr}}
+    The topic <strong>{topic_name}</strong> already exists in this stream.
+    Are you sure you want to combine messages from these topics? This cannot be undone.
+    {{/tr}}
+</p>


### PR DESCRIPTION
Fixes #27369.

[CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/unwanted.20merging.20of.20topics.20.2327369/near/1669292)

When editing a topic name via the topic header bar, it's easy to accidentally move messages into an existing topic, which is difficult to undo. This commit adds a confirmation modal for when this is about to happen.

newer screenshot:

<img width="869" alt="image" src="https://github.com/zulip/zulip/assets/5634097/61034339-0045-4e6d-9254-c39bf05bcb9d">


older screen capture:

![Kapture 2023-12-15 at 11 17 38](https://github.com/zulip/zulip/assets/5634097/78ed541b-efed-4d29-955f-3fb55e42dc40)



