### PR TITLE
remote-support: Add push notification status information.

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -11,9 +11,11 @@ from django.utils.timezone import now as timezone_now
 
 from corporate.lib.stripe import (
     BillingSession,
+    PushNotificationsEnabledStatus,
     RemoteRealmBillingSession,
     RemoteServerBillingSession,
     get_configured_fixed_price_plan_offer,
+    get_push_status_for_remote_request,
     start_of_next_billing_cycle,
 )
 from corporate.models import (
@@ -86,6 +88,7 @@ class PlanData:
 @dataclass
 class MobilePushData:
     total_mobile_users: int
+    push_notification_status: PushNotificationsEnabledStatus
     uncategorized_mobile_users: Optional[int] = None
     mobile_pushes_forwarded: Optional[int] = None
     last_mobile_push_sent: str = ""
@@ -304,8 +307,12 @@ def get_mobile_push_data(remote_entity: Union[RemoteZulipServer, RemoteRealm]) -
             ).strftime("%Y-%m-%d")
         else:
             push_forwarded_interval_start = "None"
+        push_notification_status = get_push_status_for_remote_request(
+            remote_server=remote_entity, remote_realm=None
+        )
         return MobilePushData(
             total_mobile_users=total_users,
+            push_notification_status=push_notification_status,
             uncategorized_mobile_users=uncategorized_users,
             mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
             last_mobile_push_sent=push_forwarded_interval_start,
@@ -334,8 +341,12 @@ def get_mobile_push_data(remote_entity: Union[RemoteZulipServer, RemoteRealm]) -
             ).strftime("%Y-%m-%d")
         else:
             push_forwarded_interval_start = "None"
+        push_notification_status = get_push_status_for_remote_request(
+            remote_entity.server, remote_entity
+        )
         return MobilePushData(
             total_mobile_users=mobile_users,
+            push_notification_status=push_notification_status,
             uncategorized_mobile_users=None,
             mobile_pushes_forwarded=mobile_pushes["total_forwarded"],
             last_mobile_push_sent=push_forwarded_interval_start,

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -243,11 +243,11 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
         def check_legacy_plan_with_upgrade(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(
                 [
-                    "<h4>📅 Current plan information:</h4>",
+                    "📅 Current plan information:",
                     "<b>Plan name</b>: Free (legacy plan)<br />",
                     "<b>Status</b>: New plan scheduled<br />",
                     "<b>End date</b>: 01 February 2050<br />",
-                    "<h4>⏱️ Next plan information:</h4>",
+                    "⏱️ Next plan information:",
                     "<b>Plan name</b>: Zulip Basic<br />",
                     "<b>Status</b>: Never started<br />",
                     "<b>Start date</b>: 01 February 2050<br />",
@@ -262,7 +262,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
         def check_legacy_plan_without_upgrade(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(
                 [
-                    "<h4>📅 Current plan information:</h4>",
+                    "📅 Current plan information:",
                     "<b>Plan name</b>: Free (legacy plan)<br />",
                     "<b>Status</b>: Active<br />",
                     "<b>End date</b>: 01 February 2050<br />",
@@ -271,7 +271,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             )
             self.assert_not_in_success_response(
                 [
-                    "<h4>⏱️ Next plan information:</h4>",
+                    "⏱️ Next plan information:",
                 ],
                 result,
             )

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -174,6 +174,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     "<b>Plan type</b>: Free<br />",
                     "<b>Non-guest user count</b>: 0<br />",
                     "<b>Guest user count</b>: 0<br />",
+                    "📶 Push notification status:",
                 ],
                 html_response,
             )
@@ -190,6 +191,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     "<b>Date created</b>: 01 December 2023",
                     "<b>Org type</b>: Unspecified<br />",
                     "<b>Has remote realms</b>: True<br />",
+                    "📶 Push notification status:",
                 ],
                 html_response,
             )

--- a/templates/corporate/support/current_plan_details.html
+++ b/templates/corporate/support/current_plan_details.html
@@ -1,5 +1,5 @@
 <div class="current-plan-information">
-    <h4>📅 Current plan information:</h4>
+    <p class="support-section-header">📅 Current plan information:</p>
     {% if plan_data.warning %}
     <div class="current-plan-data-missing">
         {{ plan_data.warning }}

--- a/templates/corporate/support/next_plan_details.html
+++ b/templates/corporate/support/next_plan_details.html
@@ -1,5 +1,5 @@
 <div class="next-plan-information">
-    <h4>⏱️ Next plan information:</h4>
+    <p class="support-section-header">⏱️ Next plan information:</p>
     <b>Plan name</b>: {{ plan_data.next_plan.name }}<br />
     <b>Status</b>: {{ plan_data.next_plan.get_plan_status_as_text() }}<br />
     {% if plan_data.next_plan.price_per_license %}

--- a/templates/corporate/support/next_plan_forms_support.html
+++ b/templates/corporate/support/next_plan_forms_support.html
@@ -1,4 +1,4 @@
-<h4>⏱️ Schedule fixed price plan:</h4>
+<p class="support-section-header">⏱️ Schedule fixed price plan:</p>
 <form method="POST" class="remote-form">
     <b>Fixed price</b><br />
     {% if not is_current_plan_billable %}

--- a/templates/corporate/support/push_status_details.html
+++ b/templates/corporate/support/push_status_details.html
@@ -1,0 +1,6 @@
+<div class="push-notification-status">
+    <p class="support-section-header">📶 Push notification status:</p>
+    <b>Can push</b>: {{ status.can_push }}<br />
+    <b>Expected end</b>: {{ format_optional_datetime(status.expected_end_timestamp, True) }}<br />
+    <b>Message</b>: {{ status.message }}<br />
+</div>

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -3,19 +3,19 @@
         <span class="label">remote realm</span>
         <h3>{{ remote_realm.name }}</h3>
         {% if remote_realm.realm_locally_deleted %}
-            <h4>Remote realm is locally deleted 🛑</h4>
+            <p class="support-section-header">Remote realm is locally deleted 🛑</p>
         {% endif %}
         {% if remote_realm.registration_deactivated %}
-            <h4>Remote realm registration deactivated 🛑</h4>
+            <p class="support-section-header">Remote realm registration deactivated 🛑</p>
         {% endif %}
         {% if remote_realm.realm_deactivated %}
-            <h4>Remote realm is deactivated on remote server 🛑</h4>
+            <p class="support-section-header">Remote realm is deactivated on remote server 🛑</p>
         {% endif %}
         {% if remote_realm.plan_type == SPONSORED_PLAN_TYPE %}
-            <h4>On 100% sponsored Zulip Community plan 🎉</h4>
+            <p class="support-section-header">On 100% sponsored Zulip Community plan 🎉</p>
         {% endif %}
         {% if support_data[remote_realm.id].sponsorship_data.default_discount %}
-            <h4>Has a discount 💸</h4>
+            <p class="support-section-header">Has a discount 💸</p>
         {% endif %}
         <b>Remote realm host:</b> {{ remote_realm.host }}<br />
         <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -29,6 +29,12 @@
         <b>Last push notification date</b>: {{ support_data[remote_realm.id].mobile_push_data.last_mobile_push_sent }}<br />
     </div>
 
+    {% with %}
+        {% set status = support_data[remote_realm.id].mobile_push_data.push_notification_status %}
+        {% include 'corporate/support/push_status_details.html' %}
+    {% endwith %}
+
+
     {% if remote_realm.plan_type != SPONSORED_PLAN_TYPE %}
     <div class="remote-support-sponsorship-container">
         {% with %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -68,6 +68,11 @@
                     <b>Last push notification date</b>: {{ remote_servers_support_data[remote_server.id].mobile_push_data.last_mobile_push_sent }}<br />
                 </div>
 
+                {% with %}
+                    {% set status = remote_servers_support_data[remote_server.id].mobile_push_data.push_notification_status %}
+                    {% include 'corporate/support/push_status_details.html' %}
+                {% endwith %}
+
                 {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
                 <div class="remote-support-sponsorship-container">
                     {% with %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -39,10 +39,10 @@
                     <span class="label">remote server</span>
                     <h3>{{ remote_server.hostname }} {{ server_analytics_link(remote_server.id ) }}</h3>
                     {% if remote_server.plan_type == SPONSORED_PLAN_TYPE %}
-                        <h4>On 100% sponsored Zulip Community plan 🎉</h4>
+                        <p class="support-section-header">On 100% sponsored Zulip Community plan 🎉</p>
                     {% endif %}
                     {% if remote_servers_support_data[remote_server.id].sponsorship_data.default_discount %}
-                        <h4>Has a discount 💸</h4>
+                        <p class="support-section-header">Has a discount 💸</p>
                     {% endif %}
                     <b>Contact email</b>: {{ remote_server.contact_email }}
                     <a title="Copy email" class="copy-button" data-copytext="{{ remote_server.contact_email }}">

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -64,7 +64,7 @@
 
 {% if sponsorship_data.sponsorship_pending %}
 <div class="">
-    <h4>Sponsorship request information:</h4>
+    <p class="support-section-header">Sponsorship request information:</p>
     {% if sponsorship_data.latest_sponsorship_request %}
     <ul>
         <li><b>Organization type</b>: {{ sponsorship_data.latest_sponsorship_request.org_type }}</li>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -396,14 +396,26 @@ tr.admin td:first-child {
     padding-bottom: 25px;
 }
 
+.push-notification-status,
+.realm-form-container,
+.next-plan-container,
+.current-plan-container,
+.remote-support-sponsorship-container {
+    border-radius: 4px;
+    padding: 10px;
+    margin: 10px 0;
+}
+
+.push-notification-status {
+    border: 2px solid hsl(186deg 76% 36%);
+    background-color: hsl(188deg 35% 87%);
+}
+
 .realm-form-container,
 .next-plan-container,
 .current-plan-container,
 .remote-support-sponsorship-container {
     border: 2px solid hsl(33deg 99% 60%);
-    border-radius: 4px;
-    padding: 10px;
-    margin: 10px 0;
 }
 
 .realm-form-container,

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -269,7 +269,14 @@ tr.admin td:first-child {
 .realm-support-information,
 .remote-server-information,
 .remote-realm-information {
-    padding-bottom: 15px;
+    margin-bottom: 10px;
+}
+
+.support-section-header {
+    font-size: 1.2em;
+    font-weight: bold;
+    line-height: 20px;
+    margin: 0 0 8px;
 }
 
 .support-realm-icon {


### PR DESCRIPTION
Adds the information returned by `get_push_status_for_remote_request` for remote billing users to the remote support page. 

**Notes**:
- Getting the current push status data will result in some duplicate database queries (getting customer, plan, current billed users, next billing cycle) when generating the remote support view.
- There's a prep commit to add a class for the section headers in the support views. These were all previously using the bootstrap rules for `<h4>` tags. This makes the spacing a bit more compact and consistent.

**Screenshots and screen captures:**

<details>
<summary>Example with realm deactivated notices</summary>

![Screenshot from 2024-02-23 16-50-31](https://github.com/zulip/zulip/assets/63245456/ca0e1300-d2ee-46be-8d13-0dca2eb61da8)
</details>
<details>
<summary>Example of server with realms</summary>

![Screenshot from 2024-02-23 16-53-06](https://github.com/zulip/zulip/assets/63245456/84d88ec3-3173-4a98-b92b-ac2f73412f10)
</details>
<details>
<summary>Example server on community plan</summary>

![Screenshot from 2024-02-23 16-53-15](https://github.com/zulip/zulip/assets/63245456/e4447c2d-5adc-4003-bca6-bf7e2d62b2b1)
</details>
<details>
<summary>Example of server with plan scheduled</summary>

![Screenshot from 2024-02-23 16-53-31](https://github.com/zulip/zulip/assets/63245456/29250faa-6569-4134-a54e-dfaea692ac83)
</details>
<details>
<summary>Example of server with discount and pending sponsorship</summary>

![Screenshot from 2024-02-23 16-53-54](https://github.com/zulip/zulip/assets/63245456/0889f849-7cbb-475c-8470-630bb753ab16)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
