### PR TITLE
Fix direct message narrow scroll position bugs

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -286,6 +286,15 @@ export class MessageList {
         this.data.set_selected_id(id);
 
         if (opts.force_rerender) {
+            // TODO: Because rerender() itself will call
+            // reselect_selected_id after doing the rendering, we
+            // actually end up with this function being called
+            // recursively in this case. The ordering will end up
+            // being that the message_selected.zulip event for that
+            // rerender is processed before execution returns here.
+            //
+            // The recursive call is unnecessary, so we should figure
+            // out how to avoid that, both here and in the next block.
             this.rerender();
         } else if (!opts.from_rendering) {
             this.view.maybe_rerender();

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -497,7 +497,7 @@ export function activate(raw_terms, opts) {
                 anchor,
                 cont() {
                     if (!select_immediately) {
-                        update_selection({
+                        render_message_list_with_selected_message({
                             id_info,
                             select_offset: then_select_offset,
                             msg_list: message_lists.current,
@@ -509,14 +509,14 @@ export function activate(raw_terms, opts) {
         }
 
         // Important: We need to consider opening the compose box
-        // before calling update_selection, so that the logic in
+        // before calling render_message_list_with_selected_message, so that the logic in
         // recenter_view for positioning the currently selected
         // message can take into account the space consumed by the
         // open compose box.
         compose_actions.on_narrow(opts);
 
         if (select_immediately) {
-            update_selection({
+            render_message_list_with_selected_message({
                 id_info,
                 select_offset: then_select_offset,
                 msg_list: message_lists.current,
@@ -531,7 +531,6 @@ export function activate(raw_terms, opts) {
         }
 
         handle_post_view_change(msg_list);
-
 
         unread_ui.update_unread_banner();
 
@@ -740,7 +739,7 @@ export function maybe_add_local_messages(opts) {
     return;
 }
 
-export function update_selection(opts) {
+export function render_message_list_with_selected_message(opts) {
     if (message_lists.current !== opts.msg_list) {
         // If we navigated away from a view while we were fetching
         // messages for it, don't attempt to move the currently
@@ -768,6 +767,11 @@ export function update_selection(opts) {
 
     const then_scroll = !preserve_pre_narrowing_screen_position;
 
+    // Here we render the actual message list to the DOM with the
+    // target selected message, using the force_rerender parameter.
+    //
+    // TODO: Probably this should accept the offset parameter rather
+    // than calling `set_message_offset` just after.
     message_lists.current.select_id(msg_id, {
         then_scroll,
         use_closest: true,

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -508,6 +508,13 @@ export function activate(raw_terms, opts) {
             });
         }
 
+        // Important: We need to consider opening the compose box
+        // before calling update_selection, so that the logic in
+        // recenter_view for positioning the currently selected
+        // message can take into account the space consumed by the
+        // open compose box.
+        compose_actions.on_narrow(opts);
+
         if (select_immediately) {
             update_selection({
                 id_info,
@@ -525,7 +532,6 @@ export function activate(raw_terms, opts) {
 
         handle_post_view_change(msg_list);
 
-        compose_actions.on_narrow(opts);
 
         unread_ui.update_unread_banner();
 

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -215,6 +215,7 @@ run_test("basics", ({override}) => {
         [message_feed_loading, "hide_indicators"],
         [message_lists, "save_pre_narrow_offset_for_reload"],
         [compose_banner, "clear_message_sent_banners"],
+        [compose_actions, "on_narrow"],
         [unread_ops, "process_visible"],
         [narrow_history, "save_narrow_state_and_flush"],
         [message_viewport, "stop_auto_scrolling"],
@@ -226,7 +227,6 @@ run_test("basics", ({override}) => {
         [narrow_title, "update_narrow_title"],
         [left_sidebar_navigation_area, "handle_narrow_activated"],
         [stream_list, "handle_narrow_activated"],
-        [compose_actions, "on_narrow"],
         [compose_recipient, "handle_middle_pane_transition"],
     ]);
 


### PR DESCRIPTION
Fix an issue reported in https://chat.zulip.org/#narrow/stream/9-issues/topic/DM.20conversation.20opens.20in.20wrong.20place/near/1728883 that caused the user's scroll position to be jumped up unpleasantly when visiting direct message conversations due to an unfortunate interaction with the animated auto scroll.