### PR TITLE
remote-activity: Add rows to general chart for remote realms.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -131,7 +131,7 @@ class ActivityTest(ZulipTestCase):
             hostname="demo.example.com",
             contact_email="email@example.com",
         )
-        with self.assert_database_query_count(10):
+        with self.assert_database_query_count(15):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 

--- a/analytics/views/remote_activity.py
+++ b/analytics/views/remote_activity.py
@@ -11,10 +11,15 @@ from analytics.views.activity_common import (
     remote_installation_stats_link,
     remote_installation_support_link,
 )
-from corporate.lib.analytics import get_plan_data_by_remote_server
+from corporate.lib.analytics import get_plan_data_by_remote_realm, get_plan_data_by_remote_server
 from corporate.lib.stripe import cents_to_dollar_string
 from zerver.decorator import require_server_admin
-from zilencer.models import get_remote_server_guest_and_non_guest_count
+from zerver.models.realms import get_org_type_display_name
+from zilencer.models import (
+    RemoteRealm,
+    get_remote_realm_guest_and_non_guest_count,
+    get_remote_server_guest_and_non_guest_count,
+)
 
 
 @require_server_admin
@@ -39,6 +44,18 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
                 count(distinct(user_id, user_uuid)) as push_user_count
             from zilencer_remotepushdevicetoken
             group by server_id
+        ),
+        remote_realms as (
+            select
+                server_id,
+                id as realm_id,
+                name as realm_name,
+                org_type as realm_type
+            from zilencer_remoterealm
+            where
+                is_system_bot_realm = False
+                and realm_deactivated = False
+            group by server_id, id, name, org_type
         )
         select
             rserver.id,
@@ -47,10 +64,14 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             rserver.last_version,
             rserver.last_audit_log_update,
             push_user_count,
-            push_forwarded_count
+            push_forwarded_count,
+            realm_id,
+            realm_name,
+            realm_type
         from zilencer_remotezulipserver rserver
         left join mobile_push_forwarded_count on mobile_push_forwarded_count.server_id = rserver.id
         left join remote_push_devices on remote_push_devices.server_id = rserver.id
+        left join remote_realms on remote_realms.server_id = rserver.id
         where not deactivated
         order by push_user_count DESC NULLS LAST
     """
@@ -62,12 +83,15 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         "Contact email",
         "Zulip version",
         "Last audit log update",
-        "Mobile users",
-        "Mobile pushes forwarded",
+        "Server mobile users",
+        "Server mobile pushes",
+        "Realm ID",
+        "Realm name",
+        "Organization Type",
         "Plan name",
         "Plan status",
         "ARR",
-        "Non guest users",
+        "Total users",
         "Guest users",
         "Links",
     ]
@@ -78,28 +102,60 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     LAST_AUDIT_LOG_DATE = 4
     MOBILE_USER_COUNT = 5
     MOBILE_PUSH_COUNT = 6
+    REALM_ID = 7
+    ORG_TYPE = 9
+    ARR = 12
+    TOTAL_USER_COUNT = 13
+    GUEST_COUNT = 14
 
     rows = get_query_data(query)
-    total_row = []
     plan_data_by_remote_server = get_plan_data_by_remote_server()
+    plan_data_by_remote_server_and_realm = get_plan_data_by_remote_realm()
+
+    total_row = []
+    server_mobile_data_counted = set()
+    total_revenue = 0
+    total_mobile_users = 0
+    total_pushes = 0
 
     for row in rows:
-        # Add estimated revenue for server
-        server_plan_data = plan_data_by_remote_server.get(row[SERVER_ID])
-        if server_plan_data is None:
-            row.append("---")
-            row.append("---")
-            row.append("---")
+        # Count mobile users and pushes forwarded, once per server
+        if row[SERVER_ID] not in server_mobile_data_counted:
+            if row[MOBILE_USER_COUNT] is not None:
+                total_mobile_users += row[MOBILE_USER_COUNT]  # nocoverage
+            if row[MOBILE_PUSH_COUNT] is not None:
+                total_pushes += row[MOBILE_PUSH_COUNT]  # nocoverage
+            server_mobile_data_counted.add(row[SERVER_ID])
+        if row[REALM_ID] is None:
+            plan_data = plan_data_by_remote_server.get(row[SERVER_ID])
+            user_counts = get_remote_server_guest_and_non_guest_count(row[SERVER_ID])
         else:
-            revenue = cents_to_dollar_string(server_plan_data.annual_revenue)
-            row.append(server_plan_data.current_plan_name)
-            row.append(server_plan_data.current_status)
+            server_remote_realms_data = plan_data_by_remote_server_and_realm.get(row[SERVER_ID])
+            if server_remote_realms_data is not None:
+                plan_data = server_remote_realms_data.get(row[REALM_ID])  # nocoverage
+            else:
+                plan_data = None
+            remote_realm = RemoteRealm.objects.get(id=row[REALM_ID], server_id=row[SERVER_ID])
+            user_counts = get_remote_realm_guest_and_non_guest_count(remote_realm)
+            # Format organization type for realm
+            org_type = row[ORG_TYPE]
+            row[ORG_TYPE] = get_org_type_display_name(org_type)
+        # Add estimated annual revenue and plan data
+        if plan_data is None:
+            row.append("---")
+            row.append("---")
+            row.append("---")
+        else:  # nocoverage
+            total_revenue += plan_data.annual_revenue
+            revenue = cents_to_dollar_string(plan_data.annual_revenue)
+            row.append(plan_data.current_plan_name)
+            row.append(plan_data.current_status)
             row.append(f"${revenue}")
         # Add user counts
-        remote_server_counts = get_remote_server_guest_and_non_guest_count(row[SERVER_ID])
-        row.append(remote_server_counts.non_guest_user_count)
-        row.append(remote_server_counts.guest_user_count)
-        # Add links
+        total_users = user_counts.non_guest_user_count + user_counts.guest_user_count
+        row.append(total_users)
+        row.append(user_counts.guest_user_count)
+        # Add server links
         stats = remote_installation_stats_link(row[SERVER_ID])
         support = remote_installation_support_link(row[SERVER_HOSTNAME])
         links = stats + " " + support
@@ -112,7 +168,14 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             fix_rows(rows, i, format_none_as_zero)
         if i == SERVER_ID:
             total_row.append("Total")
-        elif i in [MOBILE_USER_COUNT, MOBILE_PUSH_COUNT]:
+        elif i == MOBILE_USER_COUNT:
+            total_row.append(str(total_mobile_users))
+        elif i == MOBILE_PUSH_COUNT:
+            total_row.append(str(total_pushes))
+        elif i == ARR:
+            total_revenue_string = f"${cents_to_dollar_string(total_revenue)}"
+            total_row.append(total_revenue_string)
+        elif i in [TOTAL_USER_COUNT, GUEST_COUNT]:
             total_row.append(str(sum(row[i] for row in rows if row[i] is not None)))
         else:
             total_row.append("")

--- a/templates/analytics/remote_activity_key.html
+++ b/templates/analytics/remote_activity_key.html
@@ -1,7 +1,19 @@
 <h4>Chart key:</h4>
 <ul>
-    <li><strong>Mobile pushes forwarded</strong> - last 7 days, including today's current count</li>
-    <li><strong>ARR</strong> (annual recurring revenue) - the number of users they are paying for * annual price/user</li>
+    <li><strong>Server mobile pushes</strong>
+        <ul>
+            <li>Count of forwarded push notifications in last 7 days</li>
+            <li>Includes today's current count</li>
+        </ul>
+    </li>
+    <li><strong>ARR</strong> (annual recurring revenue)
+        <ul>
+            <li>If plan has a fixed price, displays that value</li>
+            <li>Otherwise, is an estimate based on the current users multiplied by annual price per user</li>
+            <li>Currently, does not account for first year, flat $20 discount per month</li>
+            <li>Plans with status of <strong>Free trial</strong> show estimated revenue for full year</li>
+        </ul>
+    </li>
     <li><strong>Links</strong>
         <ul>
             <li><strong><i class="fa fa-pie-chart"></i></strong> - remote server's stats page</li>


### PR DESCRIPTION
Updates the remote activity page for:
- Removes the "analytics users" column (commit 1)
- Adds a column for remote realms (ID, name, organization type) and a row is displayed in the chart for each remote realm on a remote server.
  - If the server doesn't have remote realms, then it still has a row displayed with any active plan, revenue and user information.
- Updates the remote activity key for these changes and to more clearly explain some of the existing chart data.

**Notes**:
- We were previously querying the database for each remote server to get the user counts. And adding the remote realms to the chart added two additional queries (one to get the remote realm object and then one to get the user counts)
  - Added functions to do a server and realm query for the audit logs to tally the user counts.
- We're still hitting the database for every current plan to get the revenue, so it would probably be good to see if we can get the latest license ledger with the plan query so that we can calculate a annual revenue estimate without so many queries.

@prakhar1144 and @alexmv - I'd appreciate your feedback on the database query updates in these commits. There might be some considerations around the audit logs that I haven't thought through. I'm a bit concerned where logs are bulk added with the same event time.

**Screenshots and screen captures:**

<details>
<summary>Updated remote activity view</summary>

![Screenshot from 2024-01-19 17-02-48](https://github.com/zulip/zulip/assets/63245456/ee3da08b-87b3-4960-9cb1-4e927022cf4e)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
