### PR TITLE
stream-settings: Fix stream settings panel title not updating.

### DIFF
--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -468,7 +468,10 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
             .get_content_element($("#streams_overlay_container .streams-list"))
             .append(widgets.get(stream_id));
     }
-    maybe_reset_right_panel();
+
+    if ($(".stream-row.active").hasClass("notdisplayed")) {
+        stream_edit.empty_right_panel();
+    }
     update_empty_left_panel_message();
 
     // return this for test convenience
@@ -486,14 +489,6 @@ export function get_left_panel_params() {
         sort_order,
     };
     return params;
-}
-
-export function maybe_reset_right_panel() {
-    if ($(".stream-row.active").hasClass("notdisplayed")) {
-        $(".right .settings").hide();
-        $(".nothing-selected").show();
-        $(".stream-row.active").removeClass("active");
-    }
 }
 
 // Make it explicit that our toggler is not created right away.

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -468,10 +468,6 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
             .get_content_element($("#streams_overlay_container .streams-list"))
             .append(widgets.get(stream_id));
     }
-
-    if ($(".stream-row.active").hasClass("notdisplayed")) {
-        stream_edit.empty_right_panel();
-    }
     update_empty_left_panel_message();
 
     // return this for test convenience
@@ -508,6 +504,9 @@ export function switch_stream_tab(tab_name) {
     }
 
     redraw_left_panel();
+    if ($(".stream-row.active").hasClass("notdisplayed")) {
+        stream_edit.empty_right_panel();
+    }
     stream_edit.setup_subscriptions_tab_hash(tab_name);
 }
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -670,10 +670,7 @@ export function maybe_reset_right_panel(groups_list_data) {
 
     const group_ids = new Set(groups_list_data.map((group) => group.id));
     if (!group_ids.has(active_group_id)) {
-        $(".right .settings").hide();
-        $(".nothing-selected").show();
-        $(".group-row.active").removeClass("active");
-        reset_active_group_id();
+        show_user_group_settings_pane.nothing_selected();
     }
 }
 

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -16,6 +16,10 @@ mock_esm("../src/hash_util", {
     by_stream_url() {},
 });
 
+mock_esm("../src/browser_history", {
+    update() {},
+});
+
 mock_esm("../src/hash_parser", {
     get_current_hash_section: () => denmark_stream_id,
 });
@@ -212,6 +216,9 @@ run_test("redraw_left_panel", ({mock_template}) => {
     };
 
     test_filter({input: "d", subscribed_only: true}, [poland]);
+    assert.ok($(".stream-row-denmark").hasClass("active"));
+
+    stream_settings_ui.switch_stream_tab("subscribed");
     assert.ok(!$(".stream-row-denmark").hasClass("active"));
     assert.ok(!$(".right .settings").visible());
     assert.ok($(".nothing-selected").visible());


### PR DESCRIPTION
Earlier in stream settings, clicking an unsubscribed stream in "all streams" and then clicking subscribed tab, the right side panel title and url hash would remain same as that of the unsubscribed stream.

This PR fixes the behaviour and resets the panel title and url hash to default.

This PR also fixes - 
- On searching any stream name, the right side panel also resets. The PR also fixes this behaviour of searching for stream names. The right side panel after this PR currently reloads only when the user selects an unsubscribed stream in "all streams" and then navigates to "subscribed" tab.

- In group settings, clicking a non participating group from "all groups" and then clicking "your group" would reset the right panel but the panel title would remain same as that of the non participating group. The PR also fixes this behaviour

Fixes: zulip#28465.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 18-01-24 02:48:19 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/ae25f680-b91b-4bb2-a07c-b4296f997d7d)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:

https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
