### PR TITLE
zilencer: Exclude realm_locally_deleted in get_human_user_realm_uuids.

### DIFF
--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -915,6 +915,7 @@ def get_human_user_realm_uuids(
     query = RemoteRealm.objects.filter(
         server=server,
         realm_deactivated=False,
+        realm_locally_deleted=False,
         registration_deactivated=False,
         is_system_bot_realm=False,
     ).exclude(


### PR DESCRIPTION
Just like deactivated realms should be excluded, so should locally deleted realms.

In particular, failure to exclude locally deleted realms breaks handle_customer_migration_from_server_to_realms.