### PR TITLE
Web: Use Intl.ListFormat rather than .join(", ")

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -177,7 +177,7 @@ async function test_restore_private_message_draft_via_draft_overlay(page: Page):
     await common.pm_recipient.expect(page, `${cordelia_internal_email},${hamlet_internal_email}`);
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),
-        "Cordelia, Lear's daughter, King Hamlet - Zulip Dev - Zulip",
+        "Cordelia, Lear's daughter and King Hamlet - Zulip Dev - Zulip",
         "Didn't narrow to the direct messages with cordelia and hamlet",
     );
     await page.click("#compose_close");

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -211,7 +211,11 @@ export function get_title_data(
     if (is_group) {
         // For groups, just return a string with recipient names.
         return {
-            first_line: people.get_recipients(user_ids_string),
+            first_line: util.format_array_as_list(
+                people.get_recipients(user_ids_string),
+                "long",
+                "conjunction",
+            ),
             second_line: "",
             third_line: "",
         };

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -29,7 +29,6 @@ import * as typeahead_helper from "./typeahead_helper";
 import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 import {user_settings} from "./user_settings";
-import * as util from "./util";
 
 // **********************************
 // AN IMPORTANT NOTE ABOUT TYPEAHEADS
@@ -1233,10 +1232,4 @@ export function initialize({on_enter_send}) {
     });
 
     initialize_compose_typeahead("textarea#compose-textarea");
-
-    $("#private_message_recipient").on("blur", function () {
-        const val = $(this).val();
-        const recipients = typeahead_helper.get_cleaned_pm_recipients(val);
-        $(this).val(util.format_array_as_list(recipients, "long", "conjunction"));
-    });
 }

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -29,6 +29,7 @@ import * as typeahead_helper from "./typeahead_helper";
 import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 import {user_settings} from "./user_settings";
+import * as util from "./util";
 
 // **********************************
 // AN IMPORTANT NOTE ABOUT TYPEAHEADS
@@ -1236,6 +1237,6 @@ export function initialize({on_enter_send}) {
     $("#private_message_recipient").on("blur", function () {
         const val = $(this).val();
         const recipients = typeahead_helper.get_cleaned_pm_recipients(val);
-        $(this).val(recipients.join(", "));
+        $(this).val(util.format_array_as_list(recipients, "long", "conjunction"));
     });
 }

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -567,7 +567,11 @@ function row_in_search_results(keyword, text) {
 function filter_should_hide_row({stream_id, topic, dm_key}) {
     let text;
     if (dm_key !== undefined) {
-        const recipients_string = people.get_recipients(dm_key);
+        const recipients_string = util.format_array_as_list(
+            people.get_recipients(dm_key),
+            "long",
+            "conjunction",
+        );
         text = recipients_string.toLowerCase();
     } else {
         const sub = sub_store.get(stream_id);

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -268,7 +268,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                     !funcs.appendPill(pill),
             );
 
-            store.$input.text(drafts.join(", "));
+            store.$input.text(drafts.join(","));
             // when using the `text` insertion feature with jQuery the caret is
             // placed at the beginning of the input field, so this moves it to
             // the end.

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -9,6 +9,7 @@ import * as recent_view_util from "./recent_view_util";
 import {realm} from "./state_data";
 import * as unread from "./unread";
 import type {FullUnreadCountsData} from "./unread";
+import * as util from "./util";
 
 export let unread_count = 0;
 let pm_count = 0;
@@ -52,7 +53,11 @@ export function compute_narrow_title(filter?: Filter): string {
         const user_ids = people.emails_strings_to_user_ids_string(emails);
 
         if (user_ids !== undefined) {
-            return people.get_recipients(user_ids);
+            return util.format_array_as_list(
+                people.get_recipients(user_ids),
+                "long",
+                "conjunction",
+            );
         }
         if (emails.includes(",")) {
             return $t({defaultMessage: "Invalid users"});

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -470,18 +470,18 @@ function _calc_user_and_other_ids(user_ids_string: string): {
     return {user_ids, other_ids};
 }
 
-export function get_recipients(user_ids_string: string): string {
+export function get_recipients(user_ids_string: string): string[] {
     // See message_store.get_pm_full_names() for a similar function.
 
     const {other_ids} = _calc_user_and_other_ids(user_ids_string);
 
     if (other_ids.length === 0) {
         // direct message with oneself
-        return my_full_name();
+        return [my_full_name()];
     }
 
     const names = get_display_full_names(other_ids).sort();
-    return names.join(", ");
+    return names;
 }
 
 export function pm_reply_user_string(message: Message): string | undefined {

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -8,6 +8,7 @@ import * as pm_conversations from "./pm_conversations";
 import * as unread from "./unread";
 import * as user_status from "./user_status";
 import type {UserStatusEmojiInfo} from "./user_status";
+import * as util from "./util";
 
 // Maximum number of conversation threads to show in default view.
 const max_conversations_to_show = 8;
@@ -55,7 +56,12 @@ export function get_conversations(): DisplayObject[] {
         const user_ids_string = conversation.user_ids_string;
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         assert(reply_to !== undefined);
-        const recipients_string = people.get_recipients(user_ids_string);
+        // for left side bar we want user_ids to be using .join(", ");
+        const recipients_string = util.format_array_as_list(
+            people.get_recipients(user_ids_string),
+            "narrow",
+            "conjunction",
+        );
 
         const num_unread = unread.num_unread_for_user_ids_string(user_ids_string);
         const is_group = user_ids_string.includes(",");

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -4,6 +4,7 @@ import * as typeahead from "../shared/src/typeahead";
 
 import {$t} from "./i18n";
 import * as pygments_data from "./pygments_data";
+import * as util from "./util";
 
 export type RealmPlayground = {
     id: number;
@@ -90,7 +91,13 @@ export function get_pygments_typeahead_list_for_settings(query: string): Map<str
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
-        language_labels.set(key, key + " (" + values.join(", ") + ")");
+        language_labels.set(
+            key,
+            key +
+                " (" +
+                util.format_array_as_list([...new Set(values)].sort(), "narrow", "conjunction") +
+                ")",
+        );
     }
 
     return language_labels;

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -13,6 +13,7 @@ import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
+import * as util from "./util";
 
 export const keyboard_handling_context = {
     get_items_ids() {
@@ -77,7 +78,11 @@ function format(scheduled_messages) {
                 stream_color.get_stream_privacy_icon_color(color);
         } else {
             msg_render_context.is_stream = false;
-            msg_render_context.recipients = people.get_recipients(msg.to.join(","));
+            msg_render_context.recipients = util.format_array_as_list(
+                people.get_recipients(msg.to.join(",")),
+                "long",
+                "conjunction",
+            );
         }
         const time = new Date(msg.scheduled_delivery_timestamp * 1000);
         msg_render_context.formatted_send_at_time = timerender.get_full_datetime(time, "time");

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -164,7 +164,7 @@ test("title_data", () => {
     let is_group = true;
     const user_ids_string = "9999,1000";
     let expected_group_data = {
-        first_line: "Human Selma, Old User",
+        first_line: "Human Selma and Old User",
         second_line: "",
         third_line: "",
     };

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1151,10 +1151,6 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         on_enter_send: compose.finish,
     });
 
-    $("#private_message_recipient").val("othello@zulip.com, ");
-    $("#private_message_recipient").trigger("blur");
-    assert.equal($("#private_message_recipient").val(), "othello@zulip.com");
-
     // the UI of selecting a stream is tested in puppeteer tests.
     compose_state.set_stream_id(sweden_stream.stream_id);
 

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -420,7 +420,7 @@ run_test("insert_remove", ({mock_template}) => {
 
     assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
 
-    assert.equal($pill_input.text(), "chartreuse, mauve");
+    assert.equal($pill_input.text(), "chartreuse,mauve");
 
     assert.equal(widget.is_pending(), true);
     widget.clear_text();

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -474,11 +474,11 @@ test_people("pm_lookup_key", () => {
 test_people("get_recipients", () => {
     people.add_active_user(isaac);
     people.add_active_user(linus);
-    assert.equal(people.get_recipients("30"), "Me Myself");
-    assert.equal(people.get_recipients("30,32"), "Isaac Newton");
+    assert.deepEqual(people.get_recipients("30"), ["Me Myself"]);
+    assert.deepEqual(people.get_recipients("30,32"), ["Isaac Newton"]);
 
     muted_users.add_muted_user(304);
-    assert.equal(people.get_recipients("304,32"), "Isaac Newton, translated: Muted user");
+    assert.deepEqual(people.get_recipients("304,32"), ["Isaac Newton", "translated: Muted user"]);
 });
 
 test_people("get_full_name", () => {

--- a/web/tests/realm_playground.test.js
+++ b/web/tests/realm_playground.test.js
@@ -75,14 +75,14 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     let iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js)");
     assert.equal(
         iterator.next().value[1],
-        "Python (python, bazel, py, py3, python3, sage, starlark, python, bazel, py, py3, python3, sage, starlark)",
+        "Python (bazel, py, py3, python, python3, sage, starlark)",
     );
-    assert.equal(iterator.next().value[1], "Java (java, java)");
-    assert.equal(iterator.next().value[1], "Go (go, golang, go, golang)");
-    assert.equal(iterator.next().value[1], "Rust (rust, rs, rust, rs)");
+    assert.equal(iterator.next().value[1], "Java (java)");
+    assert.equal(iterator.next().value[1], "Go (go, golang)");
+    assert.equal(iterator.next().value[1], "Rust (rs, rust)");
 
     // Test typing "cu". Previously added custom languages should show up too.
     candidates = realm_playground.get_pygments_typeahead_list_for_settings("cu");
@@ -93,10 +93,10 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     );
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js)");
     assert.equal(
         iterator.next().value[1],
-        "Python (python, bazel, py, py3, python3, sage, starlark, python, bazel, py, py3, python3, sage, starlark)",
+        "Python (bazel, py, py3, python, python3, sage, starlark)",
     );
 
     // Test typing "invent_a_lang". Make sure there is no duplicate entries.
@@ -104,9 +104,9 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js)");
     assert.equal(
         iterator.next().value[1],
-        "Python (python, bazel, py, py3, python3, sage, starlark, python, bazel, py, py3, python3, sage, starlark)",
+        "Python (bazel, py, py3, python, python3, sage, starlark)",
     );
 });

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -122,6 +122,12 @@ function test(label, f) {
     });
 }
 
+test("get_cleaned_pm_recipients", () => {
+    const query_string = "user1, user2,  user3, , user4";
+    const result = th.get_cleaned_pm_recipients(query_string);
+    assert.deepStrictEqual(result, ["user1", "user2", "user3", "user4"]);
+});
+
 test("sort_streams", ({override, override_rewire}) => {
     let test_streams = [
         {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR brings internationalization by replacing the inconsistent .join(", ") with Intl.ListFormat for accurate and localized list formatting, using a common utility function.

Screenshot of Visual Changes:
![visual_changes_direct_message](https://github.com/zulip/zulip/assets/91906953/5b711248-65dc-4e0e-b788-6b014bddcc4e)

Edit : Removed Internationalization from left side bar.
![image](https://github.com/zulip/zulip/assets/91906953/24ec45b0-c8e9-4b48-97e9-bce63a431be5)



- [x] Files which were to be internationalized are using Intl.ListFormat.
- [x]  Uses ```{ style: "long", type: "conjunction" }``` could be changed according to use.
- [x]  Add a fallback system for MacOs. 
- [x]  Refactor tests to test with the new changes.

Fixes: #26936 Use Intl.ListFormat rather than .join(", ")

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
