### PR TITLE
navigate: Make Home key jump to start of view.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -205,6 +205,11 @@ export function activate(raw_terms, opts) {
             id_info.target_id = Number.parseInt(filter.operands("id")[0], 10);
         }
 
+        if (opts.then_select_id === "first") {
+            // Set anchor to fetch first message in view
+            id_info.target_id = -1;
+        }
+
         // Narrow with near / id operator. There are two possibilities:
         // * The user is clicking a permanent link to a conversation, in which
         //   case we want to look up the anchor message and see if it has moved.

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -1,5 +1,7 @@
+import * as hash_util from "./hash_util";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
+import * as narrow from "./narrow";
 import * as unread_ops from "./unread_ops";
 
 function go_to_row(msg_id) {
@@ -41,9 +43,20 @@ export function down(with_centering) {
 }
 
 export function to_home() {
-    message_viewport.set_last_movement_direction(-1);
-    const first_id = message_lists.current.first().id;
-    message_lists.current.select_id(first_id, {then_scroll: true, from_scroll: true});
+    const found_oldest = message_lists.current.data.fetch_status.has_found_oldest();
+    if (found_oldest) {
+        message_viewport.set_last_movement_direction(-1);
+        const first_id = message_lists.current.first().id;
+        message_lists.current.select_id(first_id, {then_scroll: true, from_scroll: true});
+    } else {
+        // NB: In Firefox, window.location.hash is URI-decoded.
+        // Even if the URL bar says #%41%42%43%44, the value here will
+        // be #ABCD.
+        const hash = window.location.hash.split("/");
+        const operators = hash_util.parse_narrow(hash);
+        const opts = { trigger: "home", then_select_id: "first" };
+        narrow.activate(operators, opts);
+    }
 }
 
 export function to_end() {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously, clicking the home key in a narrow
wouldn't always jump to the true beginning of
the narrow but the currently fetched message
from the server. This could lead to confusion
and unnecessary loading of messages if users
navigated further back. This commit rectifies
this behavior by ensuring the home key
consistently positions the view at the very
first message, regardless of current scroll
position or loaded message.

Regarding `then_select_id`, Tim suggested using first to fix the message fetching issue. However, with this approach, `id_info.target_id` remained undefined. My current logic addresses this, but based on Tim's statement in [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/IDEA.3A.20Go.20to.20TOP.20of.20TOPIC/near/881527) I'm unsure if my if condition is necessary. Do I need to explicitly handle `then_select_id` being `first/latest`, or does `narrow.activate` already handle it effectively?.

Fixes #14971 

**Before.**

https://github.com/zulip/zulip/assets/117735533/ba0771fd-6d60-4734-a10e-b5372972094f




**After:**

https://github.com/zulip/zulip/assets/117735533/a14cec4e-5307-48c4-9005-ff3abe54fe4a


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [] Responsiveness and internationalization.
- [] Strings and tooltips.
- [] End-to-end functionality of buttons, interactions and flows.
- [] Corner cases, error conditions, and easily imagined bugs.
</details>
