### PR TITLE
stream_settings: Add confirmation modal for changing privacy.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 import render_settings_deactivation_stream_modal from "../templates/confirm_dialog/confirm_deactivate_stream.hbs";
 import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 import render_change_stream_info_modal from "../templates/stream_settings/change_stream_info_modal.hbs";
+import render_confirm_stream_privacy_change_modal from "../templates/stream_settings/confirm_stream_privacy_change_modal.hbs";
 import render_copy_email_address_modal from "../templates/stream_settings/copy_email_address_modal.hbs";
 import render_stream_description from "../templates/stream_settings/stream_description.hbs";
 import render_stream_settings from "../templates/stream_settings/stream_settings.hbs";
@@ -683,7 +684,23 @@ export function initialize() {
             const data = settings_org.populate_data_for_request($subsection_elem, false, sub);
 
             const url = "/json/streams/" + stream_id;
-            settings_org.save_organization_settings(data, $save_button, url);
+            if (
+                data.is_private === undefined ||
+                stream_data.get_stream_privacy_policy(stream_id) !== "invite-only"
+            ) {
+                settings_org.save_organization_settings(data, $save_button, url);
+                return;
+            }
+            dialog_widget.launch({
+                html_heading: $t_html({defaultMessage: "Confirm changing access permissions"}),
+                html_body: render_confirm_stream_privacy_change_modal,
+                id: "confirm_stream_privacy_change",
+                html_submit_button: $t_html({defaultMessage: "Confirm"}),
+                on_click() {
+                    settings_org.save_organization_settings(data, $save_button, url);
+                },
+                close_on_submit: true,
+            });
         },
     );
 

--- a/web/templates/stream_settings/confirm_stream_privacy_change_modal.hbs
+++ b/web/templates/stream_settings/confirm_stream_privacy_change_modal.hbs
@@ -1,0 +1,7 @@
+<div class="confirm-stream-privacy-modal">
+    <div class="new-style">
+        <p class="confirm-stream-privacy-info">
+            {{t "This change will make this stream's entire message history accessible according to the new configuration."}}
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds confirmation dialog widget for changing the privacy of a "Private, protected history" stream.

Fixes: #27916

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Untitled video - Made with Clipchamp (1)](https://github.com/zulip/zulip/assets/119798962/bd5f7387-6a6e-4dbc-b84a-cab355db56a6)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
