### PR TITLE
tooltips: Remove scroll button tooltip under animation.

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -11,13 +11,28 @@ import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 
+function destroyTippyInstance() {
+    // "Scroll Button" tooltip needs to be explicitly destroyed because the [data-reference-hidden] property does not work accurately under animation. Track the issue here - "https://github.com/atomiks/tippyjs/issues/1154".
+    setTimeout(() => {
+        const tippyInstance = $("#scroll-to-bottom-button-clickable-area")[0]._tippy;
+        if (tippyInstance) {
+            tippyInstance.destroy();
+        }
+    }, 500);
+}
+
 let hide_scroll_to_bottom_timer;
 export function hide_scroll_to_bottom() {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
+    $("#scroll-to-bottom-button-clickable-area").off("mouseenter");
+
     if (message_viewport.bottom_message_visible() || message_lists.current.visibly_empty()) {
         // If last message is visible, just hide the
         // scroll to bottom button.
         $show_scroll_to_bottom_button.removeClass("show");
+
+        $("#scroll-to-bottom-button-clickable-area").on("mouseenter", destroyTippyInstance);
+
         return;
     }
 
@@ -29,6 +44,8 @@ export function hide_scroll_to_bottom() {
             !$show_scroll_to_bottom_button.get(0).matches(":hover")
         ) {
             $show_scroll_to_bottom_button.removeClass("show");
+
+            $("#scroll-to-bottom-button-clickable-area").on("mouseenter", destroyTippyInstance);
         }
     }, 3000);
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously , when the "Scroll Button" tooltip was under transition to fade and it was hovered , the tippy tooltip did not disappear even when the button was vanished. 
This is due to the ```data-reference-hidden``` property not working as expected under animation.

Presently , the tippy instance has been explicitly destroyed while the button is under fade transition.

For future encounters , a new issue has been opened under tippyjs repository to solve the issue regarding ```data-reference-hidden``` property. Track [here](https://github.com/atomiks/tippyjs/issues/1154).
Fixes: #28656 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://github.com/zulip/zulip/assets/97145463/f895a44a-2353-4fe0-8c99-9882a73098e5

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
