### PR TITLE
editorconfig: Use `[[shell]]` section for shfmt options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-binary_next_line = true  # for shfmt
-switch_case_indent = true  # for shfmt
+[[shell]]
+binary_next_line = true
+switch_case_indent = true
 
 [{*.{js,json,ts},check-openapi}]
 max_line_length = 100


### PR DESCRIPTION
This was added in https://github.com/mvdan/sh/commit/7f96e7d84a265f4d1005b96493422cde800bf9d1.