### PR TITLE
Analytics: Improve do_increment_logging_stat performance.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1329,7 +1329,7 @@ class TestDoIncrementLoggingStat(AnalyticsTestCase):
 
     def test_do_increment_logging_start_query_count(self) -> None:
         stat = LoggingCountStat("test", RealmCount, CountStat.DAY)
-        with self.assert_database_query_count(2):
+        with self.assert_database_query_count(1):
             do_increment_logging_stat(self.default_realm, stat, None, self.TIME_ZERO)
 
 

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1327,6 +1327,11 @@ class TestDoIncrementLoggingStat(AnalyticsTestCase):
         do_increment_logging_stat(self.default_realm, stat, None, self.TIME_ZERO)
         self.assertTableState(RealmCount, ["value"], [[3]])
 
+    def test_do_increment_logging_start_query_count(self) -> None:
+        stat = LoggingCountStat("test", RealmCount, CountStat.DAY)
+        with self.assert_database_query_count(2):
+            do_increment_logging_stat(self.default_realm, stat, None, self.TIME_ZERO)
+
 
 class TestLoggingCountStats(AnalyticsTestCase):
     def test_aggregation(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -932,7 +932,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        with self.assert_database_query_count(105), self.assert_memcached_count(18):
+        with self.assert_database_query_count(104), self.assert_memcached_count(18):
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -906,7 +906,7 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
-        with self.assert_database_query_count(94):
+        with self.assert_database_query_count(93):
             with self.assert_memcached_count(23):
                 with self.capture_send_event_calls(expected_num_events=11) as events:
                     fred = do_create_user(


### PR DESCRIPTION
In this commit, The performance of do_increment_logging_stat has been improved by using single postgresql upsert query replacing the Django's `get_or_create` method.
fixes: #28947

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
