### PR TITLE
migrate_customers: Migrate customer from server to realms during login.

### DIFF
--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -993,21 +993,6 @@ def remote_server_post_analytics(
         if remote_server_version_updated:
             fix_remote_realm_foreign_keys(server, realms)
 
-        try:
-            handle_customer_migration_from_server_to_realms(server, realms)
-        except Exception:  # nocoverage
-            logger.exception(
-                "%s: Failed to migrate customer from server (id: %s) to realms",
-                request.path,
-                server.id,
-                stack_info=True,
-            )
-            raise JsonableError(
-                _(
-                    "Failed to migrate customer from server to realms. Please contact support for assistance."
-                )
-            )
-
     realm_id_to_remote_realm = build_realm_id_to_remote_realm_dict(server, realms)
 
     remote_realm_counts = [


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/273-kandra-billing/topic/realm_locally_deleted/near/1713870

Earlier, the `handle_customer_migration_from_server_to_realms` function was called during the send analytics step.

It resulted in an error for customers having multiple Zulip servers, one for testing and the others for not-testing, sharing a push bouncer registration.

The migration step when run in a test instance caused customers to have their legacy plan migrated to a test realm, resulting in them losing their legacy plan.

This PR moves the migration step to run during plan management login step. This reduces the chances of losing legacy
plan as we expect them to only verify that 8.0 upgrade works and not bother trying to login to plan management from their test instance.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
