### PR TITLE
activity: Add totals row as sticky footer to activity charts.

### DIFF
--- a/analytics/views/activity_common.py
+++ b/analytics/views/activity_common.py
@@ -31,6 +31,8 @@ def make_table(
     title: str,
     cols: Sequence[str],
     rows: Sequence[Any],
+    *,
+    totals: Optional[Any] = None,
     stats_link: Optional[Markup] = None,
     has_row_class: bool = False,
 ) -> str:
@@ -41,7 +43,7 @@ def make_table(
 
         rows = list(map(fix_row, rows))
 
-    data = dict(title=title, cols=cols, rows=rows, stats_link=stats_link)
+    data = dict(title=title, cols=cols, rows=rows, totals=totals, stats_link=stats_link)
 
     content = loader.render_to_string(
         "analytics/ad_hoc_query.html",

--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -23,6 +23,7 @@ from analytics.views.activity_common import (
     realm_url_link,
 )
 from analytics.views.support import get_plan_type_string
+from corporate.lib.stripe import cents_to_dollar_string
 from zerver.decorator import require_server_admin
 from zerver.lib.request import has_request_variables
 from zerver.models import Realm
@@ -210,7 +211,7 @@ def realm_summary_table() -> str:
             string_id = row["string_id"]
 
             if string_id in estimated_arrs:
-                row["arr"] = estimated_arrs[string_id]
+                row["arr"] = f"${cents_to_dollar_string(estimated_arrs[string_id])}"
 
             if row["plan_type"] in [Realm.PLAN_TYPE_STANDARD, Realm.PLAN_TYPE_PLUS]:
                 row["effective_rate"] = 100 - int(realms_with_default_discount.get(string_id, 0))
@@ -250,28 +251,34 @@ def realm_summary_table() -> str:
         total_bot_count += int(row["bot_count"])
         total_wau_count += int(row["wau_count"])
 
-    total_row = dict(
-        string_id="Total",
-        plan_type_string="",
-        org_type_string="",
-        effective_rate="",
-        arr=total_arr,
-        realm_url="",
-        stats_link="",
-        support_link="",
-        date_created_day="",
-        dau_count=total_dau_count,
-        user_profile_count=total_user_profile_count,
-        bot_count=total_bot_count,
-        wau_count=total_wau_count,
-    )
-
-    rows.insert(0, total_row)
+    total_row = [
+        "Total",
+        "",
+        "",
+        "",
+        f"${cents_to_dollar_string(total_arr)}",
+        "",
+        "",
+        total_dau_count,
+        total_wau_count,
+        total_user_profile_count,
+        total_bot_count,
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    ]
 
     content = loader.render_to_string(
         "analytics/realm_summary_table.html",
         dict(
             rows=rows,
+            totals=total_row,
             num_active_sites=num_active_sites,
             utctime=now.strftime("%Y-%m-%d %H:%M %Z"),
             billing_enabled=settings.BILLING_ENABLED,

--- a/analytics/views/realm_activity.py
+++ b/analytics/views/realm_activity.py
@@ -145,7 +145,7 @@ def realm_user_summary_table(
         return row["cells"][4]
 
     rows = sorted(rows, key=by_last_heard_from, reverse=True)
-    content = make_table(title, cols, rows, stats_link, has_row_class=True)
+    content = make_table(title, cols, rows, stats_link=stats_link, has_row_class=True)
     return content
 
 

--- a/analytics/views/remote_activity.py
+++ b/analytics/views/remote_activity.py
@@ -214,9 +214,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             total_row.append(str(sum(row[i] for row in rows if row[i] is not None)))
         else:
             total_row.append("")
-    rows.insert(0, total_row)
 
-    content = make_table(title, cols, rows)
+    content = make_table(title, cols, rows, totals=total_row)
     return render(
         request,
         "analytics/activity_details_template.html",

--- a/corporate/lib/analytics.py
+++ b/corporate/lib/analytics.py
@@ -70,7 +70,7 @@ def estimate_annual_recurring_revenue_by_realm() -> Dict[str, int]:  # nocoverag
         ).get_customer_plan_renewal_amount(plan, latest_ledger_entry)
         if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
             renewal_cents *= 12
-        annual_revenue[plan.customer.realm.string_id] = int(renewal_cents / 100)
+        annual_revenue[plan.customer.realm.string_id] = renewal_cents
     return annual_revenue
 
 

--- a/templates/analytics/ad_hoc_query.html
+++ b/templates/analytics/ad_hoc_query.html
@@ -23,4 +23,11 @@
         </tr>
         {% endfor %}
     </tbody>
+    {% if data.totals %}
+    <tfoot class="activity-foot">
+        {% for total in data.totals %}
+        <td>{{ total }}</td>
+        {% endfor %}
+    </tfoot>
+    {% endif %}
 </table>

--- a/templates/analytics/realm_summary_table.html
+++ b/templates/analytics/realm_summary_table.html
@@ -121,5 +121,9 @@
         </tr>
         {% endfor %}
     </tbody>
-
+    <tfoot class="activity-foot">
+        {% for total in totals %}
+        <td>{{ total }}</td>
+        {% endfor %}
+    </tfoot>
 </table>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -12,6 +12,13 @@
     }
 }
 
+.activity-foot {
+    background-color: hsl(208deg 100% 97%);
+    font-weight: 700;
+    position: sticky;
+    bottom: 0;
+}
+
 .table-striped {
     & tr.recently_active {
         & td {


### PR DESCRIPTION
Updates the total row for the installation and remote activity charts to be in the table footer. Makes the footer class sticky to the bottom of the view so that it is always visible even if the chart has many rows.

Also, updates the installation activity column for revenue (ARR) to be formatted as a dollar string, since this formatting was being applied in the updated total row.

**Notes**:
- Tried to add an extra row to the header, but this meant the columns were no longer sortable with the current module that's being used.

@karlstolley and @alya - Would be good to get your feedback on these changes. Thanks!

**Screenshots and screen captures:**

<details>
<summary>Activity view - for revenue string formatting</summary>

![Screenshot from 2024-01-25 16-11-06](https://github.com/zulip/zulip/assets/63245456/7c70bf52-ed58-4f0b-8bee-ad0d820b2f78)
</details>

<details>
<summary>Remote activity - with chart key visible</summary>

![Screenshot from 2024-01-24 18-03-41](https://github.com/zulip/zulip/assets/63245456/b02f51bf-6948-4437-bac6-f458a148c1bb)
</details>
<details>
<summary>Remote activity - scrolled down on page</summary>

![Screenshot from 2024-01-24 18-03-50](https://github.com/zulip/zulip/assets/63245456/a82edb9a-34c7-4746-a7f8-33e924548bb8)
</details>
<details>
<summary>Screencast of scrolling in remote activity view</summary>

[Screencast from 2024-01-24 18-04-01.webm](https://github.com/zulip/zulip/assets/63245456/e433b3e2-354b-4677-99df-28bdb67b85b9)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
