### PR TITLE
message_edit: Lay out edit buttons with flexbox

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -484,11 +484,16 @@ $time_column_min_width: 42px; /* + padding */
 
     .message-actions-button {
         box-sizing: border-box;
+        /* Display the actions buttons as
+           flex containers for positioning
+           text and spinners. */
+        display: flex;
+        align-items: center;
+        justify-content: center;
         height: 28px;
-        padding: 6px 10px;
+        padding: 0 10px;
         border-radius: 4px;
         border: 0;
-        margin-bottom: 0;
         line-height: 1;
     }
 
@@ -561,10 +566,7 @@ $time_column_min_width: 42px; /* + padding */
 
 .message_edit_save .loader {
     display: none;
-    vertical-align: top;
-    position: relative;
     height: 28px;
-    margin-top: -6px;
     width: 28px;
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -525,6 +525,156 @@ $time_column_min_width: 42px; /* + padding */
     }
 }
 
+/* Additional message-editing UI styles. */
+
+.message_edit_content {
+    line-height: 18px;
+    resize: vertical !important;
+    max-height: 24em;
+}
+
+.message_edit_countdown_timer {
+    text-align: right;
+    display: inline;
+    color: hsl(0deg 0% 63%);
+
+    &.expired {
+        color: hsl(4deg 58% 33%);
+    }
+}
+
+.message-edit-timer {
+    display: none;
+    /* Center vertically relative to
+       buttons. */
+    align-self: center;
+    /* Use flexbox to position to far right of
+       the Save and Cancel buttons. */
+    margin-left: auto;
+}
+
+.message-edit-feature-group {
+    display: flex;
+    margin: 0;
+    align-items: baseline;
+}
+
+.message_edit_save .loader {
+    display: none;
+    vertical-align: top;
+    position: relative;
+    height: 28px;
+    margin-top: -6px;
+    width: 28px;
+}
+
+.edit-controls {
+    .btn-wrapper {
+        cursor: not-allowed;
+    }
+
+    .disable-btn {
+        pointer-events: none;
+    }
+}
+
+.message_edit_spinner {
+    margin-right: 8px;
+    padding-top: 5px;
+}
+
+.message_edit_spinner .loading_indicator_spinner {
+    width: 20px;
+    height: 20px;
+}
+
+.message_edit {
+    display: none;
+}
+
+/* Reduce some of the heavy padding from Bootstrap. */
+.message_edit_form {
+    margin-bottom: 10px;
+    cursor: default;
+
+    .edit-controls {
+        margin-left: 0;
+        margin-top: 0;
+    }
+
+    /* Override the default border-radius to properly align
+       the button corners with `stream_header_colorblock`. */
+    .dropdown-toggle {
+        border-radius: 1px 4px 4px 1px !important;
+    }
+
+    .dropdown-list-widget,
+    .stream_header_colorblock {
+        margin-bottom: 10px;
+    }
+
+    & textarea {
+        width: 100%;
+        min-width: 206px;
+        box-sizing: border-box;
+        /* Setting resize as none hides the bottom right diagonal box
+           (which even has a background color of its own!). */
+        resize: none !important;
+        color: hsl(0deg 0% 33%);
+        background-color: hsl(0deg 0% 100%);
+        border-radius: 4px;
+        vertical-align: middle;
+        border: 1px solid hsl(0deg 0% 80%);
+        padding: 4px 6px;
+        margin-bottom: 10px;
+
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+        transition:
+            border linear 0.2s,
+            box-shadow linear 0.2s;
+
+        &:focus {
+            border-color: hsl(206.5deg 80% 62% / 80%);
+            outline: 0;
+
+            box-shadow:
+                inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206.5deg 80% 62% / 60%);
+        }
+
+        &:read-only,
+        &:disabled {
+            cursor: not-allowed;
+            background-color: hsl(0deg 0% 93%);
+        }
+    }
+}
+
+.message_edit_notice {
+    font-size: 10px;
+    opacity: 0.5;
+    user-select: none;
+    white-space: nowrap;
+    overflow-x: hidden;
+    overflow-x: clip;
+}
+
+.fade-in-message {
+    animation-name: fadeInMessage;
+    animation-duration: 1s;
+    animation-iteration-count: 1;
+
+    .message_edit_notice {
+        animation-name: fadeInEditNotice;
+        animation-duration: 1s;
+        animation-iteration-count: 1;
+    }
+}
+
+.message_edit_notice_hover:hover {
+    opacity: 1;
+}
+
 .recipient_row {
     /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
        for details on how this works */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -943,22 +943,6 @@ p.n-margin {
     }
 }
 
-.fade-in-message {
-    animation-name: fadeInMessage;
-    animation-duration: 1s;
-    animation-iteration-count: 1;
-
-    .message_edit_notice {
-        animation-name: fadeInEditNotice;
-        animation-duration: 1s;
-        animation-iteration-count: 1;
-    }
-}
-
-.message_edit_notice_hover:hover {
-    opacity: 1;
-}
-
 #navbar-fixed-container {
     position: fixed;
     top: 0;
@@ -1630,15 +1614,6 @@ td.pointer {
     }
 }
 
-.message_edit_notice {
-    font-size: 10px;
-    opacity: 0.5;
-    user-select: none;
-    white-space: nowrap;
-    overflow-x: hidden;
-    overflow-x: clip;
-}
-
 .messagebox-content .message_time {
     display: block;
     font-size: 13px;
@@ -2239,57 +2214,6 @@ div.focused-message-list {
     direction: rtl;
 }
 
-.message_edit_content {
-    line-height: 18px;
-    resize: vertical !important;
-    max-height: 24em;
-}
-
-.message_edit_countdown_timer {
-    text-align: right;
-    display: inline;
-    color: hsl(0deg 0% 63%);
-
-    &.expired {
-        color: hsl(4deg 58% 33%);
-    }
-}
-
-.message-edit-timer {
-    display: none;
-    /* Center vertically relative to
-       buttons. */
-    align-self: center;
-    /* Use flexbox to position to far right of
-       the Save and Cancel buttons. */
-    margin-left: auto;
-}
-
-.message-edit-feature-group {
-    display: flex;
-    margin: 0;
-    align-items: baseline;
-}
-
-.message_edit_save .loader {
-    display: none;
-    vertical-align: top;
-    position: relative;
-    height: 28px;
-    margin-top: -6px;
-    width: 28px;
-}
-
-.edit-controls {
-    .btn-wrapper {
-        cursor: not-allowed;
-    }
-
-    .disable-btn {
-        pointer-events: none;
-    }
-}
-
 .topic_edit {
     display: none;
     line-height: 22px;
@@ -2859,16 +2783,6 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-.message_edit_spinner {
-    margin-right: 8px;
-    padding-top: 5px;
-}
-
-.message_edit_spinner .loading_indicator_spinner {
-    width: 20px;
-    height: 20px;
-}
-
 textarea.invitee_emails {
     min-height: 40px;
     max-height: 300px;
@@ -3121,68 +3035,6 @@ select.invite-as {
 .sub-unsub-message span::after {
     left: 0.25em;
     margin-right: -50%;
-}
-
-.message_edit {
-    display: none;
-}
-
-/* Reduce some of the heavy padding from Bootstrap. */
-.message_edit_form {
-    margin-bottom: 10px;
-    cursor: default;
-
-    .edit-controls {
-        margin-left: 0;
-        margin-top: 0;
-    }
-
-    /* Override the default border-radius to properly align
-       the button corners with `stream_header_colorblock`. */
-    .dropdown-toggle {
-        border-radius: 1px 4px 4px 1px !important;
-    }
-
-    .dropdown-list-widget,
-    .stream_header_colorblock {
-        margin-bottom: 10px;
-    }
-
-    & textarea {
-        width: 100%;
-        min-width: 206px;
-        box-sizing: border-box;
-        /* Setting resize as none hides the bottom right diagonal box
-           (which even has a background color of its own!). */
-        resize: none !important;
-        color: hsl(0deg 0% 33%);
-        background-color: hsl(0deg 0% 100%);
-        border-radius: 4px;
-        vertical-align: middle;
-        border: 1px solid hsl(0deg 0% 80%);
-        padding: 4px 6px;
-        margin-bottom: 10px;
-
-        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
-        transition:
-            border linear 0.2s,
-            box-shadow linear 0.2s;
-
-        &:focus {
-            border-color: hsl(206.5deg 80% 62% / 80%);
-            outline: 0;
-
-            box-shadow:
-                inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                0 0 8px hsl(206.5deg 80% 62% / 60%);
-        }
-
-        &:read-only,
-        &:disabled {
-            cursor: not-allowed;
-            background-color: hsl(0deg 0% 93%);
-        }
-    }
 }
 
 #topic_edit_form {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2254,18 +2254,7 @@ div.focused-message-list {
     }
 }
 
-#message_edit_topic {
-    margin: 0 5px 10px 0;
-}
-
-.message_edit_header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-}
-
-.inline_topic_edit:focus,
-#message_edit_topic:focus {
+.inline_topic_edit:focus {
     outline: none;
 }
 
@@ -2275,8 +2264,7 @@ div.focused-message-list {
     max-width: 100%;
 }
 
-.topic_move_breadcrumb_messages,
-.message_edit_breadcrumb_messages {
+.topic_move_breadcrumb_messages {
     margin: 0 5px 5px 0;
     align-self: center;
     width: 100%;
@@ -2300,10 +2288,6 @@ div.focused-message-list {
         display: inline-block;
         margin-right: 10px;
     }
-}
-
-.message_edit_breadcrumb_messages {
-    margin-bottom: 10px;
 }
 
 .message_length_controller {


### PR DESCRIPTION
This PR does three things:

1) It moves various `message_edit` selectors and styles from `zulip.css` into `message_row.css`
2) It removes some dead CSS related to message-edit structures that no appear to exist in the codebase.
3) It strengthens the layout of the message edit buttons with flexbox, especially the load spinner on the Save button. The kinds of fiddly tweaks in #28134 should no longer be necessary, as flexbox is responsible for all alignment matters, instead of positioning and brittle pixel-offset tweaks.

**Screenshots and screen captures:**

_As this is a code-quality PR, there should be no visual changes._

| Before | After |
| --- | --- |
| <img width="470" alt="save-spinner-before" src="https://github.com/zulip/zulip/assets/170719/806881a2-61dd-4d00-8c10-cdbd4d0fd135"> | <img width="470" alt="save-spinner-after" src="https://github.com/zulip/zulip/assets/170719/a8e57a53-21cd-4530-90cb-a2c3eb4345b3"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>