### PR TITLE
email-log: Update CSS styles for dev environment email log.

### DIFF
--- a/templates/zerver/development/email_log.html
+++ b/templates/zerver/development/email_log.html
@@ -6,24 +6,21 @@
 {% endblock %}
 
 {% block content %}
-<div class="container" id="dev-emails-container">
-    <div class="header">
-        <div class="alert">
-            All the emails sent in the Zulip development environment are logged here. You can also
-            manually generate most of the emails by clicking <a href="/emails/generate">here</a>.
-            To clear this log click <a href="/emails/clear">here</a>
+<div class="container" id="dev-email-log-container">
+    <div class="dev-email-log-header">
+        <div class="dev-email-log-actions">
+            All emails sent in the Zulip development environment are logged here. <a href="/emails/clear">Clear this log</a>
+            | <a href="/emails/generate">Manually generate most emails</a>
+            | <a href="#" class="open-forward-email-modal">Forward emails to an email account</a>
         </div>
-        <div class="config-options">
+        <div class="dev-email-log-text-only">
             <label>
                 <input type="checkbox" autocomplete="off" id="toggle"/>
                 <strong>Show text only version</strong>
             </label>
-            <a href="#" class="open-forward-email-modal">
-                <strong>Forward emails to an email account</strong>
-            </a>
         </div>
     </div>
-    <div class="emails">
+    <div class="dev-email-log-content">
         {{ log |safe }}
     </div>
     <div id="forward_email_modal" class="micromodal" aria-hidden="true">
@@ -39,7 +36,7 @@
                     <div class="input-group">
                         <form id="smtp_form">
                             {{ csrf_input }}
-                            <div class="alert alert-info" id="smtp_form_status">
+                            <div class="dev-forward-email-alert" id="smtp_form_status">
                                 Updated successfully.
                             </div>
                             <label for="forward">
@@ -55,8 +52,7 @@
                                 <label for="forward_address"><strong>Address to which emails should be forwarded</strong></label>
                                 <input type="text" id="address" name="forward_address" placeholder="eg: your-email@example.com" value="{{forward_address}}"/>
                             </div>
-                            <br />
-                            <div class="alert alert-info">
+                            <div class="dev-forward-email-alert">
                                 You must set up SMTP as described
                                 <a target="_blank" rel="noopener noreferrer" href="https://zulip.readthedocs.io/en/latest/subsystems/email.html#development-and-testing"> here</a>
                                 first before enabling this.

--- a/web/styles/portico/email_log.css
+++ b/web/styles/portico/email_log.css
@@ -2,17 +2,70 @@
     --color-background-modal: hsl(0deg 0% 98%);
 }
 
-#dev-emails-container {
-    .header {
+#dev-email-log-container {
+    .dev-email-log-header {
         position: fixed;
+        font-family: sans-serif;
+        font-size: 14px;
     }
 
-    .config-options {
+    .dev-email-log-header,
+    .dev-forward-email-alert {
+        padding: 10px;
+        border: 1px solid hsl(190deg 65% 84%);
+        border-radius: 4px;
+        background-color: hsl(200deg 65% 91%);
+        color: hsl(200deg 50% 45%);
+    }
+
+    .dev-email-log-actions,
+    .dev-forward-email-alert {
+        & a {
+            color: hsl(200deg 50% 45%);
+
+            &:hover {
+                color: hsl(200deg 56% 33%);
+            }
+        }
+    }
+
+    .dev-email-log-actions {
+        padding-bottom: 5px;
+    }
+
+    .dev-email-log-text-only {
         text-align: right;
     }
 
-    .emails {
+    .dev-email-log-content {
         padding-top: 100px;
+        max-width: 1000px;
+
+        & h4 {
+            color: hsl(0deg 0% 20%);
+            margin: 2px 10px;
+        }
+
+        .email-text,
+        .email-html {
+            margin: 10px;
+        }
+
+        .email-text pre {
+            font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+            color: hsl(0deg 0% 20%);
+            display: block;
+            padding: 9.5px;
+            margin: 0 0 10px;
+            font-size: 13px;
+            line-height: 20px;
+            word-break: break-all;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+            background-color: hsl(0deg 0% 96%);
+            border: 1px solid hsl(0deg 0% 75%);
+            border-radius: 4px;
+        }
     }
 
     #smtp_form_status,
@@ -23,10 +76,14 @@
     #forward_email_modal {
         .modal__content label {
             font-size: 1rem;
+            display: block;
+            margin-bottom: 5px;
+            cursor: pointer;
         }
 
-        #forward_address_sections {
-            margin-top: 20px;
+        #forward_address_sections,
+        .dev-forward-email-alert {
+            margin: 5px 0;
         }
 
         & label.radio {

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -240,7 +240,7 @@ class DocPageTest(ZulipTestCase):
     def test_dev_environment_endpoints(self) -> None:
         self._test("/devlogin/", ["Normal users"])
         self._test("/devtools/", ["Useful development URLs"])
-        self._test("/emails/", ["manually generate most of the emails by clicking"])
+        self._test("/emails/", ["Manually generate most emails"])
 
     def test_error_endpoints(self) -> None:
         self._test("/errors/404/", ["Page not found"])

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -17,12 +17,12 @@ class EmailLogTest(ZulipTestCase):
             self.assertIn("emails", result["Location"])
 
             result = self.client_get("/emails/")
-            self.assert_in_success_response(["All the emails sent in the Zulip"], result)
+            self.assert_in_success_response(["All emails sent in the Zulip"], result)
 
             result = self.client_get("/emails/clear/")
             self.assertEqual(result.status_code, 302)
             result = self.client_get(result["Location"])
-            self.assertIn("manually generate most of the emails by clicking", str(result.content))
+            self.assertIn("Manually generate most emails", str(result.content))
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -413,7 +413,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
 
             # assert_in_success_response() is another helper that is commonly used to ensure
             # we are on the right page by verifying a string exists in the page's content.
-            self.assert_in_success_response(["All the emails sent in the Zulip"], result)
+            self.assert_in_success_response(["All emails sent in the Zulip"], result)
 
 
 class TestMocking(ZulipTestCase):


### PR DESCRIPTION
Removes reliance on bootstrap alert and label rules/styles that were used or expected for this email log page.

**Notes**:
- I think, but haven't confirmed, that when we split bootstrap to have separate copies in the portico and app bundles, that this page was overlooked.

---

**Screenshots and screen captures:**

<details>
<summary>HTML version - not scrolled</summary>

| Main | Changes |
| --- | --- |
| ![Screenshot from 2024-02-12 16-46-32](https://github.com/zulip/zulip/assets/63245456/3f884a1b-c9a7-48bc-b41f-61b31ad26588) | ![Screenshot from 2024-02-12 16-47-17](https://github.com/zulip/zulip/assets/63245456/00f6b987-737f-4be7-958c-8e93ead6c09a)
</details>
<details>
<summary>HTML version - scrolled</summary>

| Main | Changes |
| --- | --- |
| ![Screenshot from 2024-02-12 16-46-54](https://github.com/zulip/zulip/assets/63245456/59b65bba-16f9-4187-bf44-ebb2a4e509c3) | ![Screenshot from 2024-02-12 16-47-33](https://github.com/zulip/zulip/assets/63245456/fc2006d1-9a31-457a-9913-af7cac85f513)

</details>
<details>
<summary>Text version</summary>

| Main | Changes |
| --- | --- |
| ![Screenshot from 2024-02-12 16-46-39](https://github.com/zulip/zulip/assets/63245456/56a2a4c0-5d5f-460a-9122-0f4f3d44a513) | ![Screenshot from 2024-02-12 16-47-22](https://github.com/zulip/zulip/assets/63245456/d189cd00-4da2-4b21-805d-0752eb0c5c5d)

</details>
<details>
<summary>Forward email modal</summary>

| Main | Changes |
| --- | --- |
| ![Screenshot from 2024-02-12 16-48-33](https://github.com/zulip/zulip/assets/63245456/544d0c85-e906-4f63-a64d-063d98e395b3) | ![Screenshot from 2024-02-12 16-47-55](https://github.com/zulip/zulip/assets/63245456/77a79cd5-5f3c-491f-9298-f0497be0fe37)
| ![Screenshot from 2024-02-12 16-48-37](https://github.com/zulip/zulip/assets/63245456/7ccbaba9-c5f9-41ed-b455-e37ccf8b927f) | ![Screenshot from 2024-02-12 16-48-07](https://github.com/zulip/zulip/assets/63245456/aa9687cd-6927-431f-ae65-8d5663efb565)

![Screenshot from 2024-02-12 16-48-00](https://github.com/zulip/zulip/assets/63245456/2b9f6799-e68a-4eaf-908d-7e81b5856568)
</details>
<details>
<summary>Empty log</summary>

| Main | Changes |
| --- | --- |
| ![Screenshot from 2024-02-12 17-04-59](https://github.com/zulip/zulip/assets/63245456/5b5e9d57-791d-41f5-af5c-72142dbc4e10) | ![Screenshot from 2024-02-12 17-04-49](https://github.com/zulip/zulip/assets/63245456/d72cac66-71ed-496b-ac56-6a6e9d5f5297)



</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
