### PR TITLE
support: Update validation for adding or updating a discount.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -124,8 +124,7 @@ def format_discount_percentage(discount: Optional[Decimal]) -> Optional[str]:
     if type(discount) is not Decimal or discount == Decimal(0):
         return None
 
-    # Even though it looks like /activity/support only finds integers valid,
-    # this will look good for any custom discounts that we apply.
+    # This will look good for any custom discounts that we apply.
     if discount * 100 % 100 == 0:
         precision = 0
     else:

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -101,10 +101,10 @@
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     {% if plan_data[realm.id].current_plan and plan_data[realm.id].current_plan.fixed_price %}
-    <input type="number" name="discount" value="{{ get_discount(plan_data[realm.id].customer) }}" disabled />
+    <input type="number" name="discount" value="{{ format_discount(get_discount(plan_data[realm.id].customer)) }}" step="0.01" min="0" max="99.99" disabled />
     <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
     {% else %}
-    <input type="number" name="discount" value="{{ get_discount(plan_data[realm.id].customer) }}" required />
+    <input type="number" name="discount" value="{{ format_discount(get_discount(plan_data[realm.id].customer)) }}" step="0.01" min="0" max="99.99" required />
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
     {% endif %}
 </form>

--- a/templates/analytics/remote_realm_details.html
+++ b/templates/analytics/remote_realm_details.html
@@ -32,6 +32,7 @@
     {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
     {% set remote_id = remote_realm.id %}
     {% set remote_type = "remote_realm_id" %}
+    {% set format_discount = format_discount %}
     {% set has_fixed_price = support_data[remote_realm.id].plan_data.has_fixed_price %}
     {% include 'analytics/sponsorship_forms_support.html' %}
 {% endwith %}

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -67,6 +67,7 @@
                     {% set sponsorship_data = remote_servers_support_data[remote_server.id].sponsorship_data %}
                     {% set remote_id = remote_server.id %}
                     {% set remote_type = "remote_server_id" %}
+                    {% set format_discount = format_discount %}
                     {% set has_fixed_price = remote_servers_support_data[remote_server.id].plan_data.has_fixed_price %}
                     {% include 'analytics/sponsorship_forms_support.html' %}
                 {% endwith %}

--- a/templates/analytics/sponsorship_forms_support.html
+++ b/templates/analytics/sponsorship_forms_support.html
@@ -25,10 +25,10 @@
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     {% if has_fixed_price %}
-    <input type="number" name="discount" value="{{ sponsorship_data.default_discount }}" disabled />
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
     <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
     {% else %}
-    <input type="number" name="discount" value="{{ sponsorship_data.default_discount }}" required />
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" required />
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
     {% endif %}
 </form>


### PR DESCRIPTION
Updates the HTML input field to have a min of 0, max of 99.99 and allow increments of 0.01.

Also, use format_discount_percentage for displaying the customer default discount in the support form.

**Screenshots and screen captures:**

All screenshots are from the /activity page, but would be the same for the discount form on the activity/remote page.

<details>
<summary>Success setting a discount with two decimal places</summary>

![Screenshot from 2024-01-11 13-45-38](https://github.com/zulip/zulip/assets/63245456/2bf7d491-23c7-4981-b6fa-b98f4170680c)
</details>
<details>
<summary>HTML validation not allowing three decimals to be set</summary>

![Screenshot from 2024-01-11 13-45-44](https://github.com/zulip/zulip/assets/63245456/192f0a9c-1d2f-4bdc-bbef-8f784a371faa)
</details>
<details>
<summary>HTML validation not allowing negative value to be set</summary>

![Screenshot from 2024-01-11 13-45-53](https://github.com/zulip/zulip/assets/63245456/6962df3b-749b-477b-bce5-e6b71fb6f627)
</details>
<details>
<summary>HTML validation not allowing values above 99.99</summary>

![Screenshot from 2024-01-11 13-46-02](https://github.com/zulip/zulip/assets/63245456/a250c4e2-c136-4ffd-9006-ffe238485ecf)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
