### PR TITLE
Added space to between stream name and down arrow

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1104,11 +1104,6 @@ div.overlay {
     outline: none;
     color: var(--color-text-default);
 
-    .fa-chevron-down {
-        position: relative;
-        top: -1px;
-    }
-
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1178,7 +1178,7 @@ textarea.new_message_textarea,
         }
     }
 
-    .fa-chevron-down {
+    .zulip-icon-chevron-down {
         padding-left: 5px;
         color: hsl(0deg 0% 58%);
         font-weight: lighter;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -560,8 +560,8 @@
     text-align: left;
 }
 
-#recent-view-filter_widget .fa-chevron-down,
-#inbox-filter_widget .fa-chevron-down {
+#recent-view-filter_widget .zulip-icon-chevron-down,
+#inbox-filter_widget .zulip-icon-chevron-down {
     color: var(--color-icons-inbox);
     opacity: 0.4;
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1054,7 +1054,7 @@ ul {
             }
         }
 
-        .fa-chevron-down {
+        .zulip-icon-chevron-down {
             padding-left: 5px;
             color: hsl(0deg 0% 58%);
             font-weight: lighter;


### PR DESCRIPTION
The distance between the stream name and the down arrow in the compose box dropdown corrected.

Fixes:  #28797 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
<img width="931" alt="image" src="https://github.com/zulip/zulip/assets/96689162/4e68007e-319c-4a29-a265-8aaa64ab780f">

After:
<img width="888" alt="image" src="https://github.com/zulip/zulip/assets/96689162/e1a0bb49-387c-49f1-9f68-fc514a8c6fd2">
<img width="545" alt="image" src="https://github.com/zulip/zulip/assets/96689162/0fed5f56-06a1-494b-abec-4d7f77998976">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
