### PR TITLE
ui: Show bot icon consistently across the UI.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -8,6 +8,7 @@ import render_input_pill from "../templates/input_pill.hbs";
 import * as blueslip from "./blueslip";
 import type {EmojiRenderingDetails} from "./emoji";
 import * as keydown_util from "./keydown_util";
+import {user_is_bot} from "./people";
 import * as ui_util from "./ui_util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
@@ -19,6 +20,7 @@ export type InputPillItem<T> = {
     deactivated?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code?: boolean}; // TODO: Move this in user_status.js
     should_add_guest_user_indicator?: boolean;
+    user_id?: number;
 } & T;
 
 export type InputPillConfig = {
@@ -60,6 +62,7 @@ type InputPillRenderingDetails = {
     img_src?: string;
     deactivated?: boolean;
     has_status?: boolean;
+    user_is_bot?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code?: boolean};
     should_add_guest_user_indicator?: boolean;
 };
@@ -144,9 +147,13 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
             const has_image = item.img_src !== undefined;
 
+            // For compose pills to differentiate among users and bots.
+            const is_bot = item.user_id ? user_is_bot(item.user_id) : false;
+
             const opts: InputPillRenderingDetails = {
                 display_value: item.display_value,
                 has_image,
+                user_is_bot: is_bot,
                 deactivated: item.deactivated,
                 should_add_guest_user_indicator: item.should_add_guest_user_indicator,
             };

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -186,6 +186,7 @@ function get_users_for_recipient_row(message) {
     const user_ids = people.pm_with_user_ids(message);
     const users = user_ids.map((user_id) => {
         let full_name;
+        const is_bot = people.user_is_bot(user_id);
         if (muted_users.is_user_muted(user_id)) {
             full_name = $t({defaultMessage: "Muted user"});
         } else {
@@ -193,6 +194,7 @@ function get_users_for_recipient_row(message) {
         }
         return {
             full_name,
+            is_bot,
             should_add_guest_user_indicator: people.should_add_guest_user_indicator(user_id),
         };
     });

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -770,6 +770,11 @@ export function format_small_avatar_url(raw_url: string): string {
     return url.href;
 }
 
+export function user_is_bot(user_id: number): boolean {
+    const user = get_by_user_id(user_id);
+    return user.is_bot;
+}
+
 export function sender_is_bot(message: Message): boolean {
     if (message.sender_id) {
         const person = get_by_user_id(message.sender_id);

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -71,8 +71,9 @@ export function get_conversations(): DisplayObject[] {
             const recipient_user_obj = people.get_by_user_id(user_id);
 
             if (recipient_user_obj.is_bot) {
-                // We display the bot icon rather than a user circle for bots.
                 is_bot = true;
+                // Green user circle is shown for bots.
+                user_circle_class = "user_circle_green";
             } else {
                 status_emoji_info = user_status.get_status_emoji(user_id);
             }

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -101,6 +101,11 @@ export function set_name_in_mention_element(
     } else {
         $(element).text("@" + name);
     }
+
+    // Add bot icon to right of the name if it is a bot.
+    if (user_id !== undefined && people.user_is_bot(user_id)) {
+        $(element).append(`<i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>`);
+    }
 }
 
 export const update_elements = ($content: JQuery): void => {

--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -14,6 +14,7 @@ import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
+import {user_is_bot} from "./people";
 import * as scroll_util from "./scroll_util";
 import {current_user} from "./state_data";
 import * as stream_data from "./stream_data";
@@ -34,6 +35,7 @@ function format_member_list_elem(person, user_can_remove_subscribers) {
         email: person.delivery_email,
         can_remove_subscribers: user_can_remove_subscribers,
         for_user_group_members: false,
+        is_bot: user_is_bot(person.user_id),
     });
 }
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -131,6 +131,7 @@ export function render_person(person: UserOrMention): string {
         img_src: avatar_url,
         user_circle_class,
         is_person: true,
+        is_bot: person.is_bot,
         status_emoji_info,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(person.user_id),
         pronouns,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -140,6 +140,9 @@
     */
     --stream-subscriber-list-max-height: 100%;
 
+    /* Bot icon offset */
+    --margin-lefthand-bot-icon-offset: 3px;
+
     /* Colors used across the app */
     --color-date: hsl(0deg 0% 15% / 75%);
     --color-background-private-message-header: hsl(46deg 35% 93%);

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -45,6 +45,11 @@
             min-width: 0;
             align-items: center;
             margin: 0 5px;
+
+            .zulip-icon-bot {
+                font-size: 12px;
+                margin-left: var(--margin-lefthand-bot-icon-offset);
+            }
         }
 
         .pill-value {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -297,8 +297,7 @@ li.show-more-topics {
                 color: inherit;
             }
 
-            .fa-group,
-            .zulip-icon {
+            .fa-group {
                 opacity: 0.7;
             }
         }
@@ -756,6 +755,11 @@ li.top_left_scheduled_messages {
     margin-right: 3px;
 }
 
+.conversation-partners i.conversation_bot_icon {
+    /* Prevents bot emoji from colliding with unread counts. */
+    margin: 0 var(--margin-lefthand-bot-icon-offset);
+}
+
 /* New .topic-box grid definitions here. */
 #views-label-container,
 .top_left_row,
@@ -1110,8 +1114,7 @@ li.topic-list-item {
     }
 
     .zulip-icon.zulip-icon-bot {
-        font-size: 90%; /* Reduce the bulkiness of this icon */
-        padding: 3px 0 3px 1px; /* Shift reduced icon a pixel left to maintain horizontal centering. */
+        font-size: 12px; /* Reduce the bulkiness of this icon */
     }
 
     .unread_count {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -175,7 +175,9 @@
         padding: 0 3px;
         border-radius: 3px;
         white-space: nowrap;
-        display: inline-block;
+        display: flex;
+        align-items: center;
+        width: fit-content;
     }
 
     .user-mention {
@@ -189,6 +191,11 @@
 
         &:hover {
             background-color: var(--color-background-text-hover-direct-mention);
+        }
+
+        i.zulip-icon-bot {
+            font-size: 12px;
+            margin: 0 var(--margin-lefthand-bot-icon-offset);
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -219,6 +219,10 @@ h4.user_group_setting_subsection_title {
     padding-right: 8px;
 }
 
+.subscriber-name > .view_user_profile > .zulip-icon-bot {
+    margin-top: 2px;
+}
+
 .subscriber_list_add,
 .member_list_add {
     width: 100%;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1357,6 +1357,13 @@ td.pointer {
         .private_message_header_name {
             overflow: hidden;
             text-overflow: ellipsis;
+            display: flex;
+            align-items: center;
+            gap: var(--margin-lefthand-bot-icon-offset);
+
+            i.zulip-icon-bot {
+                font-size: 12px;
+            }
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -826,6 +826,11 @@ strong {
                 right: 8px;
                 display: inline-block;
             }
+
+            i.zulip-icon-bot {
+                font-size: 13px;
+                margin-top: 3px;
+            }
         }
     }
 
@@ -1852,6 +1857,10 @@ div.focused-message-list {
             margin-right: -12px;
             font-size: 0.8em;
             color: hsl(96deg 7% 73%);
+        }
+
+        & a i {
+            color: hsl(0deg 0% 100%);
         }
     }
 

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -9,6 +9,9 @@
         {{~#if has_status~}}
             {{~> status_emoji status_emoji_info~}}
         {{~/if~}}
+        {{~#if user_is_bot~}}
+            <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+        {{~/if~}}
     </span>
     <div class="exit">
         <span aria-hidden="true">&times;</span>

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -3,8 +3,6 @@
 
         {{#if is_group}}
         <span class="conversation-partners-icon fa fa-group"></span>
-        {{else if is_bot}}
-        <span class="conversation-partners-icon zulip-icon zulip-icon-bot" aria-hidden="true"></span>
         {{else}}
         <span class="conversation-partners-icon {{user_circle_class}} user_circle"></span>
         {{/if}}
@@ -12,6 +10,9 @@
         <a href="{{url}}" class="conversation-partners">
             <span class="conversation-partners-list">{{recipients}}</span>
             {{> status_emoji status_emoji_info}}
+            {{#if is_bot}}
+                <i class="zulip-icon zulip-icon-bot conversation_bot_icon" aria-label="{{t 'Bot' }}"></i>
+            {{/if}}
         </a>
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -90,7 +90,7 @@
             {{#tr}}You and <z-user-names></z-user-names>
             {{#*inline "z-user-names"}}
                 {{#each recipient_users}}
-                    {{full_name}}{{#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{/if}}{{#unless @last}},{{/unless}}
+                    {{full_name}}{{#if is_bot}}<i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>{{/if}}{{#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{/if}}{{#unless @last}},{{/unless}}
                 {{/each}}
             {{/inline}}
             {{/tr}}

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -1,6 +1,11 @@
 <tr data-subscriber-id="{{user_id}}">
     <td class="subscriber-name">
-        <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{name}}</a>
+        <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">
+            {{name}}
+            {{#if is_bot}}
+                <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+            {{/if}}
+        </a>
         {{#if is_current_user}} <span class="my_user_status">{{t "(you)"}}</span>{{/if}}
     </td>
     {{#if email}}

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -23,6 +23,9 @@
     {{else}}
         {{~ primary ~}}
     {{/if}}
+    {{~#if is_bot}}
+        <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+    {{/if}}
 </strong>
 {{~#if has_pronouns}}
     <span class="pronouns">({{pronouns}})</span>

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -157,7 +157,7 @@ test("get_conversations bot", ({override}) => {
             is_active: false,
             url: "#narrow/dm/314-Outgoing-webhook",
             status_emoji_info: undefined,
-            user_circle_class: "user_circle_empty",
+            user_circle_class: "user_circle_green",
             is_group: false,
             is_bot: true,
         },

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -49,12 +49,21 @@ const polonius = {
     full_name: "Polonius",
     is_guest: true,
 };
+
+const zulip_default_bot = {
+    email: "default-bot@zulip.com",
+    user_id: 16,
+    full_name: "Zulip Default Bot",
+    is_bot: true,
+};
+
 const inaccessible_user_id = 33;
 const inaccessible_user = people.add_inaccessible_user(inaccessible_user_id);
 people.init();
 people.add_active_user(iago);
 people.add_active_user(cordelia);
 people.add_active_user(polonius);
+people.add_active_user(zulip_default_bot);
 people.initialize_current_user(iago.user_id);
 
 const group_me = {
@@ -218,6 +227,19 @@ run_test("user-mention", () => {
     set_message_for_message_content($content, message);
     rm.update_elements($content);
     assert.ok($iago.hasClass("user-mention-me"));
+});
+
+run_test("bot-mention", () => {
+    const $bot_mention_pill = $.create("user-mention");
+    const bot_icon_html = `<i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>`;
+
+    assert.ok(!$bot_mention_pill.html().includes(bot_icon_html));
+    rm.set_name_in_mention_element(
+        $bot_mention_pill,
+        zulip_default_bot.full_name,
+        zulip_default_bot.user_id,
+    );
+    assert.ok($bot_mention_pill.html().includes(bot_icon_html));
 });
 
 run_test("user-mention without guest indicator", () => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #26831 

Places the **bot icon** to the right of bot name across the Zulip UI.
This will make it visually easy to spot and differentiate normal users from bots.

[CZO Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/more.20user.20indicators/near/1643075)

Areas covered :-

- [x] compose pill
- [x] compose recipient picker
- [x] sidebar UI  
- [x] stream settings
- [x] DM headers
- [x] mention pills   

Tests have been updated.

Apparently the bot icon is already shown in the **message feed**.
<details>
<summary>message feed</summary>
<img src="https://github.com/zulip/zulip/assets/11803841/9dc6e562-8277-4ecd-8ae2-1bb5bc02c526" width="600">

</details>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**

<details><summary>Compose pills</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/49e53891-0ac9-4798-a0bf-6482d6cbe5b0">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/f78cc4c2-d40b-4e95-ae52-ca7874029291">
</details>

<details><summary>Sidebar UI</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/1ecfdd19-a85d-4cef-9ecb-19ee217d11cd">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/26b2bccd-7c7e-4b3f-b96d-0563ceace6a6">
</details>

<details><summary>Compose recipient picker</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/a9c674bb-2cfe-4276-8c03-3b863ce6310a">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/edcff3ab-f420-4d9a-9ef7-667caea8f2fd">
</details>

<details><summary>Stream  settings</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/62851531-f4ad-46df-9d22-59a0f328e011">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/cee6cfb5-af4f-43d9-a37d-8973538f8091">
</details>

<details><summary>Bot mention pill</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/f283b7b6-3fa1-4a6a-bc46-56773ed69587">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/5ca3264a-ba6b-4bc3-b370-4e2b05870216">
</details>

<details><summary>DM headers</summary>
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/0a5615f3-5f9f-400e-ba95-9bc69c7cfc41">
<img width="370" src="https://github.com/zulip/zulip/assets/11803841/f0b1ac2f-a6a9-4dfc-8c4f-29d03cc5146c">
</details>

<details><summary>Dark theme screenshots</summary>
<img src="https://github.com/zulip/zulip/assets/11803841/5b893d6b-1b7d-4e77-8f09-b0a34355dc3b" width="550">
<img src="https://github.com/zulip/zulip/assets/11803841/f1a5f49c-91af-452b-8461-a97e5724e1b7" width="550">
<img src="https://github.com/zulip/zulip/assets/11803841/eedb5712-002c-47a0-b2a3-ad6b9e5d78cc" width="550">
<img src="https://github.com/zulip/zulip/assets/11803841/51bf0485-b179-42d4-84f2-23d536683b5d" width="550">
<img src="https://github.com/zulip/zulip/assets/11803841/40dde355-46a8-4f5d-a51c-7ad80b6a2500" width="550">
<img src="https://github.com/zulip/zulip/assets/11803841/c77687ac-25c0-4546-b3e1-5f6ceb21ff0f" width="550">


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
