### PR TITLE
Remote activity fix support links and last push notification date

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -79,7 +79,7 @@ class MobilePushData:
     total_mobile_users: int
     uncategorized_mobile_users: Optional[int] = None
     mobile_pushes_forwarded: Optional[int] = None
-    last_mobile_push_sent: Optional[datetime] = None
+    last_mobile_push_sent: str = ""
 
 
 @dataclass
@@ -259,17 +259,18 @@ def get_mobile_push_data(remote_entity: Union[RemoteZulipServer, RemoteRealm]) -
             property="mobile_pushes_forwarded::day",
         ).last()
         if latest_remote_server_push_forwarded_count is not None:  # nocoverage
-            return MobilePushData(
-                total_mobile_users=total_users,
-                uncategorized_mobile_users=uncategorized_users,
-                mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
-                last_mobile_push_sent=latest_remote_server_push_forwarded_count.end_time,
-            )
+            # mobile_pushes_forwarded is a CountStat with a day frequency,
+            # so we want to show the start of the latest day interval.
+            push_forwarded_interval_start = (
+                latest_remote_server_push_forwarded_count.end_time - timedelta(days=1)
+            ).strftime("%Y-%m-%d")
+        else:
+            push_forwarded_interval_start = "None"
         return MobilePushData(
             total_mobile_users=total_users,
             uncategorized_mobile_users=uncategorized_users,
             mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
-            last_mobile_push_sent=None,
+            last_mobile_push_sent=push_forwarded_interval_start,
         )
     else:
         assert isinstance(remote_entity, RemoteRealm)
@@ -288,17 +289,18 @@ def get_mobile_push_data(remote_entity: Union[RemoteZulipServer, RemoteRealm]) -
             property="mobile_pushes_forwarded::day",
         ).last()
         if latest_remote_realm_push_forwarded_count is not None:  # nocoverage
-            return MobilePushData(
-                total_mobile_users=mobile_users,
-                uncategorized_mobile_users=None,
-                mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
-                last_mobile_push_sent=latest_remote_realm_push_forwarded_count.end_time,
-            )
+            # mobile_pushes_forwarded is a CountStat with a day frequency,
+            # so we want to show the start of the latest day interval.
+            push_forwarded_interval_start = (
+                latest_remote_realm_push_forwarded_count.end_time - timedelta(days=1)
+            ).strftime("%Y-%m-%d")
+        else:
+            push_forwarded_interval_start = "None"
         return MobilePushData(
             total_mobile_users=mobile_users,
             uncategorized_mobile_users=None,
             mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
-            last_mobile_push_sent=None,
+            last_mobile_push_sent=push_forwarded_interval_start,
         )
 
 

--- a/corporate/views/remote_activity.py
+++ b/corporate/views/remote_activity.py
@@ -117,8 +117,8 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
     SERVER_AND_REALM_IDS = 0
     SERVER_CREATED = 1
     REALM_CREATED = 2
-    SERVER_HOST = 2
-    REALM_HOST = 3
+    SERVER_HOST = 3
+    REALM_HOST = 4
 
     # Column constants:
     DATE_CREATED = 2

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -25,7 +25,7 @@
     <br />
     <b>Mobile user count</b>: {{ support_data[remote_realm.id].mobile_push_data.total_mobile_users }}<br />
     <b>7-day mobile pushes count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_pushes_forwarded }}<br />
-    <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(support_data[remote_realm.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
+    <b>Last push notification date</b>: {{ support_data[remote_realm.id].mobile_push_data.last_mobile_push_sent }}<br />
 </div>
 
 {% if remote_realm.plan_type != SPONSORED_PLAN_TYPE %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -65,7 +65,7 @@
                     <b>Uncategorized mobile user count:</b> {{ remote_servers_support_data[remote_server.id].mobile_push_data.uncategorized_mobile_users }}<br />
                 {% endif %}
                 <b>7-day mobile pushes count</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.mobile_pushes_forwarded }}<br />
-                <b>Last push notification sent (UTC)</b>: {{ format_optional_datetime(remote_servers_support_data[remote_server.id].mobile_push_data.last_mobile_push_sent, True) }}<br />
+                <b>Last push notification date</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.last_mobile_push_sent }}<br />
             </div>
 
             {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}


### PR DESCRIPTION
**Notes**:
- The first commit fixes an error, which was introduced in commit 230294cfb31ba4b1e9fb1427147b3683c84376e6, that broke the support links in the remote activity view.
- The second commit fixes the remote support view to display the start of the day time interval for the most recent update to the mobile pushes forwarded CountStat for either the remote server or remote realm.

**Screenshots and screen captures:**

<details>
<summary>Remote support view - with either None or date for last push notification forwarded</summary>

![Screenshot from 2024-02-16 14-10-36](https://github.com/zulip/zulip/assets/63245456/f19c2110-10cc-47cf-9e01-d9a71ae5d709)
![Screenshot from 2024-02-16 14-10-45](https://github.com/zulip/zulip/assets/63245456/c575208c-46e3-4b46-9a28-fab9741ef241)
</details>
<details>
<summary>Remote activity view - hovering over support links</summary>

![Screenshot from 2024-02-16 14-13-27](https://github.com/zulip/zulip/assets/63245456/df7ebd03-7a1b-4c74-b621-24ba058f54ec)
![Screenshot from 2024-02-16 14-13-37](https://github.com/zulip/zulip/assets/63245456/e285fab6-68ab-4db3-be2e-aefab9bb8dbe)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
