### PR TITLE
support: Display if remote realm is locally deactivated.

### DIFF
--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -1,6 +1,15 @@
 <div class="remote-realm-information">
     <span class="label">remote realm</span>
     <h3>{{ remote_realm.name }}</h3>
+    {% if remote_realm.realm_locally_deleted %}
+        <h4>Remote realm is locally deleted 🛑</h4>
+    {% endif %}
+    {% if remote_realm.registration_deactivated %}
+        <h4>Remote realm registration deactivated 🛑</h4>
+    {% endif %}
+    {% if remote_realm.realm_deactivated %}
+        <h4>Remote realm is deactivated on remote server 🛑</h4>
+    {% endif %}
     {% if remote_realm.plan_type == SPONSORED_PLAN_TYPE %}
         <h4>On 100% sponsored Zulip Community plan 🎉</h4>
     {% endif %}

--- a/zilencer/management/commands/populate_billing_realms.py
+++ b/zilencer/management/commands/populate_billing_realms.py
@@ -497,9 +497,7 @@ def populate_remote_realms(customer_profile: CustomerProfile) -> Dict[str, str]:
     if remote_server is None:
         raise AssertionError("Remote server not found! Please run manage.py register_server")
 
-    update_remote_realm_data_for_server(
-        remote_server, get_realms_info_for_push_bouncer(local_realm.id)
-    )
+    update_remote_realm_data_for_server(remote_server, get_realms_info_for_push_bouncer())
 
     remote_realm = RemoteRealm.objects.get(uuid=local_realm.uuid)
     user = UserProfile.objects.filter(realm=local_realm).first()


### PR DESCRIPTION
If a remote realm on a remote server is locally deactivated, we show a header with an emoji to alert support admin. Also updates `populate_billing_realms` to not locally deactivate test remote realms when generating them.

**Screenshots and screen captures:**

<details>
<summary>Example of remote server support with locally deactivated remote realm</summary>

![Screenshot from 2024-01-03 19-47-40](https://github.com/zulip/zulip/assets/63245456/7a3a6cab-b948-4de3-864d-07b22cfa5a52)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
