### PR TITLE
Update user-profile modal to show confirmation feedback #26692

### DIFF
--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -156,7 +156,9 @@ export function initialize_custom_date_type_fields(element_id) {
     $(element_id)
         .find(".custom_user_field .remove_date")
         .on("click", function () {
-            $(this).parent().find(".custom_user_field_value").val("");
+            const $custom_user_field = $(this).parent().find(".custom_user_field_value");
+            $custom_user_field.val("");
+            $custom_user_field.trigger("input");
         });
 }
 

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -130,6 +130,11 @@ export function get_current_values($inputs: JQuery): Record<string, unknown> {
                 current_values[property_name] = this.files[0];
             } else if (property_name === "edit_bot_owner") {
                 current_values[property_name] = $(this).find(".dropdown_widget_value").text();
+            } else if ($(this).hasClass("pill-container")) {
+                // Notably, this just concatenates the pill labels;
+                // good enough for checking if something has changed,
+                // but not appropriate for many other potential uses.
+                current_values[property_name] = $(this).find(".pill-value").text();
             } else {
                 current_values[property_name] = $(this).val();
             }

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -120,6 +120,24 @@ export function close(on_hidden_callback?: () => void): void {
     modals.close(current_dialog_widget_id(), {on_hidden: on_hidden_callback});
 }
 
+export function get_current_values($inputs: JQuery): Record<string, unknown> {
+    const current_values: Record<string, unknown> = {};
+    $inputs.each(function () {
+        const property_name = $(this).attr("name")!;
+        if (property_name) {
+            if (this instanceof HTMLInputElement && this.type === "file" && this.files?.length) {
+                // If the input is a file input and a file has been selected, set value to file object
+                current_values[property_name] = this.files[0];
+            } else if (property_name === "edit_bot_owner") {
+                current_values[property_name] = $(this).find(".dropdown_widget_value").text();
+            } else {
+                current_values[property_name] = $(this).val();
+            }
+        }
+    });
+    return current_values;
+}
+
 export function launch(conf: DialogWidgetConfig): string {
     // Mandatory fields:
     // * html_heading
@@ -175,28 +193,6 @@ export function launch(conf: DialogWidgetConfig): string {
     }
 
     const $submit_button = $dialog.find(".dialog_submit_button");
-
-    function get_current_values($inputs: JQuery): Record<string, unknown> {
-        const current_values: Record<string, unknown> = {};
-        $inputs.each(function () {
-            const property_name = $(this).attr("name")!;
-            if (property_name) {
-                if (
-                    this instanceof HTMLInputElement &&
-                    this.type === "file" &&
-                    this.files?.length
-                ) {
-                    // If the input is a file input and a file has been selected, set value to file object
-                    current_values[property_name] = this.files[0];
-                } else if (property_name === "edit_bot_owner") {
-                    current_values[property_name] = $(this).find(".dropdown_widget_value").text();
-                } else {
-                    current_values[property_name] = $(this).val();
-                }
-            }
-        });
-        return current_values;
-    }
 
     if (conf.update_submit_disabled_state_on_change) {
         const $inputs = $dialog.find(".modal__content").find("input,select,textarea,button");

--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -24,6 +24,7 @@ import * as settings_streams from "./settings_streams";
 import * as settings_users from "./settings_users";
 import {current_user, realm} from "./state_data";
 import * as stream_events from "./stream_events";
+import * as user_profile from "./user_profile";
 
 export const update_person = function update(person) {
     const person_obj = people.maybe_get_user_by_id(person.user_id);
@@ -50,6 +51,7 @@ export const update_person = function update(person) {
     if (Object.hasOwn(person, "delivery_email")) {
         const delivery_email = person.delivery_email;
         person_obj.delivery_email = delivery_email;
+        user_profile.update_profile_modal_ui(person_obj, person);
         if (people.is_my_user_id(person.user_id)) {
             settings_account.update_email(delivery_email);
             current_user.delivery_email = delivery_email;
@@ -64,6 +66,7 @@ export const update_person = function update(person) {
         activity_ui.redraw();
         message_live_update.update_user_full_name(person.user_id, person.full_name);
         pm_list.update_private_messages();
+        user_profile.update_profile_modal_ui(person_obj, person);
         if (people.is_my_user_id(person.user_id)) {
             current_user.full_name = person.full_name;
             settings_account.update_full_name(person.full_name);
@@ -78,6 +81,7 @@ export const update_person = function update(person) {
         person_obj.is_guest = person.role === settings_config.user_role_values.guest.code;
         person_obj.is_moderator = person.role === settings_config.user_role_values.moderator.code;
         settings_users.update_user_data(person.user_id, person);
+        user_profile.update_profile_modal_ui(person_obj, person);
 
         if (people.is_my_user_id(person.user_id) && current_user.is_owner !== person_obj.is_owner) {
             current_user.is_owner = person_obj.is_owner;
@@ -125,10 +129,12 @@ export const update_person = function update(person) {
         }
 
         message_live_update.update_avatar(person_obj.user_id, person.avatar_url);
+        user_profile.update_profile_modal_ui(person_obj, person);
     }
 
     if (Object.hasOwn(person, "custom_profile_field")) {
         people.set_custom_profile_field_data(person.user_id, person.custom_profile_field);
+        user_profile.update_user_custom_profile_fields(person_obj);
         if (person.user_id === people.my_current_user_id()) {
             navbar_alerts.maybe_show_empty_required_profile_fields_alert();
 
@@ -164,6 +170,7 @@ export const update_person = function update(person) {
 
     if (Object.hasOwn(person, "bot_owner_id")) {
         person_obj.bot_owner_id = person.bot_owner_id;
+        user_profile.update_profile_modal_ui(person_obj, person);
     }
 
     if (Object.hasOwn(person, "is_active")) {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -1,6 +1,7 @@
 import ClipboardJS from "clipboard";
 import {parseISO} from "date-fns";
 import $ from "jquery";
+import _ from "lodash";
 
 import render_profile_access_error_model from "../templates/profile_access_error_modal.hbs";
 import render_admin_human_form from "../templates/settings/admin_human_form.hbs";
@@ -49,6 +50,7 @@ let user_streams_list_widget;
 let user_profile_subscribe_widget;
 let toggler;
 let bot_owner_dropdown_widget;
+let original_values;
 
 const INCOMING_WEBHOOK_BOT_TYPE = 2;
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
@@ -421,6 +423,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
     modals.open("user-profile-modal", {autoremove: true, on_hide: on_user_profile_hide});
     $(".tabcontent").hide();
+    $("#user-profile-modal .dialog_submit_button").prop("disabled", true);
 
     let default_tab = 0;
 
@@ -537,6 +540,11 @@ export function show_edit_bot_info_modal(user_id, $container) {
     const bot_type = bot.bot_type.toString();
     const service = bot_data.get_services(bot.user_id)[0];
     edit_bot_post_render();
+    original_values = get_current_values($("#bot-edit-form"));
+    $("#bot-edit-form").on("input", "input, select, button", (e) => {
+        e.preventDefault();
+        toggle_submit_button($("#bot-edit-form"));
+    });
     $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt($("#bot-role-select").val().trim(), 10);
         const $full_name = $("#bot-edit-form").find("input[name='full_name']");
@@ -581,7 +589,10 @@ export function show_edit_bot_info_modal(user_id, $container) {
             contentType: false,
             success() {
                 avatar_widget.clear();
-                hide_user_profile();
+                hide_button_spinner($submit_btn);
+                original_values = get_current_values($("#bot-edit-form"));
+                toggle_submit_button($("#edit-user-form"));
+                $cancel_btn.prop("disabled", false);
             },
             error(xhr) {
                 ui_report.error(
@@ -740,6 +751,23 @@ function get_human_profile_data(fields_user_pills) {
     return new_profile_data;
 }
 
+function get_current_values($edit_form) {
+    const current_values = dialog_widget.get_current_values(
+        $edit_form.find("input, select, textarea, button, .pill-container"),
+    );
+    return current_values;
+}
+
+function toggle_submit_button($edit_form) {
+    const current_values = get_current_values($edit_form);
+    const $submit_btn = $("#user-profile-modal .dialog_submit_button");
+    if (!_.isEqual(original_values, current_values)) {
+        $submit_btn.prop("disabled", false);
+    } else {
+        $submit_btn.prop("disabled", true);
+    }
+}
+
 export function show_edit_user_info_modal(user_id, $container) {
     const person = people.maybe_get_user_by_id(user_id);
     const is_active = people.is_person_active(user_id);
@@ -781,7 +809,11 @@ export function show_edit_user_info_modal(user_id, $container) {
         custom_profile_field_form_selector,
         user_id,
         true,
+        () => {
+            toggle_submit_button($("#edit-user-form"));
+        },
     );
+    original_values = get_current_values($("#edit-user-form"));
 
     // Handle deactivation
     $("#edit-user-form").on("click", ".deactivate_user_button", (e) => {
@@ -807,6 +839,11 @@ export function show_edit_user_info_modal(user_id, $container) {
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
 
+    $("#edit-user-form").on("input", "input, select, textarea", (e) => {
+        e.preventDefault();
+        toggle_submit_button($("#edit-user-form"));
+    });
+
     $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt($("#user-role-select").val().trim(), 10);
         const $full_name = $("#edit-user-form").find("input[name='full_name']");
@@ -828,7 +865,10 @@ export function show_edit_user_info_modal(user_id, $container) {
             url,
             data,
             success() {
-                hide_user_profile();
+                hide_button_spinner($submit_btn);
+                original_values = get_current_values($("#edit-user-form"));
+                toggle_submit_button($("#edit-user-form"));
+                $cancel_btn.prop("disabled", false);
             },
             error(xhr) {
                 ui_report.error(

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -592,6 +592,11 @@ export function show_edit_bot_info_modal(user_id, $container) {
                 hide_button_spinner($submit_btn);
                 original_values = get_current_values($("#bot-edit-form"));
                 toggle_submit_button($("#edit-user-form"));
+                ui_report.success(
+                    $t_html({defaultMessage: "Saved"}),
+                    $("#user-profile-modal .save-success"),
+                    1200,
+                );
                 $cancel_btn.prop("disabled", false);
             },
             error(xhr) {
@@ -868,6 +873,11 @@ export function show_edit_user_info_modal(user_id, $container) {
                 hide_button_spinner($submit_btn);
                 original_values = get_current_values($("#edit-user-form"));
                 toggle_submit_button($("#edit-user-form"));
+                ui_report.success(
+                    $t_html({defaultMessage: "Saved"}),
+                    $("#user-profile-modal .save-success"),
+                    1200,
+                );
                 $cancel_btn.prop("disabled", false);
             },
             error(xhr) {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -157,6 +157,20 @@
     color: hsl(0deg 0% 100%) !important;
 }
 
+#user-profile-modal .save-success {
+    vertical-align: top;
+    background-color: transparent;
+    border-radius: 4px;
+    margin-right: 10px;
+    color: hsl(156deg 30% 50%);
+    padding: 0.5rem 1rem;
+    line-height: 1.15;
+
+    &:not(:empty) {
+        border: 1px solid hsl(156deg 30% 50%);
+    }
+}
+
 #read_receipts_error,
 #dialog_error {
     margin-bottom: 10px;

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -7,28 +7,28 @@
     <div class="settings-profile-user-field-hint">{{ field.hint }}</div>
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}}">
         {{#if is_long_text_field}}
-        <textarea maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>
+        <textarea maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}">{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style">
+        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}">
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
             {{/each}}
         </select>
         {{else if is_user_field }}
-        <div class="pill-container person_picker">
+        <div class="pill-container person_picker" name="{{ field.id }}">
             <div class="input" contenteditable="true"></div>
         </div>
         {{else if is_date_field }}
-        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" data-field-id="{{ field.id }}" type="text"
+        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" data-field-id="{{ field.id }}" type="text"
           value="{{ field_value.value }}" />
         <span class="remove_date"><i class="fa fa-close"></i></span>
         {{else if is_url_field }}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
+        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{else}}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{/if}}
     </div>
 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -135,6 +135,7 @@
             </main>
             <div class="manage-profile-tab-footer">
                 <footer class="modal__footer">
+                    <div class="save-success"></div>
                     <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                     <button type="button" class="modal__btn dialog_submit_button">
                         <span>{{t "Save changes"}}</span>

--- a/web/tests/example4.test.js
+++ b/web/tests/example4.test.js
@@ -59,6 +59,7 @@ const activity_ui = mock_esm("../src/activity_ui");
 const message_live_update = mock_esm("../src/message_live_update");
 const pm_list = mock_esm("../src/pm_list");
 const settings_users = mock_esm("../src/settings_users");
+const user_profile = mock_esm("../src/user_profile");
 
 // Use real versions of these modules.
 const people = zrequire("people");
@@ -137,6 +138,7 @@ run_test("update user with event", ({override}) => {
     override(pm_list, "update_private_messages", noop);
     override(settings_users, "update_user_data", noop);
     override(settings_users, "update_bot_data", noop);
+    override(user_profile, "update_profile_modal_ui", noop);
 
     // Dispatch the realm_user/update event, which will update
     // data structures and have other side effects that are

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -20,6 +20,10 @@ const settings_users = mock_esm("../src/settings_users", {
     update_user_data() {},
     update_view_on_deactivate() {},
 });
+mock_esm("../src/user_profile", {
+    update_profile_modal_ui() {},
+    update_user_custom_profile_fields() {},
+});
 const stream_events = mock_esm("../src/stream_events");
 
 mock_esm("../src/activity_ui", {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR completes the original work done by #27266.

Fixes: #26692

The user-profile modal now shows a confirmation feedback when the user edits a profile field and clicks on the save changes button. This way, the user knows that the changes have been made successfully and can close the modal manually. Previously, the modal would close automatically without any feedback, which could be confusing for the user.

The user-profile modal now shows a confirmation feedback when the user edits a profile field and clicks on the save changes button. This way, the user knows that the changes have been made successfully and can close the modal manually. Previously, the modal would close automatically without any feedback, which could be confusing for the user.
The changes in user/bot profile are also reflected after clicking on save changes button.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/98596642/4d3d9dbe-a1f6-4beb-a8d6-6c9146325c1a)
![image](https://github.com/zulip/zulip/assets/98596642/5c6592d0-adcb-4b8b-873a-0d087f73efcc)

[screen-capture (4).webm](https://github.com/zulip/zulip/assets/98596642/73de2eee-79c7-4a04-bcc7-d5a68a37f2e1)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
