### PR TITLE
docs: Fix selfhoster URL to be the canonical one.

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -95,7 +95,7 @@ option:
 
 Servers running Zulip releases older than Zulip 8.0 can start the plan
 management log in process at
-<https://selfhosting.zulip.com/serverlogin>. This option is also
+<https://selfhosting.zulip.com/serverlogin/>. This option is also
 available for Zulip 8.0+ servers, and makes it possible to use a
 single plan for multiple organizations on one installation. See [help
 center documentation](https://zulip.com/help/self-hosted-billing) for

--- a/help/include/legacy-log-in.md
+++ b/help/include/legacy-log-in.md
@@ -1,4 +1,4 @@
-1. Go to <https://selfhosting.zulip.com/serverlogin>.
+1. Go to <https://selfhosting.zulip.com/serverlogin/>.
 
 1. Fill out the requested server information, and click **Continue**.
 


### PR DESCRIPTION
We redirect from `/serverlogin` to `/serverlogin/`, so save a 301.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
