### PR TITLE
remote_billing: Handle two confirmation links for same user correctly.

### DIFF
--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -683,8 +683,6 @@ def remote_billing_legacy_server_from_login_confirmation_link(
     remote_server = prereg_object.remote_server
     remote_server_uuid = str(remote_server.uuid)
 
-    # If this user (identified by email) already did this flow, meaning the have a RemoteServerBillingUser,
-    # then we don't re-do the ToS consent  again.
     remote_billing_user = RemoteServerBillingUser.objects.filter(
         remote_server=remote_server, email=prereg_object.email
     ).first()

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -448,11 +448,18 @@ def remote_realm_billing_from_login_confirmation_link(
     # Mypy is not satisfied by the above assert, so we need to cast.
     uri_scheme = cast(Literal["http://", "https://"], uri_scheme)
 
-    remote_billing_user = RemoteRealmBillingUser.objects.create(
-        email=prereg_object.email,
+    remote_billing_user, created = RemoteRealmBillingUser.objects.get_or_create(
         remote_realm=remote_realm,
         user_uuid=prereg_object.user_uuid,
+        defaults={"email": prereg_object.email},
     )
+    if not created:
+        billing_logger.info(
+            "Matching RemoteRealmBillingUser already exists for "
+            "PreregistrationRemoteRealmBillingUser %s",
+            prereg_object.id,
+        )
+
     prereg_object.created_user = remote_billing_user
     prereg_object.save(update_fields=["created_user"])
 


### PR DESCRIPTION
The bug was that a user could do the first part of the flow twice, receiving two confirmation links, before finishing signup. Then they could use the first link, followed by the second, which would case an IntegrityError due to trying to create the RemoteRealmBillingUser for the second time.

When the second link gets clicked, we should just transparently redirect the user further into the flow so that they can proceed.
