### PR TITLE
send_custom_email: Various newsletter cleanups

### DIFF
--- a/zerver/management/commands/send_custom_email.py
+++ b/zerver/management/commands/send_custom_email.py
@@ -197,7 +197,7 @@ class Command(ZulipBaseCommand):
             users = users.exclude(
                 Q(tos_version=None) | Q(tos_version=UserProfile.TOS_VERSION_BEFORE_FIRST_LOGIN)
             )
-        send_custom_email(
+        users = send_custom_email(
             users,
             dry_run=dry_run,
             options=options,


### PR DESCRIPTION
## send_custom_email: Send to recently-active plus owners and admins.

The set of `enable_marketing_emails=True` are those that have opted into getting marketing newsletter emails -- but we previously limited further to only those users active in the last month.

Broaden that to "opted in, and either recently active or an owner or an admin," with the goal of providing information to folks who may have tried out Zulip in the past.

---

## send_custom_email: Order by delivery_email if necessary.

If we `.distinct("delivery_email")` then we must also `.order_by("delivery_email")`; adc987dc43f6 added the `.order_by`
call, which broke the newsletter codepath, since it did not contain the `delivery_email` in the ordering fields.

Add a flag to distinct on emails in `send_custom_email`.

---

## send_email: Distinct emails means distinct, case-insensitively.