### PR TITLE
remote_billing: Make "plan management" always available.

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -199,12 +199,41 @@ class SelfHostedBillingEndpointBasicTest(RemoteRealmBillingTestCase):
         self_hosted_billing_json_url = "/json/self-hosted-billing"
 
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=None):
-            result = self.client_get(self_hosted_billing_url)
-            self.assertEqual(result.status_code, 404)
-            self.assert_in_response("Page not found (404)", result)
+            with self.settings(CORPORATE_ENABLED=True):
+                result = self.client_get(self_hosted_billing_url)
+                self.assertEqual(result.status_code, 404)
+                self.assert_in_response("Page not found (404)", result)
 
-            result = self.client_get(self_hosted_billing_json_url)
-            self.assert_json_error(result, "Server doesn't use the push notification service", 404)
+            with self.settings(CORPORATE_ENABLED=False):
+                result = self.client_get(self_hosted_billing_url)
+                self.assertEqual(result.status_code, 302)
+                redirect_url = result["Location"]
+                self.assertEqual(redirect_url, "/self-hosted-billing/not-configured/")
+
+                with self.assertLogs("django.request"):
+                    result = self.client_get(redirect_url)
+                    self.assert_in_response(
+                        "This server is not configured to use push notifications.", result
+                    )
+
+            with self.settings(CORPORATE_ENABLED=True):
+                result = self.client_get(self_hosted_billing_json_url)
+                self.assert_json_error(
+                    result, "Server doesn't use the push notification service", 404
+                )
+
+            with self.settings(CORPORATE_ENABLED=False):
+                result = self.client_get(self_hosted_billing_json_url)
+                self.assert_json_success(result)
+
+                redirect_url = result.json()["billing_access_url"]
+                self.assertEqual(redirect_url, "/self-hosted-billing/not-configured/")
+
+                with self.assertLogs("django.request"):
+                    result = self.client_get(redirect_url)
+                    self.assert_in_response(
+                        "This server is not configured to use push notifications.", result
+                    )
 
         with mock.patch(
             "zerver.views.push_notifications.send_to_push_bouncer",
@@ -240,6 +269,26 @@ class SelfHostedBillingEndpointBasicTest(RemoteRealmBillingTestCase):
 
 @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
 class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
+    def test_self_hosted_config_error_page(self) -> None:
+        with self.settings(
+            CORPORATE_ENABLED=False, PUSH_NOTIFICATION_BOUNCER_URL=None
+        ), self.assertLogs("django.request"):
+            result = self.client_get("/self-hosted-billing/not-configured/")
+            self.assertEqual(result.status_code, 500)
+            self.assert_in_response(
+                "This server is not configured to use push notifications.", result
+            )
+
+        # The page doesn't make sense if PUSH_NOTIFICATION_BOUNCER_URL is configured.
+        with self.settings(CORPORATE_ENABLED=False):
+            result = self.client_get("/self-hosted-billing/not-configured/")
+            self.assertEqual(result.status_code, 404)
+
+        # Also doesn't make sense on zulipchat.com (where CORPORATE_ENABLED is True).
+        with self.settings(CORPORATE_ENABLED=True, PUSH_NOTIFICATION_BOUNCER_URL=None):
+            result = self.client_get("/self-hosted-billing/not-configured/")
+            self.assertEqual(result.status_code, 404)
+
     @responses.activate
     def test_remote_billing_authentication_flow(self) -> None:
         self.login("desdemona")

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -191,6 +191,17 @@ class RemoteRealmBillingTestCase(BouncerTestCase):
 class SelfHostedBillingEndpointBasicTest(RemoteRealmBillingTestCase):
     @responses.activate
     def test_self_hosted_billing_endpoints(self) -> None:
+        # An ordinary user doesn't have access to these endpoints.
+        self.login("hamlet")
+        for url in [
+            "/self-hosted-billing/",
+            "/json/self-hosted-billing",
+            "/self-hosted-billing/not-configured/",
+        ]:
+            result = self.client_get(url)
+            self.assert_json_error(result, "Must be an organization owner")
+
+        # Login as an organization owner to gain access.
         self.login("desdemona")
 
         self.add_mock_response()
@@ -270,6 +281,8 @@ class SelfHostedBillingEndpointBasicTest(RemoteRealmBillingTestCase):
 @override_settings(PUSH_NOTIFICATION_BOUNCER_URL="https://push.zulip.org.example.com")
 class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
     def test_self_hosted_config_error_page(self) -> None:
+        self.login("desdemona")
+
         with self.settings(
             CORPORATE_ENABLED=False, PUSH_NOTIFICATION_BOUNCER_URL=None
         ), self.assertLogs("django.request"):

--- a/templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+++ b/templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
@@ -18,11 +18,10 @@
                         {% trans %} Plan management is not available for this
                         organization, because your Zulip server is already on a
                         {{ server_plan_name }} plan, which covers all
-                        organizations on this server. Follow the <a
-                        href="https://zulip.com/help/self-hosted-billing#manage-billing">log
-                        in instructions</a>
-                        for <b>All older versions</b>
-                        of the Zulip server to manage your plan.
+                        organizations on this server. See the <b>All versions</b> tab of the
+                        <a href="https://zulip.com/help/self-hosted-billing#manage-billing">log
+                        in instructions</a> to administer the plan for your
+                        Zulip server.
                         {% endtrans %}
                     </p>
                     <p>

--- a/templates/zerver/config_error/container.html
+++ b/templates/zerver/config_error/container.html
@@ -5,24 +5,28 @@
 {% endblock %}
 
 {% block portico_content %}
-    <div class="error_page" style="padding-bottom: 60px;">
-        <div class="container">
-            <div class="row-fluid">
-                <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
-                <div class="errorbox config-error">
-                    <div class="errorcontent">
-                        <h1 class="lead">{{ _("Configuration error") }}</h1>
-                        <br />
+<div id="config_error_page" class="flex full-page">
+    <div class="new-style">
+        <div class="pitch">
+            <h1>
+                {{ _("Configuration error") }}
+            </h1>
+        </div>
+        <div class="white-box">
+            <div class="errorbox config-error">
+                <div class="errorcontent">
+                    <p>
                         {% block error_content %}
                         {% endblock %}
+                    </p>
 
-                        <p>After making your changes, remember to restart
-                        the Zulip server.</p>
-                        <p><a href=""> Refresh</a> to try again or <a href="/login/">click here</a> to go back to the login page.</p>
-                    </div>
-
+                    <p>After making your changes, remember to restart
+                    the Zulip server.</p>
+                    <p><a href=""> Refresh</a> to try again or <a href="/login/">click here</a> to go back to the login page.</p>
                 </div>
+
             </div>
         </div>
     </div>
+</div>
 {% endblock %}

--- a/templates/zerver/config_error/container.html
+++ b/templates/zerver/config_error/container.html
@@ -22,7 +22,7 @@
 
                     <p>After making your changes, remember to restart
                     the Zulip server.</p>
-                    <p><a href=""> Refresh</a> to try again or <a href="/login/">click here</a> to go back to the login page.</p>
+                    <p><a href=""> Refresh</a> to try again or <a href="{{ go_back_to_url }}">go back to {{ go_back_to_url_name }}</a>.</p>
                 </div>
 
             </div>

--- a/templates/zerver/config_error/remote_billing_bouncer_not_configured.html
+++ b/templates/zerver/config_error/remote_billing_bouncer_not_configured.html
@@ -1,0 +1,9 @@
+{% extends "zerver/config_error/container.html" %}
+
+{% block error_content %}
+    {% trans doc_url="https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html" %}
+        This server is not configured to use push notifications. For instructions on how to
+        configure push notifications, please see the
+        <a href="{{ doc_url }}">documentation</a>.
+    {% endtrans %}
+{% endblock %}

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -992,6 +992,17 @@ input.new-organization-button {
     }
 }
 
+#config_error_page {
+    .pitch {
+        text-align: center;
+        width: 100%;
+    }
+
+    .white-box {
+        max-width: 600px;
+    }
+}
+
 .error_page {
     min-height: calc(100vh - 290px);
     height: 100%;

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -16,7 +16,6 @@ from zerver.lib.i18n import (
     get_language_translation_data,
 )
 from zerver.lib.narrow_helpers import NarrowTerm
-from zerver.lib.push_notifications import uses_notification_bouncer
 from zerver.lib.realm_description import get_realm_rendered_description
 from zerver.lib.request import RequestNotes
 from zerver.models import Message, Realm, Stream, UserProfile
@@ -82,8 +81,13 @@ def get_billing_info(user_profile: Optional[UserProfile]) -> BillingInfo:
     show_billing = False
     show_plans = False
     sponsorship_pending = False
+
+    # We want to always show the remote billing option as long as the user is authorized,
+    # except on zulipchat.com where it's not applicable.
     show_remote_billing = (
-        user_profile is not None and user_profile.has_billing_access and uses_notification_bouncer()
+        (not settings.CORPORATE_ENABLED)
+        and user_profile is not None
+        and user_profile.has_billing_access
     )
 
     # This query runs on home page load, so we want to avoid

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -528,6 +528,9 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             # TODO: This endpoint and the rest of its system are a work in progress,
             # we are not testing it yet.
             "self-hosted-billing/",
+            # This endpoint only returns 500 and 404 codes, so it doesn't get picked up
+            # by find_pattern above and therefore needs to be exempt.
+            "self-hosted-billing/not-configured/",
             *(webhook.url for webhook in WEBHOOK_INTEGRATIONS if not include_webhooks),
         }
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -525,9 +525,6 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "scim/v2/ServiceProviderConfig",
             "scim/v2/Groups(?:/(?P<uuid>[^/]+))?",
             "scim/v2/Groups/.search",
-            # TODO: This endpoint and the rest of its system are a work in progress,
-            # we are not testing it yet.
-            "self-hosted-billing/",
             # This endpoint only returns 500 and 404 codes, so it doesn't get picked up
             # by find_pattern above and therefore needs to be exempt.
             "self-hosted-billing/not-configured/",

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -851,7 +851,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # realm owner, with inactive CustomerPlan and realm plan_type SELF_HOSTED -> show only billing link
         customer = Customer.objects.create(realm=get_realm("zulip"), stripe_customer_id="cus_id")
@@ -868,7 +868,7 @@ class HomeTest(ZulipTestCase):
         self.assertTrue(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # realm owner, with inactive CustomerPlan and realm plan_type LIMITED -> show billing link and plans
         do_change_realm_plan_type(user.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
@@ -877,7 +877,7 @@ class HomeTest(ZulipTestCase):
         self.assertTrue(billing_info.show_billing)
         self.assertTrue(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # Always false without CORPORATE_ENABLED
         with self.settings(CORPORATE_ENABLED=False):
@@ -907,6 +907,12 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.sponsorship_pending)
         self.assertFalse(billing_info.show_remote_billing)
 
+        # Self-hosted servers show remote billing, but not for a user without
+        # billing access permission.
+        with self.settings(CORPORATE_ENABLED=False):
+            billing_info = get_billing_info(user)
+        self.assertFalse(billing_info.show_remote_billing)
+
         # billing admin, with CustomerPlan and realm plan_type STANDARD -> show only billing link
         user.role = UserProfile.ROLE_MEMBER
         user.is_billing_admin = True
@@ -917,6 +923,11 @@ class HomeTest(ZulipTestCase):
         self.assertTrue(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
+        self.assertFalse(billing_info.show_remote_billing)
+
+        # Self-hosted servers show remote billing for billing admins.
+        with self.settings(CORPORATE_ENABLED=False):
+            billing_info = get_billing_info(user)
         self.assertTrue(billing_info.show_remote_billing)
 
         # billing admin, with CustomerPlan and realm plan_type PLUS -> show only billing link
@@ -927,7 +938,7 @@ class HomeTest(ZulipTestCase):
         self.assertTrue(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # member, with CustomerPlan and realm plan_type STANDARD -> neither billing link or plans
         do_change_realm_plan_type(user.realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
@@ -961,7 +972,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # billing admin, with sponsorship pending and realm plan_type SELF_HOSTED -> show only sponsorship pending link
         customer.sponsorship_pending = True
@@ -971,7 +982,7 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertTrue(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # billing admin, no customer object and realm plan_type SELF_HOSTED -> no links
         customer.delete()
@@ -980,13 +991,14 @@ class HomeTest(ZulipTestCase):
         self.assertFalse(billing_info.show_billing)
         self.assertFalse(billing_info.show_plans)
         self.assertFalse(billing_info.sponsorship_pending)
-        self.assertTrue(billing_info.show_remote_billing)
+        self.assertFalse(billing_info.show_remote_billing)
 
         # If the server doesn't have the push bouncer configured,
-        # don't show remote billing.
-        with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=None):
+        # remote billing should be shown anyway, as the billing endpoint
+        # is supposed show a useful error page.
+        with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=None, CORPORATE_ENABLED=False):
             billing_info = get_billing_info(user)
-        self.assertFalse(billing_info.show_remote_billing)
+        self.assertTrue(billing_info.show_remote_billing)
 
     def test_promote_sponsoring_zulip_in_realm(self) -> None:
         realm = get_realm("zulip")

--- a/zerver/views/errors.py
+++ b/zerver/views/errors.py
@@ -1,12 +1,22 @@
+from typing import Optional
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
 
-def config_error(request: HttpRequest, error_name: str) -> HttpResponse:
+def config_error(
+    request: HttpRequest,
+    error_name: str,
+    *,
+    go_back_to_url: Optional[str] = None,
+    go_back_to_url_name: Optional[str] = None,
+) -> HttpResponse:
     assert "/" not in error_name
     context = {
         "error_name": error_name,
+        "go_back_to_url": go_back_to_url or "/login/",
+        "go_back_to_url_name": go_back_to_url_name or "the login page",
     }
     if settings.DEVELOPMENT:
         context["auth_settings_path"] = "zproject/dev-secrets.conf"

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -124,19 +124,19 @@ def send_test_push_notification_api(
 def self_hosting_auth_view_common(
     request: HttpRequest, user_profile: UserProfile, next_page: Optional[str] = None
 ) -> str:
+    if not user_profile.has_billing_access:
+        # We may want to replace this with an html error page at some point,
+        # but this endpoint shouldn't be accessible via the UI to an unauthorized
+        # user_profile - and they need to directly enter the URL in their browser. So a json
+        # error may be sufficient.
+        raise OrganizationOwnerRequiredError
+
     if not uses_notification_bouncer():
         if settings.CORPORATE_ENABLED:
             # This endpoint makes no sense on zulipchat.com, so just 404.
             raise ResourceNotFoundError(_("Server doesn't use the push notification service"))
         else:
             return reverse(self_hosting_auth_not_configured)
-
-    if not user_profile.has_billing_access:  # nocoverage
-        # We may want to replace this with an html error page at some point,
-        # but this endpoint shouldn't be accessible via the UI to an unauthorized
-        # user_profile - and they need to directly enter the URL in their browser. So a json
-        # error may be sufficient.
-        raise OrganizationOwnerRequiredError
 
     realm_info = get_realms_info_for_push_bouncer(user_profile.realm_id)[0]
 
@@ -218,7 +218,17 @@ def self_hosting_auth_json_endpoint(
     return json_success(request, data={"billing_access_url": redirect_url})
 
 
+@zulip_login_required
 def self_hosting_auth_not_configured(request: HttpRequest) -> HttpResponse:
+    # Use the same access model as the main endpoints for consistency
+    # and to not have to worry about this endpoint leaking some kind of
+    # sensitive configuration information in the future.
+    user = request.user
+    assert user.is_authenticated
+    assert isinstance(user, UserProfile)
+    if not user.has_billing_access:
+        raise OrganizationOwnerRequiredError
+
     if settings.CORPORATE_ENABLED or uses_notification_bouncer():
         # This error page should only be available if the config error
         # is actually real.

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -234,4 +234,9 @@ def self_hosting_auth_not_configured(request: HttpRequest) -> HttpResponse:
         # is actually real.
         return render(request, "404.html", status=404)
 
-    return config_error(request, "remote_billing_bouncer_not_configured")
+    return config_error(
+        request,
+        "remote_billing_bouncer_not_configured",
+        go_back_to_url="/",
+        go_back_to_url_name="the app",
+    )

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -99,6 +99,7 @@ from zerver.views.push_notifications import (
     remove_android_reg_id,
     remove_apns_device_token,
     self_hosting_auth_json_endpoint,
+    self_hosting_auth_not_configured,
     self_hosting_auth_redirect_endpoint,
     send_test_push_notification_api,
 )
@@ -827,6 +828,10 @@ urls += [
         "self-hosted-billing/",
         self_hosting_auth_redirect_endpoint,
         name="self_hosting_auth_redirect_endpoint",
+    ),
+    path(
+        "self-hosted-billing/not-configured/",
+        self_hosting_auth_not_configured,
     ),
     rest_path(
         "json/self-hosted-billing",


### PR DESCRIPTION
Just shows a config error page if the bouncer is not enabled. Uses a new endpoint for this so that it can work nicely for both browser and desktop app clients.
It's necessary, because the desktop app expects to get a json response with either an error or billing_access_url to redirect to. Showing a nice config error page can't be done via the json error mechanism, so instead we just serve a redirect to the new error page, which the app will open in the browser in a new window or tab.
