### PR TITLE
activity-css: Make activity charts header row sticky.

### DIFF
--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -4,6 +4,12 @@
 
 .activity-head {
     background-color: hsl(208deg 100% 97%);
+    position: sticky;
+    top: 0;
+
+    & th {
+        border-bottom: 1px solid hsl(0deg 0% 87%);
+    }
 }
 
 .table-striped {
@@ -51,6 +57,10 @@
 
     tbody > tr:nth-child(odd) > td {
         background-color: hsl(0deg 0% 98%);
+    }
+
+    tbody tr:first-child td {
+        border-top: 0;
     }
 
     thead tr:first-child > th:first-child {


### PR DESCRIPTION
This will be applied to both the overall installation activity chart as well as the associated remote, client, realm and user views.

```console
$ git grep summary-table
templates/analytics/realm_summary_table.html:<table class="table summary-table sortable table-striped table-bordered">
web/styles/portico/activity.css:.summary-table,
$ git grep analytics-table
templates/analytics/ad_hoc_query.html:<table class="table sortable table-striped table-bordered analytics-table">
web/styles/portico/activity.css:.analytics-table {
$ git grep ad_hoc_query
analytics/views/activity_common.py:        "analytics/ad_hoc_query.html",
$ git grep make_table analytics/
analytics/views/activity_common.py:def make_table(
analytics/views/installation_activity.py:    make_table,
analytics/views/installation_activity.py:    content = make_table(title, cols, rows)
analytics/views/realm_activity.py:    make_table,
analytics/views/realm_activity.py:    content = make_table(title, cols, rows, stats_link, has_row_class=True)
analytics/views/remote_activity.py:    make_table,
analytics/views/remote_activity.py:    content = make_table(title, cols, rows)
analytics/views/user_activity.py:from analytics.views.activity_common import format_date_for_activity_reports, make_table
analytics/views/user_activity.py:    content = make_table(title, cols, rows)
```

**Screenshots and screen captures:**

<details>
<summary>Installation activity in dev environment</summary>

[Screencast from 2024-01-23 17-19-40.webm](https://github.com/zulip/zulip/assets/63245456/4dc42935-5dc3-41de-9892-38d3045ee5b3)

</details>
<details>
<summary>Remote activity in dev environment</summary>

[Screencast from 2024-01-23 17-18-44.webm](https://github.com/zulip/zulip/assets/63245456/88cde450-8233-4d86-9d52-5e7b903a1001)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
