### PR TITLE
css: Making the height of compose bars steady.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -16,7 +16,7 @@
             & span {
                 font-size: 1.2em !important;
                 font-weight: 400;
-                line-height: 1em;
+                line-height: var(--line-height-compose-buttons);
             }
         }
     }
@@ -53,6 +53,7 @@
             border: none;
             background: var(--color-compose-embedded-button-background);
             border-radius: 3px;
+            line-height: var(--line-height-compose-buttons);
         }
 
         #left_bar_compose_reply_button_big {
@@ -93,6 +94,7 @@
     #new_conversation_button,
     .new_direct_message_button_container {
         flex-shrink: 0;
+        line-height: var(--line-height-compose-buttons);
 
         @media (width < $sm_min) {
             /* Override inline style injected by jQuery hide() */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -173,6 +173,13 @@ body {
     --max-unexpanded-compose-height: 40vh;
 
     /*
+    Line height of the message buttons in compose box. Here it's necessary
+    to control this value uniformly and precisely to avoid issues with
+    layout shifts originating with non-Latin characters in this area.
+    */
+    --line-height-compose-buttons: 20px;
+
+    /*
     Maximum height of the subscribers list in stream settings so that
     it doesn't cause the container to have a second scrollbar.
     This value will be overridden when stream settings is opened.


### PR DESCRIPTION
This PR   fixes the issue “Unsteady height of  message compose  bars occurring while  scrolling down Through  the  stream names  having    language  other than English  like  Korean or Chinese in recent messages  view”.
Fixes:#27837.
I have   updated the PR  implementing  css property <b> line-height : var(--line-height-compose-buttons) </b> to the compose message box buttons  with value set as  <b>20px</b> in zulip.css to <b>compose_message</b> ,   <b>start_new_conversation</b>,  <b>new_direct_message</b>,    and modified the <b>line-height </b>  property of  <b>new_direct_message_mobile_button</b> to make  their  heights  steady  while  the  text within them is changed  to non-latin  characters. Thus  setting the  exact pixel-based  line-height solves the issue.


<h3>Before Changes:</h3>

![before1](https://github.com/zulip/zulip/assets/153224120/cb865659-9f4d-4005-84ff-5d385001c906)

<h3>After  Changes:</h3>

![after1](https://github.com/zulip/zulip/assets/153224120/77cf4120-950d-40f4-a2a2-0f3dd4cfd43c)

<h3>After  Changes (mobile view):</h3>


![mob](https://github.com/zulip/zulip/assets/153224120/b38f8efb-4e10-4f29-a20f-f2d8c9c9c369)



 [CZO Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Unsteady.20height.20of.20compose.20controls.20bar.2E)
