### PR TITLE
Gracefully handle "Your plan doesn't allow sending push notifications." exception

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -51,6 +51,7 @@ class ErrorCode(Enum):
     STREAM_WILDCARD_MENTION_NOT_ALLOWED = auto()
     REMOTE_BILLING_UNAUTHENTICATED_USER = auto()
     REMOTE_REALM_SERVER_MISMATCH_ERROR = auto()
+    PUSH_NOTIFICATIONS_DISALLOWED = auto()
 
 
 class JsonableError(Exception):

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -185,6 +185,10 @@ def send_to_push_bouncer(
             raise PushNotificationBouncerError(
                 _("Push notifications bouncer error: {error}").format(error=msg)
             )
+        elif "code" in result_dict and result_dict["code"] == "PUSH_NOTIFICATIONS_DISALLOWED":
+            from zerver.lib.push_notifications import PushNotificationsDisallowedByBouncerError
+
+            raise PushNotificationsDisallowedByBouncerError(reason=msg)
         elif (
             endpoint == "push/test_notification"
             and "code" in result_dict

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2740,6 +2740,80 @@ class HandlePushNotificationTest(PushNotificationTest):
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
     @responses.activate
+    def test_end_to_end_failure_due_to_no_plan(self) -> None:
+        self.add_mock_response()
+
+        self.setup_apns_tokens()
+        self.setup_gcm_tokens()
+
+        self.server.last_api_feature_level = 237
+        self.server.save()
+
+        realm = self.user_profile.realm
+        realm.push_notifications_enabled = True
+        realm.save()
+
+        message = self.get_message(
+            Recipient.PERSONAL,
+            type_id=self.personal_recipient_user.id,
+            realm_id=self.personal_recipient_user.realm_id,
+        )
+        UserMessage.objects.create(
+            user_profile=self.user_profile,
+            message=message,
+        )
+
+        missed_message = {
+            "message_id": message.id,
+            "trigger": NotificationTriggers.DIRECT_MESSAGE,
+        }
+        with mock.patch(
+            "corporate.lib.stripe.RemoteServerBillingSession.current_count_for_billed_licenses",
+            return_value=100,
+        ) as mock_current_count, self.assertLogs(
+            "zerver.lib.push_notifications", level="INFO"
+        ) as pn_logger, self.assertLogs(
+            "zilencer.views", level="INFO"
+        ):
+            handle_push_notification(self.user_profile.id, missed_message)
+
+            self.assertEqual(
+                pn_logger.output,
+                [
+                    f"INFO:zerver.lib.push_notifications:Sending push notifications to mobile clients for user {self.user_profile.id}",
+                    "WARNING:zerver.lib.push_notifications:Bouncer refused to send push notification: Your plan doesn't allow sending push notifications. Reason provided by the server: No plan many users",
+                ],
+            )
+            realm.refresh_from_db()
+            self.assertEqual(realm.push_notifications_enabled, False)
+            self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
+
+            # Now verify the flag will correctly get flipped back if the server stops
+            # rejecting our notification.
+
+            # This will put us within the allowed number of users to use push notifications
+            # for free, so the server will accept our next request.
+            mock_current_count.return_value = 5
+
+            new_message_id = self.send_personal_message(
+                self.example_user("othello"), self.user_profile
+            )
+            new_missed_message = {
+                "message_id": new_message_id,
+                "trigger": NotificationTriggers.DIRECT_MESSAGE,
+            }
+
+            handle_push_notification(self.user_profile.id, new_missed_message)
+            self.assertIn(
+                f"Sent mobile push notifications for user {self.user_profile.id}",
+                pn_logger.output[-1],
+            )
+            realm.refresh_from_db()
+            self.assertEqual(realm.push_notifications_enabled, True)
+            self.assertEqual(realm.push_notifications_enabled_end_timestamp, None)
+
+    @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
+    @responses.activate
     def test_unregistered_client(self) -> None:
         self.add_mock_response()
         self.setup_apns_tokens()

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -829,8 +829,11 @@ class PushBouncerNotificationTest(BouncerTestCase):
             payload,
             content_type="application/json",
         )
-        self.assert_json_error(result, "Your plan doesn't allow sending push notifications.")
-        self.assertEqual(orjson.loads(result.content)["code"], "BAD_REQUEST")
+        self.assert_json_error(
+            result,
+            "Your plan doesn't allow sending push notifications. Reason provided by the server: Missing data",
+        )
+        self.assertEqual(orjson.loads(result.content)["code"], "PUSH_NOTIFICATIONS_DISALLOWED")
 
         human_counts = {
             str(UserProfile.ROLE_REALM_ADMINISTRATOR): 1,
@@ -854,8 +857,11 @@ class PushBouncerNotificationTest(BouncerTestCase):
             payload,
             content_type="application/json",
         )
-        self.assert_json_error(result, "Your plan doesn't allow sending push notifications.")
-        self.assertEqual(orjson.loads(result.content)["code"], "BAD_REQUEST")
+        self.assert_json_error(
+            result,
+            "Your plan doesn't allow sending push notifications. Reason provided by the server: No plan many users",
+        )
+        self.assertEqual(orjson.loads(result.content)["code"], "PUSH_NOTIFICATIONS_DISALLOWED")
 
         # Check that sponsored realms are allowed to send push notifications.
         remote_server.plan_type = RemoteRealm.PLAN_TYPE_COMMUNITY

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -472,6 +472,16 @@ class OldZulipServerError(JsonableError):
         self._msg: str = msg
 
 
+class PushNotificationsDisallowedError(JsonableError):
+    code = ErrorCode.PUSH_NOTIFICATIONS_DISALLOWED
+
+    def __init__(self, reason: str) -> None:
+        msg = _(
+            "Your plan doesn't allow sending push notifications. Reason provided by the server: {reason}"
+        ).format(reason=reason)
+        super().__init__(msg)
+
+
 @has_request_variables
 def remote_server_notify_push(
     request: HttpRequest,
@@ -502,7 +512,8 @@ def remote_server_notify_push(
         if server.last_api_feature_level is None:
             raise OldZulipServerError(_("Your plan doesn't allow sending push notifications."))
         else:
-            raise JsonableError(_("Your plan doesn't allow sending push notifications."))
+            reason = push_status.message
+            raise PushNotificationsDisallowedError(reason=reason)
 
     android_devices = list(
         RemotePushDeviceToken.objects.filter(


### PR DESCRIPTION
This was an uncaught JsonableError before, getting logged and email with a full traceback.

The first commit adds the bouncer-side of this fix - making this as a distinct json error with its own code.
The second takes advantage of that, by detecting that json error code, catching the exception in the appropriate place that sends a push notiification, and doing useful stuff with it