### PR TITLE
remote-support: Add billing user emails and ability to search by those emails

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -661,6 +661,20 @@ def remote_servers_support(
                 "Recent analytics data missing"
             )
 
+    def get_remote_server_billing_user_emails_as_string(remote_server: RemoteZulipServer) -> str:
+        return ", ".join(
+            remote_server.get_remote_server_billing_users()
+            .order_by("email")
+            .values_list("email", flat=True)
+        )
+
+    def get_remote_realm_billing_user_emails_as_string(remote_realm: RemoteRealm) -> str:
+        return ", ".join(
+            remote_realm.get_remote_realm_billing_users()
+            .order_by("email")
+            .values_list("email", flat=True)
+        )
+
     context["remote_servers"] = remote_servers
     context["remote_servers_support_data"] = server_support_data
     context["remote_server_to_max_monthly_messages"] = remote_server_to_max_monthly_messages
@@ -673,6 +687,10 @@ def remote_servers_support(
     context["dollar_amount"] = cents_to_dollar_string
     context["server_analytics_link"] = remote_installation_stats_link
     context["REMOTE_PLAN_TIERS"] = get_remote_plan_tier_options()
+    context["get_remote_server_billing_user_emails"] = (
+        get_remote_server_billing_user_emails_as_string
+    )
+    context["get_remote_realm_billing_user_emails"] = get_remote_realm_billing_user_emails_as_string
     context["SPONSORED_PLAN_TYPE"] = RemoteZulipServer.PLAN_TYPE_COMMUNITY
 
     return render(

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -18,6 +18,14 @@
             <p class="support-section-header">Has a discount 💸</p>
         {% endif %}
         <b>Remote realm host:</b> {{ remote_realm.host }}<br />
+        {% set billing_emails_string = get_remote_realm_billing_user_emails(remote_realm) %}
+        <b>Billing users</b>: {{ billing_emails_string }}
+        {% if billing_emails_string %}
+        <a title="Copy emails" class="copy-button" data-copytext="{{ billing_emails_string }}">
+            <i class="fa fa-copy"></i>
+        </a>
+        {% endif %}
+        <br />
         <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
         <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
         <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -49,6 +49,14 @@
                         <i class="fa fa-copy"></i>
                     </a>
                     <br />
+                    {% set billing_emails_string = get_remote_server_billing_user_emails(remote_server) %}
+                    <b>Billing users</b>: {{ billing_emails_string }}
+                    {% if billing_emails_string %}
+                    <a title="Copy emails" class="copy-button" data-copytext="{{ billing_emails_string }}">
+                        <i class="fa fa-copy"></i>
+                    </a>
+                    {% endif %}
+                    <br />
                     <b>UUID</b>: {{ remote_server.uuid }}<br />
                     <b>Date created</b>: {{ remote_servers_support_data[remote_server.id].date_created.strftime('%d %B %Y') }}<br />
                     <b>Zulip version</b>: {{ remote_server.last_version }}<br />

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -631,6 +631,7 @@ html_rules: List["Rule"] = [
             "templates/corporate/support/realm_details.html",
             "templates/corporate/support/remote_server_support.html",
             "templates/corporate/support/support.html",
+            "templates/corporate/support/remote_realm_details.html",
         },
         "description": "`title` value should be translatable.",
     },

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Max, Q, UniqueConstraint
+from django.db.models import Max, Q, QuerySet, UniqueConstraint
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
@@ -87,6 +87,12 @@ class RemoteZulipServer(models.Model):
 
     def format_requester_for_logs(self) -> str:
         return "zulip-server:" + str(self.uuid)
+
+    def get_remote_server_billing_users(self) -> QuerySet["RemoteServerBillingUser"]:
+        return RemoteServerBillingUser.objects.filter(
+            remote_server=self,
+            is_active=True,
+        )
 
 
 class RemotePushDeviceToken(AbstractPushDeviceToken):
@@ -175,6 +181,12 @@ class RemoteRealm(models.Model):
     @override
     def __str__(self) -> str:
         return f"{self.host} {str(self.uuid)[0:12]}"
+
+    def get_remote_realm_billing_users(self) -> QuerySet["RemoteRealmBillingUser"]:
+        return RemoteRealmBillingUser.objects.filter(
+            remote_realm=self,
+            is_active=True,
+        )
 
 
 class AbstractRemoteRealmBillingUser(models.Model):


### PR DESCRIPTION
**Notes**:
- Adds a list of active billing users for the remote server and remote realms. Uses a variation of how we get the admin and owner emails on the Zulip Cloud support view.
- Adds search results for emails that match either a remote server or remote realm billing user.

**Screenshots and screen captures:**

<details>
<summary>Email with no matches to billing users or remote server contact emails</summary>

![Screenshot from 2024-02-23 20-58-20](https://github.com/zulip/zulip/assets/63245456/c66dd5c3-1520-45d0-b5f3-43bb9337e7db)
</details>
<details>
<summary>Email with remote realm billing user match</summary>

## Top of response - remote server has no billing users and first remote realm has no biling users
![Screenshot from 2024-02-23 20-59-12](https://github.com/zulip/zulip/assets/63245456/1ffebf38-b5ac-4233-99d8-410a041d5e51)

## Scrolled down to remote realm with matching billing user email
![Screenshot from 2024-02-23 20-58-56](https://github.com/zulip/zulip/assets/63245456/06c50a3a-2934-4a04-9c10-7208a41c74c4)
</details>
<details>
<summary>Email with match to both contact and billing user email - one response</summary>

![Screenshot from 2024-02-23 21-06-57](https://github.com/zulip/zulip/assets/63245456/cbc97189-e1ea-48df-82ac-afb9da066746)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
