### PR TITLE
Change header of streams without description.

### DIFF
--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -10,6 +10,7 @@ import * as peer_data from "./peer_data";
 import * as recent_view_util from "./recent_view_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
+import {current_user} from "./state_data";
 
 function get_message_view_header_context(filter) {
     if (recent_view_util.is_visible()) {
@@ -47,8 +48,9 @@ function get_message_view_header_context(filter) {
         // involves a stream which exists and
         // the current user can access.
         const current_stream = filter._sub;
-        context.rendered_narrow_description = current_stream.rendered_description;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
+        context.is_admin = current_user.is_admin;
+        context.rendered_narrow_description = current_stream.rendered_description;
         context.sub_count = sub_count;
         context.stream = current_stream;
         context.stream_settings_link =

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -16,7 +16,11 @@
     {{#if rendered_narrow_description}}
     {{rendered_markdown rendered_narrow_description}}
     {{else}}
-    {{t "(no description)"}}
+    {{#if is_admin}}
+    <a href="{{stream_settings_link}}">
+        {{t "Add a description"}}
+    </a>
+    {{/if}}
     {{/if}}
 </span>
 {{else}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes: #28851

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before(Any User) | After(Admin or Owner) | After(Other User)
| --- | --- | --- |
|![Screenshot from 2024-02-07 22-53-05](https://github.com/zulip/zulip/assets/90370535/aab9d398-8452-484f-ada1-cf7130aad498)| ![Screenshot from 2024-02-15 10-25-22](https://github.com/zulip/zulip/assets/90370535/2548a52b-303f-444b-b8cb-887fbc9d8287)| ![Screenshot from 2024-02-07 22-10-23](https://github.com/zulip/zulip/assets/90370535/6ec53a04-a605-4826-bd61-eb3c6ef76627)|
|![Screenshot from 2024-02-07 22-52-41](https://github.com/zulip/zulip/assets/90370535/c5667863-622c-4ed4-b6a4-bb1f53761e4d)| ![Screenshot from 2024-02-15 10-25-01](https://github.com/zulip/zulip/assets/90370535/117a98f2-2d64-49d1-85dd-3778f91d2948)| ![Screenshot from 2024-02-07 22-10-05](https://github.com/zulip/zulip/assets/90370535/23672d5c-a415-40b7-8d30-8b2f0b7ad932) |

[Screencast from 08-02-24 04:35:56 PM IST.webm](https://github.com/zulip/zulip/assets/90370535/19f7d565-ac2a-47dd-9f5f-5b78bbf8554d)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
