### PR TITLE
queue_processors: Process user_activity in one query.

### DIFF
--- a/zerver/actions/user_activity.py
+++ b/zerver/actions/user_activity.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.models import UserActivity, UserActivityInterval, UserProfile
+from zerver.models import UserActivityInterval, UserProfile
 
 
 def do_update_user_activity_interval(user_profile: UserProfile, log_time: datetime) -> None:
@@ -27,22 +27,6 @@ def do_update_user_activity_interval(user_profile: UserProfile, log_time: dateti
     UserActivityInterval.objects.create(
         user_profile=user_profile, start=log_time, end=effective_end
     )
-
-
-def do_update_user_activity(
-    user_profile_id: int, client_id: int, query: str, count: int, log_time: datetime
-) -> None:
-    (activity, created) = UserActivity.objects.get_or_create(
-        user_profile_id=user_profile_id,
-        client_id=client_id,
-        query=query,
-        defaults={"last_visit": log_time, "count": count},
-    )
-
-    if not created:
-        activity.count += count
-        activity.last_visit = log_time
-        activity.save(update_fields=["last_visit", "count"])
 
 
 def update_user_activity_interval(user_profile: UserProfile, log_time: datetime) -> None:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -33,7 +33,7 @@ from zerver.actions.realm_settings import (
     do_set_realm_authentication_methods,
 )
 from zerver.actions.scheduled_messages import check_schedule_message
-from zerver.actions.user_activity import do_update_user_activity, do_update_user_activity_interval
+from zerver.actions.user_activity import do_update_user_activity_interval
 from zerver.actions.user_status import do_update_user_status
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.actions.users import do_deactivate_user
@@ -76,6 +76,7 @@ from zerver.models import (
     ScheduledMessage,
     Stream,
     Subscription,
+    UserActivity,
     UserGroup,
     UserGroupMembership,
     UserMessage,
@@ -1862,9 +1863,20 @@ class SingleUserExportTest(ExportFile):
             stream_id = last_recipient.type_id
             self.assertEqual(stream_id, get_stream("Scotland", realm).id)
 
-        do_update_user_activity(cordelia.id, client.id, "/some/endpoint", 2, now)
-        do_update_user_activity(cordelia.id, client.id, "/some/endpoint", 3, now)
-        do_update_user_activity(othello.id, client.id, "/bogus", 20, now)
+        UserActivity.objects.create(
+            user_profile_id=cordelia.id,
+            client_id=client.id,
+            query="/some/endpoint",
+            count=5,
+            last_visit=now,
+        )
+        UserActivity.objects.create(
+            user_profile_id=othello.id,
+            client_id=client.id,
+            query="/bogus",
+            count=20,
+            last_visit=now,
+        )
 
         @checker
         def zerver_useractivity(records: List[Record]) -> None:


### PR DESCRIPTION
This leads to significant speedups.  In a test, with 100 random unique event classes, the old code processed a batch of 100 rows (on average 66-ish unique in the batch) in 0.45 seconds.  Doing this in a single query processes the same batch in 0.0076 seconds.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
