### PR TITLE
profile: rename custom profile field types

### DIFF
--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -110,17 +110,11 @@ class CustomProfileField(models.Model):
         (LONG_TEXT, gettext_lazy("Text (long)"), check_long_string, str, "LONG_TEXT"),
         (DATE, gettext_lazy("Date"), check_date, str, "DATE"),
         (URL, gettext_lazy("Link"), check_url, str, "URL"),
-        (
-            EXTERNAL_ACCOUNT,
-            gettext_lazy("External account"),
-            check_short_string,
-            str,
-            "EXTERNAL_ACCOUNT",
-        ),
+        (EXTERNAL_ACCOUNT, gettext_lazy("External account"), check_short_string, str, "EXTERNAL_ACCOUNT"),
         (PRONOUNS, gettext_lazy("Pronouns"), check_short_string, str, "PRONOUNS"),
     ]
 
-    ALL_FIELD_TYPES = [*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA]
+    ALL_FIELD_TYPES = sorted([*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA], key=lambda x: x[1])
 
     FIELD_VALIDATORS: Dict[int, Validator[ProfileDataElementValue]] = {
         item[0]: item[2] for item in FIELD_TYPE_DATA

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -94,7 +94,7 @@ class CustomProfileField(models.Model):
         (SELECT, gettext_lazy("List of options"), validate_select_field, str, "SELECT"),
     ]
     USER_FIELD_TYPE_DATA: List[UserFieldElement] = [
-        (USER, gettext_lazy("Person picker"), check_valid_user_ids, orjson.loads, "USER"),
+        (USER, gettext_lazy("Users"), check_valid_user_ids, orjson.loads, "USER"),
     ]
 
     SELECT_FIELD_VALIDATORS: Dict[int, ExtendedValidator] = {
@@ -106,9 +106,9 @@ class CustomProfileField(models.Model):
 
     FIELD_TYPE_DATA: List[FieldElement] = [
         # Type, display name, validator, converter, keyword
-        (SHORT_TEXT, gettext_lazy("Short text"), check_short_string, str, "SHORT_TEXT"),
-        (LONG_TEXT, gettext_lazy("Long text"), check_long_string, str, "LONG_TEXT"),
-        (DATE, gettext_lazy("Date picker"), check_date, str, "DATE"),
+        (SHORT_TEXT, gettext_lazy("Text (short)"), check_short_string, str, "SHORT_TEXT"),
+        (LONG_TEXT, gettext_lazy("Text (long)"), check_long_string, str, "LONG_TEXT"),
+        (DATE, gettext_lazy("Date"), check_date, str, "DATE"),
         (URL, gettext_lazy("Link"), check_url, str, "URL"),
         (
             EXTERNAL_ACCOUNT,


### PR DESCRIPTION
Fixing issue #28511
Trying to figure out how to reorder them, any help would be appreciated.

**Screenshots and screen captures:**
Before:

<img width="293" alt="Screenshot 2024-01-11 at 12 05 43 AM" src="https://github.com/zulip/zulip/assets/104259212/70370281-f164-4ad4-b755-55b9a1f1ab5e">

After:

<img width="1038" alt="Screenshot 2024-01-11 at 12 02 40 AM" src="https://github.com/zulip/zulip/assets/104259212/1c03bbbe-7ece-434b-b49a-ceb3255316f1">
