### PR TITLE
Improve validation at the `register/server` endpoint

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -75,6 +75,7 @@ IGNORED_PHRASES = [
     r"keyword",
     r"streamname",
     r"user@example\.com",
+    r"example\.com",
     r"acme",
     # Fragments of larger strings
     r"is …",


### PR DESCRIPTION
* [x] hostname should not exist already -- prevent accidental duplication
* [x] email addresses should have a domain with an MX which resolves
* [x] email address shouldn't be @example.com
* [x] check the email address against throwaway email domains