### PR TITLE
remote-support: Expand push notification data.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -1,4 +1,3 @@
-import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -33,13 +32,6 @@ from zilencer.models import (
     RemoteZulipServer,
     get_remote_customer_user_count,
 )
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
-
-eastern_tz = zoneinfo.ZoneInfo("America/New_York")
 
 
 @dataclass
@@ -100,9 +92,11 @@ def dictfetchall(cursor: CursorWrapper) -> List[Dict[str, Any]]:
     return [dict(zip((col[0] for col in desc), row)) for row in cursor.fetchall()]
 
 
-def format_date_for_activity_reports(date: Optional[datetime]) -> str:
+def format_optional_datetime(date: Optional[datetime], display_none: bool = False) -> str:
     if date:
-        return date.astimezone(eastern_tz).strftime("%Y-%m-%d %H:%M")
+        return date.strftime("%Y-%m-%d %H:%M")
+    elif display_none:
+        return "None"
     else:
         return ""
 

--- a/corporate/views/installation_activity.py
+++ b/corporate/views/installation_activity.py
@@ -15,7 +15,7 @@ from corporate.lib.activity import (
     dictfetchall,
     estimate_annual_recurring_revenue_by_realm,
     fix_rows,
-    format_date_for_activity_reports,
+    format_optional_datetime,
     get_query_data,
     get_realms_with_default_discount_dict,
     make_table,
@@ -331,15 +331,15 @@ def get_integrations_activity(request: HttpRequest) -> HttpResponse:
         "Client",
         "Realm",
         "Hits",
-        "Last time",
+        "Last time (UTC)",
     ]
 
     rows = get_query_data(query)
     for i, col in enumerate(cols):
         if col == "Realm":
             fix_rows(rows, i, realm_activity_link)
-        elif col == "Last time":
-            fix_rows(rows, i, format_date_for_activity_reports)
+        elif col == "Last time (UTC)":
+            fix_rows(rows, i, format_optional_datetime)
 
     content = make_table(title, cols, rows)
     return render(

--- a/corporate/views/realm_activity.py
+++ b/corporate/views/realm_activity.py
@@ -11,7 +11,7 @@ from django.utils.timezone import now as timezone_now
 from markupsafe import Markup
 
 from corporate.lib.activity import (
-    format_date_for_activity_reports,
+    format_optional_datetime,
     make_table,
     realm_stats_link,
     user_activity_link,
@@ -116,8 +116,8 @@ def realm_user_summary_table(
         "Email",
         "User type",
         "Messages sent",
-        "Last heard from",
-        "Last message sent",
+        "Last heard from (UTC)",
+        "Last message sent (UTC)",
     ]
 
     rows = []
@@ -129,8 +129,8 @@ def realm_user_summary_table(
             user_summary.user_type,
             user_summary.messages_sent,
         ]
-        cells.append(format_date_for_activity_reports(user_summary.last_heard_from))
-        cells.append(format_date_for_activity_reports(user_summary.last_message_sent))
+        cells.append(format_optional_datetime(user_summary.last_heard_from))
+        cells.append(format_optional_datetime(user_summary.last_message_sent))
 
         row_class = ""
         if user_summary.last_heard_from and is_recent(user_summary.last_heard_from):

--- a/corporate/views/remote_activity.py
+++ b/corporate/views/remote_activity.py
@@ -4,8 +4,8 @@ from psycopg2.sql import SQL
 
 from corporate.lib.activity import (
     fix_rows,
-    format_date_for_activity_reports,
     format_none_as_zero,
+    format_optional_datetime,
     get_plan_data_by_remote_realm,
     get_plan_data_by_remote_server,
     get_query_data,
@@ -85,7 +85,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         "Realm host or server hostname",
         "Server contact email",
         "Server Zulip version",
-        "Server last audit log update",
+        "Server last audit log update (UTC)",
         "Server mobile users",
         "Server mobile pushes",
         "Realm organization type",
@@ -199,7 +199,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     # Format column data and add total row
     for i, col in enumerate(cols):
         if i == LAST_AUDIT_LOG_DATE:
-            fix_rows(rows, i, format_date_for_activity_reports)
+            fix_rows(rows, i, format_optional_datetime)
         if i in [MOBILE_USER_COUNT, MOBILE_PUSH_COUNT]:
             fix_rows(rows, i, format_none_as_zero)
         if i == SERVER_AND_REALM_IDS:

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -19,7 +19,7 @@ from django.utils.translation import gettext as _
 
 from confirmation.models import Confirmation, confirmation_url
 from confirmation.settings import STATUS_USED
-from corporate.lib.activity import remote_installation_stats_link
+from corporate.lib.activity import format_optional_datetime, remote_installation_stats_link
 from corporate.lib.stripe import (
     RealmBillingSession,
     RemoteRealmBillingSession,
@@ -638,6 +638,7 @@ def remote_servers_support(
     context["get_plan_type_name"] = get_plan_type_string
     context["get_org_type_display_name"] = get_org_type_display_name
     context["format_discount"] = format_discount_percentage
+    context["format_optional_datetime"] = format_optional_datetime
     context["dollar_amount"] = cents_to_dollar_string
     context["server_analytics_link"] = remote_installation_stats_link
     context["REMOTE_PLAN_TIERS"] = get_remote_plan_tier_options()

--- a/corporate/views/user_activity.py
+++ b/corporate/views/user_activity.py
@@ -4,7 +4,7 @@ from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
-from corporate.lib.activity import format_date_for_activity_reports, make_table
+from corporate.lib.activity import format_optional_datetime, make_table
 from zerver.decorator import require_server_admin
 from zerver.models import UserActivity, UserProfile
 from zerver.models.users import get_user_profile_by_id
@@ -40,7 +40,7 @@ def get_user_activity(request: HttpRequest, user_profile_id: int) -> HttpRespons
         "Query",
         "Client",
         "Count",
-        "Last visit",
+        "Last visit (UTC)",
     ]
 
     def row(record: UserActivity) -> List[Any]:
@@ -48,7 +48,7 @@ def get_user_activity(request: HttpRequest, user_profile_id: int) -> HttpRespons
             record.query,
             record.client.name,
             record.count,
-            format_date_for_activity_reports(record.last_visit),
+            format_optional_datetime(record.last_visit),
         ]
 
     rows = list(map(row, records))

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -23,7 +23,7 @@
     <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />
     <b>Guest user count</b>: {{ support_data[remote_realm.id].user_data.guest_user_count }}<br />
     <br />
-    <b>Mobile user count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_users }}<br />
+    <b>Mobile user count</b>: {{ support_data[remote_realm.id].mobile_push_data.total_mobile_users }}<br />
     <b>7-day mobile pushes count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_pushes_forwarded }}<br />
     <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(support_data[remote_realm.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
 </div>

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -20,11 +20,12 @@
     <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
     <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
     <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />
-    <br />
     <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />
     <b>Guest user count</b>: {{ support_data[remote_realm.id].user_data.guest_user_count }}<br />
+    <br />
     <b>Mobile user count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_users }}<br />
     <b>7-day mobile pushes count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_pushes_forwarded }}<br />
+    <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(support_data[remote_realm.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
 </div>
 
 {% if remote_realm.plan_type != SPONSORED_PLAN_TYPE %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -55,6 +55,7 @@
                 <b>Has remote realms</b>: {{ remote_realms[remote_server.id] != [] }}<br />
                 <br />
                 <b>Max monthly messages</b>: {{ remote_server_to_max_monthly_messages[remote_server.id] }}<br />
+                <b>Last audit log update (UTC)</b>: {{ format_optional_datetime(remote_server.last_audit_log_update, True) }}<br />
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
                 <b>Non-guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.non_guest_user_count }}<br />
                 <b>Guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.guest_user_count }}<br />

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -59,8 +59,10 @@
                 <b>Plan type</b>: {{ get_plan_type_name(remote_server.plan_type) }}<br />
                 <b>Non-guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.non_guest_user_count }}<br />
                 <b>Guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.guest_user_count }}<br />
+                <br />
                 <b>Mobile user count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.mobile_users }}<br />
                 <b>7-day mobile pushes count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.mobile_pushes_forwarded }}<br />
+                <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(remote_servers_support_data[remote_server.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
             </div>
 
             {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
@@ -116,6 +118,7 @@
                     {% set support_data = remote_realms_support_data %}
                     {% set get_plan_type_name = get_plan_type_name %}
                     {% set format_discount = format_discount %}
+                    {% set format_optional_datetime = format_optional_datetime %}
                     {% set dollar_amount = dollar_amount %}
                     {% include "corporate/support/remote_realm_details.html" %}
                 {% endwith %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -60,7 +60,10 @@
                 <b>Non-guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.non_guest_user_count }}<br />
                 <b>Guest user count</b>: {{ remote_servers_support_data[remote_server.id].user_data.guest_user_count }}<br />
                 <br />
-                <b>Mobile user count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.mobile_users }}<br />
+                <b>Total mobile user count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.total_mobile_users }}<br />
+                {% if remote_realms[remote_server.id] != [] %}
+                    <b>Uncategorized mobile user count:</b> {{ remote_servers_support_data[remote_server.id].mobile_push_data.uncategorized_mobile_users }}<br />
+                {% endif %}
                 <b>7-day mobile pushes count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.mobile_pushes_forwarded }}<br />
                 <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(remote_servers_support_data[remote_server.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
             </div>


### PR DESCRIPTION
Adds the following information to the remote support view:
- For the remote server:
  - Shows the last audit log update date/time, which is also displayed in the remote activity chart.
  - Shows the date/time that the mobile pushes forwarded count was updated for the server.
  - If there are remote realms, shows the count of mobile users that have not yet been associated with a remote realm. This helps to account for the potential discrepancy between the total mobile user count for the server and the sum of the mobile user counts for the remote realms associated with the server.
- For the remote realm:
  - Shows the date/time that the mobile pushes forwarded count was updated for the realm.

**Notes**:
- The formatting for optional date/times in the activity views was setting the timezone to be eastern US, but that wasn't indicated anywhere in the charts. Updated this to now show the date/times in UTC, which is what we store on the server, and to have the columns in the charts (or field in the support view) labeled as such.
- Adds a couple more queries when building the data for the support view. As this page is still very much in development, it seemed like these additional queries would be pretty cheap and that we can look at optimization when the page is a bit more stable.
- Manually reviewed, but did not include screenshots of the various activity chart changes.

---

**Screenshots and screen captures:**

<details>
<summary>Remote server information in remote support view</summary>

![Screenshot from 2024-02-06 14-24-23](https://github.com/zulip/zulip/assets/63245456/b8e50fa5-7f01-4e0d-ae5c-f89f348d96aa)
</details>
<details>
<summary>Remote realm information in remote support view</summary>

![Screenshot from 2024-02-06 14-24-37](https://github.com/zulip/zulip/assets/63245456/157d9d91-9577-430e-bf37-f004a11efe17)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
