### PR TITLE
Fix alignment of select-emoji of set-status-modal

### DIFF
--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -4,6 +4,7 @@
 
     .user-status-content-wrapper {
         display: flex;
+        justify-content: center;
         align-items: center;
         border: 1px solid;
         border-color: hsl(0deg 0% 0% / 60%);
@@ -30,26 +31,16 @@
                 width: 20px;
                 height: 20px;
                 cursor: pointer;
-                /*
-                    the following rule is not necessarily better than the one
-                    from a6bef5154197b15c20445526fd3f219b4f2e5379 but it works.
-                */
-                top: -2px;
             }
 
             /* For custom emojis and smiley icon to take full width. */
             & img.selected-emoji,
             .smiley-icon {
+                text-align: center;
                 min-width: 20px;
             }
 
             .smiley-icon {
-                display: block;
-                font-size: 18px;
-                position: relative;
-                top: -2px;
-                left: 2px;
-
                 &:hover {
                     text-decoration: none;
                 }

--- a/web/templates/status_emoji_selector.hbs
+++ b/web/templates/status_emoji_selector.hbs
@@ -7,5 +7,5 @@
         <div class="emoji selected-emoji emoji-{{selected_emoji.emoji_code}}"></div>
     {{/if}}
 {{else}}
-    <a type="button" class="smiley-icon show fa fa-smile-o"></a>
+    <a type="button" class="smiley-icon show zulip-icon zulip-icon-smile"></a>
 {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
fix alignment of select-emoji in set-status-modal
and replace old fa-smile icon with custom zulip-smile-icon

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | Now |
| --- | --- |
| ![Screenshot from 2023-12-19 18-58-26](https://github.com/zulip/zulip/assets/90370535/514a934e-69cd-4b04-aca6-68f1415fcf58)| ![Screenshot from 2024-01-19 22-13-47](https://github.com/zulip/zulip/assets/90370535/f9eefa7d-8943-488a-98ab-ef2d6a1f5e14)|

| Before | After |
| --- | --- |
| ![2](https://github.com/zulip/zulip/assets/90370535/096a10a8-bcf9-4637-ace6-859cc2c5ac4f) | ![Screenshot from 2024-01-19 23-08-54](https://github.com/zulip/zulip/assets/90370535/3d6ce735-70b4-4b13-b221-223780c2a064)|
| ![1](https://github.com/zulip/zulip/assets/90370535/38257055-6518-4704-9ce6-0f8c49478728) | ![a_1](https://github.com/zulip/zulip/assets/90370535/ae9b5154-b4d0-40b8-8658-342b50782a6d) |
| ![3](https://github.com/zulip/zulip/assets/90370535/4681a3e1-ce3b-4e29-91b2-7536610f671b) | ![a_3](https://github.com/zulip/zulip/assets/90370535/af83dfbf-83cf-4cbb-9a36-a2ee0eaf635c) |
| ![4](https://github.com/zulip/zulip/assets/90370535/091ca76d-6281-45e8-b8fc-db5b7a1dcaed) | ![a_4](https://github.com/zulip/zulip/assets/90370535/8437fc83-6278-487c-bcdd-d1ebd0ad9ad6) |
| ![5](https://github.com/zulip/zulip/assets/90370535/f2e2b3f4-385e-4549-8386-969d43485523) | ![a_5](https://github.com/zulip/zulip/assets/90370535/24b4ab19-3793-462e-9a9d-95cc9c77dc82) |
| ![6](https://github.com/zulip/zulip/assets/90370535/05fa8bd4-01bc-4ad2-a49d-f127ec07c6d1) | ![a_6](https://github.com/zulip/zulip/assets/90370535/cec9afc7-fb13-4e80-9893-3ce2ce4aeccc) |
| ![7](https://github.com/zulip/zulip/assets/90370535/5fb2a1e1-1569-4de7-9b2f-c767b0f007cb) | ![a_7](https://github.com/zulip/zulip/assets/90370535/f08d53d0-befc-4335-8b80-3798488f379f) |
| ![8](https://github.com/zulip/zulip/assets/90370535/29ebe941-3beb-4017-b73b-c0d6df105482) | ![a_8](https://github.com/zulip/zulip/assets/90370535/b46cf10b-c9ac-4a8c-9bff-bc59b6b2573d) |
| ![9](https://github.com/zulip/zulip/assets/90370535/580e1fc0-bcff-4e44-9123-56c1329e0aee) | ![a_9](https://github.com/zulip/zulip/assets/90370535/c631a6a4-342c-4241-b8e7-84902b875362) |
| ![11](https://github.com/zulip/zulip/assets/90370535/0aae3bc7-e475-48f0-a235-117ef24c6d66) | ![a_11](https://github.com/zulip/zulip/assets/90370535/5c5029ab-88a2-4790-ab4f-3b7a2128e484) |
| ![12](https://github.com/zulip/zulip/assets/90370535/0c9d5ab0-7266-401f-afca-1a924bcdb4e0) | ![a_12](https://github.com/zulip/zulip/assets/90370535/2935a237-0b7d-4ef4-a7d0-4461695d3554) |
| ![13](https://github.com/zulip/zulip/assets/90370535/788c537b-4abc-4333-b2eb-5d77e9a9e2ad) | ![a_13](https://github.com/zulip/zulip/assets/90370535/2942dc43-f4d8-4a41-b8c7-fa40e745cf22) |
| ![14](https://github.com/zulip/zulip/assets/90370535/553f36c8-5ee1-4696-8f9e-a152ac2f1f33) | ![a_14](https://github.com/zulip/zulip/assets/90370535/ad9e3e31-c30d-4a0f-94ab-ee89fb49b11a) |
| ![15](https://github.com/zulip/zulip/assets/90370535/9211be0a-09f8-46af-87c5-ec2d4c3b51c2) | ![a_15](https://github.com/zulip/zulip/assets/90370535/a2677d99-5b16-4d0c-a279-e253b1419d53) |
| ![Screenshot from 2024-01-05 18-16-11](https://github.com/zulip/zulip/assets/90370535/ae28d0dc-6424-4232-83f1-9fc6f1843548) | ![Screenshot from 2024-01-05 18-16-14](https://github.com/zulip/zulip/assets/90370535/ede074a7-697a-499c-b07e-48f8fe23455a) | ![1](https://github.com/zulip/zulip/assets/90370535/da09bfe5-b0e8-46fc-8272-dd250b531805) |
| ![Screenshot from 2024-01-05 18-18-36](https://github.com/zulip/zulip/assets/90370535/3b7498df-97d0-40e7-8609-a3d48a544bf2) | ![Screenshot from 2024-01-05 18-18-40](https://github.com/zulip/zulip/assets/90370535/e2eee6a6-30cf-4722-be0c-4fc1c47a6497) |


[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/set.20status.20emoji.20alignment/near/1707651)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
