### PR TITLE
validators: Allow domain-less URLs to validate.

### DIFF
--- a/zerver/tests/test_validators.py
+++ b/zerver/tests/test_validators.py
@@ -310,19 +310,24 @@ class ValidatorTestCase(ZulipTestCase):
             check_none_or(check_int)("x", x)
 
     def test_check_url(self) -> None:
-        url: Any = "http://127.0.0.1:5002/"
-        check_url("url", url)
-
-        url = "http://zulip-bots.example.com/"
-        check_url("url", url)
-
-        url = "http://127.0.0"
+        check_url("url", "http://127.0.0.1:5002/")
+        check_url("url", "http://zulip-bots.example.com/")
+        check_url("url", "http://hostname/a/b?c=d&e=f#g")
+        check_url("url", "http://[fe80::248a:b7ff:fed7:a9af]:80/")
         with self.assertRaisesRegex(ValidationError, r"url is not a URL"):
-            check_url("url", url)
+            check_url("url", "http://127.0.0")
 
-        url = 99.3
+        with self.assertRaisesRegex(ValidationError, r"url is not a URL"):
+            check_url("url", "http://foo:baz/")
+
+        with self.assertRaisesRegex(ValidationError, r"url is not a URL"):
+            check_url("url", "//[")
+
+        with self.assertRaisesRegex(ValidationError, r"url is not a URL"):
+            check_url("url", "//example/")
+
         with self.assertRaisesRegex(ValidationError, r"url is not a string"):
-            check_url("url", url)
+            check_url("url", 99.3)
 
     def test_check_string_or_int_list(self) -> None:
         x: Any = "string"


### PR DESCRIPTION
Django's URLValidator requires that its hostnames contain a domain; this relaxes the validator to allow for domain-less hostnames in URLs, by inserting a `.local` when necessary and re-attempting validation.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
