### PR TITLE
Onboarding: Improve placeholder message for dm with yourself

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -330,18 +330,10 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                             defaultMessage:
                                 "You have not sent any direct messages to yourself yet!",
                         }),
-                        html: $t_html(
-                            {
-                                defaultMessage:
-                                    "Why not <z-link>start a conversation with yourself</z-link>?",
-                            },
-                            {
-                                "z-link": (content_html) =>
-                                    `<a href="#" class="empty_feed_compose_private">${content_html.join(
-                                        "",
-                                    )}</a>`,
-                            },
-                        ),
+                        html: $t_html({
+                            defaultMessage:
+                                "Use this space for personal notes, or to test out Zulip features.",
+                        }),
                     };
                 }
                 return {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -408,7 +408,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have not sent any direct messages to yourself yet!",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start a conversation with yourself</a>?',
+            "translated HTML: Use this space for personal notes, or to test out Zulip features.",
         ),
     );
 


### PR DESCRIPTION
This pr changes placeholder text for dm with yourself from `Why not start a conversation with yourself` to `Use this space for personal notes and test messages.`

Fixes: #29078

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/91622060/3171cf8f-03f0-459e-8c0b-7a75a03b85a6)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
