### PR TITLE
remote-support: Note if emails were sent for remote server sponsorship.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -4349,17 +4349,22 @@ class RemoteServerBillingSession(BillingSession):
                 "email", flat=True
             )
         )
-        send_email(
-            "zerver/emails/sponsorship_approved_community_plan",
-            to_emails=billing_emails,
-            from_address=BILLING_SUPPORT_EMAIL,
-            context={
-                "billing_entity": self.billing_entity_display_name,
-                "plans_link": "https://zulip.com/plans/#self-hosted",
-                "link_to_zulip": "https://zulip.com/help/linking-to-zulip-website",
-            },
-        )
-        return f"Sponsorship approved for {self.billing_entity_display_name}"
+        if len(billing_emails) > 0:
+            send_email(
+                "zerver/emails/sponsorship_approved_community_plan",
+                to_emails=billing_emails,
+                from_address=BILLING_SUPPORT_EMAIL,
+                context={
+                    "billing_entity": self.billing_entity_display_name,
+                    "plans_link": "https://zulip.com/plans/#self-hosted",
+                    "link_to_zulip": "https://zulip.com/help/linking-to-zulip-website",
+                },
+            )
+            emailed_string = "Emailed existing billing users."
+        else:
+            emailed_string = "No billing users exist to email."
+
+        return f"Sponsorship approved for {self.billing_entity_display_name}; " + emailed_string
 
     @override
     def process_downgrade(


### PR DESCRIPTION
In cases where a support admin approves a sponsorship for a remote server without any billing users having been created, note that no emails were sent in the success message on the support page.

We already do this for remote realms and should be an infrequent case as ideally most remote servers will submit official sponsorship requests.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
