### PR TITLE
Improve 'Resend invitation' confirmation modal

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -277,7 +277,7 @@ export function on_load_success(
         const html_body = render_settings_resend_invite_modal({email});
 
         confirm_dialog.launch({
-            html_heading: $t_html({defaultMessage: "Resend invitation"}),
+            html_heading: $t_html({defaultMessage: "Resend invitation?"}),
             html_body,
             on_click() {
                 do_resend_invite({$row, invite_id});

--- a/web/templates/confirm_dialog/confirm_resend_invite.hbs
+++ b/web/templates/confirm_dialog/confirm_resend_invite.hbs
@@ -3,6 +3,7 @@
         Are you sure you want to resend the invitation to <z-email></z-email>?
         {{#*inline "z-email"}}<strong>{{email}}</strong>{{/inline}}
     {{/tr}}
-    <br>
+</p>
+<p>
     This will not change the expiration time for this invitation.
 </p>

--- a/web/templates/confirm_dialog/confirm_resend_invite.hbs
+++ b/web/templates/confirm_dialog/confirm_resend_invite.hbs
@@ -3,4 +3,6 @@
         Are you sure you want to resend the invitation to <z-email></z-email>?
         {{#*inline "z-email"}}<strong>{{email}}</strong>{{/inline}}
     {{/tr}}
+    <br>
+    This will not change the expiration time for this invitation.
 </p>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #28829 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

I have made the following changes to implement the required functionality:
1. Added question  mark to confirmation dialog heading in zulip/web/templates/confirm_dialog/confirm_resend_invite.hbs
2. Appended required text in confirmation dialog text in zulip/web/src/settings_invites.ts

**Before changes:**

![image](https://github.com/zulip/zulip/assets/113179991/d0cf6393-fb42-4ea2-bc6a-13f3d754e00a)

**After changes:**

![image](https://github.com/zulip/zulip/assets/113179991/295e3788-19e2-4223-9879-9fae5a255772)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).


Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.

</details>
