### PR TITLE
typeaheads: Fix mention typeaheads spill width.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1508,6 +1508,8 @@ strong {
    on :focus. */
 .typeahead-menu {
     & li {
+        word-break: break-word;
+
         & a {
             display: block;
             padding: 3px 20px;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #27825 

This PR fixes the issue of mention typeaheads spilling out of the box by limiting the max-width in accordance with the screen size.

**Screenshots and screen captures:**

Initially - 
<img width="374" alt="Screenshot 2024-01-05 at 2 23 15 AM" src="https://github.com/zulip/zulip/assets/97145463/d7f91071-5533-410b-a541-4e5a5ff684cf">

Finally - 
<img width="379" alt="Screenshot 2024-01-05 at 2 21 30 AM" src="https://github.com/zulip/zulip/assets/97145463/f093dcc7-2e1e-423c-8ed5-5055bf16b81a">


<details>
<summary>Self-review checklist</summary>



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
