### PR TITLE
start-server/restart-server: Drop privileges if necessary.

### DIFF
--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -25,6 +25,7 @@ from scripts.lib.zulip_tools import (
     has_process_fts_updates,
     overwrite_symlink,
     start_arg_parser,
+    su_to_zulip,
 )
 
 action = "restart"
@@ -41,7 +42,10 @@ args = parser.parse_args()
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 os.chdir(deploy_path)
 
-if pwd.getpwuid(os.getuid()).pw_name != "zulip":
+username = pwd.getpwuid(os.getuid()).pw_name
+if username == "root":
+    su_to_zulip()
+elif username != "zulip":
     logging.error("Must be run as user 'zulip'.")
     sys.exit(1)
 

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -18,12 +18,16 @@ from scripts.lib.zulip_tools import (
     WARNING,
     has_application_server,
     has_process_fts_updates,
+    su_to_zulip,
 )
 
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 os.chdir(deploy_path)
 
-if pwd.getpwuid(os.getuid()).pw_name != "zulip":
+username = pwd.getpwuid(os.getuid()).pw_name
+if username == "root":
+    su_to_zulip()
+elif username != "zulip":
     logging.error("Must be run as user 'zulip'.")
     sys.exit(1)
 


### PR DESCRIPTION
Rather than tell the user to re-run the command as `zulip` instead of `root`, do the privilege-dropping ourselves.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
