### PR TITLE
login: Remove external_authentication_methods from page_params

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -72,16 +72,16 @@ page can be easily identified in it's respective JavaScript file -->
                                 <button class="full-width" type="submit">{{ _('Sign up') }}</button>
                             </form>
 
-                            {% if page_params.external_authentication_methods|length > 0 %}
+                            {% if external_authentication_methods|length > 0 %}
                             <div class="or"><span>{{ _('OR') }}</span></div>
                             {% endif %}
                         {% endif %}
 
-                        {% for backend in page_params.external_authentication_methods %}
+                        {% for backend in external_authentication_methods %}
                         <div class="login-social">
                             <form class="form-inline" action="{{ backend.signup_url }}" method="get">
                                 <input type='hidden' name='multiuse_object_key' value='{{ multiuse_object_key }}' />
-                                <button id="register_{{ backend.button_id_suffix }}" class="login-social-button full-width"
+                                <button id="register_auth_button_{{ backend.name }}" class="login-social-button full-width"
                                   {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                     {{ _('Sign up with %(identity_provider)s', identity_provider=backend.display_name) }}
                                 </button>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -129,17 +129,17 @@ page can be easily identified in it's respective JavaScript file. -->
                             </button>
                         </form>
 
-                        {% if page_params.external_authentication_methods|length > 0 %}
+                        {% if external_authentication_methods|length > 0 %}
                         <div class="or"><span>{{ _('OR') }}</span></div>
                         {% endif %}
 
                     {% endif %} <!-- if password_auth_enabled -->
 
-                    {% for backend in page_params.external_authentication_methods %}
+                    {% for backend in external_authentication_methods %}
                     <div class="login-social">
                         <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
                             <input type="hidden" name="next" value="{{ next }}" />
-                            <button id="login_{{ backend.button_id_suffix }}" class="login-social-button"
+                            <button id="login_auth_button_{{ backend.name }}" class="login-social-button"
                               {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}> {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
                             </button>
                         </form>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -263,15 +263,6 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
     context["external_authentication_methods"] = get_external_method_dicts(realm)
     context["no_auth_enabled"] = no_auth_enabled
 
-    # Include another copy of external_authentication_methods in page_params for use
-    # by the desktop client. We expand it with IDs of the <button> elements corresponding
-    # to the authentication methods.
-    context["page_params"] = dict(
-        external_authentication_methods=get_external_method_dicts(realm),
-    )
-    for auth_dict in context["page_params"]["external_authentication_methods"]:
-        auth_dict["button_id_suffix"] = "auth_button_{}".format(auth_dict["name"])
-
     return context
 
 


### PR DESCRIPTION
This was used by a work-in-progress social login implementation in zulip-desktop that was reverted for security reasons and never released.

- https://github.com/zulip/zulip/pull/13782
- https://github.com/zulip/zulip-desktop/pull/863

We replaced it by a secure implementation with a maintainable API.

- https://github.com/zulip/zulip-desktop/pull/943

Tested in production on andersk.zulipdev.org.