### PR TITLE
messages: Only lock UserMessage rows, not other joined tables.

### DIFF
--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -590,17 +590,18 @@ class UserMessage(AbstractUserMessage):
 
     @staticmethod
     def select_for_update_query() -> QuerySet["UserMessage"]:
-        """This SELECT FOR UPDATE query ensures consistent ordering on
-        the row locks acquired by a bulk update operation to modify
-        message flags using bitand/bitor.
+        """This `SELECT FOR UPDATE OF zerver_usermessage` query ensures
+        consistent ordering on the row locks acquired by a bulk update
+        operation to modify message flags using bitand/bitor.
 
         This consistent ordering is important to prevent deadlocks when
         2 or more bulk updates to the same rows in the UserMessage table
         race against each other (For example, if a client submits
         simultaneous duplicate API requests to mark a certain set of
         messages as read).
+
         """
-        return UserMessage.objects.select_for_update().order_by("message_id")
+        return UserMessage.objects.select_for_update(of=("self",)).order_by("message_id")
 
     @staticmethod
     def has_any_mentions(user_profile_id: int, message_id: int) -> bool:


### PR DESCRIPTION
By default, `SELECT FOR UPDATE` will also lock any rows which are `JOIN`ed into the selected rows; in the case of UserMessage rows, this can mean arbitrary Message rows.

Since the messages themselves are not being changed, it is not necessary to lock them -- and doing so may lead to deadlocks, in the case that the UserMessage row is locked for update before the Message, and some other request has already taken a read lock on the Message and is blocked on the UserMessage write lock.

Change `select_for_update_query` to explicitly only lock UserMessage.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
