### PR TITLE
Compose: Remove denominator in character counter

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -66,7 +66,7 @@ function update_send_button_status(): void {
 
 export function get_disabled_send_tooltip(): string {
     if (message_too_long) {
-        return $t({defaultMessage: "Message length shouldn't be greater than 10000 characters."});
+        return $t({defaultMessage: "Maximum message length: 10000 characters"});
     } else if (upload_in_progress) {
         return $t({defaultMessage: "Cannot send message while files are being uploaded."});
     }
@@ -689,6 +689,7 @@ export function check_overflow_text(): number {
     // expensive.
     const text = compose_state.message_content();
     const max_length = realm.max_message_length;
+    const remaining_length = max_length - text.length;
     const $indicator = $("#compose-limit-indicator");
 
     if (text.length > max_length) {
@@ -696,8 +697,7 @@ export function check_overflow_text(): number {
         $("textarea#compose-textarea").addClass("over_limit");
         $indicator.html(
             render_compose_limit_indicator({
-                text_length: text.length,
-                max_length,
+                remaining_length,
             }),
         );
         compose_banner.show_error_message(
@@ -711,14 +711,14 @@ export function check_overflow_text(): number {
             compose_banner.CLASSNAMES.message_too_long,
             $("#compose_banners"),
         );
+
         set_message_too_long(true);
     } else if (text.length > 0.9 * max_length) {
         $indicator.removeClass("over_limit");
         $("textarea#compose-textarea").removeClass("over_limit");
         $indicator.html(
             render_compose_limit_indicator({
-                text_length: text.length,
-                max_length,
+                remaining_length,
             }),
         );
         set_message_too_long(false);

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -700,17 +700,6 @@ export function check_overflow_text(): number {
                 remaining_length,
             }),
         );
-        compose_banner.show_error_message(
-            $t(
-                {
-                    defaultMessage:
-                        "Message length shouldn't be greater than {max_length} characters.",
-                },
-                {max_length},
-            ),
-            compose_banner.CLASSNAMES.message_too_long,
-            $("#compose_banners"),
-        );
 
         set_message_too_long(true);
     } else if (text.length > 0.9 * max_length) {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -692,6 +692,8 @@ export function check_overflow_text(): number {
     const remaining_length = max_length - text.length;
     const $indicator = $("#compose-limit-indicator");
 
+    $indicator.attr("title", "Maximum message length: " + max_length + " characters");
+
     if (text.length > max_length) {
         $indicator.addClass("over_limit");
         $("textarea#compose-textarea").addClass("over_limit");
@@ -700,7 +702,6 @@ export function check_overflow_text(): number {
                 remaining_length,
             }),
         );
-
         set_message_too_long(true);
     } else if (text.length > 0.9 * max_length) {
         $indicator.removeClass("over_limit");

--- a/web/templates/compose_limit_indicator.hbs
+++ b/web/templates/compose_limit_indicator.hbs
@@ -1,2 +1,2 @@
-{{! Include a zero-width-space to allow breaks in narrow compose boxes. }}
-{{text_length}}&ZeroWidthSpace;/{{max_length}}
+{{remaining_length}}
+

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -525,18 +525,6 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
 
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
-    let banner_rendered = false;
-    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
-        assert.equal(data.classname, compose_banner.CLASSNAMES.message_too_long);
-        assert.equal(
-            data.banner_text,
-            $t({
-                defaultMessage: "Message length shouldn't be greater than 10000 characters.",
-            }),
-        );
-        banner_rendered = true;
-        return "<banner-stub>";
-    });
 
     // Indicator should show red colored text
     let limit_indicator_html;
@@ -548,27 +536,19 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
     assert.ok($indicator.hasClass("over_limit"));
     assert.equal(limit_indicator_html, "-1\n\n");
     assert.ok($textarea.hasClass("over_limit"));
-    assert.ok(banner_rendered);
-    assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
 
     // Indicator should show orange colored text
-    banner_rendered = false;
     $textarea.val("a".repeat(9000 + 1));
     compose_validate.check_overflow_text();
     assert.ok(!$indicator.hasClass("over_limit"));
     assert.equal(limit_indicator_html, "999\n\n");
     assert.ok(!$textarea.hasClass("over_limit"));
-    assert.ok(!$(".message-send-controls").hasClass("disabled-message-send-controls"));
-    assert.ok(!banner_rendered);
 
     // Indicator must be empty
-    banner_rendered = false;
     $textarea.val("a".repeat(9000));
     compose_validate.check_overflow_text();
     assert.ok(!$indicator.hasClass("over_limit"));
     assert.equal($indicator.text(), "");
-    assert.ok(!$textarea.hasClass("over_limit"));
-    assert.ok(!banner_rendered);
 });
 
 test_ui("needs_subscribe_warning", () => {

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -546,7 +546,7 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
     $textarea.val("a".repeat(10000 + 1));
     compose_validate.check_overflow_text();
     assert.ok($indicator.hasClass("over_limit"));
-    assert.equal(limit_indicator_html, "10001&ZeroWidthSpace;/10000\n");
+    assert.equal(limit_indicator_html, "-1\n\n");
     assert.ok($textarea.hasClass("over_limit"));
     assert.ok(banner_rendered);
     assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
@@ -556,7 +556,7 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
     $textarea.val("a".repeat(9000 + 1));
     compose_validate.check_overflow_text();
     assert.ok(!$indicator.hasClass("over_limit"));
-    assert.equal(limit_indicator_html, "9001&ZeroWidthSpace;/10000\n");
+    assert.equal(limit_indicator_html, "999\n\n");
     assert.ok(!$textarea.hasClass("over_limit"));
     assert.ok(!$(".message-send-controls").hasClass("disabled-message-send-controls"));
     assert.ok(!banner_rendered);


### PR DESCRIPTION
Previously, when a message approached or exceeded the character limit, the character counter displayed the format: text_length/max_length. With the changes in this PR, it now shows only the remaining characters and the negative value of exceeded characters, addressing the concerns raised in issue #28706 .

This PR optimizes the `check_overflow_text` function without altering the core logic. It enhances the handling when text.length exceeds max_length by displaying the negative count of  `exceeded characters`. In the else if condition, when text.length reaches 90%, it now shows only the `remaining characters`. The introduction of the `remainingCharacters` variable aids in these cases. This simplification improves clarity without modifying the `check_overflow_text` function logic and showing the remaining characters and negative value of exceeded characters.

- The tooltip associated with the character counter has been updated to display 'Maximum message length: 10000 characters.'
-  Additionally, I removed the banner message, as suggested by the reviewer
- Note: This PR addresses the first two issues in the reported #28706 .

Fixes: #28706

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



**Screenshots and screen captures:**
- **When Characters exceeded the limit**
<img width="1171" alt="Screenshot 2024-02-15 at 11 44 56 PM" src="https://github.com/zulip/zulip/assets/122713145/862b1dbf-8f32-4367-9314-5f0a1896d79d">





- **Show Remaining Characters**
<img width="1431" alt="Screenshot 2024-02-14 at 10 51 33 PM" src="https://github.com/zulip/zulip/assets/122713145/47a9cda5-fd48-495e-af4a-8e879646f6ce">




https://github.com/zulip/zulip/assets/122713145/39dd68a6-0fd9-4049-bc88-f27a8572e033





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
