### PR TITLE
Dropped "Find accounts" link on /help in very narrow windows.

### DIFF
--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -45,7 +45,7 @@
             {% endif %}
 
             {% if not is_self_hosting_management_page and not find_team_link_disabled %}
-            <a href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
+            <a class="find-account-link" href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
             <a href="{{ root_domain_url }}/new/">{{ _('New organization') }}</a>
             {% endif %}
         </div>

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1218,6 +1218,11 @@ input.new-organization-button {
     }
 }
 
+@media (width <= 270px) {
+    .top-links .find-account-link {
+        display:none;
+    }
+}
 .emoji {
     height: 25px;
     width: 25px;

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1220,9 +1220,10 @@ input.new-organization-button {
 
 @media (width <= 270px) {
     .top-links .find-account-link {
-        display:none;
+        display: none;
     }
 }
+
 .emoji {
     height: 25px;
     width: 25px;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #27477

**Screenshots and screen captures:**
Before -( Find accounts and New organisation) overlap in the mobile browser when the page scrolls
<img width="1440" alt="Screenshot 2023-12-27 at 12 36 34 PM" src="https://github.com/zulip/zulip/assets/131298127/1691c726-19f0-40ee-ae30-5e99cb040274">

After - fix this by dropping the "Find accounts" link when both links don't fit
<img width="1440" alt="Screenshot 2023-12-27 at 12 47 40 PM" src="https://github.com/zulip/zulip/assets/131298127/2e503e2d-68ec-4973-835c-7c09ab982019">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
