### PR TITLE
profile: reorder custom profile fields

### DIFF
--- a/help/custom-profile-fields.md
+++ b/help/custom-profile-fields.md
@@ -45,17 +45,17 @@ methods][authentication-production] documentation for details.
 
 There are several different types of fields available.
 
-* **Short text**: For one line responses, like
+* **Text (short)**: For one line responses, like
     "Job title". Responses are limited to 50 characters.
-* **Long text**: For multiline responses, like "Biography".
-* **Date picker**: For dates, like "Birthday".
+* **Text (long)**: For multiline responses, like "Biography".
+* **Date**: For dates, like "Birthday".
 * **Link**: For links to websites.
 * **External account**: For linking to GitHub, Twitter, etc.
 * **Pronouns**: What pronouns should people use to refer to the user? Pronouns
   are displayed in [user mention](/help/mention-a-user-or-group) autocomplete
   suggestions.
 * **List of options**: Creates a dropdown with a list of options.
-* **Person picker**: For selecting one or more users, like "Manager" or
+* **Users**: For selecting one or more users, like "Manager" or
     "Direct reports".
 
 ## Display custom fields on user card

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -110,17 +110,12 @@ class CustomProfileField(models.Model):
         (LONG_TEXT, gettext_lazy("Long text"), check_long_string, str, "LONG_TEXT"),
         (DATE, gettext_lazy("Date picker"), check_date, str, "DATE"),
         (URL, gettext_lazy("Link"), check_url, str, "URL"),
-        (
-            EXTERNAL_ACCOUNT,
-            gettext_lazy("External account"),
-            check_short_string,
-            str,
-            "EXTERNAL_ACCOUNT",
-        ),
+        (EXTERNAL_ACCOUNT, gettext_lazy("External account"), check_short_string, str, "EXTERNAL_ACCOUNT",),
         (PRONOUNS, gettext_lazy("Pronouns"), check_short_string, str, "PRONOUNS"),
     ]
 
-    ALL_FIELD_TYPES = [*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA]
+    ALL_FIELD_TYPES = sorted([*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA], key=lambda x: x[1])
+
 
     FIELD_VALIDATORS: Dict[int, Validator[ProfileDataElementValue]] = {
         item[0]: item[2] for item in FIELD_TYPE_DATA


### PR DESCRIPTION
Fixed Issue #28511
[profile: rename custom profile field types](https://github.com/zulip/zulip/pull/28522)

Before: 
<img width="1122" alt="Screenshot 2024-01-10 at 2 32 13 PM" src="https://github.com/zulip/zulip/assets/104259212/97b54c50-b8c3-46cd-b9a7-0701c8e3c83c">

After: 
<img width="554" alt="Screenshot 2024-01-11 at 9 49 03 AM" src="https://github.com/zulip/zulip/assets/104259212/71d75db1-48c2-40a3-86da-0d9527b167b9">
