### PR TITLE
portico: Consistently describe Zulip as organized team chat.

### DIFF
--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -19,7 +19,7 @@
         <div class="body-bg__layer"></div>
     </div>
 
-    <h1>Complete team chat solution</h1>
+    <h1>Organized team chat solution</h1>
     <div class="h1-subheader">
         From small teams to organizations with thousands of users, Zulip has you
         covered. See <a href="/plans/">plans and pricing</a>.

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -4,8 +4,7 @@
 {% set PAGE_TITLE = "Zulip for business" %}
 
 {% set PAGE_DESCRIPTION = "Zulip offers efficient communication for your
-  business, with organized and inclusive threaded team chat. Free for
-  light use!" %}
+  business. Learn how organized team chat will make your team more productive." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -19,7 +18,7 @@
     <div class="hero bg-companies">
         <div class="bg-dimmer"></div>
         <h1 class="center">Efficient communication for your business.</h1>
-        <p>Organized and inclusive threaded team chat.<br/>Free for light use!</p>
+        <p>Learn how organized team chat will <br/>make your team more productive.</p>
         <div class="hero-buttons center">
             <a href="/new/" class="button">
                 {{ _('Create organization') }}

--- a/templates/corporate/for/education.html
+++ b/templates/corporate/for/education.html
@@ -43,7 +43,7 @@
     <div class="feature-intro">
         <h1 class="center"> Make Zulip the communication hub for your class. </h1>
         <p>
-            <a href="/hello/">Zulip</a> is the only <a href="/features/">modern team chat app</a> that is <a href="/why-zulip/">ideal</a> for both live and asynchronous conversations. Post lecture notes and announcements, answer students’ questions, and coordinate with teaching staff all in one place.
+            Zulip is the <a href="/why-zulip/">organized team chat</a> app that is ideal for both live and asynchronous conversations. Post lecture notes and announcements, answer students’ questions, and coordinate with teaching staff all in one place.
         </p>
     </div>
 

--- a/templates/corporate/for/events.html
+++ b/templates/corporate/for/events.html
@@ -45,7 +45,7 @@
     <div class="feature-intro">
         <h1 class="center"> Make Zulip the communication hub for your event. </h1>
         <p>
-            <a href="/hello/">Zulip</a> is the only <a href="/features/">modern team chat app</a> that is <a href="/why-zulip/">ideal</a> for both live and asynchronous conversations. Post presentations and announcements, host Q&A sessions, and coordinate among organizers.
+            Zulip is the <a href="/why-zulip/">organized team chat</a> app that is ideal for both live and asynchronous conversations. Post presentations and announcements, host Q&A sessions, and coordinate among organizers.
         </p>
     </div>
 

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -4,7 +4,7 @@
 {% set PAGE_TITLE = "Zulip for open-source projects" %}
 
 {% set PAGE_DESCRIPTION = "Grow your community with thoughtful and inclusive
-  discussion, using the only modern team chat app that is ideal for both live
+  discussion, using the organized team chat app that is ideal for both live
   and asynchronous conversations." %}
 
 {% block customhead %}
@@ -47,8 +47,7 @@
     <div class="feature-intro">
         <h1 class="center"> Make Zulip the communication hub for your open-source community. </h1>
         <p>
-            <a href="/hello/">Zulip</a> is the only <a href="/features/">modern
-            team chat app</a> that is <a href="/why-zulip/">ideal</a> for both
+            Zulip is the <a href="/why-zulip/">organized team chat</a> app that is ideal for both
             live and asynchronous conversations. Discuss issues, pull requests
             and feature ideas, engage with users, answer questions, and
             onboard new contributors.

--- a/templates/corporate/for/research.html
+++ b/templates/corporate/for/research.html
@@ -4,7 +4,7 @@
 {% set PAGE_TITLE = "Zulip for researchers and academics" %}
 
 {% set PAGE_DESCRIPTION = "Make Zulip the communication hub for your research
-  group, department or scientific field. The only modern team chat ideal for both
+  group, department or scientific field. Organized team chat ideal for both
   live and asynchronous conversations." %}
 
 {% block customhead %}
@@ -47,7 +47,7 @@
     <div class="feature-intro">
         <h1 class="center"> Make Zulip the communication hub for your research community. </h1>
         <p>
-            <a href="/hello/">Zulip</a> is the only <a href="/features/">modern team chat app</a> that is <a href="/why-zulip/">ideal</a> for both live and asynchronous conversations. Coordinate with collaborators, post questions and ideas, and learn from others in your field.
+            Zulip is the <a href="/why-zulip/">organized team chat</a> app that is ideal for both live and asynchronous conversations. Coordinate with collaborators, post questions and ideas, and learn from others in your field.
         </p>
     </div>
 

--- a/templates/corporate/values.html
+++ b/templates/corporate/values.html
@@ -3,7 +3,8 @@
 
 {% set PAGE_TITLE = "Zulip project values" %}
 
-{% set PAGE_DESCRIPTION = "Learn about the values that are behind everything we do as we work to build the world’s best team chat software." %}
+{% set PAGE_DESCRIPTION = "Learn about the values that are behind everything we
+  do as we work to build the world’s best organized team chat software." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -18,8 +19,8 @@
         <div class="content">
             <h1 class="center">Zulip project values</h1>
             <p>
-                These values are behind everything we do <br />
-                as we work to build the world’s best team chat software.
+                These values are behind everything we do as we <br />
+                work to build the world’s best organized team chat.
             </p>
         </div>
     </div>

--- a/templates/corporate/values.md
+++ b/templates/corporate/values.md
@@ -49,11 +49,12 @@ contributing to Zulip than in their 4-year formal computer science education.
 
 ## Building a sustainable business aligned with our values
 
-Guiding the Zulip community in developing a world-class team chat product with
-apps for every major desktop and mobile platform requires leadership from a
-talented, dedicated team. We believe that the only sustainable model is for our
-core team to be compensated fairly for their time. We have thus **founded a
-company (Kandra Labs) to steward and financially support Zulip’s development**.
+Guiding the Zulip community in developing a world-class organized team chat
+product with apps for every major desktop and mobile platform requires
+leadership from a talented, dedicated team. We believe that the only sustainable
+model is for our core team to be compensated fairly for their time. We have thus
+**founded a company (Kandra Labs) to steward and financially support Zulip’s
+development**.
 
 We are **growing our business sustainably**, without venture capital funding.
 VCs are incentivized to push companies to gamble for explosive growth. Often,

--- a/templates/corporate/why-zulip.md
+++ b/templates/corporate/why-zulip.md
@@ -89,7 +89,7 @@ notifications.
 
 ## Zulip empowers teams to work flexibly anytime, from anywhere, without interruptions.
 
-With team chat that is designed for both synchronous and asynchronous
+With organized team chat that is designed for both synchronous and asynchronous
 communication, everyone can be included in decision-making without being online
 at the same time. Team members can focus when they need to, and contribute to
 discussions asynchronously without interrupting their flow.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -257,7 +257,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/hello/", ["your mission-critical communications with Zulip"])
         self._test("/communities/", ["Open communities directory"])
         self._test("/development-community/", ["Zulip development community"])
-        self._test("/features/", ["Complete team chat solution"])
+        self._test("/features/", ["Organized team chat solution"])
         self._test("/jobs/", ["Work with us"])
         self._test("/self-hosting/", ["Self-host Zulip"])
         self._test("/security/", ["TLS encryption"])


### PR DESCRIPTION
<details>
<summary>
Selected screenshots
</summary>

![Screenshot 2024-02-27 at 11 03 59 AM](https://github.com/zulip/zulip/assets/2090066/11f69bda-fd97-48f3-932f-386dac8c2f5c)
![Screenshot 2024-02-27 at 10 54 04 AM](https://github.com/zulip/zulip/assets/2090066/ed6a4c80-20ed-4905-8f3c-b91f83133bf7)
![Screenshot 2024-02-27 at 10 47 02 AM](https://github.com/zulip/zulip/assets/2090066/67b8db8f-5b8c-4c39-b722-483ee79e45e8)

</details>