### PR TITLE
dropdown_widget: Migrate _widget classes to  -widget classes.

### DIFF
--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -30,7 +30,7 @@ async function submit_notifications_stream_settings(page: Page): Promise<void> {
 }
 
 async function test_change_new_stream_notifications_setting(page: Page): Promise<void> {
-    await page.click("#realm_notifications_stream_id_widget.dropdown-widget-button");
+    await page.click("#realm_notifications_stream_id-widget.dropdown-widget-button");
     await page.waitForSelector(".dropdown-list-container", {
         visible: true,
     });
@@ -50,7 +50,7 @@ async function test_change_new_stream_notifications_setting(page: Page): Promise
 async function test_change_signup_notifications_stream(page: Page): Promise<void> {
     console.log('Changing signup notifications stream to Verona by filtering with "verona"');
 
-    await page.click("#realm_signup_notifications_stream_id_widget");
+    await page.click("#realm_signup_notifications_stream_id-widget");
     await page.waitForSelector(".dropdown-list-search-input", {visible: true});
 
     await page.type(".dropdown-list-search-input", "verona");

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -216,7 +216,7 @@ export async function check_compose_state(
         assert.equal(
             await get_text_from_selector(
                 page,
-                "#compose_select_recipient_widget .dropdown_widget_value",
+                "#compose_select_recipient-widget .dropdown_widget_value",
             ),
             params.stream_name,
         );
@@ -397,11 +397,11 @@ export async function select_stream_in_compose_via_dropdown(
     page: Page,
     stream_name: string,
 ): Promise<void> {
-    console.log(`Clicking on 'compose_select_recipient_widget' to select ${stream_name}`);
+    console.log(`Clicking on 'compose_select_recipient-widget' to select ${stream_name}`);
     const menu_visible = (await page.$(".dropdown-list-container")) !== null;
     if (!menu_visible) {
-        await page.waitForSelector("#compose_select_recipient_widget", {visible: true});
-        await page.click("#compose_select_recipient_widget");
+        await page.waitForSelector("#compose_select_recipient-widget", {visible: true});
+        await page.click("#compose_select_recipient-widget");
         await page.waitForSelector(".dropdown-list-container .list-item", {
             visible: true,
         });

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -256,7 +256,7 @@ export function build_page() {
     const is_plan_plus = page_params.realm_plan_type === 10;
     const is_plan_self_hosted = page_params.realm_plan_type === 1;
     if (page_params.is_admin && !(is_plan_plus || is_plan_self_hosted)) {
-        $("#realm_can_access_all_users_group_widget").prop("disabled", true);
+        $("#realm_can_access_all_users_group-widget").prop("disabled", true);
         const opts = {
             content: $t({
                 defaultMessage: "This feature is available on Zulip Cloud Plus. Upgrade to access.",

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -177,5 +177,5 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
     hide_compose_spinner();
 
     // Open stream select dropdown.
-    $("#compose_select_recipient_widget").trigger("click");
+    $("#compose_select_recipient-widget").trigger("click");
 }

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -152,11 +152,11 @@ function switch_message_type(message_type) {
 function update_recipient_label(stream_id) {
     const stream = stream_data.get_sub_by_id(stream_id);
     if (stream === undefined) {
-        $("#compose_select_recipient_widget .dropdown_widget_value").text(
+        $("#compose_select_recipient-widget .dropdown_widget_value").text(
             $t({defaultMessage: "Select a stream"}),
         );
     } else {
-        $("#compose_select_recipient_widget .dropdown_widget_value").html(
+        $("#compose_select_recipient-widget .dropdown_widget_value").html(
             render_inline_decorated_stream_name({stream, show_colored_icon: true}),
         );
     }
@@ -181,7 +181,7 @@ export function update_compose_for_message_type(message_type, opts) {
         // the "DM" button display string so we wouldn't have to manually change
         // it here.
         const direct_message_label = $t({defaultMessage: "DM"});
-        $("#compose_select_recipient_widget .dropdown_widget_value").html(
+        $("#compose_select_recipient-widget .dropdown_widget_value").html(
             `<i class="zulip-icon zulip-icon-users stream-privacy-type-icon"></i> ${direct_message_label}`,
         );
     }
@@ -282,7 +282,7 @@ function compose_recipient_dropdown_on_show(dropdown) {
 }
 
 export function open_compose_recipient_dropdown() {
-    $("#compose_select_recipient_widget").trigger("click");
+    $("#compose_select_recipient-widget").trigger("click");
 }
 
 function focus_compose_recipient() {

--- a/web/src/dropdown_widget.js
+++ b/web/src/dropdown_widget.js
@@ -52,7 +52,7 @@ export class DropdownWidget {
         disable_for_spectators = false,
     }) {
         this.widget_name = widget_name;
-        this.widget_id = `#${CSS.escape(widget_name)}_widget`;
+        this.widget_id = `#${CSS.escape(widget_name)}-widget`;
         // A widget wrapper may not exist based on the UI requirement.
         this.widget_wrapper_id = `${this.widget_id}_wrapper`;
         this.widget_value_selector = `${this.widget_id} .dropdown_widget_value`;

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -369,7 +369,7 @@ export function revive_current_focus() {
     }
 
     if ($current_focus_elem.hasClass("dropdown-widget-button")) {
-        $("#recent-view-filter_widget").trigger("focus");
+        $("#recent-view-filter-widget").trigger("focus");
         return true;
     }
 
@@ -1516,7 +1516,7 @@ export function initialize({
         revive_current_focus();
     });
 
-    $("body").on("click", "#recent-view-filter_widget", (e) => {
+    $("body").on("click", "#recent-view-filter-widget", (e) => {
         if (page_params.is_spectator) {
             // Filter buttons are disabled for spectator.
             return;

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -55,7 +55,7 @@ function create_choice_row() {
         const selected_stream_name = $selected_stream.attr("data-name");
         const selected_stream_id = Number.parseInt($selected_stream.data("unique-id"), 10);
 
-        const $stream_dropdown_widget = $(`#${CSS.escape(stream_dropdown_widget_name)}_widget`);
+        const $stream_dropdown_widget = $(`#${CSS.escape(stream_dropdown_widget_name)}-widget`);
         const $stream_name = $stream_dropdown_widget.find(".dropdown_widget_value");
         $stream_name.text(selected_stream_name);
         $stream_name.data("stream-id", selected_stream_id);

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -496,11 +496,11 @@ export async function build_move_topic_to_stream_popover(
         stream_bar.decorate(stream_id, $stream_header_colorblock);
         const stream = stream_data.get_sub_by_id(stream_id);
         if (stream === undefined) {
-            $("#move_topic_to_stream_widget .dropdown_widget_value").text(
+            $("#move_topic_to_stream-widget .dropdown_widget_value").text(
                 $t({defaultMessage: "Select a stream"}),
             );
         } else {
-            $("#move_topic_to_stream_widget .dropdown_widget_value").html(
+            $("#move_topic_to_stream-widget .dropdown_widget_value").html(
                 render_inline_decorated_stream_name({stream, show_colored_icon: true}),
             );
         }
@@ -563,7 +563,7 @@ export async function build_move_topic_to_stream_popover(
         }).setup();
 
         render_selected_stream();
-        $("#move_topic_to_stream_widget").prop("disabled", disable_stream_input);
+        $("#move_topic_to_stream-widget").prop("disabled", disable_stream_input);
         $("#move_topic_modal .move_messages_edit_topic").on("input", () => {
             update_submit_button_disabled_state(stream_widget_value);
         });

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -143,7 +143,7 @@ function reset_subscribe_widget() {
         $("#user-profile-modal .add-subscription-button-wrapper"),
         $t({defaultMessage: "Select a stream to subscribe"}),
     );
-    $("#user_profile_subscribe_widget .dropdown_widget_value").text(
+    $("#user_profile_subscribe-widget .dropdown_widget_value").text(
         $t({defaultMessage: "Select a stream"}),
     );
     //  There are two cases when the subscribe widget is reset: when the user_profile

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -155,7 +155,7 @@
 
     #compose-recipient {
         &.compose-recipient-direct-selected {
-            #compose_select_recipient_widget {
+            #compose_select_recipient-widget {
                 border-radius: 4px !important;
             }
 
@@ -822,7 +822,7 @@ textarea.new_message_textarea,
     }
 }
 
-#compose_select_recipient_widget {
+#compose_select_recipient-widget {
     border-radius: 0 4px 4px 0;
     width: auto;
     outline: none;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -529,7 +529,7 @@
     color: hsl(200deg 100% 40%);
 }
 
-#inbox-filter_widget {
+#inbox-filter-widget {
     margin-right: 5px;
     height: 30px;
     max-width: var(--width-inbox-filters-dropdown);
@@ -551,8 +551,8 @@
     }
 }
 
-#recent-view-filter_widget .dropdown_widget_value,
-#inbox-filter_widget .dropdown_widget_value {
+#recent-view-filter-widget .dropdown_widget_value,
+#inbox-filter-widget .dropdown_widget_value {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
@@ -560,8 +560,8 @@
     text-align: left;
 }
 
-#recent-view-filter_widget .fa-chevron-down,
-#inbox-filter_widget .fa-chevron-down {
+#recent-view-filter-widget .fa-chevron-down,
+#inbox-filter-widget .fa-chevron-down {
     color: var(--color-icons-inbox);
     opacity: 0.4;
 }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -544,7 +544,7 @@
     position: relative;
 }
 
-#recent-view-filter_widget {
+#recent-view-filter-widget {
     display: inline-flex;
     width: 150px;
     margin: 0 5px 10px 0;
@@ -558,7 +558,7 @@
     }
 }
 
-.dropdown-widget-disabled-for-spectators #recent-view-filter_widget {
+.dropdown-widget-disabled-for-spectators #recent-view-filter-widget {
     cursor: not-allowed;
     opacity: 0.5;
 }

--- a/web/templates/dropdown_widget.hbs
+++ b/web/templates/dropdown_widget.hbs
@@ -1,4 +1,4 @@
-<button id="{{widget_name}}_widget" class="dropdown-widget-button" type="button" {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
+<button id="{{widget_name}}-widget" class="dropdown-widget-button" type="button" {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
     <span class="dropdown_widget_value">{{#if default_text}}{{default_text}}{{/if}}</span>
     <i class="zulip-icon zulip-icon-chevron-down"></i>
 </button>

--- a/web/templates/dropdown_widget_with_label.hbs
+++ b/web/templates/dropdown_widget_with_label.hbs
@@ -1,5 +1,5 @@
 <div class="input-group" id="{{widget_name}}_widget_container">
-    <label class="dropdown-title" for="{{widget_name}}_widget">{{label}}
+    <label class="dropdown-title" for="{{widget_name}}-widget">{{label}}
         {{#if help_link}}{{> help_link_widget link=help_link }}{{/if}}
     </label>
     <span class="prop-element hide" id="id_{{widget_name}}" data-setting-widget-type="dropdown-list-widget" {{#if value_type}}data-setting-value-type="{{value_type}}"{{/if}}></span>


### PR DESCRIPTION
Fixes:#27658.

In this  PR  I have migrated  all dropdown classes   along with jquery target classes to  use  <b>-widget  </b> instead of  <b>_widget </b>.This  change was done as part of migrating  <b>{{widget_name}}_widget</b>  to <b>{widget_name}}-widget</b>
in  <b>dropdown_widget.hbs </b>  


As noted here https://github.com/zulip/zulip/pull/27552#discussion_r1389732810