### PR TITLE
display-settings-form -> preferences-form refer

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -481,7 +481,7 @@ input[type="checkbox"] {
     }
 }
 
-.display-settings-form,
+.preferences-form,
 .notification-settings-form {
     .subsection-header h3 {
         display: inline-block;
@@ -1427,7 +1427,7 @@ $option_title_width: 180px;
         }
     }
 
-    .display-settings-form select {
+    .preferences-form select {
         width: 245px;
     }
 }

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -1,4 +1,4 @@
-<form class="display-settings-form">
+<form class="preferences-form">
     <div class="general-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->


### PR DESCRIPTION
Fixes: a part of #26874 

PR changes  `display-settings-form`  -> `preferences-form` in below file

zulip\web\styles\settings.css
zulip\web\templates\settings\display_settings.hbs


