### PR TITLE
Collect how they know about Zulip data in new org registration.

### DIFF
--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -48,6 +48,7 @@
             <th>Bots</th>
             <th></th>
             <th colspan=8>Human messages sent, last 8 UTC days (today-so-far first)</th>
+            <th>Referrer</th>
         </tr>
     </thead>
 
@@ -118,6 +119,10 @@
             {% else %}
             <td colspan=8></td>
             {% endif %}
+
+            <td>
+                {{ row.how_realm_creator_found_zulip }}
+            </td>
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -196,6 +196,26 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
             <hr />
             {% endif %}
 
+            {% if creating_new_realm %}
+            <div class="input-group input-box" id="how-realm-creator-found-zulip">
+                <label for="how_realm_creator_found_zulip">
+                    {{ _('How did you first hear about Zulip?') }}
+                    {% if not corporate_enabled %}
+                    <i class="fa fa-question-circle-o" aria-hidden="true" data-tippy-content="{% trans %}This value is used only if you sign up for a plan, in which case it will be sent to the Zulip team.{% endtrans %}"></i>
+                    {% endif %}
+                </label>
+                <select name="how_realm_creator_found_zulip" class="required">
+                    <option value="" selected disabled>{{ _('Select an option') }}</option>
+                    {% for option_id, option_name in how_realm_creator_found_zulip_options %}
+                    <option value="{{ option_id }}">{{ option_name }}</option>
+                    {% endfor %}
+                </select>
+                <input id="how-realm-creator-found-zulip-other" type="text" placeholder="{{ _('Please describe') }}" name="how_realm_creator_found_zulip_other_text" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-where-ad" type="text" placeholder="{{ _('Where did you see the ad?') }}" name="how_realm_creator_found_zulip_where_ad" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-which-organization" type="text" placeholder="{{ _('Which organization?') }}" name="how_realm_creator_found_zulip_which_organization" maxlength="100"/>
+            </div>
+            {% endif %}
+
             <div class="input-group margin terms-of-service">
                 {% if terms_of_service %}
                 <div class="input-group">

--- a/web/e2e-tests/realm-creation.test.ts
+++ b/web/e2e-tests/realm-creation.test.ts
@@ -59,6 +59,8 @@ async function realm_creation_tests(page: Page): Promise<void> {
         full_name: "Alice",
         password: "passwordwhichisnotreallycomplex",
         terms: true,
+        how_realm_creator_found_zulip: "other",
+        how_realm_creator_found_zulip_other_text: "test",
     };
     // For some reason, page.click() does not work this for particular checkbox
     // so use page.$eval here to call the .click method in the browser.

--- a/web/src/bundles/portico.ts
+++ b/web/src/bundles/portico.ts
@@ -2,6 +2,7 @@ import "./common";
 import "../portico/header";
 import "../portico/google-analytics";
 import "../portico/portico_modals";
+import "../portico/tippyjs";
 import "../../third/bootstrap/css/bootstrap.portico.css";
 import "../../styles/portico/portico_styles.css";
 import "tippy.js/dist/tippy.css";

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -302,4 +302,40 @@ $(() => {
 
         $(e.target).hide();
     });
+
+    $("#how-realm-creator-found-zulip select").on("change", function () {
+        const elements: Record<string, string> = {
+            Other: "how-realm-creator-found-zulip-other",
+            Advertisement: "how-realm-creator-found-zulip-where-ad",
+            "At an organization that's using it":
+                "how-realm-creator-found-zulip-which-organization",
+        };
+
+        const hideElement = (element: string): void => {
+            const $element = $(`#${element}`);
+            $element.hide();
+            $element.removeAttr("required");
+            $(`#${element}-error`).hide();
+        };
+
+        const showElement = (element: string): void => {
+            const $element = $(`#${element}`);
+            $element.show();
+            $element.attr("required", "required");
+        };
+
+        // Reset state
+        for (const element of Object.values(elements)) {
+            if (element) {
+                hideElement(element);
+            }
+        }
+
+        // Show the additional input box if needed.
+        const selected_option = $("option:selected", this).text();
+        const selected_element = elements[selected_option];
+        if (selected_element) {
+            showElement(selected_element);
+        }
+    });
 });

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -2,12 +2,6 @@
     --color-background-modal: hsl(0deg 0% 98%);
 }
 
-[data-tippy-root] .tippy-box .tippy-content {
-    font-size: 14px;
-    font-weight: normal;
-    color: hsl(0deg 0% 100%);
-}
-
 .billing-upgrade-page {
     font-family: "Source Sans 3 VF", sans-serif;
     background-color: hsl(0deg 0% 98%);

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -2,6 +2,12 @@
     --color-background-modal: hsl(0deg 0% 98%);
 }
 
+[data-tippy-root] .tippy-box .tippy-content {
+    font-size: 14px;
+    font-weight: normal;
+    color: hsl(0deg 0% 100%);
+}
+
 body {
     background-color: hsl(0deg 0% 98%);
     font-family: "Source Sans 3 VF", sans-serif;

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1458,3 +1458,14 @@ button#register_auth_button_gitlab {
         max-width: 800px;
     }
 }
+
+#registration #how-realm-creator-found-zulip label {
+    top: -5px;
+}
+
+#how-realm-creator-found-zulip-where-ad,
+#how-realm-creator-found-zulip-other,
+#how-realm-creator-found-zulip-which-organization {
+    margin-top: 5px;
+    display: none;
+}

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -21,7 +21,6 @@
     ],
     "billing_auth": [
         "./src/bundles/portico",
-        "./src/portico/tippyjs",
         "./src/billing/helpers",
         "jquery-validation",
         "./src/billing/remote_billing_auth",
@@ -30,7 +29,6 @@
     ],
     "upgrade": [
         "./src/bundles/portico",
-        "./src/portico/tippyjs",
         "./src/billing/helpers",
         "./src/billing/upgrade",
         "jquery-validation",
@@ -120,8 +118,7 @@
     "stats": [
         "./src/bundles/portico",
         "./styles/portico/stats.css",
-        "./src/stats/stats",
-        "tippy.js/dist/tippy.css"
+        "./src/stats/stats"
     ],
     "app": ["./src/bundles/app"],
     "digest": ["./src/bundles/portico"]

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -115,11 +115,7 @@
     ],
     "desktop-login": ["./src/bundles/portico", "./src/portico/desktop-login"],
     "desktop-redirect": ["./src/bundles/portico", "./src/portico/desktop-redirect"],
-    "stats": [
-        "./src/bundles/portico",
-        "./styles/portico/stats.css",
-        "./src/stats/stats"
-    ],
+    "stats": ["./src/bundles/portico", "./styles/portico/stats.css", "./src/stats/stats"],
     "app": ["./src/bundles/app"],
     "digest": ["./src/bundles/portico"]
 }

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -167,6 +167,8 @@ def do_create_realm(
     enable_read_receipts: Optional[bool] = None,
     enable_spectator_access: Optional[bool] = None,
     prereg_realm: Optional[PreregistrationRealm] = None,
+    how_realm_creator_found_zulip: Optional[str] = None,
+    how_realm_creator_found_zulip_extra_context: Optional[str] = None,
 ) -> Realm:
     if string_id in [settings.SOCIAL_AUTH_SUBDOMAIN, settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN]:
         raise AssertionError(
@@ -243,6 +245,10 @@ def do_create_realm(
             realm=realm,
             event_type=RealmAuditLog.REALM_CREATED,
             event_time=realm.date_created,
+            extra_data={
+                "how_realm_creator_found_zulip": how_realm_creator_found_zulip,
+                "how_realm_creator_found_zulip_extra_context": how_realm_creator_found_zulip_extra_context,
+            },
         )
 
         realm_default_email_address_visibility = RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_EVERYONE

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -842,6 +842,8 @@ Output:
             "default_stream_group": default_stream_groups,
             "source_realm_id": source_realm_id,
             "is_demo_organization": is_demo_organization,
+            "how_realm_creator_found_zulip": "other",
+            "how_realm_creator_found_zulip_extra_context": "I found it on the internet.",
         }
         if enable_marketing_emails is not None:
             payload["enable_marketing_emails"] = enable_marketing_emails

--- a/zerver/models/realm_audit_logs.py
+++ b/zerver/models/realm_audit_logs.py
@@ -162,6 +162,18 @@ class AbstractRealmAuditLog(models.Model):
         REALM_IMPORTED,
     ]
 
+    HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS = {
+        "existing_user": "At an organization that's using it",
+        "search_engine": "Search engine",
+        "review_site": "Review site",
+        "personal_recommendation": "Personal recommendation",
+        "hacker_news": "Hacker News",
+        "ad": "Advertisement",
+        "other": "Other",
+        "forgot": "Don't remember",
+        "refuse_to_answer": "Prefer not to say",
+    }
+
     class Meta:
         abstract = True
 

--- a/zerver/views/development/registration.py
+++ b/zerver/views/development/registration.py
@@ -85,6 +85,8 @@ def register_development_realm(request: HttpRequest) -> HttpResponse:
         password="test",
         realm_subdomain=realm_subdomain,
         terms="true",
+        how_realm_creator_found_zulip="ad",
+        how_realm_creator_found_zulip_extra_context="test",
     )
 
     return accounts_register(request)
@@ -120,6 +122,8 @@ def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
         realm_subdomain=realm_subdomain,
         terms="true",
         is_demo_organization="true",
+        how_realm_creator_found_zulip="existing_user",
+        how_realm_creator_found_zulip_extra_context="test",
     )
 
     return accounts_register(request)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -82,6 +82,7 @@ from zerver.models import (
     UserProfile,
 )
 from zerver.models.constants import MAX_LANGUAGE_ID_LENGTH
+from zerver.models.realm_audit_logs import RealmAuditLog
 from zerver.models.realms import (
     DisposableEmailError,
     DomainNotAllowedForRealmError,
@@ -464,6 +465,32 @@ def registration_helper(
             realm_type = form.cleaned_data["realm_type"]
             realm_default_language = form.cleaned_data["realm_default_language"]
             is_demo_organization = form.cleaned_data["is_demo_organization"]
+            how_realm_creator_found_zulip = RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS[
+                form.cleaned_data["how_realm_creator_found_zulip"]
+            ]
+            how_realm_creator_found_zulip_extra_context = ""
+            if (
+                how_realm_creator_found_zulip
+                == RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["other"]
+            ):
+                how_realm_creator_found_zulip_extra_context = form.cleaned_data[
+                    "how_realm_creator_found_zulip_other_text"
+                ]
+            elif (
+                how_realm_creator_found_zulip
+                == RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["ad"]
+            ):
+                how_realm_creator_found_zulip_extra_context = form.cleaned_data[
+                    "how_realm_creator_found_zulip_where_ad"
+                ]
+            elif (
+                how_realm_creator_found_zulip
+                == RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["existing_user"]
+            ):
+                how_realm_creator_found_zulip_extra_context = form.cleaned_data[
+                    "how_realm_creator_found_zulip_which_organization"
+                ]
+
             realm = do_create_realm(
                 string_id,
                 realm_name,
@@ -471,6 +498,8 @@ def registration_helper(
                 default_language=realm_default_language,
                 is_demo_organization=is_demo_organization,
                 prereg_realm=prereg_realm,
+                how_realm_creator_found_zulip=how_realm_creator_found_zulip,
+                how_realm_creator_found_zulip_extra_context=how_realm_creator_found_zulip_extra_context,
             )
         assert realm is not None
 
@@ -686,6 +715,7 @@ def registration_helper(
         "email_address_visibility_moderators": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
         "email_address_visibility_nobody": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_NOBODY,
         "email_address_visibility_options_dict": UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP,
+        "how_realm_creator_found_zulip_options": RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS.items(),
     }
     # Add context for realm creation part of the form.
     context.update(get_realm_create_form_context())


### PR DESCRIPTION

<img width="738" alt="Screenshot 2024-02-15 at 9 41 59 PM" src="https://github.com/zulip/zulip/assets/25124304/135da210-fc08-4ded-8a21-d29a006d8c78">
<img width="738" alt="Screenshot 2024-02-15 at 9 41 50 PM" src="https://github.com/zulip/zulip/assets/25124304/59c77319-2a85-4043-9c17-2f26332ab92e">

<img width="1529" alt="Screenshot 2024-02-15 at 9 40 27 PM" src="https://github.com/zulip/zulip/assets/25124304/94775cbf-2556-44fc-b5d6-12e72397440b">



@timabbott what do you think about the approach here?