### PR TITLE
install: Support Ubuntu 24.04

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -145,6 +145,11 @@ jobs:
             os: jammy
             extra-args: ""
 
+          - docker_image: zulip/ci:noble
+            name: Ubuntu 24.04 production install
+            os: noble
+            extra-args: ""
+
           - docker_image: zulip/ci:bullseye
             name: Debian 11 production install with custom db name and user
             os: bullseye

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -54,6 +54,12 @@ jobs:
             os: bookworm
             include_documentation_tests: false
             include_frontend_tests: false
+          # Ubuntu 24.04 ships with Python 3.12.2.
+          - docker_image: zulip/ci:noble
+            name: Ubuntu 24.04 (Python 3.12, backend)
+            os: noble
+            include_documentation_tests: false
+            include_frontend_tests: false
 
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -19,7 +19,7 @@ One can install the Zulip development environment directly on a Linux
 host by following these instructions. Currently supported platforms
 are:
 
-- Ubuntu 20.04, 22.04
+- Ubuntu 20.04, 22.04, 24.04
 - Debian 11, 12
 - CentOS 7 (beta)
 - Fedora 38 (beta)

--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -50,7 +50,7 @@ a proxy to access the internet.)
 - **All**: 2GB available RAM, Active broadband internet connection,
   [GitHub account](#step-0-set-up-git--github).
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
-- **Ubuntu LTS**: 20.04 or 22.04
+- **Ubuntu LTS**: 20.04, 22.04, or 24.04
 - **Debian**: 11 or 12
 - **Fedora**: tested for 36
 - **Windows**: Windows 64-bit (Windows 10 recommended), hardware

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -6,6 +6,7 @@ To run a Zulip server, you will need:
 - A supported OS:
   - Ubuntu 20.04
   - Ubuntu 22.04
+  - Ubuntu 24.04
   - Debian 11
   - Debian 12
 - A supported CPU architecture:
@@ -37,7 +38,7 @@ on issues you'll encounter](install-existing-server.md).
 
 #### Operating system
 
-Ubuntu 20.04, Ubuntu 22.04, Debian 11, and Debian 12
+Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, Debian 11, and Debian 12
 are supported for running Zulip in production. You can also
 run Zulip on other platforms that support Docker using
 [docker-zulip][docker-zulip-homepage].

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -2,6 +2,9 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
+
+-r pip.in
+
 # Django itself
 Django[argon2]==4.2.*
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,7 +1,6 @@
 # After editing this file, you MUST afterward run
 # /tools/update-locked-requirements to update requirements/dev.txt.
 # See requirements/README.md for more detail.
--r pip.in
 -r prod.in
 -r docs.in
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3456,9 +3456,8 @@ zxcvbn==4.4.28 \
     # via -r requirements/common.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.4 \
-    --hash=sha256:217ae5161a0e08c0fb873858806e3478c9775caffce5168b50ec885e358c199d \
-    --hash=sha256:6773934e5f5fc3eaa8c5a44949b5b924fc122daa0a8aa9f80c835b4ca2a543fc
+https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+    --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
     # via
     #   -r requirements/pip.in
     #   pip-tools

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,3 +1,3 @@
-pip<21.0  # Our hack for installing specific commits from Git requires --use-deprecated=legacy-resolver: https://github.com/pypa/pip/issues/5780
+https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git  # Our hack for installing specific commits from Git requires --use-deprecated=legacy-resolver: https://github.com/pypa/pip/issues/5780
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -13,9 +13,8 @@ wheel==0.42.0 \
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.4 \
-    --hash=sha256:217ae5161a0e08c0fb873858806e3478c9775caffce5168b50ec885e358c199d \
-    --hash=sha256:6773934e5f5fc3eaa8c5a44949b5b924fc122daa0a8aa9f80c835b4ca2a543fc
+https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+    --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
     # via -r requirements/pip.in
 setuptools==69.1.1 \
     --hash=sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2283,6 +2283,10 @@ werkzeug==3.0.1 \
     --hash=sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc \
     --hash=sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
     # via openapi-core
+wheel==0.42.0 \
+    --hash=sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d \
+    --hash=sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8
+    # via -r requirements/pip.in
 xmlsec==1.3.13 \
     --hash=sha256:091f23765729df6f3b3a55c8a6a96f9c713fa86e76b86a19cdb756aaa6dc0646 \
     --hash=sha256:1725d70ee2bb2cd8dd66c7a7451be02bb59dc8280103db4f68e731f00135b1e0 \
@@ -2409,7 +2413,12 @@ zxcvbn==4.4.28 \
     # via -r requirements/common.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.4 \
-    --hash=sha256:217ae5161a0e08c0fb873858806e3478c9775caffce5168b50ec885e358c199d \
-    --hash=sha256:6773934e5f5fc3eaa8c5a44949b5b924fc122daa0a8aa9f80c835b4ca2a543fc
-    # via zulip-bots
+https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+    --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
+    # via
+    #   -r requirements/pip.in
+    #   zulip-bots
+setuptools==69.1.1 \
+    --hash=sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56 \
+    --hash=sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8
+    # via -r requirements/pip.in

--- a/scripts/lib/build-pgroonga
+++ b/scripts/lib/build-pgroonga
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-version="3.1.0"
-sha256=fd020a911ec223f5288e99131c91abb437a9a0aa9d5e51b8fdb96d633bd61fb9
+version="3.1.8"
+sha256=5a38743492ba21f708df447b1ca0ac07ceff9715d9604aa2303f6dda795d096e
 
 tmpdir="$(mktemp -d)"
 trap 'rm -r "$tmpdir"' EXIT

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -231,7 +231,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id $os_version_id" in
-    'debian 11' | 'debian 12' | 'ubuntu 20.04' | 'ubuntu 22.04') ;;
+    'debian 11' | 'debian 12' | 'ubuntu 20.04' | 'ubuntu 22.04' | 'ubuntu 24.04') ;;
     *)
         system_requirements_failure <<EOF
 Unsupported OS release: $os_id $os_version_id
@@ -241,6 +241,7 @@ Zulip in production is supported only on:
  - Debian 12
  - Ubuntu 20.04 LTS
  - Ubuntu 22.04 LTS
+ - Ubuntu 24.04 LTS
 EOF
         ;;
 esac

--- a/scripts/setup/apt-repos/zulip/custom.sh
+++ b/scripts/setup/apt-repos/zulip/custom.sh
@@ -28,6 +28,11 @@ if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
             read -r release
         } <<<"$os_info"
 
+        if [ "$distribution" = ubuntu ] && [ "$release" = noble ]; then
+            # PGroonga binaries are not yet provided for Ubuntu 24.04.
+            exit
+        fi
+
         if [ "$distribution" = debian ] && [ "$release" = bookworm ]; then
             # As of Debian 12, the Groonga repository depends on the
             # Apache Arrow repository.

--- a/scripts/setup/apt-repos/zulip/noble.list
+++ b/scripts/setup/apt-repos/zulip/noble.list
@@ -1,0 +1,2 @@
+deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main
+deb-src http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main

--- a/tools/ci/build-docker-images
+++ b/tools/ci/build-docker-images
@@ -3,5 +3,6 @@ set -eux
 cd "$(dirname "${BASH_SOURCE[0]}")"
 docker build . --build-arg=BASE_IMAGE=ubuntu:20.04 --pull --tag=zulip/ci:focal
 docker build . --build-arg=BASE_IMAGE=ubuntu:22.04 --pull --tag=zulip/ci:jammy
+docker build . --build-arg=BASE_IMAGE=ubuntu:24.04 --pull --tag=zulip/ci:noble
 docker build . --build-arg=BASE_IMAGE=debian:11 --pull --tag=zulip/ci:bullseye
 docker build . --build-arg=BASE_IMAGE=debian:12 --pull --tag=zulip/ci:bookworm

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -86,6 +86,8 @@ elif vendor == "ubuntu" and os_version == "21.10":  # impish
     POSTGRESQL_VERSION = "13"
 elif vendor == "ubuntu" and os_version == "22.04":  # jammy
     POSTGRESQL_VERSION = "14"
+elif vendor == "ubuntu" and os_version == "24.04":  # noble
+    POSTGRESQL_VERSION = "16"
 elif vendor == "neon" and os_version == "20.04":  # KDE Neon
     POSTGRESQL_VERSION = "12"
 elif vendor == "fedora" and os_version == "38":
@@ -126,11 +128,8 @@ UBUNTU_COMMON_APT_DEPENDENCIES = [
     "default-jre-headless",  # Required by vnu-jar
     # Puppeteer dependencies from here
     "fonts-freefont-ttf",
-    "gconf-service",
-    "libappindicator1",
     "libatk-bridge2.0-0",
     "libgbm1",
-    "libgconf-2-4",
     "libgtk-3-0",
     "libx11-xcb1",
     "libxcb-dri3-0",
@@ -160,7 +159,7 @@ COMMON_YUM_DEPENDENCIES = [
 
 BUILD_GROONGA_FROM_SOURCE = False
 BUILD_PGROONGA_FROM_SOURCE = False
-if (vendor == "debian" and os_version in []) or (vendor == "ubuntu" and os_version in []):
+if (vendor == "debian" and os_version in []) or (vendor == "ubuntu" and os_version in ["24.04"]):
     # For platforms without a PGroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True
@@ -176,14 +175,6 @@ if (vendor == "debian" and os_version in []) or (vendor == "ubuntu" and os_versi
     ]
 elif "debian" in os_families():
     DEBIAN_DEPENDENCIES = UBUNTU_COMMON_APT_DEPENDENCIES
-    # The below condition is required since libappindicator is
-    # not available for Debian 11. "libgroonga1" is an
-    # additional dependency for postgresql-13-pgdg-pgroonga.
-    #
-    # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037
-    if vendor == "debian":
-        DEBIAN_DEPENDENCIES.remove("libappindicator1")
-        DEBIAN_DEPENDENCIES.append("libgroonga0")
 
     # If we are on an aarch64 processor, ninja will be built from source,
     # so cmake is required

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 242
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (264, 1)
+PROVISION_VERSION = (264, 2)

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -29,6 +29,7 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress, send_future_email
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
 from zerver.lib.tex import change_katex_to_raw_latex
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import get_topic_resolution_and_bare_name
 from zerver.lib.url_encoding import (
     huddle_narrow_url,
@@ -686,7 +687,9 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
     user_tz = user.timezone
     if user_tz == "":
         user_tz = "UTC"
-    signup_day = user.date_joined.astimezone(zoneinfo.ZoneInfo(user_tz)).isoweekday()
+    signup_day = user.date_joined.astimezone(
+        zoneinfo.ZoneInfo(canonicalize_timezone(user_tz))
+    ).isoweekday()
 
     # General rules for scheduling welcome emails flow:
     # -Do not send emails on Saturday or Sunday

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -140,7 +140,7 @@ def check_long_string(var_name: str, val: object) -> str:
 def check_timezone(var_name: str, val: object) -> str:
     s = check_string(var_name, val)
     try:
-        zoneinfo.ZoneInfo(s)
+        zoneinfo.ZoneInfo(canonicalize_timezone(s))
     except (ValueError, zoneinfo.ZoneInfoNotFoundError):
         raise ValidationError(
             _("{var_name} is not a recognized time zone").format(var_name=var_name)
@@ -603,11 +603,12 @@ def to_decimal(var_name: str, s: str) -> Decimal:
 
 def to_timezone_or_empty(var_name: str, s: str) -> str:
     try:
+        s = canonicalize_timezone(s)
         zoneinfo.ZoneInfo(s)
     except (ValueError, zoneinfo.ZoneInfoNotFoundError):
         return ""
     else:
-        return canonicalize_timezone(s)
+        return s
 
 
 def to_converted_or_fallback(

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext as _
 from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.models import UserProfile
 
 if sys.version_info < (3, 9):  # nocoverage
@@ -96,7 +97,7 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         user_tz = user.timezone
         if user_tz == "":
             user_tz = timezone_get_current_timezone_name()
-        local_time = timezone_now().astimezone(zoneinfo.ZoneInfo(user_tz))
+        local_time = timezone_now().astimezone(zoneinfo.ZoneInfo(canonicalize_timezone(user_tz)))
         if user.twenty_four_hour_time:
             hhmm_string = local_time.strftime("%H:%M")
         else:

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -13,6 +13,7 @@ from zerver.actions.create_user import notify_new_user
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.timezone import canonicalize_timezone
 from zerver.models import Message, Realm, Recipient, Stream, UserProfile
 from zerver.models.realms import get_realm
 from zerver.signals import JUST_CREATED_THRESHOLD, get_device_browser, get_device_os
@@ -53,7 +54,7 @@ class SendLoginEmailTest(ZulipTestCase):
             firefox_windows = (
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
             )
-            user_tz = zoneinfo.ZoneInfo(user.timezone)
+            user_tz = zoneinfo.ZoneInfo(canonicalize_timezone(user.timezone))
             mock_time = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
             reference_time = mock_time.astimezone(user_tz).strftime("%A, %B %d, %Y at %I:%M %p %Z")
             with time_machine.travel(mock_time, tick=False):


### PR DESCRIPTION
The Ubuntu 24.04 feature freeze and Debian import freeze aren’t until [February 29](https://discourse.ubuntu.com/t/noble-numbat-release-schedule/35649), but Python 3.12 as default went in today, so it’s worth trying out.