### PR TITLE
Create Reactions View

### DIFF
--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -96,6 +96,7 @@ Zulip offers the following filters based on the location of the message.
 * `has:attachment`: Search messages that contain an [uploaded
   file](/help/share-and-upload-files).
 * `has:image`: Search messages that contain uploaded or linked images or videos.
+* `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
 !!! tip ""
 

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -1,8 +1,10 @@
 import $ from "jquery";
+import _ from "lodash";
 
 import type {Filter} from "./filter";
 import {localstorage} from "./localstorage";
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as resize from "./resize";
 import * as scheduled_messages from "./scheduled_messages";
 import * as settings_config from "./settings_config";
@@ -86,6 +88,7 @@ function deselect_top_left_corner_items(): void {
     remove($(".top_left_mentions"));
     remove($(".top_left_recent_view"));
     remove($(".top_left_inbox"));
+    remove($(".top_left_my_reactions"));
 }
 
 export function handle_narrow_activated(filter: Filter): void {
@@ -113,6 +116,14 @@ export function handle_narrow_activated(filter: Filter): void {
             $filter_li = $(".top_left_mentions");
             $filter_li.addClass("active-filter");
         }
+    }
+    const term_types = filter.sorted_term_types();
+    if (
+        _.isEqual(term_types, ["sender", "has-reaction"]) &&
+        filter.operands("sender")[0] === people.my_current_email()
+    ) {
+        $filter_li = $(".top_left_my_reactions");
+        $filter_li.addClass("active-filter");
     }
 }
 

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as hash_util from "./hash_util";
@@ -6,6 +7,7 @@ import * as message_lists from "./message_lists";
 import type {MessageList} from "./message_lists";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
+import * as people from "./people";
 
 function show_history_limit_notice(): void {
     $(".top-messages-logo").hide();
@@ -54,7 +56,11 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
             !filter.is_in_home() &&
             !filter.contains_only_private_messages() &&
             !filter.includes_full_stream_history() &&
-            !filter.is_personal_filter()
+            !filter.is_personal_filter() &&
+            !(
+                _.isEqual(filter._sorted_term_types, ["sender", "has-reaction"]) &&
+                filter.operands("sender")[0] === people.my_current_email()
+            )
         ) {
             show_end_of_results_notice();
         }

--- a/web/src/message_parser.ts
+++ b/web/src/message_parser.ts
@@ -23,3 +23,7 @@ export function message_has_image(message: Message): boolean {
 export function message_has_attachment(message: Message): boolean {
     return is_element_in_message_content(message, "a[href^='/user_uploads']");
 }
+
+export function message_has_reaction(message: Message): boolean {
+    return message.clean_reactions.size > 0;
+}

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import {$t, $t_html} from "./i18n";
@@ -97,6 +98,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
     }
 
     const first_term = current_filter.terms()[0]!;
+    const current_terms_types = current_filter.sorted_term_types();
     const first_operator = first_term.operator;
     const first_operand = first_term.operand;
     const num_terms = current_filter.terms().length;
@@ -158,6 +160,26 @@ function pick_empty_narrow_banner(): NarrowBannerData {
         // A stream > topic that doesn't exist yet.
         if (num_terms === 2 && streams.length === 1 && topics.length === 1) {
             return default_banner;
+        }
+
+        if (
+            _.isEqual(current_terms_types, ["sender", "has-reaction"]) &&
+            current_filter.operands("sender")[0] === people.my_current_email()
+        ) {
+            return {
+                title: $t({defaultMessage: "None of your messages have emoji reactions yet."}),
+                html: $t_html(
+                    {
+                        defaultMessage: "Learn more about emoji reactions <z-link>here</z-link>.",
+                    },
+                    {
+                        "z-link": (content_html) =>
+                            `<a target="_blank" rel="noopener noreferrer" href="/help/emoji-reactions">${content_html.join(
+                                "",
+                            )}</a>`,
+                    },
+                ),
+            };
         }
 
         // For other multi-operator narrows, we just use the default banner

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -635,6 +635,11 @@ function get_has_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
             description_html: "messages that contain attachments",
             incompatible_patterns: [{operator: "has", operand: "attachment"}],
         },
+        {
+            search_string: "has:reaction",
+            description_html: "messages that contain reactions",
+            incompatible_patterns: [{operator: "has", operand: "reaction"}],
+        },
     ];
     return get_special_filter_suggestions(last, terms, suggestions);
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -642,6 +642,7 @@ li.active-sub-filter {
 }
 
 /* Don't show unread counts on views... */
+.top_left_my_reactions,
 .top_left_inbox,
 .top_left_recent_view,
 .top_left_all_messages {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -98,6 +98,16 @@
                     <span class="unread_count"></span>
                 </a>
             </li>
+            <li class="tippy-views-tooltip top_left_my_reactions top_left_row hidden-for-spectators" data-tooltip-template-id="my-reactions-tooltip-template">
+                <a class="left-sidebar-navigation-label-container" href="#narrow/has/reaction/sender/me">
+                    <span class="filter-icon">
+                        <i class="zulip-icon zulip-icon-smile" aria-hidden="true"></i>
+                    </span>
+                    {{~!-- squash whitespace --~}}
+                    <span class="left-sidebar-navigation-label">{{t 'Reactions' }}</span>
+                    <span class="unread_count"></span>
+                </a>
+            </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -1,5 +1,14 @@
 {{! Contents of the condensed nav vdots popup }}
 <ul class="nav nav-list condensed-views-popover-menu">
+    <li class="condensed-views-popover-menu-reactions">
+        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
+        <a tabindex="0" href="#narrow/has/reaction/sender/me" class="left-sidebar-popover-icon-label-count tippy-left-sidebar-tooltip" data-tooltip-template-id="my-reactions-tooltip-template">
+            <span class="filter-icon">
+                <i class="zulip-icon zulip-icon-smile" aria-hidden="true"></i>
+            </span>
+            <span class="left-sidebar-navigation-label">{{t 'Reactions' }}</span>
+        </a>
+    </li>
     <li class="condensed-views-popover-menu-drafts">
         {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
         <a tabindex="0" href="#drafts" class="left-sidebar-popover-icon-label-count tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -100,6 +100,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">has:reaction</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages with emoji reactions.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">is:alerted</td>
                         <td class="definition">
                             {{t 'Narrow to messages with alert words.'}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -121,6 +121,11 @@
     </div>
     {{tooltip_hotkey_hints "T"}}
 </template>
+<template id="my-reactions-tooltip-template">
+    <div class="views-tooltip-container" data-view-code="recent_topics">
+        <div>{{t 'Reactions to your messages' }}</div>
+    </div>
+</template>
 <template id="inbox-tooltip-template">
     <div class="views-tooltip-container" data-view-code="inbox">
         <div>{{t 'Inbox' }}</div>

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -526,6 +526,19 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: This channel does not exist or is private."),
     );
+
+    set_filter([
+        ["has", "reaction"],
+        ["sender", "me"],
+    ]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: None of your messages have emoji reactions yet.",
+            'translated HTML: Learn more about emoji reactions <a target="_blank" rel="noopener noreferrer" href="/help/emoji-reactions">here</a>.',
+        ),
+    );
 });
 
 run_test("show_empty_narrow_message_with_search", ({mock_template}) => {

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -95,7 +95,12 @@ test("basic_get_suggestions_for_spectator", () => {
 
     const query = "";
     const suggestions = get_suggestions(query);
-    assert.deepEqual(suggestions.strings, ["has:link", "has:image", "has:attachment"]);
+    assert.deepEqual(suggestions.strings, [
+        "has:link",
+        "has:image",
+        "has:attachment",
+        "has:reaction",
+    ]);
     page_params.is_spectator = false;
 });
 
@@ -432,6 +437,7 @@ test("empty_query_suggestions", () => {
         "has:link",
         "has:image",
         "has:attachment",
+        "has:reaction",
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -462,7 +468,7 @@ test("has_suggestions", ({override, mock_template}) => {
     override(narrow_state, "stream_name", noop);
 
     let suggestions = get_suggestions(query);
-    let expected = ["h", "has:link", "has:image", "has:attachment"];
+    let expected = ["h", "has:link", "has:image", "has:attachment", "has:reaction"];
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
@@ -475,7 +481,7 @@ test("has_suggestions", ({override, mock_template}) => {
 
     query = "-h";
     suggestions = get_suggestions(query);
-    expected = ["-h", "-has:link", "-has:image", "-has:attachment"];
+    expected = ["-h", "-has:link", "-has:image", "-has:attachment", "-has:reaction"];
     assert.deepEqual(suggestions.strings, expected);
     assert.equal(describe("-has:link"), "Exclude messages that contain links");
     assert.equal(describe("-has:image"), "Exclude messages that contain images");
@@ -485,7 +491,7 @@ test("has_suggestions", ({override, mock_template}) => {
 
     query = "has:";
     suggestions = get_suggestions(query);
-    expected = ["has:link", "has:image", "has:attachment"];
+    expected = ["has:link", "has:image", "has:attachment", "has:reaction"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "has:im";


### PR DESCRIPTION
# Create Reactions View
- Created a new search operator `has:reaction`
- Added search suggestions for the new operator
- Created a new view in the left sidebar for `has:reaction sender:me`
- Updated `web/src/filter.ts` and `web/src/message_parser.ts` to deal with cached messages
- Fixed `message_reactions` undefined by cleaning reactions earlier in the flow.

## Differences from previous plans
- Used `zulip-icon-smile` instead of https://feathericons.com/?query=thumbs-up to maintain uniformity with other reaction buttons.

Fixes: [Issue 27328](https://github.com/zulip/zulip/issues/27328)

**Screenshots and screen captures:**
### Tooltip and custom heading
![image](https://github.com/zulip/zulip/assets/29176437/04802254-8d7e-4a3a-b268-f6e7e65a7a88)
### Help Menu
![image](https://github.com/zulip/zulip/assets/29176437/9105479d-efd8-4c94-aaaa-02a1b374b883)

### Empty narrow banner
![image](https://github.com/zulip/zulip/assets/29176437/077e07a6-8a9b-4bbe-a3ab-b7953527001a)

### Collapsed Sidebar
![image](https://github.com/zulip/zulip/assets/29176437/b9dd8ca1-2123-4596-a21a-e809b1e389ca)



<details>
<summary>Self-review checklist</summary>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
