### PR TITLE
portico: Reorganize top navigation area.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -17,31 +17,25 @@
                 <label for="top-menu-tab-product" class="nav-menu-label" tabindex="0">Product</label>
                 <div class="top-menu-submenu">
                     <div class="top-menu-submenu-column">
+                        <span class="top-menu-submenu-section">OVERVIEW</span>
                         <ul class="top-menu-submenu-list">
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com">Home</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/why-zulip/">Why Zulip</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/features/">Features</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/self-hosting/">Self-hosting</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/security/">Security</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/integrations/">Integrations</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/apps/">Apps</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/help/getting-your-organization-started-with-zulip">Moving to Zulip</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/try-zulip/">Try Zulip</a></li>
                         </ul>
                     </div>
                     <div class="top-menu-submenu-column">
+                        <span class="top-menu-submenu-section">FEATURES</span>
                         <ul class="top-menu-submenu-list">
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/self-hosting/">Self-hosting</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/help/getting-your-organization-started-with-zulip">Moving to Zulip</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/features/">Feature matrix</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/apps/">Desktop and mobile apps</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/integrations/">Integrations</a></li>
                             <li class="top-menu-submenu-list-item"><a href="/api/">API</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="https://github.com/zulip/zulip" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="/help/">Help center</a></li>
                         </ul>
                     </div>
-                </div>
-            </div>
-            <div class='top-menu-item top-menu-tab'>
-                <div class="top-menu-tab-unselect"></div>
-                <input type="radio" name="top-menu-tabs" class="top-menu-tab-input" id="top-menu-tab-solutions" />
-                <label for="top-menu-tab-solutions" class="nav-menu-label" tabindex="0">Solutions</label>
-                <div class="top-menu-submenu">
                     <div class="top-menu-submenu-column">
                         <span class="top-menu-submenu-section">USE CASES</span>
                         <ul class="top-menu-submenu-list">
@@ -53,8 +47,15 @@
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/for/communities/">Communities</a></li>
                         </ul>
                     </div>
+                </div>
+            </div>
+            <div class='top-menu-item top-menu-tab'>
+                <div class="top-menu-tab-unselect"></div>
+                <input type="radio" name="top-menu-tabs" class="top-menu-tab-input" id="top-menu-tab-case-studies"/>
+                <label for="top-menu-tab-case-studies" class="nav-menu-label" tabindex="0">Case studies</label>
+                <div class="top-menu-submenu" id="case-studies-submenu">
                     <div class="top-menu-submenu-column">
-                        <span class="top-menu-submenu-section">CUSTOMER STORIES</span>
+                        <span class="top-menu-submenu-section">BUSINESS</span>
                         <ul class="top-menu-submenu-list">
                             <li class="top-menu-submenu-list-item">
                                 <a href="https://zulip.com/case-studies/idrift/">
@@ -62,23 +63,33 @@
                                 </a>
                             </li>
                             <li class="top-menu-submenu-list-item">
-                                <a href="/case-studies/gut-contact/">
+                                <a href="https://zulip.com/case-studies/gut-contact/">
                                 Easy communication for 1000 agents at GUT contact
                                 </a>
                             </li>
                             <li class="top-menu-submenu-list-item">
-                                <a href="/case-studies/end-point/">
+                                <a href="https://zulip.com/case-studies/end-point/">
                                 Managing hundreds of projects at End Point Dev
                                 </a>
                             </li>
                             <li class="top-menu-submenu-list-item">
-                                <a href="/case-studies/atolio/">
+                                <a href="https://zulip.com/case-studies/atolio/">
                                 Open distributed communication at Atolio
                                 </a>
                             </li>
+                        </ul>
+                    </div>
+                    <div class="top-menu-submenu-column" id="education-and-research-submenu-column">
+                        <span class="top-menu-submenu-section">EDUCATION and RESEARCH</span>
+                        <ul class="top-menu-submenu-list">
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/tum/">Organized chat for 1000s of students at TUM</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/ucsd/">Communication hub across 6 continents at UCSD</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/lean/">Research collaboration at scale in the Lean mathematical community</a></li>
+                        </ul>
+                    </div>
+                    <div class="top-menu-submenu-column" id="one-source-and-communities-submenu-column">
+                        <span class="top-menu-submenu-section">OPEN SOURCE and COMMUNITIES</span>
+                        <ul class="top-menu-submenu-list">
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/asciidoctor/">Inclusive discussion in the open-source Asciidoctor community</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/rust/">Faster decision-making in the Rust language community</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/recurse-center/">Platform for a worldwide community since 2013 at Recurse Center</a></li>
@@ -173,27 +184,25 @@
         <details>
             <summary class="top-menu-mobile-item-summary">Product</summary>
             <div class="top-menu-mobile-submenu">
+                <span class="top-menu-mobile-submenu-section">OVERVIEW</span>
                 <ul class="top-menu-submenu-list">
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com">Home</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/why-zulip/">Why Zulip</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/features/">Features</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/self-hosting/">Self-hosting</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/security/">Security</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/integrations/">Integrations</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/apps">Apps</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/help/getting-your-organization-started-with-zulip">Moving to Zulip</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/try-zulip/">Try Zulip</a></li>
                 </ul>
             </div>
             <div class="top-menu-mobile-submenu">
+                <span class="top-menu-mobile-submenu-section">FEATURES</span>
                 <ul class="top-menu-submenu-list">
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/self-hosting/">Self-hosting</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/help/getting-your-organization-started-with-zulip">Moving to Zulip</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/features/">Feature matrix</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/apps/">Desktop and mobile apps</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/integrations/">Integrations</a></li>
                     <li class="top-menu-submenu-list-item"><a href="/api/">API</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="https://github.com/zulip/zulip" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                    <li class="top-menu-submenu-list-item"><a href="/help/">Help center</a></li>
                 </ul>
             </div>
-        </details>
-        <details>
-            <summary class="top-menu-mobile-item-summary">Solutions</summary>
             <div class="top-menu-mobile-submenu">
                 <span class="top-menu-mobile-submenu-section">USE CASES</span>
                 <ul class="top-menu-submenu-list">
@@ -204,13 +213,42 @@
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/for/open-source/">Open source projects</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/for/communities/">Communities</a></li>
                 </ul>
-                <span class="top-menu-mobile-submenu-section">CUSTOMER STORIES</span>
+            </div>
+        </details>
+        <details>
+            <summary class="top-menu-mobile-item-summary">Case Studies</summary>
+            <div class="top-menu-mobile-submenu">
+                <span class="top-menu-mobile-submenu-section">BUSINESS</span>
                 <ul class="top-menu-submenu-list">
-                    <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/idrift/">Efficient distributed team management at iDrift AS</a></li>
-                    <li class="top-menu-submenu-list-item"><a href="/case-studies/end-point/">Managing hundreds of projects at End Point Dev</a></li>
+                    <li class="top-menu-submenu-list-item">
+                        <a href="https://zulip.com/case-studies/idrift/">
+                        Efficient distributed team management at iDrift AS
+                        </a>
+                    </li>
+                    <li class="top-menu-submenu-list-item">
+                        <a href="https://zulip.com/case-studies/gut-contact/">
+                        Easy communication for 1000 agents at GUT contact
+                        </a>
+                    </li>
+                    <li class="top-menu-submenu-list-item">
+                        <a href="https://zulip.com/case-studies/end-point/">
+                        Managing hundreds of projects at End Point Dev
+                        </a>
+                    </li>
+                    <li class="top-menu-submenu-list-item">
+                        <a href="https://zulip.com/case-studies/atolio/">
+                        Open distributed communication at Atolio
+                        </a>
+                    </li>
+                </ul>
+                <span class="top-menu-mobile-submenu-section">EDUCATION and RESEARCH</span>
+                <ul class="top-menu-submenu-list">
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/tum/">Organized chat for 1000s of students at TUM</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/ucsd/">Communication hub across 6 continents at UCSD</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/lean/">Research collaboration at scale in the Lean mathematical community</a></li>
+                </ul>
+                <span class="top-menu-mobile-submenu-section">OPEN SOURCE and COMMUNITIES</span>
+                <ul class="top-menu-submenu-list">
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/asciidoctor/">Inclusive discussion in the open-source Asciidoctor community</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/rust/">Faster decision-making in the Rust language community</a></li>
                     <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/recurse-center/">Platform for a worldwide community since 2013 at Recurse Center</a></li>

--- a/web/src/portico/header.ts
+++ b/web/src/portico/header.ts
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+const EXTRA_SUBMENU_BOTTOM_PADDING = 16;
+
 $(() => {
     function on_tab_menu_selection_change(
         event?: JQuery.ChangeEvent<HTMLElement> | JQuery.ClickEvent<HTMLElement>,
@@ -11,7 +13,10 @@ $(() => {
         }
         const el = event.target.parentElement.querySelector(".top-menu-submenu");
         if (el) {
-            $("#top-menu-submenu-backdrop").css("height", Number(el.offsetHeight) + 16);
+            $("#top-menu-submenu-backdrop").css(
+                "height",
+                Number(el.offsetHeight) + EXTRA_SUBMENU_BOTTOM_PADDING,
+            );
         } else {
             $("#top-menu-submenu-backdrop").css("height", 0);
         }
@@ -23,12 +28,25 @@ $(() => {
         on_tab_menu_selection_change();
     }
 
+    function update_submenu_height_if_visible(): void {
+        if ($(".top-menu-tab-input:checked").length === 1) {
+            const sub_menu_height =
+                $(".top-menu-tab-input:checked ~ .top-menu-submenu").height() ?? 0;
+            $("#top-menu-submenu-backdrop").css(
+                "height",
+                sub_menu_height + EXTRA_SUBMENU_BOTTOM_PADDING,
+            );
+        }
+    }
+
     // In case user presses `back` with menu open.
     // See https://github.com/zulip/zulip/pull/24301#issuecomment-1418547337.
-    if ($(".top-menu-tab-input:checked").length === 1) {
-        const sub_menu_height = $(".top-menu-tab-input:checked ~ .top-menu-submenu").height() ?? 0;
-        $("#top-menu-submenu-backdrop").css("height", sub_menu_height + 16);
-    }
+    update_submenu_height_if_visible();
+
+    // Update the height again if window is resized.
+    $(window).on("resize", () => {
+        update_submenu_height_if_visible();
+    });
 
     // Close navbar if already open when user clicks outside the navbar.
     $("body").on("click", (e) => {

--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -238,6 +238,15 @@ details summary::-webkit-details-marker {
     transition: all 0.2s;
 }
 
+#case-studies-submenu {
+    flex-wrap: wrap;
+    width: 1000px;
+
+    @media (width <= 1100px) {
+        width: 600px;
+    }
+}
+
 .top-menu-tab .top-menu-tab-user-label {
     max-width: 140px;
     padding-right: 28px;


### PR DESCRIPTION
Everything other than the last 2 commits is in #28753, so this PR is just focused on the last 2 commits.

## Top nav reorg proposal

Changes in Product menu:
- Drops home page link (it seems common not to have it; the Zulip logo takes you there anyway)
- Drops GitHub link (we still have it in Resources)
- Adds help center link (duplicated from Resources)
- Renames Features -> Feature matrix (will make more sense when we switch to the new features page)
- Renames Apps -> Desktop and mobile apps (for clarity, esp. since Slack uses "Apps" for plugins)
- Rearranges the columns, adds labels
- Moves use cases into this menu

Changes to Solutions -> Case studies menu:
- Dedicated menu just for case studies
- Arranged by category

If we like these changes, we'll need to do an engineering pass to make them work at different screen sizes, etc.

<details>
<summary>
Screenshots
</summary>

![Screenshot 2024-01-30 at 12 13 47 PM](https://github.com/zulip/zulip/assets/2090066/f9986d04-af1d-4654-8edc-755e8596d04c)
![Screenshot 2024-01-30 at 12 13 26 PM](https://github.com/zulip/zulip/assets/2090066/5269ae50-cdc9-417a-8813-30f9b7010655)

</details>

## Other

I tacked on a commit to add a quote to self-hosting, as it need some CSS work to look reasonable. I wasn't able to find an existing style that would look OK here.

<details>
<summary>
Screenshots
</summary>

![Screenshot 2024-01-30 at 12 36 10 PM](https://github.com/zulip/zulip/assets/2090066/935a3eeb-6115-44b1-b263-ca60b99bdb6e)

</details>