### PR TITLE
auth: Add a configurable wrapper around authenticate calls.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -551,7 +551,9 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
 def load_subdomain_token(response: Union["TestHttpResponse", HttpResponse]) -> ExternalAuthDataDict:
     assert isinstance(response, HttpResponseRedirect)
     token = response.url.rsplit("/", 1)[1]
-    data = ExternalAuthResult(login_token=token, delete_stored_data=False).data_dict
+    data = ExternalAuthResult(
+        request=mock.MagicMock(), login_token=token, delete_stored_data=False
+    ).data_dict
     assert data is not None
     return data
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5424,7 +5424,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     def test_login_success(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
             self.assertEqual(result.status_code, 302)
             self.assert_logged_in_user_id(user_profile.id)
@@ -5433,7 +5438,10 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         username = "hamlet"
         user_profile = self.example_user("hamlet")
         with self.settings(
-            AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",),
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            ),
             SSO_APPEND_DOMAIN="zulip.com",
         ):
             result = self.client_get("/accounts/login/sso/", REMOTE_USER=username)
@@ -5443,7 +5451,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     def test_login_case_insensitive(self) -> None:
         user_profile = self.example_user("hamlet")
         email_upper = user_profile.delivery_email.upper()
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             result = self.client_get("/accounts/login/sso/", REMOTE_USER=email_upper)
             self.assertEqual(result.status_code, 302)
             self.assert_logged_in_user_id(user_profile.id)
@@ -5462,7 +5475,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_failure_due_to_nonexisting_user(self) -> None:
         email = "nonexisting@zulip.com"
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
             self.assertEqual(result.status_code, 200)
             self.assert_logged_in_user_id(None)
@@ -5470,13 +5488,21 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_failure_due_to_invalid_email(self) -> None:
         email = "hamlet"
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
             self.assert_json_error_contains(result, "Enter a valid email address.", 400)
 
     def test_login_failure_due_to_missing_field(self) -> None:
         with self.settings(
-            AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
         ), self.assertLogs("django.request", level="ERROR") as m:
             result = self.client_get("/accounts/login/sso/")
             self.assertEqual(result.status_code, 500)
@@ -5488,7 +5514,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_failure_due_to_wrong_subdomain(self) -> None:
         email = self.example_email("hamlet")
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             with mock.patch("zerver.views.auth.get_subdomain", return_value="acme"):
                 result = self.client_get(
                     "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
@@ -5499,7 +5530,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_failure_due_to_empty_subdomain(self) -> None:
         email = self.example_email("hamlet")
-        with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)):
+        with self.settings(
+            AUTHENTICATION_BACKENDS=(
+                "zproject.backends.ZulipRemoteUserBackend",
+                "zproject.backends.ZulipDummyBackend",
+            )
+        ):
             with mock.patch("zerver.views.auth.get_subdomain", return_value=""):
                 result = self.client_get(
                     "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
@@ -5513,14 +5549,22 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         email = user_profile.delivery_email
         with mock.patch("zerver.views.auth.get_subdomain", return_value="zulip"):
             with self.settings(
-                AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)
+                AUTHENTICATION_BACKENDS=(
+                    "zproject.backends.ZulipRemoteUserBackend",
+                    "zproject.backends.ZulipDummyBackend",
+                )
             ):
                 result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
                 self.assertEqual(result.status_code, 302)
                 self.assert_logged_in_user_id(user_profile.id)
 
     @override_settings(SEND_LOGIN_EMAILS=True)
-    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",))
+    @override_settings(
+        AUTHENTICATION_BACKENDS=(
+            "zproject.backends.ZulipRemoteUserBackend",
+            "zproject.backends.ZulipDummyBackend",
+        )
+    )
     def test_login_mobile_flow_otp_success_email(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
@@ -5568,7 +5612,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     @override_settings(SEND_LOGIN_EMAILS=True)
     @override_settings(SSO_APPEND_DOMAIN="zulip.com")
-    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",))
+    @override_settings(
+        AUTHENTICATION_BACKENDS=(
+            "zproject.backends.ZulipRemoteUserBackend",
+            "zproject.backends.ZulipDummyBackend",
+        )
+    )
     def test_login_mobile_flow_otp_success_username(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
@@ -5689,7 +5738,10 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
             user_profile = self.example_user("hamlet")
             email = user_profile.delivery_email
             with self.settings(
-                AUTHENTICATION_BACKENDS=("zproject.backends.ZulipRemoteUserBackend",)
+                AUTHENTICATION_BACKENDS=(
+                    "zproject.backends.ZulipRemoteUserBackend",
+                    "zproject.backends.ZulipDummyBackend",
+                )
             ):
                 result = self.client_get("/accounts/login/sso/", {"next": next}, REMOTE_USER=email)
             return result

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -931,7 +931,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        with self.assert_database_query_count(104), self.assert_memcached_count(18):
+        with self.assert_database_query_count(105), self.assert_memcached_count(18):
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 
@@ -3762,6 +3762,7 @@ class UserSignUpTest(ZulipTestCase):
         AUTHENTICATION_BACKENDS=(
             "zproject.backends.ZulipLDAPAuthBackend",
             "zproject.backends.EmailAuthBackend",
+            "zproject.backends.ZulipDummyBackend",
         )
     )
     def test_ldap_invite_user_as_admin(self) -> None:
@@ -3773,6 +3774,7 @@ class UserSignUpTest(ZulipTestCase):
         AUTHENTICATION_BACKENDS=(
             "zproject.backends.ZulipLDAPAuthBackend",
             "zproject.backends.EmailAuthBackend",
+            "zproject.backends.ZulipDummyBackend",
         )
     )
     def test_ldap_invite_user_as_guest(self) -> None:
@@ -3784,6 +3786,7 @@ class UserSignUpTest(ZulipTestCase):
         AUTHENTICATION_BACKENDS=(
             "zproject.backends.ZulipLDAPAuthBackend",
             "zproject.backends.EmailAuthBackend",
+            "zproject.backends.ZulipDummyBackend",
         )
     )
     def test_ldap_invite_streams(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -733,7 +733,7 @@ def log_into_subdomain(request: HttpRequest, token: str) -> HttpResponse:
         return HttpResponse(status=400)
 
     try:
-        result = ExternalAuthResult(login_token=token)
+        result = ExternalAuthResult(request=request, login_token=token)
     except ExternalAuthResult.InvalidTokenError:
         logging.warning("log_into_subdomain: Invalid token given: %s", token)
         return render(request, "zerver/log_into_subdomain_token_invalid.html", status=400)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -636,6 +636,7 @@ def registration_helper(
         # This dummy_backend check below confirms the user is
         # authenticating to the correct subdomain.
         auth_result = authenticate(
+            request=request,
             username=user_profile.delivery_email,
             realm=realm,
             return_data=return_data,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -1,6 +1,6 @@
 import os
 from email.headerregistry import Address
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from django_auth_ldap.config import GroupOfUniqueNamesType, LDAPGroupType
 
@@ -11,6 +11,8 @@ from .config import DEVELOPMENT, PRODUCTION, get_secret
 
 if TYPE_CHECKING:
     from django_auth_ldap.config import LDAPSearch
+
+    from zerver.models.users import UserProfile
 
 if PRODUCTION:  # nocoverage
     from .prod_settings import EXTERNAL_HOST, ZULIP_ADMINISTRATOR
@@ -619,3 +621,5 @@ CAN_ACCESS_ALL_USERS_GROUP_LIMITS_PRESENCE = False
 # General expiry time for signed tokens we may generate
 # in some places through the codebase.
 SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS = 60
+
+CUSTOM_AUTHENTICATION_WRAPPER_FUNCTION: Optional[Callable[..., Optional["UserProfile"]]] = None


### PR DESCRIPTION
Adds a decorator to `authenticate` functions to allow setting up arbitrary code to wrap them in. Here's a simplistic example that I can add in `/etc/zulip/settings.py` for restricting IP login for a user to a specific IP (when logging in via EmailAuthBackend specifically, for demonstration's sake):
```
def custom_auth_wrapper(
    auth_func, *args, **kwargs
):
    from zerver.lib.exceptions import JsonableError

    backend = args[0]
    backend_name = backend.name
    request = args[1]
    ip_address = request.META["REMOTE_ADDR"]
    backend.logger.info("%s backend. ip is %s", backend_name, ip_address)

    user_profile = auth_func(*args, **kwargs)
    if user_profile is not None and user_profile.delivery_email == "protecteduser@example.com:
        if backend_name == "email" and ip_address != "185.195.233.144":
            raise JsonableError("Your IP address is not allowed to log in as this user.")

    return user_profile

CUSTOM_AUTHENTICATION_WRAPPER_FUNCTION = custom_auth_wrapper

```

Caveats/missing stuff:
- [ ] Docs of course. Will be added if we like this interface.
- [ ] Currently wraps only certain backends, not all (mainly - not the social auth backends. I wanted to run a loop through `AUTH_BACKEND_NAME_MAP` and do something like `backend.authenticate = custom_auth_decorator(original_authenticate_func)`, but can't get that to work in any form so far. But if we think every backend should be decorated, then we can just manually add `@custom_auth_decorator` to `def authenticate` for every backend we implement.