### PR TITLE
notifications: Collapse blockquotes and "user said" paragraphs.

### DIFF
--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -15,16 +15,15 @@ export function get_hash_section(hash?: string): string {
     return parts[1] || "";
 }
 
-export function get_current_nth_hash_section(n: number): string {
-    const hash = window.location.hash;
-    // given "#settings/profile" and n=2, returns "profile"
-    // given '#streams/5/social" and n=3, returns "social"
+function get_nth_hash_section(hash: string, n: number): string {
+    // given "#settings/profile" and n=1, returns "profile"
+    // given '#streams/5/social" and n=2, returns "social"
     const parts = hash.replace(/\/$/, "").split(/\//);
-    if (parts.length < n) {
-        return "";
-    }
+    return parts.at(n) ?? "";
+}
 
-    return parts[n - 1] || "";
+export function get_current_nth_hash_section(n: number): string {
+    return get_nth_hash_section(window.location.hash, n);
 }
 
 export function get_current_hash_category(): string {

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -34,6 +34,18 @@ export function get_current_hash_section(): string {
     return get_hash_section(window.location.hash);
 }
 
+export function is_same_server_message_link(url: string): boolean {
+    // A same server message link always has category `narrow`,
+    // section `stream` or `dm`, and ends with `/near/<message_id>`,
+    // where <message_id> is a sequence of digits.
+    return (
+        get_hash_category(url) === "narrow" &&
+        (get_hash_section(url) === "stream" || get_hash_section(url) === "dm") &&
+        get_nth_hash_section(url, -2) === "near" &&
+        /^\d+$/.test(get_nth_hash_section(url, -1))
+    );
+}
+
 export function is_overlay_hash(hash: string): boolean {
     // Hash changes within this list are overlays and should not unnarrow (etc.)
     const overlay_list = [

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -253,7 +253,7 @@ function do_hashchange_overlay(old_hash) {
     if (coming_from_overlay && base === old_base) {
         if (base === "streams") {
             // e.g. #streams/29/social/subscribers
-            const right_side_tab = hash_parser.get_current_nth_hash_section(4);
+            const right_side_tab = hash_parser.get_current_nth_hash_section(3);
             stream_settings_ui.change_state(section, right_side_tab);
             return;
         }
@@ -320,7 +320,7 @@ function do_hashchange_overlay(old_hash) {
 
     if (base === "streams") {
         // e.g. #streams/29/social/subscribers
-        const right_side_tab = hash_parser.get_current_nth_hash_section(4);
+        const right_side_tab = hash_parser.get_current_nth_hash_section(3);
         stream_settings_ui.launch(section, right_side_tab);
         return;
     }

--- a/web/src/message_notifications.js
+++ b/web/src/message_notifications.js
@@ -20,6 +20,7 @@ function get_notification_content(message) {
     const $content = $("<div>").html(message.content);
     ui_util.replace_emoji_with_text($content);
     ui_util.change_katex_to_raw_latex($content);
+    ui_util.potentially_collapse_quotes($content);
     spoilers.hide_spoilers_in_notification($content);
 
     if (

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -77,14 +77,14 @@ run_test("test_get_hash_section", () => {
 
 run_test("get_current_nth_hash_section", () => {
     window.location.hash = "#settings/profile";
-    assert.equal(hash_parser.get_current_nth_hash_section(1), "#settings");
-    assert.equal(hash_parser.get_current_nth_hash_section(2), "profile");
+    assert.equal(hash_parser.get_current_nth_hash_section(0), "#settings");
+    assert.equal(hash_parser.get_current_nth_hash_section(1), "profile");
 
     window.location.hash = "#settings/10/general";
-    assert.equal(hash_parser.get_current_nth_hash_section(1), "#settings");
-    assert.equal(hash_parser.get_current_nth_hash_section(2), "10");
-    assert.equal(hash_parser.get_current_nth_hash_section(3), "general");
-    assert.equal(hash_parser.get_current_nth_hash_section(4), "");
+    assert.equal(hash_parser.get_current_nth_hash_section(0), "#settings");
+    assert.equal(hash_parser.get_current_nth_hash_section(1), "10");
+    assert.equal(hash_parser.get_current_nth_hash_section(2), "general");
+    assert.equal(hash_parser.get_current_nth_hash_section(3), "");
 });
 
 run_test("build_reload_url", () => {

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -87,6 +87,42 @@ run_test("get_current_nth_hash_section", () => {
     assert.equal(hash_parser.get_current_nth_hash_section(3), "");
 });
 
+run_test("test_is_same_server_message_link", () => {
+    const dm_message_link = "#narrow/dm/9,15-dm/near/43";
+    assert.equal(hash_parser.is_same_server_message_link(dm_message_link), true);
+
+    const group_message_link = "#narrow/dm/9,16,15-group/near/68";
+    assert.equal(hash_parser.is_same_server_message_link(group_message_link), true);
+
+    const stream_message_link = "#narrow/stream/8-design/topic/desktop/near/82";
+    assert.equal(hash_parser.is_same_server_message_link(stream_message_link), true);
+
+    const stream_link = "#narrow/stream/8-design";
+    assert.equal(hash_parser.is_same_server_message_link(stream_link), false);
+
+    const topic_link = "#narrow/stream/8-design/topic/desktop";
+    assert.equal(hash_parser.is_same_server_message_link(topic_link), false);
+
+    const dm_link = "#narrow/dm/15-John";
+    assert.equal(hash_parser.is_same_server_message_link(dm_link), false);
+
+    const search_link = "#narrow/search/database";
+    assert.equal(hash_parser.is_same_server_message_link(search_link), false);
+
+    const different_server_message_link =
+        "https://fakechat.zulip.org/#narrow/dm/8,1848,2369-group/near/1717378";
+    assert.equal(hash_parser.is_same_server_message_link(different_server_message_link), false);
+
+    const drafts_link = "#drafts";
+    assert.equal(hash_parser.is_same_server_message_link(drafts_link), false);
+
+    const empty_link = "#";
+    assert.equal(hash_parser.is_same_server_message_link(empty_link), false);
+
+    const non_zulip_link = "https://www.google.com";
+    assert.equal(hash_parser.is_same_server_message_link(non_zulip_link), false);
+});
+
 run_test("build_reload_url", () => {
     window.location.hash = "#settings/profile";
     assert.equal(hash_util.build_reload_url(), "+oldhash=settings%2Fprofile");

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -341,6 +341,7 @@ test("message_is_notifiable", () => {
 test("basic_notifications", () => {
     $("<div>").set_find_results(".emoji", {replaceWith() {}});
     $("<div>").set_find_results("span.katex", {each() {}});
+    $("<div>").children = () => [];
 
     let n; // Object for storing all notification data for assertions.
     let last_closed_message_id = null;

--- a/web/tests/ui_util.test.js
+++ b/web/tests/ui_util.test.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+const $ = require("./lib/zjquery");
+
+const ui_util = zrequire("ui_util");
+
+run_test("potentially_collapse_quotes", ({override_rewire}) => {
+    const $element = $.create("message-content");
+    let children = [];
+    $element.children = () => children;
+
+    children = [
+        $.create("normal paragraph 1"),
+        $.create("blockquote"),
+        $.create("normal paragraph 2"),
+        $.create("user said paragraph"),
+        $.create("message quote"),
+        $.create("normal paragraph 3"),
+    ];
+    override_rewire(ui_util, "get_collapsible_status_array", () => [
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+    ]);
+    // When there are both collapsible and non-collapsible elements, for
+    // multiple collapsible elements in a row, only the first element
+    // should be collapsed, and the rest's text should be removed. Non-
+    // collapsible elements should not be touched.
+    let collapsed = ui_util.potentially_collapse_quotes($element);
+    assert.equal(collapsed, true);
+    let expected_texts = ["never-been-set", "[…]", "never-been-set", "[…]", "", "never-been-set"];
+    assert.deepEqual(
+        $element.children().map(($el) => $el.text()),
+        expected_texts,
+    );
+
+    children = [
+        $.create("normal paragraph 4"),
+        $.create("normal paragraph 5"),
+        $.create("normal paragraph 6"),
+    ];
+    override_rewire(ui_util, "get_collapsible_status_array", () => [false, false, false]);
+    // For all non-collapsible elements, none should be collapsed.
+    collapsed = ui_util.potentially_collapse_quotes($element);
+    assert.equal(collapsed, false);
+    expected_texts = ["never-been-set", "never-been-set", "never-been-set"];
+    assert.deepEqual(
+        $element.children().map(($el) => $el.text()),
+        expected_texts,
+    );
+
+    children = [$.create("blockquote 1"), $.create("blockquote 2"), $.create("blockquote 3")];
+    override_rewire(ui_util, "get_collapsible_status_array", () => [true, true, true]);
+    // For all collapsible elements, none should be collapsed.
+    collapsed = ui_util.potentially_collapse_quotes($element);
+    assert.equal(collapsed, false);
+    expected_texts = ["never-been-set", "never-been-set", "never-been-set"];
+    assert.deepEqual(
+        $element.children().map(($el) => $el.text()),
+        expected_texts,
+    );
+});


### PR DESCRIPTION
Since notifications have limited space for the contents of a message, a quote from a previous message, or elsewhere, can take up most of the notification, leaving little room for the actual message, and reducing the usefulness of the notification.

To fix this, we collapse blockquotes and "user said" paragraphs to make space for the actual message.

Fixes: [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/desktop.20notifications.20and.20block.20quotes)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/28e08dd7-2527-4588-9704-8ffe40a299e9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
