### PR TITLE
templates: Remove the extraneous background color.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -687,10 +687,6 @@ input[type="checkbox"] {
     text-align: right;
 }
 
-.add-new-export-box {
-    margin: 10px 0;
-}
-
 #add-default-stream-modal {
     .dropdown-widget-button {
         display: inline-flex;

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -20,13 +20,9 @@
         <span class="export_status_text"></span>
     </div>
     <form>
-        <div class="add-new-export-box grey-box">
-            <div class="wrapper">
-                <button type="submit" class="button rounded sea-green" id="export-data">
-                    {{t 'Start export of public data' }}
-                </button>
-            </div>
-        </div>
+        <button type="submit" class="button rounded sea-green" id="export-data">
+            {{t 'Start export of public data' }}
+        </button>
     </form>
     {{/if}}
 


### PR DESCRIPTION
 This  PR  removes the extraneous background color applied only to  <b>"start export of  public data " </b>Button.
In this PR  I have removed the <b> div</b>  containing the <b>  grey-box </b>   which was responsible for the extraneous background around the button. As a part this  I have also removed  the <b> add-new-export-box </b>  class from settings.css

Fixes: #28625.
<br>
<br>





<h3>Screen Shots  Before Changes:</h3>

![Screenshot (31)](https://github.com/zulip/zulip/assets/153224120/35c91c71-1a32-4ac2-aa5b-c0db56fb12ca)


![Screenshot (30)](https://github.com/zulip/zulip/assets/153224120/d3628b08-6c2d-40af-8e38-55802b328f98)

<h3>Screen Shots After Changes:</h3>

![Screenshot (41)](https://github.com/zulip/zulip/assets/153224120/f46ca08f-6055-4751-8d55-4848fd6e2841)


![Screenshot (42)](https://github.com/zulip/zulip/assets/153224120/96616c65-c63d-468c-9ef7-e9a1abf0c3c1)

