### PR TITLE
send_password_reset_email: Add a flag to only email users who need it.

### DIFF
--- a/help/include/import-how-users-will-log-in.md
+++ b/help/include/import-how-users-will-log-in.md
@@ -62,6 +62,13 @@ If you imported your organization into Zulip Cloud, simply e-mail
      ./manage.py send_password_reset_email -r <subdomain> --all-users
      ```
 
+   If you would like to only send emails to users who have not logged in yet,
+   you can use the following variant instead:
+
+     ```
+     ./manage.py send_password_reset_email -r <subdomain> --all-users --only-never-logged-in
+     ```
+
 {end_tabs}
 
 ### Manual password resets

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -18,6 +18,11 @@ class Command(ZulipBaseCommand):
     @override
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
+            "--only-never-logged-in",
+            action="store_true",
+            help="Filter to only users which have not accepted the TOS.",
+        )
+        parser.add_argument(
             "--entire-server", action="store_true", help="Send to every user on the server. "
         )
         self.add_user_list_args(
@@ -43,6 +48,11 @@ class Command(ZulipBaseCommand):
                         "You have to pass -u/--users or -a/--all-users or --entire-server."
                     )
                 raise error
+        if options["only_never_logged_in"]:
+            users = users.filter(tos_version=-1)
+
+        if not users.exists():
+            print("No matching users!")
 
         self.send(users)
 

--- a/zerver/management/commands/send_password_reset_email.py
+++ b/zerver/management/commands/send_password_reset_email.py
@@ -1,8 +1,9 @@
 from argparse import ArgumentParser
-from typing import Any, Iterable
+from typing import Any
 
 from django.contrib.auth.tokens import default_token_generator
 from django.core.management.base import CommandError
+from django.db.models import QuerySet
 from typing_extensions import override
 
 from zerver.forms import generate_password_reset_url
@@ -29,7 +30,7 @@ class Command(ZulipBaseCommand):
     @override
     def handle(self, *args: Any, **options: str) -> None:
         if options["entire_server"]:
-            users: Iterable[UserProfile] = UserProfile.objects.filter(
+            users: QuerySet[UserProfile] = UserProfile.objects.filter(
                 is_active=True, is_bot=False, is_mirror_dummy=False
             )
         else:
@@ -45,7 +46,7 @@ class Command(ZulipBaseCommand):
 
         self.send(users)
 
-    def send(self, users: Iterable[UserProfile]) -> None:
+    def send(self, users: QuerySet[UserProfile]) -> None:
         """Sends one-use only links for resetting password to target users"""
         for user_profile in users:
             context = {


### PR DESCRIPTION
Emailing the password reset email to users who have already logged in is not as useful.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
