### PR TITLE
Set `realm_locally_deleted=True` when a realm re-appears during realm sync

### DIFF
--- a/zerver/models/realm_audit_logs.py
+++ b/zerver/models/realm_audit_logs.py
@@ -144,6 +144,7 @@ class AbstractRealmAuditLog(models.Model):
     REMOTE_REALM_VALUE_UPDATED = 20001
     REMOTE_PLAN_TRANSFERRED_SERVER_TO_REALM = 20002
     REMOTE_REALM_LOCALLY_DELETED = 20003
+    REMOTE_REALM_LOCALLY_DELETED_RESTORED = 20004
 
     event_type = models.PositiveSmallIntegerField()
 

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -780,12 +780,12 @@ def ensure_devices_set_remote_realm(
 def update_remote_realm_data_for_server(
     server: RemoteZulipServer, server_realms_info: List[RealmDataForAnalytics]
 ) -> None:
-    uuids = [realm.uuid for realm in server_realms_info]
+    reported_uuids = [realm.uuid for realm in server_realms_info]
     all_registered_remote_realms_for_server = list(RemoteRealm.objects.filter(server=server))
     already_registered_remote_realms = [
         remote_realm
         for remote_realm in all_registered_remote_realms_for_server
-        if remote_realm.uuid in uuids
+        if remote_realm.uuid in reported_uuids
     ]
     # RemoteRealm registrations that we have for this server, but aren't
     # present in the data sent to us. We assume this to mean the server
@@ -793,7 +793,7 @@ def update_remote_realm_data_for_server(
     remote_realms_missing_from_server_data = [
         remote_realm
         for remote_realm in all_registered_remote_realms_for_server
-        if remote_realm.uuid not in uuids
+        if remote_realm.uuid not in reported_uuids
     ]
 
     already_registered_uuids = {
@@ -864,7 +864,7 @@ def update_remote_realm_data_for_server(
             )
             modified = True
 
-        if remote_realm.realm_locally_deleted and remote_realm.uuid in uuids:
+        if remote_realm.realm_locally_deleted and remote_realm.uuid in reported_uuids:
             remote_realm.realm_locally_deleted = False
             remote_realm_audit_logs.append(
                 RemoteRealmAuditLog(

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -831,7 +831,7 @@ def update_remote_realm_data_for_server(
     # (for the attributes that make sense to sync like this).
     for remote_realm in already_registered_remote_realms:
         # TODO: We'll also want to check if .realm_locally_deleted is True, and if so,
-        # toggle it off (and potentially restore registration_deactivated=True too),
+        # toggle it off,
         # since the server is now sending us data for this realm again.
 
         modified = False
@@ -909,7 +909,7 @@ def update_remote_realm_data_for_server(
 
     RemoteRealm.objects.bulk_update(
         remote_realms_to_update,
-        ["realm_locally_deleted", "registration_deactivated"],
+        ["realm_locally_deleted"],
     )
     RemoteRealmAuditLog.objects.bulk_create(remote_realm_audit_logs)
 


### PR DESCRIPTION
Fixes the `TODO`.