### PR TITLE
billing: Remove unused page_params on event_status page.

### DIFF
--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -33,7 +33,6 @@
         "./styles/portico/billing.css"
     ],
     "billing-event-status": [
-        "./src/billing/page_params",
         "./src/bundles/portico",
         "./styles/portico/landing_page.css",
         "./src/billing/event_status",


### PR DESCRIPTION
a4938d3760d5d9c67fb3c4f72274d8f775321931 introduced assertions for page_params for which they were used. This caused the assertion to fail on event_status page making the page not work. Removed the page_params from running on event_status page to fix it.

@andersk FYI
