### PR TITLE
find_account: Remove emails as URL parameters.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4248,11 +4248,7 @@ class TestFindMyTeam(ZulipTestCase):
         result = self.client_post(
             "/accounts/find/", dict(emails="iago@zulip.com,cordeliA@zulip.com")
         )
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(
-            result["Location"], "/accounts/find/?emails=iago%40zulip.com%2CcordeliA%40zulip.com"
-        )
-        result = self.client_get(result["Location"])
+        self.assertEqual(result.status_code, 200)
         content = result.content.decode()
         self.assertIn("Emails sent! You will only receive emails", content)
         self.assertIn("iago@zulip.com", content)
@@ -4271,12 +4267,7 @@ class TestFindMyTeam(ZulipTestCase):
         result = self.client_post(
             "/accounts/find/", dict(emails="iago@zulip.com,invalid_email@zulip.com")
         )
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(
-            result["Location"],
-            "/accounts/find/?emails=iago%40zulip.com%2Cinvalid_email%40zulip.com",
-        )
-        result = self.client_get(result["Location"])
+        self.assertEqual(result.status_code, 200)
         content = result.content.decode()
         self.assertIn("Emails sent! You will only receive emails", content)
         self.assertIn(self.example_email("iago"), content)
@@ -4309,8 +4300,7 @@ class TestFindMyTeam(ZulipTestCase):
     def test_find_team_one_email(self) -> None:
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
 
         self.assert_length(outbox, 1)
@@ -4319,8 +4309,7 @@ class TestFindMyTeam(ZulipTestCase):
         do_deactivate_user(self.example_user("hamlet"), acting_user=None)
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
@@ -4329,8 +4318,7 @@ class TestFindMyTeam(ZulipTestCase):
         do_deactivate_realm(get_realm("zulip"), acting_user=None)
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
@@ -4338,8 +4326,7 @@ class TestFindMyTeam(ZulipTestCase):
     def test_find_team_bot_email(self) -> None:
         data = {"emails": self.example_email("webhook_bot")}
         result = self.client_post("/accounts/find/", data)
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=webhook-bot%40zulip.com")
+        self.assertEqual(result.status_code, 200)
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -102,7 +102,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
 
     # Find account email
     result = client.post("/accounts/find/", {"emails": registered_email}, HTTP_HOST=realm.host)
-    assert result.status_code == 302
+    assert result.status_code == 200
 
     # New login email
     logged_in = client.login(dev_auth_username=registered_email, realm=realm)


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> Fixes part of  #3128 

- [ ]  You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: https://slack.com/signin/find

- [ ]  We should send an email regardless of whether they are in a Zulip org or not.

- [ ] The followup page should have links to resend the email or enter a different email address.

- [x] The URL of the followup page currently has the email as a URL parameter, which should be removed.
 

- [x] Add the 'In the Zulip development environment, outgoing emails are printed to the run-dev.py console.' text (git grep for it to see how we do it elsewhere)

- [x]  On load, the cursor should go into the box where you enter your email address.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/78016781/c6146640-2a24-4440-8dd1-900d9391da3b



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
