### PR TITLE
support: Merge multiple plans with the same status and level.

### DIFF
--- a/corporate/lib/analytics.py
+++ b/corporate/lib/analytics.py
@@ -71,6 +71,8 @@ def get_plan_data_by_remote_server() -> Dict[int, RemoteActivityPlanData]:  # no
             renewal_cents = RemoteRealmBillingSession(
                 remote_realm=plan.customer.remote_realm
             ).get_customer_plan_renewal_amount(plan, timezone_now())
+            if plan.customer.remote_realm.registration_deactivated:
+                continue
 
         assert server_id is not None
 

--- a/corporate/lib/analytics.py
+++ b/corporate/lib/analytics.py
@@ -80,11 +80,21 @@ def get_plan_data_by_remote_server() -> Dict[int, RemoteActivityPlanData]:  # no
         current_data = remote_server_plan_data.get(server_id)
         if current_data is not None:
             current_revenue = remote_server_plan_data[server_id].annual_revenue
-            remote_server_plan_data[server_id] = RemoteActivityPlanData(
-                current_status="Multiple plans",
-                current_plan_name="See support view",
-                annual_revenue=current_revenue + renewal_cents,
-            )
+            if (
+                current_data.current_plan_name == plan.name
+                and current_data.current_status == plan.get_plan_status_as_text()
+            ):
+                remote_server_plan_data[server_id] = RemoteActivityPlanData(
+                    current_status=current_data.current_status,
+                    current_plan_name=current_data.current_plan_name,
+                    annual_revenue=current_revenue + renewal_cents,
+                )
+            else:
+                remote_server_plan_data[server_id] = RemoteActivityPlanData(
+                    current_status="Multiple plans",
+                    current_plan_name="See support view",
+                    annual_revenue=current_revenue + renewal_cents,
+                )
         else:
             remote_server_plan_data[server_id] = RemoteActivityPlanData(
                 current_status=plan.get_plan_status_as_text(),


### PR DESCRIPTION
If the server has multiple plans with the same status and level, there's little utility to making the user click through to the support view to see this.

----

What's the right way to test this in dev?  Trying to access `/activity/remote` on my dev server redirects me to `/`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
