### PR TITLE
find_account: Add button to send another email.

### DIFF
--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -29,6 +29,11 @@
                     {% endfor %}
                 </ul>
 
+                {% trans %}
+                If you don't receive an email, you can
+                <a href="{{ current_url }}">find accounts for another email address</a>.
+                {% endtrans %}
+
                 {% include 'zerver/dev_env_email_access_details.html' %}
 
             </div>
@@ -43,7 +48,7 @@
                     {% endtrans %}
                 </p>
                 <form class="form-inline" id="find_account" name="email_form"
-                  action="{{ current_url() }}" method="post">
+                  action="{{ current_url }}" method="post">
                     {{ csrf_input }}
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -83,6 +83,7 @@ IGNORED_PHRASES = [
     r"user",
     r"an unknown operating system",
     r"Go to Settings",
+    r"find accounts for another email address",
     # SPECIAL CASES
     # Because topics usually are lower-case, this would look weird if it were capitalized
     r"more topics",

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1145,7 +1145,7 @@ def find_account(
     return render(
         request,
         "zerver/find_account.html",
-        context={"form": form, "current_url": lambda: url, "emails": emails},
+        context={"form": form, "current_url": url, "emails": emails},
     )
 
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> Fixes part of  #3128 

- [ ]  You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: https://slack.com/signin/find

- [ ]  We should send an email regardless of whether they are in a Zulip org or not.

- [x] The followup page should have links to resend the email or enter a different email address.

- [x] The URL of the followup page currently has the email as a URL parameter, which should be removed.
 

- [x] Add the 'In the Zulip development environment, outgoing emails are printed to the run-dev.py console.' text (git grep for it to see how we do it elsewhere)

- [x]  On load, the cursor should go into the box where you enter your email address.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/78016781/a25cc6ec-d071-4927-b8c8-cfbaae8f50da)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
