### PR TITLE
plans: Link to cloud, self-hosted sponsorship areas.

### DIFF
--- a/templates/corporate/plans.html
+++ b/templates/corporate/plans.html
@@ -26,7 +26,7 @@
     <!-- This is the subsection that displays with cloud plans. -->
 
     <div class="additional-pricing-information cloud-additional-pricing">
-        <div class="discounts-section">
+        <div id="cloud-sponsorships" class="discounts-section">
             <header>
                 <h2>Sponsorship and discounts</h2>
                 <p>
@@ -114,7 +114,7 @@
     <!-- This is the subsection that displays with self-hosted plans. -->
 
     <div class="additional-pricing-information self-hosted-additional-pricing">
-        <div class="discounts-section">
+        <div id="self-hosted-sponsorships" class="discounts-section">
             <header>
                 <h2>Sponsorship and discounts</h2>
                 <p>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -43,8 +43,7 @@
                                 <li><span>Advanced <a href="/help/roles-and-permissions">roles</a> and <a href="/help/stream-permissions">permissions</a></span></li>
                                 <li><span><a href="/help/guest-users">Guest</a>
                                 accounts</span></li>
-                                <li><span>Many organizations are eligible for a free <b>Standard</b> plan</span></li>
-
+                                <li><span>Many organizations are eligible for a <a href="{{ billing_base_url }}/plans/#cloud-sponsorships">free Standard plan</a></span></li>
                             </ul>
                         </div>
                         <div class="bottom">
@@ -167,7 +166,7 @@
                             <ul class="feature-list">
                                 <li><span>Complete team chat solution, with <a href="{{ billing_base_url }}/plans/#self-hosted-plan-comparison">all Zulip features</a> included</span></li>
                                 <li><span><a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html">Mobile notifications</a> for organizations with up to 10&nbsp;users</span></li>
-                                <li><span>Many organizations are eligible for unlimited mobile notifications on the free <b>Community</b> plan</span></li>
+                                <li><span>Many organizations are eligible for unlimited mobile notifications on the <a href="{{ billing_base_url }}/plans/#self-hosted-sponsorships">free Community plan</a></span></li>
                             </ul>
                         </div>
                         <div class="bottom">


### PR DESCRIPTION
This PR adds links from the Cloud and Self-hosted plans to URL fragments on their respective sponsorship and discounts areas.

**Screenshots and screen captures:**

| Cloud linked copy | Self-hosted linked copy |
| --- | --- |
| ![cloud-copy](https://github.com/zulip/zulip/assets/170719/085049c0-b030-4269-9118-ea5a7d7df307) | ![self-hosted-copy](https://github.com/zulip/zulip/assets/170719/74a592ec-8dda-4f0c-9d4b-f589d905082f) |
