### PR TITLE
Replace _widget classes with -widget in dropdown_widget.hbs

### DIFF
--- a/web/templates/dropdown_widget.hbs
+++ b/web/templates/dropdown_widget.hbs
@@ -1,4 +1,5 @@
-<button id="{{widget_name}}_widget" class="dropdown-widget-button" type="button" {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
-    <span class="dropdown_widget_value">{{#if default_text}}{{default_text}}{{/if}}</span>
+<button id="{{widget_name}}-widget" class="dropdown-widget-button" type="button" {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
+    <span class="dropdown-widget-value">{{#if default_text}}{{default_text}}{{/if}}</span>
     <i class="zulip-icon zulip-icon-chevron-down"></i>
 </button>
+


### PR DESCRIPTION
This pull request addresses issue #27658, where the goal is to standardize the CSS class naming convention by replacing classes with underscores (`_widget`) with classes using dashes (`-widget`).

Changes made:
- Updated the class and ID names in `dropdown_widget.hbs` from `_widget` to `-widget`.

These changes ensure consistency across the codebase and adhere to the preferred naming convention. I have tested the changes locally, and they appear to function as expected without any issues. Please let me know if any further adjustments are required.
