### PR TITLE
Fix Overlapping Alert Words

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -9,6 +9,7 @@ let my_alert_words: string[] = [];
 
 export function set_words(words: string[]): void {
     my_alert_words = words;
+    my_alert_words.sort((a, b) => b.length - a.length);
 }
 
 export function get_word_list(): {word: string}[] {
@@ -87,5 +88,5 @@ export function notifies(message: Message): boolean {
 }
 
 export const initialize = (params: {alert_words: string[]}): void => {
-    my_alert_words = params.alert_words;
+    set_words(params.alert_words);
 };

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -151,7 +151,7 @@ run_test("alert_words", ({override}) => {
     const event = event_fixtures.alert_words;
     dispatch(event);
 
-    assert.deepEqual(alert_words.get_word_list(), [{word: "fire"}, {word: "lunch"}]);
+    assert.deepEqual(alert_words.get_word_list(), [{word: "lunch"}, {word: "fire"}]);
     assert.ok(alert_words.has_alert_word("fire"));
     assert.ok(alert_words.has_alert_word("lunch"));
 });


### PR DESCRIPTION
Fixes: #28415

This Pull Request addresses fixing an issue with the highlighting of alerted words.

Description:

The problem was that when a message contained a phrase that was part of our alerted words list (for example, 'natural fiber'), If we already have 'natural' as an alerted word, only the first word ('natural') was being highlighted and not ('natural fiber'). This was due to the way the existing code was handling the replace function inside a for loop.

Solution:

- Sorted the my_alert_words in descending order whenever set_words is called.
- This will allow longer text to be picked for replacement before the smaller words.

Suggestion:
- Since order of words doesn't matter we can also go use Set/Map to store alert_words so, the checks like has_alert_word and other similar operations can be optimised.

Screenshots:

Before:
<img width=200 src="https://github.com/zulip/zulip/assets/45929094/c17433b3-4e16-47c9-bb76-fce14d078d0c" />

Alerted Words = [very illustrious, natural fiber, illustrious, two words, natural]

After
<img width="146" alt="Screenshot 2024-02-28 at 12 29 32 AM" src="https://github.com/zulip/zulip/assets/45929094/51ef0a0b-90cc-4f88-9747-d1e8068e4a94">



Credits to #28431 