### PR TITLE
settings: Fix buggy conversion of emoji-display-settings-status.

### DIFF
--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -33,7 +33,7 @@
     <div class="emoji-preferences {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3 class="light">{{t "Emoji" }}</h3>
-            {{> settings_save_discard_widget section_name="emoji-preferences" show_only_indicator=(not for_realm_settings) }}
+            {{> settings_save_discard_widget section_name="emoji-preferences-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
         <div class="input-group">


### PR DESCRIPTION
6cd165386aac0aac9fb4ab500a1358ea2280663a incorrectly converted this field with different names in the two places it is used.

@Aditya8840 FYI -- you need to take responsibility for testing your refactoring changes.