### PR TITLE
bootstrap: Remove "bootstrap.btn" classes from support view buttons.

### DIFF
--- a/templates/analytics/current_plan_forms_support.html
+++ b/templates/analytics/current_plan_forms_support.html
@@ -6,7 +6,7 @@
         <option value="charge_automatically" {% if current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
         <option value="send_invoice" {% if not current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 
 {% if current_plan.end_date and current_plan.status == current_plan.ACTIVE %}
@@ -15,7 +15,7 @@
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <input type="date" name="plan_end_date" value="{{ current_plan.end_date.strftime('%Y-%m-%d') }}" required />
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 {% endif %}
 
@@ -29,5 +29,5 @@
         <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
         <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Modify</button>
+    <button type="submit" class="support-submit-button">Modify</button>
 </form>

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -38,14 +38,14 @@
         <option value="active" {% if not realm.deactivated %}selected{% endif %}>Active</option>
         <option value="deactivated" {% if realm.deactivated %}selected{% endif %}>Deactivated</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 <form method="POST">
     <b>New subdomain</b>:<br />
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <input type="text" name="new_subdomain" required />
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 <form method="POST">
     <b>Org type</b>:<br />
@@ -58,7 +58,7 @@
             </option>
         {% endfor %}
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 <form method="POST" class="support-plan-type-form">
     <b>Plan type</b>:<br />
@@ -71,7 +71,7 @@
         <option value="4" {% if realm.plan_type == 4 %}selected{% endif %}>Standard Free</option>
         <option value="10" {% if realm.plan_type == 10 %}selected{% endif %}>Plus</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 <form method="POST" class="sponsorship-pending-form">
     <b>Sponsorship pending</b>:<br />
@@ -81,7 +81,7 @@
         <option value="true" {% if plan_data[realm.id].customer and plan_data[realm.id].customer.sponsorship_pending %}selected{% endif %}>Yes</option>
         <option value="false" {% if not plan_data[realm.id].customer or not plan_data[realm.id].customer.sponsorship_pending %}selected{% endif %}>No</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 
 {% if plan_data[realm.id].customer and plan_data[realm.id].customer.sponsorship_pending %}
@@ -89,7 +89,7 @@
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <input type="hidden" name="approve_sponsorship" value="true" />
-    <button class="btn btn-default sea-green small approve-sponsorship-button">
+    <button class="approve-sponsorship-button">
         Approve full sponsorship
     </button>
     (will email organization owners).
@@ -102,10 +102,10 @@
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     {% if plan_data[realm.id].current_plan and plan_data[realm.id].current_plan.fixed_price %}
     <input type="number" name="discount" value="{{ format_discount(get_discount(plan_data[realm.id].customer)) }}" step="0.01" min="0" max="99.99" disabled />
-    <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
+    <button type="submit" class="support-submit-button" disabled>Update</button>
     {% else %}
     <input type="number" name="discount" value="{{ format_discount(get_discount(plan_data[realm.id].customer)) }}" step="0.01" min="0" max="99.99" required />
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
     {% endif %}
 </form>
 
@@ -128,7 +128,7 @@
         <option value="charge_automatically" {% if plan_data[realm.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
         <option value="send_invoice" {% if not plan_data[realm.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 
 <form method="POST" class="downgrade-plan-form">
@@ -143,7 +143,7 @@
         <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
         <option value="upgrade_plan_tier">Upgrade to the Plus plan</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Modify</button>
+    <button type="submit" class="support-submit-button">Modify</button>
 </form>
 
 {% endif %}
@@ -153,5 +153,5 @@
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <input type="hidden" name="scrub_realm" value="true" />
-    <button data-string-id="{{realm.string_id}}" class="btn btn-danger small scrub-realm-button">Scrub realm (danger)</button>
+    <button data-string-id="{{realm.string_id}}" class="scrub-realm-button">Scrub realm (danger)</button>
 </form>

--- a/templates/analytics/remote_server_support.html
+++ b/templates/analytics/remote_server_support.html
@@ -14,7 +14,7 @@
     <form>
         <center>
             <input type="text" name="q" class="input-xxlarge search-query" placeholder="hostname or contact email" value="{{ request.GET.get('q', '') }}" autofocus />
-            <button type="submit" class="btn btn-default support-search-button">Search</button>
+            <button type="submit" class="support-search-button">Search</button>
         </center>
     </form>
 

--- a/templates/analytics/sponsorship_forms_support.html
+++ b/templates/analytics/sponsorship_forms_support.html
@@ -6,7 +6,7 @@
         <option value="true" {% if sponsorship_data.sponsorship_pending %}selected{% endif %}>Yes</option>
         <option value="false" {% if not sponsorship_data.sponsorship_pending %}selected{% endif %}>No</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 
 {% if sponsorship_data.sponsorship_pending %}
@@ -14,7 +14,7 @@
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <input type="hidden" name="approve_sponsorship" value="true" />
-    <button class="btn btn-default sea-green small approve-sponsorship-button">
+    <button class="approve-sponsorship-button">
         Approve full sponsorship
     </button>
 </form>
@@ -28,10 +28,10 @@
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     {% if has_fixed_price %}
     <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
-    <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
+    <button type="submit" class="support-submit-button" disabled>Update</button>
     {% else %}
     <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" required />
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
     {% endif %}
 </form>
 
@@ -41,7 +41,7 @@
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <input type="number" name="minimum_licenses" value="{{ sponsorship_data.minimum_licenses }}" required />
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 {% endif %}
 
@@ -59,7 +59,7 @@
             {% endif %}
         {% endfor %}
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Update</button>
+    <button type="submit" class="support-submit-button">Update</button>
 </form>
 
 {% if sponsorship_data.sponsorship_pending %}

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -13,7 +13,7 @@
     <form>
         <center>
             <input type="text" name="q" class="input-xxlarge search-query" placeholder="full names, emails, string_ids, organization URLs separated by commas" value="{{ request.GET.get('q', '') }}" autofocus />
-            <button type="submit" class="btn btn-default support-search-button">Search</button>
+            <button type="submit" class="support-search-button">Search</button>
         </center>
     </form>
 
@@ -45,7 +45,7 @@
                 {{ csrf_input }}
                 <input type="hidden" name="realm_id" value="{{ realm.id }}" />
                 <input type="hidden" name="delete_user_by_id" value="{{ user.id }}" />
-                <button data-email="{{ user.delivery_email }}" data-string-id="{{ realm.string_id }}" class="btn btn-danger small delete-user-button">Delete user (danger)</button>
+                <button data-email="{{ user.delivery_email }}" data-string-id="{{ realm.string_id }}" class="delete-user-button">Delete user (danger)</button>
             </form>
             <hr />
             <div>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -170,6 +170,80 @@ tr.admin td:first-child {
     }
 }
 
+.approve-sponsorship-button,
+.support-search-button,
+.support-submit-button,
+.delete-user-button,
+.scrub-realm-button {
+    padding: 6px 12px;
+    display: inline-block;
+    margin-bottom: 0;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 1.4286;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    cursor: pointer;
+    user-select: none;
+    background-image: none;
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+
+    &:focus {
+        outline: 5px auto -webkit-focus-ring-color;
+        outline-offset: -2px;
+    }
+
+    &:active {
+        background-image: none;
+        outline: 0;
+    }
+
+    &[disabled] {
+        pointer-events: none;
+        cursor: not-allowed;
+        opacity: 0.65;
+    }
+}
+
+.approve-sponsorship-button,
+.support-search-button,
+.support-submit-button {
+    color: hsl(0deg 0% 20%);
+    background-color: hsl(0deg 0% 100%);
+    border: 1px solid hsl(0deg 0% 83%);
+    border-radius: 2px;
+
+    &:hover,
+    &:focus,
+    &:active {
+        color: hsl(0deg 0% 20%);
+        background-color: hsl(0deg 0% 92%);
+        border: 1px solid hsl(0deg 0% 68%);
+    }
+}
+
+.delete-user-button,
+.scrub-realm-button {
+    color: hsl(0deg 0% 100%);
+    background-color: hsl(2deg 64% 58%);
+    border: 1px solid hsl(2deg 64% 53%);
+    border-radius: 2px;
+
+    &:hover,
+    &:focus,
+    &:active {
+        color: hsl(0deg 0% 100%);
+        background-color: hsl(2deg 65% 50%);
+        border: 1px solid hsl(2deg 65% 41%);
+    }
+}
+
 .remote-server-information,
 .remote-realm-information {
     padding-bottom: 15px;
@@ -234,16 +308,9 @@ tr.admin td:first-child {
     top: -70px;
 }
 
-.support-search-button {
-    border-color: hsl(0deg 0% 83%);
-    border-radius: 2px;
-}
-
 .support-submit-button {
     position: relative;
     top: -3px;
-    border-color: hsl(0deg 0% 83%);
-    border-radius: 2px;
 }
 
 .search-query.input-xxlarge {


### PR DESCRIPTION
Moves CSS styles for support view buttons to `web/styles/portico.activity.css`.

As the "sea-green" styles from the web-app were not being applied to the approve sponsorship buttons, moved the applicable CSS rules to that button class, "approve-sponsorship-button".


**Screenshots and screen captures:**

<details>
<summary>Iago user support view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-01-29 12-02-45](https://github.com/zulip/zulip/assets/63245456/4cd25cd2-86f3-4eeb-b927-b1f673f4bff5) | ![Screenshot from 2024-01-29 11-59-59](https://github.com/zulip/zulip/assets/63245456/d0df87fb-98a9-4090-991d-797a4314b6b6)
</details>
<details>
<summary>remote server support view</summary>

| Before | After |
| --- | --- |
|![Screenshot from 2024-01-29 12-02-13](https://github.com/zulip/zulip/assets/63245456/5f1369eb-5da2-4830-9217-3d4463b91e80) | ![Screenshot from 2024-01-29 12-01-16](https://github.com/zulip/zulip/assets/63245456/2ef9d152-fe1b-4b94-9214-231e9b30e531)
</details>
<details>
<summary>Zulip dev support view - with sponsorship approve button</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-01-29 12-02-27](https://github.com/zulip/zulip/assets/63245456/5ac647b4-aa71-4a95-aaf3-9b6bf403e7f8) | ![Screenshot from 2024-01-29 12-00-40](https://github.com/zulip/zulip/assets/63245456/ace88d83-17cf-418d-83d7-6500065747f3)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
