### PR TITLE
icons: Add container for copy-code and code-playgrounds icons.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -716,21 +716,25 @@
         /* Having absolute positioning here ensures that the element
         doesn't scroll along with the code div in narrow windows */
         position: absolute;
-        right: 20px;
-        margin-top: -4px;
-
+        right: 2px;
         /* Remove the outline when clicking on the copy-to-clipboard button */
         &:focus {
             outline: none;
         }
     }
 
+    .code-buttons-container {
+        position: absolute;
+        right: 20px;
+        margin-top: -25px;
+    }
+
     .code_external_link {
         visibility: hidden;
         position: absolute;
-        right: 23px;
-        margin-top: -3px;
+        right: 26px;
         font-size: 17px;
+        margin-top: -16px;
         /* The default icon and on-hover colors are inherited from <a> tag.
         so we set our own to match the copy-to-clipbord icon */
         color: hsl(0deg 0% 47%);

--- a/web/templates/code_buttons_container.hbs
+++ b/web/templates/code_buttons_container.hbs
@@ -1,0 +1,7 @@
+<div class="code-buttons-container">
+    {{> copy_code_button}}
+
+    {{#if showViewInPlaygroundButton}}
+    {{> view_code_in_playground}}
+    {{/if}}
+</div>


### PR DESCRIPTION
Fixes: #29165 

<!-- Describe your pull request here.-->
As discussed on [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22view.20in.20repl.22.20and.20.22copy.20code.22.20icons.20of.20code.20block), we should add a container with an appropriate placement which contains the `view_in_playground_button` and `copy_button`. 
This prevents both buttons from overlapping each other whenever their placement is altered.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Spoiler Code-block -> 
<img width="634" alt="Screenshot 2024-02-22 at 8 39 44 PM" src="https://github.com/zulip/zulip/assets/97145463/b0434706-fd74-4036-8ee6-c810707681ee">

Code-Block->
<img width="664" alt="Screenshot 2024-02-22 at 8 40 01 PM" src="https://github.com/zulip/zulip/assets/97145463/c3b0c5f9-96be-4233-934a-020499ddc935">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
