### PR TITLE
e2e-tests: Rename display_settings_section to preferences_section.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -387,8 +387,8 @@ async function test_i18n_language_precedence(page: Page): Promise<void> {
 }
 
 async function test_default_language_setting(page: Page): Promise<void> {
-    const display_settings_section = '[data-section="preferences"]';
-    await page.click(display_settings_section);
+    const preferences_section = '[data-section="preferences"]';
+    await page.click(preferences_section);
 
     const chinese_language_data_code = "zh-hans";
     await change_language(page, chinese_language_data_code);
@@ -400,8 +400,8 @@ async function test_default_language_setting(page: Page): Promise<void> {
     });
     await assert_language_changed_to_chinese(page);
     await test_i18n_language_precedence(page);
-    await page.waitForSelector(display_settings_section, {visible: true});
-    await page.click(display_settings_section);
+    await page.waitForSelector(preferences_section, {visible: true});
+    await page.click(preferences_section);
 
     // Change the language back to English so that subsequent tests pass.
     await change_language(page, "en");
@@ -409,8 +409,8 @@ async function test_default_language_setting(page: Page): Promise<void> {
     // Check that the saved indicator appears
     await check_language_setting_status(page);
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
-    await page.waitForSelector(display_settings_section, {visible: true});
-    await page.click(display_settings_section);
+    await page.waitForSelector(preferences_section, {visible: true});
+    await page.click(preferences_section);
     await page.waitForSelector("#user-preferences .general-settings-status", {
         visible: true,
     });


### PR DESCRIPTION
Finished renaming display_settings_section to preferences_section

This helps fixes part of issue https://github.com/zulip/zulip/issues/26874.

In this pull request

Renamed display_settings_section to preferences_section in the web/e2e-tests/setting.test.ts file.

Changed Files:
web/e2e-tests/setting.test.ts

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>