### PR TITLE
message_edit_history: Fix flicker when message edit history modal is opened.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1150,7 +1150,6 @@ export function process_hotkey(e, hotkey) {
         case "view_edit_history": {
             if (realm.realm_allow_edit_history) {
                 message_edit_history.fetch_and_render_message_history(msg);
-                $("#message-history-cancel").trigger("focus");
                 return true;
             }
             return false;

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1149,7 +1149,7 @@ export function process_hotkey(e, hotkey) {
         }
         case "view_edit_history": {
             if (realm.realm_allow_edit_history) {
-                message_edit_history.show_history(msg);
+                message_edit_history.fetch_and_render_message_history(msg);
                 $("#message-history-cancel").trigger("focus");
                 return true;
             }

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -170,6 +170,7 @@ export function fetch_and_render_message_history(message: Message): void {
                 assert(message.type === "stream");
                 prev_stream_item.new_stream = sub_store.maybe_get_stream_name(message.stream_id);
             }
+            show_history();
             $("#message-history").attr("data-message-id", message.id);
             $("#message-history").html(
                 render_message_edit_history({
@@ -194,24 +195,23 @@ export function fetch_and_render_message_history(message: Message): void {
     });
 }
 
-export function show_history(message: Message): void {
-    const rendered_message_history = render_message_history_modal();
+export function show_history(): void {
+    if (!$("#message-history").length) {
+        const rendered_message_history = render_message_history_modal();
 
-    dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Message edit history"}),
-        html_body: rendered_message_history,
-        html_submit_button: $t_html({defaultMessage: "Close"}),
-        id: "message-edit-history",
-        on_click() {
-            /* do nothing */
-        },
-        close_on_submit: true,
-        focus_submit_on_open: true,
-        single_footer_button: true,
-        post_render() {
-            fetch_and_render_message_history(message);
-        },
-    });
+        dialog_widget.launch({
+            html_heading: $t_html({defaultMessage: "Message edit history"}),
+            html_body: rendered_message_history,
+            html_submit_button: $t_html({defaultMessage: "Close"}),
+            id: "message-edit-history",
+            on_click() {
+                /* do nothing */
+            },
+            close_on_submit: true,
+            focus_submit_on_open: true,
+            single_footer_button: true,
+        });
+    }
 }
 
 export function initialize(): void {
@@ -246,7 +246,7 @@ export function initialize(): void {
         }
 
         if (realm.realm_allow_edit_history) {
-            show_history(message);
+            fetch_and_render_message_history(message);
             $("#message-history-cancel").trigger("focus");
         }
     });

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -247,7 +247,6 @@ export function initialize(): void {
 
         if (realm.realm_allow_edit_history) {
             fetch_and_render_message_history(message);
-            $("#message-history-cancel").trigger("focus");
         }
     });
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #26582 

The flicker occurs because the modal is shown first, then painted with data. To fix this, we reorder the function calls such that fetching happens first, then the modal is opened. 
We move the `show_history()` function (which opens the `dialog_widget` modal into `fetch_and_render_message_history()` function and call it when the required action to open dialog box occurs.

Additionally, we remove unnecessary `focus` event triggers, since they are already handled by passing relevant parameters into `dialog_widget.create()` function.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details><summary>Before</summary>
<img src="https://github.com/zulip/zulip/assets/11803841/5636c24b-cefd-4672-b638-a38e706a9a97">
</details>
<details><summary>After</summary>
<img src="https://github.com/zulip/zulip/assets/11803841/662d7e20-8b33-49bb-8bae-0829a8f119b1">
</details>


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
