### PR TITLE
support: Exclude deactivated remote servers from search results.

### DIFF
--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -384,8 +384,10 @@ def get_remote_servers_for_support(
     if not email_to_search and not hostname_to_search:
         return []
 
-    remote_servers_query = RemoteZulipServer.objects.order_by("id").prefetch_related(
-        "remoterealm_set"
+    remote_servers_query = (
+        RemoteZulipServer.objects.order_by("id")
+        .exclude(deactivated=True)
+        .prefetch_related("remoterealm_set")
     )
     if email_to_search:
         remote_servers_query = remote_servers_query.filter(contact_email__iexact=email_to_search)


### PR DESCRIPTION
Excludes deactivated remote servers from the search results in the remote server support view.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
