### PR TITLE
find_account: Send emails to non zulip accounts

### DIFF
--- a/templates/zerver/emails/find_team.html
+++ b/templates/zerver/emails/find_team.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+{% if account_found %}
 <p>{{ _("Thanks for your request!") }}</p>
 
 {% if corporate_enabled %}
@@ -22,6 +23,19 @@
 <p>
     {% trans %}If you have trouble logging in, you can <a href="{{ help_reset_password_link }}">reset your password</a>.{% endtrans %}
 </p>
+{% else %}
+<p>
+    {{ _("You have requested a list of Zulip accounts for this email address.") }}
+    {% if corporate_enabled %}
+    {{ _("Unfortunately, no Zulip Cloud accounts were found.") }}
+    {% else %}
+    {% trans%}Unfortunately, no accounts were found in Zulip organizations hosted by {{external_host}}.{% endtrans %}
+    {% endif %}
+</p>
 
-<p>{{ _("Thanks for using Zulip!") }}</p>
+<p>
+    {% trans %}You can <a href = "{{ find_accounts_link }}" >check for accounts</a> with another email, or <a href ="{{ help_logging_in_link }}">try another way</a> to find your account.{% endtrans %}
+    {{ _("If you do not recognize this request, you can safely ignore this email.") }}
+</p>
+{% endif %}
 {% endblock %}

--- a/templates/zerver/emails/find_team.html
+++ b/templates/zerver/emails/find_team.html
@@ -7,7 +7,11 @@
 {% block content %}
 <p>{{ _("Thanks for your request!") }}</p>
 
-<p>{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by <a href="{{ external_host }}">{{ external_host }}</a>:{% endtrans %}</p>
+{% if corporate_enabled %}
+<p>{% trans %}Your email address {{ email }} has accounts with the following Zulip Cloud organizations:{% endtrans %}</p>
+{% else %}
+<p>{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:{% endtrans %}</p>
+{% endif %}
 
 <ul>
     {% for realm in realms %}
@@ -16,9 +20,7 @@
 </ul>
 
 <p>
-    {% trans help_url="https://zulip.com/help/change-your-password#if-youve-forgotten-or-never-had-a-password" %}
-    If you have trouble logging in, you can <a href="{{ help_url }}">reset your password</a>.
-    {% endtrans %}
+    {% trans %}If you have trouble logging in, you can <a href="{{ help_reset_password_link }}">reset your password</a>.{% endtrans %}
 </p>
 
 <p>{{ _("Thanks for using Zulip!") }}</p>

--- a/templates/zerver/emails/find_team.subject.txt
+++ b/templates/zerver/emails/find_team.subject.txt
@@ -1,1 +1,5 @@
-{{ _("Your Zulip accounts") }}
+{% if account_found %}
+    {{ _("Your Zulip accounts") }}
+{% else %}
+    {{ _("No Zulip accounts found") }}
+{% endif %}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,16 +1,18 @@
 {{ _("Thanks for your request!") }}
 
-{% trans -%}
-Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:
-{%- endtrans %}
+{% if corporate_enabled %}
+{% trans %}Your email address {{ email }} has accounts with the following Zulip Cloud organizations:{% endtrans %}
+{% else %}
+{% trans %}Your email address {{ email }} has accounts with the following Zulip organizations hosted by {{ external_host }}:{% endtrans %}
+{% endif %}
 
 
 {% for realm in realms %}
 * {{ realm.name }}: {{ realm.uri }}
 {% endfor %}
 
-{% trans help_url="https://zulip.com/help/change-your-password#if-youve-forgotten-or-never-had-a-password" %}
-If you have trouble logging in, you can reset your password ({{ help_url }}).
-{% endtrans %}
+{% trans %}If you have trouble logging in, you can reset your password.{% endtrans %}
+
+{{ help_reset_password_link }}
 
 {{ _("Thanks for using Zulip!") }}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,3 +1,4 @@
+{% if account_found %}
 {{ _("Thanks for your request!") }}
 
 {% if corporate_enabled %}
@@ -15,4 +16,21 @@
 
 {{ help_reset_password_link }}
 
-{{ _("Thanks for using Zulip!") }}
+{% else %}
+{% if corporate_enabled %}
+{{ _("You have requested a list of Zulip accounts for this email address.") }} {{ _("Unfortunately, no accounts in Zulip Cloud organizations were found.") }}
+
+{% trans %}You can check for accounts with another email ({{ find_accounts_link }}), or try another way to find your account ({{ help_logging_in_link }}).{% endtrans %}
+
+
+{{ _("If you do not recognize this request, you can safely ignore this email.") }}
+{% else %}
+{{ _("You have requested a list of Zulip accounts for this email address.") }} {% trans%}Unfortunately, no accounts were found in Zulip organizations hosted by {{external_host}}.{% endtrans %}
+
+
+{% trans %}You can check for accounts with another email ({{ find_accounts_link }}), or try another way to find your account ({{ help_logging_in_link }}).{% endtrans %}
+
+
+{{ _("If you do not recognize this request, you can safely ignore this email.") }}
+{% endif %}
+{% endif %}

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -17,9 +17,7 @@
             <div id="results">
                 <p>
                     {% trans %}
-                    Emails sent! You will only receive emails at addresses
-                    associated with Zulip organizations. The addresses entered
-                    on the previous page are listed below:
+                    Emails sent! The addresses entered on the previous page are listed below:
                     {% endtrans %}
                 </p>
 

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -56,9 +56,7 @@ class EmailTranslationTestCase(ZulipTestCase):
             {"email": "new-email@zulip.com"},
             HTTP_ACCEPT_LANGUAGE="pt",
         )
-        check_translation(
-            "Danke, dass du", "post", "/accounts/find/", {"emails": hamlet.delivery_email}
-        )
+        check_translation("Danke für", "post", "/accounts/find/", {"emails": hamlet.delivery_email})
         check_translation(
             "Hallo",
             "post",


### PR DESCRIPTION
Previously, the emails which weren't connected to a Zulip account were ignored but now they recieve an email stating their email isn't connected to a Zulip account

Fixes part of #3128

- [ ]  You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: https://slack.com/signin/find

- [x]  We should send an email regardless of whether they are in a Zulip org or not.

- [x] The followup page should have links to resend the email or enter a different email address.

- [x] The URL of the followup page currently has the email as a URL parameter, which should be removed.
 

- [x] Add the 'In the Zulip development environment, outgoing emails are printed to the run-dev.py console.' text (git grep for it to see how we do it elsewhere)

- [x]  On load, the cursor should go into the box where you enter your email address.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Recording:

https://github.com/zulip/zulip/assets/78016781/259d6eb4-d300-47c8-821d-cbbe6befe03b

Zulip-Cloud:
![](https://github.com/zulip/zulip/assets/78016781/2f0f689a-ce3f-4b14-bccf-45472ac0f1d6)

![image](https://github.com/zulip/zulip/assets/78016781/3744cde5-f036-4a9b-87a8-2777226e5a18)

Self-hosted:
![image](https://github.com/zulip/zulip/assets/78016781/022e40a1-16c9-40a0-9019-75dc9cadc055)

![image](https://github.com/zulip/zulip/assets/78016781/2578b0e6-ea7c-4168-8dbd-5d5f92732f8e)





