### PR TITLE
Excise "narrow" from app and help center

### DIFF
--- a/help/all-messages.md
+++ b/help/all-messages.md
@@ -4,8 +4,8 @@
 
 !!! keyboard_tip ""
 
-    Use <kbd>S</kbd> (narrow to stream) or <kbd>Shift</kbd> +
-    <kbd>S</kbd> (narrow to conversation) to zoom in, and <kbd>A</kbd> to
+    Use <kbd>S</kbd> (go to stream) or <kbd>Shift</kbd> +
+    <kbd>S</kbd> (go to conversation) to zoom in, and <kbd>A</kbd> to
     get back to **All messages**.
 
 

--- a/help/configure-multi-language-search.md
+++ b/help/configure-multi-language-search.md
@@ -1,10 +1,11 @@
 # Configure multi-language search
 
 Zulip supports [full-text search](/help/search-for-messages), which can be
-combined arbitrarily with Zulip's full suite of narrowing operators. By default,
-Zulip search only supports English text, using [PostgreSQL's built-in full-text
-search feature](https://www.postgresql.org/docs/current/textsearch.html), with a
-custom set of English stop words to improve the quality of the search results.
+combined arbitrarily with Zulip's full suite of [search
+filters](/help/search-for-messages#search-filters). By default, Zulip search
+only supports English text, using [PostgreSQL's built-in full-text search
+feature](https://www.postgresql.org/docs/current/textsearch.html), with a custom
+set of English stop words to improve the quality of the search results.
 
 Self-hosted Zulip organizations can instead set up an experimental
 [PGroonga](https://pgroonga.github.io/) integration that provides full-text

--- a/help/include/recent-conversations.md
+++ b/help/include/recent-conversations.md
@@ -9,7 +9,7 @@ for catching up on messages sent while you were away.
 {!go-to-recent-conversations.md!}
 
 1. The filters at the top help you quickly find relevant conversations.
-   For example, select **Participated** to narrow to the conversations you
+   For example, select **Participated** to filter to the conversations you
    have sent messages to.
 
 {end_tabs}

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -6,8 +6,9 @@ and use the convenient [**keyboard shortcuts reference**](#keyboard-shortcuts-re
 in the Zulip app to add more to your repertoire as needed.
 
 * [The basics](#the-basics)
+* [Search](#search)
+* [Scrolling](#scrolling)
 * [Navigation](#navigation)
-* [Narrowing](#narrowing)
 * [Composing messages](#composing-messages)
 * [Message actions](#message-actions)
 * [Drafts](#drafts)
@@ -51,13 +52,15 @@ in the Zulip app to add more to your repertoire as needed.
   until you are in the [home view](/help/configure-home-view).
 
 [disable-escape]: /help/configure-home-view#configure-whether-esc-navigates-to-the-home-view
-## Navigation
+## Search
 
 * **Search messages**: <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
 
 * **Filter streams**: <kbd>Q</kbd>
 
 * **Search people**: <kbd>W</kbd>
+
+## Scrolling
 
 * **Last message**: <kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd> —
   Also marks all messages in the current view as read.
@@ -73,32 +76,32 @@ in the Zulip app to add more to your repertoire as needed.
 * **Scroll down**: <kbd>PgDn</kbd>, <kbd>Shift</kbd> + <kbd>J</kbd>, or
   <kbd>Spacebar</kbd>
 
+## Navigation
+
 * **Go back through viewing history**: <kbd data-mac-key="⌘">Alt</kbd> +
   <kbd class="arrow-key">←</kbd>
 
 * **Go forward through viewing history**: <kbd data-mac-key="⌘">Alt</kbd> +
   <kbd class="arrow-key">→</kbd>
 
-## Narrowing
+* **Go to next unread topic**: <kbd>N</kbd>
 
-* **Narrow to next unread topic**: <kbd>N</kbd>
+* **Go to next unread direct message**: <kbd>P</kbd>
 
-* **Narrow to next unread direct message**: <kbd>P</kbd>
+* **Go to topic or DM conversation**: <kbd>S</kbd>
 
-* **Narrow to topic or DM conversation**: <kbd>S</kbd>
+* **Go to stream from topic view**: <kbd>S</kbd>
 
-* **Narrow to stream from topic view**: <kbd>S</kbd>
-
-* **Narrow to all direct messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
+* **Go to all direct messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
 
 * **Zoom to message in conversation context**: <kbd>Z</kbd> — This view does not mark messages as read.
 
-* **Cycle between stream narrows**: <kbd>Shift</kbd> + <kbd>A</kbd>
+* **Cycle between stream views**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
-* **Narrow to All messages**: <kbd>A</kbd> — Shows all unmuted messages.
+* **Go to All messages**: <kbd>A</kbd> — Shows all unmuted messages.
 
-* **Narrow to current compose box recipient**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
+* **Go to the conversation you are composing to**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 
 ## Composing messages
 

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -4,7 +4,7 @@
 
 When composing a message, Zulip lets you view a different
 [conversation](/help/recent-conversations) from the one you are composing to.
-For example, you can start a new topic without changing your narrow, send a
+For example, you can start a new topic without changing your view, send a
 direct message about the topic you're viewing, or look up a related discussion.
 
 In this context, the parts of the message view that are outside of the
@@ -43,8 +43,8 @@ will be sent.
 
 ### Go to conversation
 
-Zulip lets you narrow the message view to the
-[conversation](/help/recent-conversations) you're currently composing to.
+Zulip lets you jump to the [conversation](/help/recent-conversations) you're
+currently composing to.
 
 {start_tabs}
 

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -64,7 +64,7 @@ You can see all your direct messages in one place.
    scroll using your mouse, the arrow keys, <kbd>End</kbd>, or page up/down.
 
 1. You can click on a conversation in the left sidebar or a message recipient
-   bar to narrow to messages from that conversation.
+   bar to view that conversation.
 
 !!! keyboard_tip ""
 
@@ -94,7 +94,7 @@ on.
   scroll using your mouse, the arrow keys, <kbd>End</kbd>, or page up/down.
 
 1. You can click on a topic in the left sidebar or a message recipient bar to
-   narrow to messages from that topic.
+   view that topic.
 
 {end_tabs}
 

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -132,7 +132,7 @@ export function get_local_notify_mix_reason(message: Message): string | undefine
         current_filter.can_apply_locally() &&
         !current_filter.predicate()(message)
     ) {
-        return $t({defaultMessage: "Sent! Your message is outside your current narrow."});
+        return $t({defaultMessage: "Sent! Your message is outside your current view."});
     }
 
     return undefined;
@@ -192,7 +192,7 @@ export function notify_local_mixes(messages: Message[], need_user_to_scroll: boo
         }
 
         const link_text = $t(
-            {defaultMessage: "Narrow to {message_recipient}"},
+            {defaultMessage: "Go to {message_recipient}"},
             {message_recipient: get_message_header(message)},
         );
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -66,7 +66,7 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Navigation' }}</th>
+                        <th colspan="2">{{t 'Search' }}</th>
                     </tr>
                 </thead>
                 <tr>
@@ -81,6 +81,15 @@
                     <td class="definition">{{t 'Search people' }}</td>
                     <td><span class="hotkey"><kbd>W</kbd></span></td>
                 </tr>
+            </table>
+        </div>
+        <div>
+            <table class="hotkeys_table table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th colspan="2">{{t 'Scrolling' }}</th>
+                    </tr>
+                </thead>
                 <tr>
                     <td class="definition">{{t 'Previous message' }}</td>
                     <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></span></td>
@@ -105,6 +114,15 @@
                     <td class="definition">{{t 'First message' }}</td>
                     <td><span class="hotkey"><kbd>Home</kbd></span></td>
                 </tr>
+            </table>
+        </div>
+        <div>
+            <table class="hotkeys_table table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th colspan="2">{{t 'Navigation' }}</th>
+                    </tr>
+                </thead>
                 <tr>
                     <td class="definition">{{t 'Go back through viewing history' }}</td>
                     <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
@@ -112,6 +130,42 @@
                 <tr>
                     <td class="definition">{{t 'Go forward through viewing history' }}</td>
                     <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to topic or DM conversation' }}</td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to stream from topic view' }}</td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to all direct messages' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
+                    <td><span class="hotkey"><kbd>Z</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to next unread topic' }}</td>
+                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to next unread direct message' }}</td>
+                    <td><span class="hotkey"><kbd>P</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Cycle between stream views' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to all unmuted messages' }}</td>
+                    <td><span class="hotkey"><kbd>A</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to the conversation you are composing to' }}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -161,51 +215,6 @@
                 <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
-                </tr>
-            </table>
-        </div>
-        <div>
-            <table class="hotkeys_table table table-striped table-bordered">
-                <thead>
-                    <tr>
-                        <th colspan="2">{{t 'Narrowing' }}</th>
-                    </tr>
-                </thead>
-                <tr>
-                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to stream from topic view' }}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to all direct messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
-                    <td><span class="hotkey"><kbd>Z</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to next unread topic' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to next unread direct message' }}</td>
-                    <td><span class="hotkey"><kbd>P</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Cycle between stream narrows' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to all unmuted messages' }}</td>
-                    <td><span class="hotkey"><kbd>A</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Narrow to current compose box recipient' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Notes:
- I didn't include screenshots of all the help pages; let me know if you need them.
- Did not update api docs or contributor docs.
- The order of sections in the ? menu now matches the help center page.

---

<details>
<summary>
Banner
</summary>

![Screenshot 2024-02-23 at 1 25 53 PM](https://github.com/zulip/zulip/assets/2090066/e49c0a13-2ea7-4100-bfe3-8c2fddfd62f3)
![Screenshot 2024-02-23 at 1 25 36 PM](https://github.com/zulip/zulip/assets/2090066/6c243b65-27f4-476b-a6cd-08ce35a97f4b)

</details>

<details>
<summary>
? menu

</summary>

![Screenshot 2024-02-23 at 1 20 14 PM](https://github.com/zulip/zulip/assets/2090066/bf475191-953f-438c-abd1-abe25d2b2fb4)

![Screenshot 2024-02-23 at 1 20 23 PM](https://github.com/zulip/zulip/assets/2090066/869282d1-30d6-4c01-b7b2-c24357fad587)


</details>

Keyboard shortcuts help page: https://zulip.com/help/search-for-messages#search-filt
<details>
<summary>
Updated keyboard shortcuts help page
</summary>

![Screenshot 2024-02-23 at 1 08 24 PM](https://github.com/zulip/zulip/assets/2090066/01011f12-33fb-4549-b5e7-412ffd8b4cbf)

</details>


