### PR TITLE
plans: Reduce font-size of text comparison elements.

### DIFF
--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -215,6 +215,10 @@
         /* Set positioning context for use
            with tooltip hovers on icons. */
         position: relative;
+        /* Make non-icon text (e.g., "Billed hourly")
+           less prominent than other text in the table's
+           rows or columns. */
+        font-size: 0.9em;
     }
 
     .comparison-value-positive::after,

--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -199,16 +199,21 @@
 
     .comparison-value-positive {
         color: hsl(147deg 80% 29% / 100%);
-        position: relative;
     }
 
     .comparison-value-warning {
         color: hsl(42deg 85% 35% / 100%);
-        position: relative;
     }
 
     .comparison-value-negative {
         color: hsl(224deg 8% 50% / 100%);
+    }
+
+    .comparison-value-positive,
+    .comparison-value-warning,
+    .comparison-value-negative {
+        /* Set positioning context for use
+           with tooltip hovers on icons. */
         position: relative;
     }
 


### PR DESCRIPTION
At @terpimost's suggestion, this PR reduces the font-size of text comparison elements, such as _Billed hourly_, for a better presentation of the comparison tables for both Cloud and Self-hosted plans. As the screenshots illustrate and the code confirms, this has no effect on the size or positioning of icons.

A small prep commit consolidates `position: relative` on the same selectors that benefit from a uniform `font-size` adjustment.

**Screenshots and screen captures:**

| Cloud comparison, before | Cloud comparison, after |
| --- | --- |
| <img width="835" alt="cloud-comparison-before" src="https://github.com/zulip/zulip/assets/170719/3fb32ca4-eb87-408e-b03d-539b0e74c803"> | <img width="835" alt="cloud-comparison-after" src="https://github.com/zulip/zulip/assets/170719/3e412579-eccb-4b44-8b66-6dc0faec3d66"> |

| Self-hosted comparison, before | Self-hosted comparison, after |
| --- | --- |
| <img width="835" alt="self-hosted-comparison-before" src="https://github.com/zulip/zulip/assets/170719/bee74ed9-c9e9-4e71-a40e-b87fe24a2f65"> | <img width="835" alt="self-hosted-comparison-after" src="https://github.com/zulip/zulip/assets/170719/06b2d998-d516-441e-8931-d098d9ea9150"> |

