### PR TITLE
message_list_tooltips: Add "View bot card" tooltips for bots.

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -283,6 +283,14 @@ export function initialize() {
 
     message_list_tooltip(".view_user_card_tooltip", {
         delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const is_bot = $(instance.reference).data("is-bot");
+            if (is_bot) {
+                instance.setContent(parse_html($("#view-bot-card-tooltip-template").html()));
+            } else {
+                instance.setContent(parse_html($("#view-user-card-tooltip-template").html()));
+            }
+        },
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} message-avatar sender_info_hover view_user_card_tooltip no-select" aria-hidden="true" data-tooltip-template-id="view-user-card-tooltip-template">
+<div class="u-{{msg/sender_id}} message-avatar sender_info_hover view_user_card_tooltip no-select" aria-hidden="true" data-is-bot="{{sender_is_bot}}">
     <div class="inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}">
         <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
     </div>

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -4,7 +4,7 @@
 <span class="message_sender">
     {{#if include_sender}}
         <span class="sender_info_hover sender_name" role="button" tabindex="0">
-            <span class="view_user_card_tooltip sender_name_text" data-tooltip-template-id="view-user-card-tooltip-template">
+            <span class="view_user_card_tooltip sender_name_text" data-is-bot="{{sender_is_bot}}">
                 {{> user_full_name name=msg/sender_full_name should_add_guest_user_indicator=should_add_guest_indicator_for_sender}}
             </span>
             {{#unless status_message}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -2,6 +2,10 @@
     {{t 'View user card' }}
     {{tooltip_hotkey_hints "U"}}
 </template>
+<template id="view-bot-card-tooltip-template">
+    {{t 'View bot card' }}
+    {{tooltip_hotkey_hints "U"}}
+</template>
 <template id="compose_draft_tooltip_template">
     {{t 'Drafts' }}
     {{tooltip_hotkey_hints "D"}}


### PR DESCRIPTION
This PR aids in differentiating between a normal user and a bot account, furthur eliminating any confusion between them (a step forward, considering how good LLM bots have become in impersonating a real user).

Fixes #25958.


> [!NOTE]
> This is a completion PR for #27934.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![view_bot_card_before](https://github.com/zulip/zulip/assets/82862779/702053bc-87d1-4c23-94ce-fd2f6ef35efd) | ![view_bot_card_after](https://github.com/zulip/zulip/assets/82862779/b8419391-b105-4a11-a616-08aa88ddbd8e) |

"View user card" remains unchanged for normal users.

![view_user_card](https://github.com/zulip/zulip/assets/82862779/6e427676-be42-47ed-b38f-9069b2047b72)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
