### PR TITLE
hotkey: Add `Shift` + `V` keyboard shortcut for the read receipts menu.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -148,6 +148,9 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Show message sender's user card**: <kbd>U</kbd>
 
+* **View read receipts**: <kbd>Shift</kbd> + <kbd>V</kbd> — Same shortcut
+  also closes the read receipts menu (if open).
+
 * **View image**: <kbd>V</kbd>
 
 * **Edit message or view message source**: <kbd>E</kbd>

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -146,14 +146,14 @@ in the Zulip app to add more to your repertoire as needed.
 
 ### For a selected message (outlined in blue)
 
+* **Edit message or view message source**: <kbd>E</kbd>
+
 * **Show message sender's user card**: <kbd>U</kbd>
 
 * **View read receipts**: <kbd>Shift</kbd> + <kbd>V</kbd> — Same shortcut
   also closes the read receipts menu (if open).
 
 * **View image**: <kbd>V</kbd>
-
-* **Edit message or view message source**: <kbd>E</kbd>
 
 * **Move message and (optionally) other messages in the same topic**: <kbd>M</kbd>
 

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -161,6 +161,8 @@
 
 <div id="about-zulip-modal-container"></div>
 
+<div id="read-receipts-modal-container"></div>
+
 <audio id="user-notification-sound-audio">
     <source class="notification-sound-source-ogg" type="audio/ogg" />
     <source class="notification-sound-source-mp3" type="audio/mpeg" />

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -42,6 +42,7 @@ import * as playground_links_popover from "./playground_links_popover";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
+import * as read_receipts from "./read_receipts";
 import * as recent_view_ui from "./recent_view_ui";
 import * as recent_view_util from "./recent_view_util";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
@@ -91,6 +92,7 @@ const keydown_shift_mappings = {
     40: {name: "down_arrow", message_view_only: false}, // down arrow
     72: {name: "view_edit_history", message_view_only: true}, // 'H'
     78: {name: "narrow_to_next_unread_followed_topic", message_view_only: false}, // 'N'
+    86: {name: "toggle_read_receipts", message_view_only: true}, // 'V'
 };
 
 const keydown_unshift_mappings = {
@@ -714,8 +716,18 @@ export function process_hotkey(e, hotkey) {
         return emoji_picker.navigate(event_name);
     }
 
+    // modals.any_active() and modals.active_modal() both query the dom to
+    // find and retrieve any active modal. Thus, we limit the number of calls
+    // to the DOM by storing these values as constansts to be reused.
+    const is_any_modal_active = modals.any_active();
+    const active_modal = is_any_modal_active ? modals.active_modal() : null;
+
     // `list_util` will process the event in send later modal.
-    if (modals.any_active() && modals.active_modal() !== "#send_later_modal") {
+    if (is_any_modal_active && active_modal !== "#send_later_modal") {
+        if (event_name === "toggle_read_receipts" && active_modal === "#read_receipts_modal") {
+            read_receipts.hide_user_list();
+            return true;
+        }
         return false;
     }
 
@@ -889,7 +901,7 @@ export function process_hotkey(e, hotkey) {
     }
 
     // Prevent navigation in the background when the overlays are active.
-    if (overlays.any_active() || modals.any_active()) {
+    if (overlays.any_active() || is_any_modal_active) {
         if (event_name === "view_selected_stream" && overlays.streams_open()) {
             stream_settings_ui.view_stream();
             return true;
@@ -1143,6 +1155,10 @@ export function process_hotkey(e, hotkey) {
             }
 
             stream_popover.build_move_topic_to_stream_popover(msg.stream_id, msg.topic, false, msg);
+            return true;
+        }
+        case "toggle_read_receipts": {
+            read_receipts.show_user_list(msg.id);
             return true;
         }
         case "zoom_to_message_near": {

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -93,3 +93,7 @@ export function show_user_list(message_id: number): void {
         },
     });
 }
+
+export function hide_user_list(): void {
+    modals.close_if_open("read_receipts_modal");
+}

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1221,7 +1221,7 @@
         }
     }
 
-    #read_receipts_modal #read_receipts_list li {
+    #read_receipts_modal .read_receipts_list li {
         &:hover {
             background-color: hsl(0deg 0% 100% / 5%);
         }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -209,7 +209,7 @@
         margin: auto;
     }
 
-    #read_receipts_list {
+    .read_receipts_list {
         margin-left: 0;
 
         & li {

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -220,6 +220,10 @@
                     <td class="definition">{{t 'Edit your last message' }}</td>
                     <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
                 </tr>
+                <tr id="edit-message-hotkey-help">
+                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
+                    <td><span class="hotkey"><kbd>E</kbd></span></td>
+                </tr>
                 <tr>
                     <td class="definition">{{t "Show message sender's user card"   }}</td>
                     <td><span class="hotkey"><kbd>U</kbd></span></td>
@@ -231,10 +235,6 @@
                 <tr>
                     <td class="definition">{{t 'Show images in thread' }}</td>
                     <td><span class="hotkey"><kbd>V</kbd></span></td>
-                </tr>
-                <tr id="edit-message-hotkey-help">
-                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
-                    <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr id="move-message-hotkey-help">
                     <td class="definition">{{t 'Move messages or topic' }}</td>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -225,6 +225,10 @@
                     <td><span class="hotkey"><kbd>U</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'View read receipts' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Show images in thread' }}</td>
                     <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>

--- a/web/templates/popovers/actions_popover.hbs
+++ b/web/templates/popovers/actions_popover.hbs
@@ -104,7 +104,8 @@
     {{#if should_display_read_receipts_option}}
     <li>
         <a class="view_read_receipts" data-message-id="{{message_id}}" tabindex="0">
-            <i class="zulip-icon zulip-icon-readreceipts" aria-label="{{t 'View read receipts' }}"></i> {{t "View read receipts" }}
+            <i class="zulip-icon zulip-icon-readreceipts" aria-label="{{t 'View read receipts' }}"></i>
+            {{t "View read receipts" }} <span class="hotkey-hint">(V)</span>
         </a>
     </li>
     {{/if}}

--- a/web/templates/read_receipts.hbs
+++ b/web/templates/read_receipts.hbs
@@ -1,8 +1,6 @@
-<ul id="read_receipts_list">
-    {{#each users}}
-        <li class="view_user_profile" data-user-id="{{user_id}}" tabindex="0" role="button">
-            <img class="read_receipts_user_avatar" src="{{avatar_url}}" />
-            <span>{{full_name}}</span>
-        </li>
-    {{/each}}
-</ul>
+{{#each users}}
+    <li class="view_user_profile" data-user-id="{{user_id}}" tabindex="0" role="button">
+        <img class="read_receipts_user_avatar" src="{{avatar_url}}" />
+        <span>{{full_name}}</span>
+    </li>
+{{/each}}

--- a/web/templates/read_receipts_modal.hbs
+++ b/web/templates/read_receipts_modal.hbs
@@ -1,4 +1,4 @@
-<div class="micromodal" id="read_receipts_modal" aria-hidden="true">
+<div class="micromodal" id="read_receipts_modal" aria-hidden="true" data-message-id="{{message_id}}">
     <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="read_receipts_modal_label">
             <header class="modal__header">
@@ -13,6 +13,7 @@
                 <div class="read_receipts_info">
                 </div>
                 <div class="loading_indicator"></div>
+                <ul class="read_receipts_list"></ul>
             </main>
         </div>
     </div>

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -81,6 +81,7 @@ const popovers = mock_esm("../src/user_card_popover", {
     },
 });
 const reactions = mock_esm("../src/reactions");
+const read_receipts = mock_esm("../src/read_receipts");
 const search = mock_esm("../src/search");
 const settings_data = mock_esm("../src/settings_data");
 const stream_list = mock_esm("../src/stream_list");
@@ -185,6 +186,7 @@ run_test("mappings", () => {
     assert.equal(map_down(46).name, "delete");
     assert.equal(map_down(13, true).name, "enter");
     assert.equal(map_down(78, true).name, "narrow_to_next_unread_followed_topic");
+    assert.equal(map_down(86, true).name, "toggle_read_receipts"); // Shift + V
 
     assert.equal(map_press(47).name, "search"); // slash
     assert.equal(map_press(106).name, "vim_down"); // j
@@ -363,7 +365,7 @@ run_test("modal open", ({override}) => {
 
 run_test("misc", ({override}) => {
     // Next, test keys that only work on a selected message.
-    const message_view_only_keys = "@+>RjJkKsuvi:GM";
+    const message_view_only_keys = "@+>RjJkKsuvVi:GM";
 
     // Check that they do nothing without a selected message
     with_overrides(({override}) => {
@@ -374,7 +376,7 @@ run_test("misc", ({override}) => {
     // Check that they do nothing while in the settings overlay
     with_overrides(({override}) => {
         override(overlays, "settings_open", () => true);
-        assert_unmapped("@*+->rRjJkKsSuvi:GM");
+        assert_unmapped("@*+->rRjJkKsSuvVi:GM");
     });
 
     // TODO: Similar check for being in the subs page
@@ -413,6 +415,12 @@ run_test("misc", ({override}) => {
 
     override(message_edit, "can_move_message", () => false);
     assert_unmapped("m");
+
+    assert_mapping("V", read_receipts, "show_user_list", true, true);
+
+    override(modals, "any_active", () => true);
+    override(modals, "active_modal", () => "#read_receipts_modal");
+    assert_mapping("V", read_receipts, "hide_user_list", true, true);
 });
 
 run_test("lightbox overlay open", ({override}) => {


### PR DESCRIPTION
The read receipts option, receides under the triple-dot message actions menu. This made the process of viewing the read receipts take up multiple steps, even via a keyboard-driven workflow.

Via this PR, now while focused on a message in any message feed, and pressing `Shift` + `V`, efficiently brings up the read receipts for that message.

Fixes part of #24716.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Screencast |
|--------|
| ![shift+v](https://github.com/zulip/zulip/assets/82862779/0dd730b2-4d14-4b51-bfd5-422a94d5a1e2) |

| Desc | Before | After |
|--------|--------|--------|
| Message actions menu | ![image](https://github.com/zulip/zulip/assets/82862779/07a7e477-0020-4a18-85a5-471e7d525611) | ![image](https://github.com/zulip/zulip/assets/82862779/e5d367c4-7531-4b0c-b6ae-83cc6f3cdc77) |
| `?` menu | ![image](https://github.com/zulip/zulip/assets/82862779/80f24837-af86-4d38-b345-662ab6f4c3ae) | ![image](https://github.com/zulip/zulip/assets/82862779/33a8dcb7-4c7b-43df-bb9d-2e22d1f9cedd) |
| Help center | ![image](https://github.com/zulip/zulip/assets/82862779/d0e567eb-7a24-4605-9c10-4fa38c1342c1) | ![image](https://github.com/zulip/zulip/assets/82862779/d5f8d5d5-8fcc-4e69-b584-a10e914ec132) |
|Fix duplication bug when opening menu repeatedly | ![read-receipts-before](https://github.com/zulip/zulip/assets/82862779/f4b42da8-2c3e-4f57-a6e9-8a692d67c2ea) | ![read-receipts-after](https://github.com/zulip/zulip/assets/82862779/9961ae7a-29d2-4fc5-8e56-077be2366fa9) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
