### PR TITLE
refactor: Pass only stream id, not name, to `compose_actions.start()`.

### DIFF
--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -198,11 +198,9 @@ export function restore_message(draft) {
     let compose_args;
 
     if (draft.type === "stream") {
-        const stream_name = stream_data.get_stream_name_from_id(draft.stream_id);
         compose_args = {
             type: "stream",
             stream_id: draft.stream_id,
-            stream_name,
             topic: draft.topic,
             content: draft.content,
         };

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -29,7 +29,10 @@ function restore_draft(draft_id) {
         if (draft.stream_id !== undefined && draft.topic !== "") {
             narrow.activate(
                 [
-                    {operator: "stream", operand: compose_args.stream_name},
+                    {
+                        operator: "stream",
+                        operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
+                    },
                     {operator: "topic", operand: compose_args.topic},
                 ],
                 {trigger: "restore draft"},

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -21,7 +21,10 @@ function narrow_via_edit_scheduled_message(compose_args) {
     if (compose_args.type === "stream") {
         narrow.activate(
             [
-                {operator: "stream", operand: compose_args.stream},
+                {
+                    operator: "stream",
+                    operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
+                },
                 {operator: "topic", operand: compose_args.topic},
             ],
             {trigger: "edit scheduled message"},
@@ -39,7 +42,6 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
         compose_args = {
             type: "stream",
             stream_id: scheduled_msg.to,
-            stream: stream_data.get_stream_name_from_id(scheduled_msg.to),
             topic: scheduled_msg.topic,
             content: scheduled_msg.content,
         };


### PR DESCRIPTION
As part of the process of moving from stream names to ids, we now only pass the stream id in compose args to `compose_actions.start()`.

For when we still need the stream name, and have access to the compose args, we compute it from the id exactly where needed, to localise the instances of stream names.

Fixes issue mentioned: [here
](https://github.com/zulip/zulip/pull/27695#discussion_r1393484614)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
