### PR TITLE
api-docs: Add instructions to download `zuliprc` files.

### DIFF
--- a/api_docs/api-keys.md
+++ b/api_docs/api-keys.md
@@ -17,7 +17,7 @@ Anyone with your API key can impersonate you, so be doubly careful with it.
 
 {settings_tab|account-and-privacy}
 
-1. Under **API key**, click **Show/change your API key**.
+1. Under **API key**, click **Manage your API key**.
 
 1. Enter your password, and click **Get API key**. If you don't know your
    password, click **reset it** and follow the

--- a/api_docs/configuring-python-bindings.md
+++ b/api_docs/configuring-python-bindings.md
@@ -5,14 +5,22 @@ easily, called the [Python bindings](https://pypi.python.org/pypi/zulip/).
 One of the most notable use cases for these bindings are bots developed
 using Zulip's [bot framework](/api/writing-bots).
 
-In order to use them, you need to configure them with your API key and other
-settings. There are two ways to achieve that:
+In order to use them, you need to configure them with your identity
+(account, API key, and Zulip server URL). There are a few ways to
+achieve that:
 
- - With a file called `zuliprc` passed as an argument via the `--config-file`
-   option.
- - With
-   [environment variables](https://en.wikipedia.org/wiki/Environment_variable)
-   set up in your host machine.
+- Using a `zuliprc` file, referenced via the `--config-file` option or
+  the `config_file` option to the `zulip.Client` constructor
+  (recommended for bots).
+- Using a `zuliprc` file in your home directory at `~/.zuliprc`
+  (recommended for your own API key).
+- Using the [environment
+  variables](https://en.wikipedia.org/wiki/Environment_variable)
+  documented below.
+- Using the `--api-key`, `--email`, and `--site` variables as command
+  line parameters.
+- Using the `api_key`, `email`, and `site` parameters to the
+  `zulip.Client` constructor.
 
 ## Download a `zuliprc` file
 
@@ -24,12 +32,6 @@ settings. There are two ways to achieve that:
 
 1. Click the **download** (<i class="fa fa-download"></i>) icon on the profile
    card of the desired bot to download the bot's `zuliprc` file.
-
-!!! tip ""
-
-    If you save or move a `zuliprc` file to your home directory as `~/.zuliprc`,
-    the Python API bindings will automatically read it in (you won't have to
-    pass the `--config-file` option).
 
 !!! warn ""
 
@@ -47,11 +49,9 @@ settings. There are two ways to achieve that:
 
 1. Click **Download zuliprc** to download your `zuliprc` file.
 
-!!! tip ""
-
-    If you save or move a `zuliprc` file to your home directory as `~/.zuliprc`,
-    the Python API bindings will automatically read it in (you won't have to
-    pass the `--config-file` option).
+1. (optional) If you'd like your credentials to be used by default
+   when using the Zulip API on your computer, move the `zuliprc` file
+   to `~/.zuliprc` in your home directory.
 
 !!! warn ""
 

--- a/api_docs/configuring-python-bindings.md
+++ b/api_docs/configuring-python-bindings.md
@@ -8,12 +8,62 @@ using Zulip's [bot framework](/api/writing-bots).
 In order to use them, you need to configure them with your API key and other
 settings. There are two ways to achieve that:
 
- - With a file called `.zuliprc`, located in your home directory.
+ - With a file called `zuliprc` passed as an argument via the `--config-file`
+   option.
  - With
    [environment variables](https://en.wikipedia.org/wiki/Environment_variable)
    set up in your host machine.
 
-A `.zuliprc` file is a plain text document that looks like this:
+## Download a `zuliprc` file
+
+{start_tabs}
+
+{tab|for-a-bot}
+
+{settings_tab|your-bots}
+
+1. Click the **download** (<i class="fa fa-download"></i>) icon on the profile
+   card of the desired bot to download the bot's `zuliprc` file.
+
+!!! tip ""
+
+    If you save or move a `zuliprc` file to your home directory as `~/.zuliprc`,
+    the Python API bindings will automatically read it in (you won't have to
+    pass the `--config-file` option).
+
+!!! warn ""
+
+    Anyone with a bot's API key can impersonate the bot, so be careful with it!
+
+{tab|for-yourself}
+
+{settings_tab|account-and-privacy}
+
+1. Under **API key**, click **Manage your API key**.
+
+1. Enter your password, and click **Get API key**. If you don't know your
+   password, click **reset it** and follow the
+   instructions from there.
+
+1. Click **Download zuliprc** to download your `zuliprc` file.
+
+!!! tip ""
+
+    If you save or move a `zuliprc` file to your home directory as `~/.zuliprc`,
+    the Python API bindings will automatically read it in (you won't have to
+    pass the `--config-file` option).
+
+!!! warn ""
+
+    Anyone with your API key can impersonate you, so be doubly careful with it.
+
+{end_tabs}
+
+## Configuration keys and environment variables
+
+`zuliprc` is a configuration file written in the
+[INI file format](https://en.wikipedia.org/wiki/INI_file),
+which contains key-value pairs as shown in the following example:
 
 ```
 [api]
@@ -29,7 +79,7 @@ can be found in the following table:
 <table class="table">
     <thead>
         <tr>
-            <th><code>.zuliprc</code> key</th>
+            <th><code>zuliprc</code> key</th>
             <th>Environment variable</th>
             <th>Required</th>
             <th>Description</th>
@@ -102,3 +152,10 @@ can be found in the following table:
         </td>
     </tr>
 </table>
+
+## Related articles
+
+* [Installation instructions](/api/installation-instructions)
+* [API keys](/api/api-keys)
+* [Running bots](/api/running-bots)
+* [Deploying bots](/api/deploying-bots)

--- a/help/add-a-bot-or-integration.md
+++ b/help/add-a-bot-or-integration.md
@@ -38,7 +38,7 @@ is visible and available for anyone to use.
     as the **bot type**.
 
 Depending on the type of bot you're creating, you may need to download its
-`.zuliprc` configuration file. For that, click the **download**
+`zuliprc` configuration file. For that, click the **download**
 (<i class="fa fa-download"></i>) icon under the bot's name.
 
 ## Related articles

--- a/templates/zerver/integrations/google-calendar.md
+++ b/templates/zerver/integrations/google-calendar.md
@@ -20,7 +20,7 @@ your reminders directly in your Zulip feed.
     then clicking on **Personal settings**.
 
 1.  Click on the tab that’s labeled **Account & privacy** and click on
-    **Show/change your API key**. Enter your password if prompted, and
+    **Manage your API key**. Enter your password if prompted, and
     download the `zuliprc` file. Save this file as `.zuliprc` to your `~/`
     directory.
 

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -127,7 +127,7 @@
                 </p>
                 <div id="api_key_button_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
                     <button class="button rounded" id="api_key_button" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>
-                        {{t "Show/change your API key" }}
+                        {{t "Manage your API key" }}
                     </button>
                 </div>
             </div>

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -36,7 +36,7 @@
                 </button>
                 <div id="api_key_buttons">
                     <button class="modal__btn dialog_submit_button" id="regenerate_api_key" aria-label="{{t 'Generate new API key' }}">{{t "Generate new API key" }}</button>
-                    <a class="modal__btn dialog_submit_button" id="download_zuliprc" download="zuliprc" tabindex="0">{{t "Download .zuliprc" }}</a>
+                    <a class="modal__btn dialog_submit_button" id="download_zuliprc" download="zuliprc" tabindex="0">{{t "Download zuliprc" }}</a>
                 </div>
             </footer>
         </div>

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -112,6 +112,8 @@ TAB_SECTION_LABELS = {
     "v6": "Zulip Server 6.0+",
     "v4": "Zulip Server 4.0+",
     "all-versions": "All versions",
+    "for-a-bot": "For a bot",
+    "for-yourself": "For yourself",
 }
 
 


### PR DESCRIPTION
- Adds instructions for downloading a zuliprc file for a bot or for yourself.
- Updates the button label to "Download zuliprc", since that's the filename it downloads.
- Renames button to "Manage your API key", and updates docs accordingly.

Fixes #28881.

**Screenshots and screen captures:**
- https://chat.zulip.org/api/configuring-python-bindings
![image](https://github.com/zulip/zulip/assets/2343554/4f7833d9-d74e-402e-8f91-daca18a1e5d6)
![image](https://github.com/zulip/zulip/assets/2343554/2c3ae2a1-5be1-488d-bafd-08861f712456)

- https://chat.zulip.org/#settings/account-and-privacy
![image](https://github.com/zulip/zulip/assets/2343554/b021e20f-a9f6-4e67-967c-9dc0b3b1cf3a)
![image](https://github.com/zulip/zulip/assets/2343554/cdaf7f89-55b7-4e7b-b9d3-8c4b8ddae883)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

