### PR TITLE
realm_settings: Improve authentication_methods param validation.

### DIFF
--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -19,6 +19,7 @@ from zerver.actions.realm_settings import (
     do_set_realm_signup_notifications_stream,
     do_set_realm_user_default_setting,
     parse_and_set_setting_value_if_required,
+    validate_authentication_methods_dict_from_api,
 )
 from zerver.decorator import require_realm_admin, require_realm_owner
 from zerver.forms import check_subdomain_available as check_subdomain
@@ -196,8 +197,11 @@ def update_realm(
     if authentication_methods is not None:
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequiredError
+
+        validate_authentication_methods_dict_from_api(realm, authentication_methods)
         if True not in authentication_methods.values():
             raise JsonableError(_("At least one authentication method must be enabled."))
+
     if video_chat_provider is not None and video_chat_provider not in {
         p["id"] for p in Realm.VIDEO_CHAT_PROVIDERS.values()
     }:


### PR DESCRIPTION
The endpoint was lacking validation that the authentication_methods dict submitted by the user made sense. So e.g. it allowed submitting a nonsense key like NoSuchBackend or modifying the realm's configured authentication methods for a backend that's not enabled on the server, which should not be allowed.

Both were ultimately harmless, because:
1. Submitting NoSuchBackend would luckily just trigger a KeyError inside the transaction.atomic() block in do_set_realm_authentication_methods so it would actually roll back the database changes it was trying to make. So this couldn't actually create some weird RealmAuthenticationMethod entries.
2. Silently enabling or disabling e.g. GitHub for a realm when GitHub isn't enabled on the server doesn't really change anything. And this action is only available to the realm's admins to begin with, so there's no attack vector here.

test_supported_backends_only_updated wasn't actually testing anything, because the state it was asserting:
```
        self.assertFalse(github_auth_enabled(realm))
        self.assertTrue(dev_auth_enabled(realm))
        self.assertFalse(password_auth_enabled(realm))
```

matched the desired state submitted to the API...
```
        result = self.client_patch(
            "/json/realm",
            {
                "authentication_methods": orjson.dumps(
                    {"Email": False, "Dev": True, "GitHub": False}
                ).decode()
            },
        )
```

so we just replace it with a new test that tests the param validation.