### PR TITLE
nagios: Remove provisioning of zulip contact alias.

### DIFF
--- a/puppet/zulip_ops/manifests/profile/nagios.pp
+++ b/puppet/zulip_ops/manifests/profile/nagios.pp
@@ -108,17 +108,9 @@ class zulip_ops::profile::nagios {
     '/etc/nagios4/conf.d/contacts_nagios2.cfg',
     '/etc/nagios4/conf.d/hostgroups_nagios2.cfg',
     '/etc/nagios4/conf.d/localhost_nagios2.cfg',
+    '/etc/nagios4/conf.d/zulip_nagios.cfg',
   ]:
     ensure     => absent,
-  }
-
-  file { '/etc/nagios4/conf.d/zulip_nagios.cfg':
-    ensure => file,
-    mode   => '0644',
-    owner  => 'root',
-    group  => 'root',
-    source => '/usr/local/share/zulip/integrations/nagios/zulip_nagios.cfg',
-    notify => Service['nagios4'],
   }
 
   $hosts = zulipconf_nagios_hosts()


### PR DESCRIPTION
fcf096c52ed6 removed the callsite which would have notified this contact.  It's also not clear where
`/usr/local/share/zulip/integrations/nagios/zulip_nagios.cfg` was meant to be provisioned from.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
