### PR TITLE
bootstrap: Remove q styles.

### DIFF
--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -124,10 +124,6 @@ hr {
   border-top: 1px solid #eeeeee;
   border-bottom: 1px solid #ffffff;
 }
-q:before,
-q:after {
-  content: "";
-}
 pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;


### PR DESCRIPTION
There is no greppable evidence of the `<q>` (quote) element in use in the Zulip UI, nor that any of the Python-Markdown syntax generates them either.
