### PR TITLE
puppeteer: Disable flaky administrative UI test.

### DIFF
--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -151,8 +151,10 @@ async function test_organization_permissions(page: Page): Promise<void> {
     // See https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1733342
     console.log("Skipping", test_changing_create_streams_and_invite_to_stream_policies);
 
-    await test_set_new_user_threshold_to_three_days(page);
-    await test_set_new_user_threshold_to_N_days(page);
+    // Test temporarily disabled 2024-02-25 due to nondeterminsitic failures.
+    // See https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1743361
+    console.log("Skipping", test_set_new_user_threshold_to_three_days);
+    console.log("Skipping", test_set_new_user_threshold_to_N_days);
 }
 
 async function test_add_emoji(page: Page): Promise<void> {


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1743361

This might be similar to the failure reported in #28864.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
