### PR TITLE
billing: Remove extra space above renewal amount.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2882,7 +2882,7 @@ class BillingSession(ABC):
 
         plan_name = "Zulip Cloud Free"
         if is_remotely_hosted:
-            plan_name = "Self-managed"
+            plan_name = "Free"
 
         context: Dict[str, Any] = {
             "billing_base_url": self.billing_base_url,

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -416,7 +416,7 @@ class CustomerPlan(AbstractCustomerPlan):
             CustomerPlan.TIER_CLOUD_STANDARD: "Zulip Cloud Standard",
             CustomerPlan.TIER_CLOUD_PLUS: "Zulip Cloud Plus",
             CustomerPlan.TIER_CLOUD_ENTERPRISE: "Zulip Enterprise",
-            CustomerPlan.TIER_SELF_HOSTED_LEGACY: "Self-managed (legacy plan)",
+            CustomerPlan.TIER_SELF_HOSTED_LEGACY: "Free (legacy plan)",
             CustomerPlan.TIER_SELF_HOSTED_BASIC: "Zulip Basic",
             CustomerPlan.TIER_SELF_HOSTED_BUSINESS: "Zulip Business",
             CustomerPlan.TIER_SELF_HOSTED_COMMUNITY: "Community",

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -170,7 +170,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     "<b>Date created</b>:",
                     "<b>UUID</b>:",
                     "<b>Zulip version</b>:",
-                    "<b>Plan type</b>: Self-managed<br />",
+                    "<b>Plan type</b>: Free<br />",
                     "<b>Non-guest user count</b>: 0<br />",
                     "<b>Guest user count</b>: 0<br />",
                 ],
@@ -242,7 +242,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             self.assert_in_success_response(
                 [
                     "<h4>📅 Current plan information:</h4>",
-                    "<b>Plan name</b>: Self-managed (legacy plan)<br />",
+                    "<b>Plan name</b>: Free (legacy plan)<br />",
                     "<b>Status</b>: New plan scheduled<br />",
                     "<b>End date</b>: 01 February 2050<br />",
                     "<h4>⏱️ Next plan information:</h4>",
@@ -261,7 +261,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             self.assert_in_success_response(
                 [
                     "<h4>📅 Current plan information:</h4>",
-                    "<b>Plan name</b>: Self-managed (legacy plan)<br />",
+                    "<b>Plan name</b>: Free (legacy plan)<br />",
                     "<b>Status</b>: Active<br />",
                     "<b>End date</b>: 01 February 2050<br />",
                 ],

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -137,7 +137,7 @@ def get_plan_type_string(plan_type: int) -> str:
         Realm.PLAN_TYPE_STANDARD: "Standard",
         Realm.PLAN_TYPE_STANDARD_FREE: "Standard free",
         Realm.PLAN_TYPE_PLUS: "Plus",
-        RemoteZulipServer.PLAN_TYPE_SELF_MANAGED: "Self-managed",
+        RemoteZulipServer.PLAN_TYPE_SELF_MANAGED: "Free",
         RemoteZulipServer.PLAN_TYPE_SELF_MANAGED_LEGACY: CustomerPlan.name_from_tier(
             CustomerPlan.TIER_SELF_HOSTED_LEGACY
         ),

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -264,7 +264,6 @@
                                 </div>
                                 {% endif %}
                             </div>
-                            <br />
                             <h1>${{ renewal_amount }}</h1>
                             {% if not fixed_price_plan and using_min_licenses_for_plan %}
                             <i>Minimum purchase for this plan: {{ min_licenses_for_plan }} licenses</i>


### PR DESCRIPTION
before:
![image](https://github.com/zulip/zulip/assets/25124304/86e52eb4-5d3a-4200-a93a-ee44a34668b4)

after:
<img width="806" alt="Screenshot 2024-02-13 at 10 18 28 AM" src="https://github.com/zulip/zulip/assets/25124304/a17848c1-6fbe-49ff-8b25-d4ab619d750d">
<img width="806" alt="Screenshot 2024-02-13 at 10 21 15 AM" src="https://github.com/zulip/zulip/assets/25124304/a34a5271-34e8-40cb-a4d5-172159c73400">
