### PR TITLE
message_edit: Show typing indicator for message editing.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 264**
+
+* [`POST /message_edit_typing`](/api/set-typing-status-for-message-edit):
+  Added a new endpoint for sending typing notification when a message is
+  being edited both in streams and direct messages.
+
+* [`GET /events`](/api/get-events): The new `typing_edit_message` event
+  is sent when a user starts editing a message.
+
 **Feature level 263**:
 
 * [`POST /users/me/presence`](/api/update-presence):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 263
+API_FEATURE_LEVEL = 264
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -46,6 +46,7 @@ import * as stream_data from "./stream_data";
 import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
+import {stop_message_edit_notifications} from "./typing";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
@@ -795,6 +796,7 @@ export function end_message_row_edit($row) {
     upload.deactivate_upload(upload.edit_config(row_id));
 
     const message = message_lists.current.get(row_id);
+    stop_message_edit_notifications(message.id);
     if (message !== undefined && currently_editing_messages.has(message.id)) {
         currently_editing_messages.delete(message.id);
         message_lists.current.hide_edit_message($row);

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -37,6 +37,7 @@ import * as sub_store from "./sub_store";
 import * as submessage from "./submessage";
 import {is_same_day} from "./time_zone_util";
 import * as timerender from "./timerender";
+import {is_message_editing} from "./typing_data";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
 
@@ -451,6 +452,7 @@ export class MessageListView {
     set_calculated_message_container_variables(message_container, is_revealed) {
         set_timestr(message_container);
 
+        message_container.is_typing = is_message_editing(message_container.msg.id);
         /*
             If the message needs to be hidden because the sender was muted, we do
             a few things:

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -670,6 +670,24 @@ export function dispatch_normal_event(event) {
                     break;
             }
             break;
+        case "typing_edit_message":
+            if (event.sender.user_id === current_user.user_id) {
+                // typing notifications are sent to the user who is typing
+                // as well as recipients; we ignore such self-generated events.
+                return;
+            }
+            switch (event.op) {
+                case "start":
+                    typing_events.display_message_edit_notification(event);
+                    break;
+                case "stop":
+                    typing_events.hide_message_edit_notification(event);
+                    break;
+                default:
+                    blueslip.error("Unexpected event type typing_edit_message/" + event.op);
+                    break;
+            }
+            break;
 
         case "user_settings": {
             const notification_name = event.property;

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -1,16 +1,21 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import * as typing_status from "../shared/src/typing_status";
-import type {Recipient} from "../shared/src/typing_status";
+import type {EditingStatusWorker, Recipient} from "../shared/src/typing_status";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
+import {get} from "./message_store";
 import * as people from "./people";
+import * as rows from "./rows";
 import {realm} from "./state_data";
 import * as stream_data from "./stream_data";
 import {user_settings} from "./user_settings";
+
+let edit_box_worker: EditingStatusWorker;
 
 type TypingAPIRequest = {op: "start" | "stop"} & (
     | {
@@ -32,6 +37,25 @@ type TypingAPIRequest = {op: "start" | "stop"} & (
 function send_typing_notification_ajax(data: TypingAPIRequest): void {
     void channel.post({
         url: "/json/typing",
+        data,
+        error(xhr) {
+            if (xhr.readyState !== 0) {
+                blueslip.warn("Failed to send typing event: " + xhr.responseText);
+            }
+        },
+    });
+}
+
+function send_message_edit_typing_notification_ajax(
+    message_id: number,
+    operation: "start" | "stop",
+): void {
+    const data = {
+        message_id: JSON.stringify(message_id),
+        op: operation,
+    };
+    void channel.post({
+        url: "/json/message_edit_typing",
         data,
         error(xhr) {
             if (xhr.readyState !== 0) {
@@ -71,11 +95,30 @@ function send_typing_notification_based_on_message_type(
     to: Recipient,
     operation: "start" | "stop",
 ): void {
+    assert(to.notification_event_type === "typing");
     if (to.message_type === "direct" && user_settings.send_private_typing_notifications) {
         send_direct_message_typing_notification(to.ids, operation);
     } else if (to.message_type === "stream" && user_settings.send_stream_typing_notifications) {
         send_stream_typing_notification(to.stream_id, to.topic, operation);
     }
+}
+
+function send_typing_notifications_for_message_edit(
+    message_id: number,
+    operation: "start" | "stop",
+): void {
+    if (message_edit_typing_notifications_enabled(message_id)) {
+        send_message_edit_typing_notification_ajax(message_id, operation);
+    }
+}
+
+function message_edit_typing_notifications_enabled(message_id: number): boolean {
+    const message = get(message_id);
+    assert(message !== undefined);
+    if (message.type === "stream") {
+        return user_settings.send_stream_typing_notifications;
+    }
+    return user_settings.send_private_typing_notifications;
 }
 
 function get_user_ids_array(): number[] | null {
@@ -108,7 +151,23 @@ function notify_server_stop(to: Recipient): void {
     send_typing_notification_based_on_message_type(to, "stop");
 }
 
-export function get_recipient(): Recipient | null {
+function notify_server_editing_start(to: Recipient): void {
+    assert(to.notification_event_type === "typing_message_edit");
+    send_typing_notifications_for_message_edit(to.id, "start");
+}
+
+function notify_server_editing_stop(to: Recipient): void {
+    assert(to.notification_event_type === "typing_message_edit");
+    send_typing_notifications_for_message_edit(to.id, "stop");
+}
+
+export function get_recipient(message_id?: number): Recipient | null {
+    if (message_id !== undefined) {
+        return {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        };
+    }
     const message_type = compose_state.get_message_type();
     if (message_type === "private") {
         return {
@@ -135,11 +194,29 @@ export function get_recipient(): Recipient | null {
     return null;
 }
 
+export function stop_message_edit_notifications(message_id: number): void {
+    const recipient = get_recipient(message_id)!;
+    typing_status.update_editing_status(
+        edit_box_worker,
+        recipient,
+        "stop",
+        realm.server_typing_started_wait_period_milliseconds,
+        realm.server_typing_stopped_wait_period_milliseconds,
+    );
+}
+
 export function initialize(): void {
     const worker = {
         get_current_time,
         notify_server_start,
         notify_server_stop,
+        notification_event_type: "typing",
+    };
+
+    edit_box_worker = {
+        get_current_time,
+        notify_server_editing_start,
+        notify_server_editing_stop,
     };
 
     $(document).on("input", "#compose-textarea", () => {
@@ -149,6 +226,21 @@ export function initialize(): void {
         typing_status.update(
             worker,
             new_recipient,
+            realm.server_typing_started_wait_period_milliseconds,
+            realm.server_typing_stopped_wait_period_milliseconds,
+        );
+    });
+
+    $(document).on("input", ".message_edit_content", function (this: HTMLElement) {
+        // If our previous state was no typing notification, send a
+        // start-typing notice immediately.
+        const $message_row = $(this).closest(".message_row");
+        const message_id = rows.id($message_row);
+        const new_recipient = get_recipient(message_id)!;
+        typing_status.update_editing_status(
+            edit_box_worker,
+            new_recipient,
+            "start",
             realm.server_typing_started_wait_period_milliseconds,
             realm.server_typing_stopped_wait_period_milliseconds,
         );

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -4,6 +4,7 @@ import * as util from "./util";
 // See docs/subsystems/typing-indicators.md for details on typing indicators.
 
 const typists_dict = new Map<string, number[]>();
+const edit_message_typing_ids = new Set<number>();
 const inbound_timer_dict = new Map<string, ReturnType<typeof setInterval> | undefined>();
 
 export function clear_for_testing(): void {
@@ -70,6 +71,24 @@ export function clear_typing_data(): void {
     }
     inbound_timer_dict.clear();
     typists_dict.clear();
+}
+
+export function add_edit_message_typing_id(message_id: number): void {
+    if (!edit_message_typing_ids.has(message_id)) {
+        edit_message_typing_ids.add(message_id);
+    }
+}
+
+export function remove_edit_message_typing_id(message_id: number): boolean {
+    if (!edit_message_typing_ids.has(message_id)) {
+        return false;
+    }
+    edit_message_typing_ids.delete(message_id);
+    return true;
+}
+
+export function is_message_editing(message_id: number): boolean {
+    return edit_message_typing_ids.has(message_id);
 }
 
 // The next functions aren't pure data, but it is easy

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -153,6 +153,10 @@
         grid-area: edited;
     }
 
+    .edit_notifications {
+        grid-area: edited;
+    }
+
     .slow-send-spinner {
         display: none;
         justify-self: end;
@@ -716,5 +720,51 @@ of the base style defined for a read-only textarea in dark mode. */
         color: var(--color-date);
         /* Right padding matches time in message row and date in recipient row. */
         padding: 8px 6px 8px 4px;
+    }
+}
+
+.message-editing-animation {
+    display: inline-flex;
+    align-items: baseline;
+    margin-left: 3px;
+    width: 40px;
+    height: 5px;
+
+    .y_animated_dot {
+        width: 4px;
+        height: 4px;
+        background-color: hsl(0deg 0% 53%);
+        border-radius: 50%;
+        margin-left: 3px;
+        opacity: 0;
+
+        &:nth-child(1) {
+            animation: typing 1s infinite 0.2s;
+        }
+
+        &:nth-child(2) {
+            animation: typing 1s infinite 0.4s;
+        }
+
+        &:nth-child(3) {
+            animation: typing 1s infinite 0.6s;
+        }
+    }
+}
+
+@keyframes typing {
+    0% {
+        opacity: 0;
+        transform: translateY(0);
+    }
+
+    50% {
+        opacity: 1;
+        transform: translateY(-3px);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(0);
     }
 }

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,14 +1,17 @@
+<div id="editing_notifications" class="edit_notifications {{#unless is_typing}}hide{{/unless}}">
+    {{> editing_notifications}}
+</div>
 {{#if modified}}
     {{#if msg/local_edit_timestamp}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+        <div class="message_edit_notice {{#if is_typing}}hide{{/if}}" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
             {{t "SAVING"}}
         </div>
     {{else if moved}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last moved {last_edit_timestr}.'}}">
+        <div class="message_edit_notice {{#if is_typing}}hide{{/if}}" data-tippy-content="{{t 'Last moved {last_edit_timestr}.'}}">
             {{t "MOVED"}}
         </div>
     {{else}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+        <div class="message_edit_notice {{#if is_typing}}hide{{/if}}" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
             {{t "EDITED"}}
         </div>
     {{/if}}

--- a/web/templates/editing_notifications.hbs
+++ b/web/templates/editing_notifications.hbs
@@ -1,0 +1,6 @@
+<div class="message-editing-animation">
+    <span class="y_animated_dot"></span>
+    <span class="y_animated_dot"></span>
+    <span class="y_animated_dot"></span>
+</div>
+

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -177,6 +177,20 @@ exports.fixtures = {
         type: "invites_changed",
     },
 
+    message_edit_typing__start: {
+        type: "typing_edit_message",
+        op: "start",
+        sender: typing_person1,
+        recipients: [typing_person2],
+    },
+
+    message_edit_typing__stop: {
+        type: "typing_edit_message",
+        op: "stop",
+        sender: typing_person1,
+        recipients: [typing_person2],
+    },
+
     muted_users: {
         type: "muted_users",
         muted_users: [

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -24,6 +24,7 @@ test("basics", () => {
     const stream_id = 1;
     const topic = "typing notifications";
     const topic_typing_key = typing_data.get_topic_key(stream_id, topic);
+    let status;
 
     typing_data.add_typist(typing_data.get_direct_message_conversation_key([5, 10, 15]), 15);
     assert.deepEqual(typing_data.get_group_typists([15, 10, 5]), [15]);
@@ -88,6 +89,23 @@ test("basics", () => {
     assert.deepEqual(typing_data.get_group_typists(), []);
     assert.deepEqual(typing_data.get_all_direct_message_typists(), []);
     assert.deepEqual(typing_data.get_topic_typists(stream_id, topic), []);
+
+    // test that you can add a message_id to messages editing state
+    typing_data.add_edit_message_typing_id(3);
+    assert.deepEqual(typing_data.is_message_editing(3), true);
+
+    typing_data.add_edit_message_typing_id(7);
+    assert.deepEqual(typing_data.is_message_editing(7), true);
+
+    // test removing a message from editing state
+    status = typing_data.remove_edit_message_typing_id(3);
+    assert.deepEqual(status, true);
+    assert.deepEqual(typing_data.is_message_editing(3), false);
+
+    // test removing message_id that doesn't exist from editing
+    assert.deepEqual(typing_data.is_message_editing(3), false);
+    status = typing_data.remove_edit_message_typing_id(3);
+    assert.deepEqual(status, false);
 });
 
 test("muted_typists_excluded", () => {

--- a/web/tests/typing_status.test.js
+++ b/web/tests/typing_status.test.js
@@ -50,12 +50,20 @@ run_test("basics", ({override, override_rewire}) => {
     set_global("clearTimeout", clear_timeout);
 
     function notify_server_start(recipient) {
-        assert.deepStrictEqual(recipient, {message_type: "direct", ids: [1, 2]});
+        assert.deepStrictEqual(recipient, {
+            message_type: "direct",
+            notification_event_type: "typing",
+            ids: [1, 2],
+        });
         events.started = true;
     }
 
     function notify_server_stop(recipient) {
-        assert.deepStrictEqual(recipient, {message_type: "direct", ids: [1, 2]});
+        assert.deepStrictEqual(recipient, {
+            message_type: "direct",
+            notification_event_type: "typing",
+            ids: [1, 2],
+        });
         events.stopped = true;
     }
 
@@ -83,11 +91,11 @@ run_test("basics", ({override, override_rewire}) => {
     };
 
     // Start talking to users having ids - 1, 2.
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -99,11 +107,11 @@ run_test("basics", ({override, override_rewire}) => {
 
     // type again 3 seconds later
     worker.get_current_time = returns_time(8);
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -116,11 +124,11 @@ run_test("basics", ({override, override_rewire}) => {
     // type after 15 secs, so that we can notify the server
     // again
     worker.get_current_time = returns_time(18);
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(18 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -153,11 +161,11 @@ run_test("basics", ({override, override_rewire}) => {
 
     // Start talking to users again.
     worker.get_current_time = returns_time(50);
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(50 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -179,11 +187,11 @@ run_test("basics", ({override, override_rewire}) => {
 
     // Start talking to users again.
     worker.get_current_time = returns_time(80);
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(80 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -215,11 +223,11 @@ run_test("basics", ({override, override_rewire}) => {
 
     // Start talking to users again.
     worker.get_current_time = returns_time(170);
-    call_handler({message_type: "direct", ids: [1, 2]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [1, 2]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(170 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [1, 2]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [1, 2]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -233,15 +241,19 @@ run_test("basics", ({override, override_rewire}) => {
     worker.get_current_time = returns_time(171);
 
     worker.notify_server_start = (recipient) => {
-        assert.deepStrictEqual(recipient, {message_type: "direct", ids: [3, 4]});
+        assert.deepStrictEqual(recipient, {
+            message_type: "direct",
+            notification_event_type: "typing",
+            ids: [3, 4],
+        });
         events.started = true;
     };
 
-    call_handler({message_type: "direct", ids: [3, 4]});
+    call_handler({message_type: "direct", notification_event_type: "typing", ids: [3, 4]});
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(171 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "direct", ids: [3, 4]},
+        current_recipient: {message_type: "direct", notification_event_type: "typing", ids: [3, 4]},
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -343,12 +355,22 @@ run_test("stream_messages", ({override_rewire}) => {
     set_global("clearTimeout", clear_timeout);
 
     function notify_server_start(recipient) {
-        assert.deepStrictEqual(recipient, {message_type: "stream", stream_id: 3, topic: "test"});
+        assert.deepStrictEqual(recipient, {
+            message_type: "stream",
+            notification_event_type: "typing",
+            stream_id: 3,
+            topic: "test",
+        });
         events.started = true;
     }
 
     function notify_server_stop(recipient) {
-        assert.deepStrictEqual(recipient, {message_type: "stream", stream_id: 3, topic: "test"});
+        assert.deepStrictEqual(recipient, {
+            message_type: "stream",
+            notification_event_type: "typing",
+            stream_id: 3,
+            topic: "test",
+        });
         events.stopped = true;
     }
 
@@ -376,11 +398,21 @@ run_test("stream_messages", ({override_rewire}) => {
     };
 
     // Start typing stream message
-    call_handler({message_type: "stream", stream_id: 3, topic: "test"});
+    call_handler({
+        message_type: "stream",
+        notification_event_type: "typing",
+        stream_id: 3,
+        topic: "test",
+    });
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "stream", stream_id: 3, topic: "test"},
+        current_recipient: {
+            message_type: "stream",
+            notification_event_type: "typing",
+            stream_id: 3,
+            topic: "test",
+        },
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -392,11 +424,21 @@ run_test("stream_messages", ({override_rewire}) => {
 
     // type again 3 seconds later. Covers 'same_stream_and_topic' codepath.
     worker.get_current_time = returns_time(8);
-    call_handler({message_type: "stream", stream_id: 3, topic: "test"});
+    call_handler({
+        message_type: "stream",
+        notification_event_type: "typing",
+        stream_id: 3,
+        topic: "test",
+    });
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: "idle_timer_stub",
-        current_recipient: {message_type: "stream", stream_id: 3, topic: "test"},
+        current_recipient: {
+            message_type: "stream",
+            notification_event_type: "typing",
+            stream_id: 3,
+            topic: "test",
+        },
     });
     assert.deepEqual(events, {
         idle_callback: events.idle_callback,
@@ -409,6 +451,188 @@ run_test("stream_messages", ({override_rewire}) => {
     // Explicitly stop.
     call_handler(null);
     assert.deepEqual(typing_status.state, null);
+    assert.deepEqual(events, {
+        idle_callback: undefined,
+        started: false,
+        stopped: true,
+        timer_cleared: true,
+    });
+});
+
+run_test("edit_messages", ({override_rewire}) => {
+    override_rewire(typing_status, "state", null);
+
+    let worker = {};
+    const events = {};
+    const message_id = 7;
+
+    function set_timeout(f, delay) {
+        assert.equal(delay, 5000);
+        events.idle_callback = f;
+        return "idle_timer_stub";
+    }
+
+    function clear_timeout() {
+        events.timer_cleared = true;
+    }
+
+    set_global("setTimeout", set_timeout);
+    set_global("clearTimeout", clear_timeout);
+
+    function notify_server_editing_start(recipient) {
+        assert.deepStrictEqual(recipient, {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        });
+        events.started = true;
+    }
+
+    function notify_server_editing_stop(recipient) {
+        assert.deepStrictEqual(recipient, {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        });
+        events.stopped = true;
+    }
+
+    function clear_events() {
+        events.idle_callback = undefined;
+        events.started = false;
+        events.stopped = false;
+        events.timer_cleared = false;
+    }
+
+    function call_handler_start(new_recipient) {
+        clear_events();
+        typing_status.update_editing_status(
+            worker,
+            new_recipient,
+            "start",
+            TYPING_STARTED_WAIT_PERIOD,
+            TYPING_STOPPED_WAIT_PERIOD,
+        );
+    }
+
+    function call_handler_stop(new_recipient) {
+        clear_events();
+        typing_status.update_editing_status(
+            worker,
+            new_recipient,
+            "stop",
+            TYPING_STARTED_WAIT_PERIOD,
+            TYPING_STOPPED_WAIT_PERIOD,
+        );
+    }
+
+    worker = {
+        get_current_time: returns_time(5),
+        notify_server_editing_start,
+        notify_server_editing_stop,
+    };
+
+    // Start typing stream message
+    call_handler_start({
+        notification_event_type: "typing_message_edit",
+        id: message_id,
+    });
+    assert.deepEqual(typing_status.editing_state.get(message_id), {
+        next_send_start_time: make_time(5 + 10),
+        idle_timer: "idle_timer_stub",
+        current_recipient: {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        },
+    });
+    assert.deepEqual(events, {
+        idle_callback: events.idle_callback,
+        started: true,
+        stopped: false,
+        timer_cleared: false,
+    });
+    assert.ok(events.idle_callback);
+
+    worker.get_current_time = returns_time(8);
+    call_handler_start({
+        notification_event_type: "typing_message_edit",
+        id: message_id,
+    });
+    assert.deepEqual(typing_status.editing_state.get(message_id), {
+        next_send_start_time: make_time(5 + 10),
+        idle_timer: "idle_timer_stub",
+        current_recipient: {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        },
+    });
+    assert.deepEqual(events, {
+        idle_callback: events.idle_callback,
+        started: false,
+        stopped: false,
+        timer_cleared: true,
+    });
+    assert.ok(events.idle_callback);
+
+    worker.get_current_time = returns_time(16);
+    call_handler_start({
+        notification_event_type: "typing_message_edit",
+        id: message_id,
+    });
+    assert.deepEqual(typing_status.editing_state.get(message_id), {
+        next_send_start_time: make_time(16 + 10),
+        idle_timer: "idle_timer_stub",
+        current_recipient: {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        },
+    });
+    assert.deepEqual(events, {
+        idle_callback: events.idle_callback,
+        started: true,
+        stopped: false,
+        timer_cleared: true,
+    });
+    assert.ok(events.idle_callback);
+
+    // Now call recipients idle callback that we captured earlier.
+    const callback = events.idle_callback;
+    clear_events();
+    callback();
+    assert.deepEqual(typing_status.editing_state.get(message_id), undefined);
+    assert.deepEqual(events, {
+        idle_callback: undefined,
+        started: false,
+        stopped: true,
+        timer_cleared: true,
+    });
+
+    // Start editing message again.
+    worker.get_current_time = returns_time(50);
+    call_handler_start({
+        notification_event_type: "typing_message_edit",
+        id: message_id,
+    });
+    assert.deepEqual(typing_status.editing_state.get(message_id), {
+        next_send_start_time: make_time(50 + 10),
+        idle_timer: "idle_timer_stub",
+        current_recipient: {
+            notification_event_type: "typing_message_edit",
+            id: message_id,
+        },
+    });
+    assert.deepEqual(events, {
+        idle_callback: events.idle_callback,
+        started: true,
+        stopped: false,
+        timer_cleared: false,
+    });
+    assert.ok(events.idle_callback);
+
+    // Explicitly stop.
+    call_handler_stop({
+        notification_event_type: "typing_message_edit",
+        id: message_id,
+    });
+    assert.deepEqual(typing_status.editing_state.get(message_id), undefined);
     assert.deepEqual(events, {
         idle_callback: undefined,
         started: false,

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1519,6 +1519,47 @@ def set_typing_status(client: Client) -> None:
     validate_against_openapi_schema(result, "/typing", "post", "200")
 
 
+@openapi_test_function("/message_edit_typing:post")
+def set_message_edit_typing_status(client: Client) -> None:
+    # {code_example|start}
+    # The user has started typing while editing a message
+    message = {"type": "stream", "to": "Verona", "topic": "test_topic", "content": "test content"}
+    response = client.send_message(message)
+    message_id = response["id"]
+
+    request = {
+        "op": "start",
+        "message_id": message_id,
+    }
+    result = client.call_endpoint(
+        "message_edit_typing",
+        method="POST",
+        request=request,
+    )
+    # {code_example|end}
+
+    validate_against_openapi_schema(result, "/message_edit_typing", "post", "200")
+
+    # {code_example|start}
+    # The user has stopped typing while editing a message
+    message = {"type": "stream", "to": "Verona", "topic": "test_topic", "content": "test content"}
+    response = client.send_message(message)
+    message_id = response["id"]
+
+    request = {
+        "op": "stop",
+        "message_id": message_id,
+    }
+    result = client.call_endpoint(
+        "message_edit_typing",
+        method="POST",
+        request=request,
+    )
+    # {code_example|end}
+
+    validate_against_openapi_schema(result, "/message_edit_typing", "post", "200")
+
+
 @openapi_test_function("/realm/emoji/{emoji_name}:post")
 def upload_custom_emoji(client: Client) -> None:
     emoji_path = os.path.join(ZULIP_DIR, "zerver", "tests", "images", "img.jpg")
@@ -1675,6 +1716,7 @@ def test_invalid_stream_error(client: Client) -> None:
 def test_messages(client: Client, nonadmin_client: Client) -> None:
     render_message(client)
     message_id = send_message(client)
+    set_message_edit_typing_status(client)
     add_reaction(client, message_id)
     remove_reaction(client, message_id)
     update_message(client, message_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2877,6 +2877,112 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent when a user starts editing a message.
+
+                                Sent to all clients for users who would receive the message
+                                that was previously being typed, with the additional rule
+                                that typing notifications for stream messages are only sent to
+                                clients that included `stream_typing_notifications` in their
+                                [client capabilities][client-capabilities] when registering
+                                the event queue.
+
+                                **Changes**: New in Zulip 9.0 (feature level 251).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - typing_edit_message
+                                op:
+                                  type: string
+                                  enum:
+                                    - start
+                                sender:
+                                  additionalProperties: false
+                                  type: object
+                                  description: |
+                                    Object describing the user who was previously editing the message.
+                                  properties:
+                                    user_id:
+                                      type: integer
+                                      description: |
+                                        The user's ID.
+                                    email:
+                                      type: string
+                                      description: |
+                                        The Zulip API email address for the user.
+                                message_id:
+                                  type: integer
+                                  description: |
+                                    Indicates the message id of the message that is being edited.
+                              example:
+                                {
+                                  "type": typing_edit_message,
+                                  "op": "start",
+                                  "sender":
+                                    {
+                                      "user_id": 10,
+                                      "email": "user10@zulip.testserver",
+                                    },
+                                  "message_id": 7,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
+                                Event sent when a user stops editing the message.
+
+                                Sent to all clients for users who would receive the message
+                                that was previously being typed, with the additional rule
+                                that typing notifications for stream messages are only sent to
+                                clients that included `stream_typing_notifications` in their
+                                [client capabilities][client-capabilities] when registering
+                                the event queue.
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - typing_edit_message
+                                op:
+                                  type: string
+                                  enum:
+                                    - stop
+                                sender:
+                                  additionalProperties: false
+                                  type: object
+                                  description: |
+                                    Object describing the user who was previously editing the message.
+                                  properties:
+                                    user_id:
+                                      type: integer
+                                      description: |
+                                        The user's ID.
+                                    email:
+                                      type: string
+                                      description: |
+                                        The Zulip API email address for the user.
+                                message_id:
+                                  type: integer
+                                  description: |
+                                    Indicates the message id of the message that is being edited.
+                              example:
+                                {
+                                  "type": typing_edit_message,
+                                  "op": "stop",
+                                  "sender":
+                                    {
+                                      "user_id": 10,
+                                      "email": "user10@zulip.testserver",
+                                    },
+                                  "message_id": 7,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent to a user when [message flags][message-flags] are added
                                 to messages.
 
@@ -18898,6 +19004,45 @@ paths:
                     description: |
                       An example JSON error response when the user composes a channel message
                       and `stream_id` is not specified:
+  /message_edit_typing:
+    post:
+      operationId: set-typing-status-for-message-edit
+      summary: Set "typing" status for message editing
+      tags: ["users"]
+      description: |
+        Notify other users whether the current user is
+        [typing a message][help-typing].
+
+        It follows a similar protocol to set-typing-status.
+
+        **Changes**: New in Zulip 9.0 (feature level 264)
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                op:
+                  description: |
+                    Whether the user has started (`"start"`) or stopped (`"stop"`) editing.
+                  type: string
+                  enum:
+                    - start
+                    - stop
+                  example: start
+                message_id:
+                  description: |
+                    Describes the message id of the message being edited.
+                  type: integer
+                  example: 7
+              required:
+                - op
+                - message_id
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+
   /user_groups/create:
     post:
       operationId: create-user-group

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -3,13 +3,21 @@ from typing import List, Optional
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
-from zerver.actions.typing import check_send_typing_notification, do_send_stream_typing_notification
+from zerver.actions.message_edit import validate_user_can_edit_message
+from zerver.actions.typing import (
+    check_send_typing_notification,
+    do_send_direct_message_edit_typing_notification,
+    do_send_stream_message_edit_typing_notification,
+    do_send_stream_typing_notification,
+)
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.message import access_message
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_for_send_message
 from zerver.lib.validator import check_int, check_list, check_string_in
-from zerver.models import UserProfile
+from zerver.models import Recipient, UserProfile
+from zerver.models.recipients import get_huddle_user_ids
 
 VALID_OPERATOR_TYPES = ["start", "stop"]
 VALID_RECIPIENT_TYPES = ["direct", "stream", "channel"]
@@ -64,5 +72,42 @@ def send_notification_backend(
             raise JsonableError(_("User has disabled typing notifications for direct messages"))
 
         check_send_typing_notification(user_profile, user_ids, operator)
+
+    return json_success(request)
+
+
+@has_request_variables
+def send_message_edit_notification_backend(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    operator: str = REQ("op", str_validator=check_string_in(VALID_OPERATOR_TYPES)),
+    message_id: int = REQ(json_validator=check_int),
+) -> HttpResponse:
+    message = access_message(user_profile, message_id)
+    recipient = message.recipient
+
+    validate_user_can_edit_message(user_profile, message, 0)
+
+    if recipient.type == Recipient.STREAM:
+        if not user_profile.send_stream_typing_notifications:
+            raise JsonableError(_("User has disabled typing notifications for stream messages"))
+
+        channel_id = recipient.type_id
+        do_send_stream_message_edit_typing_notification(
+            user_profile, channel_id, message_id, operator
+        )
+
+    else:
+        if not user_profile.send_private_typing_notifications:
+            raise JsonableError(_("User has disabled typing notifications for direct messages"))
+
+        if recipient.type == Recipient.PERSONAL:
+            recipient_ids = [recipient.type_id]
+        else:
+            recipient_ids = list(get_huddle_user_ids(recipient))
+
+        do_send_direct_message_edit_typing_notification(
+            user_profile, recipient_ids, message_id, operator
+        )
 
     return json_success(request)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -178,7 +178,7 @@ from zerver.views.streams import (
 from zerver.views.submessage import process_submessage
 from zerver.views.thumbnail import backend_serve_thumbnail
 from zerver.views.tutorial import set_tutorial_status
-from zerver.views.typing import send_notification_backend
+from zerver.views.typing import send_message_edit_notification_backend, send_notification_backend
 from zerver.views.unsubscribe import email_unsubscribe
 from zerver.views.upload import (
     serve_file_backend,
@@ -374,6 +374,8 @@ v1_api_and_json_patterns = [
     # typing -> zerver.views.typing
     # POST sends a typing notification event to recipients
     rest_path("typing", POST=send_notification_backend),
+    # POST sends a message edit typing notification
+    rest_path("message_edit_typing", POST=send_message_edit_notification_backend),
     # user_uploads -> zerver.views.upload
     rest_path("user_uploads", POST=upload_file_backend),
     rest_path(


### PR DESCRIPTION
Previously, when a message was being edited, typing notification for it is not shown.

This commit adds typing indicators for message editing in stream as well as in Direct Messages, provided the send typing notification for corresponding is enabled.

Fixes #25719

<!-- Describe your pull request here.-->
API Design thread: https://chat.zulip.org/#narrow/stream/378-api-design/topic/typing.20notifications.20for.20editing.20messages/near/1720430


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


![brave_aio5ftvP3Y](https://github.com/zulip/zulip/assets/97049524/3d98118c-792a-4735-a3fb-0a256928f369)
![brave_myobIZy0C9](https://github.com/zulip/zulip/assets/97049524/d3d15d21-877c-4497-9aba-6e2625c9caa4)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
