### PR TITLE
tests: Fix how test_is_outdated_server works.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -1013,20 +1013,21 @@ class HomeTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         now = LAST_SERVER_UPGRADE_TIME.replace(tzinfo=timezone.utc)
-        with time_machine.travel((now + timedelta(days=10)), tick=False):
-            self.assertEqual(is_outdated_server(iago), False)
-            self.assertEqual(is_outdated_server(hamlet), False)
-            self.assertEqual(is_outdated_server(None), False)
+        with patch("os.path.getmtime", return_value=now.timestamp()):
+            with time_machine.travel((now + timedelta(days=10)), tick=False):
+                self.assertEqual(is_outdated_server(iago), False)
+                self.assertEqual(is_outdated_server(hamlet), False)
+                self.assertEqual(is_outdated_server(None), False)
 
-        with time_machine.travel((now + timedelta(days=397)), tick=False):
-            self.assertEqual(is_outdated_server(iago), True)
-            self.assertEqual(is_outdated_server(hamlet), True)
-            self.assertEqual(is_outdated_server(None), True)
+            with time_machine.travel((now + timedelta(days=397)), tick=False):
+                self.assertEqual(is_outdated_server(iago), True)
+                self.assertEqual(is_outdated_server(hamlet), True)
+                self.assertEqual(is_outdated_server(None), True)
 
-        with time_machine.travel((now + timedelta(days=380)), tick=False):
-            self.assertEqual(is_outdated_server(iago), True)
-            self.assertEqual(is_outdated_server(hamlet), False)
-            self.assertEqual(is_outdated_server(None), False)
+            with time_machine.travel((now + timedelta(days=380)), tick=False):
+                self.assertEqual(is_outdated_server(iago), True)
+                self.assertEqual(is_outdated_server(hamlet), False)
+                self.assertEqual(is_outdated_server(None), False)
 
     def test_furthest_read_time(self) -> None:
         msg_id = self.send_test_message("hello!", sender_name="iago")

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -124,14 +124,14 @@ def self_hosting_auth_redirect(
     request: HttpRequest,
     *,
     next_page: Optional[str] = None,
-) -> HttpResponse:  # nocoverage
-    if not uses_notification_bouncer():
+) -> HttpResponse:
+    if not uses_notification_bouncer():  # nocoverage
         return render(request, "404.html", status=404)
 
     user = request.user
     assert user.is_authenticated
     assert isinstance(user, UserProfile)
-    if not user.has_billing_access:
+    if not user.has_billing_access:  # nocoverage
         # We may want to replace this with an html error page at some point,
         # but this endpoint shouldn't be accessible via the UI to an unauthorized
         # user - and they need to directly enter the URL in their browser. So a json
@@ -164,10 +164,10 @@ def self_hosting_auth_redirect(
         # Upload realm info and re-try. It should work now.
         send_server_data_to_push_bouncer(consider_usage_statistics=False)
         result = send_to_push_bouncer("POST", "server/billing", post_data)
-    except RemoteRealmServerMismatchError:
+    except RemoteRealmServerMismatchError:  # nocoverage
         return render(request, "zilencer/remote_realm_server_mismatch_error.html", status=403)
 
-    if result["result"] != "success":
+    if result["result"] != "success":  # nocoverage
         raise JsonableError(_("Error returned by the bouncer: {result}").format(result=result))
 
     redirect_url = result["billing_access_url"]


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/49-development-help/topic/Help.20with.20CI.20tests.20Error.20Code

`os.path.getmtime` needs to be mock.patched or otherwise the success of
the test depends on the filesystem state and breaks if version.py hasn't
been modified in a while.

