### PR TITLE
Fix `handle_customer_migration_from_server_to_realms` when the RemoteRealm has a Customer object

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -56,7 +56,10 @@ class RemoteRealmBillingTestCase(BouncerTestCase):
         # This only matters if first_time_login is True, since otherwise
         # there's no confirmation link to be clicked:
         return_without_clicking_confirmation_link: bool = False,
-        server_on_active_plan_error: bool = False,
+        # This is in order to return the response early, right after accessing the
+        # authentication url for the user. This is useful for tests who expect an
+        # an error there.
+        return_from_auth_url: bool = False,
     ) -> "TestHttpResponse":
         now = timezone_now()
 
@@ -74,8 +77,7 @@ class RemoteRealmBillingTestCase(BouncerTestCase):
         with time_machine.travel(now, tick=False):
             result = self.client_get(signed_auth_url, subdomain="selfhosting")
 
-        if server_on_active_plan_error:
-            self.assert_in_response("Plan management not available", result)
+        if return_from_auth_url:
             return result
 
         if first_time_login:
@@ -702,9 +704,10 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=True
+            desdemona, return_from_auth_url=True
         )
         self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Plan management not available", result)
 
         # RemoteRealm objects should be created for all realms on the server.
         self.assert_length(RemoteRealm.objects.all(), 4)
@@ -720,7 +723,7 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management. Performs customer migration from server to realms.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=False
+            desdemona, return_from_auth_url=False
         )
         self.assertEqual(result.status_code, 302)
 
@@ -800,9 +803,10 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=True
+            desdemona, return_from_auth_url=True
         )
         self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Plan management not available", result)
 
         # Server plan status stayed the same.
         self.server.refresh_from_db()
@@ -826,7 +830,7 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management. Performs customer migration from server to realms.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=False
+            desdemona, return_from_auth_url=False
         )
         self.assertEqual(result.status_code, 302)
 
@@ -912,9 +916,10 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=True
+            desdemona, return_from_auth_url=True
         )
         self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Plan management not available", result)
 
         # Server plan status stayed the same.
         self.server.refresh_from_db()
@@ -938,7 +943,7 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management. Performs customer migration from server to realms.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=False
+            desdemona, return_from_auth_url=False
         )
         self.assertEqual(result.status_code, 302)
 
@@ -1019,9 +1024,10 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=True
+            desdemona, return_from_auth_url=True
         )
         self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Plan management not available", result)
 
         # Server stays on the same plan.
         server_plan = get_current_plan_by_customer(server_customer)
@@ -1038,9 +1044,10 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
 
         # Login to plan management.
         result = self.execute_remote_billing_authentication_flow(
-            desdemona, server_on_active_plan_error=True
+            desdemona, return_from_auth_url=True
         )
         self.assertEqual(result.status_code, 200)
+        self.assert_in_response("Plan management not available", result)
 
         # Server stays on the same plan.
         server_customer.refresh_from_db()

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -27,10 +27,12 @@ from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.lib.exceptions import RemoteRealmServerMismatchError
 from zerver.lib.rate_limiter import RateLimitedIPAddr
 from zerver.lib.remote_server import send_server_data_to_push_bouncer
+from zerver.lib.send_email import FromAddress
 from zerver.lib.test_classes import BouncerTestCase
 from zerver.lib.test_helpers import ratelimit_rule
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import Realm, UserProfile
+from zerver.models.realms import get_realm
 from zilencer.models import (
     PreregistrationRemoteRealmBillingUser,
     PreregistrationRemoteServerBillingUser,
@@ -875,6 +877,117 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
         self.assertEqual(
             RemoteRealmBillingSession(remote_realm_with_plan).get_next_plan(plan), server_next_plan
         )
+
+    @responses.activate
+    def test_transfer_plan_from_server_to_realm_when_realm_has_customer(
+        self,
+    ) -> None:
+        self.login("desdemona")
+        desdemona = self.example_user("desdemona")
+        zulip_realm = get_realm("zulip")
+
+        server_billing_session = RemoteServerBillingSession(self.server)
+        server_customer = server_billing_session.update_or_create_customer(stripe_customer_id=None)
+        server_plan = CustomerPlan.objects.create(
+            customer=server_customer,
+            billing_cycle_anchor=timezone_now(),
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
+            tier=CustomerPlan.TIER_SELF_HOSTED_COMMUNITY,
+            status=CustomerPlan.ACTIVE,
+        )
+        self.server.plan_type = RemoteZulipServer.PLAN_TYPE_COMMUNITY
+        self.server.save(update_fields=["plan_type"])
+
+        # Delete any existing remote realms.
+        RemoteRealm.objects.all().delete()
+
+        # We want there to be only a single (non-system bot) realm on the server for our setup.
+        Realm.objects.exclude(string_id__in=["zulip", "zulipinternal"]).update(deactivated=True)
+
+        # Send server data to push bouncer.
+        self.add_mock_response()
+        send_server_data_to_push_bouncer(consider_usage_statistics=False)
+
+        # Let's create a plan for the realm. This will conflict with the server plan.
+        remote_realm = RemoteRealm.objects.get(uuid=zulip_realm.uuid)
+        realm_billing_session = RemoteRealmBillingSession(remote_realm)
+        realm_customer = realm_billing_session.update_or_create_customer(stripe_customer_id=None)
+        realm_plan = CustomerPlan.objects.create(
+            customer=realm_customer,
+            billing_cycle_anchor=timezone_now(),
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
+            tier=CustomerPlan.TIER_SELF_HOSTED_LEGACY,
+            status=CustomerPlan.ACTIVE,
+        )
+        remote_realm.plan_type = RemoteRealm.PLAN_TYPE_SELF_MANAGED_LEGACY
+        remote_realm.save(update_fields=["plan_type"])
+
+        with self.assertLogs("zilencer.views", "WARN") as mock_warn:
+            result = self.execute_remote_billing_authentication_flow(
+                desdemona, return_from_auth_url=True
+            )
+        self.assertEqual(
+            mock_warn.output,
+            [
+                f"WARNING:zilencer.views:Failed to migrate customer from server (id: {remote_realm.server.id}) to realm (id: {remote_realm.id}): "
+                "RemoteRealm customer already exists and plans can't be migrated automatically."
+            ],
+        )
+        self.assert_json_error(
+            result,
+            f"Couldn't reconcile billing data between server and realm. Please contact {FromAddress.SUPPORT}",
+        )
+
+        # If the realm's plan is ENDED, it's safe to move the server plan over.
+        realm_plan.status = CustomerPlan.ENDED
+        realm_plan.save(update_fields=["status"])
+        # However, not if the server's status indicates that there's some kind
+        # of plan change queued up after the plan, since that state would be
+        # harder and more risky to try to migrate.
+        server_plan.status = CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
+        server_plan.save(update_fields=["status"])
+
+        with self.assertLogs("zilencer.views", "WARN") as mock_warn:
+            result = self.execute_remote_billing_authentication_flow(
+                desdemona, return_from_auth_url=True
+            )
+        self.assertEqual(
+            mock_warn.output,
+            [
+                f"WARNING:zilencer.views:Failed to migrate customer from server (id: {remote_realm.server.id}) to realm (id: {remote_realm.id}): "
+                "RemoteRealm customer already exists and plans can't be migrated automatically."
+            ],
+        )
+        self.assert_json_error(
+            result,
+            f"Couldn't reconcile billing data between server and realm. Please contact {FromAddress.SUPPORT}",
+        )
+
+        # Finally, we simulate a regular, ACTIVE plan for the server again. Combined with
+        # the ENDED plan for the realm, we now have a simple case, where the migration
+        # should proceed.
+        server_plan.status = CustomerPlan.ACTIVE
+        server_plan.save(update_fields=["status"])
+
+        result = self.execute_remote_billing_authentication_flow(
+            desdemona, return_from_auth_url=False
+        )
+        self.assertEqual(result.status_code, 302)
+
+        # Server plan status was reset
+        self.server.refresh_from_db()
+        self.assertEqual(self.server.plan_type, RemoteZulipServer.PLAN_TYPE_SELF_MANAGED)
+
+        # The Customer objects remain as they were.
+        self.assertEqual(get_customer_by_remote_realm(remote_realm), realm_customer)
+        self.assertEqual(get_customer_by_remote_server(self.server), server_customer)
+
+        # The plan that used to be for the server, has been migrated to the realm customer:
+        self.assertEqual(get_current_plan_by_customer(server_customer), None)
+        self.assertEqual(get_current_plan_by_customer(realm_customer), server_plan)
+
+        remote_realm.refresh_from_db()
+        self.assertEqual(remote_realm.plan_type, RemoteRealm.PLAN_TYPE_COMMUNITY)
 
     @responses.activate
     def test_transfer_business_plan_from_server_to_realm(

--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -201,6 +201,10 @@ def remote_realm_billing_finalize_login(
 
     try:
         handle_customer_migration_from_server_to_realms(server=remote_server)
+    except JsonableError:
+        # JsonableError should be propagated up, as they are meant to convey
+        # a json error response to be returned.
+        raise
     except Exception:  # nocoverage
         billing_logger.exception(
             "%s: Failed to migrate customer from server (id: %s) to realms",


### PR DESCRIPTION
Here's the most likely scenario to cause a state that this aims to fix:
1. A server was on the legacy plan
2. Admin opened realm-level "Plan management", causing the legacy plan to get migrated to the realm.
3. Legacy plan expired, the admin fills out a sponsorship form from the server-level view and gets approved for Community plan.
4. Now opening realm-level plan management will attempt to migrate the Community plan to the realm, triggering `IntegrityError`. This PR fixes that scenario.


Detailed overview copied from the commit message:

The logic in the case where there's only one realm and the function
tries to migrate the server's plan to it, had two main unhandled edge
cases that would throw exceptions:
1.
```
        remote_realm = RemoteRealm.objects.get(
            uuid=realm_uuids[0], plan_type=RemoteRealm.PLAN_TYPE_SELF_MANAGED
        )
```

This could throw an exception if the RemoteRealm exists, but has an
active e.g. Legacy plan. Then there'd be no object matching the
plan_type in the query, raising RemoteRealm.DoesNotExist.

5. If the RemoteRealm had e.g. a Legacy plan in the past, that's now
   expired, then it'd have a Customer object. Meaning that the attempt
   to move the server's customer to the realm:
   `server_plan.customer = remote_realm_customer`
   would trigger an IntegrityError since a RemoteRealm can't have two
   Customer objects.

In simple cases the situation in (2) can still be easily migrated, by
moving the plan from the server's customer to the realm's customer.

