### PR TITLE
Fix sorting of invitations by the "Expires at" column

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -127,7 +127,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
             ...ListWidget.generic_sort_functions("alphabetic", ["ref"]),
             ...ListWidget.generic_sort_functions("numeric", [
                 "invited",
-                "expires_at",
+                "expiry_date",
                 "invited_as",
             ]),
         },

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th data-sort="alphabetic" data-sort-prop="ref">{{t "Invited by" }}</th>
                 {{/if}}
                 <th data-sort="numeric" data-sort-prop="invited">{{t "Invited at" }}</th>
-                <th data-sort="numeric" data-sort-prop="expires_at">{{t "Expires at" }}</th>
+                <th data-sort="numeric" data-sort-prop="expiry_date">{{t "Expires at" }}</th>
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>


### PR DESCRIPTION
Sorting of invitations by the "Expires at" column was broken. This PR corrects the sorting logic to ensure invitations are sorted correctly based on their expiry dates.

Fixes: #29005.

----

### Fixed Expires at column:
![photo-1](https://github.com/zulip/zulip/assets/73663475/dc1c0996-7d0a-49e9-a509-0c2206085fa8)
![photo-2](https://github.com/zulip/zulip/assets/73663475/d62fe03c-1fbe-4e84-b78a-ac48ff947537)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
