### PR TITLE
navigate: Make Home/End jump to top/bottom.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -199,6 +199,31 @@ export function activate(raw_terms, opts) {
             final_select_id: undefined,
         };
 
+        /*  (issue #14971)
+
+            Previously, using "first" or "latest" as final_select_id
+            caused errors due to data type mismatch.
+            This change employs conditional assignments:
+
+            * When then_select_id is "first", target_id is set to a special value (-1).
+              This sets final_select_id to assign "oldest" to the anchor, fetching
+              messages starting from the first message.
+
+            * Similarly, for "latest", target_id is set to another special value
+              (LARGER_THAN_MAX_MESSAGE_ID) to assign "newest" to the anchor,
+              fetching messages starting from the latest message.
+
+            NB: Review the switch statement below to see how the special values are used
+        */
+        const home_key = opts.trigger === "home";
+        const end_key = opts.trigger === "end";
+        if (home_key) {
+            id_info.target_id = -1;
+        }
+        if (end_key) {
+            id_info.target_id = LARGER_THAN_MAX_MESSAGE_ID;
+        }
+
         const terms = filter.terms();
 
         // These two narrowing operators specify what message should be


### PR DESCRIPTION
Previously, clicking the home/end key in a narrow wouldn't always jump to the true start/end of the narrow but the currently
fetched messages from the server. This could lead to confusion and unnecessary loading of messages if users navigated
further ahead/below.

Now users can easily navigate to the first message in the view by clicking the home key and navigate to the latest message in the view by clicking the end key.

Co-authored-by: Vinit Singh <vinit.singh9013@gmail.com>


**TESTING** To test this run `./manage.py populate_db -n3000` so you have old enough messages they won't be in the browser local cache. 

Fixes #14971

Regarding `then_select_id`, Tim suggested using `first` to fix the message fetching issue. However, with this approach, `id_info.target_id` remained undefined. My current logic addresses this, but based on Tim's statement in [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/IDEA.3A.20Go.20to.20TOP.20of.20TOPIC/near/881527) I'm unsure if my `if condition` is necessary. Do I need to explicitly handle `then_select_id` being `first/latest`, or does `narrow.activate` already handle it effectively?.

**Before.**


https://github.com/zulip/zulip/assets/117735533/6393f4ab-44bb-4b7c-be42-14d2c6d9a356






**After:**


https://github.com/zulip/zulip/assets/117735533/c83d107c-2d57-4b32-b02f-8f5f24581441


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
