### PR TITLE
create_user: Fix initial unreads ignoring private streams.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -24,6 +24,7 @@ from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.send_email import clear_scheduled_invitation_emails
 from zerver.lib.stream_subscription import bulk_get_subscriber_peer_info
+from zerver.lib.streams import can_access_stream_history
 from zerver.lib.user_counts import realm_user_count, realm_user_count_by_role
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import (
@@ -178,9 +179,14 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
     Mark the very most recent messages as unread.
     """
 
-    # Find recipient ids for the user's streams that were passed to us.
-    # (Only look at public streams.)
-    recipient_ids = [stream.recipient_id for stream in streams if not stream.invite_only]
+    # Find recipient ids for the the user's streams, limiting to just
+    # those where we can access the streams' full history.
+    #
+    # TODO: This will do database queries in a loop if many private
+    # streams are involved.
+    recipient_ids = [
+        stream.recipient_id for stream in streams if can_access_stream_history(user_profile, stream)
+    ]
 
     # Start by finding recent messages matching those recipients.
     cutoff_date = timezone_now() - ONBOARDING_RECENT_TIMEDELTA


### PR DESCRIPTION
This logic was apparently missed when we implemented private streams with shared history; the correct check is to look at whether the user can access message history in the stream, which used to be equivalent to whether it's a private stream.
