### PR TITLE
narrow: Remove duplicate clear search form.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -44,7 +44,6 @@ import * as recent_view_ui from "./recent_view_ui";
 import * as recent_view_util from "./recent_view_util";
 import * as resize from "./resize";
 import * as scheduled_messages_feed_ui from "./scheduled_messages_feed_ui";
-import * as search from "./search";
 import {web_mark_read_on_scroll_policy_values} from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
@@ -1063,8 +1062,6 @@ export function deactivate() {
       message_list_data structure caching system that happens to have
       message_lists.home in it.
      */
-    search.clear_search_form();
-
     const coming_from_recent_view = recent_view_util.is_visible();
     const coming_from_inbox = inbox_util.is_visible();
 

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -198,11 +198,6 @@ export function initiate_search() {
     $("#search_query").typeahead("lookup").trigger("select");
 }
 
-export function clear_search_form() {
-    set_search_bar_text("");
-    $("#search_query").trigger("blur");
-}
-
 // This is what the default searchbox text would be for this narrow,
 // NOT what might be currently displayed there. We can use this both
 // to set the initial text and to see if the user has changed it.

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -11,7 +11,6 @@ import * as narrow_state from "./narrow_state";
 import * as narrow_title from "./narrow_title";
 import * as pm_list from "./pm_list";
 import * as resize from "./resize";
-import * as search from "./search";
 import * as stream_list from "./stream_list";
 import * as unread_ui from "./unread_ui";
 
@@ -86,7 +85,6 @@ export function show(opts) {
     narrow_title.update_narrow_title(narrow_state.filter());
     message_view_header.render_title_area();
     compose_recipient.handle_middle_pane_transition();
-    search.clear_search_form();
     opts.complete_rerender();
     compose_actions.on_show_navigation_view();
 

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -17,16 +17,6 @@ mock_esm("../src/filter", {
 
 const search = zrequire("search");
 
-run_test("clear_search_form", () => {
-    $("#search_query").val("noise");
-    $("#search_query").trigger("click");
-
-    search.clear_search_form();
-
-    assert.equal($("#search_query").is_focused(), false);
-    assert.equal($("#search_query").val(), "");
-});
-
 run_test("initialize", ({override_rewire, mock_template}) => {
     const $search_query_box = $("#search_query");
     const $searchbox_form = $("#searchbox_form");


### PR DESCRIPTION
This function doesn't need to be called since `render_title_area` already takes care of it which is always called when changing narrow.

First commit from #28636

Discussion: https://github.com/zulip/zulip/pull/28636#discussion_r1463715960

So, `render_title_area` already calls `set_search_bar_text("");` via `close_search_bar_and_open_narrow_description`. So, the main call that we are removing here is `$("#search_query").trigger("blur");`. I don't see a reason why we should call it. Everthing seems to work fine without out. Also, `#search_query` is already blurred after user searches. Maybe this is not what the old behaviour was and we needed to blur it after user searched something.

