### PR TITLE
portico: Add quote to /self-hosting.

### DIFF
--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -180,9 +180,15 @@
                                     Unlimited push notifications<br />until {{ customer_plan.end_date.strftime('%d %B, %Y') }}
                                 </span>
                                 {% elif not is_self_hosted_realm %}
+                                {% if rendering_page == 'self_hosting' %}
+                                <a href="https://zulip.readthedocs.io/en/stable/production/install.html" class="button get-started-button">
+                                    Install a Zulip server
+                                </a>
+                                {% else %}
                                 <a href="/self-hosting/" class="button get-started-button">
                                     Self-host Zulip
                                 </a>
+                                {% endif %}
                                 {% else %}
                                 <div class="button-placeholder"></div>
                                 {% endif %}

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -280,7 +280,10 @@
     </div>
 
     <div class="portico-pricing showing-self-hosted">
+        {% with %}
+        {% set rendering_page="self_hosting" %}
         {% include "corporate/pricing_model.html" %}
+        {% endwith %}
     </div>
 
 </div>

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -156,6 +156,14 @@
                         or with prebuilt images for <a href="https://marketplace.digitalocean.com/apps/zulip">Digital Ocean</a>
                         and <a href="https://render.com/docs/deploy-zulip">Render</a>.
                     </p>
+                    <div class="intro_quote quote-in-feature-text">
+                        <blockquote>
+                            Zulip was quite easy to set up, and worked instantly. 1000 people — no problem.
+                            <div class="author">
+                                &mdash;  Erik Dittert, Head of IT at <a href="/case-studies/gut-contact/">GUT contact</a>
+                            </div>
+                        </blockquote>
+                    </div>
                 </div>
             </div>
             <div class="feature-half md-display">

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -26,7 +26,9 @@
             <a href="#plans-and-pricing" class="button">
                 {{ _('Plans & pricing') }}
             </a>
-            <a href="https://zulip.readthedocs.io/en/stable/production/install.html" class="button">Install Zulip {{ latest_release_version }}</a>
+            <a href="https://zulip.readthedocs.io/en/stable/production/install.html" class="button">
+                Install Zulip Server {{ latest_release_version }}
+            </a>
             <a href="/for/business/" class="button">
                 {{ _('Zulip for business') }}
             </a>

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -2398,6 +2398,14 @@ button {
     }
 }
 
+.quote-in-feature-text blockquote {
+    background: transparent;
+    padding: 10px 20px;
+    margin: 20px 0;
+    font-style: italic;
+    border-left: 6px solid hsl(168.1deg 49.15% 46.27%);
+}
+
 .case-study-page,
 .solutions-page {
     .bottom-register-buttons.extra_margin_before_footer {


### PR DESCRIPTION
This got accidentally dropped from #28754.

It needs some CSS work to look reasonable. I wasn't able to find an existing style that would look OK here. @amanagr would you be up for proposing something here?

<details>
<summary>
Screenshots
</summary>

![Screenshot 2024-01-30 at 12 36 10 PM](https://github.com/zulip/zulip/assets/2090066/935a3eeb-6115-44b1-b263-ca60b99bdb6e)

</details>