### PR TITLE
tooltips: Replace default hover-box to tippy.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -137,6 +137,25 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: "#subscription_overlay .subscription_settings .sub-stream-name",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        placement: "top",
+        onShow(instance) {
+            const stream_name_element = instance.reference;
+            assert(stream_name_element instanceof HTMLElement);
+            // Only show tooltip if the stream name is truncated.
+            // See https://stackoverflow.com/questions/21064101/understanding-offsetwidth-clientwidth-scrollwidth-and-height-respectively
+            // for more details.
+            if (stream_name_element.offsetWidth >= stream_name_element.scrollWidth) {
+                return false;
+            }
+
+            return undefined;
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/templates/settings/admin_emoji_list.hbs
+++ b/web/templates/settings/admin_emoji_list.hbs
@@ -18,7 +18,7 @@
         {{/if}}
     </td>
     <td>
-        <button class="button rounded small delete btn-danger" {{#unless can_delete_emoji}}disabled="disabled"{{/unless}} data-emoji-name="{{name}}">
+        <button class="button rounded small delete btn-danger tippy-zulip-delayed-tooltip" {{#unless can_delete_emoji}}disabled="disabled"{{/unless}} data-tippy-content="{{t 'Delete' }}" data-emoji-name="{{name}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>

--- a/web/templates/settings/admin_linkifier_list.hbs
+++ b/web/templates/settings/admin_linkifier_list.hbs
@@ -14,10 +14,10 @@
     </td>
     {{#if ../can_modify}}
     <td class="no-select actions">
-        <button class="button small edit btn-warning" data-linkifier-id="{{id}}" title="{{t 'Edit' }}" aria-label="{{t 'Edit' }}">
+        <button class="button small edit btn-warning tippy-zulip-delayed-tooltip" data-linkifier-id="{{id}}" data-tippy-content="{{t 'Edit' }}" aria-label="{{t 'Edit' }}">
             <i class="fa fa-pencil"></i>
         </button>
-        <button class="button small delete btn-danger" data-linkifier-id="{{id}}" title="{{t 'Delete' }}" aria-label="{{t 'Delete' }}">
+        <button class="button small delete btn-danger tippy-zulip-delayed-tooltip" data-linkifier-id="{{id}}" data-tippy-content="{{t 'Delete' }}" aria-label="{{t 'Delete' }}">
             <i class="fa fa-trash-o"></i>
         </button>
     </td>

--- a/web/templates/settings/admin_profile_field_list.hbs
+++ b/web/templates/settings/admin_profile_field_list.hbs
@@ -33,10 +33,10 @@
     </td>
     {{#if ../can_modify}}
     <td class="actions">
-        <button class="button rounded small btn-warning open-edit-form-modal tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edit custom profile field' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small btn-warning open-edit-form-modal tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edit' }}" data-profile-field-id="{{id}}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
-        <button class="button rounded small delete btn-danger tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete custom profile field' }}" data-profile-field-id="{{id}}">
+        <button class="button rounded small delete btn-danger tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete' }}" data-profile-field-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>

--- a/web/templates/settings/alert_word_settings_item.hbs
+++ b/web/templates/settings/alert_word_settings_item.hbs
@@ -7,7 +7,7 @@
         </div>
     </td>
     <td>
-        <button type="submit" class="button rounded small delete btn-danger remove-alert-word" title="{{t 'Delete alert word' }}" data-word="{{word}}">
+        <button type="submit" class="button rounded small delete btn-danger remove-alert-word tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete' }}" data-word="{{word}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </td>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -22,7 +22,7 @@
         <div id="active_bots_list_container" class="bots_section" data-bot-settings-section="active-bots">
             <div class="config-download-text">
                 <span>{{t 'Download config of all active outgoing webhook bots in Zulip Botserver format.' }}</span>
-                <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn" title="{{t 'Download botserverrc' }}">
+                <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download botserverrc' }}">
                     <i class="fa fa-download sea-green" aria-hidden="true"></i>
                 </a>
             </div>

--- a/web/templates/settings/default_stream_choice.hbs
+++ b/web/templates/settings/default_stream_choice.hbs
@@ -1,6 +1,6 @@
 <div class="choice-row" data-value="{{value}}">
     {{> ../dropdown_widget widget_name=stream_dropdown_widget_name default_text=(t 'Select channel')}}
-    <button type="button" class="button rounded small delete-choice" title="{{t 'Delete' }}">
+    <button type="button" class="button rounded small delete-choice tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -51,7 +51,7 @@
         </div>
         <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green w-200 block" id="id_org_profile_preview">
             {{t 'Preview organization profile' }}
-            <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview organization profile' }}"></i>
+            <i class="fa fa-external-link" aria-hidden="true"></i>
         </a>
 
         <div class="subsection-header">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -64,7 +64,7 @@
             </div>
             <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
-                <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview profile' }}"></i>
+                <i class="fa fa-external-link" aria-hidden="true"></i>
             </button>
         </div>
     </div>

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -1,7 +1,7 @@
 {{#with attachment}}
 <tr class="uploaded_file_row" id="{{name}}" data-attachment-id="{{id}}">
     <td>
-        <a type="submit" href="/user_uploads/{{path_id}}" target="_blank" rel="noopener noreferrer" title="{{t 'View file' }}">
+        <a type="submit" class="tippy-zulip-delayed-tooltip" href="/user_uploads/{{path_id}}" target="_blank" rel="noopener noreferrer" data-tippy-content="{{t 'View file' }}">
             {{ name }}
         </a>
     </td>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -39,7 +39,7 @@
                   invite_only=invite_only
                   is_web_public=is_web_public }}
                 <div class="stream-name">
-                    <span class="sub-stream-name" title="{{name}}">{{name}}</span>
+                    <span class="sub-stream-name" data-tippy-content="{{name}}">{{name}}</span>
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
                 <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This is a completion PR for #27913.
Currently Zulip uses default hover-box at some places which is inconsistent with the present tooltip format i.e tippy which Zulip uses now.

This PR replaces all the default-hover box type tooltips with tippy tooltips to maintain consistency and provide better experience.
It also removes some of the additional tooltips which display the same content as their parent and were unnecessary.

Fixes: #27817 
Co-Authored-By: peterssonlinn


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="569" alt="Screenshot 2024-07-05 at 2 37 44 PM" src="https://github.com/zulip/zulip/assets/25124304/cce9de70-e490-4ff8-a040-718841cccaee">

<img width="704" alt="Screenshot 2024-01-21 at 3 39 13 AM" src="https://github.com/zulip/zulip/assets/97145463/cdada667-d1c5-40a6-89c7-079e92377167">
<img width="165" alt="Screenshot 2024-01-21 at 3 20 53 AM" src="https://github.com/zulip/zulip/assets/97145463/f44b2af8-1d54-4354-8286-a923d07efd2a">
<img width="176" alt="Screenshot 2024-01-21 at 3 21 03 AM" src="https://github.com/zulip/zulip/assets/97145463/4bba33f4-3edf-448d-bb03-93a0bc2e9a33">
<img width="692" alt="Screenshot 2024-01-21 at 3 21 28 AM" src="https://github.com/zulip/zulip/assets/97145463/afdb69bb-38df-470a-a032-63ce98a1c498">
<img width="694" alt="Screenshot 2024-01-21 at 3 21 52 AM" src="https://github.com/zulip/zulip/assets/97145463/350d4231-e125-4de0-833f-9becf6ac826b">
<img width="471" alt="Screenshot 2024-01-21 at 3 26 59 AM" src="https://github.com/zulip/zulip/assets/97145463/9751f732-721b-4fcc-9c6b-474e174bcb72">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
