### PR TITLE
integrations: Update Slack webhook to use check_send_webhook_message.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -7,20 +7,20 @@ See also the [Slack-compatible webhook](/integrations/doc/slack_incoming).
 
 1. {!create-an-incoming-webhook.md!}
 
-    Construct the URL for the {{ integration_display_name }}
-    bot using the bot's API key:
+1. {!generate-integration-url.md!}
 
-    `{{ api_url }}{{ integration_url }}?api_key=abcdefgh`
-
-    If you'd like to map Slack channels to different topics within the
-    same stream, add `&channels_map_to_topics=1` to the end of the URL.
-    This is the default behavior of the integration.
+    If you'd like to map Slack channels to different topics within the same
+    stream, add `&channels_map_to_topics=1` to the end of the URL. Note that
+    this should be used instead of specifying a topic in the URL. If a topic
+    is specified in the URL, then it will be prioritized over the channel to
+    topic mapping.
 
     If you'd like to map Slack channels to different streams, add
-    `&channels_map_to_topics=0` to the end of the URL. Make sure you
-    create streams for all your public Slack channels, and that the name
-    of each stream is the same as the name of the Slack channel it maps
-    to.
+    `&channels_map_to_topics=0` to the end of the URL. Make sure you create
+    streams for all your public Slack channels *(see step 1)*, and that the
+    name of each stream is the same as the name of the Slack channel it maps
+    to. Note that in this case, the channel to stream mapping will be
+    prioritized over the stream specified in the URL.
 
 1. Go to <https://my.slack.com/services/new/outgoing-webhook>
    and click **Add Outgoing WebHooks integration**.


### PR DESCRIPTION
Due to the `channel_map_to_topics` URL parameter in the Slack webhook, it was not migrated to use the `check_send_webhook_message`. Here we update the integration to use that function for sending the Slack integration webhook messages.

**Notes**:
- By using `check_send_webhook_message`, any topic parameter in the webhook URL will be prioritized over mapping Slack channels to topics, e.g. when `channel_map_to_topics` is true. This is because the default behaviour for incoming webhooks is to send a default topic as a parameter to `check_send_webhook_message` in case there is no topic specified in the URL.
- In contrast, we can override the stream passed in the URL when `channel_map_to_topics` is false by passing the Slack channel name to `check_send_webhook_message`. The default behaviour for incoming webhooks is to send a direct message if there is no specified stream in the URL, so a default stream is not generally passed to `check_send_webhook_message`.

[Relevant CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/slack.20webhook.20bug/near/1709700)

Fixes #27601

**Screenshots and screen captures:**

<details>
<summary>Slack integration documentation</summary>

[Current documentation](https://zulip.com/integrations/doc/slack)
![Screenshot from 2024-02-15 12-40-21](https://github.com/zulip/zulip/assets/63245456/c7d8e276-3a49-4363-95b2-cf25bfbd5553)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
