### PR TITLE
timerender: Fix get_timestamp_for_flatpickr when no parameter passed

### DIFF
--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -429,8 +429,15 @@ function get_current_time_to_hour(): Date {
     return timestamp;
 }
 
-export function get_timestamp_for_flatpickr(timestring: string): Date {
+export function get_timestamp_for_flatpickr(timestring?: string): Date {
     let timestamp;
+
+    // timestring is undefined when first opening the picker from the
+    // compose box button.
+    if (timestring === undefined) {
+        return get_current_time_to_hour();
+    }
+
     try {
         // If there's already a valid time in the compose box,
         // we use it to initialize the flatpickr instance.

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -423,6 +423,12 @@ export function get_full_time(timestamp: number): string {
     return formatISO(timestamp * 1000);
 }
 
+function get_current_time_to_hour(): Date {
+    const timestamp = new Date();
+    timestamp.setMinutes(0, 0);
+    return timestamp;
+}
+
 export function get_timestamp_for_flatpickr(timestring: string): Date {
     let timestamp;
     try {
@@ -432,8 +438,7 @@ export function get_timestamp_for_flatpickr(timestring: string): Date {
     } finally {
         // Otherwise, default to showing the current time to the hour.
         if (!timestamp || !isValid(timestamp)) {
-            timestamp = new Date();
-            timestamp.setMinutes(0, 0);
+            timestamp = get_current_time_to_hour();
         }
     }
     return timestamp;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently, when the "Add global time" of the compose box is pressed, it would result in an exception. This is because, it is using `get_timestamp_for_flatpickr`, without passing any parameter. 

This is avoided by doing an early return of current time to hour in case no string is passed to the get_timestamp_for_flatpickr method.

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Add.20global.20time.20of.20compose.20box.20broken)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
