### PR TITLE
portico: Extend proper background gradients to /plans.

### DIFF
--- a/templates/corporate/plans.html
+++ b/templates/corporate/plans.html
@@ -16,6 +16,9 @@
 {% endif %}
 
 <div class="portico-pricing plans {% if is_self_hosted_realm %} showing-self-hosted {% else %} showing-cloud {% endif %}">
+    <div class="body-bg">
+        <div class="body-bg__layer"></div>
+    </div>
     <div class="main">
         {% include "corporate/pricing_model.html" %}
     </div>

--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -40,6 +40,32 @@ ul {
     margin: 0;
 }
 
+.body-bg {
+    position: relative;
+    width: 0;
+    height: 0;
+}
+
+.body-bg__layer {
+    position: fixed;
+    z-index: -1;
+    width: 100vw;
+    height: 100vh;
+    background: linear-gradient(
+        180deg,
+        hsl(209.4deg 40.2% 50.2%) 30%,
+        hsl(238.4deg 27.9% 26.7%) 70%
+    );
+
+    @media (prefers-color-scheme: dark) {
+        background: linear-gradient(
+            180deg,
+            hsl(209deg 63% 40%) 30%,
+            hsl(238deg 28% 21%) 70%
+        );
+    }
+}
+
 .portico-hello-page {
     ._full-height-no-scroll {
         height: 100%;
@@ -61,24 +87,6 @@ ul {
 
     & img {
         border-style: none;
-    }
-
-    .body-bg {
-        position: relative;
-        width: 0;
-        height: 0;
-    }
-
-    .body-bg__layer {
-        position: fixed;
-        z-index: -1;
-        width: 100vw;
-        height: 100vh;
-        background: linear-gradient(
-            180deg,
-            hsl(209.4deg 40.2% 50.2%) 30%,
-            hsl(238.4deg 27.9% 26.7%) 70%
-        );
     }
 
     .page-wrapper {
@@ -601,14 +609,6 @@ ul {
     @media (prefers-color-scheme: dark) {
         & body {
             background: hsl(209deg 63% 40%);
-        }
-
-        .body-bg__layer {
-            background: linear-gradient(
-                180deg,
-                hsl(209deg 63% 40%) 30%,
-                hsl(238deg 28% 21%) 70%
-            );
         }
 
         .screen-1 {

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -1,3 +1,20 @@
+:root {
+    --color-background-gradient-start: hsl(209deg 40% 50%);
+    --color-background-gradient-end: hsl(210deg 48% 69%);
+
+    @media (prefers-color-scheme: dark) {
+        --color-background-gradient-start: hsl(209deg 63% 40%);
+        --color-background-gradient-end: hsl(238deg 28% 50%);
+    }
+}
+
+html {
+    /* Set the background on HTML to the starting
+       color for the plans-page gradient, so that the
+       top overscroll is undetectable. */
+    background: var(--color-background-gradient-start);
+}
+
 .portico-pricing {
     --font-ss3: "Source Sans 3 VF", sans-serif;
     --font-ops: "Open Sans Variable", sans-serif;
@@ -24,15 +41,15 @@
     padding: 102px 0 58px;
     background: linear-gradient(
         180deg,
-        hsl(209deg 40% 50%) 0%,
-        hsl(210deg 48% 69%) 100%
+        var(--color-background-gradient-start) 0%,
+        var(--color-background-gradient-end) 100%
     );
 
     @media (prefers-color-scheme: dark) {
         background: linear-gradient(
             180deg,
-            hsl(209deg 63% 40%) 30%,
-            hsl(238deg 28% 50%) 100%
+            var(--color-background-gradient-start) 30%,
+            var(--color-background-gradient-end) 100%
         );
     }
 


### PR DESCRIPTION
This applies the same structures and now more-generalized CSS from `/hello` to the `/plans` page, ensuring the correct gradient display while also masking any color shifts from top and bottom overscrolling.

**Screenshots and screen captures:**

| Light mode, before | Light mode, after |
| --- | --- |
| ![plans-gradient-light-before](https://github.com/zulip/zulip/assets/170719/ddb33a67-3f60-4860-8352-dcf1d4cb2192) | ![plans-gradient-light-after](https://github.com/zulip/zulip/assets/170719/850dd2ba-b568-48cb-8207-5f69c2ec1cb0) |

| Dark mode, before | Dark mode, after |
| --- | --- |
| ![plans-gradient-dark-before](https://github.com/zulip/zulip/assets/170719/4a8c7464-4493-42aa-8c21-0335c29e717e) | ![plans-gradient-dark-after](https://github.com/zulip/zulip/assets/170719/f3c38d8a-d7d7-4317-9de6-f0d88fa509ad) |


