### PR TITLE
Fix races when marking unread at end-of-feed.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1439,16 +1439,21 @@ export class MessageListView {
         this.message_containers.clear();
     }
 
+    is_fetched_end_rendered() {
+        return this._render_win_end === this.list.num_items();
+    }
+
     is_end_rendered() {
         // Used as a helper in checks for whether a given scroll
         // position is actually the very end of this view. It could
         // fail to be for two reasons: Either some newer messages are
         // not rendered due to a render window, or we haven't finished
         // fetching the newest messages for this view from the server.
-        return (
-            this._render_win_end === this.list.num_items() &&
-            this.list.data.fetch_status.has_found_newest()
-        );
+        return this.is_fetched_end_rendered() && this.list.data.fetch_status.has_found_newest();
+    }
+
+    is_fetched_start_rendered() {
+        return this._render_win_start === 0;
     }
 
     is_start_rendered() {
@@ -1457,7 +1462,7 @@ export class MessageListView {
         // fail to be for two reasons: Either some older messages are
         // not rendered due to a render window, or we haven't finished
         // fetching the oldest messages for this view from the server.
-        return this._render_win_start === 0 && this.list.data.fetch_status.has_found_oldest();
+        return this.is_fetched_start_rendered() && this.list.data.fetch_status.has_found_oldest();
     }
 
     get_row(id) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1439,6 +1439,10 @@ export class MessageListView {
         this.message_containers.clear();
     }
 
+    last_rendered_message() {
+        return this.list.data._items[this._render_win_end - 1];
+    }
+
     is_fetched_end_rendered() {
         return this._render_win_end === this.list.num_items();
     }
@@ -1450,6 +1454,10 @@ export class MessageListView {
         // not rendered due to a render window, or we haven't finished
         // fetching the newest messages for this view from the server.
         return this.is_fetched_end_rendered() && this.list.data.fetch_status.has_found_newest();
+    }
+
+    first_rendered_message() {
+        return this.list.data._items[this._render_win_start];
     }
 
     is_fetched_start_rendered() {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1152,7 +1152,7 @@ export class MessageListView {
     }
 
     update_render_window(selected_idx, check_for_changed) {
-        const new_start = Math.max(selected_idx - this._RENDER_WINDOW_SIZE / 2, 0);
+        const new_start = Math.max(selected_idx - Math.floor(this._RENDER_WINDOW_SIZE / 2), 0);
         if (check_for_changed && new_start === this._render_win_start) {
             return false;
         }

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -100,24 +100,31 @@ export function page_down_the_right_amount() {
 }
 
 export function page_up() {
-    if (
-        message_viewport.at_rendered_top() &&
-        !message_lists.current.visibly_empty() &&
-        message_lists.current.view.is_fetched_start_rendered()
-    ) {
-        message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
+    if (message_viewport.at_rendered_top() && !message_lists.current.visibly_empty()) {
+        if (message_lists.current.view.is_fetched_start_rendered()) {
+            message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
+        } else {
+            message_lists.current.select_id(
+                message_lists.current.view.first_rendered_message().id,
+                {
+                    then_scroll: false,
+                },
+            );
+        }
     } else {
         page_up_the_right_amount();
     }
 }
 
 export function page_down() {
-    if (
-        message_viewport.at_rendered_bottom() &&
-        !message_lists.current.visibly_empty() &&
-        message_lists.current.view.is_fetched_end_rendered()
-    ) {
-        message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
+    if (message_viewport.at_rendered_bottom() && !message_lists.current.visibly_empty()) {
+        if (message_lists.current.view.is_fetched_end_rendered()) {
+            message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
+        } else {
+            message_lists.current.select_id(message_lists.current.view.last_rendered_message().id, {
+                then_scroll: false,
+            });
+        }
         unread_ops.process_visible();
     } else {
         page_down_the_right_amount();

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -103,7 +103,7 @@ export function page_up() {
     if (
         message_viewport.at_rendered_top() &&
         !message_lists.current.visibly_empty() &&
-        message_lists.current.view.is_start_rendered()
+        message_lists.current.view.is_fetched_start_rendered()
     ) {
         message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
     } else {
@@ -115,7 +115,7 @@ export function page_down() {
     if (
         message_viewport.at_rendered_bottom() &&
         !message_lists.current.visibly_empty() &&
-        message_lists.current.view.is_end_rendered()
+        message_lists.current.view.is_fetched_end_rendered()
     ) {
         message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
         unread_ops.process_visible();

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -442,7 +442,14 @@ function process_scrolled_to_bottom() {
     }
 
     if (message_lists.current.can_mark_messages_read()) {
-        mark_current_list_as_read();
+        // Mark all the messages in this message feed as read.
+        //
+        // Important: We have not checked definitively whether there
+        // are further messages that we're waiting on the server to
+        // return that would appear below the visible part of the
+        // feed, so it would not be correct to instead ask the server
+        // to mark all messages matching this entire narrow as read.
+        notify_server_messages_read(message_lists.current.all_messages());
         return;
     }
 
@@ -460,14 +467,10 @@ export function process_visible() {
     if (
         viewport_is_visible_and_focused() &&
         message_viewport.bottom_rendered_message_visible() &&
-        message_lists.current.view.is_end_rendered()
+        message_lists.current.view.is_fetched_end_rendered()
     ) {
         process_scrolled_to_bottom();
     }
-}
-
-export function mark_current_list_as_read(options) {
-    notify_server_messages_read(message_lists.current.all_messages(), options);
 }
 
 export function mark_stream_as_read(stream_id) {

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -125,7 +125,7 @@ run_test("unread_ops", ({override}) => {
     // data setup).
     override(message_lists.current, "can_mark_messages_read", () => can_mark_messages_read);
     override(message_lists.current, "has_unread_messages", () => true);
-    override(message_lists.current.view, "is_end_rendered", () => true);
+    override(message_lists.current.view, "is_fetched_end_rendered", () => true);
 
     // First, test for a message list that cannot read messages.
     can_mark_messages_read = false;
@@ -136,11 +136,11 @@ run_test("unread_ops", ({override}) => {
     // Now flip the boolean, and get to the main thing we are testing.
     can_mark_messages_read = true;
     // Don't mark messages as read until all messages in the narrow are fetched and rendered.
-    override(message_lists.current.view, "is_end_rendered", () => false);
+    override(message_lists.current.view, "is_fetched_end_rendered", () => false);
     unread_ops.process_visible();
     assert.deepEqual(channel_post_opts, undefined);
 
-    override(message_lists.current.view, "is_end_rendered", () => true);
+    override(message_lists.current.view, "is_fetched_end_rendered", () => true);
     unread_ops.process_visible();
 
     // The most important side effect of the above call is that


### PR DESCRIPTION
This is a follow-up addressing bugs in #28772, intended to fix the bugs reported in https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20conversations.20unread.20topic.20persists/near/1732064.

See the individual commits for details.