### PR TITLE
plans: Reduce font-weight on push placeholder button.

### DIFF
--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -614,6 +614,7 @@ html {
         line-height: 16px;
         background-color: transparent;
         border: 1px solid hsl(152deg 79% 24% / 10%);
+        font-weight: normal;
     }
 
     .current-plan-button:hover {


### PR DESCRIPTION
At @terpimost's suggestion, this PR drops the font-weight on the unlimited push placeholder for legacy self-hosted billing views.

| Before | After |
| --- | --- |
| <img width="650" alt="push-notifications-placeholder-before" src="https://github.com/zulip/zulip/assets/170719/66b22f5d-fee2-4d49-99c0-66a1974fdf0d"> | <img width="650" alt="push-notifications-placeholder-after" src="https://github.com/zulip/zulip/assets/170719/a4ebf5d4-d436-4b54-a3ef-db038b984a6d"> |

