### PR TITLE
remote-activity: Add column for remote server or realm creation date.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -101,6 +101,10 @@ def format_optional_datetime(date: Optional[datetime], display_none: bool = Fals
         return ""
 
 
+def format_datetime_as_date(date: datetime) -> str:
+    return date.strftime("%Y-%m-%d")
+
+
 def format_none_as_zero(value: Optional[int]) -> int:
     if value:
         return value

--- a/corporate/tests/test_activity_views.py
+++ b/corporate/tests/test_activity_views.py
@@ -169,6 +169,11 @@ class ActivityTest(ZulipTestCase):
             hostname="demo.example.com",
             contact_email="email@example.com",
         )
+        RemoteZulipServerAuditLog.objects.create(
+            event_type=RemoteZulipServerAuditLog.REMOTE_SERVER_CREATED,
+            server=server,
+            event_time=server.last_updated,
+        )
         extra_data = {
             RemoteRealmAuditLog.ROLE_COUNT: {
                 RemoteRealmAuditLog.ROLE_COUNT_HUMANS: {

--- a/corporate/views/installation_activity.py
+++ b/corporate/views/installation_activity.py
@@ -15,6 +15,7 @@ from corporate.lib.activity import (
     dictfetchall,
     estimate_annual_recurring_revenue_by_realm,
     fix_rows,
+    format_datetime_as_date,
     format_optional_datetime,
     get_query_data,
     get_realms_with_default_discount_dict,
@@ -183,7 +184,7 @@ def realm_summary_table() -> str:
     cursor.close()
 
     for row in rows:
-        row["date_created_day"] = row["date_created"].strftime("%Y-%m-%d")
+        row["date_created_day"] = format_datetime_as_date(row["date_created"])
         row["age_days"] = int((now - row["date_created"]).total_seconds() / 86400)
         row["is_new"] = row["age_days"] < 12 * 7
 

--- a/corporate/views/remote_activity.py
+++ b/corporate/views/remote_activity.py
@@ -4,6 +4,7 @@ from psycopg2.sql import SQL
 
 from corporate.lib.activity import (
     fix_rows,
+    format_datetime_as_date,
     format_none_as_zero,
     format_optional_datetime,
     get_plan_data_by_remote_realm,
@@ -44,13 +45,23 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             from zilencer_remotepushdevicetoken
             group by server_id
         ),
+        remote_server_audit_log as (
+            select
+                server_id,
+                event_time as server_created
+            from zilencer_remotezulipserverauditlog
+            where
+                event_type = 10215
+            group by server_id, event_time
+        ),
         remote_realms as (
             select
                 server_id,
                 id as realm_id,
                 name as realm_name,
                 org_type as realm_type,
-                host as realm_host
+                host as realm_host,
+                realm_date_created as realm_created
             from zilencer_remoterealm
             where
                 is_system_bot_realm = False
@@ -60,6 +71,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         select
             rserver.id,
             realm_id,
+            server_created,
+            realm_created,
             realm_name,
             rserver.hostname,
             realm_host,
@@ -73,6 +86,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         left join mobile_push_forwarded_count on mobile_push_forwarded_count.server_id = rserver.id
         left join remote_push_devices on remote_push_devices.server_id = rserver.id
         left join remote_realms on remote_realms.server_id = rserver.id
+        left join remote_server_audit_log on remote_server_audit_log.server_id = rserver.id
         where not deactivated
         order by push_user_count DESC NULLS LAST
     """
@@ -81,6 +95,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     cols = [
         "Links",
         "IDs",
+        "Date created",
         "Realm name",
         "Realm host or server hostname",
         "Server contact email",
@@ -98,16 +113,22 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     ]
 
     # If the query or column order above changes, update the constants below
+    # Query constants:
     SERVER_AND_REALM_IDS = 0
+    SERVER_CREATED = 1
+    REALM_CREATED = 2
     SERVER_HOST = 2
     REALM_HOST = 3
-    LAST_AUDIT_LOG_DATE = 6
-    MOBILE_USER_COUNT = 7
-    MOBILE_PUSH_COUNT = 8
-    ORG_TYPE = 9
-    ARR = 12
-    TOTAL_USER_COUNT = 14
-    GUEST_COUNT = 15
+
+    # Column constants:
+    DATE_CREATED = 2
+    LAST_AUDIT_LOG_DATE = 7
+    MOBILE_USER_COUNT = 8
+    MOBILE_PUSH_COUNT = 9
+    ORG_TYPE = 10
+    ARR = 13
+    TOTAL_USER_COUNT = 15
+    GUEST_COUNT = 16
 
     rows = get_query_data(query)
     plan_data_by_remote_server = get_plan_data_by_remote_server()
@@ -130,6 +151,14 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
         else:
             ids_string = f"{server_id}"
         row.insert(SERVER_AND_REALM_IDS, ids_string)
+
+        # Set date created data
+        # For remote realm row, remove server created value;
+        # for remote server row, remove realm created value
+        if realm_id is not None:
+            row.pop(SERVER_CREATED)
+        else:
+            row.pop(REALM_CREATED)
 
         # Get server_host for support link
         # For remote realm row, remove server hostname value;
@@ -202,6 +231,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             fix_rows(rows, i, format_optional_datetime)
         if i in [MOBILE_USER_COUNT, MOBILE_PUSH_COUNT]:
             fix_rows(rows, i, format_none_as_zero)
+        if i == DATE_CREATED:
+            fix_rows(rows, i, format_datetime_as_date)
         if i == SERVER_AND_REALM_IDS:
             total_row.append("Total")
         elif i == MOBILE_USER_COUNT:


### PR DESCRIPTION
Expands the main query for remote servers to get the audit log event datetime for when the server was created/registered.

The remote realm object has a field for when the remote realm was created on the remote server.

**Notes**:
- I'm not sure if getting the audit log for the remote server creation date will make that big query much slower. But if it does, then we could consider an index for it.
- Creates a tiny helper function for formatting the datetime value in the chart. And updates the installation activity chart to use this function since there is an intention to potentially refactor that chart to be generated in a similar manner to the other activity charts in the future.

**Screenshots and screen captures:**

<details>
<summary>Updated remote activity chart</summary>

![Screenshot from 2024-02-15 15-23-45](https://github.com/zulip/zulip/assets/63245456/c99885ba-6b6d-4561-9fe4-7eba860df7f9)
</details>
<details>
<summary>Installation activity chart - confirming no visible changes</summary>

![Screenshot from 2024-02-15 15-24-02](https://github.com/zulip/zulip/assets/63245456/2322dc5d-2302-4172-8857-d236eb25cbac)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
