### PR TITLE
remote_billing: Fix handle_customer_migration_from_server_to_realms.

### DIFF
--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -47,11 +47,7 @@ from zerver.lib.exceptions import (
     RemoteBillingAuthenticationError,
     RemoteRealmServerMismatchError,
 )
-from zerver.lib.remote_server import (
-    RealmDataForAnalytics,
-    UserDataForRemoteBilling,
-    get_realms_info_for_push_bouncer,
-)
+from zerver.lib.remote_server import RealmDataForAnalytics, UserDataForRemoteBilling
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -200,9 +196,7 @@ def remote_realm_billing_finalize_login(
         raise AssertionError
 
     try:
-        handle_customer_migration_from_server_to_realms(
-            server=remote_server, realms=get_realms_info_for_push_bouncer()
-        )
+        handle_customer_migration_from_server_to_realms(server=remote_server)
     except Exception:  # nocoverage
         billing_logger.exception(
             "%s: Failed to migrate customer from server (id: %s) to realms",


### PR DESCRIPTION
This was a bug from 4715a058b0ace97e92f360ac1cbf169648e3441d where this was just incorrectly called. get_realms_info_for_push_bouncer() is a function meant to be called on a self-hosted server - and this handle_... call happens on the bouncer. Therefore this returns all zulipchat realms in production.

With the way, handle_... is being called right now, there's no reason for it to have an argument for passing a list of realms. It should just fetch the relevant RemoteRealm entries  by itself, given the server arg.

