### PR TITLE
tooltips: Include counts for tooltips for views in left sidebar.

### DIFF
--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -844,6 +844,10 @@ export type FullUnreadCountsData = {
     home_unread_messages: number;
 };
 
+export function get_mentioned_message_count(): number {
+    return unread_mentions_counter.size;
+}
+
 // Return a data structure with various counts.  This function should be
 // pretty cheap, even if you don't care about all the counts, and you
 // should strive to keep it free of side effects on globals or DOM.

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -30,7 +30,7 @@
                     </a>
                 </li>
                 <li class="top_left_mentions left-sidebar-navigation-condensed-item">
-                    <a href="#narrow/is/mentioned" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="mentions-tooltip-template">
+                    <a href="#narrow/is/mentioned" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="mentions-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                         </span>
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="top_left_starred_messages left-sidebar-navigation-condensed-item">
-                    <a href="#narrow/is/starred" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="starred-tooltip-template">
+                    <a href="#narrow/is/starred" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="starred-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-star-filled" aria-hidden="true"></i>
                         </span>
@@ -88,7 +88,7 @@
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>
-            <li class="top_left_mentions top_left_row hidden-for-spectators">
+            <li class="tippy-views-tooltip top_left_mentions top_left_row hidden-for-spectators" data-tooltip-template-id="mentions-tooltip-template">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
@@ -98,7 +98,7 @@
                     <span class="unread_count"></span>
                 </a>
             </li>
-            <li class="top_left_starred_messages top_left_row hidden-for-spectators">
+            <li class="tippy-views-tooltip top_left_starred_messages top_left_row hidden-for-spectators" data-tooltip-template-id="starred-tooltip-template">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-star-filled" aria-hidden="true"></i>
@@ -109,7 +109,7 @@
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="tippy-left-sidebar-tooltip top_left_drafts top_left_row hidden-for-spectators" data-tooltip-template-id="drafts-tooltip-template">
+            <li class="tippy-views-tooltip top_left_drafts top_left_row hidden-for-spectators" data-tooltip-template-id="drafts-tooltip-template">
                 <a href="#drafts" class="left-sidebar-navigation-label-container">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
@@ -120,7 +120,7 @@
                 </a>
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
+            <li class="tippy-views-tooltip top_left_scheduled_messages top_left_row hidden-for-spectators" data-tooltip-template-id="scheduled-tooltip-template">
                 <a class="left-sidebar-navigation-label-container" href="#scheduled">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-scheduled-messages" aria-hidden="true"></i>

--- a/web/templates/popovers/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar_condensed_views_popover.hbs
@@ -1,8 +1,8 @@
 {{! Contents of the condensed nav vdots popup }}
 <ul class="nav nav-list condensed-views-popover-menu">
-    <li class="condensed-views-popover-menu-drafts">
+    <li class="tippy-views-tooltip condensed-views-popover-menu-drafts" data-tooltip-template-id="drafts-tooltip-template">
         {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" href="#drafts" class="left-sidebar-popover-icon-label-count tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
+        <a tabindex="0" href="#drafts" class="left-sidebar-popover-icon-label-count">
             <span class="filter-icon">
                 <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
             </span>
@@ -11,7 +11,7 @@
         </a>
     </li>
     {{#if has_scheduled_messages }}
-    <li class="condensed-views-popover-menu-scheduled-messages">
+    <li class="tippy-views-tooltip condensed-views-popover-menu-scheduled-messages" data-tooltip-template-id="scheduled-tooltip-template">
         <a tabindex="0" href="#scheduled" class="left-sidebar-popover-icon-label-count">
             <span class="filter-icon">
                 <i class="zulip-icon zulip-icon-scheduled-messages" aria-hidden="true"></i>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -106,19 +106,34 @@
     </div>
     {{tooltip_hotkey_hints "Shift" "I"}}
 </template>
+<template id="starred-tooltip-template">
+    <div class="views-tooltip-container">
+        <div>{{t 'Starred messages'}}</div>
+        <div class="tooltip-inner-content italic"></div>
+    </div>
+</template>
+<template id="mentions-tooltip-template">
+    <div class="views-tooltip-container">
+        <div>{{t 'Mentions'}}</div>
+        <div class="tooltip-inner-content italic"></div>
+    </div>
+</template>
 <template id="drafts-tooltip-template">
-    {{t 'Drafts' }}
+    <div class="views-tooltip-container">
+        <div>{{t 'Drafts' }}</div>
+        <div class="tooltip-inner-content italic"></div>
+    </div>
     {{tooltip_hotkey_hints "D"}}
+</template>
+<template id="scheduled-tooltip-template">
+    <div class="views-tooltip-container">
+        <div>{{t 'Scheduled messages'}}</div>
+        <div class="tooltip-inner-content italic"></div>
+    </div>
 </template>
 <template id="show-all-pms-template">
     {{t 'All direct messages' }}
     {{tooltip_hotkey_hints "Shift" "P"}}
-</template>
-<template id="mentions-tooltip-template">
-    {{t 'Mentions' }}
-</template>
-<template id="starred-tooltip-template">
-    {{t 'Starred messages' }}
 </template>
 <template id="filter-streams-tooltip-template">
     {{t 'Filter streams' }}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

For different views in left sidebar, show their respective counts within the tooltips.
Numbers and translation are handled properly. 
The tooltips for both open and collapsed views are made common.

Fixes: #25901 <!-- Issue link, or clear description.-->

[CZO Thread](https://chat.zulip.org/#narrow/stream/6-frontend/topic/tooltips.20for.20top.20left.20sidebar.2C.20.2325500/near/1583366)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>All messages</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/ff53a133-1374-4b3c-b7c4-58bbebec84db">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/f07eb8ba-fb39-4b0f-9f3e-fefb01bcd284">
<h5>Previous</h5>
<img width="350" src="https://github.com/zulip/zulip/assets/11803841/f76fb122-d23e-4638-9788-931858f3a653">
</details>

<details><summary>Mentions</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/39ac1f21-3816-4495-91a3-3c2ed763d0dd">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/15cce0c0-bb32-465a-b7bd-7412be56ec07">
<h5>Previous</h5>
<img width="350" src="https://github.com/zulip/zulip/assets/11803841/66a7e635-4f2b-45b8-9c57-45f1fd0cfb95">
</details>

<details><summary>Starred Messages</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/db821ac2-94ef-402e-9554-355b5fc8742d">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/19bc2e24-da90-4ebe-9e7f-4aede18a0a8f">
<h5>Previous</h5>
<img width="350" src="https://github.com/zulip/zulip/assets/11803841/1f7e59b9-a65e-422f-840f-c33fbe76a201">
</details>

<details><summary>Drafts</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/f7a314fe-357d-4bc1-9737-26f73174b004">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/a4b9dde5-e108-4040-9824-17e8846ba565">
<h5>Previous</h5>
<img width="350" src="https://github.com/zulip/zulip/assets/11803841/6e3f5112-54d5-447b-9a35-fbaee7978a19">
</details>

<details><summary>Scheduled Messages</summary>
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/2909e1a6-8d32-41aa-9e6e-856fe4a58481">
<img width="400" src="https://github.com/zulip/zulip/assets/11803841/3ca149dd-b12b-4b59-885f-8bf2112f617b">
<h5>Previous</h5>
<img width="350" src="https://github.com/zulip/zulip/assets/11803841/e0ca5586-0746-4ea8-a473-828ebfb70e59">
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
