### PR TITLE
Proposed revision for /apps

### DIFF
--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -26,13 +26,13 @@
                     <div class="cta">
                         <h1>Zulip for <span class="platform"></span></h1>
                         <p class="description"></p>
-                        <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank" rel="noopener noreferrer">desktop app install guide</a>.</p>
                         <a class="desktop-download-link no-action" hidden href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
                         <a class="download-from-google-play-store" hidden href=""><img src="{{ static('images/store-badges/google-play-badge.png') }}" alt=""/></a>
                         <a class="download-from-apple-app-store" hidden href=""><img src="{{ static('images/store-badges/app-store-badge.svg') }}" alt=""/></a>
-                        <span><a id="download-from-microsoft-store" hidden href="https://apps.microsoft.com/store/detail/XP8HN41S4PLGZ3">or download from the Microsoft Store</a></span>
-                        <span><a id="download-android-apk" hidden href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
-                        <span><a id="download-mac-arm64" hidden href="">or download Apple silicon native build</a></span>
+                        <span id="download-from-microsoft-store" hidden>or <a href="https://apps.microsoft.com/store/detail/XP8HN41S4PLGZ3">download from the Microsoft Store</a></span>
+                        <span id="download-android-apk" hidden>or <a href="https://github.com/zulip/zulip-mobile/releases/latest">manually download APK</a></span>
+                        <span id="download-mac-arm64" hidden>or <a href="">download Apple silicon native build</a></span>
+                        <p class="download-instructions"></p>
                     </div>
                 </div>
             </div>

--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -15,25 +15,30 @@ const apps_events = function () {
         windows: {
             alt: "Windows",
             description:
-                "Zulip for Windows is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
+                "The Zulip desktop app comes with native <a class='apps-page-link' href='/help/desktop-notifications'>desktop notifications</a>, support for multiple Zulip accounts, and a dedicated tray icon.",
             download_link: "/apps/download/windows",
             show_instructions: true,
             install_guide: "/help/desktop-app-install-guide",
             app_type: "desktop",
+            download_instructions:
+                'For help or to install offline, see our <a class="apps-page-link" href="/help/desktop-app-install-guide" target="_blank" rel="noopener noreferrer">installation guide</a>.',
         },
         mac: {
             alt: "macOS",
             description:
-                "Zulip on macOS is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
+                "The Zulip desktop app comes with native <a class='apps-page-link' href='/help/desktop-notifications'>desktop notifications</a>, support for multiple Zulip accounts, and a dedicated tray icon.",
             download_link: "/apps/download/mac",
             mac_arm64_link: "/apps/download/mac-arm64",
             show_instructions: true,
             install_guide: "/help/desktop-app-install-guide",
             app_type: "desktop",
+            download_instructions:
+                'For help or to install via Homebrew, see our <a class="apps-page-link" href="/help/desktop-app-install-guide" target="_blank" rel="noopener noreferrer">installation guide</a>.',
         },
         android: {
             alt: "Android",
-            description: "Zulip's native Android app makes it easy to keep up while on the go.",
+            description:
+                "Zulip's native Android app makes it easy to keep up while on the go, with fully customizable <a class='apps-page-link' href='/help/mobile-notifications'>mobile notifications</a>.",
             show_instructions: false,
             play_store_link: "https://play.google.com/store/apps/details?id=com.zulipmobile",
             download_link: "https://github.com/zulip/zulip-mobile/releases/latest",
@@ -41,7 +46,8 @@ const apps_events = function () {
         },
         ios: {
             alt: "iOS",
-            description: "Zulip's native iOS app makes it easy to keep up while on the go.",
+            description:
+                "Zulip's native iOS app makes it easy to keep up while on the go, with fully customizable <a class='apps-page-link' href='/help/mobile-notifications'>mobile notifications</a>.",
             show_instructions: false,
             app_store_link: "https://itunes.apple.com/us/app/zulip/id1203036395",
             app_type: "mobile",
@@ -49,11 +55,13 @@ const apps_events = function () {
         linux: {
             alt: "Linux",
             description:
-                "Zulip on the Linux desktop is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
+                "The Zulip desktop app comes with native <a class='apps-page-link' href='/help/desktop-notifications'>desktop notifications</a>, support for multiple Zulip accounts, and a dedicated tray icon.",
             download_link: "/apps/download/linux",
             show_instructions: true,
             install_guide: "/help/desktop-app-install-guide",
             app_type: "desktop",
+            download_instructions:
+                'For help or to install via a package manager, see our <a class="apps-page-link" href="/help/desktop-app-install-guide" target="_blank" rel="noopener noreferrer">installation guide</a>.',
         },
     };
 
@@ -85,13 +93,13 @@ const apps_events = function () {
         const version_info = info[version];
 
         $(".info .platform").text(version_info.alt);
-        $(".info .description").text(version_info.description);
+        $(".info .description").html(version_info.description);
         $desktop_download_link.attr("href", version_info.download_link);
         $download_from_google_play_store.attr("href", version_info.play_store_link);
         $download_from_apple_app_store.attr("href", version_info.app_store_link);
-        $download_android_apk.attr("href", version_info.download_link);
-        $download_mac_arm64.attr("href", version_info.mac_arm64_link);
-        $download_instructions.find("a").attr("href", version_info.install_guide);
+        $download_android_apk.find("a").attr("href", version_info.download_link);
+        $download_mac_arm64.find("a").attr("href", version_info.mac_arm64_link);
+        $download_instructions.html(version_info.download_instructions);
 
         $download_instructions.toggle(version_info.show_instructions);
 

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -1041,7 +1041,7 @@ button {
         hsl(197deg 100% 16%),
         hsl(166deg 45% 49%)
     );
-    height: 600px;
+    height: 450px;
 
     color: hsl(0deg 0% 100%);
 
@@ -1082,10 +1082,11 @@ button {
 
 .portico-landing.apps .hero .info .cta {
     text-shadow: 0 0 60px hsl(0deg 0% 0% / 30%);
+    text-align: center;
 }
 
 .portico-landing.apps .hero .info .flex {
-    height: 500px;
+    height: 300px;
     min-height: 0;
 }
 
@@ -2155,10 +2156,23 @@ button {
 #download-from-microsoft-store,
 #download-android-apk,
 #download-mac-arm64 {
-    display: inline-block;
+    display: block;
     color: hsl(0deg 0% 100%);
     font-size: 13px;
     padding-left: 10px;
+
+    & a {
+        color: hsl(0deg 0% 100%);
+    }
+}
+
+#download-from-microsoft-store,
+#download-mac-arm64 {
+    margin-top: 10px;
+}
+
+.download-instructions {
+    margin-top: 30px;
 }
 
 .feature-container {
@@ -2879,4 +2893,9 @@ button {
             box-shadow: 0 3px 10px hsl(0deg 0% 0% / 30%);
         }
     }
+}
+
+.apps .apps-page-link {
+    text-decoration: underline;
+    color: hsl(0deg 0% 100%);
 }


### PR DESCRIPTION
Builds on #28773.

The following needs engineering help:
- Rebase on `main`, since #28773 has been merged.
  - Change "download APK" back to "manually download APK".
- Link "desktop notifications" to /help/desktop-notifications
- Link "mobile notifications" to /help/mobile-notifications
- Customize the wording for the help installation instructions help links by platform, replacing "Need help? See installation guide." in this PR.
    - Mac: For help or to install via Homebrew, see our [installation guide](https://zulip.com/help/desktop-app-install-guide).
    - Windows: For help or to install offline, see our [installation guide](https://zulip.com/help/desktop-app-install-guide).
    - Linux: For help or to install via a package manager, see our [installation guide](https://zulip.com/help/desktop-app-install-guide).
- Formatting tweaks:
  - I think it's better to make the links not bold.
  - I'd prefer to remove "or " from the link part of the alternate download links, but it messed up the formatting when I tried it. Not worth worrying about if it's a pain.
- We should make the top area significantly less tall, which will remove unnecessary empty space, and leave more vertical room for the "Apps for every platform." section.


**Note:**
- The Desktop app intro text is now the same for all 3 apps.

Current: https://zulip.com/apps/mac
<details>
<summary>
Updated screenshot
</summary>

<img width="617" alt="Screenshot 2024-01-31 at 3 14 20 PM" src="https://github.com/zulip/zulip/assets/2090066/0edcafcf-6e52-4b8f-809b-6750327ecf24">

</details>

Current: https://zulip.com/apps/android

<details>
<summary>
Updated screenshot
</summary>

<img width="798" alt="Screenshot 2024-01-31 at 3 14 06 PM" src="https://github.com/zulip/zulip/assets/2090066/c6d2eb7e-8987-4b78-9e7c-0c0501508c9f">


</details>