### PR TITLE
Fix reactions not being displayed on changing narrow for the same message.

### DIFF
--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -461,10 +461,9 @@ function abort_message(message) {
 }
 
 export function display_slow_send_loading_spinner(message) {
-    const message_list_id = message_lists.current.id;
-    const $row = $(`#message-row-${message_list_id}-${CSS.escape(message.id)}`);
+    const $rows = message_lists.all_rendered_row_for_message_id(message.id);
     if (message.locally_echoed && !message.failed_request) {
-        $row.find(".slow-send-spinner").removeClass("hidden");
+        $rows.find(".slow-send-spinner").removeClass("hidden");
         // We don't need to do anything special to ensure this gets
         // cleaned up if the message is delivered, because the
         // message's HTML gets replaced once the message is

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -54,6 +54,7 @@ function hide_retry_spinner($row) {
 function show_message_failed(message_id, failed_msg) {
     // Failed to send message, so display inline retry/cancel
     message_live_update.update_message_in_all_views(message_id, ($row) => {
+        $row.find(".slow-send-spinner").addClass("hidden");
         const $failed_div = $row.find(".message_failed");
         $failed_div.toggleClass("hide", false);
         $failed_div.find(".failed_text").attr("title", failed_msg);
@@ -448,7 +449,10 @@ export function _patch_waiting_for_ack(data) {
 
 export function message_send_error(message_id, error_response) {
     // Error sending message, show inline
-    message_store.get(message_id).failed_request = true;
+    const message = message_store.get(message_id);
+    message.failed_request = true;
+    message.show_slow_send_spinner = false;
+
     show_message_failed(message_id, error_response);
 }
 
@@ -463,6 +467,7 @@ function abort_message(message) {
 export function display_slow_send_loading_spinner(message) {
     const $rows = message_lists.all_rendered_row_for_message_id(message.id);
     if (message.locally_echoed && !message.failed_request) {
+        message.show_slow_send_spinner = true;
         $rows.find(".slow-send-spinner").removeClass("hidden");
         // We don't need to do anything special to ensure this gets
         // cleaned up if the message is delivered, because the

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1445,7 +1445,7 @@ export class MessageListView {
         if ($row === undefined) {
             // For legacy reasons we need to return an empty
             // jQuery object here.
-            return $(undefined);
+            return $();
         }
 
         return $row;

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip";
@@ -57,6 +58,14 @@ export function all_rendered_message_lists(): MessageList[] {
         rendered_message_lists.push(current);
     }
     return rendered_message_lists;
+}
+
+export function all_rendered_row_for_message_id(message_id: number): JQuery {
+    let $rows = $();
+    for (const msg_list of all_rendered_message_lists()) {
+        $rows = $rows.add(msg_list.get_row(message_id));
+    }
+    return $rows;
 }
 
 export function all_current_message_rows(): JQuery {

--- a/web/src/reactions.js
+++ b/web/src/reactions.js
@@ -205,10 +205,8 @@ export function get_reaction_title_data(message_id, local_id) {
 }
 
 export function get_reaction_section(message_id) {
-    const message_list_id = message_lists.current.id;
-    return $(`#message-row-${message_list_id}-${CSS.escape(message_id)}`).find(
-        ".message_reactions",
-    );
+    const $rows = message_lists.all_rendered_row_for_message_id(message_id);
+    return $rows.find(".message_reactions");
 }
 
 export function find_reaction(message_id, local_id) {

--- a/web/src/reactions.js
+++ b/web/src/reactions.js
@@ -204,19 +204,19 @@ export function get_reaction_title_data(message_id, local_id) {
     return title;
 }
 
-export function get_reaction_section(message_id) {
+export function get_reaction_sections(message_id) {
     const $rows = message_lists.all_rendered_row_for_message_id(message_id);
     return $rows.find(".message_reactions");
 }
 
 export function find_reaction(message_id, local_id) {
-    const $reaction_section = get_reaction_section(message_id);
+    const $reaction_section = get_reaction_sections(message_id);
     const $reaction = $reaction_section.find(`[data-reaction-id='${CSS.escape(local_id)}']`);
     return $reaction;
 }
 
 export function get_add_reaction_button(message_id) {
-    const $reaction_section = get_reaction_section(message_id);
+    const $reaction_section = get_reaction_sections(message_id);
     const $add_button = $reaction_section.find(".reaction_button");
     return $add_button;
 }

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -33,8 +33,8 @@
     {{timestr}}
 </a>
 
-{{#if msg/locally_echoed}}
-    <span class="fa fa-circle-o-notch slow-send-spinner hidden"></span>
+{{#if (and (not msg/failed_request) msg/locally_echoed)}}
+    <span class="fa fa-circle-o-notch slow-send-spinner{{#unless msg/show_slow_send_spinner }} hidden{{/unless}}"></span>
 {{/if}}
 
 {{> message_controls}}

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -44,9 +44,12 @@ const settings_data = mock_esm("../src/settings_data");
 const spectators = mock_esm("../src/spectators", {
     login_to_access() {},
 });
-mock_esm("../src/message_lists", {
+const message_lists = mock_esm("../src/message_lists", {
     current: {
         id: 1,
+    },
+    home: {
+        id: 2,
     },
 });
 
@@ -417,6 +420,7 @@ test("prevent_simultaneous_requests_updating_reaction", ({override, override_rew
 function stub_reactions(message_id) {
     const $message_reactions = $.create("reactions-stub");
     const $message_row = $.create(`#message-row-1-${CSS.escape(message_id)}`);
+    message_lists.all_rendered_row_for_message_id = () => $message_row;
     $message_row.set_find_results(".message_reactions", $message_reactions);
     return $message_reactions;
 }

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -545,10 +545,10 @@ test("find_reaction", () => {
     assert.equal(reactions.find_reaction(message_id, local_id), $reaction);
 });
 
-test("get_reaction_section", () => {
+test("get_reaction_sections", () => {
     const $message_reactions = stub_reactions(555);
 
-    const $section = reactions.get_reaction_section(555);
+    const $section = reactions.get_reaction_sections(555);
 
     assert.equal($section, $message_reactions);
 });


### PR DESCRIPTION
Reproducer:
* React to a message in a narrow.
* Go to All messages view.
* The message no longer has the reaction.

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/All.20message.20emoji.20reactions.20broken