### PR TITLE
eslint: Enable @typescript-eslint/method-signature-style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -182,6 +182,7 @@
                     {"allowExpressions": true}
                 ],
                 "@typescript-eslint/member-ordering": "error",
+                "@typescript-eslint/method-signature-style": "error",
                 "@typescript-eslint/no-non-null-assertion": "off",
                 "@typescript-eslint/no-unnecessary-condition": "off",
                 "@typescript-eslint/no-unnecessary-qualifier": "error",

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -16,13 +16,13 @@ import * as keydown_util from "./keydown_util";
 */
 
 export type Toggle = {
-    maybe_go_left(): boolean;
-    maybe_go_right(): boolean;
-    disable_tab(name: string): void;
-    enable_tab(name: string): void;
-    value(): string | undefined;
-    get(): JQuery;
-    goto(name: string): void;
+    maybe_go_left: () => boolean;
+    maybe_go_right: () => boolean;
+    disable_tab: (name: string) => void;
+    enable_tab: (name: string) => void;
+    value: () => string | undefined;
+    get: () => JQuery;
+    goto: (name: string) => void;
 };
 
 export function toggle(opts: {

--- a/web/src/compose_fade_users.ts
+++ b/web/src/compose_fade_users.ts
@@ -2,9 +2,9 @@ import * as compose_fade_helper from "./compose_fade_helper";
 import * as people from "./people";
 
 export type UserFadeConfig = {
-    get_user_id($li: JQuery): number;
-    fade($li: JQuery): void;
-    unfade($li: JQuery): void;
+    get_user_id: ($li: JQuery) => number;
+    fade: ($li: JQuery) => void;
+    unfade: ($li: JQuery) => void;
 };
 
 function update_user_row_when_fading($li: JQuery, conf: UserFadeConfig): void {

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -26,7 +26,11 @@ export function initialize_pill(): UserPillWidget {
     return pill;
 }
 
-export function initialize({on_pill_create_or_remove}: {on_pill_create_or_remove(): void}): void {
+export function initialize({
+    on_pill_create_or_remove,
+}: {
+    on_pill_create_or_remove: () => void;
+}): void {
     widget = initialize_pill();
 
     widget.onPillCreate(() => {

--- a/web/src/electron_bridge.d.ts
+++ b/web/src/electron_bridge.d.ts
@@ -6,7 +6,7 @@ export type NotificationData = {
     tag: string;
     icon: string;
     data: unknown;
-    close(): void;
+    close: () => void;
 };
 
 export type ClipboardDecrypter = {
@@ -16,25 +16,25 @@ export type ClipboardDecrypter = {
 };
 
 export type ElectronBridge = {
-    send_event(eventName: string | symbol, ...args: unknown[]): boolean;
-    on_event(
+    send_event: (eventName: string | symbol, ...args: unknown[]) => boolean;
+    on_event: ((
         eventName: "logout" | "show-keyboard-shortcuts" | "show-notification-settings",
         listener: () => void,
-    ): void;
-    on_event(
-        eventName: "send_notification_reply_message",
-        listener: (message_id: unknown, reply: unknown) => void,
-    ): void;
-    new_notification?(
+    ) => void) &
+        ((
+            eventName: "send_notification_reply_message",
+            listener: (message_id: unknown, reply: unknown) => void,
+        ) => void);
+    new_notification?: (
         title: string,
         options: NotificationOptions,
         dispatch: (type: string, eventInit: EventInit) => boolean,
-    ): NotificationData;
-    get_idle_on_system?(): boolean;
-    get_last_active_on_system?(): number;
-    get_send_notification_reply_message_supported?(): boolean;
-    set_send_notification_reply_message_supported?(value: boolean): void;
-    decrypt_clipboard?(version: number): ClipboardDecrypter;
+    ) => NotificationData;
+    get_idle_on_system?: () => boolean;
+    get_last_active_on_system?: () => number;
+    get_send_notification_reply_message_supported?: () => boolean;
+    set_send_notification_reply_message_supported?: (value: boolean) => void;
+    decrypt_clipboard?: (version: number) => ClipboardDecrypter;
 };
 
 declare global {

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -33,21 +33,20 @@ declare namespace JQueryValidation {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface JQuery {
-    expectOne(): this;
-    get_offset_to_window(): DOMRect;
-    tab(action?: string): this; // From web/third/bootstrap
+    expectOne: () => this;
+    get_offset_to_window: () => DOMRect;
+    tab: (action?: string) => this; // From web/third/bootstrap
 
     // Types for jquery-caret-plugin
-    caret(): number;
-    caret(arg: number | string): this;
-    range(): JQueryCaretRange;
-    range(start: number, end?: number): this;
-    range(text: string): this;
-    selectAll(): this;
-    deselectAll(): this;
+    caret: (() => number) & ((arg: number | string) => this);
+    range: (() => JQueryCaretRange) &
+        ((start: number, end?: number) => this) &
+        ((text: string) => this);
+    selectAll: () => this;
+    deselectAll: () => this;
 
     // Types for jquery-idle plugin
-    idle(opts: JQueryIdleOptions): {
+    idle: (opts: JQueryIdleOptions) => {
         cancel: () => void;
         reset: () => void;
     };

--- a/web/src/list_cursor.ts
+++ b/web/src/list_cursor.ts
@@ -5,10 +5,10 @@ import * as scroll_util from "./scroll_util";
 
 type List<Key> = {
     scroll_container_selector: string;
-    find_li(opts: {key: Key; force_render: boolean}): JQuery;
-    first_key(): Key | undefined;
-    prev_key(key: Key): Key | undefined;
-    next_key(key: Key): Key | undefined;
+    find_li: (opts: {key: Key; force_render: boolean}) => JQuery;
+    first_key: () => Key | undefined;
+    prev_key: (key: Key) => Key | undefined;
+    next_key: (key: Key) => Key | undefined;
 };
 
 export class ListCursor<Key> {
@@ -36,7 +36,7 @@ export class ListCursor<Key> {
         return this.curr_key;
     }
 
-    get_row(key: Key | undefined): {highlight(): void; clear(): void} | undefined {
+    get_row(key: Key | undefined): {highlight: () => void; clear: () => void} | undefined {
         // TODO: The list class should probably do more of the work
         //       here, so we're not so coupled to jQuery, and
         //       so we instead just get back a widget we can say

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -9,7 +9,7 @@ import * as scroll_util from "./scroll_util";
 
 type SortingFunction<T> = (a: T, b: T) => number;
 
-type ListWidgetMeta<Key = unknown, Item = Key> = {
+type ListWidgetMeta<Key, Item = Key> = {
     sorting_function: SortingFunction<Item> | null;
     sorting_functions: Map<string, SortingFunction<Item>>;
     filter_value: string;
@@ -21,7 +21,7 @@ type ListWidgetMeta<Key = unknown, Item = Key> = {
 };
 
 // This type ensures the mutually exclusive nature of the predicate and filterer options.
-type ListWidgetFilterOpts<Item = unknown> = {
+type ListWidgetFilterOpts<Item> = {
     $element?: JQuery<HTMLInputElement>;
     onupdate?: () => void;
 } & (
@@ -35,7 +35,7 @@ type ListWidgetFilterOpts<Item = unknown> = {
       }
 );
 
-type ListWidgetOpts<Key = unknown, Item = Key> = {
+type ListWidgetOpts<Key, Item = Key> = {
     name?: string;
     get_item: (key: Key) => Item;
     modifier_html: (item: Item, filter_value: string) => string;
@@ -55,7 +55,11 @@ type ListWidgetOpts<Key = unknown, Item = Key> = {
     $parent_container?: JQuery;
 };
 
-type ListWidget<Key = unknown, Item = Key> = {
+type BaseListWidget = {
+    clear_event_handlers(): void;
+};
+
+type ListWidget<Key, Item = Key> = BaseListWidget & {
     get_current_list(): Item[];
     filter_and_sort(): void;
     retain_selected_items(): void;
@@ -67,7 +71,6 @@ type ListWidget<Key = unknown, Item = Key> = {
     set_reverse_mode(reverse_mode: boolean): void;
     set_sorting_function(sorting_function: string | SortingFunction<Item>): void;
     set_up_event_handlers(): void;
-    clear_event_handlers(): void;
     increase_rendered_offset(): void;
     reduce_rendered_offset(): void;
     remove_rendered_row(row: JQuery): void;
@@ -81,7 +84,7 @@ type ListWidget<Key = unknown, Item = Key> = {
 const DEFAULTS = {
     INITIAL_RENDER_COUNT: 80,
     LOAD_COUNT: 20,
-    instances: new Map<string, ListWidget>(),
+    instances: new Map<string, BaseListWidget>(),
 };
 
 // ----------------------------------------------------
@@ -244,7 +247,7 @@ export function render_empty_list_message_if_needed(
 // $container: jQuery object to append to.
 // list: The list of items to progressively append.
 // opts: An object of random preferences.
-export function create<Key = unknown, Item = Key>(
+export function create<Key, Item = Key>(
     $container: JQuery,
     list: Key[],
     opts: ListWidgetOpts<Key, Item>,
@@ -594,4 +597,4 @@ export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>)
     list.sort(sort_type, prop_name);
 }
 
-export const default_get_item = <T = unknown>(item: T): T => item;
+export const default_get_item = <T>(item: T): T => item;

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -559,10 +559,6 @@ export function create<Key = unknown, Item = Key>(
     return widget;
 }
 
-export function get(name: string): ListWidget | false {
-    return DEFAULTS.instances.get(name) ?? false;
-}
-
 export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>): void {
     /*
         one would specify sort parameters like this:

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -563,7 +563,7 @@ export function get(name: string): ListWidget | false {
     return DEFAULTS.instances.get(name) ?? false;
 }
 
-export function handle_sort($th: JQuery, list: ListWidget): void {
+export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>): void {
     /*
         one would specify sort parameters like this:
             - name => sort alphabetic.

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -56,29 +56,32 @@ type ListWidgetOpts<Key, Item = Key> = {
 };
 
 type BaseListWidget = {
-    clear_event_handlers(): void;
+    clear_event_handlers: () => void;
 };
 
 type ListWidget<Key, Item = Key> = BaseListWidget & {
-    get_current_list(): Item[];
-    filter_and_sort(): void;
-    retain_selected_items(): void;
-    all_rendered(): boolean;
-    render(how_many?: number): void;
-    render_item(item: Item): void;
-    clear(): void;
-    set_filter_value(value: string): void;
-    set_reverse_mode(reverse_mode: boolean): void;
-    set_sorting_function(sorting_function: string | SortingFunction<Item>): void;
-    set_up_event_handlers(): void;
-    increase_rendered_offset(): void;
-    reduce_rendered_offset(): void;
-    remove_rendered_row(row: JQuery): void;
-    clean_redraw(): void;
-    hard_redraw(): void;
-    insert_rendered_row(item: Item, get_insert_index: (list: Item[], item: Item) => number): void;
-    sort(sorting_function: string, prop?: string): void;
-    replace_list_data(list: Key[]): void;
+    get_current_list: () => Item[];
+    filter_and_sort: () => void;
+    retain_selected_items: () => void;
+    all_rendered: () => boolean;
+    render: (how_many?: number) => void;
+    render_item: (item: Item) => void;
+    clear: () => void;
+    set_filter_value: (value: string) => void;
+    set_reverse_mode: (reverse_mode: boolean) => void;
+    set_sorting_function: (sorting_function: string | SortingFunction<Item>) => void;
+    set_up_event_handlers: () => void;
+    increase_rendered_offset: () => void;
+    reduce_rendered_offset: () => void;
+    remove_rendered_row: (row: JQuery) => void;
+    clean_redraw: () => void;
+    hard_redraw: () => void;
+    insert_rendered_row: (
+        item: Item,
+        get_insert_index: (list: Item[], item: Item) => number,
+    ) => void;
+    sort: (sorting_function: string, prop?: string) => void;
+    replace_list_data: (list: Key[]) => void;
 };
 
 const DEFAULTS = {

--- a/web/src/localstorage.ts
+++ b/web/src/localstorage.ts
@@ -15,20 +15,20 @@ const formDataSchema = z
 type FormData = z.infer<typeof formDataSchema>;
 
 export type LocalStorage = {
-    setExpiry(expires: number, isGlobal: boolean): LocalStorage;
-    get(name: string): unknown;
-    set(name: string, data: unknown): boolean;
-    remove(name: string): void;
-    removeDataRegexWithCondition(
+    setExpiry: (expires: number, isGlobal: boolean) => LocalStorage;
+    get: (name: string) => unknown;
+    set: (name: string, data: unknown) => boolean;
+    remove: (name: string) => void;
+    removeDataRegexWithCondition: (
         name: string,
         condition_checker: (value: string | null | undefined) => boolean,
-    ): void;
-    migrate<T = unknown>(
+    ) => void;
+    migrate: <T = unknown>(
         name: string,
         v1: number,
         v2: number,
         callback: (data: unknown) => T,
-    ): T | undefined;
+    ) => T | undefined;
 };
 
 const ls = {

--- a/web/src/markdown_config.ts
+++ b/web/src/markdown_config.ts
@@ -33,40 +33,40 @@ import {user_settings} from "./user_settings";
 
 // TODO/typescript: Move this to markdown
 type AbstractMap<K, V> = {
-    keys(): Iterator<K>;
-    entries(): Iterator<[K, V]>;
-    get(k: K): V | undefined;
+    keys: () => Iterator<K>;
+    entries: () => Iterator<[K, V]>;
+    get: (k: K) => V | undefined;
 };
 
 // TODO/typescript: Move this to markdown
 type MarkdownHelpers = {
     // user stuff
-    get_actual_name_from_user_id(user_id: number): string | undefined;
-    get_user_id_from_name(full_name: string): number | undefined;
-    is_valid_full_name_and_user_id(full_name: string, user_id: number): boolean;
-    my_user_id(): number;
-    is_valid_user_id(user_id: number): boolean;
+    get_actual_name_from_user_id: (user_id: number) => string | undefined;
+    get_user_id_from_name: (full_name: string) => number | undefined;
+    is_valid_full_name_and_user_id: (full_name: string, user_id: number) => boolean;
+    my_user_id: () => number;
+    is_valid_user_id: (user_id: number) => boolean;
 
     // user groups
-    get_user_group_from_name(name: string): {id: number; name: string} | undefined;
-    is_member_of_user_group(user_id: number, user_group_id: number): boolean;
+    get_user_group_from_name: (name: string) => {id: number; name: string} | undefined;
+    is_member_of_user_group: (user_id: number, user_group_id: number) => boolean;
 
     // stream hashes
-    get_stream_by_name(stream_name: string): {stream_id: number; name: string} | undefined;
-    stream_hash(stream_id: number): string;
-    stream_topic_hash(stream_id: number, topic: string): string;
+    get_stream_by_name: (stream_name: string) => {stream_id: number; name: string} | undefined;
+    stream_hash: (stream_id: number) => string;
+    stream_topic_hash: (stream_id: number, topic: string) => string;
 
     // settings
-    should_translate_emoticons(): boolean;
+    should_translate_emoticons: () => boolean;
 
     // emojis
-    get_emoji_name(codepoint: string): string | undefined;
-    get_emoji_codepoint(emoji_name: string): string | undefined;
-    get_emoticon_translations(): {regex: RegExp; replacement_text: string}[];
-    get_realm_emoji_url(emoji_name: string): string | undefined;
+    get_emoji_name: (codepoint: string) => string | undefined;
+    get_emoji_codepoint: (emoji_name: string) => string | undefined;
+    get_emoticon_translations: () => {regex: RegExp; replacement_text: string}[];
+    get_realm_emoji_url: (emoji_name: string) => string | undefined;
 
     // linkifiers
-    get_linkifier_map(): AbstractMap<
+    get_linkifier_map: () => AbstractMap<
         RegExp,
         {url_template: url_template_lib.Template; group_number_to_name: Record<number, string>}
     >;

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -7,9 +7,9 @@ type Context = {
     row_item_selector: string;
     box_item_selector: string;
     id_attribute_name: string;
-    get_items_ids(): number[];
-    on_enter(): void;
-    on_delete(): void;
+    get_items_ids: () => number[];
+    on_enter: () => void;
+    on_delete: () => void;
 };
 
 export function row_with_focus(context: Context): JQuery {

--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -28,7 +28,7 @@ type ExtraData =
 declare global {
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
     interface JQuery {
-        handle_events(events: Event[]): void;
+        handle_events: (events: Event[]) => void;
     }
 }
 

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -1,8 +1,8 @@
 import {$t} from "./i18n";
 
 export type UploadWidget = {
-    clear(): void;
-    close(): void;
+    clear: () => void;
+    close: () => void;
 };
 
 export type UploadFunction = (

--- a/web/src/url-template.d.ts
+++ b/web/src/url-template.d.ts
@@ -7,12 +7,12 @@ declare module "url-template" {
     export type PrimitiveValue = string | number | boolean | null;
 
     export type Template = {
-        expand(
+        expand: (
             context: Record<
                 string,
                 PrimitiveValue | PrimitiveValue[] | Record<string, PrimitiveValue>
             >,
-        ): string;
+        ) => string;
     };
 
     export function parse(template: string): Template;

--- a/web/src/vdom.ts
+++ b/web/src/vdom.ts
@@ -5,6 +5,8 @@ import * as blueslip from "./blueslip";
 export type Node = {
     key: unknown;
     render: () => string;
+    // TODO: This is hiding type errors due to bivariance.
+    // eslint-disable-next-line @typescript-eslint/method-signature-style
     eq(other: Node): boolean;
 };
 

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -506,7 +506,7 @@ run_test("custom sort", () => {
         return a.x * a.y - b.x * b.y;
     }
 
-    ListWidget.create($container, list, {
+    const widget = ListWidget.create($container, list, {
         name: "custom-sort-list",
         modifier_html: (n) => "(" + n.x + ", " + n.y + ")",
         get_item: (item) => item,
@@ -519,8 +519,6 @@ run_test("custom sort", () => {
     });
 
     assert.deepEqual($container.$appended_data.html(), "(6, 7)(1, 43)(4, 11)");
-
-    const widget = ListWidget.get("custom-sort-list");
 
     widget.sort("x_value");
     assert.deepEqual($container.$appended_data.html(), "(1, 43)(4, 11)(6, 7)");
@@ -597,7 +595,7 @@ run_test("replace_list_data w/filter update", () => {
     const list = [1, 2, 3, 4];
     let num_updates = 0;
 
-    ListWidget.create($container, list, {
+    const widget = ListWidget.create($container, list, {
         name: "replace-list",
         modifier_html: (n) => "(" + n.toString() + ")",
         get_item: (item) => item,
@@ -614,7 +612,6 @@ run_test("replace_list_data w/filter update", () => {
 
     assert.deepEqual($container.$appended_data.html(), "(2)(4)");
 
-    const widget = ListWidget.get("replace-list");
     widget.replace_list_data([5, 6, 7, 8]);
 
     assert.equal(num_updates, 1);


### PR DESCRIPTION
For historical reasons, TypeScript ignores variance errors for method shorthand type declarations even in strict mode. Prefer the correctly checked style.

https://typescript-eslint.io/rules/method-signature-style