### PR TITLE
support: Update remote server support view for UUID and date created.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -150,6 +150,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     f"<h3>{hostname}</h3>",
                     f"<b>Contact email</b>: admin@{hostname}",
                     "<b>Date created</b>:",
+                    "<b>UUID</b>:",
                     "<b>Zulip version</b>:",
                     "<b>Plan type</b>: Self-managed<br />",
                     "<b>Non-guest user count</b>: 0<br />",
@@ -168,7 +169,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     f"<b>Remote realm host:</b> {host}<br />",
                     "<b>Date created</b>: 01 December 2023",
                     "<b>Org type</b>: Unspecified<br />",
-                    "<b>Has remote realm(s)</b>: True<br />",
+                    "<b>Has remote realms</b>: True<br />",
                 ],
                 html_response,
             )
@@ -179,7 +180,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             self.assert_not_in_success_response(
                 ["<h3>zulip-2.example.com</h3>", "<b>Remote realm host:</b>"], result
             )
-            self.assert_in_success_response(["<b>Has remote realm(s)</b>: False<br />"], result)
+            self.assert_in_success_response(["<b>Has remote realms</b>: False<br />"], result)
 
         def check_sponsorship_request_no_website(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(

--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 import uuid
 
-from zilencer.models import RemoteRealm, RemoteZulipServer
+from zilencer.models import RemoteRealm, RemoteZulipServer, RemoteZulipServerAuditLog
 
 
 class TestRemoteServerSupportEndpoint(ZulipTestCase):
@@ -97,6 +97,11 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             remote_server = RemoteZulipServer.objects.create(
                 hostname=hostname, contact_email=f"admin@{hostname}", uuid=uuid.uuid4()
             )
+            RemoteZulipServerAuditLog.objects.create(
+                event_type=RemoteZulipServerAuditLog.REMOTE_SERVER_CREATED,
+                server=remote_server,
+                event_time=remote_server.last_updated,
+            )
             # We want at least one RemoteZulipServer that has no RemoteRealm
             # as an example of a pre-8.0 release registered remote server.
             if i > 1:
@@ -108,7 +113,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     uuid=realm_uuid,
                     host=realm_host,
                     name=realm_name,
-                    realm_date_created=timezone_now(),
+                    realm_date_created=datetime(2023, 12, 1, tzinfo=timezone.utc),
                 )
 
         # Add a deactivated server, which should be excluded from search results.
@@ -144,7 +149,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                 [
                     f"<h3>{hostname}</h3>",
                     f"<b>Contact email</b>: admin@{hostname}",
-                    "<b>Last updated</b>:",
+                    "<b>Date created</b>:",
                     "<b>Zulip version</b>:",
                     "<b>Plan type</b>: Self-managed<br />",
                     "<b>Non-guest user count</b>: 0<br />",
@@ -161,7 +166,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                 [
                     f"<h3>{name}</h3>",
                     f"<b>Remote realm host:</b> {host}<br />",
-                    "<b>Date created</b>: ",
+                    "<b>Date created</b>: 01 December 2023",
                     "<b>Org type</b>: Unspecified<br />",
                     "<b>Has remote realm(s)</b>: True<br />",
                 ],

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -5,7 +5,7 @@
         <h4>On 100% sponsored Zulip Community plan 🎉</h4>
     {% endif %}
     {% if support_data[remote_realm.id].sponsorship_data.default_discount %}
-        <h4>Has a discount 🟢</h4>
+        <h4>Has a discount 💸</h4>
     {% endif %}
     <b>Remote realm host:</b> {{ remote_realm.host }}<br />
     <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -8,7 +8,7 @@
         <h4>Has a discount 🟢</h4>
     {% endif %}
     <b>Remote realm host:</b> {{ remote_realm.host }}<br />
-    <b>Date created</b>: {{ remote_realm.realm_date_created.strftime('%d %B %Y') }}<br />
+    <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
     <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
     <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />
     <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -49,7 +49,7 @@
                     <i class="fa fa-copy"></i>
                 </a>
                 <br />
-                <b>Last updated</b>: {{ remote_server.last_updated|timesince }} ago<br />
+                <b>Date created</b>: {{ remote_servers_support_data[remote_server.id].date_created.strftime('%d %B %Y') }}<br />
                 <b>Zulip version</b>: {{ remote_server.last_version }}<br />
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -42,18 +42,20 @@
                     <h4>On 100% sponsored Zulip Community plan 🎉</h4>
                 {% endif %}
                 {% if remote_servers_support_data[remote_server.id].sponsorship_data.default_discount %}
-                    <h4>Has a discount 🟢</h4>
+                    <h4>Has a discount 💸</h4>
                 {% endif %}
                 <b>Contact email</b>: {{ remote_server.contact_email }}
                 <a title="Copy email" class="copy-button" data-copytext="{{ remote_server.contact_email }}">
                     <i class="fa fa-copy"></i>
                 </a>
                 <br />
+                <b>UUID</b>: {{ remote_server.uuid }}<br />
                 <b>Date created</b>: {{ remote_servers_support_data[remote_server.id].date_created.strftime('%d %B %Y') }}<br />
                 <b>Zulip version</b>: {{ remote_server.last_version }}<br />
+                <b>Has remote realms</b>: {{ remote_realms[remote_server.id] != [] }}<br />
+                <br />
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
-                <b>Has remote realm(s)</b>: {{ remote_realms[remote_server.id] != [] }}<br />
                 <b>Non-guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.non_guest_user_count }}<br />
                 <b>Guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.guest_user_count }}<br />
             </div>

--- a/zilencer/management/commands/populate_billing_realms.py
+++ b/zilencer/management/commands/populate_billing_realms.py
@@ -33,6 +33,7 @@ from zilencer.models import (
     RemoteRealmBillingUser,
     RemoteServerBillingUser,
     RemoteZulipServer,
+    RemoteZulipServerAuditLog,
 )
 from zilencer.views import update_remote_realm_data_for_server
 from zproject.config import get_secret
@@ -419,6 +420,12 @@ def populate_remote_server(customer_profile: CustomerProfile) -> Dict[str, str]:
         plan_type=plan_type,
         # TODO: Save property audit log data for server.
         last_audit_log_update=timezone_now(),
+    )
+
+    RemoteZulipServerAuditLog.objects.create(
+        event_type=RemoteZulipServerAuditLog.REMOTE_SERVER_CREATED,
+        server=remote_server,
+        event_time=remote_server.last_updated,
     )
 
     billing_user = RemoteServerBillingUser.objects.create(

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -71,7 +71,7 @@ from zerver.models.realms import get_realm
 from zerver.models.recipients import get_or_create_huddle
 from zerver.models.streams import get_stream
 from zerver.models.users import get_user, get_user_by_delivery_email, get_user_profile_by_id
-from zilencer.models import RemoteRealm, RemoteZulipServer
+from zilencer.models import RemoteRealm, RemoteZulipServer, RemoteZulipServerAuditLog
 from zilencer.views import update_remote_realm_data_for_server
 
 settings.USING_TORNADO = False
@@ -389,6 +389,11 @@ class Command(BaseCommand):
                 hostname=settings.EXTERNAL_HOST,
                 last_updated=timezone_now(),
                 contact_email="remotezulipserver@zulip.com",
+            )
+            RemoteZulipServerAuditLog.objects.create(
+                event_type=RemoteZulipServerAuditLog.REMOTE_SERVER_CREATED,
+                server=server,
+                event_time=server.last_updated,
             )
             update_remote_realm_data_for_server(server, get_realms_info_for_push_bouncer())
 


### PR DESCRIPTION
Updates to remote server support view:
- Removes the last updated field and replaces it with the date the remote server was created based on the audit log data.
- Adds a remote server UUID field to the remote server information.
- Changes the emoji that highlights when a remote realm or server has an active discount.
- Moves the 'has remote realms' field to be after the Zulip version information, and adds an extra break there to visually highlight that field as well as the following 'max monthly messages' field.

**Screenshots and screen captures:**

<details>
<summary>Example legacy server with upgrade scheduled and discount set</summary>

![Screenshot from 2024-01-02 20-14-06](https://github.com/zulip/zulip/assets/63245456/4c4711b4-3703-43c3-98f0-89cae4a5994c)
</details>
<details>
<summary>Example server with multiple realms</summary>

![Screenshot from 2024-01-02 20-15-05](https://github.com/zulip/zulip/assets/63245456/d57fdb13-dcc7-45cd-b4bb-40f8236b3669)
</details>
<details>
<summary>Example legacy sponsored server</summary>

![Screenshot from 2024-01-02 20-15-37](https://github.com/zulip/zulip/assets/63245456/1197a6ec-2475-4508-853f-ed9c704c8587)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
