### PR TITLE
support: Always show the option to update end_date on /support page.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1312,7 +1312,6 @@ class BillingSession(ABC):
         if customer is not None:
             plan = get_current_plan_by_customer(customer)
             if plan is not None:
-                assert plan.end_date is not None
                 assert plan.status == CustomerPlan.ACTIVE
                 old_end_date = plan.end_date
                 plan.end_date = new_end_date

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1218,7 +1218,6 @@ class BillingSession(ABC):
         fixed_price_plan_params: Dict[str, Any] = {
             "fixed_price": fixed_price_cents,
             "tier": customer.required_plan_tier,
-            "status": CustomerPlan.NEVER_STARTED,
         }
 
         current_plan = get_current_plan_by_customer(customer)
@@ -1228,6 +1227,7 @@ class BillingSession(ABC):
                     f"Configure {self.billing_entity_display_name} current plan end-date, before scheduling a new plan."
                 )
             fixed_price_plan_params["billing_cycle_anchor"] = current_plan.end_date
+            fixed_price_plan_params["status"] = CustomerPlan.NEVER_STARTED
             fixed_price_plan_params["next_invoice_date"] = current_plan.end_date
             fixed_price_plan_params["invoicing_status"] = (
                 CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT

--- a/templates/corporate/support/current_plan_forms_support.html
+++ b/templates/corporate/support/current_plan_forms_support.html
@@ -9,12 +9,13 @@
     <button type="submit" class="support-submit-button">Update</button>
 </form>
 
-{% if current_plan.end_date and current_plan.status == current_plan.ACTIVE %}
+{% if current_plan.status == current_plan.ACTIVE %}
 <form method="POST" class="remote-form">
     <b>Plan end date</b><br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    <input type="date" name="plan_end_date" value="{{ current_plan.end_date.strftime('%Y-%m-%d') }}" required />
+    <input type="date" name="plan_end_date" {% if current_plan.end_date %}
+      value="{{ current_plan.end_date.strftime('%Y-%m-%d') }}" {% endif %} required />
     <button type="submit" class="support-submit-button">Update</button>
 </form>
 {% endif %}


### PR DESCRIPTION
**Commit 1**: https://github.com/zulip/zulip/pull/28596#discussion_r1470062164

**Commit 2**:

If a plan is already on `basic` or `business` plan and wants to switch to a fixed-price `basic` / `business` plan, then it is necessary that the current plan should have an end date configured.

Earlier, we could update the `end_date` only if the current plan already had an `end_date` set.

This commit makes it possible to always show the option to set or update `end_date`.

---

**Screenshots and screen captures:**

<details><summary>Plan already has end_date</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/74881b8c-e1de-4610-bbe9-262dce8c5aef">
</img>
</details> 

<details><summary>No end_date</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/14135d1f-e9ff-4264-9b42-a1760f1cb805">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
