### PR TITLE
settings: Rename display-settings-form to preferences-settings-form.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -481,7 +481,7 @@ input[type="checkbox"] {
     }
 }
 
-.display-settings-form,
+.preferences-settings-form,
 .notification-settings-form {
     .subsection-header h3 {
         display: inline-block;
@@ -1427,7 +1427,7 @@ $option_title_width: 180px;
         }
     }
 
-    .display-settings-form select {
+    .preferences-settings-form select {
         width: 245px;
     }
 }

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -1,4 +1,4 @@
-<form class="display-settings-form">
+<form class="preferences-settings-form">
     <div class="general-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->


### PR DESCRIPTION
Finished renaming display-settings-form to preferences-settings-form

This helps fixes part of issue https://github.com/zulip/zulip/issues/26874.

In this pull request

Renamed display-settings-form to preferences-settings-form.

Changed Files:
web/styles/settings.css
web/templates/settings/display_settings.hbs

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>