### PR TITLE
settings: Rename display_settings_labels to preferences_settings_labels.

### DIFF
--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -61,7 +61,7 @@ function setup_settings_label() {
         }),
 
         ...settings_config.notification_settings_labels,
-        ...settings_config.display_settings_labels,
+        ...settings_config.preferences_settings_labels,
     };
 }
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -536,7 +536,7 @@ export const expires_in_values = {
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
 
-export const display_settings_labels = {
+export const preferences_settings_labels = {
     dense_mode: $t({defaultMessage: "Dense mode"}),
     fluid_layout_width: $t({defaultMessage: "Use full width on wide screens"}),
     high_contrast_mode: $t({defaultMessage: "High contrast mode"}),
@@ -593,7 +593,7 @@ export const notification_settings_labels = {
 
 export const realm_user_settings_defaults_labels = {
     ...notification_settings_labels,
-    ...display_settings_labels,
+    ...preferences_settings_labels,
 
     /* Overrides to remove "I" from labels for the realm-level versions of these labels. */
     enable_online_push_notifications: $t({


### PR DESCRIPTION
Finished renaming display_settings_labels to preferences_settings_labels

This helps fixes part of issue #26874.

In this pull request

Renamed display_settings_labels to preferences_settings_labels.

Changed Files:
web/src/settings.js
web/src/settings_config.ts

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>