### PR TITLE
api-docs: Clarify realm_authentication_methods in /register response

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4133,9 +4133,14 @@ paths:
                                           is enabled in this organization.
                                         type: boolean
                                       description: |
-                                        Dictionary of 'authentication_method_name': 'boolean' with each
-                                        entry describing whether the authentication name can be used for
-                                        authenticating into the organization.
+                                        Dictionary of authentication method keys with boolean values that
+                                        describe whether the named authentication method is enabled for the
+                                        organization.
+
+                                        Clients should use this to implement server-settings UI to change which
+                                        methods are enabled for the organization. For authentication UI itself,
+                                        clients should use the pre-authentication metadata returned by
+                                        [`GET /server_settings`](/api/get-server-settings).
                                     bot_creation_policy:
                                       type: integer
                                       description: |
@@ -14273,9 +14278,14 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Dictionary of 'authentication_method_name': 'boolean' with each
-                          entry describing whether the authentication name can be used for
-                          authenticating into the organization.
+                          Dictionary of authentication method keys with boolean values that
+                          describe whether the named authentication method is enabled for the
+                          organization.
+
+                          Clients should use this to implement server-settings UI to change which
+                          methods are enabled for the organization. For authentication UI itself,
+                          clients should use the pre-authentication metadata returned by
+                          [`GET /server_settings`](/api/get-server-settings).
                       realm_allow_message_editing:
                         type: boolean
                         description: |


### PR DESCRIPTION
Following discussion:
  https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60realm_authentication_methods.60/near/1723399

-----

Would it be good to add the same text to `authentication_methods` in the [`realm/update_dict` event doc](https://zulip.com/api/get-events#realm-update_dict)? I guess we probably assume that people will read both the event doc and the corresponding field in the `/register` doc; I always check both. So maybe not necessary.