### PR TITLE
fix: Emoji picker scroll events can happen while refill_section_head_offsets has unset section_head_offsets #24776

### DIFF
--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -589,6 +589,12 @@ export function emoji_select_tab($elt) {
         currently_selected = section_head_offsets.at(-1).section;
     }
     // Handles the corner case of the scrolling back to top.
+
+    if(scrolltop === 0)
+    {
+        currently_selected = "Popular";
+    }
+
     if (scrolltop === 0 && section_head_offsets.length()) {
         currently_selected = section_head_offsets[0].section;
     }

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -589,7 +589,7 @@ export function emoji_select_tab($elt) {
         currently_selected = section_head_offsets.at(-1).section;
     }
     // Handles the corner case of the scrolling back to top.
-    if (scrolltop === 0) {
+    if (scrolltop === 0 && section_head_offsets.length()) {
         currently_selected = section_head_offsets[0].section;
     }
     if (currently_selected) {


### PR DESCRIPTION
> We should run refill_section_head_offsets synchronously, or just hardcode "Popular" as the value if currently_selected in this case.

The above requirement is fullfilled.

Fixes: #24776

Changes made in the code:

```js

    if(scrolltop === 0)
    {
        currently_selected = "Popular";
    }

    if (scrolltop === 0 && section_head_offsets.length()) {
        currently_selected = section_head_offsets[0].section;
    }   

```
