### PR TITLE
message feed: Refine dark mode styles for alert_word.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -198,6 +198,7 @@
     --color-background-popover: hsl(0deg 0% 100%);
     --color-background-alert-word: hsl(18deg 100% 84%);
     --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
+    --color-text-link-tag-alert-word: hsl(200deg 100% 40%);
 
     /* Compose box colors */
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
@@ -486,8 +487,10 @@
     --color-background-tab-picker-selected-tab: hsl(0deg 0% 100% / 7%);
     --color-outline-tab-picker-tab-option: hsl(0deg 0% 100% / 12%);
     --color-background-tab-picker-tab-option-hover: hsl(0deg 0% 100% / 5%);
-    --color-background-alert-word: hsl(22deg 70% 35%);
     --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
+    --color-background-alert-word: hsl(18deg 100% 75%);
+    --color-text-alert-word: hsl(0deg 0% 15%);
+    --color-text-link-tag-alert-word: hsl(210deg 100% 25%);
 
     /* Compose box colors */
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -491,6 +491,8 @@
     --color-background-alert-word: hsl(18deg 100% 75%);
     --color-text-alert-word: hsl(0deg 0% 15%);
     --color-text-link-tag-alert-word: hsl(210deg 100% 25%);
+    --color-background-search-highlight: hsl(51deg 100% 72%);
+    --color-text-search-highlight: hsl(0deg 0% 15%);
 
     /* Compose box colors */
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1081,7 +1081,8 @@
 
     /* Search highlight used in both topics and rendered_markdown */
     .highlight {
-        background-color: hsl(51deg 100% 23%);
+        background-color: var(--color-background-search-highlight);
+        color: var(--color-text-search-highlight);
     }
 
     .streams_subheader {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -210,8 +210,15 @@
         }
     }
 
+    a .alert-word {
+        background-color: var(--color-background-alert-word);
+        color: var(--color-text-link-tag-alert-word);
+        font-weight: 500;
+    }
+
     .alert-word {
         background-color: var(--color-background-alert-word);
+        color: var(--color-text-alert-word);
     }
 
     /* Timestamps */


### PR DESCRIPTION
This pull request addresses various style enhancements in dark mode to improve readability and accessibility:
- All colors used in this pull request have been suggested  in [#12614(comment)](https://github.com/zulip/zulip/issues/12614#issuecomment-1556028086)
- Adjusts the color and background-color of alert words for better visibility.
- Modifies the alert_word link color to enhance contrast and readability.
- Improves the search result background-color for a more cohesive dark mode experience.
- I've ensured that the changes made for dark mode don't affect the light mode. Attached is a screenshot of the light mode that shows the adjustments made exclusively for dark mode, ensuring readability and accessibility.


Fixes: #12614 

**Screenshots and screen captures:**

- **Dark Mode Before Changes for Alert Word:**

<img width="1435" alt="Screenshot 2024-02-11 at 2 37 51 PM" src="https://github.com/zulip/zulip/assets/122713145/b38e8a5d-face-40d4-8920-c710b6a279b4">

- **Dark Mode After Changes for Alert Word:**

<img width="1429" alt="Screenshot 2024-02-17 at 3 10 39 PM" src="https://github.com/zulip/zulip/assets/122713145/d1bf9bff-79ca-49a2-bf84-fbde8e5e901b">

- **Dark Mode Before Changes for Alert Word Link tag:**

<img width="1436" alt="Screenshot 2024-02-17 at 3 45 54 PM" src="https://github.com/zulip/zulip/assets/122713145/f5bcaef0-d3eb-4b23-bdf7-e8339c5bd326">


- **Dark Mode After Changes for Alert Word Link tag:**

<img width="1435" alt="Screenshot 2024-02-17 at 3 12 56 PM" src="https://github.com/zulip/zulip/assets/122713145/9cb4155e-fe0a-44ff-8de6-adf60d302b9c">


- **Dark Mode Before Changes for search results**

<img width="1433" alt="Screenshot 2024-02-11 at 2 38 32 PM" src="https://github.com/zulip/zulip/assets/122713145/4735bece-dee6-4597-a73f-08f2ef623f2e">

- **Dark Mode After Changes for search results**

<img width="1413" alt="Screenshot 2024-02-03 at 12 54 37 PM" src="https://github.com/zulip/zulip/assets/122713145/630ee44e-d20c-407e-9f25-98ffa73c4acc">

- **Light Mode:**

  - **Doesn't Effect the Changes for Search Results:**

<img width="1406" alt="Screenshot 2024-02-03 at 12 56 50 PM" src="https://github.com/zulip/zulip/assets/122713145/124bc7f7-698f-49c1-9158-f221768e0331">

  - **Doesn't Effect the Changes for Alert Word:**

<img width="1214" alt="Screenshot 2024-02-03 at 12 57 13 PM" src="https://github.com/zulip/zulip/assets/122713145/180fd3da-6372-4e91-b267-fe2af728a01d">

  - **Before Changes for highlighted link text:**

<img width="1434" alt="Screenshot 2024-02-15 at 11 27 46 AM" src="https://github.com/zulip/zulip/assets/122713145/13123d19-6a5c-4552-bfd5-c5e0112e3b78">
  
  - **After Changes for highlighted link text:**
<img width="1433" alt="Screenshot 2024-02-15 at 11 43 05 AM" src="https://github.com/zulip/zulip/assets/122713145/bbd5741c-407c-4ce0-8450-f3c8a74d9f8c">






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
