### PR TITLE
scheduled_messages: Convert module to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -185,7 +185,7 @@ EXEMPT_FILES = make_set(
         "web/src/resize.js",
         "web/src/resize_handler.js",
         "web/src/rows.ts",
-        "web/src/scheduled_messages.js",
+        "web/src/scheduled_messages.ts",
         "web/src/scheduled_messages_feed_ui.js",
         "web/src/scheduled_messages_overlay_ui.js",
         "web/src/scheduled_messages_popover.js",

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -5,7 +5,7 @@ import * as timerender from "./timerender";
 export const MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS = 5 * 60;
 
 // scheduled_messages_data is a dictionary where key=scheduled_message_id and value=scheduled_messages
-export const scheduled_messages_data = {};
+export const scheduled_messages_data = new Map();
 
 let selected_send_later_timestamp;
 
@@ -35,22 +35,22 @@ function compute_send_times(now = new Date()) {
 
 export function add_scheduled_messages(scheduled_messages) {
     for (const scheduled_message of scheduled_messages) {
-        scheduled_messages_data[scheduled_message.scheduled_message_id] = scheduled_message;
+        scheduled_messages_data.set(scheduled_message.scheduled_message_id, scheduled_message);
     }
 }
 
 export function remove_scheduled_message(scheduled_message_id) {
-    if (scheduled_messages_data[scheduled_message_id] !== undefined) {
-        delete scheduled_messages_data[scheduled_message_id];
+    if (scheduled_messages_data.has(scheduled_message_id)) {
+        scheduled_messages_data.delete(scheduled_message_id);
     }
 }
 
 export function update_scheduled_message(scheduled_message) {
-    if (scheduled_messages_data[scheduled_message.scheduled_message_id] === undefined) {
+    if (!scheduled_messages_data.has(scheduled_message.scheduled_message_id)) {
         return;
     }
 
-    scheduled_messages_data[scheduled_message.scheduled_message_id] = scheduled_message;
+    scheduled_messages_data.set(scheduled_message.scheduled_message_id, scheduled_message);
 }
 
 export function delete_scheduled_message(scheduled_msg_id, success = () => {}) {
@@ -61,7 +61,7 @@ export function delete_scheduled_message(scheduled_msg_id, success = () => {}) {
 }
 
 export function get_count() {
-    return Object.keys(scheduled_messages_data).length;
+    return scheduled_messages_data.size;
 }
 
 export function get_filtered_send_opts(date) {

--- a/web/src/scheduled_messages_feed_ui.js
+++ b/web/src/scheduled_messages_feed_ui.js
@@ -7,7 +7,7 @@ import * as scheduled_messages from "./scheduled_messages";
 import * as util from "./util";
 
 function get_scheduled_messages_matching_narrow() {
-    const scheduled_messages_list = Object.values(scheduled_messages.scheduled_messages_data);
+    const scheduled_messages_list = [...scheduled_messages.scheduled_messages_data.values()];
     const filter = narrow_state.filter();
     const is_conversation_view = filter === undefined ? false : filter.is_conversation_view();
     const current_view_type = narrow_state.narrowed_to_pms() ? "private" : "stream";

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -50,7 +50,7 @@ export const keyboard_handling_context = {
 };
 
 function sort_scheduled_messages(scheduled_messages) {
-    const sorted_messages = Object.values(scheduled_messages).sort(
+    const sorted_messages = [...scheduled_messages.values()].sort(
         (msg1, msg2) => msg1.scheduled_delivery_timestamp - msg2.scheduled_delivery_timestamp,
     );
     return sorted_messages;

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -90,7 +90,7 @@ function show_message_unscheduled_banner(scheduled_delivery_timestamp) {
 }
 
 export function edit_scheduled_message(scheduled_message_id, should_narrow_to_recipient = true) {
-    const scheduled_msg = scheduled_messages.scheduled_messages_data[scheduled_message_id];
+    const scheduled_msg = scheduled_messages.scheduled_messages_data.get(scheduled_message_id);
     scheduled_messages.delete_scheduled_message(scheduled_message_id, () => {
         open_scheduled_message_in_compose(scheduled_msg, should_narrow_to_recipient);
         show_message_unscheduled_banner(scheduled_msg.scheduled_delivery_timestamp);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The first commit converts `scheduled_messages_data` from an `object` to a `Map`. The second commit converts `scheduled_message` to TypeScript.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[message.webm](https://github.com/zulip/zulip/assets/123243429/f77f90e8-381c-4f07-97a0-68819f7d7b28)


