### PR TITLE
skip_navigation: Add a skip navigation link to the /help and /api sites

### DIFF
--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -27,7 +27,7 @@
     </svg>
 
     <div class="markdown">
-        <div class="content">
+        <div class="content" id="main-content">
             {% if page_is_policy_center %}
             {{ render_markdown_path(article) }}
             {% elif page_is_help_center %}

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,5 +1,8 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
+        {% if page_is_help_center or page_is_api_center %}
+        <a id="skip-navigation" href="#main-content">{{ _('Skip to main content') }}</a>
+        {% endif %}
         <div class="float-left">
             {% if custom_logo_url %}
             <a class="brand logo" href="{{ root_domain_url }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -121,4 +121,22 @@ $(".markdown").on("click", () => {
 
 render_tabbed_sections();
 
-$(".highlighted")[0]?.scrollIntoView({block: "center"});
+if ($(window).width() > 800) {
+    $(".highlighted")[0]?.scrollIntoView({block: "center"});
+    $(".highlighted").eq(0).trigger("focus");
+    $(".highlighted")
+        .eq(0)
+        .on("keydown", (e) => {
+            if (e.key === "Tab" && !e.shiftKey && !$("#skip-navigation").hasClass("tabbed")) {
+                e.preventDefault();
+                $("#skip-navigation").trigger("focus");
+            }
+        });
+    $("#skip-navigation").on("keydown", function (e) {
+        if (e.key === "Tab" && !e.shiftKey) {
+            e.preventDefault();
+            $(".highlighted").eq(0).trigger("focus");
+            $(this).addClass("tabbed");
+        }
+    });
+}

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1050,6 +1050,25 @@ input.new-organization-button {
     margin-bottom: 25px !important;
 }
 
+#skip-navigation {
+    background-color: hsl(170deg 47% 33%);
+    color: hsl(0deg 0% 100%);
+    border-radius: 4px;
+    display: inline-block;
+    font-weight: 600;
+    left: 330px;
+    outline: none;
+    padding: 5px 12px;
+    position: absolute;
+    top: -1000px;
+    z-index: 100;
+}
+
+#skip-navigation:focus-visible {
+    text-underline-offset: 2px;
+    top: 25px;
+}
+
 @media (width <= 800px) {
     .app.help {
         .markdown {
@@ -1122,6 +1141,14 @@ input.new-organization-button {
         &:not(.show) a.highlighted {
             background-color: transparent;
         }
+    }
+
+    #skip-navigation {
+        left: 80px;
+    }
+
+    #skip-navigation:focus-visible {
+        top: 30px;
     }
 }
 
@@ -1213,6 +1240,14 @@ input.new-organization-button {
     .header-main {
         max-width: 100vw;
         padding: 0 10px;
+    }
+
+    #skip-navigation {
+        left: 60px;
+    }
+
+    #skip-navigation:focus-visible {
+        top: 10px;
     }
 }
 


### PR DESCRIPTION
This PR fixes issue #28564 

I have added "Skip to main content" button which links the main content. Keyboard and screen readers can now skip to the main content without traveling long.

**Screenshots and screen captures:**

On Clicking Tab:
![image](https://github.com/zulip/zulip/assets/112728411/2453a200-ea61-47a3-ac9f-849db755eab3)


On Clicking Enter:
![image](https://github.com/zulip/zulip/assets/112728411/46ac9ae0-33ca-4f16-853a-3313c53cd29b)



- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Individual commits are ready for review
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.



Please review my code. This is my first contribution to Zulip :)
