### PR TITLE
management: Provide a way to deactivate the push registration.

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -287,10 +287,50 @@ If you'd like to rotate your server's API key for this service
 generate a new `zulip_org_key` and store that new key in
 `/etc/zulip/zulip-secrets.conf`.
 
+## Deactivating your server's registration
+
+If you are deleting your Zulip server or otherwise no longer want to
+use the Mobile Push Notification Service, you can deactivate your server's
+registration.
+
+1. [Cancel any paid
+   plans](https://zulip.com/help/self-hosted-billing#cancel-paid-plan)
+   associated with your server.
+
+1. Run the deregistration command. If you installed Zulip directly on
+   the server (without Docker), run as root:
+
+   ```
+   su zulip -c '/home/zulip/deployments/current/manage.py register_server --deactivate'
+   ```
+
+   Or if you're using Docker, run:
+
+   ```
+   docker exec -it -u zulip <container_name> /home/zulip/deployments/current/manage.py register_server --deactivate
+   ```
+
+1. Comment out the
+   `PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'` line
+   in your `/etc/zulip/settings.py` file (i.e., add `# ` at the
+   start of the line), and [restart your Zulip
+   server](settings.md#making-changes).
+
+If you ever need to reactivate your server's registration, [contact Zulip
+support](https://zulip.com/help/contact-support).
+
+### Pausing use of the Mobile Push Notification Service
+
+You can temporarily stop using the Mobile Push Notification Service. Comment out
+the `PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'` line in your
+`/etc/zulip/settings.py` file (i.e., add `# ` at the start of the line), and
+[restart your Zulip server](settings.md#making-changes). This approach makes it
+easy to start using the service again by uncommenting the same line.
+
 ## Sending push notifications directly from your server
 
 This section documents an alternative way to send push notifications
-that does not involve using the Mobile Push Notifications Service at
+that does not involve using the Mobile Push Notification Service at
 the cost of needing to compile and distribute modified versions of the
 Zulip mobile apps.
 


### PR DESCRIPTION
Doing so immediately regenerates the UUID and key, since we do not allow reactivating deactivated servers.

<details><summary>Command-line example</summary>

```
zulip@alexmv-prod:~/deployments/current$ ./manage.py register_server
This command registers your server for the Mobile Push Notifications Service.
Doing so will share basic metadata with the service's maintainers:

* This server's configured hostname: alexmv-prod.zulipdev.org
* This server's configured contact email address: alexmv@zulip.com
* Metadata about each organization hosted by the server; see:

    <https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata>

Use of this service is governed by the Zulip Terms of Service:

    <https://zulip.com/policies/terms>

Do you want to agree to the Zulip Terms of Service and proceed? [Y/n]

Mobile Push Notification Service registration successfully updated!
```
```
zulip@alexmv-prod:~/deployments/current$ ./manage.py register_server --deactivate
Mobile Push Notification Service registration successfully deactivated!
Generated new secrets in /etc/zulip/zulip-secrets.conf.
```
```
zulip@alexmv-prod:~/deployments/current$ ./manage.py register_server
This command registers your server for the Mobile Push Notifications Service.
Doing so will share basic metadata with the service's maintainers:

* This server's configured hostname: alexmv-prod.zulipdev.org
* This server's configured contact email address: alexmv@zulip.com
* Metadata about each organization hosted by the server; see:

    <https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata>

Use of this service is governed by the Zulip Terms of Service:

    <https://zulip.com/policies/terms>

Do you want to agree to the Zulip Terms of Service and proceed? [Y/n] y

Your server is now registered for the Mobile Push Notification Service!
Return to the documentation for next steps.
```

</p>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
