### PR TITLE
Fixed Incorrect Highlighting With Overlapping Alert Words.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -41,6 +41,8 @@ export function process_message(message: Message): void {
         return;
     }
 
+    my_alert_words.sort((a, b) => b.length - a.length);
+
     for (const word of my_alert_words) {
         const clean = _.escapeRegExp(word).replaceAll(
             /["&'<>]/g,


### PR DESCRIPTION
Fixes #28415

This Pull Request addresses fixing an issue with the highlighting of alerted words.

**Description:**

The problem was that when a message contained a phrase that was part of our alerted words list (for example, 'natural fiber'), If we already have 'natural' as an alerted word, only the first word ('natural') was being highlighted and not ('natural fiber'). This was due to the way the existing code was handling the `replace` function inside a `for` loop.

**Solution:**

To fix this issue, I have made a small but significant change to the `process_message` function. Now I added a sort function that sorts the `my_alert_words` array in descending order based on the length of the words/phrases before the `for` loop. This ensures that longer phrases like 'natural fiber' are replaced before shorter ones like 'natural'

**Screenshots:**

Before:
<img width="194" alt="before" src="https://github.com/zulip/zulip/assets/87448628/658821ef-8642-447f-a923-a9332b66f982">

Alerted Words = [very illustrious, natural fiber, illustrious, two words, natural]

After:
![after](https://github.com/zulip/zulip/assets/87448628/edaf7560-95c5-4358-8a2d-f6c86248931f)

