### PR TITLE
settings: Improve placeholder text for empty settings tables

### DIFF
--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -37,7 +37,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_bots_table" class="admin_bot_table"
-              data-empty="{{t 'No bots found.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
+              data-empty="{{t 'There are no bots.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -40,7 +40,7 @@
                 <th>{{t "Status" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_exports_table" data-empty="{{t 'No exports found.' }}"></tbody>
+            <tbody id="admin_exports_table" data-empty="{{t 'There are no exports.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -20,7 +20,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_deactivated_users_table" class="admin_user_table"
-              data-empty="{{t 'No deactivated users found.' }}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
+              data-empty="{{t 'There are no deactivated users.' }}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_deactivated_users_loading_indicator"></div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody data-empty="{{t 'No default streams found.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
+            <tbody data-empty="{{t 'There are no default streams.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -22,7 +22,7 @@
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emojis found.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
+            <tbody id="admin_emoji_table" data-empty="{{t 'There are no custom emoji.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -23,7 +23,7 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'No invites found.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'There are no invites.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers configured.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #27250 

This PR fixes the first two items of the issue:

1. Changing the string "No X found" to "There are no X" in settings tables.
2. Using "emoji" rather than "emojis", like elsewhere on this page / in our documentation.
3. Replaces "No linkifers set." to "No linkifiers configured." (to match the Playgrounds placeholder text)

Before Changes

![Screenshot from 2024-02-11 19-50-56](https://github.com/zulip/zulip/assets/120193805/609c2ff0-8a89-4512-8bc9-210a1ac27520)

After Changes

![Screenshot from 2024-02-11 19-52-44](https://github.com/zulip/zulip/assets/120193805/5da17c85-e43c-483c-afac-47019ffc9b0d)

Before Changes

![Screenshot from 2024-02-11 19-54-18](https://github.com/zulip/zulip/assets/120193805/2f1ced4d-b9b6-4b2c-a970-ee94b120872f)

After Changes

![Screenshot from 2024-02-11 19-55-33](https://github.com/zulip/zulip/assets/120193805/fa91d12b-db48-4f9e-af57-74f62af984f0)

Before Changes

![Screenshot from 2024-02-11 19-56-17](https://github.com/zulip/zulip/assets/120193805/1054a6b3-19a9-4243-bc7c-7f66980bdb46)

After Changes

![Screenshot from 2024-02-11 19-57-19](https://github.com/zulip/zulip/assets/120193805/fda33aee-87ce-4fc3-83d3-ebf8256eca1b)

Before Changes

![Screenshot from 2024-02-11 19-58-29](https://github.com/zulip/zulip/assets/120193805/5837477a-80cb-41cf-a503-5a74ffc3f08c)

After Changes

![Screenshot from 2024-02-11 19-59-07](https://github.com/zulip/zulip/assets/120193805/5a1ec302-86d7-4d99-b8a3-59d54af63908)

Before Changes
![Screenshot from 2024-02-11 20-00-09](https://github.com/zulip/zulip/assets/120193805/a5cded1c-6af5-4846-b6ac-5e044a3af9be)

After Changes
![Screenshot from 2024-02-11 20-00-41](https://github.com/zulip/zulip/assets/120193805/b3e6574d-b243-44e1-b71c-6d6312e2e2c0)

Before Changes

![Screenshot from 2024-02-11 20-01-18](https://github.com/zulip/zulip/assets/120193805/40f1d254-21cf-4659-85d4-7e506b329af3)

After Changes

![Screenshot from 2024-02-11 20-01-49](https://github.com/zulip/zulip/assets/120193805/4e7018f5-4004-4bef-bc02-8a844cfa3aa8)


















