### PR TITLE
uploads: Fix duplicate drag-and-drop uploads during message editing.

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -34,7 +34,7 @@ import * as user_topics from "./user_topics";
 
 export function abort_xhr() {
     $("#compose-send-button").prop("disabled", false);
-    upload.compose_upload_object.cancelAll();
+    upload.compose_upload_cancel();
 }
 
 function setup_compose_actions_hooks() {

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -793,9 +793,15 @@ export function end_inline_topic_edit($row) {
 
 function remove_uploads_from_row(row_id) {
     const uploads_for_row = upload.upload_objects_by_message_edit_row.get(row_id);
+    if (!uploads_for_row) {
+        return;
+    }
     // We need to cancel all uploads, reset their progress,
     // and clear the files upon ending the edit.
-    uploads_for_row?.cancelAll();
+    upload.deactivate_upload(uploads_for_row, {
+        mode: "edit",
+        row: row_id,
+    });
     // Since we removed all the uploads from the row, we should
     // now remove the corresponding upload object from the store.
     upload.upload_objects_by_message_edit_row.delete(row_id);

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -577,11 +577,10 @@ function start_edit_with_content($row, content, edit_box_open_callback) {
         edit_box_open_callback();
     }
     const row_id = rows.id($row);
-    const upload_object = upload.setup_upload({
+    upload.setup_upload({
         mode: "edit",
         row: row_id,
     });
-    upload.upload_objects_by_message_edit_row.set(row_id, upload_object);
 }
 
 export function start($row, edit_box_open_callback) {
@@ -791,25 +790,11 @@ export function end_inline_topic_edit($row) {
     message_lists.current.hide_edit_topic_on_recipient_row($row);
 }
 
-function remove_uploads_from_row(row_id) {
-    const uploads_for_row = upload.upload_objects_by_message_edit_row.get(row_id);
-    if (!uploads_for_row) {
-        return;
-    }
-    // We need to cancel all uploads, reset their progress,
-    // and clear the files upon ending the edit.
-    upload.deactivate_upload(uploads_for_row, {
-        mode: "edit",
-        row: row_id,
-    });
-    // Since we removed all the uploads from the row, we should
-    // now remove the corresponding upload object from the store.
-    upload.upload_objects_by_message_edit_row.delete(row_id);
-}
-
 export function end_message_row_edit($row) {
     const row_id = rows.id($row);
-    remove_uploads_from_row(row_id);
+
+    // Clean up the upload handler
+    upload.deactivate_upload({mode: "edit", row: row_id});
 
     const message = message_lists.current.get(row_id);
     if (message !== undefined && currently_editing_messages.has(message.id)) {

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -437,6 +437,18 @@ export function setup_upload(config) {
     return uppy;
 }
 
+export function deactivate_upload(uppy, config) {
+    // Remove event listeners added for handling uploads.
+    $(get_item("file_input_identifier", config)).off("change");
+    get_item("banner_container", config).off("click");
+    get_item("drag_drop_container", config).off("dragover dragenter drop paste");
+
+    // Uninstall all plugins and close down the Uppy instance.
+    // Also runs uppy.cancelAll() before uninstalling - which
+    // cancels all uploads, resets progress and removes all files.
+    uppy.close();
+}
+
 export function initialize() {
     compose_upload_object = setup_upload({
         mode: "compose",

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -508,10 +508,8 @@ test_ui("initialize", ({override}) => {
     realm.max_file_upload_size_mib = 512;
 
     let uppy_cancel_all_called = false;
-    override(upload, "compose_upload_object", {
-        cancelAll() {
-            uppy_cancel_all_called = true;
-        },
+    override(upload, "compose_upload_cancel", () => {
+        uppy_cancel_all_called = true;
     });
     override(upload, "feature_check", noop);
 


### PR DESCRIPTION
Every time a user edits a message, we call the `setup_upload` method which creates a new Uppy instance and adds some event listeners to enable the upload process. These event listeners were not being removed during the cleanup process of message editing, which led to multiple event listeners being attached to the edit message form. Due to this, multiple duplicate files would get attached via these multiple event listeners if a user opened the edit message form for the same message multiple times.

This PR adds the `deactivate_upload` method to perform all the necessary cleanups while closing the edit message form. Via this method, we remove the event listeners attached and close the Uppy instance which cancels all uploads, resets progress and removes all files.

Fixes: [CZO issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/duplicate.20image.20uploads/near/1736103)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![duplicate-image-on-edit-BEFORE](https://github.com/zulip/zulip/assets/82862779/f00ac047-654a-4639-a56a-61b1ba9c03b3) | ![duplicate-image-on-edit-AFTER](https://github.com/zulip/zulip/assets/82862779/6a10c099-63ac-4b2a-836d-c6f472a1ab6b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
