### PR TITLE
Solved cancel button disable look issue.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -6,6 +6,7 @@
     --color-exit-button-border: hsl(300deg 2% 11% / 30%);
     --color-exit-button-background: hsl(0deg 0% 100%);
     --color-exit-button-background-interactive: hsl(0deg 0% 97%);
+    --color-exit-button-background-disabled: hsl(0deg 0% 90%);
 }
 
 .modal__overlay {
@@ -143,6 +144,10 @@
 
     &:hover {
         background: var(--color-exit-button-background-interactive);
+    }
+
+    &:disabled {
+        background: var(--color-exit-button-background-disabled);
     }
 }
 


### PR DESCRIPTION
Solved the issue of "Cancel" button of dialog widget gets functionally disabled whenever the changes are saved, but in light theme, it doesn't look disabled visually when it should be.

Fixes:  #28803 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
<img width="655" alt="image" src="https://github.com/zulip/zulip/assets/96689162/5c0263d6-2c01-483c-b9b0-715dddf42c3c">

After:
<img width="655" alt="image" src="https://github.com/zulip/zulip/assets/96689162/2751f26d-166a-4acd-a644-542fb0fb6ccd">
<img width="657" alt="image" src="https://github.com/zulip/zulip/assets/96689162/4c02f03b-aeb3-4df1-adb3-c001a61ed489">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
