### PR TITLE
user_profile: Add links to group settings.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -64,6 +64,13 @@ function show_all_message_view() {
     });
 }
 
+function is_somebody_else_profile_open() {
+    return (
+        user_profile.get_user_id_if_user_profile_modal_open() !== undefined &&
+        user_profile.get_user_id_if_user_profile_modal_open() !== people.my_current_user_id()
+    );
+}
+
 export function set_hash_to_home_view() {
     let home_view_hash = `#${user_settings.web_home_view}`;
     if (home_view_hash === "#recent_topics") {
@@ -277,7 +284,7 @@ function do_hashchange_overlay(old_hash) {
 
         if (base === "groups") {
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
-            user_group_edit.change_state(section, right_side_tab);
+            user_group_edit.change_state(section, undefined, right_side_tab);
         }
 
         if (base === "settings") {
@@ -345,7 +352,17 @@ function do_hashchange_overlay(old_hash) {
 
     if (base === "groups") {
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
-        user_group_edit.launch(section, right_side_tab);
+
+        if (is_somebody_else_profile_open()) {
+            user_group_edit.launch(section, "all-groups", right_side_tab);
+            return;
+        }
+
+        // We pass left_side_tab as undefined in change_state to
+        // select the tab based on user's membership. "My groups" is
+        // selected if user is a member of group being edited.
+        // Otherwise "All groups" is selected.
+        user_group_edit.launch(section, undefined, right_side_tab);
         return;
     }
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -278,7 +278,7 @@ function do_hashchange_overlay(old_hash) {
         if (base === "streams") {
             // e.g. #streams/29/social/subscribers
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
-            stream_settings_ui.change_state(section, right_side_tab);
+            stream_settings_ui.change_state(section, undefined, right_side_tab);
             return;
         }
 
@@ -346,7 +346,17 @@ function do_hashchange_overlay(old_hash) {
     if (base === "streams") {
         // e.g. #streams/29/social/subscribers
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
-        stream_settings_ui.launch(section, right_side_tab);
+
+        if (is_somebody_else_profile_open()) {
+            stream_settings_ui.launch(section, "all-streams", right_side_tab);
+            return;
+        }
+
+        // We pass left_side_tab as undefined in change_state to
+        // select the tab based on user's subscriptions. "Subscribed" is
+        // selected if user is subscribed to the stream being edited.
+        // Otherwise "All streams" is selected.
+        stream_settings_ui.launch(section, undefined, right_side_tab);
         return;
     }
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -699,7 +699,7 @@ function show_right_section() {
     resize.resize_stream_subscribers_list();
 }
 
-export function change_state(section, right_side_tab) {
+export function change_state(section, left_side_tab, right_side_tab) {
     // if in #streams/new form.
     if (section === "new") {
         do_open_create_stream();
@@ -718,6 +718,20 @@ export function change_state(section, right_side_tab) {
         const stream_id = Number.parseInt(section, 10);
         show_right_section();
         stream_edit_toggler.set_select_tab(right_side_tab);
+
+        if (left_side_tab === undefined) {
+            left_side_tab = "all-streams";
+            if (stream_data.is_subscribed(stream_id)) {
+                left_side_tab = "subscribed";
+            }
+        }
+
+        // Callback to .goto() will update browser_history unless a
+        // stream is being edited. We are always editing a stream here
+        // so its safe to call
+        if (left_side_tab !== toggler.value()) {
+            toggler.goto(left_side_tab);
+        }
         switch_to_stream_row(stream_id);
         return;
     }
@@ -726,7 +740,7 @@ export function change_state(section, right_side_tab) {
     stream_edit.empty_right_panel();
 }
 
-export function launch(section, right_side_tab) {
+export function launch(section, left_side_tab, right_side_tab) {
     setup_page(() => {
         overlays.open_overlay({
             name: "subscriptions",
@@ -736,7 +750,7 @@ export function launch(section, right_side_tab) {
                 $(".colorpicker").spectrum("destroy");
             },
         });
-        change_state(section, right_side_tab);
+        change_state(section, left_side_tab, right_side_tab);
     });
     if (!stream_settings_components.get_active_data().id) {
         if (section === "new") {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -555,7 +555,7 @@ export function update_group(group_id) {
     }
 }
 
-export function change_state(section, right_side_tab) {
+export function change_state(section, left_side_tab, right_side_tab) {
     if (section === "new") {
         do_open_create_user_group();
         redraw_user_group_list();
@@ -573,11 +573,22 @@ export function change_state(section, right_side_tab) {
         const group_id = Number.parseInt(section, 10);
         const group = user_groups.get_user_group_from_id(group_id);
         show_right_section();
-        // We show the list of user groups in the left panel
-        // based on the tab that is active. It is `your-groups`
-        // tab by default.
-        redraw_user_group_list();
         select_tab = right_side_tab;
+
+        if (left_side_tab === undefined) {
+            left_side_tab = "all-groups";
+            if (user_groups.is_direct_member_of(current_user.user_id, group_id)) {
+                left_side_tab = "your-groups";
+            }
+        }
+
+        // Callback to .goto() will update browser_history unless a
+        // group is being edited. We are always editing a group here
+        // so its safe to call
+        if (left_side_tab !== group_list_toggler.value()) {
+            set_active_group_id(group.id);
+            group_list_toggler.goto(left_side_tab);
+        }
         switch_to_group_row(group);
         return;
     }
@@ -954,7 +965,7 @@ export function initialize() {
     );
 }
 
-export function launch(section, right_side_tab) {
+export function launch(section, left_side_tab, right_side_tab) {
     setup_page(() => {
         overlays.open_overlay({
             name: "group_subscriptions",
@@ -963,7 +974,7 @@ export function launch(section, right_side_tab) {
                 browser_history.exit_overlay();
             },
         });
-        change_state(section, right_side_tab);
+        change_state(section, left_side_tab, right_side_tab);
     });
     if (!get_active_data().id) {
         if (section === "new") {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -204,6 +204,8 @@ function format_user_group_list_item_html(group) {
     return render_user_group_list_item({
         group_id: group.id,
         name: group.name,
+        group_edit_url: hash_util.group_edit_url(group),
+        is_guest: current_user.is_guest,
     });
 }
 
@@ -950,6 +952,10 @@ export function initialize() {
     });
 
     $("body").on("click", "#user-profile-modal .stream_list_item", () => {
+        hide_user_profile();
+    });
+
+    $("body").on("click", "#user-profile-modal .group_list_item_link", () => {
         hide_user_profile();
     });
 

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -1,5 +1,9 @@
 <tr data-group-id="{{group_id}}">
     <td class="group_list_item">
-        {{name}}
+        {{#if is_guest}}
+            {{name}}
+        {{else}}
+            <a class="group_list_item_link" href="{{group_edit_url}}">{{name}}</a>
+        {{/if}}
     </td>
 </tr>


### PR DESCRIPTION
This is a possible fix for #25214
Still waiting for clarification on whether we want similar controls as in "Streams" tab or not. But i'll hazard a guess that we don't, atleast for this issue. 

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>git grep output</summary>

```bash
$ git grep .group_list_item_link

web/src/user_profile.js:    $("body").on("click", "#user-profile-modal .group_list_item_link", () => {
web/templates/user_group_list_item.hbs:            <a class = "group_list_item_link" href="{{group_edit_url}}">{{name}}</a>
```
</details>

**Screenshots and screen captures:**
<details>
<summary>Before: all users</summary>

![image](https://github.com/zulip/zulip/assets/133781250/c2dbe7ce-81b5-40c3-8167-9b8cce64e266)
</details>

<details>
<summary>After: normal users</summary>

![image](https://github.com/zulip/zulip/assets/133781250/f2c002ee-bdd7-4f5d-b31a-30f08883e6b6)

https://github.com/zulip/zulip/assets/133781250/4f8ce6e0-ffe5-4852-8714-b21562513ab5
</details>

<details>
<summary>After: guest users</summary>

![image](https://github.com/zulip/zulip/assets/133781250/c2dbe7ce-81b5-40c3-8167-9b8cce64e266)
</details>


<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
