### PR TITLE
models: Rename display_settings_legacy to preferences_settings_legacy.

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -480,7 +480,7 @@ def do_change_user_setting(
         }
         send_event_on_commit(user_profile.realm, legacy_event, [user_profile.id])
 
-    if setting_name in UserProfile.display_settings_legacy or setting_name == "timezone":
+    if setting_name in UserProfile.preferences_settings_legacy or setting_name == "timezone":
         # This legacy event format is for backwards-compatibility with
         # clients that don't support the new user_settings event type.
         # We only send this for settings added before Feature level 89.

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -641,7 +641,7 @@ def fetch_initial_state_data(
         state["stop_words"] = read_stop_words()
 
     if want("update_display_settings") and not user_settings_object:
-        for prop in UserProfile.display_settings_legacy:
+        for prop in UserProfile.preferences_settings_legacy:
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = canonicalize_timezone(settings_user.timezone)
@@ -1407,7 +1407,7 @@ def apply_event(
         state["realm_playgrounds"] = event["realm_playgrounds"]
     elif event["type"] == "update_display_settings":
         if event["setting_name"] != "timezone":
-            assert event["setting_name"] in UserProfile.display_settings_legacy
+            assert event["setting_name"] in UserProfile.preferences_settings_legacy
         state[event["setting_name"]] = event["setting"]
     elif event["type"] == "update_global_notifications":
         assert event["notification_name"] in UserProfile.notification_settings_legacy
@@ -1418,7 +1418,7 @@ def apply_event(
         if event["property"] != "timezone":
             assert event["property"] in UserProfile.property_types
         if event["property"] in {
-            **UserProfile.display_settings_legacy,
+            **UserProfile.preferences_settings_legacy,
             **UserProfile.notification_settings_legacy,
         }:
             state[event["property"]] = event["value"]

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -259,7 +259,7 @@ class UserBaseSettings(models.Model):
 
     EMAIL_ADDRESS_VISIBILITY_TYPES = list(EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.keys())
 
-    display_settings_legacy = dict(
+    preferences_settings_legacy = dict(
         # Don't add anything new to this legacy dict.
         # Instead, see `modern_settings` below.
         color_scheme=int,
@@ -335,7 +335,7 @@ class UserBaseSettings(models.Model):
 
     # Define the types of the various automatically managed properties
     property_types = {
-        **display_settings_legacy,
+        **preferences_settings_legacy,
         **notification_setting_types,
         **modern_settings,
     }

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -746,7 +746,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assertIn("user_settings", result)
         for prop in UserProfile.property_types:
             if prop in {
-                **UserProfile.display_settings_legacy,
+                **UserProfile.preferences_settings_legacy,
                 **UserProfile.notification_settings_legacy,
             }:
                 # Only legacy settings are included in the top level.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3817,7 +3817,7 @@ class UserDisplayActionTest(BaseAction):
         user_settings_object = True
         num_events = 1
 
-        legacy_setting = setting_name in UserProfile.display_settings_legacy
+        legacy_setting = setting_name in UserProfile.preferences_settings_legacy
         if legacy_setting:
             # Two events:`update_display_settings` and `user_settings`.
             # `update_display_settings` is only sent for settings added


### PR DESCRIPTION
Finished renaming display_settings_legacy to preferences_settings_legacy

This helps fixes part of issue #26874.

In this pull request

Renamed display_settings_legacy to preferences_settings_legacy.

Changed Files:
zerver/models/users.py
zerver/actions/user_settings.py
zerver/lib/events.py
zerver/tests/test_event_system.py
zerver/tests/test_events.py

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>