### PR TITLE
zilencer: Set .remote_realm for existing RemotePushDeviceToken.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -289,7 +289,7 @@ class SendTestPushNotificationEndpointTest(BouncerTestCase):
         self.add_mock_response()
 
         user = self.example_user("cordelia")
-        server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        server = self.server
 
         token = "111222"
         token_kind = PushDeviceToken.GCM
@@ -605,7 +605,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
     def test_send_notification_endpoint(self) -> None:
         hamlet = self.example_user("hamlet")
-        server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        server = self.server
         token = "aaaa"
         android_tokens = []
         uuid_android_tokens = []
@@ -713,7 +713,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
     def test_send_notification_endpoint_on_free_plans(self) -> None:
         hamlet = self.example_user("hamlet")
-        remote_server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        remote_server = self.server
         RemotePushDeviceToken.objects.create(
             kind=RemotePushDeviceToken.GCM,
             token=hex_to_b64("aaaaaa"),
@@ -921,7 +921,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
             kind=RemotePushDeviceToken.GCM,
             token=hex_to_b64("aaaaaa"),
             user_id=hamlet.id,
-            server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+            server=self.server,
         )
 
         time_sent = now().replace(microsecond=234000)
@@ -1123,7 +1123,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         self.add_mock_response()
         user = self.example_user("cordelia")
         self.login_user(user)
-        server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        server = self.server
 
         endpoints: List[Tuple[str, str, int, Mapping[str, str]]] = [
             (
@@ -1396,7 +1396,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
         self.add_mock_response()
         # Send any existing data over, so that we can start the test with a "clean" slate
-        remote_server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        remote_server = self.server
         assert remote_server is not None
         assert remote_server.last_version is None
 
@@ -1407,7 +1407,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
         assert audit_log is not None
         audit_log_max_id = audit_log.id
 
-        remote_server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
+        remote_server.refresh_from_db()
         assert remote_server.last_version == ZULIP_VERSION
 
         remote_audit_log_count = RemoteRealmAuditLog.objects.count()
@@ -2494,14 +2494,14 @@ class PushNotificationTest(BouncerTestCase):
                 token=hex_to_b64(id_token),
                 ios_app_id=appid,
                 user_id=self.user_profile.id,
-                server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+                server=self.server,
             )
             RemotePushDeviceToken.objects.create(
                 kind=RemotePushDeviceToken.APNS,
                 token=hex_to_b64(uuid_token),
                 ios_app_id=appid,
                 user_uuid=self.user_profile.uuid,
-                server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+                server=self.server,
             )
 
     def setup_gcm_tokens(self) -> None:
@@ -2520,13 +2520,13 @@ class PushNotificationTest(BouncerTestCase):
                 kind=RemotePushDeviceToken.GCM,
                 token=hex_to_b64(id_token),
                 user_id=self.user_profile.id,
-                server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+                server=self.server,
             )
             RemotePushDeviceToken.objects.create(
                 kind=RemotePushDeviceToken.GCM,
                 token=hex_to_b64(uuid_token),
                 user_uuid=self.user_profile.uuid,
-                server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+                server=self.server,
             )
 
 
@@ -3524,7 +3524,7 @@ class TestAPNs(PushNotificationTest):
             token="1234",
             ios_app_id=None,
             user_id=self.user_profile.id,
-            server=RemoteZulipServer.objects.get(uuid=self.server_uuid),
+            server=self.server,
         )
         with self.mock_apns() as (apns_context, send_notification), self.assertLogs(
             "zerver.lib.push_notifications", level="INFO"

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -494,6 +494,9 @@ def remote_server_notify_push(
         increment=len(android_devices) + len(apple_devices),
     )
     if remote_realm is not None:
+        ensure_devices_set_remote_realm(
+            android_devices=android_devices, apple_devices=apple_devices, remote_realm=remote_realm
+        )
         do_increment_logging_stat(
             remote_realm,
             COUNT_STATS["mobile_pushes_received::day"],
@@ -669,6 +672,20 @@ def batch_create_table_data(
             server.hostname,
             server.uuid,
         )
+
+
+def ensure_devices_set_remote_realm(
+    android_devices: List[RemotePushDeviceToken],
+    apple_devices: List[RemotePushDeviceToken],
+    remote_realm: RemoteRealm,
+) -> None:
+    devices_to_update = []
+    for device in android_devices + apple_devices:
+        if device.remote_realm_id is None:
+            device.remote_realm = remote_realm
+            devices_to_update.append(device)
+
+    RemotePushDeviceToken.objects.bulk_update(devices_to_update, ["remote_realm"])
 
 
 def update_remote_realm_data_for_server(


### PR DESCRIPTION
Old RemotePushDeviceTokens were created without this attribute. But when processing a notification, if we have remote_realm, we can take the opportunity to to set this for all the registrations for this user.

