### PR TITLE
corporate: Fix 'free_trial=True` for legacy customers during upgrade.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1736,6 +1736,9 @@ class BillingSession(ABC):
                 free_trial = False
 
         remote_server_legacy_plan = self.get_remote_server_legacy_plan(customer)
+        if remote_server_legacy_plan is not None:
+            # Free trial is not available for legacy customers.
+            free_trial = False
         should_schedule_upgrade_for_legacy_remote_server = (
             remote_server_legacy_plan is not None
             and upgrade_request.remote_server_plan_start_date == "billing_cycle_end_date"


### PR DESCRIPTION
Earlier, we were not setting `free_trial` = False for legacy customers in `do_upgrade`.

This lead to a bug where customers were upgraded even before the payment was complete (Actual payment happened within an hour). `process_initial_upgrade` was always getting called instead of `setup_upgrade_payment_intent_and_charge`.

This PR fixes the incorrect behaviour.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
