### PR TITLE
remote_billing: Add rate-limiting for confirmation email sending.

### DIFF
--- a/templates/corporate/remote_server_rate_limit_exceeded.html
+++ b/templates/corporate/remote_server_rate_limit_exceeded.html
@@ -1,0 +1,27 @@
+{% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>{{ _("Rate limit exceeded") }} | Zulip</title>
+{% endblock %}
+
+{% block portico_content %}
+
+<div class="error_page">
+    <div class="container">
+        <div class="row-fluid">
+            <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
+            <div class="errorbox">
+                <div class="errorcontent">
+                    <h1 class="lead">{{ _("Rate limit exceeded.") }}</h1>
+                    <p>
+                        {% trans %}Your server has exceeded the limit for how
+                        often this action can be performed.{% endtrans %}
+                        {% trans %}You can try again in {{retry_after}} seconds.{% endtrans %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -291,6 +291,12 @@ DEFAULT_RATE_LIMITING_RULES = {
         # 1000 per day per file
         (86400, 1000),
     ],
+    # A zilencer-only limit that applies to requests to the
+    # remote billing system that trigger the sending of an email.
+    "sends_email_by_remote_server": [
+        # 10 emails per day
+        (86400, 10),
+    ],
 }
 # Rate limiting defaults can be individually overridden by adding
 # entries in this object, which is merged with

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -256,6 +256,7 @@ RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "sends_email_by_ip": [],
     "email_change_by_user": [],
     "password_reset_form_by_email": [],
+    "sends_email_by_remote_server": [],
 }
 
 CLOUD_FREE_TRIAL_DAYS: Optional[int] = None


### PR DESCRIPTION
These should be rate-limited by both IP using our regular sends_email_by_ip bucket as well as by server, using a new bucket dedicated to this.
