### PR TITLE
events: Do nothing in apply_event for restart events.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1531,6 +1531,9 @@ def apply_event(
         # possible, but the worst expected outcome is that the client
         # retains the old JS instead of reloading.
         logging.warning("Got a web_reload_client event during apply_events")
+    elif event["type"] == "restart":
+        # The Tornado process restarted.  This has no effect; we ignore it.
+        pass
     else:
         raise AssertionError("Unexpected event type {}".format(event["type"]))
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -248,6 +248,7 @@ from zerver.tornado.event_queue import (
     clear_client_event_queues_for_testing,
     create_heartbeat_event,
     mark_clients_to_reload,
+    send_restart_events,
     send_web_reload_client_events,
 )
 from zerver.views.realm_playgrounds import access_playground_by_id
@@ -3477,6 +3478,13 @@ class NormalActionsTest(BaseAction):
 
         events = self.verify_action(lambda: do_set_zoom_token(self.user_profile, None))
         check_has_zoom_token("events[0]", events[0], value=False)
+
+    def test_restart_event(self) -> None:
+        self.verify_action(
+            lambda: send_restart_events(),
+            num_events=1,
+            state_change_expected=False,
+        )
 
     def test_web_reload_client_event(self) -> None:
         self.verify_action(


### PR DESCRIPTION
These signal that the Tornado process restarted, which in itself is not notable for apply_events.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
