### PR TITLE
settings: Deduplicate show and hide spinner functions.

### DIFF
--- a/web/src/alert_words_ui.ts
+++ b/web/src/alert_words_ui.ts
@@ -8,6 +8,7 @@ import * as channel from "./channel";
 import * as dialog_widget from "./dialog_widget";
 import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
+import * as loading from "./loading";
 import * as ui_report from "./ui_report";
 
 export let loaded = false;
@@ -54,7 +55,8 @@ function add_alert_word(): void {
             $t({defaultMessage: "Alert word already exists!"}),
             $("#dialog_error"),
         );
-        dialog_widget.hide_dialog_spinner();
+        const $button = $("#dialog_widget_modal .modal__btn");
+        loading.hide_spinner($button);
         return;
     }
 

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -79,24 +79,6 @@ export function hide_dialog_spinner(): void {
     loading.destroy_indicator($spinner);
 }
 
-export function show_dialog_spinner(): void {
-    // Disable both the buttons.
-    $("#dialog_widget_modal .modal__btn").prop("disabled", true);
-
-    const $spinner = $("#dialog_widget_modal .modal__spinner");
-    const dialog_submit_button_span_width = $(".dialog_submit_button span").width();
-    const dialog_submit_button_span_height = $(".dialog_submit_button span").height();
-
-    // Hide the submit button after computing its height, since submit
-    // buttons with long text might affect the size of the button.
-    $(".dialog_submit_button span").hide();
-
-    loading.make_indicator($spinner, {
-        width: dialog_submit_button_span_width,
-        height: dialog_submit_button_span_height,
-    });
-}
-
 // Supports a callback to be called once the modal finishes closing.
 export function close(on_hidden_callback?: () => void): void {
     modals.close("dialog_widget_modal", {on_hidden: on_hidden_callback});
@@ -202,7 +184,8 @@ export function launch(conf: DialogWidgetConfig): void {
             return;
         }
         if (conf.loading_spinner) {
-            show_dialog_spinner();
+            const $button = $("#dialog_widget_modal .modal__btn");
+            loading.show_spinner($button);
         } else if (conf.close_on_submit) {
             close();
         }
@@ -236,7 +219,8 @@ export function submit_api_request(
         error_continuation,
     }: RequestOpts = {},
 ): void {
-    show_dialog_spinner();
+    const $button = $("#dialog_widget_modal .modal__btn");
+    loading.show_spinner($button);
     void request_method({
         url,
         data,

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -71,14 +71,6 @@ type RequestOpts = {
     error_continuation?: Parameters<AjaxRequestHandler>[0]["error"];
 };
 
-export function hide_dialog_spinner(): void {
-    $(".dialog_submit_button span").show();
-    $("#dialog_widget_modal .modal__btn").prop("disabled", false);
-
-    const $spinner = $("#dialog_widget_modal .modal__spinner");
-    loading.destroy_indicator($spinner);
-}
-
 // Supports a callback to be called once the modal finishes closing.
 export function close(on_hidden_callback?: () => void): void {
     modals.close("dialog_widget_modal", {on_hidden: on_hidden_callback});
@@ -232,7 +224,7 @@ export function submit_api_request(
         },
         error(xhr, error_type, xhn) {
             ui_report.error(failure_msg_html, xhr, $("#dialog_error"));
-            hide_dialog_spinner();
+            loading.hide_spinner($button);
             if (error_continuation !== undefined) {
                 error_continuation(xhr, error_type, xhn);
             }

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -109,3 +109,10 @@ export function show_spinner($button: JQuery): void {
         height: dialog_submit_button_span_height,
     });
 }
+
+export function hide_spinner($button: JQuery): void {
+    const $spinner = $button.find(".modal__spinner");
+    $button.prop("disabled", false);
+    $button.find("span").show();
+    destroy_indicator($spinner);
+}

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -92,3 +92,20 @@ export function show_button_spinner($elt: JQuery, using_dark_theme: boolean): vo
     }
     $elt.css("display", "inline-block");
 }
+
+// For showing spinners at dialog_widget and user_profile.
+export function show_spinner($button: JQuery): void {
+    const $spinner = $button.find(".modal__spinner");
+    const dialog_submit_button_span_width = $button.find("span").width();
+    const dialog_submit_button_span_height = $button.find("span").height();
+
+    // Disable buttons.
+    $button.prop("disabled", true);
+    $button.find("span").hide();
+
+    // Show spinner.
+    make_indicator($spinner, {
+        width: dialog_submit_button_span_width,
+        height: dialog_submit_button_span_height,
+    });
+}

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1160,7 +1160,8 @@ export function delete_message(msg_id) {
                 currently_deleting_messages = currently_deleting_messages.filter(
                     (id) => id !== msg_id,
                 );
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
                 dialog_widget.close();
             },
             error(xhr) {
@@ -1168,7 +1169,8 @@ export function delete_message(msg_id) {
                     (id) => id !== msg_id,
                 );
 
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
                 ui_report.error(
                     $t_html({defaultMessage: "Error deleting message"}),
                     xhr,
@@ -1269,7 +1271,8 @@ export function move_topic_containing_message_to_stream(
         currently_topic_editing_messages = currently_topic_editing_messages.filter(
             (id) => id !== message_id,
         );
-        dialog_widget.hide_dialog_spinner();
+        const $button = $("#dialog_widget_modal .modal__btn");
+        loading.hide_spinner($button);
     }
     if (currently_topic_editing_messages.includes(message_id)) {
         ui_report.client_error(

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -17,6 +17,7 @@ import * as custom_profile_fields_ui from "./custom_profile_fields_ui";
 import * as dialog_widget from "./dialog_widget";
 import {$t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
+import * as loading from "./loading";
 import * as modals from "./modals";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -494,7 +495,8 @@ export function set_up() {
                 dialog_widget.close();
             },
             error_continuation() {
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
                 channel.set_password_change_in_progress(false);
             },
             $error_msg_element: $change_password_error,
@@ -543,7 +545,8 @@ export function set_up() {
                 dialog_widget.close();
             },
             error_continuation() {
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
             },
             $error_msg_element: $change_email_error,
             success_msg_html: $t_html(
@@ -602,7 +605,8 @@ export function set_up() {
                 dialog_widget.close();
             },
             error_continuation() {
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
             },
             $error_msg_element: $change_email_error,
             success_msg_html: $t_html(
@@ -704,7 +708,8 @@ export function set_up() {
             channel.del({
                 url: "/json/users/me",
                 success() {
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                     dialog_widget.close();
                     window.location.href = "/login/";
                 },
@@ -732,7 +737,8 @@ export function set_up() {
                             rendered_error_msg = error_last_user;
                         }
                     }
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                     dialog_widget.close();
                     $("#account-settings-status")
                         .addClass("alert-error")

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -15,6 +15,7 @@ import * as dialog_widget from "./dialog_widget";
 import {$t, $t_html} from "./i18n";
 import * as integration_url_modal from "./integration_url_modal";
 import * as list_widget from "./list_widget";
+import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_data from "./settings_data";
@@ -249,7 +250,8 @@ export function add_a_new_bot() {
             },
             error(xhr) {
                 ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
             },
         });
     }
@@ -388,7 +390,8 @@ export function set_up() {
                 },
                 error(xhr) {
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                 },
             });
         }

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -232,7 +232,8 @@ function show_modal(): void {
                 },
                 error(xhr) {
                     $("#dialog_error").hide();
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $emoji_status);
                 },
             });
@@ -247,7 +248,8 @@ function show_modal(): void {
                 $t_html({defaultMessage: "Failed: Emoji name is required."}),
                 $emoji_status,
             );
-            dialog_widget.hide_dialog_spinner();
+            const $button = $("#dialog_widget_modal .modal__btn");
+            loading.hide_spinner($button);
             return;
         }
 
@@ -258,7 +260,8 @@ function show_modal(): void {
                 }),
                 $emoji_status,
             );
-            dialog_widget.hide_dialog_spinner();
+            const $button = $("#dialog_widget_modal .modal__btn");
+            loading.hide_spinner($button);
             return;
         }
 
@@ -278,7 +281,8 @@ function show_modal(): void {
                     }),
                     $emoji_status,
                 );
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
                 return;
             }
 

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -214,7 +214,8 @@ function show_modal(): void {
     const html_body = render_add_emoji({});
 
     function add_custom_emoji(): void {
-        dialog_widget.show_dialog_spinner();
+        const $button = $("#dialog_widget_modal .modal__btn");
+        loading.show_spinner($button);
 
         const $emoji_status = $("#dialog_error");
         const emoji: Record<string, string> = {};

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -191,7 +191,8 @@ function show_add_default_streams_modal() {
                         xhr,
                         $("#dialog_error"),
                     );
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                 },
             });
         }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -13,6 +13,7 @@ import * as dialog_widget from "./dialog_widget";
 import * as dropdown_widget from "./dropdown_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
+import * as loading from "./loading";
 import * as message_edit from "./message_edit";
 import * as message_lists from "./message_lists";
 import * as popover_menus from "./popover_menus";
@@ -460,7 +461,8 @@ export async function build_move_topic_to_stream_popover(
             return;
         }
 
-        dialog_widget.show_dialog_spinner();
+        const $button = $("#dialog_widget_modal .modal__btn");
+        loading.show_spinner($button);
         message_edit.with_first_message_id(
             current_stream_id,
             old_topic_name,

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -477,7 +477,8 @@ export async function build_move_topic_to_stream_popover(
                 );
             },
             (xhr) => {
-                dialog_widget.hide_dialog_spinner();
+                const $button = $("#dialog_widget_modal .modal__btn");
+                loading.hide_spinner($button);
                 ui_report.error(
                     $t_html({defaultMessage: "Error moving topic"}),
                     xhr,

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -181,7 +181,8 @@ function bulk_update_read_flags_for_narrow(narrow, op, args = {}) {
                     body: xhr.responseText,
                 });
             }
-            dialog_widget.hide_dialog_spinner();
+            const $button = $("#dialog_widget_modal .modal__btn");
+            loading.hide_spinner($button);
         },
     });
 }

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -21,6 +21,7 @@ import {show_copied_confirmation} from "./copied_tooltip";
 import * as dialog_widget from "./dialog_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
+import * as loading from "./loading";
 import * as message_lists from "./message_lists";
 import * as muted_users from "./muted_users";
 import * as narrow from "./narrow";
@@ -729,7 +730,8 @@ function register_click_handlers() {
                 },
                 error(xhr) {
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
-                    dialog_widget.hide_dialog_spinner();
+                    const $button = $("#dialog_widget_modal .modal__btn");
+                    loading.hide_spinner($button);
                 },
             });
         }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -51,18 +51,6 @@ const INCOMING_WEBHOOK_BOT_TYPE = 2;
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const EMBEDDED_BOT_TYPE = "4";
 
-export function show_button_spinner($button) {
-    const $spinner = $button.find(".modal__spinner");
-    const dialog_submit_button_span_width = $button.find("span").width();
-    const dialog_submit_button_span_height = $button.find("span").height();
-    $button.prop("disabled", true);
-    $button.find("span").hide();
-    loading.make_indicator($spinner, {
-        width: dialog_submit_button_span_width,
-        height: dialog_submit_button_span_height,
-    });
-}
-
 export function hide_button_spinner($button) {
     const $spinner = $button.find(".modal__spinner");
     $button.prop("disabled", false);
@@ -544,7 +532,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
 
         const $submit_btn = $("#user-profile-modal .dialog_submit_button");
         const $cancel_btn = $("#user-profile-modal .dialog_exit_button");
-        show_button_spinner($submit_btn);
+        loading.show_spinner($submit_btn);
         $cancel_btn.prop("disabled", true);
 
         channel.patch({
@@ -790,7 +778,7 @@ export function show_edit_user_info_modal(user_id, $container) {
 
         const $submit_btn = $("#user-profile-modal .dialog_submit_button");
         const $cancel_btn = $("#user-profile-modal .dialog_exit_button");
-        show_button_spinner($submit_btn);
+        loading.show_spinner($submit_btn);
         $cancel_btn.prop("disabled", true);
 
         channel.patch({


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Factors out the `dialog_widget.show_dialog_spinner`, `dialog_widget.hide_dialog_spinner` and
`user_profile.show_button_spinner`, `user_profile.hide_button_spinner` into the common
`loading.ts` module with names `show_spinner()` and `hide_spinner()`.

They take in a **JQuery button** object as the argument on which the spinner has to be shown.

```ts

// loading.ts
export function show_spinner($button: JQuery): void {
    // ...
}

export function hide_spinner($button: JQuery): void {
    // ...
}

```

Replaced the function invocations in different modules accordingly.

Fixes: #26691 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
