### PR TITLE
reactions: Increase prominence of own reactions.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -279,12 +279,12 @@
     --color-tab-picker-icon: hsl(200deg 100% 40%);
 
     /* Reaction container colors */
-    --color-message-reaction-border: hsl(0deg 0% 0% / 12%);
-    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 40%);
+    --color-message-reaction-border: hsl(0deg 0% 0% / 10%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 60%);
     --color-message-reaction-background: hsl(0deg 0% 100%);
     --color-message-reaction-background-reacted: hsl(0deg 0% 100%);
     --color-message-reaction-background-hover: hsl(210deg 30% 96%);
-    --color-message-reaction-shadow-inner: hsl(210deg 50% 50% / 15%);
+    --color-message-reaction-shadow-inner: hsl(210deg 50% 50% / 8%);
     --color-message-reaction-text: hsl(210deg 20% 25% / 100%);
     --color-message-reaction-text-reacted: hsl(210deg 20% 20% / 100%);
     --color-message-reaction-button-text: hsl(210deg 20% 20% / 60%);
@@ -577,7 +577,7 @@
 
     /* Reaction container colors */
     --color-message-reaction-border: hsl(0deg 0% 100% / 15%);
-    --color-message-reaction-border-reacted: hsl(0deg 0% 100% / 50%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 100% / 70%);
     --color-message-reaction-background: hsl(0deg 0% 0% / 30%);
     --color-message-reaction-background-reacted: hsl(0deg 0% 0% / 80%);
     --color-message-reaction-background-hover: hsl(0deg 0% 100% / 10%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -280,7 +280,7 @@
 
     /* Reaction container colors */
     --color-message-reaction-border: hsl(0deg 0% 0% / 10%);
-    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 60%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 45%);
     --color-message-reaction-background: hsl(0deg 0% 100%);
     --color-message-reaction-background-reacted: hsl(0deg 0% 100%);
     --color-message-reaction-background-hover: hsl(210deg 30% 96%);

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -4,7 +4,9 @@
 
     .message_reaction {
         display: flex;
-        padding: 1px 4px 1px 3px;
+        /* Set a pixel and half padding to maintain
+           pill height adjacent own reactions. */
+        padding: 1.5px 4px 1.5px 3px;
         box-sizing: border-box;
         min-width: 44px;
         cursor: pointer;
@@ -22,6 +24,13 @@
             color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
+            /* Make this border thicker by half a pixel,
+               to make own reactions more prominent. */
+            border-width: 1.5px;
+            /* Reduce the padding top and bottom by half
+               a pixel accordingly, to maintain the same
+               pill height. */
+            padding: 1px 4px 1px 3px;
             font-weight: var(--font-weight-message-reaction);
             box-shadow: none;
         }
@@ -37,7 +46,9 @@
         + .reaction_button {
             visibility: hidden;
             pointer-events: none;
-            padding: 4px 6px;
+            /* Set top/bottom padding to accommodate borders
+               and padding around reaction pills. */
+            padding: 4.5px 6px;
             height: 13px;
             border-radius: 21px;
             color: var(--color-message-reaction-button-text);


### PR DESCRIPTION
This PR increases the prominence of one's own emoji reactions by:

1. Setting a pixel-and-a-half border around own reactions
2. Reducing the alpha on the inner drop shadow of other reactions
3. Increasing the contrast on own reactions borders (and decreasing them, in dark mode, on other reactions)

Space around the emoji is maintained as in the current design in the own reactions. Other reactions benefit from an additional half pixel of padding, top and bottom, which is necessary to keep the pills (and the hover reaction button) the same height as each other--regardless of whether there's an own reaction among them or not. Padding is reduced in line with the increased border on own reactions.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/8.2E0.20reactions.20changes.20for.20own.20reactions/near/1732099)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![singletons-light-before](https://github.com/zulip/zulip/assets/170719/d0acb02e-2fcb-4740-82b6-89c62529e37a) | ![singletons-light](https://github.com/zulip/zulip/assets/170719/68608990-7d21-4a7c-a401-7df1621bcf8b) |
| ![singletons-dark-before](https://github.com/zulip/zulip/assets/170719/dd4231e0-6c54-4a10-8f8a-1b9aa2569540) | ![singletons-dark](https://github.com/zulip/zulip/assets/170719/4ced5de9-c2a4-4566-abbd-d421b28cda59) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>