### PR TITLE
portico: Tweak "contact sales" line on Cloud plans page.

### DIFF
--- a/templates/corporate/plans.html
+++ b/templates/corporate/plans.html
@@ -109,8 +109,8 @@
                     </li>
                 </ul>
                 <p>
-                    If you have any other questions, please don’t hesitate to
-                    contact
+                    To discuss <b>enterprise pricing and services</b>, or for
+                    any other questions, contact
                     <a href="mailto:sales@zulip.com">sales@zulip.com</a>.
                 </p>
             </div>


### PR DESCRIPTION
Current: https://zulip.com/plans/#cloud
<details>
<summary>
Updated
</summary>

<img width="558" alt="Screenshot 2024-02-22 at 5 00 33 AM" src="https://github.com/zulip/zulip/assets/2090066/2a9d5b2e-fb43-437b-9a61-e54bdb12d984">

</details>