### PR TITLE
Implement Event Filtering for Webhook Integration URL Generation 

### DIFF
--- a/help/generate-integration-url.md
+++ b/help/generate-integration-url.md
@@ -24,6 +24,9 @@ integration URL.
 1. _(optional)_ Select **Send all notifications to a single topic**, and
    enter the topic name.
 
+1. _(optional)_ Select **Filter events that will trigger notifications?**,
+   and select which supported events should trigger notifications.
+
 1. Click **Copy URL** to add the URL to your clipboard.
 
 !!! tip ""
@@ -49,6 +52,9 @@ integration URL.
 
 1. _(optional)_ Select **Send all notifications to a single topic**, and
    enter the topic name.
+
+1. _(optional)_ Select **Filter events that will trigger notifications?**,
+   and select which supported events should trigger notifications.
 
 1. Click **Copy URL** to add the URL to your clipboard.
 

--- a/templates/zerver/integrations/include/event-filtering-instruction.md
+++ b/templates/zerver/integrations/include/event-filtering-instruction.md
@@ -1,14 +1,6 @@
-To filter the events that trigger the notifications, you can append
-either `&only_events=["event_a","event_b"]` or `&exclude_events=["event_a","event_b"]`
-(or both, with different events) to the URL you generated with an arbitrary
-number of supported events.
-
-Below are the events that {{ integration_display_name }} bot supports:
+You will be able to configure which of the following
+{{ integration_display_name }} events trigger notifications:
 
 {% set comma = joiner(", ") %}
 
 {% for event_type in all_event_types -%} {{- comma() -}} `{{ event_type }}` {%- endfor %}
-
-Note that you can also use UNIX-style wildcards like `*` to include
-multiple events. E.g., `test*` matches every event that starts with
-`test`.

--- a/templates/zerver/integrations/include/generate-integration-url.md
+++ b/templates/zerver/integrations/include/generate-integration-url.md
@@ -1,18 +1,18 @@
 [Generate the URL][generate-url] for your {{ integration_display_name }}
 integration.
 
-The generated URL will be something like:
-
-{!webhook-url.md!}
-
-*To manually construct the URL for an incoming webhook integration,
-see [the webhook URLs specification][incoming-webhook-urls].*
-
 {% if all_event_types is defined %}
 
 {!event-filtering-instruction.md!}
 
 {% endif %}
+
+The generated URL will look something like this:
+
+{!webhook-url.md!}
+
+*To manually construct the URL for an incoming webhook integration,
+see [the webhook URLs specification][incoming-webhook-urls].*
 
 [generate-url]: /help/generate-integration-url
 [incoming-webhook-urls]: /api/incoming-webhooks-overview#urls

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -41,6 +41,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         const $dialog_submit_button = $("#generate-integration-url-modal .dialog_submit_button");
 
         $dialog_submit_button.prop("disabled", true);
+        $("#integration-url-stream_widget").prop("disabled", true);
 
         const clipboard = new ClipboardJS("#generate-integration-url-modal .dialog_submit_button", {
             text() {
@@ -63,11 +64,12 @@ export function show_generate_integration_url_modal(api_key: string): void {
         function update_url(): void {
             selected_integration = integration_input_dropdown_widget.value()!.toString();
             if (selected_integration === default_integration_option.unique_id) {
+                $("#integration-url-stream_widget").prop("disabled", true);
                 $integration_url.text(default_url_message);
                 $dialog_submit_button.prop("disabled", true);
                 return;
             }
-
+            $("#integration-url-stream_widget").prop("disabled", false);
             const stream_id = stream_input_dropdown_widget.value();
             const topic_name = $topic_input.val()!;
 

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -74,7 +74,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             const params = new URLSearchParams({api_key});
             if (stream_id !== -1) {
                 params.set("stream", stream_id!.toString());
-                if (topic_name !== "") {
+                if ($override_topic.prop("checked") && topic_name !== "") {
                     params.set("topic", topic_name);
                 }
             }

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -3,6 +3,7 @@ import $ from "jquery";
 import type {Instance} from "tippy.js";
 
 import render_generate_integration_url_modal from "../templates/settings/generate_integration_url_modal.hbs";
+import render_integration_events from "../templates/settings/integration_events.hbs";
 
 import {show_copied_confirmation} from "./copied_tooltip";
 import * as dialog_widget from "./dialog_widget";
@@ -39,6 +40,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         const $topic_input = $<HTMLInputElement>("input#integration-url-topic-input");
         const $integration_url = $("#generate-integration-url-modal .integration-url");
         const $dialog_submit_button = $("#generate-integration-url-modal .dialog_submit_button");
+        const $show_integration_events = $("#show-integration-events");
 
         $dialog_submit_button.prop("disabled", true);
         $("#integration-url-stream_widget").prop("disabled", true);
@@ -57,11 +59,33 @@ export function show_generate_integration_url_modal(api_key: string): void {
             $topic_input.parent().toggleClass("hide", !checked);
         });
 
+        $show_integration_events.on("change", () => {
+            $("#integrations-event-container").toggleClass(
+                "hide",
+                !$show_integration_events.prop("checked"),
+            );
+            update_url(true);
+        });
+
+        $(document).on("change", "#integrations-event-container .integration-event", () => {
+            update_url();
+        });
+
+        $("#add-all-integration-events").on("click", () => {
+            $("#integrations-event-container .integration-event").prop("checked", true);
+            update_url();
+        });
+
+        $("#remove-all-integration-events").on("click", () => {
+            $("#integrations-event-container .integration-event").prop("checked", false);
+            update_url();
+        });
+
         $("#generate-integration-url-modal .integration-url-parameter").on("change input", () => {
             update_url();
         });
 
-        function update_url(): void {
+        function update_url(render_events = false): void {
             selected_integration = integration_input_dropdown_widget.value()!.toString();
             if (selected_integration === default_integration_option.unique_id) {
                 $("#integration-url-stream_widget").prop("disabled", true);
@@ -73,6 +97,35 @@ export function show_generate_integration_url_modal(api_key: string): void {
             const stream_id = stream_input_dropdown_widget.value();
             const topic_name = $topic_input.val()!;
 
+            const selected_integration_data = realm.realm_incoming_webhook_bots.find(
+                (bot) => bot.name === selected_integration,
+            );
+            const all_event_types = selected_integration_data?.all_event_types;
+
+            if (all_event_types !== null) {
+                $("#integration-events-parameter").removeClass("hide");
+            } else {
+                $("#integration-events-parameter").addClass("hide");
+                $("#integrations-event-container").addClass("hide");
+                $("#integrations-event-options").empty();
+                $show_integration_events.prop("checked", false);
+            }
+
+            if ($show_integration_events.prop("checked") && render_events) {
+                const events_with_ids = all_event_types?.map((event) => {
+                    const event_id = event.replaceAll(/\s+/g, "-");
+                    return {
+                        event,
+                        event_id,
+                    };
+                });
+                events_with_ids?.sort((a, b) => a.event.localeCompare(b.event));
+                const events = render_integration_events({
+                    events: events_with_ids,
+                });
+                $("#integrations-event-options").empty().append(events);
+            }
+
             const params = new URLSearchParams({api_key});
             if (stream_id !== -1) {
                 params.set("stream", stream_id!.toString());
@@ -80,13 +133,17 @@ export function show_generate_integration_url_modal(api_key: string): void {
                     params.set("topic", topic_name);
                 }
             }
+            const selected_events = set_events_param(params);
 
             const realm_url = realm.realm_uri;
             const base_url = `${realm_url}/api/v1/external/`;
             $integration_url.text(`${base_url}${selected_integration}?${params.toString()}`);
             $dialog_submit_button.prop("disabled", false);
 
-            if ($override_topic.prop("checked") && topic_name === "") {
+            if (
+                ($override_topic.prop("checked") && topic_name === "") ||
+                ($show_integration_events.prop("checked") && !selected_events)
+            ) {
                 $dialog_submit_button.prop("disabled", true);
             }
         }
@@ -173,6 +230,26 @@ export function show_generate_integration_url_modal(api_key: string): void {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
+        }
+
+        function set_events_param(params: URLSearchParams): boolean {
+            if (!$show_integration_events.prop("checked")) {
+                return false;
+            }
+            const $selected_integration_events = $(
+                "#integrations-event-container .integration-event:checked",
+            );
+
+            const selected_events = $selected_integration_events
+                .map(function () {
+                    return $(this).val();
+                })
+                .get();
+            if (selected_events.length > 0) {
+                params.set("only_events", JSON.stringify(selected_events));
+                return true;
+            }
+            return false;
         }
     }
 

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -35,6 +35,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         let selected_integration = "";
         let stream_input_dropdown_widget: DropdownWidget;
         let integration_input_dropdown_widget: DropdownWidget;
+        let previous_selected_integration = "";
 
         const $override_topic = $("#integration-url-override-topic");
         const $topic_input = $<HTMLInputElement>("input#integration-url-topic-input");
@@ -87,6 +88,9 @@ export function show_generate_integration_url_modal(api_key: string): void {
 
         function update_url(render_events = false): void {
             selected_integration = integration_input_dropdown_widget.value()!.toString();
+            if (previous_selected_integration !== selected_integration) {
+                reset_to_blank_state();
+            }
             if (selected_integration === default_integration_option.unique_id) {
                 $("#integration-url-stream_widget").prop("disabled", true);
                 $integration_url.text(default_url_message);
@@ -94,6 +98,8 @@ export function show_generate_integration_url_modal(api_key: string): void {
                 return;
             }
             $("#integration-url-stream_widget").prop("disabled", false);
+            previous_selected_integration = selected_integration;
+
             const stream_id = stream_input_dropdown_widget.value();
             const topic_name = $topic_input.val()!;
 
@@ -104,11 +110,6 @@ export function show_generate_integration_url_modal(api_key: string): void {
 
             if (all_event_types !== null) {
                 $("#integration-events-parameter").removeClass("hide");
-            } else {
-                $("#integration-events-parameter").addClass("hide");
-                $("#integrations-event-container").addClass("hide");
-                $("#integrations-event-options").empty();
-                $show_integration_events.prop("checked", false);
             }
 
             if ($show_integration_events.prop("checked") && render_events) {
@@ -250,6 +251,21 @@ export function show_generate_integration_url_modal(api_key: string): void {
                 return true;
             }
             return false;
+        }
+
+        function reset_to_blank_state(): void {
+            $("#integration-events-parameter").addClass("hide");
+            $("#integrations-event-container").addClass("hide");
+            $("#integrations-event-options").empty();
+            $("#integrations-event-container .integration-event").prop("checked", false);
+            $show_integration_events.prop("checked", false);
+
+            $override_topic.prop("checked", false).prop("disabled", true);
+            $override_topic.closest(".input-group").addClass("control-label-disabled");
+            $topic_input.val("");
+            $topic_input.parent().addClass("hide");
+
+            stream_input_dropdown_widget.render(direct_messages_option.unique_id);
         }
     }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -482,3 +482,23 @@
         border: 1px solid var(--color-hotkey-hint);
     }
 }
+
+#generate-integration-url-modal {
+    #integrations-event-container {
+        .integration-all-events-buttons {
+            display: flex;
+            gap: 10px;
+            margin: 5px 0 10px;
+        }
+
+        #integrations-event-options {
+            .integration-event-wrapper {
+                margin: 5px 0;
+            }
+
+            .integration-event-name {
+                word-break: break-all;
+            }
+        }
+    }
+}

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -26,6 +26,23 @@
         <label for="integration-url-topic-input">{{t "Topic"}}</label>
         <input type="text" id="integration-url-topic-input" class="modal_text_input integration-url-parameter" maxlength="{{ max_topic_length }}" />
     </div>
+    <div id="integration-events-parameter" class="input-group hide">
+        <label class="checkbox">
+            <input type="checkbox" id="show-integration-events"/>
+            <span></span>
+        </label>
+        <label class="inline" for="show-integration-events">
+            {{t "Filter events that will trigger notifications?"}}
+        </label>
+    </div>
+    <div class="input-group hide" id="integrations-event-container">
+        <label for="integrations-event-options">{{t "Events to include:"}}</label>
+        <div class="integration-all-events-buttons">
+            <button class="button rounded" id="add-all-integration-events">{{t "Check all"}}</button>
+            <button class="button rounded" id="remove-all-integration-events">{{t "Uncheck all"}}</button>
+        </div>
+        <div id="integrations-event-options"></div>
+    </div>
     <hr />
     <p class="integration-url-header">{{t "URL for your integration"}}</p>
     <div class="integration-url">

--- a/web/templates/settings/integration_events.hbs
+++ b/web/templates/settings/integration_events.hbs
@@ -1,0 +1,13 @@
+{{#each events }}
+    <div class="integration-event-wrapper">
+        <label class="checkbox">
+            <input type="checkbox" class="integration-event" id="{{this.event_id}}" checked=true
+              value="{{this.event}}" />
+            <span>
+            </span>
+        </label>
+        <label for="{{this.event_id}}" class="inline integration-event-name">
+            {{this.event}}
+        </label>
+    </div>
+{{/each}}


### PR DESCRIPTION
## Description:

Fixes: #27628

Following up on #25976, this PR introduces the ability to filter events when generating the URL for an incoming webhook integration. The new feature includes a checkbox UI for selecting events. The UI is designed with a one-column better readability and responsiveness, replacing the three-column  or two-column layout that was causing readability issues.

## Screenshots and screen captures:
| **Dark Events** | **Light Events** |
| ------------------- | -------------------- |
| ![Dark events](https://github.com/zulip/zulip/assets/73663475/acc3e8be-3c81-4db6-a782-a5b27a5000ef) | ![Light events](https://github.com/zulip/zulip/assets/73663475/6a1b8a6c-91fa-4aed-b56b-47346ad99481) |

## Documentaion:
| **Before** | **After** |
| ------------------- | -------------------- |
| ![Dark events](https://github.com/zulip/zulip/assets/73663475/e37043c6-c74b-46a4-9fa7-43bced516df9) | ![Light events](https://github.com/zulip/zulip/assets/73663475/175edce9-1005-43e3-a0b5-843b9a0ff00d) |

**Before [link to the docs](https://chat.zulip.org/help/generate-integration-url#generate-url-for-an-integration)**:
| **Personal setting** | **Organization setting** |
| ------------------- | -------------------- |
| ![Dark events](https://github.com/zulip/zulip/assets/73663475/0332976b-35a6-4cf1-8948-733593b12b13) | ![Light events](https://github.com/zulip/zulip/assets/73663475/fe0f15f4-cf80-48ad-9da7-86a9eaf929d9) |

---

**After**:
| **Personal setting** | **Organization setting** |
| ------------------- | -------------------- |
| ![Dark events](https://github.com/zulip/zulip/assets/73663475/23eb07da-6b58-4c2a-a57f-29c62236376c) | ![Light events](https://github.com/zulip/zulip/assets/73663475/d830f622-429e-402d-a9aa-d79fd32b7b67) |


**Before [link to the docs](https://chat.zulip.org/api/incoming-webhooks-overview#urls)**:
| **Before** | **After** |
| ------------------- | -------------------- |
| ![Dark events](https://github.com/zulip/zulip/assets/73663475/4c253ca2-582c-4bda-8ec3-bafc749b2f82) | ![Light events](https://github.com/zulip/zulip/assets/73663475/726a2d18-8b41-4e7a-b03d-1e39b761dffc) |

[Events design discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/integration.20events.20design/near/1716277)

co-authored : @laurynmm 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked. -->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).

- [x] Highlights technical choices and bugs encountered.

 - In the implementation, I utilized $(document).on("change", ".integration-event-checkbox", () => { update_url(true); }); to handle the event binding. This choice was made to overcome an event binding problem. Additionally, a new parameter, is_event_checkbox_change, was introduced in the update_url function. This parameter is passed every time a checkbox changes. To prevent redundant printing of events with each checkbox change, a condition !is_event_checkbox_change was added. This ensures that the checkbox is checked properly, and the events are updated only when necessary.



Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
 - Responsiveness is checked, internationalization was not mentioned in issue.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


