### PR TITLE
Show mention indicator

### DIFF
--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -174,6 +174,9 @@ function format_dm(user_ids_string, unread_count, latest_msg_id) {
         is_hidden: filter_should_hide_row({dm_key: user_ids_string}),
         is_collapsed: collapsed_containers.has("inbox-dm-header"),
         latest_msg_id,
+        mention_in_unread_dms: unread.dms_has_mention(
+            unread.get_msg_ids_for_user_ids_string(user_ids_string),
+        ),
     };
 
     return context;
@@ -429,6 +432,7 @@ function reset_data() {
     const unread_dms = unread.get_unread_pm(include_per_bucket_max_msg_id);
     const unread_dms_count = unread_dms.total_count;
     const unread_dms_dict = unread_dms.pm_dict;
+    const mention_in_unread_dms = unread.dms_has_mention(unread.get_msg_ids_for_dms());
 
     const include_per_topic_max_msg_id = true;
     const unread_stream_message = unread.get_unread_topics(include_per_topic_max_msg_id);
@@ -471,6 +475,7 @@ function reset_data() {
     const is_dms_collapsed = collapsed_containers.has("inbox-dm-header");
 
     return {
+        mention_in_unread_dms,
         unread_dms_count,
         is_dms_collapsed,
         has_dms_post_filter,
@@ -1013,6 +1018,8 @@ export function update() {
         $inbox_dm_header.addClass("hidden_by_filters");
     } else {
         $inbox_dm_header.removeClass("hidden_by_filters");
+        const mention_in_unread_dms = unread.dms_has_mention(unread.get_msg_ids_for_dms());
+        $inbox_dm_header.find(".unread_mention_info").text(mention_in_unread_dms ? "@" : "");
         $inbox_dm_header.find(".unread_count").text(unread_dms_count);
     }
 

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -53,6 +53,9 @@ export function get_conversations(): DisplayObject[] {
 
     for (const conversation of private_messages) {
         const user_ids_string = conversation.user_ids_string;
+        const dms_contain_unread_mention = unread.dms_has_mention(
+            unread.get_msg_ids_for_user_ids_string(user_ids_string),
+        );
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         assert(reply_to !== undefined);
         const recipients_string = people.get_recipients(user_ids_string);
@@ -89,6 +92,7 @@ export function get_conversations(): DisplayObject[] {
             user_circle_class,
             is_group,
             is_bot,
+            dms_contain_unread_mention,
         };
         display_objects.push(display_object);
     }

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -532,6 +532,9 @@ function format_conversation(conversation_data) {
     } else if (type === "private") {
         // Direct message info
         context.user_ids_string = last_msg.to_user_ids;
+        context.mention_in_unread_dms = unread.dms_has_mention(
+            unread.get_msg_ids_for_user_ids_string(context.user_ids_string),
+        );
         context.rendered_pm_with = last_msg.display_recipient
             .filter(
                 (recipient) =>

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -964,6 +964,17 @@ export function get_msg_ids_for_topic(stream_id: number, topic_name: string): nu
     return unread_topic_counter.get_msg_ids_for_topic(stream_id, topic_name);
 }
 
+export function dms_has_mention(msg_ids: number | number[]): boolean {
+    const idsToCheck = Array.isArray(msg_ids) ? msg_ids : [msg_ids];
+
+    for (const msg_id of idsToCheck) {
+        if (message_has_mention(msg_id)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function get_msg_ids_for_user_ids_string(user_ids_string: string): number[] {
     return unread_direct_message_counter.get_msg_ids_for_user_ids_string(user_ids_string);
 }
@@ -1016,6 +1027,14 @@ type UnreadHuddleInfo = {
     user_ids_string: string;
     unread_message_ids: number[];
 };
+
+export function get_msg_ids_for_dms(): number[] {
+    return unread_direct_message_counter.get_msg_ids();
+}
+
+export function message_has_mention(message_id: number): boolean {
+    return direct_message_with_mention_count.has(message_id);
+}
 
 type UnreadMessagesParams = {
     unread_msgs: {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -974,6 +974,26 @@ li.top_left_scheduled_messages {
     }
 }
 
+.dm-markers-and-controls {
+    grid-area: markers-and-controls;
+    display: flex;
+    /* Present a uniform space between icons */
+    gap: 5px;
+    align-items: center;
+
+    .unread_mention_info {
+        /* Unset margin in favor of flex gap. */
+        margin: 0;
+    }
+
+    .unread_count {
+        /* Height is set here by the flexbox; this
+           decouples .unread_count from the app-wide
+           definition. */
+        height: 15px;
+    }
+}
+
 .bottom_left_row .sidebar-menu-icon {
     grid-area: ending-anchor-element;
 }

--- a/web/templates/inbox_view/inbox_list.hbs
+++ b/web/templates/inbox_view/inbox_list.hbs
@@ -9,6 +9,9 @@
                         <a tabindex="-1" role="button" href="/#narrow/is/private">{{t 'Direct message'}}</a>
                     </div>
                 </div>
+                <span class="unread_mention_info tippy-zulip-tooltip"
+                  {{#unless mention_in_unread_dms}}hidden{{/unless}}
+                  data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <div class="unread-count-focus-outline" tabindex="0">
                     <span class="unread_count tippy-zulip-tooltip on_hover_all_dms_read"
                       data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -19,6 +19,9 @@
                                 <span class="recipients_name">{{{rendered_dm_with}}}</span>
                             </span>
                         </a>
+                        <span class="unread_mention_info tippy-zulip-tooltip
+                          {{#unless mention_in_unread_dms}}hidden{{/unless}}"
+                          data-tippy-content="{{t 'You have mentions'}}">@</span>
                         <div class="unread-count-focus-outline" tabindex="0">
                             <span class="unread_count tippy-zulip-tooltip on_hover_dm_read"
                               data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -13,8 +13,17 @@
             <span class="conversation-partners-list">{{recipients}}</span>
             {{> status_emoji status_emoji_info}}
         </a>
-        <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
-            {{unread}}
-        </span>
+        <div class="dm-markers-and-controls">
+            {{#if dms_contain_unread_mention}}
+                <span class="unread_mention_info">
+                    @
+                </span>
+            {{else if is_followed}}
+                <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
+            {{/if}}
+            <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
+                {{unread}}
+            </span>
+        </div>
     </div>
 </li>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -39,6 +39,8 @@
             </div>
             <div class="right_part">
                 {{#if is_private}}
+                <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread_dms}}unread_hidden{{/unless}}"
+                  data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable">
                         <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -5,7 +5,10 @@ const {strict: assert} = require("assert");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
-const unread = mock_esm("../src/unread");
+const unread = mock_esm("../src/unread", {
+    get_msg_ids_for_user_ids_string: () => false,
+    dms_has_mention: () => false,
+});
 
 mock_esm("../src/user_status", {
     get_status_emoji: () => ({
@@ -109,6 +112,7 @@ test("get_conversations", ({override}) => {
             status_emoji_info: {
                 emoji_code: "20",
             },
+            dms_contain_unread_mention: false,
         },
         {
             recipients: "Alice, Bob",
@@ -121,6 +125,7 @@ test("get_conversations", ({override}) => {
             is_group: true,
             is_bot: false,
             status_emoji_info: undefined,
+            dms_contain_unread_mention: false,
         },
     ];
 
@@ -160,6 +165,7 @@ test("get_conversations bot", ({override}) => {
             user_circle_class: "user_circle_empty",
             is_group: false,
             is_bot: true,
+            dms_contain_unread_mention: false,
         },
         {
             recipients: "Alice, Bob",
@@ -172,6 +178,7 @@ test("get_conversations bot", ({override}) => {
             status_emoji_info: undefined,
             is_group: true,
             is_bot: false,
+            dms_contain_unread_mention: false,
         },
     ];
 

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -175,6 +175,9 @@ mock_esm("../src/unread", {
     num_unread_for_user_ids_string() {
         return 0;
     },
+    get_msg_ids_for_user_ids_string: () => false,
+    message_has_mention: () => false,
+    dms_has_mention: () => false,
     topic_has_any_unread_mentions: () => false,
 });
 mock_esm("../src/resize", {

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -562,6 +562,15 @@ test("mentions", () => {
         unread: true,
     };
 
+    const private_not_mention_me_message = {
+        id: 20,
+        type: "private",
+        display_recipient: [{id: anybody.user_id}],
+        mentioned: false,
+        mentioned_me_directly: false,
+        unread: true,
+    };
+
     unread.process_loaded_messages([
         already_read_message,
         mention_me_message,
@@ -587,6 +596,35 @@ test("mentions", () => {
         private_mention_me_message.id,
     ]);
     test_notifiable_count(counts.home_unread_messages, 4);
+    assert.equal(unread.message_has_mention(private_mention_me_message.id), true);
+    assert.equal(unread.message_has_mention(muted_direct_mention_message.id), false);
+    assert.equal(unread.message_has_mention(private_not_mention_me_message.id), false);
+    assert.equal(unread.message_has_mention(mention_all_message.id), false);
+    assert.equal(unread.message_has_mention(mention_me_message.id), false);
+
+    assert.equal(unread.dms_has_mention(private_mention_me_message.id), true);
+    assert.equal(unread.dms_has_mention(muted_direct_mention_message.id), false);
+    assert.equal(unread.dms_has_mention(private_not_mention_me_message.id), false);
+    assert.equal(
+        unread.dms_has_mention([mention_all_message.id, muted_direct_mention_message.id]),
+        false,
+    );
+    assert.equal(
+        unread.dms_has_mention([
+            mention_me_message.id,
+            muted_direct_mention_message.id,
+            private_mention_me_message,
+        ]),
+        false,
+    );
+    assert.equal(
+        unread.dms_has_mention([
+            mention_me_message.id,
+            muted_direct_mention_message.id,
+            private_not_mention_me_message,
+        ]),
+        false,
+    );
 
     unread.mark_as_read(mention_me_message.id);
     unread.mark_as_read(mention_all_message.id);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR allows showing the special @ indicator for unread @-mentions in DMs in Recent conversations and Inbox in left sidebar which was only showed before in Mentions in left sidebar.
I have added these functionalities:
1. Takes related unread message ids (from inbox and recent_view  javascript files) in specific context from zulip/web/src/unread.ts.
2. Takes unread messages ids and checked if the dms have mention from zulip/web/src/util.ts which checks presence of mention in each message separately from message_has_mention function from zulip/web/src/unread.ts .
3. Then rendered mention indicator on front-end based on presence of mention in dm.

Fixes: #28849 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
[Showing_mention_indicators.webm](https://github.com/zulip/zulip/assets/113179991/8f5244f1-7c54-4b53-8218-700b93da7081)

Mention indicators in light mode:

![Light-mode-inbox-view](https://github.com/zulip/zulip/assets/113179991/f0eedd4c-690e-4851-855b-ec1cc519331f)

![Light-mode-Recent-conversations](https://github.com/zulip/zulip/assets/113179991/33155cb3-770b-46bc-ae4c-24ec7489cd4e)

Mention indicators in dark mode:

![Dark-mode-Inbox-view](https://github.com/zulip/zulip/assets/113179991/92468693-dec8-4ed7-8b84-fa9e3655cb61)


![Dark-mode-Recent-conversations](https://github.com/zulip/zulip/assets/113179991/d8dd40c5-65c0-41c7-ba40-fe5aab534d65)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.

</details>

