### PR TITLE
[WIP] Make it possible to split long messages

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1385,24 +1385,29 @@ def check_send_message(
     read_by_sender: bool = False,
 ) -> SentMessageResult:
     addressee = Addressee.legacy_build(sender, recipient_type_name, message_to, topic_name)
+    pieces = message_content.split("\n\n\n")
+    message_split = [s for s in pieces if s]
+    messages_to_send = []
     try:
-        message = check_message(
-            sender,
-            client,
-            addressee,
-            message_content,
-            realm,
-            forged,
-            forged_timestamp,
-            forwarder_user_profile,
-            local_id,
-            sender_queue_id,
-            widget_content,
-            skip_stream_access_check=skip_stream_access_check,
-        )
+        for message_content in message_split:
+            message = check_message(
+                sender,
+                client,
+                addressee,
+                message_content,
+                realm,
+                forged,
+                forged_timestamp,
+                forwarder_user_profile,
+                local_id,
+                sender_queue_id,
+                widget_content,
+                skip_stream_access_check=skip_stream_access_check,
+            )
+            messages_to_send.append(message)
     except ZephyrMessageAlreadySentError as e:
         return SentMessageResult(message_id=e.message_id)
-    return do_send_messages([message], mark_as_read=[sender.id] if read_by_sender else [])[0]
+    return do_send_messages(messages_to_send, mark_as_read=[sender.id] if read_by_sender else [])[0]
 
 
 def send_rate_limited_pm_notification_to_bot_owner(


### PR DESCRIPTION
[WIP] Long messages can be split upon encountering two blank lines

Fixes: #28626 



**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/88523649/8c571e62-9a32-4106-86c5-99bded46bd7a)
![image](https://github.com/zulip/zulip/assets/88523649/f65539cb-9bed-4691-aa8f-2510a6623bea)

The message splits at the desired points.

Presently I have applied the changes only to the ```check_send_message``` function in ```zerver/actions/message_send.py```.
I have divided the entire work into the following sub-tasks:

- [ ] Apply message splitting logic to every place where ```do_send_messages``` is called.
- [ ] Add an option in the UI to enable message splitting.
- [ ] Store the choice made by the user (whether to split messages or not)

Please review and provide feedback.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
