### PR TITLE
page_params: Set and expect state_data = null for spectators

### DIFF
--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -51,7 +51,7 @@ const home_params_schema = default_params_schema
         show_plans: z.boolean(),
         show_webathena: z.boolean(),
         sponsorship_pending: z.boolean(),
-        state_data: state_data_schema.optional(),
+        state_data: state_data_schema.nullable(),
         translation_data: z.record(z.string()),
     })
     // TODO/typescript: Remove .passthrough() when all consumers have been

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -169,14 +169,13 @@ def build_page_params_for_home_page_load(
             narrow=narrow,
             include_streams=False,
         )
+        queue_id = state_data["queue_id"]
         default_language = state_data["user_settings"]["default_language"]
     else:
         # The spectator client will be fetching the /register response
-        # for spectators via the API. But we still need to set the
-        # values not presence in that object.
-        state_data = {
-            "queue_id": None,
-        }
+        # for spectators via the API.
+        state_data = None
+        queue_id = None
         default_language = realm.default_language
 
     if user_profile is None:
@@ -239,7 +238,7 @@ def build_page_params_for_home_page_load(
 
     page_params["state_data"] = state_data
 
-    if narrow_stream is not None:
+    if narrow_stream is not None and state_data is not None:
         # In narrow_stream context, initial pointer is just latest message
         recipient = narrow_stream.recipient
         state_data["max_message_id"] = -1
@@ -269,4 +268,4 @@ def build_page_params_for_home_page_load(
         page_params["realm_rendered_description"] = get_realm_rendered_description(realm)
         page_params["language_cookie_name"] = settings.LANGUAGE_COOKIE_NAME
 
-    return state_data["queue_id"], page_params
+    return queue_id, page_params

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -366,10 +366,7 @@ class HomeTest(ZulipTestCase):
             "warn_no_email",
         ]
         self.assertCountEqual(page_params, expected_keys)
-        expected_state_data_keys = [
-            "queue_id",
-        ]
-        self.assertCountEqual(page_params["state_data"], expected_state_data_keys)
+        self.assertIsNone(page_params["state_data"])
 
     def test_sentry_keys(self) -> None:
         def home_params() -> Dict[str, Any]:


### PR DESCRIPTION
Fix a ZodError when spectators load the app, introduced by commit a4938d3760d5d9c67fb3c4f72274d8f775321931 (#28971).