### PR TITLE
Change topic typeahead behaviortypeahead: change topic typeahead behavior

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -40,14 +40,6 @@ async function create_stream_message_draft(page: Page): Promise<void> {
         content: "Test stream message.",
     });
     await page.type("#stream_message_recipient_topic", "tests", {delay: 100});
-
-    // Ideally, we don't need to click on the typeahead to create a draft with this topic but
-    // the typeahead seems bugged and remains open in the next compose session even after it
-    // is being closed via clicking on #compose_close.
-    const entry = await page.waitForSelector('.typeahead[style*="display: block"] .active a', {
-        visible: true,
-    });
-    await entry!.click();
     await page.click("#compose_close");
 }
 

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -40,7 +40,7 @@ export const pm_recipient = {
         // input typeahead is different from the topic input
         // typeahead but both can be present in the DOM.
         const entry = await page.waitForSelector('.typeahead[style*="display: block"] .active a', {
-            visible: true,
+            visible: false,
         });
         await entry!.click();
     },

--- a/web/e2e-tests/mention.test.ts
+++ b/web/e2e-tests/mention.test.ts
@@ -12,12 +12,9 @@ async function test_mention(page: Page): Promise<void> {
     await page.waitForSelector("#compose", {visible: true});
 
     await common.select_stream_in_compose_via_dropdown(page, "Verona");
-    await common.select_item_via_typeahead(
-        page,
-        "#stream_message_recipient_topic",
-        "Test mention all",
-        "Test mention all",
-    );
+    await common.fill_form(page, 'form[action^="/json/messages"]', {
+        stream_message_recipient_topic: "Test mention all",
+    });
     await common.select_item_via_typeahead(page, "#compose-textarea", "@**all", "all");
     await common.ensure_enter_does_not_send(page);
 

--- a/web/src/bootstrap_typeahead.js
+++ b/web/src/bootstrap_typeahead.js
@@ -513,13 +513,20 @@ Typeahead.prototype = {
                 break;
 
             case 9: // tab
-                if (!this.options.tabIsEnter) {
+                // If the typeahead is not shown or tabIsEnter option is not set, do nothing and return
+                if (!this.options.tabIsEnter || !this.shown) {
                     return;
                 }
-                if (!this.shown) {
-                    return;
-                }
+
                 this.select(e);
+
+                if (e.currentTarget.id === "stream_message_recipient_topic") {
+                    // Move the cursor to the end of the topic
+                    const topic_length = this.$element.val().length;
+                    this.$element[0].selectionStart = topic_length;
+                    this.$element[0].selectionEnd = topic_length;
+                }
+
                 break;
 
             case 13: // enter

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -1175,7 +1175,7 @@ export function initialize({on_enter_send}) {
         },
         sorter(items) {
             const sorted = typeahead_helper.sorter(this.query, items, (x) => x);
-            if (!sorted.includes(this.query)) {
+            if (sorted.length > 0 && !sorted.includes(this.query)) {
                 sorted.unshift(this.query);
             }
             return sorted;

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -812,7 +812,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         // Suggest the query if this query doesn't match any existing topic.
         options.query = "non-existing-topic";
         actual_value = options.sorter([]);
-        expected_value = ["non-existing-topic"];
+        expected_value = [];
         assert.deepEqual(actual_value, expected_value);
 
         topic_typeahead_called = true;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In this PR, I have added functionalities in web/third/bootsrap-typeahead/typeahead.js which will improve topic typeahead beahviour as shown in video below.

Fixes: #29006 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before changes:
[Before_making_typeahead_changes.webm](https://github.com/zulip/zulip/assets/113179991/c257abe4-833e-4a1a-80b0-eb3b4e1350ba)
After changes:
[After_making_typeahead_changes.webm](https://github.com/zulip/zulip/assets/113179991/e686daab-dbdf-4a3d-9d95-e5a794161de2)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] End-to-end functionality of buttons, interactions and flows.
</details>
