### PR TITLE
Fix: Preserves dm: syntax in search bar

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -298,6 +298,9 @@ function pick_empty_narrow_banner(): NarrowBannerData {
         }
         case "dm": {
             if (!people.is_valid_bulk_emails_for_compose(first_operand.split(","))) {
+                if (first_operand.trim().length === 0) {
+                    $("#search_query").val("dm:");
+                }
                 if (!first_operand.includes(",")) {
                     return {
                         title: $t({defaultMessage: "This user does not exist!"}),


### PR DESCRIPTION
Solves the issue with dm: syntax when the operand is blank

Fixes: https://github.com/zulip/zulip/issues/20073

![image](https://github.com/zulip/zulip/assets/116712190/11e88f66-4091-483b-8dc1-732f7d86ece7)



