### PR TITLE
filter: Use terms instead of operands.

### DIFF
--- a/web/src/compose_reply.js
+++ b/web/src/compose_reply.js
@@ -56,7 +56,7 @@ export function respond_to_message(opts) {
                 return;
             }
             const current_filter = narrow_state.filter();
-            const first_term = current_filter.operators()[0];
+            const first_term = current_filter.terms()[0];
             const first_operator = first_term.operator;
             const first_operand = first_term.operand;
 

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -7,7 +7,8 @@ import * as sub_store from "./sub_store";
 import type {StreamSubscription} from "./sub_store";
 import type {UserGroup} from "./user_groups";
 
-type Operator = {operator: string; operand: string; negated?: boolean};
+// TODO(typescript): Move to filter.js when it's converted to typescript.
+type Term = {operator: string; operand: string; negated?: boolean};
 
 export function build_reload_url(): string {
     let hash = window.location.hash;
@@ -79,21 +80,21 @@ export function by_stream_topic_url(stream_id: number, topic: string): string {
     return internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
 }
 
-// Encodes an operator list into the
+// Encodes a term list into the
 // corresponding hash: the # component
 // of the narrow URL
-export function operators_to_hash(operators?: Operator[]): string {
+export function search_terms_to_hash(terms?: Term[]): string {
     let hash = "#";
 
-    if (operators !== undefined) {
+    if (terms !== undefined) {
         hash = "#narrow";
 
-        for (const elem of operators) {
+        for (const term of terms) {
             // Support legacy tuples.
-            const operator = elem.operator;
-            const operand = elem.operand;
+            const operator = term.operator;
+            const operand = term.operand;
 
-            const sign = elem.negated ? "-" : "";
+            const sign = term.negated ? "-" : "";
             hash +=
                 "/" +
                 sign +
@@ -107,7 +108,7 @@ export function operators_to_hash(operators?: Operator[]): string {
 }
 
 export function by_sender_url(reply_to: string): string {
-    return operators_to_hash([{operator: "sender", operand: reply_to}]);
+    return search_terms_to_hash([{operator: "sender", operand: reply_to}]);
 }
 
 export function pm_with_url(reply_to: string): string {
@@ -151,16 +152,16 @@ export function group_edit_url(group: UserGroup): string {
     return hash;
 }
 
-export function search_public_streams_notice_url(operators: Operator[]): string {
+export function search_public_streams_notice_url(terms: Term[]): string {
     const public_operator = {operator: "streams", operand: "public"};
-    return operators_to_hash([public_operator, ...operators]);
+    return search_terms_to_hash([public_operator, ...terms]);
 }
 
-export function parse_narrow(hash: string): Operator[] | undefined {
+export function parse_narrow(hash: string): Term[] | undefined {
     // This will throw an exception when passed an invalid hash
     // at the decodeHashComponent call, handle appropriately.
     let i;
-    const operators = [];
+    const terms = [];
     for (i = 1; i < hash.length; i += 2) {
         // We don't construct URLs with an odd number of components,
         // but the user might write one.
@@ -183,7 +184,7 @@ export function parse_narrow(hash: string): Operator[] | undefined {
         }
 
         const operand = decode_operand(operator, raw_operand);
-        operators.push({negated, operator, operand});
+        terms.push({negated, operator, operand});
     }
-    return operators;
+    return terms;
 }

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -117,10 +117,10 @@ function do_hashchange_normal(from_reload) {
 
     switch (hash[0]) {
         case "#narrow": {
-            let operators;
+            let terms;
             try {
                 // TODO: Show possible valid URLs to the user.
-                operators = hash_util.parse_narrow(hash);
+                terms = hash_util.parse_narrow(hash);
             } catch {
                 ui_report.error(
                     $t_html({defaultMessage: "Invalid URL"}),
@@ -129,7 +129,7 @@ function do_hashchange_normal(from_reload) {
                     2000,
                 );
             }
-            if (operators === undefined) {
+            if (terms === undefined) {
                 // If the narrow URL didn't parse,
                 // send them to web_home_view.
                 // We cannot clear hash here since
@@ -156,7 +156,7 @@ function do_hashchange_normal(from_reload) {
                 narrow_opts.then_select_id = location_data_for_hash.narrow_pointer;
                 narrow_opts.then_select_offset = location_data_for_hash.narrow_offset;
             }
-            narrow.activate(operators, narrow_opts);
+            narrow.activate(terms, narrow_opts);
             return true;
         }
         case "":

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -45,7 +45,7 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
         url: "/json/messages/matches_narrow",
         data: {
             msg_ids: JSON.stringify(ids),
-            narrow: JSON.stringify(narrow_state.public_operators()),
+            narrow: JSON.stringify(narrow_state.public_search_terms()),
         },
         timeout: 5000,
         success(data) {
@@ -421,12 +421,12 @@ export function update_messages(events) {
                 //       with data fetched from the server (which is already updated)
                 //       when we move to new narrow and what data is locally available.
                 if (changed_narrow) {
-                    const operators = new_filter.operators();
+                    const terms = new_filter.terms();
                     const opts = {
                         trigger: "stream/topic change",
                         then_select_id: current_selected_id,
                     };
-                    narrow.activate(operators, opts);
+                    narrow.activate(terms, opts);
                 }
             }
 

--- a/web/src/message_feed_top_notices.js
+++ b/web/src/message_feed_top_notices.js
@@ -25,8 +25,8 @@ function show_end_of_results_notice() {
 
     // Set the link to point to this search with streams:public added.
     // Note that element we adjust is not visible to spectators.
-    const operators = narrow_state.filter().operators();
-    const update_hash = hash_util.search_public_streams_notice_url(operators);
+    const terms = narrow_state.filter().terms();
+    const update_hash = hash_util.search_public_streams_notice_url(terms);
     $(".all-messages-search-caution a.search-shared-history").attr("href", update_hash);
 }
 

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -241,7 +241,7 @@ export function load_messages(opts, attempt = 1) {
     }
 
     // This block is a hack; structurally, we want to set
-    //   data.narrow = opts.msg_list.data.filter.public_operators()
+    //   data.narrow = opts.msg_list.data.filter.public_terms()
     //
     // But support for the all_messages_data sharing of data with
     // message_lists.home and the (hacky) page_params.narrow feature
@@ -256,11 +256,11 @@ export function load_messages(opts, attempt = 1) {
         // streams and topics even though message_lists.home's in:home
         // operators will filter those.
     } else {
-        let operators = msg_list_data.filter.public_operators();
+        let terms = msg_list_data.filter.public_terms();
         if (page_params.narrow !== undefined) {
-            operators = [...operators, ...page_params.narrow];
+            terms = [...terms, ...page_params.narrow];
         }
-        data.narrow = JSON.stringify(operators);
+        data.narrow = JSON.stringify(terms);
     }
 
     let update_loading_indicator = opts.msg_list === message_lists.current;

--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -92,12 +92,12 @@ function pick_empty_narrow_banner() {
         return default_banner;
     }
 
-    const first_term = current_filter.operators()[0];
+    const first_term = current_filter.terms()[0];
     const first_operator = first_term.operator;
     const first_operand = first_term.operand;
-    const num_operators = current_filter.operators().length;
+    const num_terms = current_filter.terms().length;
 
-    if (num_operators !== 1) {
+    if (num_terms !== 1) {
         // For invalid-multi-operator narrows, we display an invalid narrow message
         const streams = current_filter.operands("stream");
         const topics = current_filter.operands("topic");
@@ -152,7 +152,7 @@ function pick_empty_narrow_banner() {
         }
 
         // A stream > topic that doesn't exist yet.
-        if (num_operators === 2 && streams.length === 1 && topics.length === 1) {
+        if (num_terms === 2 && streams.length === 1 && topics.length === 1) {
             return default_banner;
         }
 

--- a/web/src/narrow_history.ts
+++ b/web/src/narrow_history.ts
@@ -15,7 +15,7 @@ function _save_narrow_state(): void {
     // We don't want to save state in the middle of a narrow change
     // to the wrong hash.
     const current_filter = message_lists.current.data.filter;
-    if (hash_util.operators_to_hash(current_filter.operators()) !== window.location.hash) {
+    if (hash_util.search_terms_to_hash(current_filter.terms()) !== window.location.hash) {
         return;
     }
 

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -31,11 +31,11 @@ export function filter(): Filter | undefined {
     return current_filter;
 }
 
-export function operators(): Term[] {
+export function search_terms(): Term[] {
     if (current_filter === undefined) {
-        return new Filter(page_params.narrow).operators();
+        return new Filter(page_params.narrow).terms();
     }
-    return current_filter.operators();
+    return current_filter.terms();
 }
 
 export function is_message_feed_visible(): boolean {
@@ -48,30 +48,30 @@ export function update_email(user_id: number, new_email: string): void {
     }
 }
 
-/* Operators we should send to the server. */
-export function public_operators(): Term[] | undefined {
+/* Search terms we should send to the server. */
+export function public_search_terms(): Term[] | undefined {
     if (current_filter === undefined) {
         return undefined;
     }
-    return current_filter.public_operators();
+    return current_filter.public_terms();
 }
 
 export function search_string(): string {
-    return Filter.unparse(operators());
+    return Filter.unparse(search_terms());
 }
 
-// Collect operators which appear only once into an object,
+// Collect terms which appear only once into an object,
 // and discard those which appear more than once.
-function collect_single(operators: Term[]): Map<string, string> {
+function collect_single(terms: Term[]): Map<string, string> {
     const seen = new Map();
     const result = new Map();
 
-    for (const elem of operators) {
-        const key = elem.operator;
+    for (const term of terms) {
+        const key = term.operator;
         if (seen.has(key)) {
             result.delete(key);
         } else {
-            result.set(key, elem.operand);
+            result.set(key, term.operand);
             seen.set(key, true);
         }
     }
@@ -84,14 +84,14 @@ function collect_single(operators: Term[]): Map<string, string> {
 //
 // This logic is here and not in the 'compose' module because
 // it will get more complicated as we add things to the narrow
-// operator language.
+// search term language.
 export function set_compose_defaults(): {
     stream_id?: number;
     topic?: string;
     private_message_recipient?: string;
 } {
     const opts: {stream_id?: number; topic?: string; private_message_recipient?: string} = {};
-    const single = collect_single(operators());
+    const single = collect_single(search_terms());
 
     // Set the stream, topic, and/or direct message recipient
     // if they are uniquely specified in the narrow view.
@@ -318,17 +318,17 @@ export function narrowed_by_pm_reply(): boolean {
     if (current_filter === undefined) {
         return false;
     }
-    const operators = current_filter.operators();
-    return operators.length === 1 && current_filter.has_operator("dm");
+    const terms = current_filter.terms();
+    return terms.length === 1 && current_filter.has_operator("dm");
 }
 
 export function narrowed_by_topic_reply(): boolean {
     if (current_filter === undefined) {
         return false;
     }
-    const operators = current_filter.operators();
+    const terms = current_filter.terms();
     return (
-        operators.length === 2 &&
+        terms.length === 2 &&
         current_filter.operands("stream").length === 1 &&
         current_filter.operands("topic").length === 1
     );
@@ -345,8 +345,8 @@ export function narrowed_by_stream_reply(): boolean {
     if (current_filter === undefined) {
         return false;
     }
-    const operators = current_filter.operators();
-    return operators.length === 1 && current_filter.operands("stream").length === 1;
+    const terms = current_filter.terms();
+    return terms.length === 1 && current_filter.operands("stream").length === 1;
 }
 
 export function narrowed_to_topic(): boolean {

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -24,14 +24,14 @@ export function narrow_or_search_for_term(search_string, {on_narrow_search}) {
         return $search_query_box.val();
     }
 
-    const operators = Filter.parse(search_string);
-    on_narrow_search(operators, {trigger: "search"});
+    const terms = Filter.parse(search_string);
+    on_narrow_search(terms, {trigger: "search"});
 
     // It's sort of annoying that this is not in a position to
     // blur the search box, because it means that Esc won't
     // unnarrow, it'll leave the searchbox.
 
-    // Narrowing will have already put some operators in the search box,
+    // Narrowing will have already put some terms in the search box,
     // so leave the current text in.
     $search_query_box.trigger("blur");
     return $search_query_box.val();
@@ -125,7 +125,7 @@ export function initialize({on_narrow_search}) {
                 // We just pressed Enter and the box had focus, which
                 // means we didn't use the typeahead at all.  In that
                 // case, we should act as though we're searching by
-                // operators.  (The reason the other actions don't call
+                // terms.  (The reason the other actions don't call
                 // this codepath is that they first all blur the box to
                 // indicate that they've done what they need to do)
 
@@ -231,7 +231,7 @@ function exit_search(opts) {
 
 export function open_search_bar_and_close_narrow_description() {
     // Preserve user input if they've already started typing, but
-    // otherwise fill the input field with the text operators for
+    // otherwise fill the input field with the text terms for
     // the current narrow.
     if ($("#search_query").val() === "") {
         reset_searchbox_text();

--- a/web/src/typing_events.js
+++ b/web/src/typing_events.js
@@ -33,7 +33,7 @@ function get_users_typing_for_narrow() {
         return [];
     }
 
-    const first_term = narrow_state.operators()[0];
+    const first_term = narrow_state.search_terms()[0];
     if (first_term.operator === "dm") {
         // Get list of users typing in this conversation
         const narrow_emails_string = first_term.operand;

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -178,7 +178,7 @@ export function mark_as_unread_from_here(
     narrow,
 ) {
     if (narrow === undefined) {
-        narrow = JSON.stringify(message_lists.current.data.filter.operators());
+        narrow = JSON.stringify(message_lists.current.data.filter.terms());
     }
     message_lists.current.prevent_reading();
     const opts = {

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -184,24 +184,24 @@ run_test("test_by_conversation_and_time_url", () => {
 });
 
 run_test("test_search_public_streams_notice_url", () => {
-    function get_operators(url) {
+    function get_terms(url) {
         return hash_util.parse_narrow(url.split("/"));
     }
 
     assert.equal(
-        hash_util.search_public_streams_notice_url(get_operators("#narrow/search/abc")),
+        hash_util.search_public_streams_notice_url(get_terms("#narrow/search/abc")),
         "#narrow/streams/public/search/abc",
     );
 
     assert.equal(
         hash_util.search_public_streams_notice_url(
-            get_operators("#narrow/has/link/has/image/has/attachment"),
+            get_terms("#narrow/has/link/has/image/has/attachment"),
         ),
         "#narrow/streams/public/has/link/has/image/has/attachment",
     );
 
     assert.equal(
-        hash_util.search_public_streams_notice_url(get_operators("#narrow/sender/15")),
+        hash_util.search_public_streams_notice_url(get_terms("#narrow/sender/15")),
         "#narrow/streams/public/sender/15-Hamlet",
     );
 });

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -34,16 +34,16 @@ const hashchange = zrequire("hashchange");
 const narrow = zrequire("../src/narrow");
 const stream_data = zrequire("stream_data");
 
-run_test("operators_round_trip", () => {
-    let operators;
+run_test("terms_round_trip", () => {
+    let terms;
     let hash;
     let narrow;
 
-    operators = [
+    terms = [
         {operator: "stream", operand: "devel"},
         {operator: "topic", operand: "algol"},
     ];
-    hash = hash_util.operators_to_hash(operators);
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/stream/devel/topic/algol");
 
     narrow = hash_util.parse_narrow(hash.split("/"));
@@ -52,11 +52,11 @@ run_test("operators_round_trip", () => {
         {operator: "topic", operand: "algol", negated: false},
     ]);
 
-    operators = [
+    terms = [
         {operator: "stream", operand: "devel"},
         {operator: "topic", operand: "visual c++", negated: true},
     ];
-    hash = hash_util.operators_to_hash(operators);
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/stream/devel/-topic/visual.20c.2B.2B");
 
     narrow = hash_util.parse_narrow(hash.split("/"));
@@ -71,14 +71,14 @@ run_test("operators_round_trip", () => {
         stream_id: 987,
     };
     stream_data.add_sub(florida_stream);
-    operators = [{operator: "stream", operand: "Florida, USA"}];
-    hash = hash_util.operators_to_hash(operators);
+    terms = [{operator: "stream", operand: "Florida, USA"}];
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/stream/987-Florida.2C-USA");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [{operator: "stream", operand: "Florida, USA", negated: false}]);
 });
 
-run_test("operators_trailing_slash", () => {
+run_test("terms_trailing_slash", () => {
     const hash = "#narrow/stream/devel/topic/algol/";
     const narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [
@@ -88,7 +88,7 @@ run_test("operators_trailing_slash", () => {
 });
 
 run_test("people_slugs", () => {
-    let operators;
+    let terms;
     let hash;
     let narrow;
 
@@ -99,22 +99,22 @@ run_test("people_slugs", () => {
     };
 
     people.add_active_user(alice);
-    operators = [{operator: "sender", operand: "alice@example.com"}];
-    hash = hash_util.operators_to_hash(operators);
+    terms = [{operator: "sender", operand: "alice@example.com"}];
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/sender/42-Alice-Smith");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [{operator: "sender", operand: "alice@example.com", negated: false}]);
 
-    operators = [{operator: "dm", operand: "alice@example.com"}];
-    hash = hash_util.operators_to_hash(operators);
+    terms = [{operator: "dm", operand: "alice@example.com"}];
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/dm/42-Alice-Smith");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [{operator: "dm", operand: "alice@example.com", negated: false}]);
 
     // Even though we renamed "pm-with" to "dm", preexisting
     // links/URLs with "pm-with" operator are handled correctly.
-    operators = [{operator: "pm-with", operand: "alice@example.com"}];
-    hash = hash_util.operators_to_hash(operators);
+    terms = [{operator: "pm-with", operand: "alice@example.com"}];
+    hash = hash_util.search_terms_to_hash(terms);
     assert.equal(hash, "#narrow/pm-with/42-Alice-Smith");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [{operator: "pm-with", operand: "alice@example.com", negated: false}]);
@@ -334,10 +334,10 @@ run_test("hash_interactions", ({override, override_rewire}) => {
 run_test("save_narrow", ({override, override_rewire}) => {
     const helper = test_helper({override, override_rewire});
 
-    let operators = [{operator: "is", operand: "dm"}];
+    let terms = [{operator: "is", operand: "dm"}];
 
     blueslip.expect("error", "browser does not support pushState");
-    narrow.save_narrow(operators);
+    narrow.save_narrow(terms);
 
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(window.location.hash, "#narrow/is/dm");
@@ -347,10 +347,10 @@ run_test("save_narrow", ({override, override_rewire}) => {
         url_pushed = url;
     });
 
-    operators = [{operator: "is", operand: "starred"}];
+    terms = [{operator: "is", operand: "starred"}];
 
     helper.clear_events();
-    narrow.save_narrow(operators);
+    narrow.save_narrow(terms);
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(url_pushed, "http://zulip.zulipdev.com/#narrow/is/starred");
 });

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -38,12 +38,12 @@ function empty_narrow_html(title, html, search_data) {
     return require("../templates/empty_feed_notice.hbs")(opts);
 }
 
-function set_filter(operators) {
-    operators = operators.map((op) => ({
+function set_filter(terms) {
+    terms = terms.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));
-    narrow_state.set_current_filter(new Filter(operators));
+    narrow_state.set_current_filter(new Filter(terms));
 }
 
 const me = {
@@ -671,8 +671,8 @@ run_test("narrow_to_compose_target errors", ({disallow_rewire}) => {
 
 run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     const args = {called: false};
-    override_rewire(narrow, "activate", (operators, opts) => {
-        args.operators = operators;
+    override_rewire(narrow, "activate", (terms, opts) => {
+        args.terms = terms;
         args.opts = opts;
         args.called = true;
     });
@@ -687,7 +687,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.equal(args.opts.trigger, "narrow_to_compose_target");
-    assert.deepEqual(args.operators, [
+    assert.deepEqual(args.terms, [
         {operator: "stream", operand: "ROME"},
         {operator: "topic", operand: "one"},
     ]);
@@ -697,7 +697,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [
+    assert.deepEqual(args.terms, [
         {operator: "stream", operand: "ROME"},
         {operator: "topic", operand: "four"},
     ]);
@@ -707,20 +707,20 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "stream", operand: "ROME"}]);
 
     // Test with no topic
     compose_state.topic(undefined);
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "stream", operand: "ROME"}]);
 });
 
 run_test("narrow_to_compose_target direct messages", ({override, override_rewire}) => {
     const args = {called: false};
-    override_rewire(narrow, "activate", (operators, opts) => {
-        args.operators = operators;
+    override_rewire(narrow, "activate", (terms, opts) => {
+        args.terms = terms;
         args.opts = opts;
         args.called = true;
     });
@@ -738,37 +738,35 @@ run_test("narrow_to_compose_target direct messages", ({override, override_rewire
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "dm", operand: "alice@example.com"}]);
+    assert.deepEqual(args.terms, [{operator: "dm", operand: "alice@example.com"}]);
 
     // Test with valid persons
     emails = "alice@example.com,ray@example.com";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [
-        {operator: "dm", operand: "alice@example.com,ray@example.com"},
-    ]);
+    assert.deepEqual(args.terms, [{operator: "dm", operand: "alice@example.com,ray@example.com"}]);
 
     // Test with some invalid persons
     emails = "alice@example.com,random,ray@example.com";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "is", operand: "dm"}]);
+    assert.deepEqual(args.terms, [{operator: "is", operand: "dm"}]);
 
     // Test with all invalid persons
     emails = "alice,random,ray";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "is", operand: "dm"}]);
+    assert.deepEqual(args.terms, [{operator: "is", operand: "dm"}]);
 
     // Test with no persons
     emails = "";
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.operators, [{operator: "is", operand: "dm"}]);
+    assert.deepEqual(args.terms, [{operator: "is", operand: "dm"}]);
 });
 
 run_test("narrow_compute_title", () => {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -10,12 +10,12 @@ const {Filter} = zrequire("../src/filter");
 const stream_data = zrequire("stream_data");
 const narrow_state = zrequire("narrow_state");
 
-function set_filter(operators) {
-    operators = operators.map((op) => ({
+function set_filter(raw_terms) {
+    const terms = raw_terms.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));
-    narrow_state.set_current_filter(new Filter(operators));
+    narrow_state.set_current_filter(new Filter(terms));
 }
 
 function test(label, f) {
@@ -27,7 +27,7 @@ function test(label, f) {
 }
 
 test("stream", () => {
-    assert.equal(narrow_state.public_operators(), undefined);
+    assert.equal(narrow_state.public_search_terms(), undefined);
     assert.ok(!narrow_state.active());
     assert.equal(narrow_state.stream_id(), undefined);
 
@@ -49,14 +49,14 @@ test("stream", () => {
     assert.equal(narrow_state.topic(), "Bar");
     assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));
 
-    const expected_operators = [
+    const expected_terms = [
         {negated: false, operator: "stream", operand: "Test"},
         {negated: false, operator: "topic", operand: "Bar"},
         {negated: false, operator: "search", operand: "yo"},
     ];
 
-    const public_operators = narrow_state.public_operators();
-    assert.deepEqual(public_operators, expected_operators);
+    const public_terms = narrow_state.public_search_terms();
+    assert.deepEqual(public_terms, expected_terms);
     assert.equal(narrow_state.search_string(), "stream:Test topic:Bar yo");
 });
 
@@ -125,13 +125,13 @@ test("narrowed", () => {
     assert.ok(narrow_state.narrowed_to_starred());
 });
 
-test("operators", () => {
+test("terms", () => {
     set_filter([
         ["stream", "Foo"],
         ["topic", "Bar"],
         ["search", "Yo"],
     ]);
-    let result = narrow_state.operators();
+    let result = narrow_state.search_terms();
     assert.equal(result.length, 3);
     assert.equal(result[0].operator, "stream");
     assert.equal(result[0].operand, "Foo");
@@ -143,7 +143,7 @@ test("operators", () => {
     assert.equal(result[2].operand, "yo");
 
     narrow_state.reset_current_filter();
-    result = narrow_state.operators();
+    result = narrow_state.search_terms();
     assert.equal(result.length, 0);
 });
 

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -43,7 +43,7 @@ run_test("initialize", ({override_rewire, mock_template}) => {
     });
 
     search_suggestion.max_num_of_search_results = 999;
-    let operators;
+    let terms;
 
     $search_query_box.typeahead = (opts) => {
         assert.equal(opts.items, 999);
@@ -182,11 +182,11 @@ run_test("initialize", ({override_rewire, mock_template}) => {
                 $search_query_box.val(search_box_val);
                 Filter.parse = (search_string) => {
                     assert.equal(search_string, search_box_val);
-                    return operators;
+                    return terms;
                 };
             };
 
-            operators = [
+            terms = [
                 {
                     negated: false,
                     operator: "search",
@@ -197,7 +197,7 @@ run_test("initialize", ({override_rewire, mock_template}) => {
             assert.equal(opts.updater("ver"), "ver");
             assert.ok(is_blurred);
 
-            operators = [
+            terms = [
                 {
                     negated: false,
                     operator: "stream",
@@ -219,8 +219,8 @@ run_test("initialize", ({override_rewire, mock_template}) => {
     };
 
     search.initialize({
-        on_narrow_search(raw_operators, options) {
-            assert.deepEqual(raw_operators, operators);
+        on_narrow_search(raw_terms, options) {
+            assert.deepEqual(raw_terms, terms);
             assert.deepEqual(options, {trigger: "search"});
         },
     });
@@ -268,11 +268,11 @@ run_test("initialize", ({override_rewire, mock_template}) => {
         $search_query_box.val(search_box_val);
         Filter.parse = (search_string) => {
             assert.equal(search_string, search_box_val);
-            return operators;
+            return terms;
         };
     };
 
-    operators = [
+    terms = [
         {
             negated: false,
             operator: "search",

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -333,7 +333,7 @@ test("group_suggestions", ({mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    // Test multiple operators
+    // Test multiple terms
     query = "is:starred has:link dm:bob@zulip.com,Smit";
     suggestions = get_suggestions(query);
     expected = [


### PR DESCRIPTION
Operand is a confusing name because this
data structure has an attribute *called*
operand. This commit renames references to
this structure to "term", short for "search
term".

This PR is a followup from this comment https://github.com/zulip/zulip/pull/28229#discussion_r1427278515 and a conversation with Anders.

This seems like a brittle change, so I'm putting it in its own PR. It seems easy to forget a rename and have it not caught by tests or the linter. Curious if there are ways that would be good for testing this.