### PR TITLE
portico: Features table fixes.

### DIFF
--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -363,9 +363,8 @@
             font-size: 13px;
             line-height: 16px;
             box-sizing: border-box;
-            height: 44px;
-            padding-bottom: 4px;
-            padding-top: 4px;
+            padding-top: 10px;
+            padding-bottom: 8px;
         }
 
         .comparison-table td.comparison-table-feature {
@@ -576,7 +575,8 @@
         }
 
         .comparison-table td.stuck {
-            padding-top: 24px;
+            padding-top: 20px;
+            padding-bottom: 6px;
             vertical-align: top;
         }
     }
@@ -591,7 +591,32 @@
         .comparison-table td.subheader.comparison-table-feature {
             /* Line up features with plan titles. */
             line-height: 14px;
+            min-width: auto;
         }
+
+        .comparison-table td.stuck {
+            top: 64px;
+            height: 55px;
+        }
+    }
+}
+
+@media (width <= 500px) {
+    .comparison-table td.subheader.comparison-table-feature {
+        min-width: max-content;
+    }
+}
+
+@media (width <= 356px) {
+    .zulip-plans-comparison
+        .comparison-table
+        td.subheader.comparison-table-feature {
+        height: 51px;
+        top: 60px;
+    }
+
+    .zulip-plans-comparison .comparison-table th {
+        height: 51px;
     }
 }
 

--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -599,6 +599,23 @@
             height: 55px;
         }
     }
+
+    @media (width <= 405px) {
+        /* For very tiny views, we get rid of the luxury
+           of any horizontal padding that's left. */
+        .comparison-table-feature,
+        .cloud-cell,
+        .self-hosted-cell {
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        /* Keep the comparison-table features from
+           colliding with the left screen edge, though. */
+        .comparison-table-feature {
+            padding-left: 2px;
+        }
+    }
 }
 
 @media (width <= 500px) {


### PR DESCRIPTION
This PR corrects a whole bunch of different edge cases, largely at smaller screen sizes, where sticky headers spilled over the top of the header row or fell out of nice alignment with the plans labels.

It also provides a fix for overscrolling on the features table's All view, which can be viewed in viewports as narrow as 374px (previously, it needed a viewport of at least 406px to not begin to scroll).

**Screenshots and screen captures:**

_Firefox does not capture blur effects, so disregard the lack of blur behind the menus here._

| Cloud view, before | Cloud view, after |
| --- | --- |
| ![cloud-view-before](https://github.com/zulip/zulip/assets/170719/f2fb4ccf-de76-49dc-aad1-fea336e2fc35) | ![cloud-view-after](https://github.com/zulip/zulip/assets/170719/4390580c-1f10-4b77-a0f1-3756ceb1a8e0) |

| All view sticky header, before | All view, after |
| --- | --- |
| ![all-view-before](https://github.com/zulip/zulip/assets/170719/6ea2273c-1708-4113-9641-b9030cf16a4d) | ![all-view-after-corrected](https://github.com/zulip/zulip/assets/170719/694068e1-be73-4dff-a2c1-bb22b244e88f) |

| iPhone Overscroll, before | iPhone Overscroll, after (none) |
| --- | --- |
| ![iphone-before](https://github.com/zulip/zulip/assets/170719/88d81d8d-7c84-4475-858f-d538d7d54f6f) | ![iphone-after](https://github.com/zulip/zulip/assets/170719/438f9150-4284-44c6-927d-db844b482c0e) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
