### PR TITLE
desktop_app: Close popover when clicking on "Plan management".

### DIFF
--- a/web/src/desktop_integration.js
+++ b/web/src/desktop_integration.js
@@ -6,6 +6,7 @@ import * as feedback_widget from "./feedback_widget";
 import {$t} from "./i18n";
 import * as message_store from "./message_store";
 import * as narrow from "./narrow";
+import * as popovers from "./popovers";
 import * as stream_data from "./stream_data";
 
 if (window.electron_bridge !== undefined) {
@@ -80,6 +81,7 @@ export function initialize() {
             url,
             success(data) {
                 window.open(data.billing_access_url, "_blank", "noopener,noreferrer");
+                popovers.hide_all();
             },
             error(xhr) {
                 if (xhr.responseJSON?.msg) {


### PR DESCRIPTION
Closes the gear menu in the desktop app when clicking "Plan management"
[Screencast from 2024-01-18 22-27-33.webm](https://github.com/zulip/zulip/assets/45007152/3582f350-848f-40ac-944e-0f1f89ccd85a)

Though I also noticed that at least for me, in the desktop application the behavior of not closing the gear menu happens when I click on "Integrations", "API documentation" and such, not sure why. 