### PR TITLE
page_params: Fix types of narrow, server_sentry_dsn, user_id

### DIFF
--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -35,7 +35,7 @@ export const page_params: {
         code: string;
         locale: string;
         name: string;
-        percent_translated: number | undefined;
+        percent_translated?: number;
     }[];
     login_page: string;
     max_avatar_file_size_mib: number;
@@ -43,8 +43,8 @@ export const page_params: {
     max_logo_file_size_mib: number;
     max_message_id: number;
     muted_users: {id: number; timestamp: number}[];
+    narrow?: Term[];
     narrow_stream?: string;
-    narrow: Term[];
     needs_tutorial: boolean;
     promote_sponsoring_zulip: boolean;
     realm_add_custom_emoji_policy: number;
@@ -65,6 +65,7 @@ export const page_params: {
     realm_description: string;
     realm_edit_topic_policy: number;
     realm_email_changes_disabled: boolean;
+    realm_enable_guest_user_indicator: boolean;
     realm_enable_spectator_access: boolean;
     realm_icon_source: string;
     realm_icon_url: string;
@@ -84,8 +85,7 @@ export const page_params: {
     realm_plan_type: number;
     realm_private_message_policy: number;
     realm_push_notifications_enabled: boolean;
-    realm_sentry_key: string | undefined;
-    realm_enable_guest_user_indicator: boolean;
+    realm_sentry_key?: string;
     realm_upload_quota_mib: number | null;
     realm_uri: string;
     realm_user_group_edit_policy: number;
@@ -97,10 +97,10 @@ export const page_params: {
     server_name_changes_disabled: boolean;
     server_needs_upgrade: boolean;
     server_presence_offline_threshold_seconds: number;
-    server_sentry_dsn: string | undefined;
-    server_sentry_environment: string | undefined;
-    server_sentry_sample_rate: number | undefined;
-    server_sentry_trace_rate: number | undefined;
+    server_sentry_dsn: string | null;
+    server_sentry_environment?: string;
+    server_sentry_sample_rate?: number;
+    server_sentry_trace_rate?: number;
     server_supported_permission_settings: {
         realm: Record<string, GroupPermissionSetting>;
         stream: Record<string, GroupPermissionSetting>;
@@ -112,7 +112,7 @@ export const page_params: {
     show_webathena: boolean;
     sponsorship_pending: boolean;
     translation_data: Record<string, string>;
-    user_id: number | undefined;
+    user_id: number;
     zulip_merge_base: string;
     zulip_plan_is_not_limited: boolean;
     zulip_version: string;

--- a/web/src/stream_create_subscribers_data.ts
+++ b/web/src/stream_create_subscribers_data.ts
@@ -1,5 +1,3 @@
-import assert from "minimalistic-assert";
-
 import {page_params} from "./page_params";
 import * as people from "./people";
 import type {User} from "./people";
@@ -7,10 +5,7 @@ import type {User} from "./people";
 let user_id_set: Set<number>;
 
 export function initialize_with_current_user(): void {
-    const current_user_id = page_params.user_id;
-    user_id_set = new Set<number>();
-    assert(current_user_id !== undefined, "Current user's id is undefined");
-    user_id_set.add(current_user_id);
+    user_id_set = new Set([page_params.user_id]);
 }
 
 export function sorted_user_ids(): number[] {

--- a/web/src/user_group_create_members_data.ts
+++ b/web/src/user_group_create_members_data.ts
@@ -1,5 +1,3 @@
-import assert from "minimalistic-assert";
-
 import {page_params} from "./page_params";
 import * as people from "./people";
 import type {User} from "./people";
@@ -7,10 +5,7 @@ import type {User} from "./people";
 let user_id_set: Set<number>;
 
 export function initialize_with_current_user(): void {
-    const current_user_id = page_params.user_id;
-    user_id_set = new Set<number>();
-    assert(current_user_id !== undefined, "Current user's id is undefined");
-    user_id_set.add(current_user_id);
+    user_id_set = new Set([page_params.user_id]);
 }
 
 export function sorted_user_ids(): number[] {

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -96,17 +96,10 @@ export function get_realm_user_groups(): UserGroup[] {
 }
 
 export function get_user_groups_allowed_to_mention(): UserGroup[] {
-    if (page_params.user_id === undefined) {
-        return [];
-    }
-
     const user_groups = get_realm_user_groups();
     return user_groups.filter((group) => {
         const can_mention_group_id = group.can_mention_group;
-        return (
-            page_params.user_id !== undefined &&
-            is_user_in_group(can_mention_group_id, page_params.user_id)
-        );
+        return is_user_in_group(can_mention_group_id, page_params.user_id);
     });
 }
 


### PR DESCRIPTION
`page_params.narrow` may be undefined, `page_params.server_sentry_dsn` may be `null` but not undefined, and `page_params.user_id` may be `0` (for spectators) but not undefined.

Cc @alexmv (#24382), @evykassirer (#28323).