### PR TITLE
design: Use focus visible instead focus

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -38,7 +38,7 @@
         transition: all 0.2s ease;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             background-color: var(
                 --color-compose-collapsed-reply-button-area-background-interactive
             );
@@ -717,7 +717,7 @@ textarea.new_message_textarea {
     background-color: hsl(0deg 0% 100%);
 
     &.over_limit,
-    &.over_limit:focus {
+    &.over_limit:focus-visible {
         box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
 
         &.flash {
@@ -732,7 +732,7 @@ textarea.new_message_textarea {
     }
 
     &.invalid,
-    &.invalid:focus {
+    &.invalid:focus-visible {
         border: 1px solid hsl(3deg 57% 33%);
         box-shadow: 0 0 2px hsl(3deg 57% 33%);
     }
@@ -745,7 +745,7 @@ textarea.new_message_textarea,
     transition: border 0.2s ease;
     color: var(--color-text-default);
 
-    &:focus {
+    &:focus-visible {
         outline: 0;
         border: 1px solid hsl(0deg 0% 67%);
         box-shadow: none;
@@ -809,8 +809,8 @@ textarea.new_message_textarea,
             color: var(--color-compose-embedded-button-text-color-hover);
         }
 
-        &:focus {
-            outline: 0;
+        &:focus:not(:focus-visible) {
+            outline: none;
         }
     }
 
@@ -846,8 +846,8 @@ textarea.new_message_textarea,
         transform: scale(0.96);
     }
 
-    &:focus {
-        outline: 0;
+    &:focus:not(:focus-visible) {
+        outline: none;
     }
 
     &:focus-visible {
@@ -914,7 +914,7 @@ textarea.new_message_textarea,
             cursor: pointer;
             margin: 4px 0 0;
 
-            &:focus {
+            &:focus-visible {
                 outline: 1px dotted hsl(0deg 0% 20%);
                 outline: 5px auto -webkit-focus-ring-color;
                 outline-offset: -2px;
@@ -1236,7 +1236,7 @@ textarea.new_message_textarea,
         transform: scale(0.96);
     }
 
-    &:focus {
+    &:focus:not(:focus-visible) {
         outline: 0;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1294,16 +1294,7 @@ label {
     line-height: inherit;
 }
 
-/* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
-a:not(:active):focus,
-button:focus,
-.new-style label.checkbox input[type="checkbox"]:focus ~ span,
-i.fa:focus,
-i.zulip-icon:focus-visible,
-[role="button"]:focus {
-    outline: 2px solid var(--color-outline-focus);
-    /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
-}
+
 
 /* List of text-like input types taken from Bootstrap */
 input {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1294,8 +1294,6 @@ label {
     line-height: inherit;
 }
 
-
-
 /* List of text-like input types taken from Bootstrap */
 input {
     &[type="text"],


### PR DESCRIPTION
Fixes:#27117.
This  PR  makes the compose  box to use  <b>  :focus-visible </b> instead  of   <b>:focus </b>  so that the interactive elements show outline only for keyboard navigation not for mouse clicks.
This PR  also  removes the outline color overrides  to use the default  color of the browser for the outlines.
As  suggested in  [CZO thread](https://chat.zulip.org/#narrow/stream/6-frontend/topic/select.20boxes)
If this PR is  approved   I will work on applying this change on entire  app which completely solves above mentioned issue.
----> In this  I have removed all the <b> bootstrap overrides </b> for focus.
---->used  <b>:focus-visible </b> instead of  <b>:focus </b>.


<h3>Before changes these  elements of compose box showed outline for both mouse clicks and keyboard navigation with bootstrap colors  blue for light theme and grey for dark theme </h3>

![before3](https://github.com/zulip/zulip/assets/153224120/44554712-a35d-4d5d-82c0-4da91d2ba357)


<h3>After changes :</h3>
<h3>No display of outline on mouse clicks</h3>

![after3 1](https://github.com/zulip/zulip/assets/153224120/c95b099e-5394-4a4f-bb17-8fe5240fce78)

<h3>outline color for keyboard navigation use default browser colors</h3>

![after3 2](https://github.com/zulip/zulip/assets/153224120/c70106d4-8c63-4f82-9ce0-067aea30da68)



