### PR TITLE
hbs:  Use correct tooltips for deactivated bots.

### DIFF
--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -3,7 +3,11 @@
         <span class="user_name" >
             <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>
             {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
+        {{#if is_bot}}
+        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Bot is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
+        {{else}}
         <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
+        {{/if}}
     </td>
     {{#if display_email}}
     <td>


### PR DESCRIPTION
Added handlebars if-else conditions to display
'User is deactivated' tooltip for deactivated users and 'Bot is deactivated' tooltip for deactivated bots.

Fixes:#28593.

<h3>Bots table and Deactivated users table before changes:</h3>


![before4 1](https://github.com/zulip/zulip/assets/153224120/3436627f-df4d-4403-9eda-bd98b4ae7681) 
  
![before4 2](https://github.com/zulip/zulip/assets/153224120/448bfba9-94fc-4d5e-bdc9-c9c568fb87f2)

<h3>Bots table and Deactivated users table After changes:</h3>

![after4](https://github.com/zulip/zulip/assets/153224120/66b0c765-dc7b-4b9f-9013-a12725c9f7c9)

![before4 2](https://github.com/zulip/zulip/assets/153224120/448bfba9-94fc-4d5e-bdc9-c9c568fb87f2)
