### PR TITLE
stream_settings_ui: Fix tab switching in stream settings.

### DIFF
--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -792,9 +792,10 @@ export function switch_rows(event) {
     }
 
     const row_data = get_row_data($switch_row);
+    const selected_tab = $(".stream_settings_header .tab-switcher .selected").data("tab-key");
     if (row_data) {
         const stream_id = row_data.id;
-        switch_to_stream_row(stream_id, "general");
+        switch_to_stream_row(stream_id, selected_tab);
     } else if (event === "up_arrow" && !row_data) {
         $("#search_stream_name").trigger("focus");
     }


### PR DESCRIPTION
Previously, when a user is navigating to another stream in stream settings using up or down arrows, the stream tab changes to general, which should actually change to the tab that the user is currently viewing.

This PR uses `selected_tab`, which defines the current tab that is selected and later used in the `switch_to_stream_row` function to ensure switching to that current tab.

Fixes #28422.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
 
**Before :**

https://github.com/zulip/zulip/assets/88829894/10b72759-d4ae-4cd9-aed4-32a58b81a807


**After :**


https://github.com/zulip/zulip/assets/88829894/65158003-eb6a-45bc-a171-35cd598dcf7b




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
