### PR TITLE
webpack: Remove extraneous inclusions of page_params

### DIFF
--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -7,14 +7,12 @@
         "./styles/portico/activity.css"
     ],
     "billing": [
-        "./src/billing/page_params",
         "./src/bundles/portico",
         "./src/billing/helpers",
         "./src/billing/billing",
         "./styles/portico/billing.css"
     ],
     "sponsorship": [
-        "./src/billing/page_params",
         "./src/bundles/portico",
         "jquery-validation",
         "./src/portico/signup",
@@ -22,7 +20,6 @@
         "./styles/portico/billing.css"
     ],
     "upgrade": [
-        "./src/billing/page_params",
         "./src/bundles/portico",
         "./src/portico/tippyjs",
         "./src/billing/helpers",
@@ -114,7 +111,6 @@
     "desktop-login": ["./src/bundles/portico", "./src/portico/desktop-login"],
     "desktop-redirect": ["./src/bundles/portico", "./src/portico/desktop-redirect"],
     "stats": [
-        "./src/stats/page_params",
         "./src/bundles/portico",
         "./styles/portico/stats.css",
         "./src/stats/stats",


### PR DESCRIPTION
Commit a4938d3760d5d9c67fb3c4f72274d8f775321931 (#28971) fixed the order-sensitivity of these modules, so it suffices to just import them where they are used.