### PR TITLE
page_params: Move page_load_time to zulip_test

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -64,9 +64,7 @@ async function navigate_to_private_messages(page: Page): Promise<void> {
 }
 
 async function test_reload_hash(page: Page): Promise<void> {
-    const initial_page_load_time = await page.evaluate(
-        (): number => zulip_test.page_params.page_load_time,
-    );
+    const initial_page_load_time = await page.evaluate((): number => zulip_test.page_load_time);
     console.log(`initial load time: ${initial_page_load_time}`);
 
     const initial_hash = await page.evaluate(() => window.location.hash);
@@ -75,7 +73,7 @@ async function test_reload_hash(page: Page): Promise<void> {
     await page.waitForNavigation();
     await page.waitForSelector("#zfilt", {visible: true});
 
-    const page_load_time = await page.evaluate(() => zulip_test.page_params.page_load_time);
+    const page_load_time = await page.evaluate(() => zulip_test.page_load_time);
     assert.ok(page_load_time > initial_page_load_time, "Page not reloaded.");
 
     const hash = await page.evaluate(() => window.location.hash);

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -47,7 +47,6 @@ export const page_params: {
     narrow_stream?: string;
     narrow: Term[];
     needs_tutorial: boolean;
-    page_load_time: number;
     promote_sponsoring_zulip: boolean;
     realm_add_custom_emoji_policy: number;
     realm_available_video_chat_providers: {

--- a/web/src/setup.ts
+++ b/web/src/setup.ts
@@ -5,6 +5,8 @@ import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as util from "./util";
 
+export let page_load_time: number | undefined;
+
 // Miscellaneous early setup.
 $(() => {
     if (util.is_mobile()) {
@@ -12,7 +14,7 @@ $(() => {
         page_params.needs_tutorial = false;
     }
 
-    page_params.page_load_time = Date.now();
+    page_load_time = Date.now();
 
     // Display loading indicator.  This disappears after the first
     // get_events completes.

--- a/web/src/zulip_test.js
+++ b/web/src/zulip_test.js
@@ -11,4 +11,5 @@ export {last_visible as last_visible_row, id as row_id} from "./rows";
 export {cancel as cancel_compose} from "./compose_actions";
 export {page_params, page_params_parse_time} from "./page_params";
 export {initiate as initiate_reload} from "./reload";
+export {page_load_time} from "./setup";
 export {add_user_id_to_new_stream} from "./stream_create_subscribers";


### PR DESCRIPTION
This isn’t sent by the server; it’s a client-side global variable.