### PR TITLE
compose: Revamp and improve test suite for compose formatting buttons.

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -581,8 +581,8 @@ export function format_text($textarea, type, inserted_content) {
     };
 
     const format_spoiler = () => {
-        let spoiler_syntax_start = "```spoiler \n";
-        const spoiler_syntax_start_without_break = "```spoiler ";
+        const spoiler_syntax_start = "```spoiler \n";
+        let spoiler_syntax_start_without_break = "```spoiler ";
         let spoiler_syntax_end = "\n```";
 
         // For when the entire spoiler block (with no header) is selected.
@@ -708,7 +708,7 @@ export function format_text($textarea, type, inserted_content) {
         }
 
         if (range.start > 0 && text[range.start - 1] !== "\n") {
-            spoiler_syntax_start = "\n" + spoiler_syntax_start;
+            spoiler_syntax_start_without_break = "\n" + spoiler_syntax_start_without_break;
         }
         if (range.end < text.length && text[range.end] !== "\n") {
             spoiler_syntax_end = spoiler_syntax_end + "\n";
@@ -720,7 +720,7 @@ export function format_text($textarea, type, inserted_content) {
         wrapSelection(field, spoiler_syntax_start_with_header, spoiler_syntax_end);
 
         field.setSelectionRange(
-            range.start + spoiler_syntax_start.length - 1,
+            range.start + spoiler_syntax_start_without_break.length,
             range.start + spoiler_syntax_start_with_header.length - 1,
         );
     };


### PR DESCRIPTION
compose: Revamp and improve test suite for compose formatting buttons.

Earlier, the tests for compose formatting were verbose, hard to read as well as extend, and overly granular, without even having the ability to test the final text selection or the cursor position.

Now, new test helpers, `init_textarea_state` and `get_textarea_state`, have been added, enabling the tests to be more concise and readable, while also being more powerful. A representative string alone now describes the textarea state (the text and the selection / cursor), making each test case as easy as defining the initial state as a string and comparing the expected state post formatting with another string.

These new tests helped surface a couple bugs which have been fixed in preceding commits.

compose: Fix bug where toggling off link formatting left extra spaces.

In cases where either the description or the URL, or both were empty, there would be an unneeded space, originally intended to space out the description and URL, lingering even when the description and/or URL was missing. The resulting highlight would also be off at times.

Now we only add in a space if both the description and URL are present, and the highlight too is as intended.

compose: Fix bug where spoiler would not always start on a new line.

Earlier, when a selection not starting at the beginning of a line was formatted as a spoiler, the spoiler would not start on a new line, and so would not be rendered as a spoiler. The `Header` highlighting too was off by one character.

Now, the spoiler starts on a new line, and the `Header` highlighting works as expected too.

Fixes issue brought up in [this PR review comment](https://github.com/zulip/zulip/pull/26783#discussion_r1372430216)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
