### PR TITLE
push_notification: Check users count for plans to be downgraded.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -94,6 +94,7 @@ from zerver.models.clients import get_client
 from zerver.models.realms import get_realm
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.streams import get_stream
+from zilencer.lib.remote_counts import MissingDataError
 from zilencer.models import RemoteZulipServerAuditLog
 from zilencer.views import DevicesToCleanUpDict
 
@@ -2271,9 +2272,69 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 return_value=dummy_customer_plan,
             ):
                 with mock.patch(
-                    "corporate.lib.stripe.RemoteRealmBillingSession.get_next_billing_cycle",
-                    return_value=dummy_date,
-                ) as m, self.assertLogs("zulip.analytics", level="INFO") as info_log:
+                    "corporate.lib.stripe.RemoteRealmBillingSession.current_count_for_billed_licenses",
+                    return_value=11,
+                ):
+                    with mock.patch(
+                        "corporate.lib.stripe.RemoteRealmBillingSession.get_next_billing_cycle",
+                        return_value=dummy_date,
+                    ) as m, self.assertLogs("zulip.analytics", level="INFO") as info_log:
+                        send_server_data_to_push_bouncer(consider_usage_statistics=False)
+                        m.assert_called()
+                        realms = Realm.objects.all()
+                        for realm in realms:
+                            self.assertEqual(realm.push_notifications_enabled, True)
+                            self.assertEqual(
+                                realm.push_notifications_enabled_end_timestamp,
+                                dummy_date,
+                            )
+                        self.assertIn(
+                            "INFO:zulip.analytics:Reported 0 records",
+                            info_log.output[0],
+                        )
+
+        with mock.patch(
+            "corporate.lib.stripe.RemoteRealmBillingSession.get_customer",
+            return_value=dummy_customer,
+        ):
+            with mock.patch(
+                "corporate.lib.stripe.get_current_plan_by_customer",
+                return_value=dummy_customer_plan,
+            ):
+                with mock.patch(
+                    "corporate.lib.stripe.RemoteRealmBillingSession.current_count_for_billed_licenses",
+                    side_effect=MissingDataError,
+                ):
+                    with mock.patch(
+                        "corporate.lib.stripe.RemoteRealmBillingSession.get_next_billing_cycle",
+                        return_value=dummy_date,
+                    ) as m, self.assertLogs("zulip.analytics", level="INFO") as info_log:
+                        send_server_data_to_push_bouncer(consider_usage_statistics=False)
+                        m.assert_called()
+                        realms = Realm.objects.all()
+                        for realm in realms:
+                            self.assertEqual(realm.push_notifications_enabled, True)
+                            self.assertEqual(
+                                realm.push_notifications_enabled_end_timestamp,
+                                dummy_date,
+                            )
+                        self.assertIn(
+                            "INFO:zulip.analytics:Reported 0 records",
+                            info_log.output[0],
+                        )
+
+        with mock.patch(
+            "corporate.lib.stripe.RemoteRealmBillingSession.get_customer",
+            return_value=dummy_customer,
+        ):
+            with mock.patch(
+                "corporate.lib.stripe.get_current_plan_by_customer",
+                return_value=dummy_customer_plan,
+            ):
+                with mock.patch(
+                    "corporate.lib.stripe.RemoteRealmBillingSession.current_count_for_billed_licenses",
+                    return_value=10,
+                ):
                     send_server_data_to_push_bouncer(consider_usage_statistics=False)
                     m.assert_called()
                     realms = Realm.objects.all()
@@ -2281,12 +2342,8 @@ class AnalyticsBouncerTest(BouncerTestCase):
                         self.assertEqual(realm.push_notifications_enabled, True)
                         self.assertEqual(
                             realm.push_notifications_enabled_end_timestamp,
-                            dummy_date,
+                            None,
                         )
-                    self.assertIn(
-                        "INFO:zulip.analytics:Reported 0 records",
-                        info_log.output[0],
-                    )
 
         dummy_customer_plan = mock.MagicMock()
         dummy_customer_plan.status = CustomerPlan.ACTIVE


### PR DESCRIPTION
We return expected_end_timestamp as "None" for the plans to be downgraded if number of users is not more than MAX_USERS_WITHOUT_PLAN.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
