### PR TITLE
drafts: Fix flaky drafts tests.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -37,9 +37,17 @@ async function create_stream_message_draft(page: Page): Promise<void> {
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
     await common.select_stream_in_compose_via_dropdown(page, "Denmark");
     await common.fill_form(page, "form#send_message_form", {
-        stream_message_recipient_topic: "tests",
         content: "Test stream message.",
     });
+    await page.type("#stream_message_recipient_topic", "tests", {delay: 100});
+
+    // Ideally, we don't need to click on the typeahead to create a draft with this topic but
+    // the typeahead seems bugged and remains open in the next compose session even after it
+    // is being closed via clicking on #compose_close.
+    const entry = await page.waitForSelector('.typeahead[style*="display: block"] .active a', {
+        visible: true,
+    });
+    await entry!.click();
     await page.click("#compose_close");
 }
 


### PR DESCRIPTION
There were two typeahead displayed while we were testing create_private_message_draft. One was topic typeahead from previous create_stream_message_draft test and the other was cordelia DM typeahead. So, when clicking on the typeahead, we clicked the topic typeahead when we really wanted to select the cordelia typeahead. This resulted in drafts test failing.
<img width="858" alt="Screenshot 2024-01-16 at 1 39 28 PM" src="https://github.com/zulip/zulip/assets/25124304/e2123621-134a-4711-96fd-6baeeb601987">

