### PR TITLE
custom_profile_fields: Make name, required, hint, field_data optional during update

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,10 +22,10 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 252**
 
-* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint`, `display_in_profile_summary`
-  and `field_data` fields are now optional during an update. Previously we required
-  the clients to populate the fields in the PATCH request even if there was no
-  change to those fields' values.
+* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint`, `display_in_profile_summary`,
+  `required` and `field_data` fields are now optional during an update. Previously we
+  required the clients to populate the fields in the PATCH request even if there was
+  no change to those fields' values.
 
 **Feature level 251**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 252**
+
+* `PATCH /realm/profile_fields/{field_id}`: `name` and `hint` fields are now
+  optional during an update. Previously we required the clients to populate
+  the fields in the PATCH request even if there was no change to those fields'
+  values.
+
 **Feature level 251**
 
 * [`POST /register`](/api/register-queue): Fixed `realm_upload_quota_mib`

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,10 +22,10 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 252**
 
-* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint` and `field_data` fields are
-  now optional during an update. Previously we required the clients to populate
-  the fields in the PATCH request even if there was no change to those fields'
-  values.
+* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint`, `display_in_profile_summary`
+  and `field_data` fields are now optional during an update. Previously we required
+  the clients to populate the fields in the PATCH request even if there was no
+  change to those fields' values.
 
 **Feature level 251**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,8 +22,8 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 252**
 
-* `PATCH /realm/profile_fields/{field_id}`: `name` and `hint` fields are now
-  optional during an update. Previously we required the clients to populate
+* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint` and `field_data` fields are
+  now optional during an update. Previously we required the clients to populate
   the fields in the PATCH request even if there was no change to those fields'
   values.
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 251
+API_FEATURE_LEVEL = 252
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -104,7 +104,7 @@ def try_update_realm_custom_profile_field(
     name: Optional[str] = None,
     hint: Optional[str] = None,
     field_data: Optional[ProfileFieldData] = None,
-    display_in_profile_summary: bool = False,
+    display_in_profile_summary: Optional[bool] = None,
     required: bool = False,
 ) -> None:
     if name is not None:
@@ -112,8 +112,9 @@ def try_update_realm_custom_profile_field(
     if hint is not None:
         field.hint = hint
 
-    field.display_in_profile_summary = display_in_profile_summary
     field.required = required
+    if display_in_profile_summary is not None:
+        field.display_in_profile_summary = display_in_profile_summary
 
     if field.field_type in (
         CustomProfileField.SELECT,

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -105,14 +105,14 @@ def try_update_realm_custom_profile_field(
     hint: Optional[str] = None,
     field_data: Optional[ProfileFieldData] = None,
     display_in_profile_summary: Optional[bool] = None,
-    required: bool = False,
+    required: Optional[bool] = None,
 ) -> None:
     if name is not None:
         field.name = name
     if hint is not None:
         field.hint = hint
-
-    field.required = required
+    if required is not None:
+        field.required = required
     if display_in_profile_summary is not None:
         field.display_in_profile_summary = display_in_profile_summary
 

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -114,11 +114,20 @@ def try_update_realm_custom_profile_field(
 
     field.display_in_profile_summary = display_in_profile_summary
     field.required = required
-    if field.field_type in (CustomProfileField.SELECT, CustomProfileField.EXTERNAL_ACCOUNT):
-        if field.field_type == CustomProfileField.SELECT:
-            assert field_data is not None
+
+    if field.field_type in (
+        CustomProfileField.SELECT,
+        CustomProfileField.EXTERNAL_ACCOUNT,
+    ):
+        # If field_data is None, field_data is unchanged and there is no need for
+        # comparing field_data values.
+        if field_data is not None and field.field_type == CustomProfileField.SELECT:
             remove_custom_profile_field_value_if_required(field, field_data)
-        field.field_data = orjson.dumps(field_data or {}).decode()
+
+        # If field.field_data is the default empty string, we will set field_data
+        # to an empty dict.
+        if field_data is not None or field.field_data == "":
+            field.field_data = orjson.dumps(field_data or {}).decode()
     field.save()
     notify_realm_custom_profile_fields(realm)
 

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -101,14 +101,17 @@ def remove_custom_profile_field_value_if_required(
 def try_update_realm_custom_profile_field(
     realm: Realm,
     field: CustomProfileField,
-    name: str,
-    hint: str = "",
+    name: Optional[str] = None,
+    hint: Optional[str] = None,
     field_data: Optional[ProfileFieldData] = None,
     display_in_profile_summary: bool = False,
     required: bool = False,
 ) -> None:
-    field.name = name
-    field.hint = hint
+    if name is not None:
+        field.name = name
+    if hint is not None:
+        field.hint = hint
+
     field.display_in_profile_summary = display_in_profile_summary
     field.required = required
     if field.field_type in (CustomProfileField.SELECT, CustomProfileField.EXTERNAL_ACCOUNT):

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -494,7 +494,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": "New phone number",
                 "hint": "*" * 81,
             },
         )
@@ -504,8 +503,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": "New phone number",
-                "hint": "New contact number",
                 "display_in_profile_summary": "invalid value",
             },
         )
@@ -515,8 +512,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": "New phone number",
-                "hint": "New contact number",
                 "required": "invalid value",
             },
         )
@@ -554,7 +549,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         field = CustomProfileField.objects.get(name="Favorite editor", realm=realm)
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "Favorite editor", "field_data": "invalid"},
+            info={"field_data": "invalid"},
         )
         self.assert_json_error(result, 'Argument "field_data" is not valid JSON.')
 
@@ -566,7 +561,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         ).decode()
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "Favorite editor", "field_data": field_data},
+            info={"field_data": field_data},
         )
         self.assert_json_error(result, "field_data is not a dict")
 
@@ -580,7 +575,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": "Favorite editor",
                 "field_data": field_data,
                 "display_in_profile_summary": "true",
             },
@@ -591,14 +585,21 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={
-                "name": field.name,
-                "hint": field.hint,
                 "display_in_profile_summary": "true",
             },
         )
         self.assert_json_error(
             result, "Only 2 custom profile fields can be displayed in the profile summary."
         )
+
+        # Empty string for hint should set it to an empty string
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={"hint": ""},
+        )
+        self.assert_json_success(result)
+        field.refresh_from_db()
+        self.assertEqual(field.hint, "")
 
     def test_update_is_aware_of_uniqueness(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -581,6 +581,18 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         )
         self.assert_json_success(result)
 
+        # Not sending display_in_profile_summary should not set it to false.
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={
+                "hint": "Fav editor",
+            },
+        )
+        field.refresh_from_db()
+        self.assertEqual(field.hint, "Fav editor")
+        self.assertEqual(field.display_in_profile_summary, True)
+        self.assert_json_success(result)
+
         field = CustomProfileField.objects.get(name="Birthday", realm=realm)
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -528,13 +528,24 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             },
         )
         self.assert_json_success(result)
-
-        field = CustomProfileField.objects.get(id=field.id, realm=realm)
+        field.refresh_from_db()
         self.assertEqual(CustomProfileField.objects.count(), self.original_count)
         self.assertEqual(field.name, "New phone number")
         self.assertEqual(field.hint, "New contact number")
         self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
         self.assertEqual(field.display_in_profile_summary, True)
+        self.assertEqual(field.required, True)
+
+        # Not sending required should not set it to false.
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={
+                "hint": "New hint",
+            },
+        )
+        self.assert_json_success(result)
+        field.refresh_from_db()
+        self.assertEqual(field.hint, "New hint")
         self.assertEqual(field.required, True)
 
         result = self.client_patch(

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -601,6 +601,17 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         field.refresh_from_db()
         self.assertEqual(field.hint, "")
 
+        field = CustomProfileField.objects.get(name="Favorite editor", realm=realm)
+
+        # Empty field_data should not be allowed
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={
+                "field_data": {},
+            },
+        )
+        self.assert_json_error(result, "Field must have at least one choice.")
+
     def test_update_is_aware_of_uniqueness(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1390,7 +1390,11 @@ class NormalActionsTest(BaseAction):
 
         events = self.verify_action(
             lambda: try_update_realm_custom_profile_field(
-                realm, field, name, hint=hint, display_in_profile_summary=display_in_profile_summary
+                realm=realm,
+                field=field,
+                name=name,
+                hint=hint,
+                display_in_profile_summary=display_in_profile_summary,
             )
         )
         check_custom_profile_fields("events[0]", events[0])
@@ -1416,7 +1420,9 @@ class NormalActionsTest(BaseAction):
 
         hint = "What pronouns should people use to refer you?"
         events = self.verify_action(
-            lambda: try_update_realm_custom_profile_field(realm, field, name, hint=hint),
+            lambda: try_update_realm_custom_profile_field(
+                realm=realm, field=field, name=name, hint=hint
+            ),
             pronouns_field_type_supported=False,
         )
         check_custom_profile_fields("events[0]", events[0])

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -247,7 +247,7 @@ def update_realm_custom_profile_field(
     field_data: Optional[ProfileFieldData] = REQ(
         default=None, json_validator=check_profile_field_data
     ),
-    required: bool = REQ(default=False, json_validator=check_bool),
+    required: Optional[bool] = REQ(default=None, json_validator=check_bool),
     display_in_profile_summary: Optional[bool] = REQ(default=None, json_validator=check_bool),
 ) -> HttpResponse:
     realm = user_profile.realm

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -118,7 +118,7 @@ def validate_custom_profile_field(
 
 def validate_custom_profile_field_update(
     field: CustomProfileField,
-    display_in_profile_summary: bool,
+    display_in_profile_summary: Optional[bool] = None,
     field_data: Optional[ProfileFieldData] = None,
     name: Optional[str] = None,
     hint: Optional[str] = None,
@@ -134,6 +134,8 @@ def validate_custom_profile_field_update(
             field_data = {}
         else:
             field_data = orjson.loads(field.field_data)
+    if display_in_profile_summary is None:
+        display_in_profile_summary = field.display_in_profile_summary
 
     assert field_data is not None
     validate_custom_profile_field(
@@ -245,8 +247,8 @@ def update_realm_custom_profile_field(
     field_data: Optional[ProfileFieldData] = REQ(
         default=None, json_validator=check_profile_field_data
     ),
-    display_in_profile_summary: bool = REQ(default=False, json_validator=check_bool),
     required: bool = REQ(default=False, json_validator=check_bool),
+    display_in_profile_summary: Optional[bool] = REQ(default=None, json_validator=check_bool),
 ) -> HttpResponse:
     realm = user_profile.realm
     try:

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -116,20 +116,36 @@ def validate_custom_profile_field(
     validate_display_in_profile_summary_field(field_type, display_in_profile_summary)
 
 
+def validate_custom_profile_field_update(
+    field: CustomProfileField,
+    field_data: ProfileFieldData,
+    display_in_profile_summary: bool,
+    name: Optional[str] = None,
+    hint: Optional[str] = None,
+) -> None:
+    if name is None:
+        name = field.name
+    if hint is None:
+        hint = field.hint
+    validate_custom_profile_field(
+        name, hint, field.field_type, field_data, display_in_profile_summary
+    )
+
+
 check_profile_field_data: Validator[ProfileFieldData] = check_dict(
     value_validator=check_union([check_dict(value_validator=check_string), check_string])
 )
 
 
 def update_only_display_in_profile_summary(
-    requested_name: str,
-    requested_hint: str,
     requested_field_data: ProfileFieldData,
     existing_field: CustomProfileField,
+    requested_name: Optional[str] = None,
+    requested_hint: Optional[str] = None,
 ) -> bool:
     if (
-        requested_name != existing_field.name
-        or requested_hint != existing_field.hint
+        (requested_name is not None and requested_name != existing_field.name)
+        or (requested_hint is not None and requested_hint != existing_field.hint)
         or requested_field_data != orjson.loads(existing_field.field_data)
     ):
         return False
@@ -208,8 +224,8 @@ def update_realm_custom_profile_field(
     request: HttpRequest,
     user_profile: UserProfile,
     field_id: int,
-    name: str = REQ(default="", converter=lambda var_name, x: x.strip()),
-    hint: str = REQ(default=""),
+    name: Optional[str] = REQ(default=None, converter=lambda var_name, x: x.strip()),
+    hint: Optional[str] = REQ(default=None),
     field_data: ProfileFieldData = REQ(default={}, json_validator=check_profile_field_data),
     display_in_profile_summary: bool = REQ(default=False, json_validator=check_bool),
     required: bool = REQ(default=False, json_validator=check_bool),
@@ -235,18 +251,16 @@ def update_realm_custom_profile_field(
         # TODO: Make the name/hint/field_data parameters optional, and
         # just require that None was passed for all of them for this case.
         and is_default_external_field(field.field_type, orjson.loads(field.field_data))
-        and not update_only_display_in_profile_summary(name, hint, field_data, field)
+        and not update_only_display_in_profile_summary(field_data, field, name, hint)
     ):
         raise JsonableError(_("Default custom field cannot be updated."))
 
-    validate_custom_profile_field(
-        name, hint, field.field_type, field_data, display_in_profile_summary
-    )
+    validate_custom_profile_field_update(field, field_data, display_in_profile_summary, name, hint)
     try:
         try_update_realm_custom_profile_field(
-            realm,
-            field,
-            name,
+            realm=realm,
+            field=field,
+            name=name,
             hint=hint,
             field_data=field_data,
             display_in_profile_summary=display_in_profile_summary,


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #23022 

This PR makes the following 4 fields optional i.e. you could not pass them if they are unchanged for the patch request.

1. Name
2. Hint
3. field_data
4. required

I have not made any changes on the frontend code which handles the API requests to not pass these fields if they are unchanged. IMO they should be tackled in a separate issue once this gets merged, so its not too many changes to review at one.

NOTE: As for the documentation, I have not added anything since I could find a relevant entry in `rest-endpoints.md`. Since this is an existing endpoint, is that intentional? If not intentional, do we track it in another issue or fix it in this one? IMO another issue will be better for ease of review. 

**Screenshots and screen captures:**
No UI changes
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
Not a UI change
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
