### PR TITLE
Remove fictional variables from `page_params`

### DIFF
--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -549,7 +549,7 @@ Then add the new form control in `web/src/admin.js`.
          full_name: page_params.full_name,
          realm_name: page_params.realm_name,
          // ...
-+        realm_mandatory_topics: page_params.mandatory_topics,
++        realm_mandatory_topics: page_params.realm_mandatory_topics,
          // ...
 ```
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -11,6 +11,7 @@ import {$t_html} from "./i18n";
 import * as inbox_ui from "./inbox_ui";
 import * as inbox_util from "./inbox_util";
 import * as info_overlay from "./info_overlay";
+import * as message_fetch from "./message_fetch";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as modals from "./modals";
@@ -143,10 +144,10 @@ function do_hashchange_normal(from_reload) {
             };
             if (from_reload) {
                 blueslip.debug("We are narrowing as part of a reload.");
-                if (page_params.initial_narrow_pointer !== undefined) {
-                    message_lists.home.pre_narrow_offset = page_params.initial_offset;
-                    narrow_opts.then_select_id = page_params.initial_narrow_pointer;
-                    narrow_opts.then_select_offset = page_params.initial_narrow_offset;
+                if (message_fetch.initial_narrow_pointer !== undefined) {
+                    message_lists.home.pre_narrow_offset = message_fetch.initial_offset;
+                    narrow_opts.then_select_id = message_fetch.initial_narrow_pointer;
+                    narrow_opts.then_select_offset = message_fetch.initial_narrow_offset;
                 }
             }
 

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -19,6 +19,11 @@ import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as ui_report from "./ui_report";
 
+export let initial_pointer;
+export let initial_offset;
+export let initial_narrow_pointer;
+export let initial_narrow_offset;
+
 let is_all_messages_data_loaded = false;
 
 const consts = {
@@ -512,6 +517,13 @@ export function start_backfilling_messages() {
     });
 }
 
+export function set_initial_pointer_and_offset({pointer, offset, narrow_pointer, narrow_offset}) {
+    initial_pointer = pointer;
+    initial_offset = offset;
+    initial_narrow_pointer = narrow_pointer;
+    initial_narrow_offset = narrow_offset;
+}
+
 export function initialize(home_view_loaded) {
     // get the initial message list
     function load_more(data) {
@@ -524,7 +536,7 @@ export function initialize(home_view_loaded) {
             message_lists.home.select_id(data.anchor, {
                 then_scroll: true,
                 use_closest: true,
-                target_scroll_offset: page_params.initial_offset,
+                target_scroll_offset: initial_offset,
             });
         }
 
@@ -564,10 +576,10 @@ export function initialize(home_view_loaded) {
     }
 
     let anchor;
-    if (page_params.initial_pointer) {
+    if (initial_pointer !== undefined) {
         // If we're doing a server-initiated reload, similar to a
         // near: narrow query, we want to select a specific message.
-        anchor = page_params.initial_pointer;
+        anchor = initial_pointer;
     } else {
         // Otherwise, we should just use the first unread message in
         // the user's unmuted history as our anchor.

--- a/web/src/reload_setup.js
+++ b/web/src/reload_setup.js
@@ -3,8 +3,8 @@ import * as blueslip from "./blueslip";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import {localstorage} from "./localstorage";
+import * as message_fetch from "./message_fetch";
 import * as narrow from "./narrow";
-import {page_params} from "./page_params";
 
 // Check if we're doing a compose-preserving reload.  This must be
 // done before the first call to get_events
@@ -68,23 +68,15 @@ export function initialize() {
     }
 
     const pointer = Number.parseInt(vars.pointer, 10);
-
-    if (pointer) {
-        page_params.initial_pointer = pointer;
-    }
     const offset = Number.parseInt(vars.offset, 10);
-    if (offset) {
-        page_params.initial_offset = offset;
-    }
-
     const narrow_pointer = Number.parseInt(vars.narrow_pointer, 10);
-    if (narrow_pointer) {
-        page_params.initial_narrow_pointer = narrow_pointer;
-    }
     const narrow_offset = Number.parseInt(vars.narrow_offset, 10);
-    if (narrow_offset) {
-        page_params.initial_narrow_offset = narrow_offset;
-    }
+    message_fetch.set_initial_pointer_and_offset({
+        pointer: Number.isNaN(pointer) ? undefined : pointer,
+        offset: Number.isNaN(offset) ? undefined : offset,
+        narrow_pointer: Number.isNaN(narrow_pointer) ? undefined : narrow_pointer,
+        narrow_offset: Number.isNaN(narrow_offset) ? undefined : narrow_offset,
+    });
 
     activity.set_new_user_input(false);
     narrow.changehash(vars.oldhash);

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -103,7 +103,7 @@ run_test("is_topic_editable", ({override}) => {
     message.failed_request = false;
     assert.equal(message_edit.is_topic_editable(message), true);
 
-    page_params.sent_by_me = false;
+    message.sent_by_me = false;
     assert.equal(message_edit.is_topic_editable(message), true);
 
     override(settings_data, "user_can_move_messages_to_another_topic", () => false);
@@ -157,7 +157,7 @@ run_test("is_stream_editable", ({override}) => {
     message.failed_request = false;
     assert.equal(message_edit.is_stream_editable(message), true);
 
-    page_params.sent_by_me = false;
+    message.sent_by_me = false;
     assert.equal(message_edit.is_stream_editable(message), true);
 
     override(settings_data, "user_can_move_messages_between_streams", () => false);


### PR DESCRIPTION
`events_queue_expired`, `initial_pointer`, `initial_offset`, `initial_narrow_pointer`, `initial_narrow_offset` are client-side global variables and are never sent by the server. `sent_by_me` has never existed. `mandatory_topics` was renamed.