### PR TITLE
Upgrade configuration for Ruff v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ init_typed = true
 warn_required_dynamic_aliases = true
 
 [tool.ruff]
+line-length = 100
+src = [".", "tools"]
+target-version = "py38"
+
+[tool.ruff.lint]
 # See https://github.com/astral-sh/ruff#rules for error code definitions.
 select = [
     "ANN", # annotations
@@ -180,13 +185,10 @@ ignore = [
     "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM401", # Use `d.get(key, default)` instead of an `if` block
 ]
-line-length = 100
-src = [".", "tools"]
-target-version = "py38"
 
-[tool.ruff.flake8-gettext]
+[tool.ruff.lint.flake8-gettext]
 extend-function-names = ["gettext_lazy"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = ["zulip"]
 split-on-trailing-comma = false

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -634,12 +634,10 @@ def run_parallel_wrapper(
     logging.info("Distributing %s items across %s threads", len(full_items), threads)
 
     with ProcessPoolExecutor(max_workers=threads) as executor:
-        count = 0
-        for future in as_completed(
-            executor.submit(wrapping_function, f, item) for item in full_items
+        for count, future in enumerate(
+            as_completed(executor.submit(wrapping_function, f, item) for item in full_items), 1
         ):
             future.result()
-            count += 1
             if count % 1000 == 0:
                 logging.info("Finished %s items", count)
 

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1318,7 +1318,7 @@ def fetch_team_icons(
     records = []
 
     team_icons_dict = team_info_dict["icon"]
-    if "image_default" in team_icons_dict and team_icons_dict["image_default"]:
+    if team_icons_dict.get("image_default", False):
         return []
 
     icon_url = (

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os
 import posixpath
@@ -754,17 +755,7 @@ def convert_slack_workspace_messages(
         zerver_subscription=realm["zerver_subscription"],
     )
 
-    while True:
-        message_data = []
-        _counter = 0
-        for msg in all_messages:
-            _counter += 1
-            message_data.append(msg)
-            if _counter == chunk_size:
-                break
-        if len(message_data) == 0:
-            break
-
+    while message_data := list(itertools.islice(all_messages, chunk_size)):
         (
             zerver_message,
             zerver_usermessage,

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1715,9 +1715,8 @@ def export_files_from_s3(
 def export_uploads_from_local(
     realm: Realm, local_dir: Path, output_dir: Path, attachments: List[Attachment]
 ) -> None:
-    count = 0
     records = []
-    for attachment in attachments:
+    for count, attachment in enumerate(attachments, 1):
         # Use 'mark_sanitized' to work around false positive caused by Pysa
         # thinking that 'realm' (and thus 'attachment' and 'attachment.path_id')
         # are user controlled
@@ -1740,8 +1739,6 @@ def export_uploads_from_local(
             content_type=None,
         )
         records.append(record)
-
-        count += 1
 
         if count % 100 == 0:
             logging.info("Finished %s", count)
@@ -1831,9 +1828,8 @@ def get_emoji_path(realm_emoji: RealmEmoji) -> str:
 def export_emoji_from_local(
     realm: Realm, local_dir: Path, output_dir: Path, realm_emojis: List[RealmEmoji]
 ) -> None:
-    count = 0
     records = []
-    for realm_emoji in realm_emojis:
+    for count, realm_emoji in enumerate(realm_emojis, 1):
         emoji_path = get_emoji_path(realm_emoji)
 
         # Use 'mark_sanitized' to work around false positive caused by Pysa
@@ -1862,7 +1858,6 @@ def export_emoji_from_local(
         )
         records.append(record)
 
-        count += 1
         if count % 100 == 0:
             logging.info("Finished %s", count)
 

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -786,12 +786,7 @@ def import_uploads(
             bucket_name = settings.S3_AUTH_UPLOADS_BUCKET
         bucket = get_bucket(bucket_name)
 
-    count = 0
-    for record in records:
-        count += 1
-        if count % 1000 == 0:
-            logging.info("Processed %s/%s uploads", count, len(records))
-
+    for count, record in enumerate(records, 1):
         if processing_avatars:
             # For avatars, we need to rehash the user ID with the
             # new server's avatar salt
@@ -877,6 +872,9 @@ def import_uploads(
             orig_file_path = os.path.join(import_dir, record["path"])
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             shutil.copy(orig_file_path, file_path)
+
+        if count % 1000 == 0:
+            logging.info("Processed %s/%s uploads", count, len(records))
 
     if processing_avatars:
         # Ensure that we have medium-size avatar images for every

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -278,6 +278,6 @@ def generate_data_type(schema: Mapping[str, Any]) -> str:
         data_type = "(" + generate_data_type(schema["items"]) + ")[]"
     else:
         data_type = schema["type"]
-        if "nullable" in schema and schema["nullable"]:
+        if schema.get("nullable", False):
             data_type = data_type + " | null"
     return data_type

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -81,7 +81,7 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
 
     @override
     def process_success(self, response_json: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        if "response_not_required" in response_json and response_json["response_not_required"]:
+        if response_json.get("response_not_required", False):
             return None
 
         if "response_string" in response_json:

--- a/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
+++ b/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
@@ -15,10 +15,9 @@ def reset_is_private_flag(apps: StateApps, schema_editor: BaseDatabaseSchemaEdit
     # zerver/migrations/0100_usermessage_remove_is_me_message.py
     # didn't clean the field after removing it.
 
-    i = 0
     total = len(user_profile_ids)
     print("Setting default values for the new flag...", flush=True)
-    for user_id in user_profile_ids:
+    for i, user_id in enumerate(user_profile_ids, 1):
         while True:
             # Ideally, we'd just do a single database query per user.
             # Unfortunately, Django doesn't use the fancy new index on
@@ -39,7 +38,6 @@ def reset_is_private_flag(apps: StateApps, schema_editor: BaseDatabaseSchemaEdit
             if count < 1000:
                 break
 
-        i += 1
         if i % 50 == 0 or i == total:
             percent = round((i / total) * 100, 2)
             print(f"Processed {i}/{total} {percent}%", flush=True)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -996,8 +996,7 @@ class EditMessageTest(EditMessageTestCase):
 
         # We reverse the message history view output so that the IDs line up with the above.
         message_history = list(reversed(json_response["message_history"]))
-        i = 0
-        for entry in message_history:
+        for i, entry in enumerate(message_history):
             expected_entries = {"content", "rendered_content", "topic", "timestamp", "user_id"}
             if i in {0, 2, 4}:
                 expected_entries.add("prev_topic")
@@ -1009,7 +1008,6 @@ class EditMessageTest(EditMessageTestCase):
             if i in {0, 3}:
                 expected_entries.add("prev_stream")
                 expected_entries.add("stream")
-            i += 1
             self.assertEqual(expected_entries, set(entry.keys()))
         self.assert_length(message_history, 7)
         self.assertEqual(message_history[0]["topic"], "topic 4")

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -343,7 +343,7 @@ class EventQueue:
     def from_dict(cls, d: Dict[str, Any]) -> "EventQueue":
         ret = cls(d["id"])
         ret.next_event_id = d["next_event_id"]
-        ret.newest_pruned_id = d.get("newest_pruned_id", None)
+        ret.newest_pruned_id = d.get("newest_pruned_id")
         ret.queue = deque(d["queue"])
         ret.virtual_events = d.get("virtual_events", {})
         return ret

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -61,16 +61,16 @@ def api_slack_incoming_webhook(
         user_specified_topic = "(no topic)"
 
     pieces: List[str] = []
-    if "blocks" in payload and payload["blocks"]:
+    if payload.get("blocks"):
         pieces += map(render_block, payload["blocks"])
 
-    if "attachments" in payload and payload["attachments"]:
+    if payload.get("attachments"):
         pieces += map(render_attachment, payload["attachments"])
 
     body = "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
 
-    if body == "" and "text" in payload and payload["text"]:
-        if "icon_emoji" in payload and payload["icon_emoji"]:
+    if body == "" and payload.get("text"):
+        if payload.get("icon_emoji"):
             body = payload["icon_emoji"].tame(check_string) + " "
         body += payload["text"].tame(check_string)
         body = body.strip()
@@ -192,16 +192,16 @@ def render_attachment(attachment: WildValue) -> str:
     # rest of the fields we handle here are legacy fields. These fields are
     # optional and may contain null values.
     pieces = []
-    if "title" in attachment and attachment["title"]:
+    if attachment.get("title"):
         title = attachment["title"].tame(check_string)
-        if "title_link" in attachment and attachment["title_link"]:
+        if attachment.get("title_link"):
             title_link = attachment["title_link"].tame(check_url)
             pieces.append(f"## [{title}]({title_link})")
         else:
             pieces.append(f"## {title}")
-    if "pretext" in attachment and attachment["pretext"]:
+    if attachment.get("pretext"):
         pieces.append(attachment["pretext"].tame(check_string))
-    if "text" in attachment and attachment["text"]:
+    if attachment.get("text"):
         pieces.append(attachment["text"].tame(check_string))
     if "fields" in attachment:
         fields = []
@@ -210,20 +210,20 @@ def render_attachment(attachment: WildValue) -> str:
                 title = field["title"].tame(check_string)
                 value = field["value"].tame(check_string)
                 fields.append(f"*{title}*: {value}")
-            elif "title" in field and field["title"]:
+            elif field.get("title"):
                 title = field["title"].tame(check_string)
                 fields.append(f"*{title}*")
-            elif "value" in field and field["value"]:
+            elif field.get("value"):
                 value = field["value"].tame(check_string)
                 fields.append(f"{value}")
         pieces.append("\n".join(fields))
-    if "blocks" in attachment and attachment["blocks"]:
+    if attachment.get("blocks"):
         pieces += map(render_block, attachment["blocks"])
-    if "image_url" in attachment and attachment["image_url"]:
+    if attachment.get("image_url"):
         pieces.append("[]({})".format(attachment["image_url"].tame(check_url)))
-    if "footer" in attachment and attachment["footer"]:
+    if attachment.get("footer"):
         pieces.append(attachment["footer"].tame(check_string))
-    if "ts" in attachment and attachment["ts"]:
+    if attachment.get("ts"):
         time = attachment["ts"].tame(check_int)
         pieces.append(f"<time:{time}>")
 


### PR DESCRIPTION
## Summary

This PR upgrades Zulip's Ruff configuration in preparation for Ruff's v0.2.0 release. (The changes are compatible with Ruff v0.1.14, which Zulip uses today.)

Specifically, we're now warning when linter-only options are specified under `[tool.ruff]` instead of `[tool.ruff.lint]`. We've also stabilized some changes to `RUF019` (and other rules) that led to some new violations, so I just went ahead and applied the fixers. `ruff check` now passes without error on Zulip with Ruff v0.2.0.
