### PR TITLE
remote-activity: Reduce number of database queries for view.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -187,7 +187,7 @@ class ActivityTest(ZulipTestCase):
             event_time=timezone_now() - timedelta(days=1),
             extra_data=extra_data,
         )
-        with self.assert_database_query_count(11):
+        with self.assert_database_query_count(9):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)
 
@@ -362,6 +362,6 @@ class ActivityTest(ZulipTestCase):
         add_audit_log_data(realm.server, remote_realm=realm, realm_id=None)
 
         self.login("iago")
-        with self.assert_database_query_count(27):
+        with self.assert_database_query_count(11):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1844,20 +1844,12 @@ class BillingSession(ABC):
     def get_customer_plan_renewal_amount(
         self,
         plan: CustomerPlan,
-        event_time: datetime,
-        last_ledger_entry: Optional[LicenseLedger] = None,
+        last_ledger_entry: LicenseLedger,
     ) -> int:
         if plan.fixed_price is not None:
             return plan.fixed_price
-        new_plan = None
-        if last_ledger_entry is None:
-            new_plan, last_ledger_entry = self.make_end_of_cycle_updates_if_needed(plan, event_time)
-        if last_ledger_entry is None:
-            return 0  # nocoverage
         if last_ledger_entry.licenses_at_next_renewal is None:
             return 0  # nocoverage
-        if new_plan is not None:
-            plan = new_plan  # nocoverage
         assert plan.price_per_license is not None  # for mypy
         return plan.price_per_license * last_ledger_entry.licenses_at_next_renewal
 
@@ -1916,7 +1908,7 @@ class BillingSession(ABC):
             num_months_next_cycle = (
                 12 if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_ANNUAL else 1
             )
-            renewal_cents = self.get_customer_plan_renewal_amount(plan, now, last_ledger_entry)
+            renewal_cents = self.get_customer_plan_renewal_amount(plan, last_ledger_entry)
 
             if plan.price_per_license is None:
                 price_per_license = ""

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -203,12 +203,15 @@ def get_current_plan_data_for_support_view(billing_session: BillingSession) -> P
         )
         plan_data.has_fixed_price = plan_data.current_plan.fixed_price is not None
         annual_invoice_count = get_annual_invoice_count(plan_data.current_plan.billing_schedule)
-        plan_data.annual_recurring_revenue = (
-            billing_session.get_customer_plan_renewal_amount(
-                plan_data.current_plan, timezone_now(), last_ledger_entry
+        if last_ledger_entry is not None:
+            plan_data.annual_recurring_revenue = (
+                billing_session.get_customer_plan_renewal_amount(
+                    plan_data.current_plan, last_ledger_entry
+                )
+                * annual_invoice_count
             )
-            * annual_invoice_count
-        )
+        else:
+            plan_data.annual_recurring_revenue = 0  # nocoverage
 
     return plan_data
 


### PR DESCRIPTION
**Notes**:
- Adds a test for the remote activity view with a more robust data set for customer plans and audit log data.
- Updates the query for customer plans to prefetch the related license ledger entry to calculate the estimated annual recurring revenue.
- Updates the query for the remote realm audit logs to select the related remote_realm to have the remote realm ID for the dict key.
- The query count in the new test goes from 27 to 11 with the updated queries.


<details>
<summary>console log 11 queries</summary>

```console
ITEMS:

#1
sql: SELECT "zerver_realm"."id", "zerver_realm"."name", "zerver_realm"."description", "zerver_realm"."string_id", "zerver_realm"."uuid", "zerver_realm"."uuid_owner_secret", "zerver_realm"."push_notifications_enabled", "zerver_realm"."push_notifications_enabled_end_timestamp", "zerver_realm"."date_created", "zerver_realm"."demo_organization_scheduled_deletion_date", "zerver_realm"."deactivated", "zerver_realm"."deactivated_redirect", "zerver_realm"."emails_restricted_to_domains", "zerver_realm"."invite_required", "zerver_realm"."max_invites", "zerver_realm"."disallow_disposable_email_addresses", "zerver_realm"."enable_spectator_access", "zerver_realm"."want_advertise_in_communities_directory", "zerver_realm"."inline_image_preview", "zerver_realm"."inline_url_embed_preview", "zerver_realm"."digest_emails_enabled", "zerver_realm"."digest_weekday", "zerver_realm"."send_welcome_emails", "zerver_realm"."message_content_allowed_in_email_notifications", "zerver_realm"."mandatory_topics", "zerver_realm"."name_changes_disabled", "zerver_realm"."email_changes_disabled", "zerver_realm"."avatar_changes_disabled", "zerver_realm"."move_messages_within_stream_limit_seconds", "zerver_realm"."move_messages_between_streams_limit_seconds", "zerver_realm"."add_custom_emoji_policy", "zerver_realm"."create_public_stream_policy", "zerver_realm"."create_private_stream_policy", "zerver_realm"."create_web_public_stream_policy", "zerver_realm"."delete_own_message_policy", "zerver_realm"."edit_topic_policy", "zerver_realm"."invite_to_realm_policy", "zerver_realm"."create_multiuse_invite_group_id", "zerver_realm"."can_access_all_users_group_id", "zerver_realm"."invite_to_stream_policy", "zerver_realm"."move_messages_between_streams_policy", "zerver_realm"."user_group_edit_policy", "zerver_realm"."private_message_policy", "zerver_realm"."wildcard_mention_policy", "zerver_realm"."waiting_period_threshold", "zerver_realm"."message_content_delete_limit_seconds", "zerver_realm"."allow_message_editing", "zerver_realm"."message_content_edit_limit_seconds", "zerver_realm"."allow_edit_history", "zerver_realm"."default_language", "zerver_realm"."notifications_stream_id", "zerver_realm"."signup_notifications_stream_id", "zerver_realm"."message_retention_days", "zerver_realm"."message_visibility_limit", "zerver_realm"."first_visible_message_id", "zerver_realm"."org_type", "zerver_realm"."plan_type", "zerver_realm"."bot_creation_policy", "zerver_realm"."upload_quota_gb", "zerver_realm"."video_chat_provider", "zerver_realm"."jitsi_server_url", "zerver_realm"."giphy_rating", "zerver_realm"."default_code_block_language", "zerver_realm"."enable_read_receipts", "zerver_realm"."enable_guest_user_indicator", "zerver_realm"."icon_source", "zerver_realm"."icon_version", "zerver_realm"."logo_source", "zerver_realm"."logo_version", "zerver_realm"."night_logo_source", "zerver_realm"."night_logo_version" FROM "zerver_realm" WHERE "zerver_realm"."string_id" = 'zulip' LIMIT 21
time: 0.001

#2
sql: SELECT "django_session"."session_key", "django_session"."session_data", "django_session"."expire_date" FROM "django_session" WHERE ("django_session"."expire_date" > '2024-01-22T19:52:50.380381+00:00'::timestamptz AND "django_session"."session_key" = 'wa92j2rpkz20n02cku0s2b5a1id2muog') LIMIT 21
time: 0.000

#3
sql: SELECT "zerver_userprofile"."id", "zerver_userprofile"."password", "zerver_userprofile"."last_login", "zerver_userprofile"."is_superuser", "zerver_userprofile"."enter_sends", "zerver_userprofile"."left_side_userlist", "zerver_userprofile"."default_language", "zerver_userprofile"."web_home_view", "zerver_userprofile"."web_escape_navigates_to_home_view", "zerver_userprofile"."dense_mode", "zerver_userprofile"."fluid_layout_width", "zerver_userprofile"."high_contrast_mode", "zerver_userprofile"."translate_emoticons", "zerver_userprofile"."display_emoji_reaction_users", "zerver_userprofile"."twenty_four_hour_time", "zerver_userprofile"."starred_message_counts", "zerver_userprofile"."color_scheme", "zerver_userprofile"."demote_inactive_streams", "zerver_userprofile"."web_mark_read_on_scroll_policy", "zerver_userprofile"."emojiset", "zerver_userprofile"."user_list_style", "zerver_userprofile"."web_stream_unreads_count_display_policy", "zerver_userprofile"."email_notifications_batching_period_seconds", "zerver_userprofile"."enable_stream_desktop_notifications", "zerver_userprofile"."enable_stream_email_notifications", "zerver_userprofile"."enable_stream_push_notifications", "zerver_userprofile"."enable_stream_audible_notifications", "zerver_userprofile"."notification_sound", "zerver_userprofile"."wildcard_mentions_notify", "zerver_userprofile"."enable_followed_topic_desktop_notifications", "zerver_userprofile"."enable_followed_topic_email_notifications", "zerver_userprofile"."enable_followed_topic_push_notifications", "zerver_userprofile"."enable_followed_topic_audible_notifications", "zerver_userprofile"."enable_followed_topic_wildcard_mentions_notify", "zerver_userprofile"."enable_desktop_notifications", "zerver_userprofile"."pm_content_in_desktop_notifications", "zerver_userprofile"."enable_sounds", "zerver_userprofile"."enable_offline_email_notifications", "zerver_userprofile"."message_content_in_email_notifications", "zerver_userprofile"."enable_offline_push_notifications", "zerver_userprofile"."enable_online_push_notifications", "zerver_userprofile"."desktop_icon_count_display", "zerver_userprofile"."enable_digest_emails", "zerver_userprofile"."enable_login_emails", "zerver_userprofile"."enable_marketing_emails", "zerver_userprofile"."presence_enabled", "zerver_userprofile"."realm_name_in_email_notifications_policy", "zerver_userprofile"."automatically_follow_topics_policy", "zerver_userprofile"."automatically_unmute_topics_in_muted_streams_policy", "zerver_userprofile"."automatically_follow_topics_where_mentioned", "zerver_userprofile"."enable_drafts_synchronization", "zerver_userprofile"."send_stream_typing_notifications", "zerver_userprofile"."send_private_typing_notifications", "zerver_userprofile"."send_read_receipts", "zerver_userprofile"."email_address_visibility", "zerver_userprofile"."delivery_email", "zerver_userprofile"."email", "zerver_userprofile"."realm_id", "zerver_userprofile"."recipient_id", "zerver_userprofile"."full_name", "zerver_userprofile"."date_joined", "zerver_userprofile"."tos_version", "zerver_userprofile"."api_key", "zerver_userprofile"."uuid", "zerver_userprofile"."is_staff", "zerver_userprofile"."is_active", "zerver_userprofile"."is_billing_admin", "zerver_userprofile"."is_bot", "zerver_userprofile"."bot_type", "zerver_userprofile"."bot_owner_id", "zerver_userprofile"."role", "zerver_userprofile"."long_term_idle", "zerver_userprofile"."last_active_message_id", "zerver_userprofile"."is_mirror_dummy", "zerver_userprofile"."can_forge_sender", "zerver_userprofile"."can_create_users", "zerver_userprofile"."last_reminder", "zerver_userprofile"."rate_limits", "zerver_userprofile"."default_sending_stream_id", "zerver_userprofile"."default_events_register_stream_id", "zerver_userprofile"."default_all_public_streams", "zerver_userprofile"."timezone", "zerver_userprofile"."avatar_source", "zerver_userprofile"."avatar_version", "zerver_userprofile"."avatar_hash", "zerver_userprofile"."tutorial_status", "zerver_userprofile"."onboarding_steps", "zerver_userprofile"."zoom_token", "zerver_realm"."id", "zerver_realm"."name", "zerver_realm"."description", "zerver_realm"."string_id", "zerver_realm"."uuid", "zerver_realm"."uuid_owner_secret", "zerver_realm"."push_notifications_enabled", "zerver_realm"."push_notifications_enabled_end_timestamp", "zerver_realm"."date_created", "zerver_realm"."demo_organization_scheduled_deletion_date", "zerver_realm"."deactivated", "zerver_realm"."deactivated_redirect", "zerver_realm"."emails_restricted_to_domains", "zerver_realm"."invite_required", "zerver_realm"."max_invites", "zerver_realm"."disallow_disposable_email_addresses", "zerver_realm"."enable_spectator_access", "zerver_realm"."want_advertise_in_communities_directory", "zerver_realm"."inline_image_preview", "zerver_realm"."inline_url_embed_preview", "zerver_realm"."digest_emails_enabled", "zerver_realm"."digest_weekday", "zerver_realm"."send_welcome_emails", "zerver_realm"."message_content_allowed_in_email_notifications", "zerver_realm"."mandatory_topics", "zerver_realm"."name_changes_disabled", "zerver_realm"."email_changes_disabled", "zerver_realm"."avatar_changes_disabled", "zerver_realm"."move_messages_within_stream_limit_seconds", "zerver_realm"."move_messages_between_streams_limit_seconds", "zerver_realm"."add_custom_emoji_policy", "zerver_realm"."create_public_stream_policy", "zerver_realm"."create_private_stream_policy", "zerver_realm"."create_web_public_stream_policy", "zerver_realm"."delete_own_message_policy", "zerver_realm"."edit_topic_policy", "zerver_realm"."invite_to_realm_policy", "zerver_realm"."create_multiuse_invite_group_id", "zerver_realm"."can_access_all_users_group_id", "zerver_realm"."invite_to_stream_policy", "zerver_realm"."move_messages_between_streams_policy", "zerver_realm"."user_group_edit_policy", "zerver_realm"."private_message_policy", "zerver_realm"."wildcard_mention_policy", "zerver_realm"."waiting_period_threshold", "zerver_realm"."message_content_delete_limit_seconds", "zerver_realm"."allow_message_editing", "zerver_realm"."message_content_edit_limit_seconds", "zerver_realm"."allow_edit_history", "zerver_realm"."default_language", "zerver_realm"."notifications_stream_id", "zerver_realm"."signup_notifications_stream_id", "zerver_realm"."message_retention_days", "zerver_realm"."message_visibility_limit", "zerver_realm"."first_visible_message_id", "zerver_realm"."org_type", "zerver_realm"."plan_type", "zerver_realm"."bot_creation_policy", "zerver_realm"."upload_quota_gb", "zerver_realm"."video_chat_provider", "zerver_realm"."jitsi_server_url", "zerver_realm"."giphy_rating", "zerver_realm"."default_code_block_language", "zerver_realm"."enable_read_receipts", "zerver_realm"."enable_guest_user_indicator", "zerver_realm"."icon_source", "zerver_realm"."icon_version", "zerver_realm"."logo_source", "zerver_realm"."logo_version", "zerver_realm"."night_logo_source", "zerver_realm"."night_logo_version", "zerver_usergroup"."id", "zerver_usergroup"."name", "zerver_usergroup"."realm_id", "zerver_usergroup"."description", "zerver_usergroup"."is_system_group", "zerver_usergroup"."can_mention_group_id", T4."id", T4."password", T4."last_login", T4."is_superuser", T4."enter_sends", T4."left_side_userlist", T4."default_language", T4."web_home_view", T4."web_escape_navigates_to_home_view", T4."dense_mode", T4."fluid_layout_width", T4."high_contrast_mode", T4."translate_emoticons", T4."display_emoji_reaction_users", T4."twenty_four_hour_time", T4."starred_message_counts", T4."color_scheme", T4."demote_inactive_streams", T4."web_mark_read_on_scroll_policy", T4."emojiset", T4."user_list_style", T4."web_stream_unreads_count_display_policy", T4."email_notifications_batching_period_seconds", T4."enable_stream_desktop_notifications", T4."enable_stream_email_notifications", T4."enable_stream_push_notifications", T4."enable_stream_audible_notifications", T4."notification_sound", T4."wildcard_mentions_notify", T4."enable_followed_topic_desktop_notifications", T4."enable_followed_topic_email_notifications", T4."enable_followed_topic_push_notifications", T4."enable_followed_topic_audible_notifications", T4."enable_followed_topic_wildcard_mentions_notify", T4."enable_desktop_notifications", T4."pm_content_in_desktop_notifications", T4."enable_sounds", T4."enable_offline_email_notifications", T4."message_content_in_email_notifications", T4."enable_offline_push_notifications", T4."enable_online_push_notifications", T4."desktop_icon_count_display", T4."enable_digest_emails", T4."enable_login_emails", T4."enable_marketing_emails", T4."presence_enabled", T4."realm_name_in_email_notifications_policy", T4."automatically_follow_topics_policy", T4."automatically_unmute_topics_in_muted_streams_policy", T4."automatically_follow_topics_where_mentioned", T4."enable_drafts_synchronization", T4."send_stream_typing_notifications", T4."send_private_typing_notifications", T4."send_read_receipts", T4."email_address_visibility", T4."delivery_email", T4."email", T4."realm_id", T4."recipient_id", T4."full_name", T4."date_joined", T4."tos_version", T4."api_key", T4."uuid", T4."is_staff", T4."is_active", T4."is_billing_admin", T4."is_bot", T4."bot_type", T4."bot_owner_id", T4."role", T4."long_term_idle", T4."last_active_message_id", T4."is_mirror_dummy", T4."can_forge_sender", T4."can_create_users", T4."last_reminder", T4."rate_limits", T4."default_sending_stream_id", T4."default_events_register_stream_id", T4."default_all_public_streams", T4."timezone", T4."avatar_source", T4."avatar_version", T4."avatar_hash", T4."tutorial_status", T4."onboarding_steps", T4."zoom_token" FROM "zerver_userprofile" INNER JOIN "zerver_realm" ON ("zerver_userprofile"."realm_id" = "zerver_realm"."id") INNER JOIN "zerver_usergroup" ON ("zerver_realm"."can_access_all_users_group_id" = "zerver_usergroup"."id") LEFT OUTER JOIN "zerver_userprofile" T4 ON ("zerver_userprofile"."bot_owner_id" = T4."id") WHERE "zerver_userprofile"."id" = 11 LIMIT 21
time: 0.003

#4
sql: SELECT "zerver_client"."id", "zerver_client"."name" FROM "zerver_client" WHERE "zerver_client"."name" = 'website' LIMIT 21
time: 0.000

#5
sql: 
        with mobile_push_forwarded_count as (
            select
                server_id,
                sum(coalesce(value, 0)) as push_forwarded_count
            from zilencer_remoteinstallationcount
            where
                property = 'mobile_pushes_forwarded::day'
                and end_time >= current_timestamp(0) - interval '7 days'
            group by server_id
        ),
        remote_push_devices as (
            select
                server_id,
                count(distinct(user_id, user_uuid)) as push_user_count
            from zilencer_remotepushdevicetoken
            group by server_id
        ),
        remote_realms as (
            select
                server_id,
                id as realm_id,
                name as realm_name,
                org_type as realm_type
            from zilencer_remoterealm
            where
                is_system_bot_realm = False
                and realm_deactivated = False
            group by server_id, id, name, org_type
        )
        select
            rserver.id,
            rserver.hostname,
            rserver.contact_email,
            rserver.last_version,
            rserver.last_audit_log_update,
            push_user_count,
            push_forwarded_count,
            realm_id,
            realm_name,
            realm_type
        from zilencer_remotezulipserver rserver
        left join mobile_push_forwarded_count on mobile_push_forwarded_count.server_id = rserver.id
        left join remote_push_devices on remote_push_devices.server_id = rserver.id
        left join remote_realms on remote_realms.server_id = rserver.id
        where not deactivated
        order by push_user_count DESC NULLS LAST
    
time: 0.001

#6
sql: SELECT "corporate_customerplan"."id", "corporate_customerplan"."customer_id", "corporate_customerplan"."automanage_licenses", "corporate_customerplan"."charge_automatically", "corporate_customerplan"."price_per_license", "corporate_customerplan"."fixed_price", "corporate_customerplan"."discount", "corporate_customerplan"."billing_cycle_anchor", "corporate_customerplan"."billing_schedule", "corporate_customerplan"."next_invoice_date", "corporate_customerplan"."invoice_overdue_email_sent", "corporate_customerplan"."invoiced_through_id", "corporate_customerplan"."end_date", "corporate_customerplan"."invoicing_status", "corporate_customerplan"."tier", "corporate_customerplan"."status", "corporate_customer"."id", "corporate_customer"."realm_id", "corporate_customer"."remote_realm_id", "corporate_customer"."remote_server_id", "corporate_customer"."stripe_customer_id", "corporate_customer"."sponsorship_pending", "corporate_customer"."default_discount", "corporate_customer"."minimum_licenses", "corporate_customer"."required_plan_tier", "corporate_customer"."exempt_from_license_number_check", "corporate_customer"."flat_discount", "corporate_customer"."flat_discounted_months", "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "corporate_customerplan" INNER JOIN "corporate_customer" ON ("corporate_customerplan"."customer_id" = "corporate_customer"."id") INNER JOIN "zilencer_remotezulipserver" ON ("corporate_customer"."remote_server_id" = "zilencer_remotezulipserver"."id") WHERE ("corporate_customer"."realm_id" IS NULL AND "corporate_customer"."remote_realm_id" IS NULL AND NOT "zilencer_remotezulipserver"."deactivated" AND "corporate_customerplan"."status" < 10)
time: 0.001

#7
sql: SELECT DISTINCT ON ("corporate_licenseledger"."plan_id") "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" IN (2, 3) ORDER BY "corporate_licenseledger"."plan_id" ASC, "corporate_licenseledger"."id" DESC
time: 0.000

#8
sql: SELECT "corporate_customerplan"."id", "corporate_customerplan"."customer_id", "corporate_customerplan"."automanage_licenses", "corporate_customerplan"."charge_automatically", "corporate_customerplan"."price_per_license", "corporate_customerplan"."fixed_price", "corporate_customerplan"."discount", "corporate_customerplan"."billing_cycle_anchor", "corporate_customerplan"."billing_schedule", "corporate_customerplan"."next_invoice_date", "corporate_customerplan"."invoice_overdue_email_sent", "corporate_customerplan"."invoiced_through_id", "corporate_customerplan"."end_date", "corporate_customerplan"."invoicing_status", "corporate_customerplan"."tier", "corporate_customerplan"."status", "corporate_customer"."id", "corporate_customer"."realm_id", "corporate_customer"."remote_realm_id", "corporate_customer"."remote_server_id", "corporate_customer"."stripe_customer_id", "corporate_customer"."sponsorship_pending", "corporate_customer"."default_discount", "corporate_customer"."minimum_licenses", "corporate_customer"."required_plan_tier", "corporate_customer"."exempt_from_license_number_check", "corporate_customer"."flat_discount", "corporate_customer"."flat_discounted_months", "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "corporate_customerplan" INNER JOIN "corporate_customer" ON ("corporate_customerplan"."customer_id" = "corporate_customer"."id") INNER JOIN "zilencer_remoterealm" ON ("corporate_customer"."remote_realm_id" = "zilencer_remoterealm"."id") WHERE ("corporate_customer"."realm_id" IS NULL AND NOT "zilencer_remoterealm"."is_system_bot_realm" AND NOT "zilencer_remoterealm"."realm_deactivated" AND "corporate_customer"."remote_server_id" IS NULL AND "corporate_customerplan"."status" < 10)
time: 0.001

#9
sql: SELECT DISTINCT ON ("corporate_licenseledger"."plan_id") "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" IN (4, 5, 6, 7) ORDER BY "corporate_licenseledger"."plan_id" ASC, "corporate_licenseledger"."id" DESC
time: 0.000

#10
sql: SELECT DISTINCT ON ("zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."realm_id") "zilencer_remoterealmauditlog"."id", "zilencer_remoterealmauditlog"."event_time", "zilencer_remoterealmauditlog"."backfilled", "zilencer_remoterealmauditlog"."extra_data", "zilencer_remoterealmauditlog"."event_type", "zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."remote_realm_id", "zilencer_remoterealmauditlog"."realm_id", "zilencer_remoterealmauditlog"."remote_id", "zilencer_remoterealmauditlog"."acting_remote_user_id", "zilencer_remoterealmauditlog"."acting_support_user_id", "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remoterealmauditlog" INNER JOIN "zilencer_remotezulipserver" ON ("zilencer_remoterealmauditlog"."server_id" = "zilencer_remotezulipserver"."id") WHERE ("zilencer_remoterealmauditlog"."event_time" <= '2024-01-22T19:52:45.978107+00:00'::timestamptz AND "zilencer_remoterealmauditlog"."event_type" IN (101, 102, 103, 104, 105, 201, 202, 229) AND NOT ("zilencer_remoterealmauditlog"."extra_data" = '{}')) ORDER BY "zilencer_remoterealmauditlog"."server_id" ASC, "zilencer_remoterealmauditlog"."realm_id" ASC, "zilencer_remoterealmauditlog"."event_time" DESC
time: 0.001

#11
sql: SELECT DISTINCT ON ("zilencer_remoterealmauditlog"."remote_realm_id") "zilencer_remoterealmauditlog"."id", "zilencer_remoterealmauditlog"."event_time", "zilencer_remoterealmauditlog"."backfilled", "zilencer_remoterealmauditlog"."extra_data", "zilencer_remoterealmauditlog"."event_type", "zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."remote_realm_id", "zilencer_remoterealmauditlog"."realm_id", "zilencer_remoterealmauditlog"."remote_id", "zilencer_remoterealmauditlog"."acting_remote_user_id", "zilencer_remoterealmauditlog"."acting_support_user_id", "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "zilencer_remoterealmauditlog" INNER JOIN "zilencer_remoterealm" ON ("zilencer_remoterealmauditlog"."remote_realm_id" = "zilencer_remoterealm"."id") WHERE ("zilencer_remoterealmauditlog"."event_time" <= '2024-01-22T19:52:45.978086+00:00'::timestamptz AND "zilencer_remoterealmauditlog"."event_type" IN (101, 102, 103, 104, 105, 201, 202, 229) AND "zilencer_remoterealmauditlog"."remote_realm_id" IS NOT NULL AND NOT ("zilencer_remoterealmauditlog"."extra_data" = '{}')) ORDER BY "zilencer_remoterealmauditlog"."remote_realm_id" ASC, "zilencer_remoterealmauditlog"."event_time" DESC
time: 0.001

```
</details>


<details>
<summary>console log 27 queries</summary>

```console
ITEMS:

#1
sql: SELECT "zerver_realm"."id", "zerver_realm"."name", "zerver_realm"."description", "zerver_realm"."string_id", "zerver_realm"."uuid", "zerver_realm"."uuid_owner_secret", "zerver_realm"."push_notifications_enabled", "zerver_realm"."push_notifications_enabled_end_timestamp", "zerver_realm"."date_created", "zerver_realm"."demo_organization_scheduled_deletion_date", "zerver_realm"."deactivated", "zerver_realm"."deactivated_redirect", "zerver_realm"."emails_restricted_to_domains", "zerver_realm"."invite_required", "zerver_realm"."max_invites", "zerver_realm"."disallow_disposable_email_addresses", "zerver_realm"."enable_spectator_access", "zerver_realm"."want_advertise_in_communities_directory", "zerver_realm"."inline_image_preview", "zerver_realm"."inline_url_embed_preview", "zerver_realm"."digest_emails_enabled", "zerver_realm"."digest_weekday", "zerver_realm"."send_welcome_emails", "zerver_realm"."message_content_allowed_in_email_notifications", "zerver_realm"."mandatory_topics", "zerver_realm"."name_changes_disabled", "zerver_realm"."email_changes_disabled", "zerver_realm"."avatar_changes_disabled", "zerver_realm"."move_messages_within_stream_limit_seconds", "zerver_realm"."move_messages_between_streams_limit_seconds", "zerver_realm"."add_custom_emoji_policy", "zerver_realm"."create_public_stream_policy", "zerver_realm"."create_private_stream_policy", "zerver_realm"."create_web_public_stream_policy", "zerver_realm"."delete_own_message_policy", "zerver_realm"."edit_topic_policy", "zerver_realm"."invite_to_realm_policy", "zerver_realm"."create_multiuse_invite_group_id", "zerver_realm"."can_access_all_users_group_id", "zerver_realm"."invite_to_stream_policy", "zerver_realm"."move_messages_between_streams_policy", "zerver_realm"."user_group_edit_policy", "zerver_realm"."private_message_policy", "zerver_realm"."wildcard_mention_policy", "zerver_realm"."waiting_period_threshold", "zerver_realm"."message_content_delete_limit_seconds", "zerver_realm"."allow_message_editing", "zerver_realm"."message_content_edit_limit_seconds", "zerver_realm"."allow_edit_history", "zerver_realm"."default_language", "zerver_realm"."notifications_stream_id", "zerver_realm"."signup_notifications_stream_id", "zerver_realm"."message_retention_days", "zerver_realm"."message_visibility_limit", "zerver_realm"."first_visible_message_id", "zerver_realm"."org_type", "zerver_realm"."plan_type", "zerver_realm"."bot_creation_policy", "zerver_realm"."upload_quota_gb", "zerver_realm"."video_chat_provider", "zerver_realm"."jitsi_server_url", "zerver_realm"."giphy_rating", "zerver_realm"."default_code_block_language", "zerver_realm"."enable_read_receipts", "zerver_realm"."enable_guest_user_indicator", "zerver_realm"."icon_source", "zerver_realm"."icon_version", "zerver_realm"."logo_source", "zerver_realm"."logo_version", "zerver_realm"."night_logo_source", "zerver_realm"."night_logo_version" FROM "zerver_realm" WHERE "zerver_realm"."string_id" = 'zulip' LIMIT 21
time: 0.001

#2
sql: SELECT "django_session"."session_key", "django_session"."session_data", "django_session"."expire_date" FROM "django_session" WHERE ("django_session"."expire_date" > '2024-01-22T19:04:28.202161+00:00'::timestamptz AND "django_session"."session_key" = 'c0iwztbfr7jktjez3uerpkakehido0ue') LIMIT 21
time: 0.000

#3
sql: SELECT "zerver_userprofile"."id", "zerver_userprofile"."password", "zerver_userprofile"."last_login", "zerver_userprofile"."is_superuser", "zerver_userprofile"."enter_sends", "zerver_userprofile"."left_side_userlist", "zerver_userprofile"."default_language", "zerver_userprofile"."web_home_view", "zerver_userprofile"."web_escape_navigates_to_home_view", "zerver_userprofile"."dense_mode", "zerver_userprofile"."fluid_layout_width", "zerver_userprofile"."high_contrast_mode", "zerver_userprofile"."translate_emoticons", "zerver_userprofile"."display_emoji_reaction_users", "zerver_userprofile"."twenty_four_hour_time", "zerver_userprofile"."starred_message_counts", "zerver_userprofile"."color_scheme", "zerver_userprofile"."demote_inactive_streams", "zerver_userprofile"."web_mark_read_on_scroll_policy", "zerver_userprofile"."emojiset", "zerver_userprofile"."user_list_style", "zerver_userprofile"."web_stream_unreads_count_display_policy", "zerver_userprofile"."email_notifications_batching_period_seconds", "zerver_userprofile"."enable_stream_desktop_notifications", "zerver_userprofile"."enable_stream_email_notifications", "zerver_userprofile"."enable_stream_push_notifications", "zerver_userprofile"."enable_stream_audible_notifications", "zerver_userprofile"."notification_sound", "zerver_userprofile"."wildcard_mentions_notify", "zerver_userprofile"."enable_followed_topic_desktop_notifications", "zerver_userprofile"."enable_followed_topic_email_notifications", "zerver_userprofile"."enable_followed_topic_push_notifications", "zerver_userprofile"."enable_followed_topic_audible_notifications", "zerver_userprofile"."enable_followed_topic_wildcard_mentions_notify", "zerver_userprofile"."enable_desktop_notifications", "zerver_userprofile"."pm_content_in_desktop_notifications", "zerver_userprofile"."enable_sounds", "zerver_userprofile"."enable_offline_email_notifications", "zerver_userprofile"."message_content_in_email_notifications", "zerver_userprofile"."enable_offline_push_notifications", "zerver_userprofile"."enable_online_push_notifications", "zerver_userprofile"."desktop_icon_count_display", "zerver_userprofile"."enable_digest_emails", "zerver_userprofile"."enable_login_emails", "zerver_userprofile"."enable_marketing_emails", "zerver_userprofile"."presence_enabled", "zerver_userprofile"."realm_name_in_email_notifications_policy", "zerver_userprofile"."automatically_follow_topics_policy", "zerver_userprofile"."automatically_unmute_topics_in_muted_streams_policy", "zerver_userprofile"."automatically_follow_topics_where_mentioned", "zerver_userprofile"."enable_drafts_synchronization", "zerver_userprofile"."send_stream_typing_notifications", "zerver_userprofile"."send_private_typing_notifications", "zerver_userprofile"."send_read_receipts", "zerver_userprofile"."email_address_visibility", "zerver_userprofile"."delivery_email", "zerver_userprofile"."email", "zerver_userprofile"."realm_id", "zerver_userprofile"."recipient_id", "zerver_userprofile"."full_name", "zerver_userprofile"."date_joined", "zerver_userprofile"."tos_version", "zerver_userprofile"."api_key", "zerver_userprofile"."uuid", "zerver_userprofile"."is_staff", "zerver_userprofile"."is_active", "zerver_userprofile"."is_billing_admin", "zerver_userprofile"."is_bot", "zerver_userprofile"."bot_type", "zerver_userprofile"."bot_owner_id", "zerver_userprofile"."role", "zerver_userprofile"."long_term_idle", "zerver_userprofile"."last_active_message_id", "zerver_userprofile"."is_mirror_dummy", "zerver_userprofile"."can_forge_sender", "zerver_userprofile"."can_create_users", "zerver_userprofile"."last_reminder", "zerver_userprofile"."rate_limits", "zerver_userprofile"."default_sending_stream_id", "zerver_userprofile"."default_events_register_stream_id", "zerver_userprofile"."default_all_public_streams", "zerver_userprofile"."timezone", "zerver_userprofile"."avatar_source", "zerver_userprofile"."avatar_version", "zerver_userprofile"."avatar_hash", "zerver_userprofile"."tutorial_status", "zerver_userprofile"."onboarding_steps", "zerver_userprofile"."zoom_token", "zerver_realm"."id", "zerver_realm"."name", "zerver_realm"."description", "zerver_realm"."string_id", "zerver_realm"."uuid", "zerver_realm"."uuid_owner_secret", "zerver_realm"."push_notifications_enabled", "zerver_realm"."push_notifications_enabled_end_timestamp", "zerver_realm"."date_created", "zerver_realm"."demo_organization_scheduled_deletion_date", "zerver_realm"."deactivated", "zerver_realm"."deactivated_redirect", "zerver_realm"."emails_restricted_to_domains", "zerver_realm"."invite_required", "zerver_realm"."max_invites", "zerver_realm"."disallow_disposable_email_addresses", "zerver_realm"."enable_spectator_access", "zerver_realm"."want_advertise_in_communities_directory", "zerver_realm"."inline_image_preview", "zerver_realm"."inline_url_embed_preview", "zerver_realm"."digest_emails_enabled", "zerver_realm"."digest_weekday", "zerver_realm"."send_welcome_emails", "zerver_realm"."message_content_allowed_in_email_notifications", "zerver_realm"."mandatory_topics", "zerver_realm"."name_changes_disabled", "zerver_realm"."email_changes_disabled", "zerver_realm"."avatar_changes_disabled", "zerver_realm"."move_messages_within_stream_limit_seconds", "zerver_realm"."move_messages_between_streams_limit_seconds", "zerver_realm"."add_custom_emoji_policy", "zerver_realm"."create_public_stream_policy", "zerver_realm"."create_private_stream_policy", "zerver_realm"."create_web_public_stream_policy", "zerver_realm"."delete_own_message_policy", "zerver_realm"."edit_topic_policy", "zerver_realm"."invite_to_realm_policy", "zerver_realm"."create_multiuse_invite_group_id", "zerver_realm"."can_access_all_users_group_id", "zerver_realm"."invite_to_stream_policy", "zerver_realm"."move_messages_between_streams_policy", "zerver_realm"."user_group_edit_policy", "zerver_realm"."private_message_policy", "zerver_realm"."wildcard_mention_policy", "zerver_realm"."waiting_period_threshold", "zerver_realm"."message_content_delete_limit_seconds", "zerver_realm"."allow_message_editing", "zerver_realm"."message_content_edit_limit_seconds", "zerver_realm"."allow_edit_history", "zerver_realm"."default_language", "zerver_realm"."notifications_stream_id", "zerver_realm"."signup_notifications_stream_id", "zerver_realm"."message_retention_days", "zerver_realm"."message_visibility_limit", "zerver_realm"."first_visible_message_id", "zerver_realm"."org_type", "zerver_realm"."plan_type", "zerver_realm"."bot_creation_policy", "zerver_realm"."upload_quota_gb", "zerver_realm"."video_chat_provider", "zerver_realm"."jitsi_server_url", "zerver_realm"."giphy_rating", "zerver_realm"."default_code_block_language", "zerver_realm"."enable_read_receipts", "zerver_realm"."enable_guest_user_indicator", "zerver_realm"."icon_source", "zerver_realm"."icon_version", "zerver_realm"."logo_source", "zerver_realm"."logo_version", "zerver_realm"."night_logo_source", "zerver_realm"."night_logo_version", "zerver_usergroup"."id", "zerver_usergroup"."name", "zerver_usergroup"."realm_id", "zerver_usergroup"."description", "zerver_usergroup"."is_system_group", "zerver_usergroup"."can_mention_group_id", T4."id", T4."password", T4."last_login", T4."is_superuser", T4."enter_sends", T4."left_side_userlist", T4."default_language", T4."web_home_view", T4."web_escape_navigates_to_home_view", T4."dense_mode", T4."fluid_layout_width", T4."high_contrast_mode", T4."translate_emoticons", T4."display_emoji_reaction_users", T4."twenty_four_hour_time", T4."starred_message_counts", T4."color_scheme", T4."demote_inactive_streams", T4."web_mark_read_on_scroll_policy", T4."emojiset", T4."user_list_style", T4."web_stream_unreads_count_display_policy", T4."email_notifications_batching_period_seconds", T4."enable_stream_desktop_notifications", T4."enable_stream_email_notifications", T4."enable_stream_push_notifications", T4."enable_stream_audible_notifications", T4."notification_sound", T4."wildcard_mentions_notify", T4."enable_followed_topic_desktop_notifications", T4."enable_followed_topic_email_notifications", T4."enable_followed_topic_push_notifications", T4."enable_followed_topic_audible_notifications", T4."enable_followed_topic_wildcard_mentions_notify", T4."enable_desktop_notifications", T4."pm_content_in_desktop_notifications", T4."enable_sounds", T4."enable_offline_email_notifications", T4."message_content_in_email_notifications", T4."enable_offline_push_notifications", T4."enable_online_push_notifications", T4."desktop_icon_count_display", T4."enable_digest_emails", T4."enable_login_emails", T4."enable_marketing_emails", T4."presence_enabled", T4."realm_name_in_email_notifications_policy", T4."automatically_follow_topics_policy", T4."automatically_unmute_topics_in_muted_streams_policy", T4."automatically_follow_topics_where_mentioned", T4."enable_drafts_synchronization", T4."send_stream_typing_notifications", T4."send_private_typing_notifications", T4."send_read_receipts", T4."email_address_visibility", T4."delivery_email", T4."email", T4."realm_id", T4."recipient_id", T4."full_name", T4."date_joined", T4."tos_version", T4."api_key", T4."uuid", T4."is_staff", T4."is_active", T4."is_billing_admin", T4."is_bot", T4."bot_type", T4."bot_owner_id", T4."role", T4."long_term_idle", T4."last_active_message_id", T4."is_mirror_dummy", T4."can_forge_sender", T4."can_create_users", T4."last_reminder", T4."rate_limits", T4."default_sending_stream_id", T4."default_events_register_stream_id", T4."default_all_public_streams", T4."timezone", T4."avatar_source", T4."avatar_version", T4."avatar_hash", T4."tutorial_status", T4."onboarding_steps", T4."zoom_token" FROM "zerver_userprofile" INNER JOIN "zerver_realm" ON ("zerver_userprofile"."realm_id" = "zerver_realm"."id") INNER JOIN "zerver_usergroup" ON ("zerver_realm"."can_access_all_users_group_id" = "zerver_usergroup"."id") LEFT OUTER JOIN "zerver_userprofile" T4 ON ("zerver_userprofile"."bot_owner_id" = T4."id") WHERE "zerver_userprofile"."id" = 11 LIMIT 21
time: 0.002

#4
sql: SELECT "zerver_client"."id", "zerver_client"."name" FROM "zerver_client" WHERE "zerver_client"."name" = 'website' LIMIT 21
time: 0.001

#5
sql: 
        with mobile_push_forwarded_count as (
            select
                server_id,
                sum(coalesce(value, 0)) as push_forwarded_count
            from zilencer_remoteinstallationcount
            where
                property = 'mobile_pushes_forwarded::day'
                and end_time >= current_timestamp(0) - interval '7 days'
            group by server_id
        ),
        remote_push_devices as (
            select
                server_id,
                count(distinct(user_id, user_uuid)) as push_user_count
            from zilencer_remotepushdevicetoken
            group by server_id
        ),
        remote_realms as (
            select
                server_id,
                id as realm_id,
                name as realm_name,
                org_type as realm_type
            from zilencer_remoterealm
            where
                is_system_bot_realm = False
                and realm_deactivated = False
            group by server_id, id, name, org_type
        )
        select
            rserver.id,
            rserver.hostname,
            rserver.contact_email,
            rserver.last_version,
            rserver.last_audit_log_update,
            push_user_count,
            push_forwarded_count,
            realm_id,
            realm_name,
            realm_type
        from zilencer_remotezulipserver rserver
        left join mobile_push_forwarded_count on mobile_push_forwarded_count.server_id = rserver.id
        left join remote_push_devices on remote_push_devices.server_id = rserver.id
        left join remote_realms on remote_realms.server_id = rserver.id
        where not deactivated
        order by push_user_count DESC NULLS LAST
    
time: 0.001

#6
sql: SELECT "corporate_customerplan"."id", "corporate_customerplan"."customer_id", "corporate_customerplan"."automanage_licenses", "corporate_customerplan"."charge_automatically", "corporate_customerplan"."price_per_license", "corporate_customerplan"."fixed_price", "corporate_customerplan"."discount", "corporate_customerplan"."billing_cycle_anchor", "corporate_customerplan"."billing_schedule", "corporate_customerplan"."next_invoice_date", "corporate_customerplan"."invoice_overdue_email_sent", "corporate_customerplan"."invoiced_through_id", "corporate_customerplan"."end_date", "corporate_customerplan"."invoicing_status", "corporate_customerplan"."tier", "corporate_customerplan"."status", "corporate_customer"."id", "corporate_customer"."realm_id", "corporate_customer"."remote_realm_id", "corporate_customer"."remote_server_id", "corporate_customer"."stripe_customer_id", "corporate_customer"."sponsorship_pending", "corporate_customer"."default_discount", "corporate_customer"."minimum_licenses", "corporate_customer"."required_plan_tier", "corporate_customer"."exempt_from_license_number_check", "corporate_customer"."flat_discount", "corporate_customer"."flat_discounted_months", "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "corporate_customerplan" INNER JOIN "corporate_customer" ON ("corporate_customerplan"."customer_id" = "corporate_customer"."id") INNER JOIN "zilencer_remotezulipserver" ON ("corporate_customer"."remote_server_id" = "zilencer_remotezulipserver"."id") WHERE ("corporate_customer"."realm_id" IS NULL AND "corporate_customer"."remote_realm_id" IS NULL AND NOT "zilencer_remotezulipserver"."deactivated" AND "corporate_customerplan"."status" < 10)
time: 0.001

#7
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" = 2 ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.001

#8
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE ("corporate_licenseledger"."is_renewal" AND "corporate_licenseledger"."plan_id" = 2) ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.001

#9
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" = 3 ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#10
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE ("corporate_licenseledger"."is_renewal" AND "corporate_licenseledger"."plan_id" = 3) ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#11
sql: SELECT "corporate_customerplan"."id", "corporate_customerplan"."customer_id", "corporate_customerplan"."automanage_licenses", "corporate_customerplan"."charge_automatically", "corporate_customerplan"."price_per_license", "corporate_customerplan"."fixed_price", "corporate_customerplan"."discount", "corporate_customerplan"."billing_cycle_anchor", "corporate_customerplan"."billing_schedule", "corporate_customerplan"."next_invoice_date", "corporate_customerplan"."invoice_overdue_email_sent", "corporate_customerplan"."invoiced_through_id", "corporate_customerplan"."end_date", "corporate_customerplan"."invoicing_status", "corporate_customerplan"."tier", "corporate_customerplan"."status", "corporate_customer"."id", "corporate_customer"."realm_id", "corporate_customer"."remote_realm_id", "corporate_customer"."remote_server_id", "corporate_customer"."stripe_customer_id", "corporate_customer"."sponsorship_pending", "corporate_customer"."default_discount", "corporate_customer"."minimum_licenses", "corporate_customer"."required_plan_tier", "corporate_customer"."exempt_from_license_number_check", "corporate_customer"."flat_discount", "corporate_customer"."flat_discounted_months", "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "corporate_customerplan" INNER JOIN "corporate_customer" ON ("corporate_customerplan"."customer_id" = "corporate_customer"."id") INNER JOIN "zilencer_remoterealm" ON ("corporate_customer"."remote_realm_id" = "zilencer_remoterealm"."id") WHERE ("corporate_customer"."realm_id" IS NULL AND NOT "zilencer_remoterealm"."is_system_bot_realm" AND NOT "zilencer_remoterealm"."realm_deactivated" AND "corporate_customer"."remote_server_id" IS NULL AND "corporate_customerplan"."status" < 10)
time: 0.001

#12
sql: SELECT "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remotezulipserver" WHERE "zilencer_remotezulipserver"."id" = 6 LIMIT 21
time: 0.000

#13
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" = 4 ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#14
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE ("corporate_licenseledger"."is_renewal" AND "corporate_licenseledger"."plan_id" = 4) ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#15
sql: SELECT "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remotezulipserver" WHERE "zilencer_remotezulipserver"."id" = 7 LIMIT 21
time: 0.000

#16
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" = 5 ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#17
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE ("corporate_licenseledger"."is_renewal" AND "corporate_licenseledger"."plan_id" = 5) ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#18
sql: SELECT "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remotezulipserver" WHERE "zilencer_remotezulipserver"."id" = 8 LIMIT 21
time: 0.000

#19
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE "corporate_licenseledger"."plan_id" = 6 ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#20
sql: SELECT "corporate_licenseledger"."id", "corporate_licenseledger"."plan_id", "corporate_licenseledger"."is_renewal", "corporate_licenseledger"."event_time", "corporate_licenseledger"."licenses", "corporate_licenseledger"."licenses_at_next_renewal" FROM "corporate_licenseledger" WHERE ("corporate_licenseledger"."is_renewal" AND "corporate_licenseledger"."plan_id" = 6) ORDER BY "corporate_licenseledger"."id" DESC LIMIT 1
time: 0.000

#21
sql: SELECT "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remotezulipserver" WHERE "zilencer_remotezulipserver"."id" = 8 LIMIT 21
time: 0.000

#22
sql: SELECT DISTINCT ON ("zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."realm_id") "zilencer_remoterealmauditlog"."id", "zilencer_remoterealmauditlog"."event_time", "zilencer_remoterealmauditlog"."backfilled", "zilencer_remoterealmauditlog"."extra_data", "zilencer_remoterealmauditlog"."event_type", "zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."remote_realm_id", "zilencer_remoterealmauditlog"."realm_id", "zilencer_remoterealmauditlog"."remote_id", "zilencer_remoterealmauditlog"."acting_remote_user_id", "zilencer_remoterealmauditlog"."acting_support_user_id", "zilencer_remotezulipserver"."id", "zilencer_remotezulipserver"."uuid", "zilencer_remotezulipserver"."api_key", "zilencer_remotezulipserver"."hostname", "zilencer_remotezulipserver"."contact_email", "zilencer_remotezulipserver"."last_updated", "zilencer_remotezulipserver"."last_request_datetime", "zilencer_remotezulipserver"."last_version", "zilencer_remotezulipserver"."last_api_feature_level", "zilencer_remotezulipserver"."deactivated", "zilencer_remotezulipserver"."plan_type", "zilencer_remotezulipserver"."org_type", "zilencer_remotezulipserver"."last_audit_log_update" FROM "zilencer_remoterealmauditlog" INNER JOIN "zilencer_remotezulipserver" ON ("zilencer_remoterealmauditlog"."server_id" = "zilencer_remotezulipserver"."id") WHERE ("zilencer_remoterealmauditlog"."event_time" <= '2024-01-22T19:04:23.541709+00:00'::timestamptz AND "zilencer_remoterealmauditlog"."event_type" IN (101, 102, 103, 104, 105, 201, 202, 229) AND NOT ("zilencer_remoterealmauditlog"."extra_data" = '{}')) ORDER BY "zilencer_remoterealmauditlog"."server_id" ASC, "zilencer_remoterealmauditlog"."realm_id" ASC, "zilencer_remoterealmauditlog"."event_time" DESC
time: 0.001

#23
sql: SELECT DISTINCT ON ("zilencer_remoterealmauditlog"."remote_realm_id") "zilencer_remoterealmauditlog"."id", "zilencer_remoterealmauditlog"."event_time", "zilencer_remoterealmauditlog"."backfilled", "zilencer_remoterealmauditlog"."extra_data", "zilencer_remoterealmauditlog"."event_type", "zilencer_remoterealmauditlog"."server_id", "zilencer_remoterealmauditlog"."remote_realm_id", "zilencer_remoterealmauditlog"."realm_id", "zilencer_remoterealmauditlog"."remote_id", "zilencer_remoterealmauditlog"."acting_remote_user_id", "zilencer_remoterealmauditlog"."acting_support_user_id" FROM "zilencer_remoterealmauditlog" WHERE ("zilencer_remoterealmauditlog"."event_time" <= '2024-01-22T19:04:23.541680+00:00'::timestamptz AND "zilencer_remoterealmauditlog"."event_type" IN (101, 102, 103, 104, 105, 201, 202, 229) AND "zilencer_remoterealmauditlog"."remote_realm_id" IS NOT NULL AND NOT ("zilencer_remoterealmauditlog"."extra_data" = '{}')) ORDER BY "zilencer_remoterealmauditlog"."remote_realm_id" ASC, "zilencer_remoterealmauditlog"."event_time" DESC
time: 0.000

#24
sql: SELECT "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "zilencer_remoterealm" WHERE "zilencer_remoterealm"."id" = 5 LIMIT 21
time: 0.000

#25
sql: SELECT "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "zilencer_remoterealm" WHERE "zilencer_remoterealm"."id" = 6 LIMIT 21
time: 0.000

#26
sql: SELECT "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "zilencer_remoterealm" WHERE "zilencer_remoterealm"."id" = 7 LIMIT 21
time: 0.000

#27
sql: SELECT "zilencer_remoterealm"."id", "zilencer_remoterealm"."server_id", "zilencer_remoterealm"."uuid", "zilencer_remoterealm"."uuid_owner_secret", "zilencer_remoterealm"."host", "zilencer_remoterealm"."name", "zilencer_remoterealm"."is_system_bot_realm", "zilencer_remoterealm"."authentication_methods", "zilencer_remoterealm"."org_type", "zilencer_remoterealm"."last_updated", "zilencer_remoterealm"."last_request_datetime", "zilencer_remoterealm"."registration_deactivated", "zilencer_remoterealm"."realm_deactivated", "zilencer_remoterealm"."realm_locally_deleted", "zilencer_remoterealm"."realm_date_created", "zilencer_remoterealm"."plan_type" FROM "zilencer_remoterealm" WHERE "zilencer_remoterealm"."id" = 8 LIMIT 21
time: 0.000
```
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
