### PR TITLE
puppet: statuspage-pusher uses zulip.conf for page_id.

### DIFF
--- a/puppet/zulip_ops/files/statuspage-pusher
+++ b/puppet/zulip_ops/files/statuspage-pusher
@@ -61,7 +61,7 @@ def main() -> None:
     config_file.read("/etc/zulip/zulip.conf")
     page_id = config_file.get("statuspage", "page_id")
     if page_id is None:
-        raise RuntimeError("statuspage_page_id secret is required")
+        raise RuntimeError("statuspage.page_id in zulip.conf is required")
 
     metrics_file = configparser.RawConfigParser()
     metrics_file.read("/etc/zulip/statuspage.conf")

--- a/puppet/zulip_ops/manifests/statuspage.pp
+++ b/puppet/zulip_ops/manifests/statuspage.pp
@@ -13,7 +13,6 @@ class zulip_ops::statuspage {
     source => 'puppet:///modules/zulip_ops/statuspage-pusher',
   }
 
-  $page_id = zulipsecret('secrets','statuspage_page_id','')
   file { "${zulip::common::supervisor_conf_dir}/statuspage-pusher.conf":
     ensure  => file,
     require => [


### PR DESCRIPTION
This was changed midway through the implementation, from reading it from `zulip-secrets.conf`, and a couple locations still reference the secrets path.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
