### PR TITLE
topic: Fix history order for topic moves.

### DIFF
--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -195,15 +195,15 @@ def update_messages_for_topic_edit(
         "edit_history": Cast(
             Func(
                 Cast(
+                    Value(orjson.dumps([edit_history_event]).decode()),
+                    JSONField(),
+                ),
+                Cast(
                     Func(
                         F("edit_history"),
                         Value("[]"),
                         function="COALESCE",
                     ),
-                    JSONField(),
-                ),
-                Cast(
-                    Value(orjson.dumps([edit_history_event]).decode()),
                     JSONField(),
                 ),
                 function="",

--- a/zerver/migrations/0497_resort_edit_history.py
+++ b/zerver/migrations/0497_resort_edit_history.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("zerver", "0496_alter_scheduledmessage_read_by_sender"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            # Update with properly-sorted history for messages changed
+            # after 5c96f942060e was merged.
+            """
+            WITH sorted_history AS (
+                SELECT zerver_message.id AS rowid,
+                       JSONB_AGG(value ORDER BY (value->>'timestamp')::NUMERIC desc) AS updated_history
+                FROM zerver_message
+                    CROSS JOIN JSONB_ARRAY_ELEMENTS(zerver_message.edit_history::jsonb)
+                WHERE zerver_message.edit_history IS NOT NULL
+                  AND zerver_message.last_edit_time > '2024-02-14'
+                  AND JSONB_ARRAY_LENGTH(zerver_message.edit_history::jsonb) > 1
+                GROUP BY zerver_message.id
+                ORDER BY zerver_message.id
+            )
+            UPDATE zerver_message
+                SET edit_history = sorted_history.updated_history::text
+            FROM sorted_history
+            WHERE zerver_message.id = sorted_history.rowid
+              AND zerver_message.edit_history::jsonb != sorted_history.updated_history
+            """,
+            reverse_sql="",
+            elidable=True,
+        )
+    ]


### PR DESCRIPTION
5c96f942060e mistakenly appended, rather than prepended, the edit to the history.  This caused AssertionErrors when attempting to view the history of moved messages, which check that the `last_edit_time` matches the timestamp of the first edit in the list.

Fix the ordering, and update the `edit_history` for messages that were affected.  We limit to only messages edited since the commit was merged, since that helps bound the affected messages somewhat.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
