### PR TITLE
billing: Change background color of reactivate subscription.

### DIFF
--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -534,6 +534,11 @@ input[name="licenses"] {
     background-color: hsl(0deg 70% 40%);
 }
 
+#reactivate-subscription
+    .reactivate-current-plan-button.plan-toggle-action-button {
+    background-color: hsl(146deg 92% 26%);
+}
+
 #server-deactivate-button,
 #remote-billing-confirm-login-button,
 #remote-billing-confirm-email-button,


### PR DESCRIPTION
Fixes #28428

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/133737627/8e4000a5-0c0a-4131-9a5d-6c995326dec4)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
