### PR TITLE
populate_billing_realms: Add a legacy remote realm.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -6223,6 +6223,12 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         self.assertEqual(fixed_price_plan_offer.fixed_price, annual_fixed_price * 100)
         self.assertEqual(fixed_price_plan_offer.get_plan_status_as_text(), "Configured")
 
+        result = self.client_get("/activity/remote/support", {"q": "example.com"})
+        self.assert_in_success_response(
+            ["Next plan information:", "Zulip Basic", "Configured", "Plan has a fixed price."],
+            result,
+        )
+
         self.logout()
         self.login("hamlet")
         hamlet = self.example_user("hamlet")
@@ -6886,7 +6892,6 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
 
         new_plan = self.billing_session.get_next_plan(realm_legacy_plan)
         assert new_plan is not None
-        assert type(new_plan) is CustomerPlan
         self.assertEqual(new_plan.tier, CustomerPlan.TIER_SELF_HOSTED_BUSINESS)
         self.assertEqual(new_plan.status, CustomerPlan.NEVER_STARTED)
         self.assertEqual(
@@ -7247,7 +7252,6 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         self.assertEqual(customer_plan.end_date, end_date)
         new_customer_plan = self.billing_session.get_next_plan(customer_plan)
         assert new_customer_plan is not None
-        assert type(new_customer_plan) is CustomerPlan
         self.assertEqual(new_customer_plan.tier, CustomerPlan.TIER_SELF_HOSTED_BUSINESS)
         self.assertEqual(new_customer_plan.status, CustomerPlan.NEVER_STARTED)
         self.assertEqual(new_customer_plan.billing_cycle_anchor, end_date)
@@ -8082,7 +8086,6 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         self.assertEqual(legacy_plan.status, CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END)
         new_plan = self.billing_session.get_next_plan(legacy_plan)
         assert new_plan is not None
-        assert type(new_plan) is CustomerPlan
         self.assertEqual(new_plan.tier, CustomerPlan.TIER_SELF_HOSTED_BUSINESS)
         self.assertEqual(new_plan.status, CustomerPlan.NEVER_STARTED)
         self.assertEqual(

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -404,7 +404,6 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
         assert plan is not None
         next_plan = billing_session.get_next_plan(plan)
         assert next_plan is not None
-        assert type(next_plan) is CustomerPlan
         self.assertEqual(plan.status, CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END)
         self.assertEqual(next_plan.status, CustomerPlan.NEVER_STARTED)
 

--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -16,6 +16,7 @@ from corporate.lib.decorator import (
 from corporate.lib.stripe import (
     RemoteRealmBillingSession,
     RemoteServerBillingSession,
+    get_configured_fixed_price_plan_offer,
     get_free_trial_days,
 )
 from corporate.models import CustomerPlan, get_current_plan_by_customer, get_customer_by_realm
@@ -152,6 +153,15 @@ def remote_realm_plans_page(
     if customer is not None:  # nocoverage
         context.sponsorship_pending = customer.sponsorship_pending
         context.customer_plan = get_current_plan_by_customer(customer)
+
+        if customer.required_plan_tier is not None:
+            configure_fixed_price_plan = get_configured_fixed_price_plan_offer(
+                customer, customer.required_plan_tier
+            )
+            # Free trial is disabled for customers with fixed-price plan configured.
+            if configure_fixed_price_plan is not None:
+                context.free_trial_days = None
+
         if context.customer_plan is None:
             context.on_free_tier = not context.is_sponsored
         else:
@@ -209,6 +219,15 @@ def remote_server_plans_page(
     if customer is not None:  # nocoverage
         context.sponsorship_pending = customer.sponsorship_pending
         context.customer_plan = get_current_plan_by_customer(customer)
+
+        if customer.required_plan_tier is not None:
+            configure_fixed_price_plan = get_configured_fixed_price_plan_offer(
+                customer, customer.required_plan_tier
+            )
+            # Free trial is disabled for customers with fixed-price plan configured.
+            if configure_fixed_price_plan is not None:
+                context.free_trial_days = None
+
         if context.customer_plan is None:
             context.on_free_tier = not context.is_sponsored
         else:


### PR DESCRIPTION
Commit 1: Adds a `legacy remote-realm` to make it easy to test such realms.
Commit 2: Fix next plan info missing on support page for customers with no current plan.

For `free-tier-remote-realm` (no current plan), when fixed-price plan is configured:
<details><summary>Earlier Next plan info was missing</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/0d630aac-751f-47b1-836a-dc4748cef69b">
</img>
</details> 

Commit 3: Restrict free-trial when fixed-price plan is configured.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
