### PR TITLE
docs: Add warning about failed provisioning on macOS.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -314,6 +314,16 @@ cd zulip
 vagrant up --provider=docker
 ```
 
+:::{warning}
+There is a [known upstream issue on macOS](https://chat.zulip.org/#narrow/stream/21-provision-help/topic/provision.20error.20ERR_PNPM_LINKING_FAILED/near/1649241)
+that can cause provisioning to fail with `ERR_PNPM_LINKING_FAILED` or other errors. The temporary
+fix is to open the Docker desktop app's settings panel, and choose `osxfs (legacy)` under "Choose
+file sharing implementation for your containers." Once Docker restarts, you should be able to
+successfully run `vagrant up --provider=docker`. Back in Docker, you can return to using VirtioFS
+for better system performance while developing, but you may need to revert to `osxfs (legacy)`
+whenever you need to re-provision.
+:::
+
 The first time you run this command it will take some time because Vagrant
 does the following:
 


### PR DESCRIPTION
This PR adds a warning targeted to macOS users who may experience provisioning failures.

[CZO discussion](https://chat.zulip.org/#narrow/stream/21-provision-help/topic/provision.20error.20ERR_PNPM_LINKING_FAILED/near/1697894)

Fixes: #28370

![pnpm-linking-warning-fixed](https://github.com/zulip/zulip/assets/170719/937b0455-2df9-4a79-a48b-858748e119e8)
