### PR TITLE
Preparatory commits for #28585

### DIFF
--- a/web/shared/src/typing_status.ts
+++ b/web/shared/src/typing_status.ts
@@ -8,10 +8,12 @@ type StreamTopic = {
 export type Recipient =
     | {
           message_type: "direct";
+          notification_event_type: "typing";
           ids: number[];
       }
     | (StreamTopic & {
           message_type: "stream";
+          notification_event_type: "typing";
       });
 type TypingStatusWorker = {
     get_current_time: () => number;

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -355,9 +355,6 @@ export class MessageListView {
         //   * `edited_alongside_sender` -- when label appears alongside sender info.
         //   * `edited_status_msg`       -- when label appears for a "/me" message.
         const last_edit_timestr = this._get_msg_timestring(message_container);
-        const include_sender = message_container.include_sender;
-        const is_hidden = message_container.is_hidden;
-        const status_message = Boolean(message_container.status_message);
         const edit_history_details = analyze_edit_history(message_container.msg, last_edit_timestr);
 
         if (
@@ -377,10 +374,8 @@ export class MessageListView {
         }
 
         message_container.last_edit_timestr = last_edit_timestr;
-        message_container.edited_in_left_col = !include_sender && !is_hidden;
-        message_container.edited_alongside_sender = include_sender && !status_message;
-        message_container.edited_status_msg = include_sender && status_message;
         message_container.moved = edit_history_details.moved && !edit_history_details.edited;
+        message_container.modified = true;
     }
 
     set_calculated_message_container_variables(message_container, is_revealed) {
@@ -803,6 +798,18 @@ export class MessageListView {
         );
     }
 
+    set_edited_notice_locations(message_container) {
+        // Based on the variables that define the overall message's HTML layout, set
+        // variables defining where the message-edited notices should be placed.
+        const include_sender = message_container.include_sender;
+        const is_hidden = message_container.is_hidden;
+        const status_message = Boolean(message_container.status_message);
+        message_container.message_edit_notices_in_left_col = !include_sender && !is_hidden;
+        message_container.message_edit_notices_alongside_sender = include_sender && !status_message;
+        message_container.message_edit_notices_for_status_message =
+            include_sender && status_message;
+    }
+
     render(messages, where, messages_are_new) {
         // This function processes messages into chunks with separators between them,
         // and templates them to be inserted as table rows into the DOM.
@@ -866,6 +873,7 @@ export class MessageListView {
         let $last_group_row;
 
         for (const message_container of message_containers) {
+            this.set_edited_notice_locations(message_container);
             this.message_containers.set(message_container.msg.id, message_container);
         }
 

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -113,6 +113,7 @@ export function get_recipient(): Recipient | null {
     if (message_type === "private") {
         return {
             message_type: "direct",
+            notification_event_type: "typing",
             ids: get_user_ids_array()!,
         };
     }
@@ -122,6 +123,7 @@ export function get_recipient(): Recipient | null {
         const topic = compose_state.topic();
         return {
             message_type: "stream",
+            notification_event_type: "typing",
             stream_id,
             topic,
         };

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,13 +1,15 @@
-{{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.' }}">
-    {{t "SAVING" }}
-</div>
-{{else if moved}}
-<div class="message_edit_notice" data-tippy-content="{{t 'Last moved {last_edit_timestr}.' }}">
-    {{t "MOVED" }}
-</div>
-{{else}}
-<div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.' }}">
-    {{t "EDITED" }}
-</div>
+{{#if modified}}
+    {{#if msg/local_edit_timestamp}}
+        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+            {{t "SAVING"}}
+        </div>
+    {{else if moved}}
+        <div class="message_edit_notice" data-tippy-content="{{t 'Last moved {last_edit_timestr}.'}}">
+            {{t "MOVED"}}
+        </div>
+    {{else}}
+        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+            {{t "EDITED"}}
+        </div>
+    {{/if}}
 {{/if}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -16,11 +16,11 @@
         {{/if}}
         {{#if status_message}}
             <span class="rendered_markdown status-message">{{rendered_markdown status_message}}</span>
-            {{#if edited_status_msg}}
+            {{#if message_edit_notices_for_status_message}}
                 {{> edited_notice}}
             {{/if}}
         {{/if}}
-        {{#if edited_alongside_sender}}
+        {{#if message_edit_notices_alongside_sender}}
             {{> edited_notice}}
         {{/if}}
     {{/if}}
@@ -55,7 +55,7 @@
     {{/unless}}
 {{/unless}}
 
-{{#if edited_in_left_col}}
+{{#if message_edit_notices_in_left_col}}
 {{> edited_notice}}
 {{/if}}
 

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -199,8 +199,9 @@ test("msg_moved_var", () => {
 
 test("msg_edited_vars", () => {
     // This is a test to verify that only one of the three bools,
-    // `edited_in_left_col`, `edited_alongside_sender`, `edited_status_msg`
-    // is not false; Tests for three different kinds of messages:
+    // `message_edit_notices_in_left_col`, `message_edit_notices_alongside_sender`,
+    // `message_edit_notices_for_status_message` is not false; Tests for three
+    // different kinds of messages:
     //   * "/me" message
     //   * message that includes sender
     //   * message without sender
@@ -236,21 +237,34 @@ test("msg_edited_vars", () => {
     }
 
     function assert_left_col(message_container) {
-        assert.equal(message_container.edited_in_left_col, true);
-        assert.equal(message_container.edited_alongside_sender, false);
-        assert.equal(message_container.edited_status_msg, false);
+        assert.equal(message_container.modified, true);
+        assert.equal(message_container.message_edit_notices_in_left_col, true);
+        assert.equal(message_container.message_edit_notices_alongside_sender, false);
+        assert.equal(message_container.message_edit_notices_for_status_message, false);
     }
 
     function assert_alongside_sender(message_container) {
-        assert.equal(message_container.edited_in_left_col, false);
-        assert.equal(message_container.edited_alongside_sender, true);
-        assert.equal(message_container.edited_status_msg, false);
+        assert.equal(message_container.modified, true);
+        assert.equal(message_container.message_edit_notices_in_left_col, false);
+        assert.equal(message_container.message_edit_notices_alongside_sender, true);
+        assert.equal(message_container.message_edit_notices_for_status_message, false);
     }
 
     function assert_status_msg(message_container) {
-        assert.equal(message_container.edited_in_left_col, false);
-        assert.equal(message_container.edited_alongside_sender, false);
-        assert.equal(message_container.edited_status_msg, true);
+        assert.equal(message_container.modified, true);
+        assert.equal(message_container.message_edit_notices_in_left_col, false);
+        assert.equal(message_container.message_edit_notices_alongside_sender, false);
+        assert.equal(message_container.message_edit_notices_for_status_message, true);
+    }
+
+    function set_edited_notice_locations(message_container) {
+        const include_sender = message_container.include_sender;
+        const is_hidden = message_container.is_hidden;
+        const status_message = Boolean(message_container.status_message);
+        message_container.message_edit_notices_in_left_col = !include_sender && !is_hidden;
+        message_container.message_edit_notices_alongside_sender = include_sender && !status_message;
+        message_container.message_edit_notices_for_status_message =
+            include_sender && status_message;
     }
 
     (function test_msg_edited_vars() {
@@ -269,8 +283,13 @@ test("msg_edited_vars", () => {
 
         const result = list._message_groups[0].message_containers;
 
+        set_edited_notice_locations(result[0]);
         assert_alongside_sender(result[0]);
+
+        set_edited_notice_locations(result[1]);
         assert_left_col(result[1]);
+
+        set_edited_notice_locations(result[2]);
         assert_status_msg(result[2]);
     })();
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR contains 3 preparatory as suggested in the review of the PR - #28585

- First commit (`fd887ca`): Refactors the editing notices as suggested in [review 1](https://github.com/zulip/zulip/pull/28585#discussion_r1480419695), [review 2](https://github.com/zulip/zulip/pull/28585#discussion_r1456298156) and [CZO]([CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/issue.20in.20message_list_view.20rendering.20logic)).
- Second commit (`fbbec5f`): Extracts the checks for message editing into a method, as suggested in the [review](https://github.com/zulip/zulip/pull/28585#discussion_r1480421982).
- Third commit (`b31ce04`): adds an extra `notification_event_type: "typing"` as suggested in the [review](https://github.com/zulip/zulip/pull/28585#discussion_r1484877271). 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
