### PR TITLE
help: Add poll icon to "Create a poll".

### DIFF
--- a/help/create-a-poll.md
+++ b/help/create-a-poll.md
@@ -14,7 +14,8 @@ edit the question.
 
 1. Make sure the compose box is empty.
 
-1. Click the **Add poll** icon at the bottom of the compose box.
+1. Click the **Add poll** (<i class="zulip-icon zulip-icon-poll"></i>) icon at
+   the bottom of the compose box.
 
 1. Fill out poll information as desired, and click **Add poll** to insert poll
    formatting.


### PR DESCRIPTION
Adds missing icon for the poll button.

Fixes #29051.

**Screenshots and screen captures:**

- https://zulip.com/help/create-a-poll#create-a-poll
![image](https://github.com/zulip/zulip/assets/2343554/82d792a4-9075-4451-a2bc-165603773deb)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

