### PR TITLE
fix(ui): tooltip for deactivated bots

### DIFF
--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -3,7 +3,7 @@
         <span class="user_name" >
             <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>
             {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
-        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
+        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{#if is_bot}}{{t 'Bot is deactivated' }}{{else}} {{t 'User is deactivated'}} {{/if}}" {{#if is_active}}style="display: none;"{{/if}}></i>
     </td>
     {{#if display_email}}
     <td>


### PR DESCRIPTION
Fixed the mistake in the tooltip for the deactivated bot.

Fixes: #28593

**Screenshots**

Before: 
![Screenshot 2024-01-17 190241](https://github.com/zulip/zulip/assets/108459152/b4e08194-51ce-4d15-979e-29a47e78900b)


After: 
![Screenshot 2024-01-17 190308](https://github.com/zulip/zulip/assets/108459152/123e8ce4-b07a-479d-9770-0404869bc581)

For deactivated users:
![Screenshot 2024-01-17 190323](https://github.com/zulip/zulip/assets/108459152/3ebb9a1e-9822-4e8c-a299-288fc98f2566)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
