### PR TITLE
help: Improve integrations documentation (follow-up).

### DIFF
--- a/templates/corporate/comparison_table_cloud.html
+++ b/templates/corporate/comparison_table_cloud.html
@@ -314,7 +314,7 @@
             </tr>
             <tr>
                 <td class="comparison-table-feature">
-                    <a href="/help/bots-and-integrations">
+                    <a href="/help/bots-overview">
                         Admin controls for all bots and integrations
                     </a>
                 </td>

--- a/templates/corporate/comparison_table_self_hosted.html
+++ b/templates/corporate/comparison_table_self_hosted.html
@@ -353,7 +353,7 @@
             </tr>
             <tr>
                 <td class="comparison-table-feature">
-                    <a href="/help/bots-and-integrations">
+                    <a href="/help/bots-overview">
                         Admin controls for all bots and integrations
                     </a>
                 </td>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -42,7 +42,7 @@
                     {% if page_is_policy_center %}
                     <p>Please contact {{ support_email_html_tag }} with any questions about Zulip's policies.</p>
                     {% else %}
-                    <p>Your feedback helps us make Zulip better for everyone! Please <a href="mailto:{{ support_email }}">contact us</a> with questions, suggestions, and feature requests.</p>
+                    <p>Your feedback helps us make Zulip better for everyone! Please <a href="/help/contact-support">contact us</a> with questions, suggestions, and feature requests.</p>
                     {% endif %}
                 {% else %}
                     <p>Don't see an answer to your question? <a href="mailto:{{ support_email }}">Contact this Zulip server's administrators</a> for support.</p>

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -3,7 +3,7 @@
         <div class="input-group">
             <label for="bot_type">
                 {{t "Bot type" }}
-                {{> ../help_link_widget link="/help/bots-and-integrations#bot-type" }}
+                {{> ../help_link_widget link="/help/bots-overview#bot-type" }}
             </label>
             <select name="bot_type" id="create_bot_type" class="modal_select bootstrap-focus-style">
                 {{#each bot_types}}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8952,7 +8952,7 @@ paths:
         Note that for private streams with [protected
         history](/help/stream-permissions), the user will only have access to
         topics of messages sent after they [subscribed to](/api/subscribe) the
-        stream. Similarly, a user's [bot](/help/bots-and-integrations#bot-type)
+        stream. Similarly, a user's [bot](/help/bots-overview#bot-type)
         will only have access to messages sent after the bot was subscribed to
         the stream, instead of when the user subscribed.
       parameters:


### PR DESCRIPTION
This is a follow-up PR (#28775).

- Fixes "contact us" link in the footer of documentation pages.
- Updates links to "Bots overview" help center page.
