### PR TITLE
user_topics: Validate 'topic' parameter length <= max_topic_length. 

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9498,6 +9498,10 @@ paths:
           description: |
             The topic to (un)mute. Note that the request will succeed regardless of
             whether any messages have been sent to the specified topic.
+
+            Clients should use the `max_topic_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum topic length.
           schema:
             type: string
           example: dinner
@@ -9594,6 +9598,10 @@ paths:
             The topic for which the personal preferences needs to be updated.
             Note that the request will succeed regardless of whether
             any messages have been sent to the specified topic.
+
+            Clients should use the `max_topic_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum topic length.
           schema:
             type: string
           example: dinner

--- a/zerver/views/user_topics.py
+++ b/zerver/views/user_topics.py
@@ -15,8 +15,9 @@ from zerver.lib.streams import (
     access_stream_to_remove_visibility_policy_by_name,
     check_for_exactly_one_stream_arg,
 )
-from zerver.lib.validator import check_int, check_int_in, check_string_in
+from zerver.lib.validator import check_capped_string, check_int, check_int_in, check_string_in
 from zerver.models import UserProfile, UserTopic
+from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 
 
 def mute_topic(
@@ -66,7 +67,7 @@ def update_muted_topic(
     user_profile: UserProfile,
     stream_id: Optional[int] = REQ(json_validator=check_int, default=None),
     stream: Optional[str] = REQ(default=None),
-    topic: str = REQ(),
+    topic: str = REQ(str_validator=check_capped_string(MAX_TOPIC_NAME_LENGTH)),
     op: str = REQ(str_validator=check_string_in(["add", "remove"])),
 ) -> HttpResponse:
     check_for_exactly_one_stream_arg(stream_id=stream_id, stream=stream)
@@ -94,7 +95,7 @@ def update_user_topic(
     request: HttpRequest,
     user_profile: UserProfile,
     stream_id: int = REQ(json_validator=check_int),
-    topic: str = REQ(),
+    topic: str = REQ(str_validator=check_capped_string(MAX_TOPIC_NAME_LENGTH)),
     visibility_policy: int = REQ(json_validator=check_int_in(UserTopic.VisibilityPolicy.values)),
 ) -> HttpResponse:
     if visibility_policy == UserTopic.VisibilityPolicy.INHERIT:


### PR DESCRIPTION
For endpoints:
* [`/users/me/subscriptions/muted_topics` ](https://zulip.com/api/mute-topic)
* [`/user_topics`](https://zulip.com/api/update-user-topic)

`topic` length was not validated before DB operations which resulted in an exception.

This commit adds a validation for the topic name length <= 'max_topic_length' characters.

Fixes #27796.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>Docs</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/68742b23-1ad0-4cbe-8d8f-02cc277328dd">
</img>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
