### PR TITLE
push-bouncer: Exclude LoggingCountStats with partial data.

### DIFF
--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -9,6 +9,7 @@ from django.db.models import QuerySet
 from django.utils.translation import gettext as _
 from pydantic import UUID4, BaseModel, ConfigDict, Field, Json, field_validator
 
+from analytics.lib.counts import LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER
 from analytics.models import InstallationCount, RealmCount
 from version import API_FEATURE_LEVEL, ZULIP_VERSION
 from zerver.actions.realm_settings import (
@@ -364,8 +365,10 @@ def send_server_data_to_push_bouncer(consider_usage_statistics: bool = True) -> 
         # uploading such statistics enabled.
         installation_count_query = InstallationCount.objects.filter(
             id__gt=last_acked_installation_count_id
+        ).exclude(property__in=LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER)
+        realm_count_query = RealmCount.objects.filter(id__gt=last_acked_realm_count_id).exclude(
+            property__in=LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER
         )
-        realm_count_query = RealmCount.objects.filter(id__gt=last_acked_realm_count_id)
     else:
         installation_count_query = InstallationCount.objects.none()
         realm_count_query = RealmCount.objects.none()


### PR DESCRIPTION
`LoggingCountStat`s with a daily duration and that are directly stored on the `RealmCount` table (not via aggregation in `process_count_stat`), can be in a state, after the hourly cron job to update analytics counts, where the logged value will be live-updated later, because the end time for the stat is still in the future.

As these logging counts are designed to be used on the self-hosted installation for either debugging or rate limiting, sending these partial/incomplete counts to the bouncer has low value.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
