### PR TITLE
help: Clarify that newsletter only goes to Zulip Cloud users.

### DIFF
--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -118,11 +118,13 @@ feel excessive.
 ## Low-traffic newsletter
 
 Zulip sends out a low-traffic newsletter (expect 2-4 emails a year)
-announcing major changes in Zulip.
+to Zulip Cloud users announcing major changes in Zulip.
 
 ### Managing your newsletter subscription
 
 {start_tabs}
+
+{tab|zulip-cloud}
 
 {settings_tab|notifications}
 


### PR DESCRIPTION
Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/setting.20to.20manage.20newsletter/near/1726656

Current: https://zulip.com/help/email-notifications#low-traffic-newsletter

Updated:
<img width="853" alt="Screenshot 2024-01-26 at 9 38 35 AM" src="https://github.com/zulip/zulip/assets/2090066/82c295d0-01bf-4339-8194-962e7f9afcd1">
