### PR TITLE
page_params: Remove max_message_id from type

### DIFF
--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -21,7 +21,6 @@ export const page_params: {
         percent_translated?: number;
     }[];
     login_page: string;
-    max_message_id: number;
     narrow?: Term[];
     narrow_stream?: string;
     needs_tutorial: boolean;


### PR DESCRIPTION
As of commit fd2ad130f91805fd64e894b9058ec043726c4ac1 (#28930) this is popped in `ui_init.initialize_everything` now.