### PR TITLE
emoji_picker: Fix status emoji picker inconsistencies.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -515,6 +515,12 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
+    .emoji-picker-popover .emoji-showcase-container,
+    .emoji-picker-popover .emoji-popover .emoji-popover-category-tabs,
+    .emoji-picker-popover .emoji-popover .emoji-popover-top {
+        background-color: hsl(0deg 0% 0% / 20%);
+    }
+
     .emoji-picker-popover
         .emoji-popover
         .emoji-popover-category-tabs
@@ -522,10 +528,21 @@
         background-color: hsl(0deg 0% 0% / 50%);
     }
 
+    .emoji-popover-emoji {
+        &:focus {
+            background-color: hsl(212deg 28% 8% / 75%);
+            box-shadow: 0 0 1px hsl(0deg 0% 98%);
+        }
+
+        &.reacted {
+            background-color: hsl(0deg 0% 0% / 50%);
+            border-color: hsl(0deg 0% 0% / 90%);
+        }
+    }
+
     .new-style .tab-switcher .ind-tab.selected,
     div.message_content thead,
-    .table-striped thead th,
-    .emoji-popover .reaction.reacted {
+    .table-striped thead th {
         background-color: hsl(0deg 0% 0% / 50%);
         border-color: hsl(0deg 0% 0% / 90%);
     }
@@ -536,10 +553,6 @@
 
     .message_time:hover {
         color: var(--color-message-action-interactive);
-    }
-
-    .emoji-popover .reaction:focus {
-        box-shadow: 0 0 1px hsl(0deg 0% 98%);
     }
 
     & input[type="text"]:focus,
@@ -593,10 +606,7 @@
     #groups_overlay
         #user-group-creation
         #user_group_creation_form
-        #user_group_creating_indicator:not(:empty),
-    .emoji-picker-popover
-        .emoji-popover
-        .emoji-popover-emoji:not(.reacted):focus {
+        #user_group_creating_indicator:not(:empty) {
         background-color: hsl(212deg 28% 8% / 75%);
     }
 
@@ -678,10 +688,7 @@
     }
 
     .group-row.active,
-    .stream-row.active,
-    .emoji-picker-popover .emoji-showcase-container,
-    .emoji-picker-popover .emoji-popover .emoji-popover-category-tabs,
-    .emoji-picker-popover .emoji-popover .emoji-popover-top {
+    .stream-row.active {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -182,11 +182,6 @@
     .emoji-popover {
         width: 250px;
 
-        .reacted {
-            background-color: hsl(195deg 50% 95%);
-            border-color: hsl(195deg 52% 79%);
-        }
-
         .emoji-popover-top {
             position: relative;
 
@@ -276,14 +271,18 @@
             height: 25px;
             width: 25px;
 
-            &.reacted.reaction:focus {
-                background-color: hsl(195deg 55% 88%);
+            &:focus {
+                background-color: hsl(0deg 0% 93%);
                 outline: none;
             }
 
-            &:not(.reacted):focus {
-                background-color: hsl(0deg 0% 93%);
-                outline: none;
+            &.reacted {
+                background-color: hsl(195deg 50% 95%);
+                border-color: hsl(195deg 52% 79%);
+            }
+
+            &.reacted:focus {
+                background-color: hsl(195deg 55% 88%);
             }
 
             &.hide {

--- a/web/templates/popovers/emoji/emoji_popover.hbs
+++ b/web/templates/popovers/emoji/emoji_popover.hbs
@@ -1,4 +1,4 @@
-<div class="emoji-picker-popover">
+<div class="emoji-picker-popover" data-emoji-destination="{{#if message_id }}reaction{{else if is_status_emoji_popover}}status{{else}}composition{{/if}}">
     <div class="emoji-popover">
         <div class="emoji-popover-top">
             <input class="emoji-popover-filter filter_text_input" type="text" placeholder="{{t 'Search' }}" />

--- a/web/templates/popovers/emoji/emoji_popover_emoji.hbs
+++ b/web/templates/popovers/emoji/emoji_popover_emoji.hbs
@@ -1,5 +1,5 @@
 {{#with emoji_dict}}
-<div class="emoji-popover-emoji {{#if ../message_id }}{{#if has_reacted}} reacted {{/if}} reaction {{else if ../is_status_emoji_popover}} status-emoji {{else}} composition {{/if}}" data-emoji-name="{{name}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
+<div class="emoji-popover-emoji {{#if has_reacted}}reacted{{/if}}" data-emoji-name="{{name}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
     {{#if is_realm_emoji}}
     <img src="{{url}}" class="emoji"/>
     {{else}}


### PR DESCRIPTION
Due to a logical bug in the `process_enter_while_filtering` function, the `toggle_reaction` was being called when pressing enter while filtering the emojis in the status emoji picker.

This PR fixes the above bug, while also adding some cleanups to the `emoji_picker.js` by combining multiple click handlers and aggregating all the logic related to an emoji being selected into a common function.

Fixes: #28464

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Steps to reproduce**: Go to "Set  Modal > Open emoji picker > Enter random words to filter > Press Enter

[before-status-emoji-picker.webm](https://github.com/zulip/zulip/assets/82862779/bb35aae7-0ab7-4daf-9ab5-8f4e4a760d57)

[after-status-emoji-picker.webm](https://github.com/zulip/zulip/assets/82862779/d83652c0-760b-4511-8759-28b691a9b46a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
