### PR TITLE
bundles: Remove unnecessary imports of effect-free modules

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -10,12 +10,7 @@ import "jquery-validation";
 // Import app JS
 import "../setup";
 import "../reload";
-import "../hotkey";
-import "../desktop_notifications";
-import "../server_events";
 import "../templates";
-import "../settings";
-import "../desktop_integration";
 import "../zulip_test";
 
 // Import styles

--- a/web/src/desktop_integration.js
+++ b/web/src/desktop_integration.js
@@ -8,7 +8,11 @@ import * as message_store from "./message_store";
 import * as narrow from "./narrow";
 import * as stream_data from "./stream_data";
 
-if (window.electron_bridge !== undefined) {
+export function initialize() {
+    if (window.electron_bridge === undefined) {
+        return;
+    }
+
     window.electron_bridge.on_event("logout", () => {
         $("#logout_form").trigger("submit");
     });
@@ -64,12 +68,6 @@ if (window.electron_bridge !== undefined) {
             error,
         });
     });
-}
-
-export function initialize() {
-    if (window.electron_bridge === undefined) {
-        return;
-    }
 
     $(document).on("click", "#open-self-hosted-billing", (event) => {
         event.preventDefault();

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -292,6 +292,9 @@ export function initialize(params) {
     last_event_id = params.last_event_id;
     event_queue_longpoll_timeout_seconds = params.event_queue_longpoll_timeout_seconds;
 
+    window.addEventListener("beforeunload", () => {
+        cleanup_event_queue();
+    });
     reload.add_reload_hook(cleanup_event_queue);
     watchdog.on_unsuspend(() => {
         // Immediately poll for new events on unsuspend
@@ -316,10 +319,6 @@ function cleanup_event_queue() {
         ignore_reload: true,
     });
 }
-
-window.addEventListener("beforeunload", () => {
-    cleanup_event_queue();
-});
 
 // For unit testing
 export const _get_events_success = get_events_success;

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -25,25 +25,6 @@ import {user_settings} from "./user_settings";
 
 export let settings_label;
 
-$(() => {
-    $("#settings_overlay_container").on("click", (e) => {
-        if (!modals.any_active()) {
-            return;
-        }
-        if ($(e.target).closest(".micromodal").length > 0) {
-            return;
-        }
-        e.preventDefault();
-        e.stopPropagation();
-        // Whenever opening a modal(over settings overlay) in an event handler
-        // attached to a click event, make sure to stop the propagation of the
-        // event to the parent container otherwise the modal will not open. This
-        // is so because this event handler will get fired on any click in settings
-        // overlay and subsequently close any open modal.
-        modals.close_active();
-    });
-});
-
 function setup_settings_label() {
     settings_label = {
         // settings_notification
@@ -193,4 +174,21 @@ export function initialize() {
         can_create_new_bots: settings_bots.can_create_new_bots(),
     });
     $("#settings_overlay_container").append(rendered_settings_overlay);
+
+    $("#settings_overlay_container").on("click", (e) => {
+        if (!modals.any_active()) {
+            return;
+        }
+        if ($(e.target).closest(".micromodal").length > 0) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        // Whenever opening a modal(over settings overlay) in an event handler
+        // attached to a click event, make sure to stop the propagation of the
+        // event to the parent container otherwise the modal will not open. This
+        // is so because this event handler will get fired on any click in settings
+        // overlay and subsequently close any open modal.
+        modals.close_active();
+    });
 }


### PR DESCRIPTION
Some of these may have once been necessary to enforce an ordering on cyclic imports, but we’ve fixed all of those now.