### PR TITLE
plans: Bring comparison link-styles in line with the mocked design.

### DIFF
--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -108,6 +108,7 @@
     }
 
     .comparison-table a:active {
+        color: var(--color-table-link-active);
         text-decoration-color: var(--color-table-link-decoration-active);
     }
 

--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -97,21 +97,17 @@
 
     .comparison-table a {
         color: var(--color-table-link);
-        text-decoration: underline !important;
         text-underline-offset: 4px;
         text-decoration-thickness: 1px;
         text-decoration-color: var(--color-table-link-decoration);
     }
 
     .comparison-table a:hover {
-        text-decoration: underline !important;
         color: var(--color-table-link-hover);
         text-decoration-color: var(--color-table-link-decoration-hover);
     }
 
     .comparison-table a:active {
-        text-decoration: underline !important;
-        color: !important;
         text-decoration-color: var(--color-table-link-decoration-active);
     }
 


### PR DESCRIPTION
This PR establishes the correct, expected link styles on the comparison tables. It does so by removing `!important` declarations that were unnecessary and interfered with expected link, :hover, and :active styles.

It also uses a previously declared but unused CSS variable for specifying the text color for active-state links.

**Screenshots and screen captures:**

_These provide context of link styles across the whole page; there were no expected changes in any of the non-comparison-table areas, but this serves to confirm._

| Before | After |
| --- | --- |
| ![comparison-links-before](https://github.com/zulip/zulip/assets/170719/a595bfd6-d0fd-44e0-ba64-cf5fbe4ea773) | ![comparison-links-after](https://github.com/zulip/zulip/assets/170719/d3b165ab-4963-4b2b-a3ab-6bec88be169f) |

_Comparison of PR (left side of images) with @terpimost's mock (right)._

| Static and hover styles | Static and active styles |
| --- | --- |
| <img width="835" alt="link-static-and-hover-comparison" src="https://github.com/zulip/zulip/assets/170719/d9fc0ee1-8cad-4b88-a1ed-35273db8d7e5"> | <img width="835" alt="link-active-comparison" src="https://github.com/zulip/zulip/assets/170719/d9bed78f-c03a-4d07-a879-7b5bead7c7ea"> |

