### PR TITLE
lint: Remove .lock extension from frontend group

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -62,7 +62,6 @@ def run() -> None:
                 "hbs",
                 "html",
                 "js",
-                "lock",
                 "ts",
             ],
         },


### PR DESCRIPTION
Commit 3a27b12a7dc9580e565946d3252720cbdce08934 (#24731) migrated yarn.lock to pnpm-lock.yaml.