### PR TITLE
narrow.js: Remove redundant else if block from deactivate function.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -1036,10 +1036,6 @@ export function deactivate() {
         recent_view_ui.hide();
     } else if (coming_from_inbox) {
         inbox_ui.hide();
-    } else if (narrow_state.filter() === undefined && has_visited_all_messages) {
-        // If we're already looking at the All messages view, exit without
-        // doing any work.
-        return;
     } else {
         // We must instead be switching from another message view.
         // Save the scroll position in that message list, so that


### PR DESCRIPTION
it's okay to remove because the else if condition
narrow_state.filter() === undefined && has_visited_all_messages is always false narrow_state.filter() === undefined is true when default view is all messages. has_visited_all_messages is true when coming from a different view that isn't all messages. Both cannot be true simultaneously.

<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
