### PR TITLE
css:Making the height of compose bars steady.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -10,6 +10,7 @@
             font-size: 1em;
             padding: 3px 10px;
             vertical-align: middle;
+            font-variant-caps: unicase;
         }
 
         .compose_mobile_button {


### PR DESCRIPTION
This PR   fixes the issue “Unsteady height of  message compose  bars occurring while  scrolling down Through  the  stream names  having    language  other than English  like  Korean or Chinese in recent messages  view”.
Fixes:#27837.
<h3>Cause of this  Issue:</h3>
The   font  uses  different glyphs for  different  languages  making the height of the button unsteady  during the language change.

![Issue1](https://github.com/zulip/zulip/assets/153224120/f14090f9-3c10-4406-9b14-4b0650f6546e)

<h3>Quick  solution :</h3>

For this issue  setting  fixed height of  button can  be  a  quick  solution but  it  not generic solution and it  affects the  responsive design of the application.
For example  if  we consider the Korean/Chinese  language and  fix a  particular  height of the button then  it may work only  for that language causing the issue of text spilling out of the button for other  languages.

Height fixed  for Korean language:

![Screenshot (13)](https://github.com/zulip/zulip/assets/153224120/2bcfe30f-8c1a-4c66-a146-57e74373fed5)


Text spilling out of the button for other languages if height of the button is fixed:


![Screenshot (14)](https://github.com/zulip/zulip/assets/153224120/123f727f-6e47-46bd-bef6-be9c0e2a7d7e)

<h3>Generic  Solution :</h3>
The  ultimate  solution to this problem is  to ensure that the font uses same glyph for  every characters. This  can be achieved  using the font-variant-caps property of the CSS. When the value of this property is set to (unicase) it makes the font to use the glyph of   lowercase  letters to  every language resulting in  same height for every character in turn making the height of the compose bars steady .  

Changes made in web/styles/compose.css


![Screenshot (15)](https://github.com/zulip/zulip/assets/153224120/8b292b71-4223-4610-9af0-168bdd0f1eb8)

<h3>Before Changes:</h3>

![before](https://github.com/zulip/zulip/assets/153224120/611e7ea2-472c-4ea2-a591-be0a3ddd453e)

<h3>After Changes:</h3>


![after](https://github.com/zulip/zulip/assets/153224120/7b158b05-2542-403b-8e56-3bf2b6202195)
