### PR TITLE
stream_settings: Convert name to pills.

### DIFF
--- a/web/src/stream_create_subscribers.js
+++ b/web/src/stream_create_subscribers.js
@@ -97,6 +97,7 @@ export function build_widgets() {
                 full_name: user.full_name,
                 is_current_user: user.user_id === current_user_id,
                 disabled: stream_create_subscribers_data.must_be_subscribed(user.user_id),
+                img_src: people.small_avatar_url_for_person(user),
             };
             return render_new_stream_user(item);
         },

--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -34,6 +34,7 @@ function format_member_list_elem(person, user_can_remove_subscribers) {
         email: person.delivery_email,
         can_remove_subscribers: user_can_remove_subscribers,
         for_user_group_members: false,
+        img_src: people.small_avatar_url_for_person(person),
     });
 }
 

--- a/web/src/user_group_create_members.js
+++ b/web/src/user_group_create_members.js
@@ -105,6 +105,7 @@ export function build_widgets() {
                 user_id: user.user_id,
                 full_name: user.full_name,
                 is_current_user: user.user_id === current_user_id,
+                img_src: people.small_avatar_url_for_person(user),
             };
             return render_new_user_group_user(item);
         },

--- a/web/src/user_group_edit_members.js
+++ b/web/src/user_group_edit_members.js
@@ -57,6 +57,7 @@ function format_member_list_elem(person) {
         email: person.delivery_email,
         can_remove_subscribers: settings_data.can_edit_user_group(current_group_id),
         for_user_group_members: true,
+        img_src: people.small_avatar_url_for_person(person),
     });
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1207,6 +1207,19 @@
         }
     }
 
+    .panel_subscriber_member_list > .pill-container {
+        &:hover {
+            color: inherit;
+        }
+
+        > .pill {
+            &:focus,
+            &:hover {
+                color: inherit;
+            }
+        }
+    }
+
     /* Originally the icon inherits the color of label, but when the setting
     is disabled, the color of the label is changed and thus the icon becomes
     too light. So, we set the color explicitly to original color of label to

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -156,6 +156,29 @@
     }
 }
 
+.panel_subscriber_member_list > .pill-container {
+    background-color: hsl(0deg 0% 0% / 7%);
+
+    &:hover {
+        color: inherit;
+    }
+
+    > .pill {
+        background-color: transparent;
+        border: none;
+        text-decoration: none;
+
+        &:focus {
+            color: inherit;
+        }
+
+        > .pill-value {
+            padding: 5px;
+            max-width: 165px;
+        }
+    }
+}
+
 @keyframes shake {
     10%,
     90% {

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -1,7 +1,6 @@
 <tr>
-    <td>
-        <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>
-        {{#if is_current_user}} <span class="my_user_status">{{t "(you)"}}</span>{{/if}}
+    <td class="panel_subscriber_member_list">
+        {{> ../user_display_only_pill display_value=full_name}}
     </td>
     {{#if email}}
         <td class="subscriber-email">{{email}}</td>

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -1,7 +1,6 @@
 <tr data-subscriber-id="{{user_id}}">
-    <td class="subscriber-name">
-        <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{name}}</a>
-        {{#if is_current_user}} <span class="my_user_status">{{t "(you)"}}</span>{{/if}}
+    <td class="subscriber-name panel_subscriber_member_list">
+        {{> ../user_display_only_pill display_value=name}}
     </td>
     {{#if email}}
     <td class="subscriber-email">{{email}}</td>

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -1,0 +1,14 @@
+<span class="pill-container">
+    <a data-user-id="{{user_id}}" class="view_user_profile pill" tabindex="0">
+        {{#if img_src}}
+        <img class="pill-image" src="{{img_src}}" />
+        {{/if}}
+        <span class="pill-value">{{display_value}}</span>
+        {{#if is_current_user}} <span class="my_user_status">{{t "(you)"}}</span>{{/if}}
+        {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
+        {{~#if deactivated}}&nbsp;({{t 'deactivated'}}){{~/if~}}
+        {{~#if has_status~}}
+        {{~> status_emoji status_emoji_info~}}
+        {{~/if~}}
+    </a>
+</span>


### PR DESCRIPTION
## Description:
In the **create stream** UI and in stream , user/bot names have been transformed from plain links to pills. Additionally, names are now displayed as pills in Members tables for both new and existing groups in /#groups.

Handling of long names has been addressed to ensure reasonable presentation, especially on narrow screens. Long names are now appropriately abbreviated with "..." when necessary.

To display  avatar of user ```src``` key is added in respective files.

Fixes:  [#25724](https://github.com/zulip/zulip/issues/25724)

## Screenshots and screen captures:

### Input pills:
| **Dark Input Pill** | **Light Input Pill** |
| ------------------- | -------------------- |
| ![Dark Pill](https://github.com/zulip/zulip/assets/73663475/30e69bd9-a57c-4dce-af06-a263da56eab0) | ![Light Pill](https://github.com/zulip/zulip/assets/73663475/ef032b84-074c-4293-a2ea-52b6395e59af) |

### Stream settings:
| **Dark Create stream Preview** | **Light Create Stream Preview** |
| ----------------------- | ------------------------ |
| ![image](https://github.com/zulip/zulip/assets/73663475/cdbdb243-4d9a-4566-b641-93c8a3066923) | ![Light Stream](https://github.com/zulip/zulip/assets/73663475/6f70e050-d12f-4574-9adb-e9a8d3a2197f) |
---
| **Dark Stream Preview** | **Light Stream Preview** |
| ----------------------- | ------------------------ |
| ![Dark Stream](https://github.com/zulip/zulip/assets/73663475/8fb1c283-377b-4207-bc47-64e7bec980b9) | ![image](https://github.com/zulip/zulip/assets/73663475/a6560963-b5de-4a29-8916-51584f347f56) |


### Group settings:
| **Dark Create user group Preview** | **Light Create User group Preview** |
| ----------------------- | ------------------------ |
|![dark-create-user-group](https://github.com/zulip/zulip/assets/73663475/4ffe1a64-c8e9-4149-8edb-07f023864e3e) |![light-create-user-group](https://github.com/zulip/zulip/assets/73663475/aa6202c7-9b27-4e80-92b2-7ecca556e44a)|
---
| **Dark User group Preview** | **Light User group Preview** |
| ----------------------- | ------------------------ |
|![dark-user-group](https://github.com/zulip/zulip/assets/73663475/534b5de9-9c56-4956-8bce-e1fcf77137a5)|![light-user-group](https://github.com/zulip/zulip/assets/73663475/66c2919f-7dac-493e-9f0f-52f3952feaf8)|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

