### PR TITLE
puppet: Adjust uptrack permissions and ownership to match package's.

### DIFF
--- a/puppet/zulip_ops/manifests/ksplice_uptrack.pp
+++ b/puppet/zulip_ops/manifests/ksplice_uptrack.pp
@@ -4,14 +4,14 @@ class zulip_ops::ksplice_uptrack {
     file { '/etc/uptrack':
       ensure => directory,
       owner  => 'root',
-      group  => 'adm',
-      mode   => '0750',
+      group  => 'root',
+      mode   => '0755',
     }
     file { '/etc/uptrack/uptrack.conf':
       ensure  => file,
       owner   => 'root',
-      group   => 'adm',
-      mode    => '0640',
+      group   => 'root',
+      mode    => '0644',
       content => template('zulip_ops/uptrack/uptrack.conf.erb'),
     }
     $setup_apt_repo_file = "${::zulip_scripts_path}/lib/setup-apt-repo"


### PR DESCRIPTION
This reverts a759d26a327cd4337d68eaa1d45d6a69edc9161c; apparently the package has switched back.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
