### PR TITLE
Improve 'Resend invitation' confirmation modal

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -277,7 +277,7 @@ export function on_load_success(
         const html_body = render_settings_resend_invite_modal({email});
 
         confirm_dialog.launch({
-            html_heading: $t_html({defaultMessage: "Resend invitation"}),
+            html_heading: $t_html({defaultMessage: "Resend invitation?"}),
             html_body,
             on_click() {
                 do_resend_invite({$row, invite_id});

--- a/web/templates/confirm_dialog/confirm_resend_invite.hbs
+++ b/web/templates/confirm_dialog/confirm_resend_invite.hbs
@@ -4,3 +4,8 @@
         {{#*inline "z-email"}}<strong>{{email}}</strong>{{/inline}}
     {{/tr}}
 </p>
+<p>
+    {{#tr}}
+    This will not change the expiration time for this invitation.
+    {{/tr}}
+</p>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #28829 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

I have made the following changes to implement the required functionality:
1. Added question  mark to confirmation dialog heading in zulip/web/templates/confirm_dialog/confirm_resend_invite.hbs
2. Appended required text in confirmation dialog text in zulip/web/src/settings_invites.ts

**Before changes:**

![Screenshot from 2024-02-08 15-29-54](https://github.com/zulip/zulip/assets/113179991/9913b0fd-fea6-42b5-b646-a171bdea4eba)

**After changes:**

![Screenshot from 2024-02-08 15-48-58](https://github.com/zulip/zulip/assets/113179991/85bda3f9-fb54-4889-a326-ab23dd30a2ac)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).


Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.

</details>
