### PR TITLE
logrotate: smokescreen has its own config file.

### DIFF
--- a/puppet/zulip/templates/logrotate/zulip.template.erb
+++ b/puppet/zulip/templates/logrotate/zulip.template.erb
@@ -10,7 +10,6 @@
 /var/log/zulip/message_retention.log
 /var/log/zulip/deliver_scheduled_messages.log
 /var/log/zulip/send_email.log
-/var/log/zulip/smokescreen.log
 /var/log/zulip/slow_queries.log
 /var/log/zulip/soft_deactivation.log
 /var/log/zulip/sync_ldap_user_data.log


### PR DESCRIPTION
149bea83090951db5daac5d9c49396cae87fc561 added a separate config file for smokescreen (which is necessary because it can be installed separately) but failed ot notice that `zulip.template.erb` already had a config line for it.  This leads to failures starting the logrotate service:

```
logrotate[4158688]: error: zulip:1 duplicate log entry for /var/log/zulip/smokescreen.log
logrotate[4158688]: error: found error in file zulip, skipping
```

Remove the duplicate line.
