### PR TITLE
Ensure email server failures do not stop all workers from making progress

### DIFF
--- a/zerver/management/commands/process_queue.py
+++ b/zerver/management/commands/process_queue.py
@@ -119,15 +119,13 @@ class ThreadedWorker(threading.Thread):
         self.logger = logger
         self.queue_name = queue_name
 
-        with log_and_exit_if_exception(logger, queue_name, threaded=True):
-            self.worker = get_worker(queue_name, threaded=True)
-
     @override
     def run(self) -> None:
         with configure_scope() as scope, log_and_exit_if_exception(
             self.logger, self.queue_name, threaded=True
         ):
-            scope.set_tag("queue_worker", self.worker.queue_name)
-            self.worker.setup()
-            logging.debug("starting consuming %s", self.worker.queue_name)
-            self.worker.start()
+            scope.set_tag("queue_worker", self.queue_name)
+            worker = get_worker(self.queue_name, threaded=True)
+            worker.setup()
+            logging.debug("starting consuming %s", self.queue_name)
+            worker.start()

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -790,7 +790,7 @@ class MissedMessageWorker(QueueProcessingWorker):
 class EmailSendingWorker(LoopQueueProcessingWorker):
     def __init__(self, threaded: bool = False, disable_timeout: bool = False) -> None:
         super().__init__(threaded, disable_timeout)
-        self.connection: BaseEmailBackend = initialize_connection(None)
+        self.connection: Optional[BaseEmailBackend] = None
 
     @retry_send_email_failures
     def send_email(self, event: Dict[str, Any]) -> None:
@@ -812,7 +812,8 @@ class EmailSendingWorker(LoopQueueProcessingWorker):
     @override
     def stop(self) -> None:
         try:
-            self.connection.close()
+            if self.connection is not None:
+                self.connection.close()
         finally:
             super().stop()
 


### PR DESCRIPTION
queue_processors: Defer initial email connection creation.

We previously created the connection to the outgoing email server when the EmailSendingWorker was first created.  Since creating the connection can fail (e.g. because of firewalls or typos in the hostname), this can cause the `QueueProcessingWorker` creation to raise an exception.  In multi-threaded mode, exceptions in the worker threads which are _not_ during the handling of a specific event percolate out to `log_and_exit_if_exception` and trigger the termination of the entire process -- stopping all worker threads from making forward progress.

Contain the blast radius of misconfigured email servers by deferring the opening of the connection until it is first needed.  This will not cause any overall performance change, since it only affects the latency of the very first email after startup.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
