### PR TITLE
corporate: Fix `next_invoice_date` not updated on `end_date` extension.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1444,7 +1444,12 @@ class BillingSession(ABC):
                 assert plan.status == CustomerPlan.ACTIVE
                 old_end_date = plan.end_date
                 plan.end_date = new_end_date
-                plan.save(update_fields=["end_date"])
+                old_next_invoice_date = plan.next_invoice_date
+                # Legacy plans should be invoiced once on the end_date to
+                # downgrade or switch to a new tier.
+                if plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY:
+                    plan.next_invoice_date = new_end_date
+                plan.save(update_fields=["end_date", "next_invoice_date"])
                 self.write_to_audit_log(
                     event_type=AuditLogEventType.CUSTOMER_PLAN_PROPERTY_CHANGED,
                     event_time=timezone_now(),
@@ -1455,6 +1460,17 @@ class BillingSession(ABC):
                         "property": "end_date",
                     },
                 )
+                if old_next_invoice_date != plan.next_invoice_date:
+                    self.write_to_audit_log(
+                        event_type=AuditLogEventType.CUSTOMER_PLAN_PROPERTY_CHANGED,
+                        event_time=timezone_now(),
+                        extra_data={
+                            "old_value": old_next_invoice_date,
+                            "new_value": new_end_date,
+                            "plan_id": plan.id,
+                            "property": "next_invoice_date",
+                        },
+                    )
                 return f"Current plan for {self.billing_entity_display_name} updated to end on {end_date_string}."
         raise SupportRequestError(
             f"No current plan for {self.billing_entity_display_name}."

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -353,6 +353,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
         assert plan is not None
         self.assertEqual(plan.status, CustomerPlan.ACTIVE)
         self.assertEqual(plan.end_date, datetime(2050, 2, 1, tzinfo=timezone.utc))
+        self.assertEqual(plan.next_invoice_date, datetime(2050, 2, 1, tzinfo=timezone.utc))
 
         cordelia = self.example_user("cordelia")
         self.login_user(cordelia)
@@ -375,17 +376,22 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
         )
         plan.refresh_from_db()
         self.assertEqual(plan.end_date, datetime(2040, 1, 1, tzinfo=timezone.utc))
-        audit_log = RemoteRealmAuditLog.objects.filter(
+        self.assertEqual(plan.next_invoice_date, datetime(2040, 1, 1, tzinfo=timezone.utc))
+        audit_logs = RemoteRealmAuditLog.objects.filter(
             event_type=RemoteRealmAuditLog.CUSTOMER_PLAN_PROPERTY_CHANGED
-        ).last()
-        assert audit_log is not None
+        ).order_by("-id")
+        assert audit_logs.exists()
+        next_invoice_date_changed_audit_log = audit_logs[0]
+        end_date_changed_audit_log = audit_logs[1]
         expected_extra_data = {
             "old_value": "2050-02-01T00:00:00Z",
             "new_value": "2040-01-01T00:00:00Z",
             "property": "end_date",
             "plan_id": plan.id,
         }
-        self.assertEqual(audit_log.extra_data, expected_extra_data)
+        self.assertEqual(end_date_changed_audit_log.extra_data, expected_extra_data)
+        expected_extra_data["property"] = "next_invoice_date"
+        self.assertEqual(next_invoice_date_changed_audit_log.extra_data, expected_extra_data)
 
         result = self.client_post(
             "/activity/remote/support",


### PR DESCRIPTION
Earlier, on extending `end_date` for legacy plans, `next_invoice_date` was not extended which resulted in `invoice_plan()` run for such legacy plans before the `end_date`.

The intended behaviour is that the legacy plan should be invoiced only once on the `end_date` to downgrade or switch to a new tier.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
