### PR TITLE
docs: Update links to new "Reverse proxies" page.

### DIFF
--- a/puppet/zulip/templates/nginx/trusted-proto.template.erb
+++ b/puppet/zulip/templates/nginx/trusted-proto.template.erb
@@ -5,7 +5,7 @@ map $remote_addr $trusted_x_forwarded_proto {
 }
 map $http_x_forwarded_for $x_proxy_misconfiguration {
     default "";
-    "~." "No proxies configured in Zulip, but proxy headers detected from proxy at $remote_addr; see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+    "~." "No proxies configured in Zulip, but proxy headers detected from proxy at $remote_addr; see https://zulip.readthedocs.io/en/latest/production/reverse-proxies.html";
 }
 <% else %>
 # Check if the request's original `REMOTE_ADDR` header was from a
@@ -37,8 +37,8 @@ map $is_x_forwarded_proto_trusted $trusted_x_forwarded_proto {
 }
 
 map "$is_from_proxy:$is_x_forwarded_proto_trusted:$http_x_forwarded_proto" $x_proxy_misconfiguration {
-    "~^0:0:" "Incorrect reverse proxy IPs set in Zulip (try $remote_addr?); see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
-    "~^0:1:$" "No X-Forwarded-Proto header sent from trusted proxy $realip_remote_addr; see example configurations in https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+    "~^0:0:" "Incorrect reverse proxy IPs set in Zulip (try $remote_addr?); see https://zulip.readthedocs.io/en/latest/production/reverse-proxies.html";
+    "~^0:1:$" "No X-Forwarded-Proto header sent from trusted proxy $realip_remote_addr; see example configurations in https://zulip.readthedocs.io/en/latest/production/reverse-proxies.html";
     default "";
 }
 <% end %>

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -1085,7 +1085,7 @@
             <tr class="self-hosted-feature-only">
                 <td class="comparison-table-feature">
                     <a
-                      href="https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy">
+                      href="https://zulip.readthedocs.io/en/latest/production/reverse-proxies.html">
                         Custom TLS server termination</a>
                 </td>
                 <td class="comparison-value-null cloud-cell"></td>


### PR DESCRIPTION
Following up on #28969, this PR updates outdated links to new [Reverse proxies](https://zulip.readthedocs.io/en/latest/production/reverse-proxies.html) documentation page.