### PR TITLE
portico: Correct spacing at footer bottom.

### DIFF
--- a/web/styles/portico/footer.css
+++ b/web/styles/portico/footer.css
@@ -97,12 +97,11 @@
     }
 
     .footer__legal {
-        margin: 12px 0 5px;
+        margin: 12px 0 0;
         padding: 0 52px;
         border-top: 1px solid hsl(0deg 0% 100% / 10%);
 
         & a {
-            margin-bottom: 10px;
             border-bottom: 1px solid var(--color-footer-background);
 
             &:hover {
@@ -117,9 +116,9 @@
 
     .footer__legal-container {
         max-width: 1132px;
-        padding-top: 15px;
+        padding: 15px 0;
         display: flex;
-        justify-content: space-between;
+        place-content: center space-between;
         flex-flow: row wrap;
         margin: 0 auto;
 
@@ -136,7 +135,13 @@
 
     .footer__legal-container .copyright {
         color: hsl(0deg 0% 100% / 50%);
-        margin-bottom: 8px;
+
+        @media screen and (width <= 600px) {
+            /* Maintain space between copyright
+               and legal links when flex-wrapping
+               at narrower viewports. */
+            margin-bottom: 8px;
+        }
     }
 
     .footer__legal-container a {


### PR DESCRIPTION
This corrects an undesired 5px open space beneath the portico footer, while improving the vertical alignment of legal footer elements on wider screens by putting flexbox in full control of vertical alignment. (Prior use of margin on individual flex items in the legal area were intended to keep the `border-bottom` borders adjacent the link text, but that was a poor pushback against flexbox's default stretch behavior.)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![portico-footer-narrow-before](https://github.com/zulip/zulip/assets/170719/c969a40c-3278-4872-980b-afe3b372c5a5) | ![portico-footer-narrow-after](https://github.com/zulip/zulip/assets/170719/eeaf72c6-4357-4fd3-8d6e-895b62226b1a) |
| ![portico-footer-wide-before](https://github.com/zulip/zulip/assets/170719/a6787507-272c-4ed9-9e35-cdcfefbc4633) | ![portico-footer-wide-after](https://github.com/zulip/zulip/assets/170719/4e98a818-7dbd-498c-83cb-3e21dd3fe673) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>