### PR TITLE
unread: Stop treating bottom of render windows as the global bottom.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1451,6 +1451,15 @@ export class MessageListView {
         );
     }
 
+    is_start_rendered() {
+        // Used as a helper in checks for whether a given scroll
+        // position is actually the very start of this view. It could
+        // fail to be for two reasons: Either some older messages are
+        // not rendered due to a render window, or we haven't finished
+        // fetching the oldest messages for this view from the server.
+        return this._render_win_start === 0 && this.list.data.fetch_status.has_found_oldest();
+    }
+
     get_row(id) {
         const $row = this._rows.get(id);
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1439,6 +1439,18 @@ export class MessageListView {
         this.message_containers.clear();
     }
 
+    is_end_rendered() {
+        // Used as a helper in checks for whether a given scroll
+        // position is actually the very end of this view. It could
+        // fail to be for two reasons: Either some newer messages are
+        // not rendered due to a render window, or we haven't finished
+        // fetching the newest messages for this view from the server.
+        return (
+            this._render_win_end === this.list.num_items() &&
+            this.list.data.fetch_status.has_found_newest()
+        );
+    }
+
     get_row(id) {
         const $row = this._rows.get(id);
 

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -83,12 +83,18 @@ export function scroll_finished() {
     }
 
     if (message_viewport.at_rendered_top()) {
+        // Subtle note: While we've only checked that we're at the
+        // very top of the render window (i.e. there may be some more
+        // cached messages to render), it's a good idea to fetch
+        // additional message history even if we're not actually at
+        // the edge of what we already have from the server.
         message_fetch.maybe_load_older_messages({
             msg_list: message_lists.current,
         });
     }
 
     if (message_viewport.at_rendered_bottom()) {
+        // See the similar message_viewport.at_rendered_top block.
         message_fetch.maybe_load_newer_messages({
             msg_list: message_lists.current,
         });

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -14,7 +14,10 @@ import * as unread_ui from "./unread_ui";
 let hide_scroll_to_bottom_timer;
 export function hide_scroll_to_bottom() {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
-    if (message_viewport.bottom_message_visible() || message_lists.current.visibly_empty()) {
+    if (
+        message_viewport.bottom_rendered_message_visible() ||
+        message_lists.current.visibly_empty()
+    ) {
         // If last message is visible, just hide the
         // scroll to bottom button.
         $show_scroll_to_bottom_button.removeClass("show");
@@ -34,7 +37,7 @@ export function hide_scroll_to_bottom() {
 }
 
 export function show_scroll_to_bottom_button() {
-    if (message_viewport.bottom_message_visible()) {
+    if (message_viewport.bottom_rendered_message_visible()) {
         // Only show scroll to bottom button when
         // last message is not visible in the
         // current scroll position.

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -88,7 +88,7 @@ export function scroll_finished() {
         });
     }
 
-    if (message_viewport.at_bottom()) {
+    if (message_viewport.at_rendered_bottom()) {
         message_fetch.maybe_load_newer_messages({
             msg_list: message_lists.current,
         });

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -82,7 +82,7 @@ export function scroll_finished() {
         message_scroll_state.set_update_selection_on_next_scroll(true);
     }
 
-    if (message_viewport.at_top()) {
+    if (message_viewport.at_rendered_top()) {
         message_fetch.maybe_load_older_messages({
             msg_list: message_lists.current,
         });

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -75,7 +75,7 @@ export function message_viewport_info(): MessageViewportInfo {
 // rendered message feed; messages that are not displayed due to a
 // limited render window or because they have not been fetched from
 // the server are not considered.
-export function at_bottom(): boolean {
+export function at_rendered_bottom(): boolean {
     const bottom = scrollTop() + height();
     const full_height = $scroll_container.prop("scrollHeight");
 
@@ -86,8 +86,9 @@ export function at_bottom(): boolean {
     return bottom + 2 >= full_height;
 }
 
-// This differs from at_bottom in that it only requires the bottom message to
-// be visible, but you may be able to scroll down further.
+// This differs from at_rendered_bottom in that it only requires the
+// bottom message to be visible, but you may be able to scroll down
+// further to see the rest of that message.
 export function bottom_rendered_message_visible(): boolean {
     const $last_row = rows.last_visible();
     if ($last_row.length) {
@@ -485,7 +486,7 @@ export function keep_pointer_in_view(): void {
     }
 
     function message_is_far_enough_up(): boolean {
-        return at_bottom() || $next_row.get_offset_to_window().top <= bottom_threshold;
+        return at_rendered_bottom() || $next_row.get_offset_to_window().top <= bottom_threshold;
     }
 
     function adjust(

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -71,6 +71,10 @@ export function message_viewport_info(): MessageViewportInfo {
     };
 }
 
+// Important note: These functions just look at the state of the
+// rendered message feed; messages that are not displayed due to a
+// limited render window or because they have not been fetched from
+// the server are not considered.
 export function at_bottom(): boolean {
     const bottom = scrollTop() + height();
     const full_height = $scroll_container.prop("scrollHeight");

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -38,7 +38,7 @@ export function set_last_movement_direction(value: number): void {
     last_movement_direction = value;
 }
 
-export function at_top(): boolean {
+export function at_rendered_top(): boolean {
     return scrollTop() <= 0;
 }
 
@@ -461,7 +461,7 @@ export function keep_pointer_in_view(): void {
     const bottom_threshold = info.visible_top + (9 / 10) * info.visible_height;
 
     function message_is_far_enough_down(): boolean {
-        if (at_top()) {
+        if (at_rendered_top()) {
             return true;
         }
 

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -88,7 +88,7 @@ export function at_bottom(): boolean {
 
 // This differs from at_bottom in that it only requires the bottom message to
 // be visible, but you may be able to scroll down further.
-export function bottom_message_visible(): boolean {
+export function bottom_rendered_message_visible(): boolean {
     const $last_row = rows.last_visible();
     if ($last_row.length) {
         const message_bottom = $last_row[0].getBoundingClientRect().bottom;

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -108,7 +108,7 @@ export function page_up() {
 }
 
 export function page_down() {
-    if (message_viewport.at_bottom() && !message_lists.current.visibly_empty()) {
+    if (message_viewport.at_rendered_bottom() && !message_lists.current.visibly_empty()) {
         message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
         unread_ops.process_visible();
     } else {

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -100,7 +100,7 @@ export function page_down_the_right_amount() {
 }
 
 export function page_up() {
-    if (message_viewport.at_top() && !message_lists.current.visibly_empty()) {
+    if (message_viewport.at_rendered_top() && !message_lists.current.visibly_empty()) {
         message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
     } else {
         page_up_the_right_amount();

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -100,7 +100,11 @@ export function page_down_the_right_amount() {
 }
 
 export function page_up() {
-    if (message_viewport.at_rendered_top() && !message_lists.current.visibly_empty()) {
+    if (
+        message_viewport.at_rendered_top() &&
+        !message_lists.current.visibly_empty() &&
+        message_lists.current.view.is_start_rendered()
+    ) {
         message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
     } else {
         page_up_the_right_amount();
@@ -108,7 +112,11 @@ export function page_up() {
 }
 
 export function page_down() {
-    if (message_viewport.at_rendered_bottom() && !message_lists.current.visibly_empty()) {
+    if (
+        message_viewport.at_rendered_bottom() &&
+        !message_lists.current.visibly_empty() &&
+        message_lists.current.view.is_end_rendered()
+    ) {
         message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
         unread_ops.process_visible();
     } else {

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -26,7 +26,7 @@ export function down(with_centering) {
             message_viewport.scrollTop(
                 ($current_msg_list.outerHeight(true) ?? 0) - message_viewport.height() * 0.1,
             );
-            unread_ops.process_scrolled_to_bottom();
+            unread_ops.process_visible();
         }
 
         return;
@@ -50,7 +50,7 @@ export function to_end() {
     const next_id = message_lists.current.last().id;
     message_viewport.set_last_movement_direction(1);
     message_lists.current.select_id(next_id, {then_scroll: true, from_scroll: true});
-    unread_ops.process_scrolled_to_bottom();
+    unread_ops.process_visible();
 }
 
 function amount_to_paginate() {
@@ -110,7 +110,7 @@ export function page_up() {
 export function page_down() {
     if (message_viewport.at_bottom() && !message_lists.current.visibly_empty()) {
         message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
-        unread_ops.process_scrolled_to_bottom();
+        unread_ops.process_visible();
     } else {
         page_down_the_right_amount();
     }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -197,7 +197,7 @@ export function initialize_kitchen_sink_stuff() {
         // scroll handler, but when we're at the top or bottom of the
         // page, the pointer may still need to move.
 
-        if (delta < 0 && message_viewport.at_top()) {
+        if (delta < 0 && message_viewport.at_rendered_top()) {
             navigate.up();
         } else if (delta > 0 && message_viewport.at_rendered_bottom()) {
             navigate.down();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -199,7 +199,7 @@ export function initialize_kitchen_sink_stuff() {
 
         if (delta < 0 && message_viewport.at_top()) {
             navigate.up();
-        } else if (delta > 0 && message_viewport.at_bottom()) {
+        } else if (delta > 0 && message_viewport.at_rendered_bottom()) {
             navigate.down();
         }
 

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -463,7 +463,7 @@ function process_scrolled_to_bottom() {
 export function process_visible() {
     if (
         viewport_is_visible_and_focused() &&
-        message_viewport.bottom_message_visible() &&
+        message_viewport.bottom_rendered_message_visible() &&
         message_lists.current.view.is_end_rendered()
     ) {
         process_scrolled_to_bottom();

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -439,7 +439,7 @@ export function notify_server_message_read(message, options) {
     notify_server_messages_read([message], options);
 }
 
-export function process_scrolled_to_bottom() {
+function process_scrolled_to_bottom() {
     if (!narrow_state.is_message_feed_visible()) {
         // First, verify the current message list is visible.
         return;
@@ -459,9 +459,13 @@ export function process_scrolled_to_bottom() {
 }
 
 // If we ever materially change the algorithm for this function, we
-// may need to update notifications.received_messages as well.
+// may need to update message_notifications.received_messages as well.
 export function process_visible() {
-    if (viewport_is_visible_and_focused() && message_viewport.bottom_message_visible()) {
+    if (
+        viewport_is_visible_and_focused() &&
+        message_viewport.bottom_message_visible() &&
+        message_lists.current.view.is_end_rendered()
+    ) {
         process_scrolled_to_bottom();
     }
 }

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -100,7 +100,7 @@ run_test("unread_ops", ({override}) => {
     $("#message_feed_container").show();
 
     // Make our "test" message appear visible.
-    override(message_viewport, "bottom_message_visible", () => true);
+    override(message_viewport, "bottom_rendered_message_visible", () => true);
 
     // Set message_lists.current containing messages that can be marked read
     override(message_lists.current, "all_messages", () => test_messages);

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -125,6 +125,7 @@ run_test("unread_ops", ({override}) => {
     // data setup).
     override(message_lists.current, "can_mark_messages_read", () => can_mark_messages_read);
     override(message_lists.current, "has_unread_messages", () => true);
+    override(message_lists.current.view, "is_end_rendered", () => true);
 
     // First, test for a message list that cannot read messages.
     can_mark_messages_read = false;
@@ -134,6 +135,12 @@ run_test("unread_ops", ({override}) => {
 
     // Now flip the boolean, and get to the main thing we are testing.
     can_mark_messages_read = true;
+    // Don't mark messages as read until all messages in the narrow are fetched and rendered.
+    override(message_lists.current.view, "is_end_rendered", () => false);
+    unread_ops.process_visible();
+    assert.deepEqual(channel_post_opts, undefined);
+
+    override(message_lists.current.view, "is_end_rendered", () => true);
     unread_ops.process_visible();
 
     // The most important side effect of the above call is that


### PR DESCRIPTION
The previous logic for both scrolling down and using pagedown would incorrectly mark an entire conversation as read when reaching the bottom of a render window, even if there were more messages loaded or to fetch from the server.

Fix this error in the calculation by asking the correct data structures if we're actually at the bottom.

To avoid the navigate.js keyboard shortcut code paths circumventing this new logic, or needing to duplicate it, they now call process_visible, rather than its helper.
