### PR TITLE
message_view: Allow quoting selected message text, via popover option.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -29,7 +29,8 @@ type PopoverName =
     | "change_visibility_policy"
     | "personal_menu"
     | "gear_menu"
-    | "help_menu";
+    | "help_menu"
+    | "quote";
 
 export const popover_instances: Record<PopoverName, PopoverInstance | null> = {
     compose_control_buttons: null,
@@ -48,6 +49,7 @@ export const popover_instances: Record<PopoverName, PopoverInstance | null> = {
     personal_menu: null,
     gear_menu: null,
     help_menu: null,
+    quote: null,
 };
 
 /* Keyboard UI functions */

--- a/web/templates/popovers/quote_selection_popover.hbs
+++ b/web/templates/popovers/quote_selection_popover.hbs
@@ -1,0 +1,7 @@
+<ul class="nav nav-list">
+    <li>
+        <a class="quote_selection">
+            {{t "Quote selection" }}
+        </a>
+    </li>
+</ul>


### PR DESCRIPTION
Whenever the user selects text within a single message, a tooltip, with the option to quote and reply, will appear next to the selection. Clicking it will quote the markdown version of the selection, hence preserving any formatting, in the compose box, opening it if necessary.

Any other elements of the message, outside of the content, selected presumably by accident (like the timestamp or sender name), will be ignored.

The 2 standard ways to quote and reply, via the message actions menu, and the `>` keyboard shortcut, still behave as before, quoting the whole message.

Fixes: #19712.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
