### PR TITLE
test-api: Exclude generated curl examples for specific documented endpoints.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -117,3 +117,4 @@
 
 * [Fetch an API key (production)](/api/fetch-api-key)
 * [Fetch an API key (development only)](/api/dev-fetch-api-key)
+* [Send a test notification to mobile device(s)](/api/test-notify)

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -24,6 +24,12 @@ from zerver.openapi.curl_param_value_generators import (
 )
 from zerver.openapi.openapi import get_endpoint_from_operationid
 
+UNTESTED_GENERATED_CURL_EXAMPLES = {
+    # Would need push notification bouncer set up to test the
+    # generated curl example for this endpoint.
+    "test-notify",
+}
+
 
 def test_generated_curl_examples_for_success(client: Client) -> None:
     default_authentication_line = f"{client.email}:{client.api_key}"
@@ -42,9 +48,10 @@ def test_generated_curl_examples_for_success(client: Client) -> None:
     with open(rest_endpoints_path) as f:
         rest_endpoints_raw = f.read()
     ENDPOINT_REGEXP = re.compile(r"/api/\s*(.*?)\)")
-    endpoint_list = sorted(set(re.findall(ENDPOINT_REGEXP, rest_endpoints_raw)))
+    documented_endpoints = set(re.findall(ENDPOINT_REGEXP, rest_endpoints_raw))
+    endpoints_to_test = sorted(documented_endpoints.difference(UNTESTED_GENERATED_CURL_EXAMPLES))
 
-    for endpoint in endpoint_list:
+    for endpoint in endpoints_to_test:
         article_name = endpoint + ".md"
         file_name = os.path.join(settings.DEPLOY_ROOT, "api_docs/", article_name)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9523,17 +9523,17 @@ paths:
   /mobile_push/test_notification:
     post:
       operationId: test-notify
-      summary: Sends a test notification to the user's mobile device(s)
+      summary: Send a test notification to mobile device(s)
       tags: ["mobile"]
       description: |
-        This endpoint allows a user to trigger a test push notification to their
-        selected mobile device, or all their mobile devices.
+        Trigger sending a test push notification to the user's
+        selected mobile device or all of their mobile devices.
 
         **Changes**: Starting with Zulip 8.0 (feature level 234), test
         notifications sent via this endpoint use `test` rather than
-        `test-by-device-token` in the `event` field. (All mobile push
-        notifications also now include a `realm_name` field as well as
-        of this feature level).
+        `test-by-device-token` in the `event` field. Also, as of this
+        feature level, all mobile push notifications now include a
+        `realm_name` field.
 
         New in Zulip 8.0 (feature level 217).
       parameters:
@@ -9542,11 +9542,11 @@ paths:
           description: |
             The push token for the device to which to send the test notification.
 
-            If this parameter is not submitted, the test notification will be sent to all of the
-            user's devices registered on the server.
+            If this parameter is not submitted, the test notification will be sent
+            to all of the user's devices registered on the server.
 
-            Mobile device clients should pass this parameter in order to trigger a notification
-            that is only delivered to this client.
+            A mobile client should pass this parameter, to avoid triggering a test
+            notification for other clients.
           schema:
             type: string
           example: "111222"


### PR DESCRIPTION
As discussed in [#api documentation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/test.20notification.20endpoint/near/1690326) on CZO, creates the ability to exclude testing the generated curl examples for specific documented endpoints. Currently, this is limited to the endpoint for testing push notifications on mobile devices.

Also, updates some of the descriptive text for said test notifications endpoint; see screenshot below. And, adds that endpoint to the sidebar list of documented endpoints, in the specialty endpoints section.

@chrisbobbe - Could you look over the API documentation text changes? Also, I wonder if you have thoughts on the final sentence in the `token` parameter description. There's something about the final "this client" that sounds off to me, but I'm not sure how best to rephrase that.

---

**Screenshots and screen captures:**

<details>
<summary>Updated /mobile_push/test_notification description</summary>

[Current documentation](https://zulip.com/api/test-notify)
![Screenshot from 2024-01-05 12-57-56](https://github.com/zulip/zulip/assets/63245456/21dd9ad8-9abf-4cc5-aedf-5a83ea0b744a)
</details>
<details>
<summary>Updated specialty endpoints section in API documentation sidebar</summary>

![Screenshot from 2024-01-05 13-01-06](https://github.com/zulip/zulip/assets/63245456/7e7f6203-5450-4093-b466-e750ba029a23)

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
