### PR TITLE
documentation: Support having no sidebar for policies docs.

### DIFF
--- a/templates/zerver/policies_minimal/privacy.md
+++ b/templates/zerver/policies_minimal/privacy.md
@@ -1,0 +1,1 @@
+This is the custom privacy policy.

--- a/templates/zerver/policies_minimal/terms.md
+++ b/templates/zerver/policies_minimal/terms.md
@@ -1,0 +1,1 @@
+These are the custom terms and conditions.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -694,6 +694,10 @@ class PrivacyTermsTest(ZulipTestCase):
             response = self.client_get("/policies/terms")
         self.assert_in_response(not_configured_message, response)
 
+        with self.settings(POLICIES_DIRECTORY="zerver/policies_minimal"):
+            response = self.client_get("/policies/terms")
+        self.assert_in_success_response(["These are the custom terms and conditions."], response)
+
         with self.settings(POLICIES_DIRECTORY="corporate/policies"):
             response = self.client_get("/policies/terms")
         self.assert_in_success_response(["Kandra Labs"], response)
@@ -703,6 +707,10 @@ class PrivacyTermsTest(ZulipTestCase):
         with self.settings(POLICIES_DIRECTORY="zerver/policies_absent"):
             response = self.client_get("/policies/privacy")
         self.assert_in_response(not_configured_message, response)
+
+        with self.settings(POLICIES_DIRECTORY="zerver/policies_minimal"):
+            response = self.client_get("/policies/privacy")
+        self.assert_in_success_response(["This is the custom privacy policy."], response)
 
         with self.settings(POLICIES_DIRECTORY="corporate/policies"):
             response = self.client_get("/policies/privacy")

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -182,7 +182,10 @@ class MarkdownDirectoryView(ApiURLView):
             context["doc_root"] = "/policies/"
             context["doc_root_title"] = "Terms and policies"
             sidebar_article = self.get_path("sidebar_index")
-            sidebar_index = sidebar_article.article_path
+            if sidebar_article.article_http_status == 200:
+                sidebar_index = sidebar_article.article_path
+            else:
+                sidebar_index = None
             title_base = "Zulip terms and policies"
         elif self.api_doc_view:
             context["page_is_api_center"] = True
@@ -234,7 +237,10 @@ class MarkdownDirectoryView(ApiURLView):
         if endpoint_name and endpoint_method:
             context["api_url_context"]["API_ENDPOINT_NAME"] = endpoint_name + ":" + endpoint_method
 
-        sidebar_html = render_markdown_path(sidebar_index)
+        if sidebar_index is not None:
+            sidebar_html = render_markdown_path(sidebar_index)
+        else:
+            sidebar_html = ""
         tree = html.fragment_fromstring(sidebar_html, create_parent=True)
         if not context.get("page_is_policy_center", False):
             home_h1 = Element("h1")


### PR DESCRIPTION
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
