### PR TITLE
playgrounds: Replace replit playground example with Rust playground.

### DIFF
--- a/help/code-blocks.md
+++ b/help/code-blocks.md
@@ -110,8 +110,8 @@ blocks without any syntax highlighting (E.g. to paste an error message).
 
 ## Code playgrounds
 
-Code playgrounds are interactive in-browser development environments, such as
-[replit](https://replit.com), that are designed to make it convenient to edit
+Code playgrounds are interactive in-browser development environments
+that are designed to make it convenient to edit
 and debug code. Code playgrounds can be configured for any programming language.
 Zulip code blocks that are tagged with the language will have a button visible
 on hover that allows you to open the code block in the code playground site.
@@ -124,22 +124,19 @@ on hover that allows you to open the code block in the code playground site.
 
 {settings_tab|playground-settings}
 
-1. Under **Add a new code playground**, enter a **Name**, **Language** and **URL
-prefix**.
+1. Under **Add a new code playground**, enter a **Language**, **Name**, and
+**URL template**.
 
 1. Click **Add code playground**.
 
 {end_tabs}
 
-For example, to configure code playgrounds for languages like Python or
-JavaScript, you could specify the language and URL templates as:
+For example, to configure code a playground for Rust, you could specify the
+language and URL template as `Rust` and `https://play.rust-lang.org/?code={code}`.
 
-* `Python` and `https://replit.com/languages/python3/code={code}`
-* `JavaScript` and `https://replit.com/languages/javascript/code={code}`
-
-When a code block is labeled as Python or JavaScript (either explicitly or by
-organization default), users would get a on-hover option to open the code block
-in the specified code playground.
+When a code block is labeled as `rust` (either explicitly or by organization
+default), users would get an on-hover option to open the code block in the
+specified code playground.
 
 !!! tip ""
 

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -3,27 +3,26 @@
         <p>
             {{#tr}}
                 Code playgrounds are interactive in-browser development environments,
-                such as <z-link-repl>replit</z-link-repl>, that are designed to make
+                that are designed to make
                 it convenient to edit and debug code. Zulip <z-link-code-blocks>code blocks</z-link-code-blocks>
                 that are tagged with a programming language will have a button visible on
                 hover that allows users to open the code block on the code playground site.
-                {{#*inline "z-link-repl"}}<a href="https://replit.com/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                 {{#*inline "z-link-code-blocks"}}<a href="/help/code-blocks" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
         <p>
-            {{t "For example, to configure a code playground for code blocks tagged as Python,
+            {{t "For example, to configure a code playground for code blocks tagged as Rust,
               you can set:" }}
         </p>
         <ul>
             <li>
-                {{t "Language" }}: <span class="rendered_markdown"><code>Python</code></span>
+                {{t "Language" }}: <span class="rendered_markdown"><code>Rust</code></span>
             </li>
             <li>
-                {{t "Name" }}: <span class="rendered_markdown"><code>Python3 playground</code></span>
+                {{t "Name" }}: <span class="rendered_markdown"><code>Rust playground</code></span>
             </li>
             <li>
-                {{t "URL template" }}: <span class="rendered_markdown"><code>https://replit.com/languages/python3/?code={code}</code></span>
+                {{t "URL template" }}: <span class="rendered_markdown"><code>https://play.rust-lang.org/?code={code}</code></span>
             </li>
         </ul>
         <p>
@@ -45,15 +44,15 @@
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="input-group">
                         <label for="playground_pygments_language"> {{t "Language" }}</label>
-                        <input type="text" id="playground_pygments_language" class="settings_text_input" name="pygments_language" autocomplete="off" placeholder="Python" />
+                        <input type="text" id="playground_pygments_language" class="settings_text_input" name="pygments_language" autocomplete="off" placeholder="Rust" />
                     </div>
                     <div class="input-group">
                         <label for="playground_name"> {{t "Name" }}</label>
-                        <input type="text" id="playground_name" class="settings_text_input" name="playground_name" autocomplete="off" placeholder="Python3 playground" />
+                        <input type="text" id="playground_name" class="settings_text_input" name="playground_name" autocomplete="off" placeholder="Rust playground" />
                     </div>
                     <div class="input-group">
                         <label for="playground_url_template"> {{t "URL template" }}</label>
-                        <input type="text" id="playground_url_template" class="settings_text_input" name="url_template" placeholder="https://replit.com/languages/python3/?code={code}" />
+                        <input type="text" id="playground_url_template" class="settings_text_input" name="url_template" placeholder="https://play.rust-lang.org/?code={code}" />
                     </div>
                     <button type="submit" id="submit_playground_button" class="button rounded sea-green">
                         {{t 'Add code playground' }}


### PR DESCRIPTION
`git grep replit | grep -v locale/` produces no results after these changes.


---

Settings panel:

<img width="770" alt="Screenshot 2024-02-22 at 11 12 42 PM" src="https://github.com/zulip/zulip/assets/2090066/07270ec4-cfc0-402f-ba35-ea41a3f01c42">


---

Current help center section: https://zulip.com/help/code-blocks#code-playgrounds

Updated:

I also edited the second step to match the current settings UI.

<img width="753" alt="Screenshot 2024-02-22 at 11 38 01 PM" src="https://github.com/zulip/zulip/assets/2090066/1fe33aa8-3e4d-4a42-aa94-a98734e95526">
