### PR TITLE
settings: Rename and reorder custom profile fields

### DIFF
--- a/help/custom-profile-fields.md
+++ b/help/custom-profile-fields.md
@@ -45,17 +45,17 @@ methods][authentication-production] documentation for details.
 
 There are several different types of fields available.
 
-* **Short text**: For one line responses, like
+* **Text (short)**: For one line responses, like
     "Job title". Responses are limited to 50 characters.
-* **Long text**: For multiline responses, like "Biography".
-* **Date picker**: For dates, like "Birthday".
+* **Text (long)**: For multiline responses, like "Biography".
+* **Date**: For dates, like "Birthday".
 * **Link**: For links to websites.
 * **External account**: For linking to GitHub, Twitter, etc.
 * **Pronouns**: What pronouns should people use to refer to the user? Pronouns
   are displayed in [user mention](/help/mention-a-user-or-group) autocomplete
   suggestions.
 * **List of options**: Creates a dropdown with a list of options.
-* **Person picker**: For selecting one or more users, like "Manager" or
+* **Users**: For selecting one or more users, like "Manager" or
     "Direct reports".
 
 ## Display custom fields on user card

--- a/web/e2e-tests/custom-profile.test.ts
+++ b/web/e2e-tests/custom-profile.test.ts
@@ -31,7 +31,7 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
-        "Short text",
+        "Text (short)",
     );
 }
 
@@ -57,7 +57,7 @@ async function test_edit_profile_field(page: Page): Promise<void> {
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
-        "Short text",
+        "Text (short)",
     );
 }
 

--- a/zerver/migrations/0417_alter_customprofilefield_field_type.py
+++ b/zerver/migrations/0417_alter_customprofilefield_field_type.py
@@ -14,13 +14,13 @@ class Migration(migrations.Migration):
             name="field_type",
             field=models.PositiveSmallIntegerField(
                 choices=[
-                    (1, "Text (short)"),
-                    (2, "Text (long)"),
                     (4, "Date"),
-                    (5, "Link"),
                     (7, "External account"),
-                    (8, "Pronouns"),
+                    (5, "Link"),
                     (3, "List of options"),
+                    (8, "Pronouns"),
+                    (2, "Text (long)"),
+                    (1, "Text (short)"),
                     (6, "Users"),
                 ],
                 default=1,

--- a/zerver/migrations/0417_alter_customprofilefield_field_type.py
+++ b/zerver/migrations/0417_alter_customprofilefield_field_type.py
@@ -14,14 +14,14 @@ class Migration(migrations.Migration):
             name="field_type",
             field=models.PositiveSmallIntegerField(
                 choices=[
-                    (1, "Short text"),
-                    (2, "Long text"),
-                    (4, "Date picker"),
+                    (1, "Text (short)"),
+                    (2, "Text (long)"),
+                    (4, "Date"),
                     (5, "Link"),
                     (7, "External account"),
                     (8, "Pronouns"),
                     (3, "List of options"),
-                    (6, "Person picker"),
+                    (6, "Users"),
                 ],
                 default=1,
             ),

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -120,7 +120,9 @@ class CustomProfileField(models.Model):
         (PRONOUNS, gettext_lazy("Pronouns"), check_short_string, str, "PRONOUNS"),
     ]
 
-    ALL_FIELD_TYPES = [*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA]
+    ALL_FIELD_TYPES = sorted(
+        [*FIELD_TYPE_DATA, *SELECT_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA], key=lambda x: x[1]
+    )
 
     FIELD_VALIDATORS: Dict[int, Validator[ProfileDataElementValue]] = {
         item[0]: item[2] for item in FIELD_TYPE_DATA

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -94,7 +94,7 @@ class CustomProfileField(models.Model):
         (SELECT, gettext_lazy("List of options"), validate_select_field, str, "SELECT"),
     ]
     USER_FIELD_TYPE_DATA: List[UserFieldElement] = [
-        (USER, gettext_lazy("Person picker"), check_valid_user_ids, orjson.loads, "USER"),
+        (USER, gettext_lazy("Users"), check_valid_user_ids, orjson.loads, "USER"),
     ]
 
     SELECT_FIELD_VALIDATORS: Dict[int, ExtendedValidator] = {
@@ -106,9 +106,9 @@ class CustomProfileField(models.Model):
 
     FIELD_TYPE_DATA: List[FieldElement] = [
         # Type, display name, validator, converter, keyword
-        (SHORT_TEXT, gettext_lazy("Short text"), check_short_string, str, "SHORT_TEXT"),
-        (LONG_TEXT, gettext_lazy("Long text"), check_long_string, str, "LONG_TEXT"),
-        (DATE, gettext_lazy("Date picker"), check_date, str, "DATE"),
+        (SHORT_TEXT, gettext_lazy("Text (short)"), check_short_string, str, "SHORT_TEXT"),
+        (LONG_TEXT, gettext_lazy("Text (long)"), check_long_string, str, "LONG_TEXT"),
+        (DATE, gettext_lazy("Date"), check_date, str, "DATE"),
         (URL, gettext_lazy("Link"), check_url, str, "URL"),
         (
             EXTERNAL_ACCOUNT,


### PR DESCRIPTION
This changes the name of four custom profile field types and reorders them in alphabetical order. It also updates the documentation to reflect the new names.

Fixes: #28511 

Previous menu:
<img width="270" alt="image" src="https://github.com/zulip/zulip/assets/48129706/356eadc8-5b48-481c-b908-de5a1aaafebd">

Updated menu:
<img width="274" alt="Screenshot 2024-01-10 at 5 49 13 PM" src="https://github.com/zulip/zulip/assets/48129706/20e4fa9e-3714-4945-926e-774c1b496aa1">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
