### PR TITLE
hotkey: Introduce hotkey Alt+P to toggle preview for compose box.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -73,10 +73,10 @@ in the Zulip app to add more to your repertoire as needed.
 * **Scroll down**: <kbd>PgDn</kbd>, <kbd>Shift</kbd> + <kbd>J</kbd>, or
   <kbd>Spacebar</kbd>
 
-* **Go back through viewing history**: <kbd>Alt</kbd> +
+* **Go back through viewing history**: <kbd data-mac-key="⌘">Alt</kbd> +
   <kbd class="arrow-key">←</kbd>
 
-* **Go forward through viewing history**: <kbd>Alt</kbd> +
+* **Go forward through viewing history**: <kbd data-mac-key="⌘">Alt</kbd> +
   <kbd class="arrow-key">→</kbd>
 
 ## Narrowing

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -134,6 +134,8 @@ in the Zulip app to add more to your repertoire as needed.
 * **Insert link**: `[Zulip website](https://zulip.org)` or <kbd>Ctrl</kbd> +
   <kbd>Shift</kbd> + <kbd>L</kbd>
 
+* **Toggle preview mode**: <kbd>Alt</kbd> + <kbd>P</kbd>
+
 * **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
   <kbd>[</kbd> — Close the compose box and save the unsent message as a draft.
 

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -45,7 +45,7 @@ const keys_map = new Map([
     ["PgUp", "↑"],
     ["PgDn", "↓"],
     ["Ctrl", "⌘"],
-    ["Alt", "⌘"],
+    ["Alt", "⌥"],
 ]);
 
 const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
@@ -69,7 +69,12 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
             $(this).addClass("arrow-key");
         }
 
-        const replace_key = keys_map.get(key_text);
+        // We use data-mac-key attribute to override the default key in case
+        // of exceptions. Currently, there are 2 shortcuts (for navigating back
+        // and forth in browser history) which need `Cmd` instead of the expected
+        // mapping (`Opt`) for the `Alt` key, so we use this attribute to override
+        // `Opt` with `Cmd`.
+        const replace_key = $(this).attr("data-mac-key") ?? keys_map.get(key_text);
         if (replace_key !== undefined) {
             key_text = replace_key;
         }

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -58,6 +58,26 @@ export function clear_preview_area() {
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", 0);
 }
 
+export function show_preview_area() {
+    // Disable unneeded compose_control_buttons as we don't
+    // need them in preview mode.
+    $("#compose").addClass("preview_mode");
+    $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
+
+    const content = $("textarea#compose-textarea").val();
+    $("textarea#compose-textarea").hide();
+    $("#compose .markdown_preview").hide();
+    $("#compose .undo_markdown_preview").show();
+    $("#compose .undo_markdown_preview").trigger("focus");
+    $("#compose .preview_message_area").show();
+
+    render_and_show_preview(
+        $("#compose .markdown_preview_spinner"),
+        $("#compose .preview_content"),
+        content,
+    );
+}
+
 export function create_message_object() {
     // Topics are optional, and we provide a placeholder if one isn't given.
     let topic = compose_state.topic();

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -389,23 +389,7 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
-        // Disable unneeded compose_control_buttons as we don't
-        // need them in preview mode.
-        $("#compose").addClass("preview_mode");
-        $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
-
-        const content = $("textarea#compose-textarea").val();
-        $("textarea#compose-textarea").hide();
-        $("#compose .markdown_preview").hide();
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .undo_markdown_preview").trigger("focus");
-        $("#compose .preview_message_area").show();
-
-        compose.render_and_show_preview(
-            $("#compose .markdown_preview_spinner"),
-            $("#compose .preview_content"),
-            content,
-        );
+        compose.show_preview_area();
     });
 
     $("#compose").on("click", ".undo_markdown_preview", (e) => {

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -120,6 +120,10 @@ const keydown_cmd_or_ctrl_mappings = {
     190: {name: "narrow_to_compose_target", message_view_only: true}, // '.'
 };
 
+const keydown_alt_mappings = {
+    80: {name: "toggle_compose_preview", message_view_only: true}, // 'P'
+};
+
 const keydown_either_mappings = {
     // these can be triggered by key or Shift + key
     // Note that codes for letters are still case sensitive!
@@ -185,11 +189,15 @@ const keypress_mappings = {
 };
 
 export function get_keydown_hotkey(e) {
+    let hotkey;
+
     if (e.altKey) {
+        hotkey = keydown_alt_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
         return undefined;
     }
-
-    let hotkey;
 
     if (e.ctrlKey && !e.shiftKey) {
         hotkey = keydown_ctrl_mappings[e.which];
@@ -776,6 +784,15 @@ export function process_hotkey(e, hotkey) {
 
     if (event_name === "down_arrow" && list_util.inside_list(e)) {
         list_util.go_down(e);
+        return true;
+    }
+
+    if (event_name === "toggle_compose_preview" && compose_state.composing()) {
+        if ($("#compose .markdown_preview").is(":visible")) {
+            compose.show_preview_area();
+        } else {
+            compose.clear_preview_area();
+        }
         return true;
     }
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -155,6 +155,10 @@
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Toggle preview mode' }}</td>
+                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd>P</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -107,11 +107,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go back through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
+                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go forward through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
+                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
             </table>
         </div>

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -89,7 +89,7 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
         ["PgUp", "↑"],
         ["PgDn", "↓"],
         ["Ctrl", "⌘"],
-        ["Alt", "⌘"],
+        ["Alt", "⌥"],
         ["#stream_name", "#stream_name"],
         ["Ctrl+K", "Ctrl+K"],
         ["[", "["],
@@ -153,7 +153,6 @@ run_test("adjust_mac_tooltip_keys mac expected", ({override}) => {
         [["PgUp"], ["Fn", "↑"]],
         [["PgDn"], ["Fn", "↓"]],
         [["Ctrl"], ["⌘"]],
-        [["Alt"], ["⌘"]],
     ]);
 
     override(navigator, "platform", "MacIntel");
@@ -191,14 +190,6 @@ run_test("adjust_mac_tooltip_keys mac random", ({override}) => {
             ["Shift", "G"],
         ],
         [["Space"], ["Space"]],
-        [
-            ["Alt", "←"],
-            ["⌘", "←"],
-        ],
-        [
-            ["Alt", "→"],
-            ["⌘", "→"],
-        ],
     ]);
 
     override(navigator, "platform", "MacIntel");

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -159,12 +159,13 @@ run_test("mappings", () => {
         });
     }
 
-    function map_down(which, shiftKey, ctrlKey, metaKey) {
+    function map_down(which, shiftKey, ctrlKey, metaKey, altKey) {
         return hotkey.get_keydown_hotkey({
             which,
             shiftKey,
             ctrlKey,
             metaKey,
+            altKey,
         });
     }
 
@@ -193,6 +194,8 @@ run_test("mappings", () => {
     assert.equal(map_down(75, false, true).name, "search_with_k"); // Ctrl + K
     assert.equal(map_down(83, false, true).name, "star_message"); // Ctrl + S
     assert.equal(map_down(190, false, true).name, "narrow_to_compose_target"); // Ctrl + .
+
+    assert.equal(map_down(80, false, false, false, true).name, "toggle_compose_preview"); // Alt + P
 
     // More negative tests.
     assert.equal(map_down(47), undefined);


### PR DESCRIPTION
On Mac, it's Option+P.

Fixes: #18471.

refactor: Extract new function `show_preview_area` for the compose box.

The code responsible for switching from edit mode to preview mode from `compose_setup.js` is now extracted into a new function in `compose.js`, to facilitate reuse.

This is a prep commit for introducing a hotkey to toggle between edit and preview mode for the compose box.

Revision of #26841 

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/21ab23c1-bc96-489d-b142-abdd8b3715a9)
![image](https://github.com/zulip/zulip/assets/68962290/7d86b3e0-a667-46ed-aa34-5ff8c1814f22)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
