### PR TITLE
plans: Precisely determine min- and max-widths.

### DIFF
--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -18,6 +18,8 @@
     --icon-right-outward-tab-curve: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='white' d='M16 16H0V0c0 8.837 7.163 16 16 16Z'/%3e%3c/svg%3e");
     --icon-question-header-swoosh: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='33' height='56' fill='none' viewBox='0 0 33 56'%3e%3cpath fill='%23E2EBF4' d='M33 37 1 56C1 35-3.5 0 33 0 7.5 3 7.776 37 33 37Z'/%3e%3c/svg%3e");
     --icon-current-plan-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' viewBox='0 0 22 22'%3e%3cg fill='%230F8544'%3e%3cpath d='M14.396 9.813a.914.914 0 1 0-1.293-1.293l-3.02 3.02-1.186-1.186a.914.914 0 1 0-1.294 1.293l1.834 1.833a.914.914 0 0 0 1.293 0l3.666-3.667Z'/%3e%3cpath fill-rule='evenodd' d='M11 .923a4.58 4.58 0 0 0-3.495 1.62 4.581 4.581 0 0 0-4.961 4.949 4.58 4.58 0 0 0 0 7.016 4.58 4.58 0 0 0 4.96 4.949 4.583 4.583 0 0 0 7.003-.001 4.582 4.582 0 0 0 4.95-4.96 4.583 4.583 0 0 0 0-6.991 4.58 4.58 0 0 0-4.962-4.962A4.581 4.581 0 0 0 11 .923ZM9.678 3.09a2.752 2.752 0 0 1 3.64.932.914.914 0 0 0 .972.4 2.752 2.752 0 0 1 3.289 3.288.914.914 0 0 0 .4.971 2.753 2.753 0 0 1 0 4.638.914.914 0 0 0-.4.97 2.752 2.752 0 0 1-3.283 3.29.914.914 0 0 0-.97.401 2.75 2.75 0 0 1-4.644 0 .914.914 0 0 0-.971-.401 2.752 2.752 0 0 1-3.29-3.283.914.914 0 0 0-.403-.97 2.753 2.753 0 0 1 0-4.652.914.914 0 0 0 .404-.97A2.752 2.752 0 0 1 7.71 4.42a.914.914 0 0 0 .97-.4c.25-.389.592-.709.997-.93Z' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e");
+    --width-price-box-min: 285px;
+    --width-price-box-max: 355px;
 
     padding: 102px 0 58px;
     background: linear-gradient(
@@ -155,6 +157,12 @@
             minmax(0, 420px) 1fr 56px;
         column-gap: 2px;
         margin: 50px auto 38px;
+        /* We use the plan count on the respective `.showing-` class
+           to determine a maximum width, beyond which the plans will
+           grow no wider. */
+        max-width: calc(
+            (var(--count-plans) * var(--width-price-box-max)) + 40px
+        );
 
         @media screen and (width <= 700px) {
             grid-template-columns:
@@ -177,20 +185,8 @@
         grid-area: cloud-title;
     }
 
-    .cloud-plan-pricing {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-        grid-template-rows: auto;
-    }
-
     .self-hosted-plan-title {
         grid-area: self-hosted-title;
-    }
-
-    .self-hosted-plan-pricing {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-        grid-template-rows: auto;
     }
 
     .pricing-tab,
@@ -261,22 +257,20 @@
     }
 
     .pricing-pane {
+        display: grid;
+        grid-template-columns: repeat(
+            auto-fit,
+            minmax(var(--width-price-box-min), 1fr)
+        );
+        grid-template-rows: auto;
+        /* We use the plan count on the respective `.showing-` class
+           to determine a minimum width, at which point the plans scroll. */
+        min-width: calc(var(--count-plans) * var(--width-price-box-min));
         padding: 20px;
         border-radius: 16px;
         color: var(--color-box-copy);
         background: var(--color-background-box);
         margin: 0 16px;
-        /* 1040 + 16px*2 margin */
-        @media (width <= 1072px) {
-            min-width: 1040px;
-        }
-
-        &.self-hosted-plan-pricing {
-            /* 1220 + 16px*2 margin */
-            @media (width <= 1252px) {
-                min-width: 1220px;
-            }
-        }
 
         @media screen and (width <= 700px) {
             margin: 0 8px;
@@ -581,9 +575,7 @@
     }
 
     &.showing-cloud {
-        .pricing-container {
-            max-width: 1100px;
-        }
+        --count-plans: 3;
 
         .self-hosted-scroll,
         .self-hosted-plan-pricing,
@@ -631,9 +623,7 @@
     }
 
     &.showing-self-hosted {
-        .pricing-container {
-            max-width: 1400px;
-        }
+        --count-plans: 4;
 
         .cloud-scroll,
         .cloud-plan-pricing,


### PR DESCRIPTION
This takes some of the eyeballing, guesswork, and media-queries out of the sizing of the plans panes, and ensures that systems set to always display scrollbars only take them when they are required.

**Screenshots and screen captures:**

Responsiveness:

![calculate-min-max-panes](https://github.com/zulip/zulip/assets/170719/c7ea0d6c-1a0f-4d77-b567-42128b5ee39c)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>