### PR TITLE
help: Document "Zulip update announcements" setting.

### DIFF
--- a/help/configure-notification-bot.md
+++ b/help/configure-notification-bot.md
@@ -69,6 +69,26 @@ these messages is "signups".
 
 {end_tabs}
 
+### Zulip update announcements
+
+Zulip announces new features and important product and design changes
+via automated notifications sent to the "Zulip updates" topic in a
+configurable stream.
+
+You can configure where the Zulip notification bot sends these updates,
+or disable the Zulip update messages entirely.
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Automated messages and emails**, configure **Zulip update
+   announcements**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
 ## Related articles
 
 * [Organization language for automated messages and invitation emails][org-lang]


### PR DESCRIPTION
As noted in https://github.com/zulip/zulip/pull/29049#issuecomment-1962741151, this PR adds basic documentation for the new organization setting for posting Zulip news.

See #28604.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/2343554/58914cf6-362f-4310-9246-161a7b6c0d0f)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
