### PR TITLE
left_sidebar: Add mark all messages unread to three dot topic menu.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -16,6 +16,7 @@ import * as settings_data from "./settings_data";
 import * as starred_messages from "./starred_messages";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
+import {num_unread_for_topic} from "./unread";
 import {user_settings} from "./user_settings";
 import * as user_status from "./user_status";
 import * as user_topics from "./user_topics";
@@ -118,6 +119,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
     const sub = sub_store.get(stream_id);
     const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
+    const has_unread_messages = num_unread_for_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = settings_data.user_can_move_messages_between_streams();
     const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
@@ -133,6 +135,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         is_realm_admin: page_params.is_admin,
         topic_is_resolved: resolved_topic.is_resolved(topic_name),
         has_starred_messages,
+        has_unread_messages,
         url,
         visibility_policy,
         all_visibility_policies,

--- a/web/src/topic_popover.js
+++ b/web/src/topic_popover.js
@@ -123,6 +123,11 @@ export function initialize() {
                     instance.hide();
                 });
 
+                $popper.one("click", ".sidebar-popover-mark-topic-unread", () => {
+                    unread_ops.mark_topic_as_unread(stream_id, topic_name);
+                    instance.hide();
+                });
+
                 $popper.one("click", ".sidebar-popover-delete-topic-messages", () => {
                     const html_body = render_delete_topic_modal({topic_name});
 

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -498,6 +498,20 @@ export function mark_topic_as_read(stream_id, topic) {
     );
 }
 
+export function mark_topic_as_unread(stream_id, topic) {
+    bulk_update_read_flags_for_narrow(
+        [
+            {operator: "stream", operand: stream_id},
+            {operator: "topic", operand: topic},
+        ],
+        "remove",
+        {
+            stream_id,
+            topic,
+        },
+    );
+}
+
 export function mark_all_as_read() {
     bulk_update_read_flags_for_narrow(all_unread_messages_narrow, "add");
 }

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -35,12 +35,21 @@
     </li>
     {{/if}}
 
+    {{#if has_unread_messages}}
     <li class="topic-menu-item hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
+    {{else}}
+    <li class="topic-menu-item hidden-for-spectators">
+        <a tabindex="0" class="sidebar-popover-mark-topic-unread" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-book" aria-hidden="true"></i>
+            {{t "Mark all messages as unread"}}
+        </a>
+    </li>
+    {{/if}}
 
     <li class="topic-menu-item">
         <a tabindex="0" class="sidebar-popover-copy-link-to-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}">


### PR DESCRIPTION
This commit adds a new option to the three-dot topic menu in the left sidebar to mark all the messages of topic as unread, provided the topic's messages are already read before choosing this option.

The  `bulk_mark_messages_as_read` method is slightly modified so that it can now mark bulk messages as read or unread.

Fixes #25085

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![brave_JBqGmWXjvV](https://github.com/zulip/zulip/assets/97049524/420c5232-d7e5-41d6-86d9-fcc380e9f007)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
