### PR TITLE
tooltips: Rename LaTeX button to "Math (LaTeX)".

### DIFF
--- a/help/latex.md
+++ b/help/latex.md
@@ -4,7 +4,7 @@
 
 ## Insert LaTeX formatting
 
-Zulip's compose box has a smart **LaTeX** (<i class="zulip-icon
+Zulip's compose box has a smart **Math (LaTeX)** (<i class="zulip-icon
 zulip-icon-math"></i>) button, which inserts contextually appropriate LaTeX
 formatting:
 
@@ -22,12 +22,12 @@ formatting:
 
 1. _(optional)_ Select the text you want to format.
 
-1. Click the **LaTeX** (<i class="zulip-icon zulip-icon-math"></i>) icon at the
+1. Click the **Math (LaTeX)** (<i class="zulip-icon zulip-icon-math"></i>) icon at the
    bottom of the compose box to insert LaTeX formatting.
 
 !!! tip ""
 
-    You can also use the **LaTeX** (<i class="zulip-icon zulip-icon-math"></i>)
+    You can also use the **Math (LaTeX)** (<i class="zulip-icon zulip-icon-math"></i>)
     icon to remove existing LaTeX formatting from the selected text.
 
 {tab|via-markdown}

--- a/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
+++ b/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
@@ -5,7 +5,7 @@
     <a role="button" data-format-type="quote" class="compose_control_button zulip-icon zulip-icon-quote formatting_button" aria-label="{{t 'Quote' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Quote' }}"></a>
     <a role="button" data-format-type="spoiler" class="compose_control_button zulip-icon zulip-icon-spoiler formatting_button" aria-label="{{t 'Spoiler' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Spoiler' }}"></a>
     <a role="button" data-format-type="code" class="compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Code' }}"></a>
-    <a role="button" data-format-type="latex" class="compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'LaTeX' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'LaTeX' }}"></a>
+    <a role="button" data-format-type="latex" class="compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
     <div class="divider">|</div>
 </div>
 <a role="button" class="compose_control_button compose_help_button zulip-icon zulip-icon-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>


### PR DESCRIPTION
Current help page: https://zulip.com/help/latex

<img width="152" alt="Screenshot 2024-02-23 at 10 04 13 PM" src="https://github.com/zulip/zulip/assets/2090066/c1f26952-c5db-48b7-836b-ea7a645612d5">
<img width="766" alt="Screenshot 2024-02-23 at 10 45 50 PM" src="https://github.com/zulip/zulip/assets/2090066/2fc10b0b-5a45-4883-9e18-f7fabfa3642f">
