### PR TITLE
portico: Correct tab/scroll logic for self-hosted fragments.

### DIFF
--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -138,21 +138,22 @@ $(() => {
 
     if (window.location.pathname.endsWith("/plans/")) {
         const tabs = ["#cloud", "#self-hosted"];
-        const target_hash =
-            window.location.hash === "#self-hosted-plan-comparison"
-                ? "#self-hosted"
-                : window.location.hash;
-        if (!tabs.includes(target_hash)) {
-            return;
-        }
-        const tab_to_show = target_hash;
+        // Default to showing the #cloud tab
+        let tab_to_show = "#cloud";
+        const target_hash = window.location.hash;
 
-        // Don't scroll to the target element
-        if (target_hash === "#self-hosted") {
+        // Capture self-hosted-based fragments, such as
+        // #self-hosted-plan-comparison, and show the
+        // #self-hosted tab
+        if (target_hash.startsWith("#self-hosted")) {
+            tab_to_show = "#self-hosted";
+        }
+
+        // Don't scroll to tab targets
+        if (tabs.includes(target_hash)) {
             window.scroll({top: 0});
         }
-        // Display the self-hosted tabs when the URL fragment is #self-hosted
-        // or #self-hosted-plan-comparison
+
         const $pricing_wrapper = $(".portico-pricing");
         $pricing_wrapper.removeClass("showing-cloud showing-self-hosted");
         $pricing_wrapper.addClass(`showing-${tab_to_show.slice(1)}`);


### PR DESCRIPTION
This clarifies and corrects the tab-visibility and scrolling logic on the `/plans` page.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>