### PR TITLE
portico: Fix up display of /plans pages.

### DIFF
--- a/templates/corporate/comparison_table_self_hosted.html
+++ b/templates/corporate/comparison_table_self_hosted.html
@@ -16,7 +16,7 @@
         <thead>
             <tr>
                 <th class="comparison-table-feature">Features</th>
-                <th>Self-<wbr />managed</th>
+                <th>Free</th>
                 <th>Basic</th>
                 <th>Busi<wbr />ness</th>
                 <th>Enter<wbr />prise</th>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -172,7 +172,7 @@
                         <div class="bottom">
                             <div class="text-content">
                                 <div class="standard-price-box">
-                                    <div class="price no-discount">Free</div>
+                                    <div class="price">Free</div>
                                 </div>
                                 {% if is_self_hosted_realm and customer_plan and customer_plan.tier == customer_plan.TIER_SELF_HOSTED_LEGACY %}
                                 <span class="button current-plan-descriptor" type="button">
@@ -205,15 +205,15 @@
                                     {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BASIC)
                                       or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Basic")
                                       or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
-                                    <div class="price no-discount"><span class="currency-symbol">$</span>3.50</div>
-                                    <div class="details no-discount singular-billing-frequency">
+                                    <div class="price"><span class="currency-symbol">$</span>3.50</div>
+                                    <div class="details">
                                         <p>
                                             /user/month billed monthly
                                         </p>
                                     </div>
                                     {% else %}
                                     <div class="price"><span class="currency-symbol">$</span>3.50</div>
-                                    <div class="details singular-billing-frequency">
+                                    <div class="details">
                                         <p>
                                             /user/month billed monthly
                                         </p>
@@ -290,7 +290,7 @@
                                     {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS)
                                       or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Business")
                                       or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
-                                    <div class="price no-discount"><span class="currency-symbol">$</span>6.67</div>
+                                    <div class="price"><span class="currency-symbol">$</span>6.67</div>
                                     <div class="details">
                                         <p>
                                             /user/month billed annually

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -287,30 +287,28 @@
                         <div class="bottom">
                             <div class="text-content">
                                 <div class="standard-price-box">
-                                    <div class="standard-price-box">
-                                        {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS)
-                                          or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Business")
-                                          or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
-                                        <div class="price no-discount"><span class="currency-symbol">$</span>6.67</div>
-                                        <div class="details">
-                                            <p>
-                                                /user/month billed annually
-                                                or&nbsp;<b>$8</b>&nbsp;billed monthly
-                                            </p>
-                                        </div>
-                                        {% else %}
-                                        <div class="price"><span class="currency-symbol">$</span>6.67</div>
-                                        <div class="details">
-                                            <p>
-                                                /user/month billed annually
-                                                or&nbsp;<b>$8</b>&nbsp;billed monthly
-                                            </p>
-                                        </div>
-                                        <div class="discount">
-                                            <b>$20/month off</b> for the first year!
-                                        </div>
-                                        {% endif %}
+                                    {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS)
+                                      or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Business")
+                                      or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
+                                    <div class="price no-discount"><span class="currency-symbol">$</span>6.67</div>
+                                    <div class="details">
+                                        <p>
+                                            /user/month billed annually
+                                            or&nbsp;<b>$8</b>&nbsp;billed monthly
+                                        </p>
                                     </div>
+                                    {% else %}
+                                    <div class="price"><span class="currency-symbol">$</span>6.67</div>
+                                    <div class="details">
+                                        <p>
+                                            /user/month billed annually
+                                            or&nbsp;<b>$8</b>&nbsp;billed monthly
+                                        </p>
+                                    </div>
+                                    <div class="discount">
+                                        <b>$20/month off</b> for the first year!
+                                    </div>
+                                    {% endif %}
                                 </div>
                                 {% if is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS %}
                                 <a href="{{ billing_base_url }}/billing/" class="button current-plan-button">

--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -73,6 +73,7 @@
 
         a {
             color: inherit;
+            text-decoration: none;
             border-bottom: 1px solid hsl(0deg 0% 100% / 50%) !important;
             transition: border 0.4s ease-out;
 

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -87,6 +87,7 @@
             transition: border 0.4s ease-out;
 
             &:hover {
+                text-decoration: none;
                 color: inherit;
                 border-bottom: 2px solid hsl(0deg 0% 100%);
                 transition: none;
@@ -147,6 +148,7 @@
 
         &:hover {
             color: var(--color-link-hover);
+            text-decoration: underline;
             text-decoration-color: var(--color-link-underline-hover);
         }
     }
@@ -322,11 +324,11 @@
             font-family: var(--font-ops);
             font-weight: 400;
             font-size: 15px;
-            line-height: 21px;
         }
 
         li {
             margin-bottom: 10px;
+            line-height: 21px;
         }
 
         .price-box {
@@ -379,6 +381,7 @@
             align-items: flex-start;
             gap: 4px;
             margin: 24px 0 6px;
+            font-weight: 400;
 
             /* For supporting browsers, constrain the height
                of the standard price box when it includes a
@@ -391,6 +394,7 @@
 
             .price {
                 font-size: 38px;
+                font-weight: 400;
                 line-height: 1;
                 letter-spacing: -1px;
             }
@@ -514,6 +518,7 @@
                 text-decoration-color: var(--color-link-underline-alternate);
 
                 &:hover {
+                    text-decoration: underline;
                     text-decoration-color: var(
                         --color-link-underline-alternate-hover
                     );
@@ -610,6 +615,7 @@
         background-color: hsl(146deg 92% 26%);
 
         &:hover {
+            text-decoration: none;
             color: hsl(0deg 0% 100%);
             background-color: hsl(146deg 92% 24%);
         }
@@ -620,6 +626,7 @@
         background-color: hsl(219deg 62% 54%);
 
         &:hover {
+            text-decoration: none;
             color: hsl(0deg 0% 100%);
             background-color: hsl(219deg 62% 50%);
         }
@@ -656,6 +663,7 @@
     }
 
     .current-plan-button:hover {
+        text-decoration: none;
         color: hsl(147deg 57% 25%);
         background-color: hsl(152deg 79% 24% / 14%);
     }
@@ -665,6 +673,7 @@
         background-color: hsl(152deg 79% 24% / 10%);
 
         &:hover {
+            text-decoration: none;
             color: hsl(147deg 57% 25%);
             background-color: hsla(146deg 92% 24% / 15%);
         }

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -29,8 +29,10 @@
     --icon-right-outward-tab-curve: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='white' d='M16 16H0V0c0 8.837 7.163 16 16 16Z'/%3e%3c/svg%3e");
     --icon-question-header-swoosh: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='33' height='56' fill='none' viewBox='0 0 33 56'%3e%3cpath fill='%23E2EBF4' d='M33 37 1 56C1 35-3.5 0 33 0 7.5 3 7.776 37 33 37Z'/%3e%3c/svg%3e");
     --icon-current-plan-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' viewBox='0 0 22 22'%3e%3cg fill='%230F8544'%3e%3cpath d='M14.396 9.813a.914.914 0 1 0-1.293-1.293l-3.02 3.02-1.186-1.186a.914.914 0 1 0-1.294 1.293l1.834 1.833a.914.914 0 0 0 1.293 0l3.666-3.667Z'/%3e%3cpath fill-rule='evenodd' d='M11 .923a4.58 4.58 0 0 0-3.495 1.62 4.581 4.581 0 0 0-4.961 4.949 4.58 4.58 0 0 0 0 7.016 4.58 4.58 0 0 0 4.96 4.949 4.583 4.583 0 0 0 7.003-.001 4.582 4.582 0 0 0 4.95-4.96 4.583 4.583 0 0 0 0-6.991 4.58 4.58 0 0 0-4.962-4.962A4.581 4.581 0 0 0 11 .923ZM9.678 3.09a2.752 2.752 0 0 1 3.64.932.914.914 0 0 0 .972.4 2.752 2.752 0 0 1 3.289 3.288.914.914 0 0 0 .4.971 2.753 2.753 0 0 1 0 4.638.914.914 0 0 0-.4.97 2.752 2.752 0 0 1-3.283 3.29.914.914 0 0 0-.97.401 2.75 2.75 0 0 1-4.644 0 .914.914 0 0 0-.971-.401 2.752 2.752 0 0 1-3.29-3.283.914.914 0 0 0-.403-.97 2.753 2.753 0 0 1 0-4.652.914.914 0 0 0 .404-.97A2.752 2.752 0 0 1 7.71 4.42a.914.914 0 0 0 .97-.4c.25-.389.592-.709.997-.93Z' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e");
+    --icon-discount-tooltip-curve: url("data:image/svg+xml,%3Csvg width='35' height='14' viewBox='0 0 35 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.4814 14C16.3229 6.40469 8.98604 0 0.5 0L34.5 0C26.0153 0 18.4853 6.40469 17.4814 14Z' fill='%23F4F9FE'/%3E%3C/svg%3E");
     --width-price-box-min: 240px;
     --width-price-box-max: 355px;
+    --height-discounted-price-box: 98px;
     --height-price-details-min: 53px;
 
     padding: 102px 0 58px;
@@ -351,6 +353,12 @@
                to the text column above. */
             .bottom {
                 padding: 0 16px;
+
+                .text-content {
+                    /* But allow buttons and price info
+                       a bit more breathing room. */
+                    padding: 0;
+                }
             }
         }
 
@@ -370,8 +378,16 @@
             flex-wrap: wrap;
             align-items: flex-start;
             gap: 4px;
-            min-height: 56px;
-            margin-top: 24px;
+            margin: 24px 0 6px;
+
+            /* For supporting browsers, constrain the height
+               of the standard price box when it includes a
+               discount. This keeps discount tooltips on the
+               same horizontal line, while also maintaining
+               alignment of non-discounted price box prices. */
+            &:has(.discount) {
+                height: var(--height-discounted-price-box);
+            }
 
             .price {
                 font-size: 38px;
@@ -402,11 +418,43 @@
                 /* Keep the discount to its own
                    line in the wrapping flexbox. */
                 flex: 0 0 100%;
+                /* But move it to the top of the
+                   flex area. */
+                order: -1;
                 text-align: center;
-                padding: 1px 0 6px;
-                margin-bottom: -5px;
-                border-radius: 4px 4px 0 0;
-                background-color: hsl(0deg 0% 85%);
+                padding: 9px 0 10px;
+                margin-bottom: 9px;
+                border-radius: 30px;
+                background-color: hsl(210deg 83% 98%);
+                position: relative;
+                font-family: var(--font-ops);
+                font-size: 15px;
+                /* Use padding to better position
+                   text within its single line. */
+                line-height: 1;
+
+                @media screen and (width <= 1240px) {
+                    /* Pad the discount balloon... */
+                    padding: 8px 5px 9px;
+                    /* But pull out the margins an equal
+                       amount so it can breathe. */
+                    margin: 0 -5px 9px;
+                }
+
+                & b {
+                    font-weight: 650;
+                }
+
+                &::after {
+                    content: "";
+                    background-image: var(--icon-discount-tooltip-curve);
+                    display: block;
+                    width: 35px;
+                    height: 14px;
+                    bottom: -14px;
+                    left: calc(50% - 17.5px);
+                    position: absolute;
+                }
             }
 
             .price,
@@ -747,6 +795,7 @@
 
             .standard-price-box {
                 --height-price-details-min: 48px;
+                --height-discounted-price-box: 91px;
 
                 .price {
                     font-size: 32px;
@@ -757,6 +806,10 @@
                         font-size: 13px;
                         line-height: 16px;
                     }
+                }
+
+                .discount {
+                    font-size: 13px;
                 }
             }
         }

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -11,8 +11,9 @@
 .portico-pricing {
     --font-ss3: "Source Sans 3 VF", sans-serif;
     --font-ops: "Open Sans Variable", sans-serif;
-    --color-background-box: hsla(210deg 44% 92%);
+    --color-background-box: hsl(210deg 44% 92%);
     --color-background-box-muted: hsl(0deg 0% 100% / 50%);
+    --color-background-box-muted-hover: hsl(0deg 0% 100% / 60%);
     --color-plan-tab-header: hsl(223deg 40% 30%);
     --color-plan-tab-copy: hsl(223deg 40% 25% / 70%);
     --color-box-header: hsl(223deg 43% 25%);
@@ -39,6 +40,8 @@
     );
 
     @media (prefers-color-scheme: dark) {
+        --color-background-box: hsl(221deg 35% 89%);
+
         background: linear-gradient(
             180deg,
             var(--color-background-gradient-start) 30%,
@@ -441,7 +444,7 @@
                 width: 32px;
                 height: 56px;
                 position: absolute;
-                background-color: hsla(210deg 44% 92%);
+                background-color: var(--color-background-box);
                 top: 30px;
                 left: -0.5px;
                 mask-position: center;
@@ -670,6 +673,10 @@
             border-radius: 16px 16px 0 14px;
             margin-bottom: 2px;
             background-color: var(--color-background-box-muted);
+
+            &:hover {
+                background-color: var(--color-background-box-muted-hover);
+            }
         }
     }
 
@@ -686,6 +693,10 @@
             border-radius: 16px 16px 14px 0;
             margin-bottom: 2px;
             background-color: var(--color-background-box-muted);
+
+            &:hover {
+                background-color: var(--color-background-box-muted-hover);
+            }
         }
 
         .self-hosted-plan-title {

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -29,8 +29,9 @@
     --icon-right-outward-tab-curve: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='white' d='M16 16H0V0c0 8.837 7.163 16 16 16Z'/%3e%3c/svg%3e");
     --icon-question-header-swoosh: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='33' height='56' fill='none' viewBox='0 0 33 56'%3e%3cpath fill='%23E2EBF4' d='M33 37 1 56C1 35-3.5 0 33 0 7.5 3 7.776 37 33 37Z'/%3e%3c/svg%3e");
     --icon-current-plan-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' viewBox='0 0 22 22'%3e%3cg fill='%230F8544'%3e%3cpath d='M14.396 9.813a.914.914 0 1 0-1.293-1.293l-3.02 3.02-1.186-1.186a.914.914 0 1 0-1.294 1.293l1.834 1.833a.914.914 0 0 0 1.293 0l3.666-3.667Z'/%3e%3cpath fill-rule='evenodd' d='M11 .923a4.58 4.58 0 0 0-3.495 1.62 4.581 4.581 0 0 0-4.961 4.949 4.58 4.58 0 0 0 0 7.016 4.58 4.58 0 0 0 4.96 4.949 4.583 4.583 0 0 0 7.003-.001 4.582 4.582 0 0 0 4.95-4.96 4.583 4.583 0 0 0 0-6.991 4.58 4.58 0 0 0-4.962-4.962A4.581 4.581 0 0 0 11 .923ZM9.678 3.09a2.752 2.752 0 0 1 3.64.932.914.914 0 0 0 .972.4 2.752 2.752 0 0 1 3.289 3.288.914.914 0 0 0 .4.971 2.753 2.753 0 0 1 0 4.638.914.914 0 0 0-.4.97 2.752 2.752 0 0 1-3.283 3.29.914.914 0 0 0-.97.401 2.75 2.75 0 0 1-4.644 0 .914.914 0 0 0-.971-.401 2.752 2.752 0 0 1-3.29-3.283.914.914 0 0 0-.403-.97 2.753 2.753 0 0 1 0-4.652.914.914 0 0 0 .404-.97A2.752 2.752 0 0 1 7.71 4.42a.914.914 0 0 0 .97-.4c.25-.389.592-.709.997-.93Z' clip-rule='evenodd'/%3e%3c/g%3e%3c/svg%3e");
-    --width-price-box-min: 285px;
+    --width-price-box-min: 240px;
     --width-price-box-max: 355px;
+    --height-price-details-min: 53px;
 
     padding: 102px 0 58px;
     background: linear-gradient(
@@ -279,7 +280,7 @@
         /* We use the plan count on the respective `.showing-` class
            to determine a minimum width, at which point the plans scroll. */
         min-width: calc(var(--count-plans) * var(--width-price-box-min));
-        padding: 20px;
+        padding: 20px 5px;
         border-radius: 16px;
         color: var(--color-box-copy);
         background: var(--color-background-box);
@@ -410,12 +411,10 @@
 
             .price,
             .details {
-                &.no-discount {
-                    /* Pad prices that do not have
-                       a discount (e.g., Free, or a
-                       customer's current plan). */
-                    padding-bottom: 25px;
-                }
+                /* Preserve a height for allowing
+                   price details to wrap as many
+                   as three lines. */
+                min-height: var(--height-price-details-min);
             }
         }
     }
@@ -740,7 +739,60 @@
         }
     }
 
+    @media screen and (width <= 1140px) {
+        .self-hosted-plan-pricing {
+            ul {
+                font-size: 14px;
+            }
+
+            .standard-price-box {
+                --height-price-details-min: 48px;
+
+                .price {
+                    font-size: 32px;
+                }
+
+                .details {
+                    p {
+                        font-size: 13px;
+                        line-height: 16px;
+                    }
+                }
+            }
+        }
+    }
+
     @media screen and (width <= 940px) {
+        /* This block of styles duplicates the adjustments
+           to .self-hosted-plan-pricing above; because of the
+           fewer number of Cloud plans, we don't need these
+           adjustments until this breakpoint. */
+        .cloud-plan-pricing {
+            ul {
+                font-size: 14px;
+            }
+
+            .standard-price-box {
+                --height-price-details-min: 48px;
+                --height-discounted-price-box: 91px;
+
+                .price {
+                    font-size: 32px;
+                }
+
+                .details {
+                    p {
+                        font-size: 13px;
+                        line-height: 16px;
+                    }
+                }
+
+                .discount {
+                    font-size: 13px;
+                }
+            }
+        }
+
         h1 {
             font-size: 40px;
         }
@@ -749,19 +801,28 @@
             font-size: 16px;
         }
 
-        .pricing-tab h2 {
-            font-size: 24px;
-            line-height: 26px;
-            margin-bottom: 0;
+        .pricing-tab {
+            h2 {
+                font-size: 24px;
+                line-height: 26px;
+                margin-bottom: 5px;
+            }
+
+            p {
+                font-size: 14px;
+                padding-bottom: 10px;
+            }
         }
 
-        .pricing-pane h2 {
-            font-size: 22px;
-            margin: 4px 0 12px;
+        .pricing-pane {
+            h2 {
+                font-size: 22px;
+                margin: 4px 0 12px;
+            }
         }
     }
 
-    @media screen and (width <= 900px) {
+    @media screen and (width <= 920px) {
         .additional-pricing-information header h2 {
             font-size: 24px;
         }

--- a/web/styles/portico/pricing_plans.css
+++ b/web/styles/portico/pricing_plans.css
@@ -407,11 +407,6 @@
                     font-size: 15px;
                     line-height: 17px;
                 }
-
-                &.singular-billing-frequency {
-                    align-self: flex-end;
-                    margin-bottom: 5px;
-                }
             }
 
             .discount {


### PR DESCRIPTION
This PR includes numerous fixes and improvements to the /plans page, including:

* Cleaning up structures and unused CSS
* Opening up the available width for plans panes for better line-wrapping
* Implementing finer details (font-sizing, hovers, minor dark-mode adjustments) from @terpimost's original design
* Adding a tooltip-style discount balloon on self-hosted plans
* Ensuring concord in the plans presentations between `/plans` and `/for/business`

This work began as a small set of prep commits for the scrolling controls, but got large enough to warrant its own preparatory PR.

**Screenshots and screen captures:**

| Large screens, before (`/plans`) | Large screens, after (`/plans`) |
| --- | --- |
| ![plans-cloud-before](https://github.com/zulip/zulip/assets/170719/dd908b21-e9fe-409c-9354-a7f39e3e40a0) | ![plans-cloud-after](https://github.com/zulip/zulip/assets/170719/38259c74-7624-4302-9781-f946d2ac770c) |
| ![plans-self-hosted-before](https://github.com/zulip/zulip/assets/170719/8b65699e-54ee-4444-86ef-64942450f8f2) | ![plans-self-hosted-after](https://github.com/zulip/zulip/assets/170719/649168da-eec1-4c58-9637-f577fba94ca8) |

| Small screens, before (`/plans`) | Small screens, after (`/plans`) |
| --- | --- |
| ![small-cloud-before](https://github.com/zulip/zulip/assets/170719/38398d75-3ca0-4fa1-a6cf-7be140678871) | ![small-cloud-after](https://github.com/zulip/zulip/assets/170719/6333ce4b-f16c-46b7-88c4-0558eb10a79d) |
| ![small-self-hosted-before](https://github.com/zulip/zulip/assets/170719/2c41e5a6-02e3-4d11-ac3e-19ca46efc1ca) | ![small-self-hosted-after](https://github.com/zulip/zulip/assets/170719/18a85a65-6f5f-476e-8763-979bc6f366d2) |

There were numerous subtle differences between the presentation of plans on `/plans` and `/for/business`. The first set of images are before comparisons on Zulip Cloud and Self-hosted panes, and the second set is after comparisons, where differences are negligible:

| `/plans` Before | `/for/business` Before |
| --- | --- |
| ![plans-cloud-before](https://github.com/zulip/zulip/assets/170719/bb6c91b2-bd4e-450b-87da-ae88a7fe6971) | ![for-business-cloud-before](https://github.com/zulip/zulip/assets/170719/aff3e533-f7ec-4ea6-b692-9a9b54168c56) |
| ![plans-self-hosted-before](https://github.com/zulip/zulip/assets/170719/56d2b5d7-9afb-4032-879a-d72a011adabc) | ![for-business-self-hosted-before](https://github.com/zulip/zulip/assets/170719/466758da-de69-42c3-beaa-bd04310baeef) |

| `/plans` After | `/for/business` After |
| --- | --- |
| ![plans-cloud-after](https://github.com/zulip/zulip/assets/170719/5a24dbdb-0c4e-4bd2-9aee-6a7bdac25f47) | ![for-business-cloud-after](https://github.com/zulip/zulip/assets/170719/2966abc2-905b-4675-a3bd-08063112e5a3) |
| ![plans-self-hosted-after](https://github.com/zulip/zulip/assets/170719/ec36f73d-b8d4-421c-9a4f-dd139f66d86c) | ![for-business-self-hosted-after](https://github.com/zulip/zulip/assets/170719/5e3df726-3d90-45a4-b6d8-6311e07acbf8) |




