### PR TITLE
popovers: Show user and group popovers when pill clicked in stream and group settings.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -215,14 +215,9 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         // this would generally be used for DOM-provoked actions, such as a user
         // clicking on a pill to remove it.
         removePill(element: HTMLElement) {
-            let idx: number | undefined;
-            for (let x = 0; x < store.pills.length; x += 1) {
-                if (store.pills[x].$element[0] === element) {
-                    idx = x;
-                }
-            }
+            const idx = store.pills.findIndex((pill) => pill.$element[0] === element);
 
-            if (idx !== undefined) {
+            if (idx !== -1) {
                 store.pills[idx].$element.remove();
                 const pill = store.pills.splice(idx, 1);
                 if (store.removePillFunction !== undefined) {

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -19,6 +19,8 @@ export type InputPillItem<T> = {
     deactivated?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code?: boolean}; // TODO: Move this in user_status.js
     should_add_guest_user_indicator?: boolean;
+    user_id?: number;
+    id?: number;
 } & T;
 
 export type InputPillConfig = {
@@ -62,6 +64,8 @@ type InputPillRenderingDetails = {
     has_status?: boolean;
     status_emoji_info?: EmojiRenderingDetails & {emoji_alt_code?: boolean};
     should_add_guest_user_indicator?: boolean;
+    user_id?: number;
+    group_id?: number;
 };
 
 // These are the functions that are exposed to other modules.
@@ -150,6 +154,13 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 deactivated: item.deactivated,
                 should_add_guest_user_indicator: item.should_add_guest_user_indicator,
             };
+
+            if (item.user_id) {
+                opts.user_id = item.user_id;
+            }
+            if (item.id) {
+                opts.group_id = item.id;
+            }
 
             if (has_image) {
                 opts.img_src = item.img_src;

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -337,6 +337,10 @@ function show_user_card_popover(
         popover_html = render_user_card_popover(args);
     }
 
+    function hide_popover_on_back_navigation() {
+        user_card_popovers[template_class].hide();
+    }
+
     popover_menus.toggle_popover_menu(
         $popover_element[0],
         {
@@ -357,8 +361,10 @@ function show_user_card_popover(
                         user_is_guest: user.is_guest,
                     }),
                 );
+                $(window).on("popstate", hide_popover_on_back_navigation);
             },
             onHidden() {
+                $(window).off("popstate", hide_popover_on_back_navigation);
                 user_card_popovers[template_class].hide();
             },
             onMount(instance) {
@@ -874,6 +880,18 @@ function register_click_handlers() {
         const user = people.get_by_user_id(user_id);
         toggle_user_card_popover_manage_menu(e.target, user);
     });
+
+    // Show user_card_popover when pill clicked in stream settings and group settings.
+    $("body").on("click", ".pill[user-id]", (e) => {
+        const $pill = $(e.target).closest(".pill");
+        const user_id_string = $pill.attr("user-id");
+        if (user_id_string !== undefined) {
+            const user_id = Number.parseInt(user_id_string, 10);
+            const user = people.get_by_user_id(user_id);
+            toggle_user_card_popover($pill[0], user);
+        }
+    });
+
     new ClipboardJS(".copy-custom-field-url", {
         text(trigger) {
             return $(trigger)

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -52,22 +52,32 @@ export function handle_keyboard(key: string): void {
     popover_menus.popover_items_handle_keyboard(key, $items);
 }
 
-// element is the target element to pop off of;
-// message_id is the message id containing it, which should be selected;
+// Function called with `message_id` when user-group-mention is clicked.
+// Function called with user_group object when input_pill is clicked.
+// `element` is the target element to pop off of;
+// `message_id` is the message id containing it, which should be selected;
 export function toggle_user_group_info_popover(
     element: ReferenceElement,
-    message_id: number,
+    group_or_message: number | user_groups.UserGroup,
 ): void {
     if (is_open()) {
         hide();
         return;
     }
-    const $elt = $(element);
-    const user_group_id_str = $elt.attr("data-user-group-id");
-    assert(user_group_id_str !== undefined);
 
-    const user_group_id = Number.parseInt(user_group_id_str, 10);
-    const group = user_groups.get_user_group_from_id(user_group_id);
+    let group: user_groups.UserGroup;
+    let message_id: number | undefined;
+
+    if (typeof group_or_message === "number") {
+        message_id = group_or_message;
+        const $elt = $(element);
+        const user_group_id_str = $elt.attr("data-user-group-id");
+        assert(user_group_id_str !== undefined);
+        const user_group_id = Number.parseInt(user_group_id_str, 10);
+        group = user_groups.get_user_group_from_id(user_group_id);
+    } else {
+        group = group_or_message;
+    }
 
     popover_menus.toggle_popover_menu(
         element,

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -110,9 +110,11 @@ export function toggle_user_group_info_popover(
                     is_guest: current_user.is_guest,
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
+                $(window).on("popstate", hide);
             },
             onHidden() {
                 hide();
+                $(window).off("popstate", hide);
             },
         },
         {
@@ -139,6 +141,17 @@ export function register_click_handlers(): void {
         } catch {
             // This user group has likely been deleted.
             blueslip.info("Unable to find user group in message" + message.sender_id);
+        }
+    });
+
+    // Show the user_group_popover when pill clicked in subscriber settings.
+    $("body").on("click", ".pill[group-id]", (e) => {
+        const $pill = $(e.target).closest(".pill");
+        const group_id_string = $pill.attr("group-id");
+        if (group_id_string !== undefined) {
+            const group_id = Number.parseInt(group_id_string, 10);
+            const group = user_groups.get_user_group_from_id(group_id);
+            toggle_user_group_info_popover($pill[0], group);
         }
     });
 }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -60,7 +60,7 @@
             margin-right: 3px;
         }
 
-        &:hover .exit {
+        .exit:hover {
             opacity: 1;
         }
     }

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -1,4 +1,4 @@
-<div class='pill {{#if deactivated}} deactivated-pill {{/if}}' tabindex=0>
+<div class='pill {{#if deactivated}} deactivated-pill {{/if}}'{{#if user_id}}user-id="{{user_id}}"{{/if}}{{#if group_id}}group-id="{{group_id}}"{{/if}} tabindex=0>
     {{#if has_image}}
     <img class="pill-image" src="{{img_src}}" />
     {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Clicking on the user/group pill in stream/group settings UI to select user/group pill opens up the user/group popover. Applies to both user/group creation and editing UI.

Hover style on the `x` button of pill occurs only when the `x` button is hovered, not when the pill is hovered.

Additionally one of the commit optimizes the `removePill` function of `input_pill.ts` module as discussed in the [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Input.20pill.20code.20optimization).

[CZO Thread](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Import.20.60.2Ejs.60.20in.20a.20.60.2Ets.60.20module.2E)

Fixes: #28687 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>X button hover</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/a01b5b26-6abf-4939-88c3-92bbd7f95fba">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/68a5286e-98aa-4cd5-a75c-fd042de4b0cd">
</details>

<details><summary>Group Settings</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/693222eb-696b-4c04-9951-1fcd34c0f1a5">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/f4aed076-db16-4313-8c27-88ec0c4902b3">
</details>

<details><summary>Stream Settings</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/6d844a26-3564-4fe8-a92a-31acee202467">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/be3c9c7c-902b-4798-8b56-ffaaa21243b6">
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
