### PR TITLE
Remove bootstrap css for `btn-link` elements.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2811,6 +2811,18 @@ select.invite-as {
     vertical-align: bottom;
 }
 
+.invite-stream-controls button {
+    color: hsl(207.79deg 56.2% 52.55%);
+    background-color: transparent;
+
+    &:focus,
+    &:hover {
+        color: hsl(207.78deg 56.25% 37.65%);
+        text-decoration: underline;
+        background-color: transparent;
+    }
+}
+
 #invite-stream-checkboxes {
     & i.zulip-icon-globe {
         font-size: 80%;

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -80,8 +80,8 @@
             </div>
             {{/if}}
             <div class="invite-stream-controls">
-                <button class="btn btn-link" type="button" id="invite_check_all_button">{{t "Check all" }}</button> |
-                <button class="btn btn-link" type="button" id="invite_uncheck_all_button">{{t "Uncheck all" }}</button>
+                <button class="btn" type="button" id="invite_check_all_button">{{t "Check all" }}</button> |
+                <button class="btn" type="button" id="invite_uncheck_all_button">{{t "Uncheck all" }}</button>
             </div>
             <div id="invite-stream-checkboxes" class="new-style">
                 {{#each streams}}

--- a/web/third/bootstrap/css/bootstrap-btn.css
+++ b/web/third/bootstrap/css/bootstrap-btn.css
@@ -185,33 +185,3 @@ THE SOFTWARE.
   color: #d9534f;
   background-color: #fff;
 }
-.btn-link {
-  font-weight: normal;
-  color: #428bca;
-  cursor: pointer;
-  border-radius: 0;
-}
-.btn-link,
-.btn-link:active,
-.btn-link[disabled] {
-  background-color: transparent;
-  -webkit-box-shadow: none;
-          box-shadow: none;
-}
-.btn-link,
-.btn-link:hover,
-.btn-link:focus,
-.btn-link:active {
-  border-color: transparent;
-}
-.btn-link:hover,
-.btn-link:focus {
-  color: #2a6496;
-  text-decoration: underline;
-  background-color: transparent;
-}
-.btn-link[disabled]:hover,
-.btn-link[disabled]:focus {
-  color: #999;
-  text-decoration: none;
-}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to re-add bootstrap CSS for `btn-link` elements in invite modal.
- Second commit removes bootstrap CSS rules for `btn-link` elements.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
