### PR TITLE
compose: Fix duplicate warning banners for the same private stream.

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -163,13 +163,24 @@ export function warn_if_private_stream_is_linked(linked_stream, $textarea) {
         return;
     }
 
-    const new_row_html = render_private_stream_warning({
-        banner_type: compose_banner.WARNING,
-        stream_name: linked_stream.name,
-        classname: compose_banner.CLASSNAMES.private_stream_warning,
-    });
-    const $container = compose_banner.get_compose_banner_container($textarea);
-    compose_banner.append_compose_banner_to_banner_list($(new_row_html), $container);
+    const $banner_container = compose_banner.get_compose_banner_container($textarea);
+    const $existing_stream_warnings_area = $banner_container.find(
+        `.${CSS.escape(compose_banner.CLASSNAMES.private_stream_warning)}`,
+    );
+
+    const existing_stream_warnings = [...$existing_stream_warnings_area].map((stream_row) =>
+        Number.parseInt($(stream_row).data("stream-id"), 10),
+    );
+
+    if (!existing_stream_warnings.includes(linked_stream.stream_id)) {
+        const new_row_html = render_private_stream_warning({
+            stream_id: linked_stream.stream_id,
+            banner_type: compose_banner.WARNING,
+            stream_name: linked_stream.name,
+            classname: compose_banner.CLASSNAMES.private_stream_warning,
+        });
+        compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
+    }
 }
 
 export function warn_if_mentioning_unsubscribed_user(mentioned, $textarea) {

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -700,8 +700,26 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     };
     stream_data.add_sub(secret_stream);
     banner_rendered = false;
+    const $banner_container = $("#compose_banners");
+    $banner_container.set_find_results(".private_stream_warning", []);
     compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
     assert.ok(banner_rendered);
+
+    // Simulate that the row was added to the DOM.
+    const $warning_row = $("#compose_banners .private_stream_warning");
+    $warning_row.data = (key) =>
+        ({
+            "stream-id": "22",
+        })[key];
+    $("#compose_banners .private_stream_warning").length = 1;
+    $("#compose_banners .private_stream_warning")[0] = $warning_row;
+
+    // Now try to mention the same stream again. The template should
+    // not render.
+    banner_rendered = false;
+    $banner_container.set_find_results(".private_stream_warning", $warning_row);
+    compose_validate.warn_if_private_stream_is_linked(secret_stream, $textarea);
+    assert.ok(!banner_rendered);
 });
 
 test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {


### PR DESCRIPTION
Earlier, a new banner would be showed for each mention of the same private stream in the compose box. This commit fixes that by checking if the private stream warning banners already shown include the private stream just mentioned, and if so, not showing a new banner.

This implementation is in line with the one for warnings for mentions of users not subscribed to the current stream.

Fixes: #26914.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/094176eb-98ba-43d4-82af-9a028fd45276)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
