### PR TITLE
Web: Add an "Alphabetize choices" button for custom profile field.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1878,6 +1878,17 @@ $option_title_width: 180px;
     }
 }
 
+#alphabetize-choices-btn {
+    color: var(--color-exit-button-text);
+    background: var(--color-exit-button-background);
+    border: 1px solid var(--color-exit-button-border);
+    margin: 12px 0 0;
+
+    &:hover {
+        background: var(--color-exit-button-background-interactive);
+    }
+}
+
 .settings_url_input,
 .settings_text_input {
     padding: 4px 6px;

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -31,6 +31,9 @@
             <table class="profile_field_choices_table">
                 <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
             </table>
+            <button class="button rounded" id="alphabetize-choices-btn" >
+                {{t 'Alphabetize choices' }}
+            </button>
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">
             <label for="custom_field_url_pattern" >{{t "URL pattern" }}</label>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -12,12 +12,14 @@
     <div class="input-group">
         <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
-            <hr />
             <div class="edit_profile_field_choices_container">
                 {{#each choices}}
                     {{> profile_field_choice }}
                 {{/each}}
             </div>
+            <button class="button rounded" id="alphabetize-choices-btn" >
+                {{t 'Alphabetize choices' }}
+            </button>
         </div>
     </div>
     {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds a button to automatically alphabetize options in a "List of options" custom profile fields.

Fixes: zulip#28607.

**How it works**
**--start--**
case  **"Add a new custom profile field"**
In this case we use the function ```alphabetize_choices```, this function collects the field_data in an array, then sorts the array, stores back the sorted values accordingly in each element (input) value.

case  **"Edit custom profile field"**
This is a bit complicated case, we can't just sort and store back the values, as it will create duplicate ```data_value``` for a very specific case, ( i.e. when the user try to add a new element and then alphabetize with already existing elements in some choices, then just simply following the above case will create duplicate ```data_value```), which will cause error in keeping track of ```old_option_value_map``` and might delete some necessary data. 

So instead of this, we follow to delete the whole element inside the ```edit_profile_field_choices_container``` and then add alphabetize data, with each of it's unique ```data_value```, to not create duplicates and alphabetize our field choices.

Since such case could not exist in the case of **"Add a new custom profile field"**, so we can go with just sorting and storing back the values.
**--end--**

**Example code of each choice row**
```HTML
<div class="choice-row movable-row" data-value="0">
            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
            <input type="text" class="modal_text_input" placeholder="New option" value="">
    
            <button type="button" class="button rounded small delete-choice" title="Delete">
                <i class="fa fa-trash-o" aria-hidden="true"></i>
            </button>
        </div>

```

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

https://github.com/zulip/zulip/assets/91906953/6ba45941-6a71-4ba0-bd1a-e7b669471fdc


case  **"Add a new custom profile field"**
![image](https://github.com/zulip/zulip/assets/91906953/a13c5550-b682-46d8-b76e-57c5633e7ada)                 ![image](https://github.com/zulip/zulip/assets/91906953/1f0aa495-951a-4c7b-a7f4-446edbe4f9d2)

![image](https://github.com/zulip/zulip/assets/91906953/4e8f1ce0-d5b6-494c-bb36-7a8f4253eff2)                    ![image](https://github.com/zulip/zulip/assets/91906953/360d7a1b-44e4-41c1-88f3-faa3d737072f)


case  **"Edit custom profile field"**
![image](https://github.com/zulip/zulip/assets/91906953/fb89a297-24dd-474e-a876-e75d5752619d)                 ![image](https://github.com/zulip/zulip/assets/91906953/62e53673-116e-4f14-bcb0-561fd4f39e33)


![image](https://github.com/zulip/zulip/assets/91906953/5526d75d-7b9e-492b-8a55-0400dbdc300c)                ![image](https://github.com/zulip/zulip/assets/91906953/57c5e9c9-0bf6-48cf-8f48-0ad684d900fb)
</details>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zuli.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->




<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
