### PR TITLE
compose: Fix bug where sometimes message draft remained post sending it.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -144,13 +144,11 @@ export function clear_compose_box() {
 
 export function send_message_success(request, data) {
     if (!request.locally_echoed) {
-        if ($("textarea#compose-textarea").data("draft-id")) {
-            drafts.draft_model.deleteDraft($("textarea#compose-textarea").data("draft-id"));
-        }
         clear_compose_box();
     }
 
     echo.reify_message_id(request.local_id, data.id);
+    drafts.draft_model.deleteDraft(request.draft_id);
 
     if (request.type === "stream") {
         if (data.automatic_new_visibility_policy) {
@@ -178,6 +176,10 @@ export function send_message(request = create_message_object()) {
     } else {
         request.to = JSON.stringify([request.to]);
     }
+
+    // Silently save / update a draft to ensure the message is not lost in case send fails.
+    // We delete the draft on successful send.
+    request.draft_id = drafts.update_draft({no_notify: true, update_count: false});
 
     let local_id;
     let locally_echoed;

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -5,7 +5,6 @@ import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as compose_notifications from "./compose_notifications";
 import * as compose_ui from "./compose_ui";
-import * as drafts from "./drafts";
 import * as local_message from "./local_message";
 import * as markdown from "./markdown";
 import * as message_lists from "./message_lists";
@@ -243,14 +242,6 @@ export function try_deliver_locally(message_request, insert_new_messages) {
         return undefined;
     }
 
-    // Save a locally echoed message in drafts, so it cannot be
-    // lost. It will be cleared if the message is sent successfully.
-    // We ask the drafts system to not notify the user or update the
-    // draft count, since that would be quite distracting in the very
-    // common case that the message sends normally.
-    const draft_id = drafts.update_draft({no_notify: true, update_count: false});
-    message_request.draft_id = draft_id;
-
     // Now that we've committed to delivering the message locally, we
     // shrink the compose-box if it is in the full-screen state. This
     // would have happened anyway in clear_compose_box, however, we
@@ -360,11 +351,6 @@ export function reify_message_id(local_id, server_id) {
 
     message.id = server_id;
     message.locally_echoed = false;
-
-    if (message.draft_id) {
-        // Delete the draft if message was locally echoed
-        drafts.draft_model.deleteDraft(message.draft_id);
-    }
 
     const opts = {old_id: Number.parseFloat(local_id), new_id: server_id};
 

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -50,7 +50,6 @@ message_lists.home = {
 };
 message_lists.all_rendered_message_lists = () => [message_lists.home, message_lists.current];
 
-const drafts = zrequire("drafts");
 const echo = zrequire("echo");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
@@ -315,7 +314,6 @@ run_test("test reify_message_id", ({override}) => {
 
     let message_store_reify_called = false;
     let notifications_reify_called = false;
-    let draft_deleted = false;
 
     override(message_store, "reify_message_id", () => {
         message_store_reify_called = true;
@@ -325,17 +323,10 @@ run_test("test reify_message_id", ({override}) => {
         notifications_reify_called = true;
     });
 
-    const draft_model = drafts.draft_model;
-    override(draft_model, "deleteDraft", (draft_id) => {
-        assert.ok(draft_id, 100);
-        draft_deleted = true;
-    });
-
     echo.reify_message_id(local_id_float.toString(), 110);
 
     assert.ok(message_store_reify_called);
     assert.ok(notifications_reify_called);
-    assert.ok(draft_deleted);
 });
 
 run_test("reset MockDate", () => {


### PR DESCRIPTION
Now whenever we initiate sending a message, we save / update its draft, which is deleted on a successful send. Earlier, we did this only for locally echoed messages. Hence a non locally echoed message's draft would remain, if created in the timeframe between initiating send and receiving the same message from the server, which can be significant for slow connections.

Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/able.20to.20send.20message.20and.20save.20draft.20together/near/1733960)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
