### PR TITLE
support: Show date for start of next billing cycle for current plan.

### DIFF
--- a/templates/analytics/current_plan_details.html
+++ b/templates/analytics/current_plan_details.html
@@ -24,6 +24,6 @@
         <b>Plan has a fixed price.</b>
     {% endif %}
     <b>Annual recurring revenue</b>: ${{ dollar_amount(plan_data.annual_recurring_revenue) }}<br />
-    <b>Next invoice date</b>: {{ plan_data.current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
+    <b>Start of next billing cycle</b>: {{ plan_data.next_billing_cycle_start.strftime('%d %B %Y') }}<br />
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Instead of showing the next invoice date for the plan, show the date for the next billing cycle start (e.g. the next plan renewal charge date), except for plans currently on a free trial.

For plans on a free trial, the next plan renewal date will be when the free trial ends, which is stored as the next invoice date on the plan.

These changes will apply to both Cloud and remote support views.

**Screenshots and screen captures:**

<details>
<summary>Basic remote realm</summary>

![Screenshot from 2024-01-22 12-50-29](https://github.com/zulip/zulip/assets/63245456/11914904-b574-4f25-9809-440fa756119b)
</details>
<details>
<summary>Free trial remote realm</summary>

**Note that the free trial end date is set to 2 months in populate_billing_realms for the dev environment.**
![Screenshot from 2024-01-22 12-50-42](https://github.com/zulip/zulip/assets/63245456/f4ef8b89-3367-49b6-8fe2-8a5a3a10c6dd)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
