### PR TITLE
compose: Make it possible to split messages on delimiter.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -179,6 +179,8 @@ export function toggle_split_messages() {
         show_preview_area();
     }
     compose_banner.update_split_messages_info_banner();
+    compose_validate.check_overflow_text($("#send_message_form"));
+    compose_validate.validate_and_update_send_button_status();
 }
 
 export let send_message = (message_content = compose_state.message_content()) => {

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -129,6 +129,7 @@ export function clear_compose_box() {
     }
     $("textarea#compose-textarea").val("").trigger("focus");
     compose_ui.compose_textarea_typeahead?.hide();
+    compose_banner.clear_split_messages_info_banner();
     compose_validate.check_overflow_text($("#send_message_form"));
     compose_validate.clear_topic_resolved_warning();
     drafts.set_compose_draft_id(undefined);
@@ -166,6 +167,18 @@ export function send_message_success(request, data) {
             compose_notifications.notify_unmute(muted_narrow, request.stream_id, request.topic);
         }
     }
+}
+
+export function toggle_split_messages() {
+    const state = compose_split_messages.is_split_messages_enabled();
+    compose_split_messages.set_split_messages_enabled(!state);
+    // preview area and compose banner should be updated with the new setting
+    if ($("#compose .preview_message_area").css("display") !== "none") {
+        // re-render the preview area if it is currently visible
+        clear_preview_area();
+        show_preview_area();
+    }
+    compose_banner.update_split_messages_info_banner();
 }
 
 export let send_message = (message_content = compose_state.message_content()) => {
@@ -223,6 +236,8 @@ export let send_message = (message_content = compose_state.message_content()) =>
         send_message_success(request, data);
         if (will_split_message) {
             send_message(rest_of_the_content, true);
+        } else {
+            compose_banner.clear_split_messages_info_banner();
         }
     }
 

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -220,6 +220,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     compose_recipient.update_narrow_to_recipient_visibility();
     compose_recipient.update_recipient_row_attention_level();
     compose_banner.update_split_messages_info_banner();
+    compose_validate.check_overflow_text($("#send_message_form"));
 
     // This logic catches the corner case of starting a new topic
     // from within an existing *general chat* topic via buttons

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -152,6 +152,7 @@ function clear_box(): void {
     compose_validate.clear_stream_wildcard_warnings($("#compose_banners"));
     compose_validate.clear_guest_in_dm_recipient_warning();
     compose_validate.set_user_acknowledged_stream_wildcard_flag(false);
+    compose_banner.clear_split_messages_info_banner();
 
     compose_state.set_recipient_edited_manually(false);
     compose_state.set_is_content_unedited_restored_draft(false);
@@ -218,6 +219,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     compose_recipient.update_compose_area_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
     compose_recipient.update_recipient_row_attention_level();
+    compose_banner.update_split_messages_info_banner();
 
     // This logic catches the corner case of starting a new topic
     // from within an existing *general chat* topic via buttons

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -2,10 +2,12 @@ import $ from "jquery";
 
 import render_cannot_send_direct_message_error from "../templates/compose_banner/cannot_send_direct_message_error.hbs";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
+import render_split_message_banner from "../templates/compose_banner/split_message_banner.hbs";
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
 import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
 
+import * as compose_split_messages from "./compose_split_messages.ts";
 import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as stream_data from "./stream_data.ts";
@@ -67,6 +69,7 @@ export const CLASSNAMES = {
     generic_compose_error: "generic_compose_error",
     user_not_subscribed: "user_not_subscribed",
     unknown_zoom_user: "unknown_zoom_user",
+    split_messages: "split_messages",
 };
 
 export function get_compose_banner_container($textarea: JQuery): JQuery {
@@ -311,4 +314,32 @@ export function show_convert_pasted_text_to_file_banner(cb: () => void): JQuery 
     $new_row.on("click", ".main-view-banner-action-button", cb);
     append_compose_banner_to_banner_list($new_row, $("#compose_banners"));
     return $new_row;
+}
+
+export function update_split_messages_info_banner(): void {
+    if (compose_split_messages.will_split_into_multiple_messages()) {
+        update_or_append_banner(
+            $(split_messages_info_banner_content()),
+            CLASSNAMES.split_messages,
+            $("#compose_banners"),
+        );
+    } else {
+        clear_split_messages_info_banner();
+    }
+}
+
+function split_messages_info_banner_content(): string {
+    const context = {
+        banner_type: INFO,
+        button_text: $t({
+            defaultMessage: "Send as a single message",
+        }),
+        message_count: compose_split_messages.count_message_content_split_parts(),
+        classname: CLASSNAMES.split_messages,
+    };
+    return render_split_message_banner(context);
+}
+
+export function clear_split_messages_info_banner(): void {
+    $(`#compose_banners .${CSS.escape(CLASSNAMES.split_messages)}`).remove();
 }

--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -7,6 +7,7 @@ import render_send_later_popover from "../templates/popovers/send_later_popover.
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import * as compose from "./compose.js";
+import * as compose_split_messages from "./compose_split_messages.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as drafts from "./drafts.ts";
@@ -213,6 +214,7 @@ export function initialize() {
                         enter_sends_true: user_settings.enter_sends,
                         formatted_send_later_time,
                         show_compose_new_message,
+                        split_messages_enabled: compose_split_messages.is_split_messages_enabled(),
                     }),
                 ),
             );
@@ -269,6 +271,13 @@ export function initialize() {
                 compose.clear_compose_box();
                 compose.clear_preview_area();
                 popover_menus.hide_current_popover_if_visible(instance);
+            });
+            // Handle split messages clicks.
+            $popper.one("click", "#split_messages_checkbox", () => {
+                compose.toggle_split_messages();
+                setTimeout(() => {
+                    popover_menus.hide_current_popover_if_visible(instance);
+                }, ENTER_SENDS_SELECTION_DELAY);
             });
         },
         onHidden(instance) {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -14,6 +14,7 @@ import * as compose_fade from "./compose_fade.ts";
 import * as compose_notifications from "./compose_notifications.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_send_menu_popover from "./compose_send_menu_popover.js";
+import * as compose_split_messages from "./compose_split_messages.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -71,6 +72,11 @@ export function initialize() {
         compose_ui.handle_keyup(event, $("textarea#compose-textarea").expectOne());
     });
 
+    const debounced_update_split_message_banner = _.debounce(
+        () => compose_banner.update_split_messages_info_banner(),
+        300,
+    );
+
     $("textarea#compose-textarea").on("input", () => {
         if ($("#compose").hasClass("preview_mode")) {
             compose.render_preview_area();
@@ -98,6 +104,11 @@ export function initialize() {
 
         if (compose_state.get_is_content_unedited_restored_draft()) {
             compose_state.set_is_content_unedited_restored_draft(false);
+        }
+
+        // update banner if splitting messages is enabled
+        if (compose_split_messages.is_split_messages_enabled()) {
+            debounced_update_split_message_banner();
         }
     });
 
@@ -212,6 +223,15 @@ export function initialize() {
                 }
                 compose_validate.clear_topic_resolved_warning(true);
             });
+        },
+    );
+
+    $("body").on(
+        "click",
+        `.${CSS.escape(compose_banner.CLASSNAMES.split_messages)} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            compose.toggle_split_messages();
         },
     );
 

--- a/web/src/compose_split_messages.ts
+++ b/web/src/compose_split_messages.ts
@@ -1,0 +1,66 @@
+import * as compose_state from "./compose_state.ts";
+import * as compose_textarea from "./compose_textarea.ts";
+
+export const SPLIT_DELIMITER = "\n\n\n";
+let split_messages_enabled = true;
+
+export function is_split_messages_enabled(): boolean {
+    return split_messages_enabled;
+}
+
+export function set_split_messages_enabled(enable: boolean): void {
+    split_messages_enabled = enable;
+}
+
+// Returns index of the first delimiter which is not inside a code block.
+export function delimiter_index_outside_code_block(content: string): number {
+    let index = content.indexOf(SPLIT_DELIMITER);
+    while (index !== -1) {
+        if (!compose_textarea.position_inside_code_block(content, index + 1)) {
+            return index;
+        }
+        index = content.indexOf(SPLIT_DELIMITER, index + 1);
+    }
+    return -1;
+}
+
+export function trim_except_whitespace_before_text(content: string): string {
+    return content.replace(/^(\n|\s*\n)+/, "").trimEnd();
+}
+
+export function split_message(raw_message_content: string): [string, string] {
+    if (!is_split_messages_enabled()) {
+        return [raw_message_content, ""];
+    }
+    // Trim leading newlines to avoid empty messages due to multiple delimiters.
+    // Whitespace before text is markdown syntax for code blocks, so we should not trim it.
+    const message_content = trim_except_whitespace_before_text(raw_message_content);
+
+    // We do not wish to split inside code blocks, so we ignore delimiters inside code blocks.
+    const index = delimiter_index_outside_code_block(message_content);
+    if (index === -1) {
+        return [message_content, ""];
+    }
+    const send_content = message_content.slice(0, index);
+    const rest_content = message_content.slice(index);
+    return [send_content, rest_content];
+}
+
+export function count_message_content_split_parts(): number {
+    const message_content = compose_state.message_content();
+    let count = 1;
+    let parts = split_message(message_content);
+    while (parts[1]) {
+        count += 1;
+        parts = split_message(parts[1]);
+    }
+    return count;
+}
+
+export function will_split_into_multiple_messages(): boolean {
+    if (!is_split_messages_enabled()) {
+        return false;
+    }
+    // If there is a non-empty remaining part, splitting will occur.
+    return Boolean(split_message(compose_state.message_content())[1]);
+}

--- a/web/src/compose_split_messages.ts
+++ b/web/src/compose_split_messages.ts
@@ -57,6 +57,17 @@ export function count_message_content_split_parts(): number {
     return count;
 }
 
+export function get_all_split_parts(message_content: string): string[] {
+    const parts: string[] = [];
+    let remaining_content = message_content;
+    while (remaining_content) {
+        const [part, rest] = split_message(remaining_content);
+        parts.push(part);
+        remaining_content = rest;
+    }
+    return parts;
+}
+
 export function will_split_into_multiple_messages(): boolean {
     if (!is_split_messages_enabled()) {
         return false;

--- a/web/src/compose_textarea.ts
+++ b/web/src/compose_textarea.ts
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+import * as markdown from "./markdown.ts";
+
 // Save the compose content cursor position and restore when we
 // shift-tab back in (see hotkey.js).
 let saved_compose_cursor = 0;
@@ -18,6 +20,19 @@ function set_compose_textarea_handlers(): void {
 
 export function restore_compose_cursor(): void {
     $("textarea#compose-textarea").trigger("focus").caret(saved_compose_cursor);
+}
+
+export function position_inside_code_block(content: string, position: number): boolean {
+    let unique_insert = "UNIQUEINSERT:" + Math.random();
+    while (content.includes(unique_insert)) {
+        unique_insert = "UNIQUEINSERT:" + Math.random();
+    }
+    const unique_insert_content =
+        content.slice(0, position) + unique_insert + content.slice(position);
+    const rendered_content = markdown.parse_non_message(unique_insert_content);
+    const rendered_html = new DOMParser().parseFromString(rendered_content, "text/html");
+    const code_blocks = rendered_html.querySelectorAll("pre > code");
+    return [...code_blocks].some((code_block) => code_block?.textContent?.includes(unique_insert));
 }
 
 export function initialize(): void {

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -240,13 +240,26 @@ export function initialize(): void {
         trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
-            instance.setContent(
+            const $indicator = $(instance.reference);
+            const $container = $(instance.popper).find(".tooltip-container");
+            $container.find(".max-length-indicator").text(
                 $t(
-                    {defaultMessage: `Maximum message length: {max_length} characters`},
-                    {max_length: realm.max_message_length},
+                    {
+                        defaultMessage: "Maximum message length: {max_message_length} characters.",
+                    },
+                    {
+                        max_message_length: realm.max_message_length,
+                    },
                 ),
             );
+            $container
+                .find(".exceeding-position")
+                .text($indicator.attr("data-additional-text") ?? "");
         },
+        // Prevent tooltip from hiding on mouseout
+        interactive: true,
+        // Optionally, set duration to 0 to avoid fade-out delay
+        duration: 0,
     });
 
     tippy.delegate("body", {

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -17,6 +17,7 @@ import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util.ts";
 import * as channel from "./channel.ts";
 import * as common from "./common.ts";
+import * as compose_textarea from "./compose_textarea.ts";
 import * as compose_state from "./compose_state.ts";
 import type {TypeaheadSuggestion} from "./composebox_typeahead.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -630,20 +631,7 @@ export function cursor_inside_code_block($textarea: JQuery<HTMLTextAreaElement>)
     const cursor_position = $textarea.caret();
     const current_content = $textarea.val()!;
 
-    return position_inside_code_block(current_content, cursor_position);
-}
-
-export function position_inside_code_block(content: string, position: number): boolean {
-    let unique_insert = "UNIQUEINSERT:" + Math.random();
-    while (content.includes(unique_insert)) {
-        unique_insert = "UNIQUEINSERT:" + Math.random();
-    }
-    const unique_insert_content =
-        content.slice(0, position) + unique_insert + content.slice(position);
-    const rendered_content = markdown.parse_non_message(unique_insert_content);
-    const rendered_html = new DOMParser().parseFromString(rendered_content, "text/html");
-    const code_blocks = rendered_html.querySelectorAll("pre > code");
-    return [...code_blocks].some((code_block) => code_block?.textContent?.includes(unique_insert));
+    return compose_textarea.position_inside_code_block(current_content, cursor_position);
 }
 
 export let format_text = (

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -13,12 +13,15 @@ import {
 } from "text-field-edit";
 import * as z from "zod/mini";
 
+import render_enumerated_split_message_part from "../templates/enumerated_split_message_part.hbs";
+
 import type {Typeahead} from "./bootstrap_typeahead.ts";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util.ts";
 import * as channel from "./channel.ts";
 import * as common from "./common.ts";
-import * as compose_textarea from "./compose_textarea.ts";
+import * as compose_split_messages from "./compose_split_messages.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_textarea from "./compose_textarea.ts";
 import type {TypeaheadSuggestion} from "./composebox_typeahead.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
@@ -1314,7 +1317,11 @@ export function render_and_show_preview(
     const preview_render_count = compose_state.get_preview_render_count() + 1;
     compose_state.set_preview_render_count(preview_render_count);
 
-    function show_preview(rendered_content: string, raw_content?: string): void {
+    function show_preview(
+        rendered_content: string,
+        message_number?: number,
+        raw_content?: string,
+    ): void {
         // content is passed to check for status messages ("/me ...")
         // and will be undefined in case of errors
         let rendered_preview_html;
@@ -1329,53 +1336,86 @@ export function render_and_show_preview(
             rendered_preview_html = rendered_content;
         }
 
-        $preview_content_box.html(postprocess_content(rendered_preview_html));
-        rendered_markdown.update_elements($preview_content_box);
+        if (message_number) {
+            // A positive number means that the message should be
+            // enumerated.
+            const enumerated_rendered_preview_html = render_enumerated_split_message_part({
+                message_number,
+                rendered_preview_html,
+            });
+            $preview_content_box.append($(postprocess_content(enumerated_rendered_preview_html)));
+        } else {
+            $preview_content_box.html(postprocess_content(rendered_preview_html));
+        }
+        // console.log(
+        //     {rendered_preview_html},
+        //     render_enumerated_split_message_part({
+        //         message_number,
+        //         rendered_preview_html,
+        //     }),
+        // );
     }
 
     if (content.length === 0) {
         show_preview($t_html({defaultMessage: "Nothing to preview"}));
     } else {
-        if (markdown.contains_backend_only_syntax(content)) {
-            const $spinner = $preview_spinner.expectOne();
-            loading.make_indicator($spinner);
-        } else {
-            // For messages that don't appear to contain syntax that
-            // is only supported by our backend Markdown processor, we
-            // render using the frontend Markdown processor (but still
-            // render server-side to ensure the preview is accurate;
-            // if the `markdown.contains_backend_only_syntax` logic is
-            // wrong, users will see a brief flicker of the locally
-            // echoed frontend rendering before receiving the
-            // authoritative backend rendering from the server).
-            markdown.render(content);
+        render_message_part(content, 1);
+        function render_message_part(whole_content: string, message_number: number): void {
+            const [content, remaining_content] =
+                compose_split_messages.split_message(whole_content);
+            if (!remaining_content && message_number === 1) {
+                // if no content remains on splitting the message once,
+                // it means that the message will not be split into parts
+                // and we should not enumerate the parts.
+                message_number = 0;
+            }
+            if (markdown.contains_backend_only_syntax(content)) {
+                const $spinner = $preview_spinner.expectOne();
+                loading.make_indicator($spinner);
+            } else {
+                // For messages that don't appear to contain syntax that
+                // is only supported by our backend Markdown processor, we
+                // render using the frontend Markdown processor (but still
+                // render server-side to ensure the preview is accurate;
+                // if the `markdown.contains_backend_only_syntax` logic is
+                // wrong, users will see a brief flicker of the locally
+                // echoed frontend rendering before receiving the
+                // authoritative backend rendering from the server).
+                markdown.render(content);
+            }
+            void channel.post({
+                url: "/json/messages/render",
+                data: {content},
+                success(response_data) {
+                    if (
+                        preview_render_count !== compose_state.get_preview_render_count() ||
+                        !$preview_container.hasClass("preview_mode")
+                    ) {
+                        // The user is no longer in preview mode or the compose
+                        // input has already been updated with new raw Markdown
+                        // since this rendering request was sent off to the server, so
+                        // there's nothing to do.
+                        return;
+                    }
+                    const data = message_render_response_schema.parse(response_data);
+                    if (markdown.contains_backend_only_syntax(content)) {
+                        loading.destroy_indicator($preview_spinner);
+                    }
+                    show_preview(data.rendered, message_number, content);
+                    if (remaining_content) {
+                        render_message_part(remaining_content, message_number + 1);
+                    } else {
+                        // All the message parts are now rendered.
+                        rendered_markdown.update_elements($preview_content_box);
+                    }
+                },
+                error() {
+                    if (markdown.contains_backend_only_syntax(content)) {
+                        loading.destroy_indicator($preview_spinner);
+                    }
+                    show_preview($t_html({defaultMessage: "Failed to generate preview"}));
+                },
+            });
         }
-        void channel.post({
-            url: "/json/messages/render",
-            data: {content},
-            success(response_data) {
-                if (
-                    preview_render_count !== compose_state.get_preview_render_count() ||
-                    !$preview_container.hasClass("preview_mode")
-                ) {
-                    // The user is no longer in preview mode or the compose
-                    // input has already been updated with new raw Markdown
-                    // since this rendering request was sent off to the server, so
-                    // there's nothing to do.
-                    return;
-                }
-                const data = message_render_response_schema.parse(response_data);
-                if (markdown.contains_backend_only_syntax(content)) {
-                    loading.destroy_indicator($preview_spinner);
-                }
-                show_preview(data.rendered, content);
-            },
-            error() {
-                if (markdown.contains_backend_only_syntax(content)) {
-                    loading.destroy_indicator($preview_spinner);
-                }
-                show_preview($t_html({defaultMessage: "Failed to generate preview"}));
-            },
-        });
     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2038,3 +2038,35 @@ textarea.new_message_textarea {
         overflow: hidden;
     }
 }
+
+.split_message_fragment:not(:first-child) {
+    padding-top: 12px;
+}
+
+.split_message_enumerated {
+    padding-left: 5px;
+    padding-top: 2px;
+    color: hsl(0deg 0% 50%);
+}
+
+.split_message_content {
+    padding: 5px;
+    border: 1px solid hsl(0deg 0% 50%);
+    border-radius: 8px;
+}
+
+.split_message_content p:last-child {
+    margin: 0;
+}
+
+.split_message_content .zulip-code-block:last-child pre {
+    margin-bottom: 1px;
+}
+
+.split_message_content .spoiler-block:last-child {
+    margin-bottom: 1px;
+}
+
+.split_message_content blockquote:last-child {
+    margin-bottom: 1px;
+}

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2070,3 +2070,8 @@ textarea.new_message_textarea {
 .split_message_content blockquote:last-child {
     margin-bottom: 1px;
 }
+
+#split_messages_menu_item {
+    padding: 0.2em 0.6666em;
+    color: var(--color-text-popover-menu);
+}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -99,7 +99,7 @@
                             <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts">
                                 <span class="compose-drafts-text">{{t 'Drafts' }}</span><span class="compose-drafts-count-container">(<span class="compose-drafts-count"></span>)</span>
                             </a>
-                            <span id="compose-limit-indicator" class="message-limit-indicator"></span>
+                            <span id="compose-limit-indicator" class="message-limit-indicator" data-tooltip-template-id="message-length-tooltip-template"></span>
                             <div class="message-send-controls">
                                 <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
                                     <img class="loader" alt="" src="" />

--- a/web/templates/compose_banner/split_message_banner.hbs
+++ b/web/templates/compose_banner/split_message_banner.hbs
@@ -1,0 +1,13 @@
+<div class="above_compose_banner main-view-banner {{banner_type}} {{classname}}">
+    <p class="banner_content">
+        {{#tr}}
+        The text in your compose box will be split at <b>two consecutive blank lines</b> into <b>{message_count}</b>
+        messages.
+        {{/tr}}
+    </p>
+    <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if
+      scheduling_message}}data-validation-trigger="schedule" {{/if}}>
+        {{t "Don't split"}}
+    </button>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+</div>

--- a/web/templates/enumerated_split_message_part.hbs
+++ b/web/templates/enumerated_split_message_part.hbs
@@ -1,0 +1,8 @@
+<div class="split_message_fragment">
+    <div class="split_message_enumerated">
+        {{#tr}}
+        Message {message_number}
+        {{/tr}}
+    </div>
+    <div class="split_message_content rendered_markdown">{{{rendered_preview_html}}}</div>
+</div>

--- a/web/templates/popovers/send_later_popover.hbs
+++ b/web/templates/popovers/send_later_popover.hbs
@@ -40,6 +40,16 @@
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-list-item">
+            <div id="split_messages_menu_item">
+                <label role="menuitem" class="checkbox" tabindex="0">
+                    <input class="popover-menu-icon inline-block setting-widget" id="split_messages_checkbox" type="checkbox" {{#if split_messages_enabled}}checked{{/if}} />
+                    <span class="rendered-checkbox popover-menu-icon"></span>
+                    <span class="popover-menu-label">{{t "Send as multiple messages" }}</span>
+                </label>
+            </div>
+        </li>
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="open_send_later_modal popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-calendar" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Schedule message" }}</span>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -303,3 +303,9 @@
         </div>
     </div>
 </template>
+<template id="message-length-tooltip-template">
+    <div class="tooltip-container">
+        <div class="max-length-indicator">{{t 'Maximum message length' }}</div>
+        <div class="tootlip-inner-content exceeding-position italic"></div>
+    </div>
+</template>

--- a/web/tests/compose_split_messages.test.cjs
+++ b/web/tests/compose_split_messages.test.cjs
@@ -1,0 +1,101 @@
+"use strict";
+
+const {strict: assert} = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const compose_state = mock_esm("../src/compose_state");
+
+const compose_split_messages = zrequire("../src/compose_split_messages");
+
+mock_esm("../src/compose_textarea", {
+    position_inside_code_block(content, position) {
+        const first = content.slice(0, position);
+        const second = content.slice(position);
+        // a simplified version of what compose_textarea.position_inside_code_block does
+        return first.includes("```") && second.includes("```");
+    },
+});
+
+run_test("trim_except_whitespace_before_text", () => {
+    compose_split_messages.set_split_messages_enabled(true);
+    assert.equal(compose_split_messages.trim_except_whitespace_before_text("\n\n\nhello"), "hello");
+    assert.equal(
+        compose_split_messages.trim_except_whitespace_before_text("\n\n\n    \n\nhello"),
+        "hello",
+    );
+    assert.equal(
+        compose_split_messages.trim_except_whitespace_before_text("    \n\n\n    hello"),
+        "    hello",
+    );
+    assert.equal(
+        compose_split_messages.trim_except_whitespace_before_text("\n \n \n hello"),
+        " hello",
+    );
+});
+
+const test_messages = [
+    `\n\n\n\n\n\nzulip\n\n\n`,
+    `\n\n       \n\n \n\n \n\n   zulip\n\n\n    chat`,
+    `\`\`\`\n\n\n\`\`\``,
+    `\`\`\`python\n\n\n\n\n\nprint("hi")\n\n\n\`\`\`\n\n\n\n`,
+    `\`\`\`python\n\n\n\n\n\nprint("hi")\n\n\n\`\`\`\n\n\n   ZULIP\n\n\n`,
+];
+
+run_test("delimiter_index_outside_code_block", () => {
+    compose_split_messages.set_split_messages_enabled(true);
+    const first_delimiter_indices = [0, 25, -1, 32, 32];
+    let i = 0;
+    for (const message of test_messages) {
+        assert.equal(
+            compose_split_messages.delimiter_index_outside_code_block(message),
+            first_delimiter_indices[i],
+        );
+        i += 1;
+    }
+});
+
+let dummy_message = `First line\n\n\nSecond line\n\n\n\n\n\n    third line\n\n\n\`\`\`python\n\n\n\n\n\nprint("code")\n\n\n\n\n\n\`\`\`\n\n\nafter code`;
+
+run_test("split_message", () => {
+    compose_split_messages.set_split_messages_enabled(true);
+    const split_messages = [
+        ["zulip", ""],
+        ["   zulip", "\n\n\n    chat"],
+        [`\`\`\`\n\n\n\`\`\``, ""],
+        [`\`\`\`python\n\n\n\n\n\nprint("hi")\n\n\n\`\`\``, ""],
+        [`\`\`\`python\n\n\n\n\n\nprint("hi")\n\n\n\`\`\``, "\n\n\n   ZULIP"],
+    ];
+    let i = 0;
+    for (const message of test_messages) {
+        const actual = compose_split_messages.split_message(message);
+        const expected = split_messages[i];
+        assert.equal(actual[0], expected[0]);
+        assert.equal(actual[1], expected[1]);
+        i += 1;
+    }
+
+    compose_split_messages.set_split_messages_enabled(false);
+    const split = compose_split_messages.split_message(dummy_message);
+    assert.equal(split[0], dummy_message);
+    assert.equal(split[1], "");
+});
+
+run_test("count_message_content_split_parts", ({override}) => {
+    compose_split_messages.set_split_messages_enabled(true);
+    override(compose_state, "message_content", () => dummy_message);
+    assert.equal(compose_split_messages.count_message_content_split_parts(), 5);
+});
+
+run_test("will_split_into_multiple_messages", ({override}) => {
+    override(compose_state, "message_content", () => dummy_message);
+    compose_split_messages.set_split_messages_enabled(false);
+    assert.equal(compose_split_messages.will_split_into_multiple_messages(), false);
+    compose_split_messages.set_split_messages_enabled(true);
+    assert.equal(compose_split_messages.will_split_into_multiple_messages(), true);
+
+    dummy_message = "\n\n\nThis will not split\n\n\n\n\n";
+    override(compose_state, "message_content", () => dummy_message);
+    assert.equal(compose_split_messages.will_split_into_multiple_messages(), false);
+});


### PR DESCRIPTION
This PR implements the following:

- A message can be split at two blank lines into multiple parts. (`\n\n\n` is the delimiter)
- A checkbox is provided in the message actions popover to enable/disable this behaviour. 
- A compose banner notifies whether the message will actually split, and into how many parts it will split.
- No splitting will occur if the delimiter occurs inside a code block.
- The state of the option isn't yet saved in localstorage or in the database.
- The compose banner indicating the number of split parts is updated in a debounced fashion (to avoid expensive calls to `position_inside_code_block`)
- When one of the messages in the sequence fails to send, all the unsent content is restored in the compose box.

The setting is enabled by default.

Each message part has the same length constraints as a normal message.
In the message length indicator, we show the counter for the first message that exceeds the character limit. If there are none, we show the counter for the first message that's near the character limit. We use the same prioritization for the color around the compose box.

fixes #28626

CZO: [#frontend > issue #28626: Make it possible to automatically split long m @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/issue.20.2328626.3A.20Make.20it.20possible.20to.20automatically.20split.20long.20m/near/2190177)




<details>

<summary> Screenshots</summary>

*Message actions popover*
<img width="281" alt="image" src="https://github.com/user-attachments/assets/2fe996b0-08a9-45e7-99d5-b4da50c51164" />

<img width="624" alt="image" src="https://github.com/user-attachments/assets/66abdfe2-a277-43a7-b8a4-763f4e3358fc" />


<img width="628" alt="image" src="https://github.com/user-attachments/assets/ab3ce64e-7471-41c7-b02d-856c6675c00a" />




Sent message:
*Added reactions to make it clear that these are separate messages.*

<img width="622" alt="image" src="https://github.com/user-attachments/assets/191058a6-2589-4799-a565-8cc28e04b17b" />

*Light mode*

<img width="275" alt="image" src="https://github.com/user-attachments/assets/d089e1af-94ad-48bf-9c73-e1e763d00594" />

<img width="635" alt="image" src="https://github.com/user-attachments/assets/20fefa4d-2240-4d18-b853-54e13a851b75" />


Warnings and errors:

<img width="972" height="307" alt="image" src="https://github.com/user-attachments/assets/a23f81fc-e427-4cc1-b10c-c7186785a650" />

<img width="981" height="314" alt="image" src="https://github.com/user-attachments/assets/1c74c094-30b9-46ec-891c-2eeaef7616f7" />



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
