### PR TITLE
Fix early reads of page_params

### DIFF
--- a/web/src/settings_profile_fields.js
+++ b/web/src/settings_profile_fields.js
@@ -41,10 +41,9 @@ export function maybe_disable_widgets() {
 
 let display_in_profile_summary_fields_limit_reached = false;
 let order = [];
-const field_types = page_params.custom_profile_field_types;
 
 export function field_type_id_to_string(type_id) {
-    for (const field_type of Object.values(field_types)) {
+    for (const field_type of Object.values(page_params.custom_profile_field_types)) {
         if (field_type.id === type_id) {
             // Few necessary modifications in field-type-name for
             // table-list view of custom fields UI in org settings
@@ -61,6 +60,7 @@ export function field_type_id_to_string(type_id) {
 
 // Checking custom profile field type is valid for showing display on user card checkbox field.
 function is_valid_to_display_in_summary(field_type) {
+    const field_types = page_params.custom_profile_field_types;
     if (field_type === field_types.LONG_TEXT.id || field_type === field_types.USER.id) {
         return false;
     }
@@ -163,6 +163,8 @@ function create_choice_row(container) {
 }
 
 function clear_form_data() {
+    const field_types = page_params.custom_profile_field_types;
+
     $("#profile_field_name").val("").closest(".input-group").show();
     $("#profile_field_hint").val("").closest(".input-group").show();
     // Set default type "Short text" in field type dropdown
@@ -181,6 +183,8 @@ function clear_form_data() {
 }
 
 function set_up_create_field_form() {
+    const field_types = page_params.custom_profile_field_types;
+
     // Hide error on field type change.
     $("#dialog_error").hide();
     const $field_elem = $("#profile_field_external_accounts");
@@ -233,6 +237,8 @@ function set_up_create_field_form() {
 }
 
 function read_field_data_from_form(field_type_id, $profile_field_form, old_field_data) {
+    const field_types = page_params.custom_profile_field_types;
+
     // Only read field data if we are creating a select field
     // or external account field.
     if (field_type_id === field_types.SELECT.id) {
@@ -428,6 +434,8 @@ function set_up_select_field_edit_form($profile_field_form, field_data) {
 }
 
 function open_edit_form_modal(e) {
+    const field_types = page_params.custom_profile_field_types;
+
     const field_id = Number.parseInt($(e.currentTarget).attr("data-profile-field-id"), 10);
     const field = get_profile_field(field_id);
 
@@ -619,6 +627,8 @@ export function populate_profile_fields(profile_fields_data) {
 }
 
 export function do_populate_profile_fields(profile_fields_data) {
+    const field_types = page_params.custom_profile_field_types;
+
     // We should only call this internally or from tests.
     const $profile_fields_table = $("#admin_profile_fields_table").expectOne();
 
@@ -681,6 +691,8 @@ export function do_populate_profile_fields(profile_fields_data) {
 }
 
 function set_up_select_field() {
+    const field_types = page_params.custom_profile_field_types;
+
     create_choice_row("#profile_field_choices");
 
     if (page_params.is_admin) {

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -117,9 +117,7 @@ class StreamNameError {
 const stream_name_error = new StreamNameError();
 
 // Stores the previous state of the stream creation checkbox.
-let stream_announce_previous_value =
-    settings_data.user_can_create_public_streams() ||
-    settings_data.user_can_create_web_public_streams();
+let stream_announce_previous_value;
 
 // Within the new stream modal...
 function update_announce_stream_state() {
@@ -383,6 +381,10 @@ export function show_new_stream_modal() {
 }
 
 export function set_up_handlers() {
+    stream_announce_previous_value =
+        settings_data.user_can_create_public_streams() ||
+        settings_data.user_can_create_web_public_streams();
+
     const $people_to_add_holder = $("#people_to_add").expectOne();
     stream_create_subscribers.create_handlers($people_to_add_holder);
 

--- a/web/src/typing.js
+++ b/web/src/typing.js
@@ -16,13 +16,6 @@ import {user_settings} from "./user_settings";
 // when we are typing.  For the inbound side see typing_events.js.
 // See docs/subsystems/typing-indicators.md for more details.
 
-// How frequently 'start' notifications are sent to extend
-// the expiry of active typing indicators.
-const typing_started_wait_period = page_params.server_typing_started_wait_period_milliseconds;
-// How long after someone stops editing in the compose box
-// do we send a 'stop' notification.
-const typing_stopped_wait_period = page_params.server_typing_stopped_wait_period_milliseconds;
-
 function send_typing_notification_ajax(data) {
     channel.post({
         url: "/json/typing",
@@ -121,14 +114,19 @@ export function initialize() {
         typing_status.update(
             worker,
             new_recipient,
-            typing_started_wait_period,
-            typing_stopped_wait_period,
+            page_params.server_typing_started_wait_period_milliseconds,
+            page_params.server_typing_stopped_wait_period_milliseconds,
         );
     });
 
     // We send a stop-typing notification immediately when compose is
     // closed/cancelled
     $(document).on("compose_canceled.zulip compose_finished.zulip", () => {
-        typing_status.update(worker, null, typing_started_wait_period, typing_stopped_wait_period);
+        typing_status.update(
+            worker,
+            null,
+            page_params.server_typing_started_wait_period_milliseconds,
+            page_params.server_typing_stopped_wait_period_milliseconds,
+        );
     });
 }

--- a/web/src/typing_events.js
+++ b/web/src/typing_events.js
@@ -15,10 +15,6 @@ import * as typing_data from "./typing_data";
 //
 // We also handle the local event of re-narrowing.
 // (For the outbound code, see typing.js.)
-//
-// How long before we assume a client has gone away
-// and expire the active typing indicator.
-const typing_started_expiry_period = page_params.server_typing_started_expiry_period_milliseconds;
 
 // If number of users typing exceed this,
 // we render "Several people are typing..."
@@ -115,7 +111,11 @@ export function display_notification(event) {
 
     render_notifications_for_narrow();
 
-    typing_data.kickstart_inbound_timer(key, typing_started_expiry_period, () => {
-        hide_notification(event);
-    });
+    typing_data.kickstart_inbound_timer(
+        key,
+        page_params.server_typing_started_expiry_period_milliseconds,
+        () => {
+            hide_notification(event);
+        },
+    );
 }

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -45,8 +45,6 @@ const custom_profile_field_types = {
     },
 };
 
-page_params.custom_profile_field_types = custom_profile_field_types;
-
 mock_esm("sortablejs", {Sortable: {create() {}}});
 
 const settings_profile_fields = zrequire("settings_profile_fields");
@@ -54,6 +52,7 @@ const settings_profile_fields = zrequire("settings_profile_fields");
 function test_populate(opts, template_data) {
     const fields_data = opts.fields_data;
 
+    page_params.custom_profile_field_types = custom_profile_field_types;
     page_params.is_admin = opts.is_admin;
     const $table = $("#admin_profile_fields_table");
     const $rows = $.create("rows");


### PR DESCRIPTION
For spectators, most of `page_params` has not been initialized yet at module load time.