### PR TITLE
bootstrap: Remove html, body components.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -21,6 +21,8 @@ html {
 
 body {
     width: 100%;
+    margin: 0;
+    padding: 0;
     font-size: 14px;
     line-height: calc(20 / 14);
     font-family: "Source Sans 3 VF", sans-serif;
@@ -3198,10 +3200,6 @@ select.invite-as {
 }
 
 @media (width < $md_min) {
-    body {
-        padding: 0;
-    }
-
     .column-left {
         display: none;
 

--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -13,11 +13,6 @@ nav,
 section {
   display: block;
 }
-html {
-  font-size: 100%;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-}
 a:focus {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;

--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -57,10 +57,6 @@ label,
 button {
   cursor: pointer;
 }
-body {
-  margin: 0;
-  line-height: 20px;
-}
 a {
   color: #0088cc;
   text-decoration: none;
@@ -312,12 +308,6 @@ button.close {
   display: none;
   visibility: hidden;
 }
-@media (max-width: 767px) {
-  body {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
-}
 @media (min-width: 768px) and (max-width: 979px) {
   input {
     margin-left: 0;
@@ -326,10 +316,5 @@ button.close {
 @media (min-width: 1180px) {
   input {
     margin-left: 0;
-  }
-}
-@media (max-width: 979px) {
-  body {
-    padding-top: 0;
   }
 }


### PR DESCRIPTION
This PR removes the `html` & `body` selectors and styles from `bootstrap.app.css`, redeclaring only zeroed `margin` and `padding` values on `body` explicitly in `zulip.css`.

**Screenshots and screen captures:**

Removing the `text-size-adjust` properties does not affect Zulip web in horizontal orientation on an iPhone:

| Before | After |
| --- | --- |
| ![html-bootstrap-before](https://github.com/zulip/zulip/assets/170719/e190b642-1610-43c4-b0ff-3d5ed98ddb3f) | ![html-bootstrap-after](https://github.com/zulip/zulip/assets/170719/15d8510d-a75e-4a20-be4d-fafdcd1699a6) |


Before and after of the interface looks identical:
| Before | After |
| --- | --- |
| ![bootstrap-root-removal-before](https://github.com/zulip/zulip/assets/170719/2e40a9db-8a16-482e-bb12-675adaa250e1) | ![bootstrap-root-removal-after](https://github.com/zulip/zulip/assets/170719/31d1b0cd-56f2-4556-89c4-6c55a6c24c7d) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
