### PR TITLE
Finish renaming Display settings -> Preferences  

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -387,8 +387,8 @@ async function test_i18n_language_precedence(page: Page): Promise<void> {
 }
 
 async function test_default_language_setting(page: Page): Promise<void> {
-    const display_settings_section = '[data-section="preferences"]';
-    await page.click(display_settings_section);
+    const preferences_section = '[data-section="preferences"]';
+    await page.click(preferences_section);
 
     const chinese_language_data_code = "zh-hans";
     await change_language(page, chinese_language_data_code);
@@ -400,8 +400,8 @@ async function test_default_language_setting(page: Page): Promise<void> {
     });
     await assert_language_changed_to_chinese(page);
     await test_i18n_language_precedence(page);
-    await page.waitForSelector(display_settings_section, {visible: true});
-    await page.click(display_settings_section);
+    await page.waitForSelector(preferences_section, {visible: true});
+    await page.click(preferences_section);
 
     // Change the language back to English so that subsequent tests pass.
     await change_language(page, "en");
@@ -409,8 +409,8 @@ async function test_default_language_setting(page: Page): Promise<void> {
     // Check that the saved indicator appears
     await check_language_setting_status(page);
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
-    await page.waitForSelector(display_settings_section, {visible: true});
-    await page.click(display_settings_section);
+    await page.waitForSelector(preferences_section, {visible: true});
+    await page.click(preferences_section);
     await page.waitForSelector("#user-preferences .general-settings-status", {
         visible: true,
     });

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -186,7 +186,7 @@ export function build_page() {
         color_scheme_values: settings_config.color_scheme_values,
         web_home_view_values: settings_config.web_home_view_values,
         settings_object: realm_user_settings_defaults,
-        display_settings: settings_config.get_all_display_settings(),
+        display_settings: settings_config.get_all_preferences(),
         settings_label: settings_config.realm_user_settings_defaults_labels,
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         enable_sound_select:

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -186,7 +186,7 @@ export function build_page() {
         color_scheme_values: settings_config.color_scheme_values,
         web_home_view_values: settings_config.web_home_view_values,
         settings_object: realm_user_settings_defaults,
-        display_settings: settings_config.get_all_preferences(),
+        preferences: settings_config.get_all_preferences(),
         settings_label: settings_config.realm_user_settings_defaults_labels,
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         enable_sound_select:

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -134,7 +134,7 @@ export function build_page() {
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         show_push_notifications_tooltip:
             settings_config.all_notifications(user_settings).show_push_notifications_tooltip,
-        display_settings: settings_config.get_all_display_settings(),
+        display_settings: settings_config.get_all_preferences(),
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_can_change_email: settings_data.user_can_change_email(),

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -61,7 +61,7 @@ function setup_settings_label() {
         }),
 
         ...settings_config.notification_settings_labels,
-        ...settings_config.display_settings_labels,
+        ...settings_config.preferences_labels,
     };
 }
 

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -134,7 +134,7 @@ export function build_page() {
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         show_push_notifications_tooltip:
             settings_config.all_notifications(user_settings).show_push_notifications_tooltip,
-        display_settings: settings_config.get_all_preferences(),
+        preferences: settings_config.get_all_preferences(),
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_can_change_email: settings_data.user_can_change_email(),

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -536,7 +536,7 @@ export const expires_in_values = {
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
 
-export const display_settings_labels = {
+export const preferences_labels = {
     dense_mode: $t({defaultMessage: "Dense mode"}),
     fluid_layout_width: $t({defaultMessage: "Use full width on wide screens"}),
     high_contrast_mode: $t({defaultMessage: "High contrast mode"}),
@@ -593,7 +593,7 @@ export const notification_settings_labels = {
 
 export const realm_user_settings_defaults_labels = {
     ...notification_settings_labels,
-    ...display_settings_labels,
+    ...preferences_labels,
 
     /* Overrides to remove "I" from labels for the realm-level versions of these labels. */
     enable_online_push_notifications: $t({

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -139,7 +139,7 @@ export type DisplaySettings = {
 };
 
 /* istanbul ignore next */
-export const get_all_display_settings = (): DisplaySettings => ({
+export const get_all_preferences = (): DisplaySettings => ({
     settings: {
         user_display_settings: [
             "dense_mode",

--- a/web/src/settings_display.js
+++ b/web/src/settings_display.js
@@ -209,7 +209,7 @@ export function set_up(settings_panel) {
         if (current_emojiset === data.emojiset) {
             return;
         }
-        const $spinner = $container.find(".emoji-display-settings-status").expectOne();
+        const $spinner = $container.find(".emoji-preferences-status").expectOne();
         loading.make_indicator($spinner, {text: settings_ui.strings.saving});
 
         channel.patch({
@@ -220,7 +220,7 @@ export function set_up(settings_panel) {
                 ui_report.error(
                     settings_ui.strings.failure_html,
                     xhr,
-                    $container.find(".emoji-display-settings-status").expectOne(),
+                    $container.find(".emoji-preferences-status").expectOne(),
                 );
             },
         });
@@ -259,7 +259,7 @@ export async function report_emojiset_change(settings_panel) {
     // update in all active browser windows.
     await emojisets.select(settings_panel.settings_object.emojiset);
 
-    const $spinner = $(settings_panel.container).find(".emoji-display-settings-status");
+    const $spinner = $(settings_panel.container).find(".emoji-preferences-status");
     if ($spinner.length) {
         loading.destroy_indicator($spinner);
         ui_report.success(

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1107,7 +1107,7 @@ input[type="checkbox"] {
     padding: 0 10px;
 }
 
-label.display-settings-radio-choice-label {
+label.preferences-radio-choice-labeld {
     border-bottom: 1px solid hsl(0deg 0% 0% / 20%);
     padding: 8px 0 10px;
     display: flex;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -481,7 +481,7 @@ input[type="checkbox"] {
     }
 }
 
-.display-settings-form,
+.preferences-form,
 .notification-settings-form {
     .subsection-header h3 {
         display: inline-block;
@@ -1427,7 +1427,7 @@ $option_title_width: 180px;
         }
     }
 
-    .display-settings-form select {
+    .preferences-form select {
         width: 245px;
     }
 }

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -30,10 +30,10 @@
         </div>
     </div>
 
-    <div class="emoji-display-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="emoji-preferences {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3 class="light">{{t "Emoji" }}</h3>
-            {{> settings_save_discard_widget section_name="emoji-display-settings" show_only_indicator=(not for_realm_settings) }}
+            {{> settings_save_discard_widget section_name="emoji-preferences" show_only_indicator=(not for_realm_settings) }}
         </div>
 
         <div class="input-group">

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -40,7 +40,7 @@
             <label class="emoji-theme title">{{t "Emoji theme" }}</label>
             <div class="emojiset_choices grey-box prop-element" id="{{prefix}}emojiset" data-setting-widget-type="radio-group" data-setting-choice-type="string">
                 {{#each settings_object.emojiset_choices}}
-                    <label class="display-settings-radio-choice-label">
+                    <label class="preferences-radio-choice-labeld">
                         <div class="radio-choice-controls">
                             <input type="radio" class="setting_emojiset_choice" name="emojiset" value="{{this.key}}"/>
                             <span>{{this.text}}</span>
@@ -97,7 +97,7 @@
             <label class="title">{{t "User list style" }}</label>
             <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
                 {{#each user_list_style_values}}
-                    <label class="display-settings-radio-choice-label">
+                    <label class="preferences-radio-choice-labeld">
                         <div class="radio-choice-controls">
                             <input type="radio" class="setting_user_list_style_choice" name="user_list_style" value="{{this.code}}"/>
                             <span>{{this.description}}</span>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -1,4 +1,4 @@
-<form class="display-settings-form">
+<form class="preferences-form">
     <div class="general-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -6,7 +6,7 @@
             {{#*inline "z-link"}}<a href="/help/configure-default-new-user-settings" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
         {{/tr}}
     </div>
-    {{> display_settings prefix="realm_" for_realm_settings=true full_name=full_name}}
+    {{> preferences prefix="realm_" for_realm_settings=true full_name=full_name}}
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
 

--- a/web/templates/settings/preferences.hbs
+++ b/web/templates/settings/preferences.hbs
@@ -155,12 +155,12 @@
             </select>
         </div>
 
-        {{#each display_settings.settings.user_display_settings}}
+        {{#each preferences.settings.user_display_settings}}
             {{> settings_checkbox
               setting_name=this
               is_checked=(lookup ../settings_object this)
               label=(lookup ../settings_label this)
-              render_only=(lookup ../display_settings.render_only this)
+              render_only=(lookup ../preferences.render_only this)
               prefix=../prefix}}
         {{/each}}
 

--- a/web/templates/settings/user_display_settings.hbs
+++ b/web/templates/settings/user_display_settings.hbs
@@ -1,3 +1,3 @@
 <div id="user-preferences" class="settings-section" data-name="preferences">
-    {{> display_settings prefix="user_" for_realm_settings=false}}
+    {{> preferences prefix="user_" for_realm_settings=false}}
 </div>

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -89,7 +89,7 @@ run_test("tr_tag", ({mock_template}) => {
     const args = {
         botserverrc: "botserverrc",
         date_joined_text: "Mar 21, 2022",
-        display_settings: {
+        preferences: {
             settings: {},
         },
         notification_settings: {},

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -480,7 +480,7 @@ def do_change_user_setting(
         }
         send_event_on_commit(user_profile.realm, legacy_event, [user_profile.id])
 
-    if setting_name in UserProfile.display_settings_legacy or setting_name == "timezone":
+    if setting_name in UserProfile.preferences_legacy or setting_name == "timezone":
         # This legacy event format is for backwards-compatibility with
         # clients that don't support the new user_settings event type.
         # We only send this for settings added before Feature level 89.

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1517,7 +1517,7 @@ update_display_settings_event = event_dict_type(
         ("language_name", str),
     ],
 )
-_check_update_display_settings = make_checker(update_display_settings_event)
+_check_update_preferences = make_checker(update_display_settings_event)
 
 user_settings_update_event = event_dict_type(
     required_keys=[
@@ -1534,7 +1534,7 @@ user_settings_update_event = event_dict_type(
 _check_user_settings_update = make_checker(user_settings_update_event)
 
 
-def check_update_preferences(
+def check_update_display_settings(
     var_name: str,
     event: Dict[str, object],
 ) -> None:
@@ -1543,7 +1543,7 @@ def check_update_preferences(
     is more specifically typed according to the
     UserProfile.property_types dictionary.
     """
-    _check_update_display_settings(var_name, event)
+    _check_update_preferences(var_name, event)
     setting_name = event["setting_name"]
     setting = event["setting"]
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1517,7 +1517,7 @@ update_display_settings_event = event_dict_type(
         ("language_name", str),
     ],
 )
-_check_update_display_settings = make_checker(update_display_settings_event)
+_check_update_preferences = make_checker(update_display_settings_event)
 
 user_settings_update_event = event_dict_type(
     required_keys=[
@@ -1543,7 +1543,7 @@ def check_update_display_settings(
     is more specifically typed according to the
     UserProfile.property_types dictionary.
     """
-    _check_update_display_settings(var_name, event)
+    _check_update_preferences(var_name, event)
     setting_name = event["setting_name"]
     setting = event["setting"]
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1534,7 +1534,7 @@ user_settings_update_event = event_dict_type(
 _check_user_settings_update = make_checker(user_settings_update_event)
 
 
-def check_update_display_settings(
+def check_update_preferences(
     var_name: str,
     event: Dict[str, object],
 ) -> None:

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1517,7 +1517,7 @@ update_display_settings_event = event_dict_type(
         ("language_name", str),
     ],
 )
-_check_update_preferences = make_checker(update_display_settings_event)
+_check_update_display_settings = make_checker(update_display_settings_event)
 
 user_settings_update_event = event_dict_type(
     required_keys=[
@@ -1543,7 +1543,7 @@ def check_update_preferences(
     is more specifically typed according to the
     UserProfile.property_types dictionary.
     """
-    _check_update_preferences(var_name, event)
+    _check_update_display_settings(var_name, event)
     setting_name = event["setting_name"]
     setting = event["setting"]
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -641,7 +641,7 @@ def fetch_initial_state_data(
         state["stop_words"] = read_stop_words()
 
     if want("update_display_settings") and not user_settings_object:
-        for prop in UserProfile.display_settings_legacy:
+        for prop in UserProfile.preferences_legacy:
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = canonicalize_timezone(settings_user.timezone)
@@ -1407,7 +1407,7 @@ def apply_event(
         state["realm_playgrounds"] = event["realm_playgrounds"]
     elif event["type"] == "update_display_settings":
         if event["setting_name"] != "timezone":
-            assert event["setting_name"] in UserProfile.display_settings_legacy
+            assert event["setting_name"] in UserProfile.preferences_legacy
         state[event["setting_name"]] = event["setting"]
     elif event["type"] == "update_global_notifications":
         assert event["notification_name"] in UserProfile.notification_settings_legacy
@@ -1418,7 +1418,7 @@ def apply_event(
         if event["property"] != "timezone":
             assert event["property"] in UserProfile.property_types
         if event["property"] in {
-            **UserProfile.display_settings_legacy,
+            **UserProfile.preferences_legacy,
             **UserProfile.notification_settings_legacy,
         }:
             state[event["property"]] = event["value"]

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -259,7 +259,7 @@ class UserBaseSettings(models.Model):
 
     EMAIL_ADDRESS_VISIBILITY_TYPES = list(EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.keys())
 
-    display_settings_legacy = dict(
+    preferences_legacy = dict(
         # Don't add anything new to this legacy dict.
         # Instead, see `modern_settings` below.
         color_scheme=int,
@@ -335,7 +335,7 @@ class UserBaseSettings(models.Model):
 
     # Define the types of the various automatically managed properties
     property_types = {
-        **display_settings_legacy,
+        **preferences_legacy,
         **notification_setting_types,
         **modern_settings,
     }

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -746,7 +746,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assertIn("user_settings", result)
         for prop in UserProfile.property_types:
             if prop in {
-                **UserProfile.display_settings_legacy,
+                **UserProfile.preferences_legacy,
                 **UserProfile.notification_settings_legacy,
             }:
                 # Only legacy settings are included in the top level.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -184,7 +184,7 @@ from zerver.lib.event_schema import (
     check_subscription_update,
     check_typing_start,
     check_typing_stop,
-    check_update_display_settings,
+    check_update_preferences,
     check_update_global_notifications,
     check_update_message,
     check_update_message_flags_add,
@@ -3870,7 +3870,7 @@ class UserDisplayActionTest(BaseAction):
                 # Only settings added before feature level 89
                 # generate this event.
                 self.assert_length(events, 2)
-                check_update_display_settings("events[1]", events[1])
+                check_update_preferences("events[1]", events[1])
 
     def test_change_user_settings(self) -> None:
         for prop in UserProfile.property_types:
@@ -3896,7 +3896,7 @@ class UserDisplayActionTest(BaseAction):
             )
 
             check_user_settings_update("events[0]", events[0])
-            check_update_display_settings("events[1]", events[1])
+            check_update_preferences("events[1]", events[1])
             check_realm_user_update("events[2]", events[2], "timezone")
 
     def test_delivery_email_events_on_changing_email_address_visibility(self) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3817,7 +3817,7 @@ class UserDisplayActionTest(BaseAction):
         user_settings_object = True
         num_events = 1
 
-        legacy_setting = setting_name in UserProfile.display_settings_legacy
+        legacy_setting = setting_name in UserProfile.preferences_legacy
         if legacy_setting:
             # Two events:`update_display_settings` and `user_settings`.
             # `update_display_settings` is only sent for settings added

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -184,7 +184,7 @@ from zerver.lib.event_schema import (
     check_subscription_update,
     check_typing_start,
     check_typing_stop,
-    check_update_preferences,
+    check_update_display_settings,
     check_update_global_notifications,
     check_update_message,
     check_update_message_flags_add,
@@ -3870,7 +3870,7 @@ class UserDisplayActionTest(BaseAction):
                 # Only settings added before feature level 89
                 # generate this event.
                 self.assert_length(events, 2)
-                check_update_preferences("events[1]", events[1])
+                check_update_display_settings("events[1]", events[1])
 
     def test_change_user_settings(self) -> None:
         for prop in UserProfile.property_types:
@@ -3896,7 +3896,7 @@ class UserDisplayActionTest(BaseAction):
             )
 
             check_user_settings_update("events[0]", events[0])
-            check_update_preferences("events[1]", events[1])
+            check_update_display_settings("events[1]", events[1])
             check_realm_user_update("events[2]", events[2], "timezone")
 
     def test_delivery_email_events_on_changing_email_address_visibility(self) -> None:


### PR DESCRIPTION
Fixes:  #26874
PR  Finish renaming 
`display-settings-form` -> `preferences-form` 
zulip\web\styles\settings.css
zulip\web\templates\settings\display_settings.hbs

`display-settings-radio-choice-label` -> `preferences-radio-choice-labeld` 
zulip\web\styles\settings.css
zulip\web\templates\settings\display_settings.hbs

`emoji-display-settings-status` -> `emoji-preferences-status`
zulip\web\src\settings_display.js

`emoji-display-settings` -> `emoji-preferences`
web\templates\settings\display_settings.hbs

`display_settings_legacy` -> `preferences_legacy`
zulip\zerver\actions\user_settings.py
zulip\zerver\lib\events.py
zulip\zerver\models\users.py
zulip\zerver\tests\test_events.py
zulip\zerver\tests\test_event_system.py

`display_settings_labels` -> `preferences_labels`
zulip\web\src\settings.js
zulip\web\src\settings_config.ts

`get_all_display_settings` -> `get_all_preferences`
zulip\web\src\admin.js
zulip\web\src\settings.js
zulip\web\src\settings_config.ts

`_check_update_display_settings` -> `_check_update_preferences`
zulip\zerver\lib\event_schema.py

`display_settings` -> `preferences`
zulip\web\src\admin.js
zulip\web\src\settings.js
zulip\web\templates\settings\display_settings.hbs
zulip\web\templates\settings\organization_user_settings_defaults.hbs
zulip\web\templates\settings\user_display_settings.hbs
zulip\web\tests\i18n.test.js

'display_settings.hbs' ->  'preferences.hbs'

`display_settings_section` -> `preferences_section`
zulip\web\e2e-tests\settings.test.ts