### PR TITLE
compose_actions: Fix incorrect condition.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -126,7 +126,7 @@ export function complete_starting_tasks(msg_type, opts) {
 }
 
 export function maybe_scroll_up_selected_message(opts) {
-    if (!opts.skip_scrolling_selected_message) {
+    if (opts.skip_scrolling_selected_message) {
         return;
     }
 


### PR DESCRIPTION
This was introduced in #28767 with the intention to skip scrolling the selected message.

So, the actual bug that the PR fixed would have been just fixed by opening the compose box early.
