### PR TITLE
settings: Fix color leak during linkifier row drag in settings

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -791,12 +791,20 @@
     #settings_page .settings-header,
     #settings_page .sidebar li.active,
     #settings_page .sidebar-wrapper .tab-container,
-    .table-striped tbody tr:nth-child(even) td,
     .table-striped tbody tr:nth-child(odd) th,
     #subscription_overlay #stream-creation .settings-sticky-footer,
     #groups_overlay #user-group-creation .settings-sticky-footer {
         border-color: hsl(0deg 0% 0% / 20%);
         background-color: hsl(0deg 0% 0% / 20%);
+    }
+
+    .table-striped tbody tr:nth-child(even) td {
+        border-color: hsl(0deg 0% 0% / 20%);
+        background-color: color-mix(
+            in srgb,
+            hsl(0deg 0% 0%) 20%,
+            var(--color-background-modal)
+        );
     }
 
     .table-striped tbody tr:nth-child(odd) td {


### PR DESCRIPTION
Fixes: #26480 

**Screenshots and screen captures:**
These are screenshots and screen captures after i have made the changes:-
![Screenshot from 2023-12-12 19-36-56](https://github.com/zulip/zulip/assets/119888263/2a713ec9-54cb-4a4e-a2cd-2ae9fb05c4c3)
![Screenshot from 2023-12-12 19-37-08](https://github.com/zulip/zulip/assets/119888263/d320acfa-83b6-49dc-9686-caf1b7e4c99f)



https://github.com/zulip/zulip/assets/119888263/833d835e-9fcd-438c-9057-d1523c41ce9c




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
I had adjusted the background hsl color value which was causing the problem
it would be greate if someone reviews the PR and please tell me weather any changes needed!!
Thank You : ) 