### PR TITLE
bootstrap: Remove duplicate `invoice` class.

### DIFF
--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -329,9 +329,6 @@ button.close {
 .show {
   display: block;
 }
-.invisible {
-  visibility: hidden;
-}
 @-ms-viewport {
   width: device-width;
 }


### PR DESCRIPTION
The same definition is already present app_components.css, so we don't need it here.


discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/bootstrap