### PR TITLE
state_data: Fix custom_profile_fields type for CHOICE → SELECT rename

### DIFF
--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -34,7 +34,7 @@ export let realm: {
             id: number;
             name: string;
         };
-        CHOICE: {
+        SELECT: {
             id: number;
             name: string;
         };

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12034,7 +12034,7 @@ paths:
                             - `SHORT_TEXT`
                             - `LONG_TEXT`
                             - `DATE` for date-based fields.
-                            - `CHOICE` for a list of options.
+                            - `SELECT` for a list of options.
                             - `URL` for links.
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.


### PR DESCRIPTION
Commit bd6471f0e34fe6ae69cb4c4d179e9a43ee74e3ed (#28691) added this reference to the old name, even though it had already been renamed in commit b220d29fedea5e447f8a1b3d272fe0715dd096a7 (#17775), presumably because that had failed to update the OpenAPI description.