### PR TITLE
help: Link to /help/reading-conversations to define "conversation".

### DIFF
--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -33,12 +33,10 @@ helps in a few ways:
   the email would go out.
 * Edits made by the sender soon after sending a message will be
   reflected in the email.
-* Multiple messages in the same Zulip [conversation](/help/recent-conversations)
+* Multiple messages in the same Zulip [conversation](/help/reading-conversations)
   are combined into a single email. (Different conversations will always be in
   separate emails, so that you can [respond directly from your
-  email][reply-from-email]).
-
-[reply-from-email]: /help/using-zulip-via-email
+  email](/help/using-zulip-via-email)).
 
 To configure the delay for message notification emails:
 

--- a/help/include/view-mentions.md
+++ b/help/include/view-mentions.md
@@ -7,7 +7,7 @@
    section is collapsed) in the left sidebar.
 
 1. Browse your mentions. You can click on a message recipient bar to go
-   to the [conversation](/help/recent-conversations) where you were mentioned.
+   to the [conversation](/help/reading-conversations) where you were mentioned.
 
 !!! tip ""
 

--- a/help/link-to-a-message-or-conversation.md
+++ b/help/link-to-a-message-or-conversation.md
@@ -1,7 +1,7 @@
 # Link to a message or conversation
 
 Zulip makes it easy to share links to messages, topics, and streams. You can
-link from one Zulip [conversation](/help/recent-conversations) to another, or
+link from one Zulip [conversation](/help/reading-conversations) to another, or
 share links to Zulip conversations in issue trackers, emails, or other external
 tools.
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -23,7 +23,7 @@ are at your computer. You will still be able to
 
 1. Under **Advanced**, click on the **Automatically mark messages as
    read** dropdown, and select **Always**, **Never** or **Only in
-   [conversation](/help/recent-conversations) views**.
+   [conversation](/help/reading-conversations) views**.
 
 {tab|mobile}
 
@@ -34,7 +34,7 @@ are at your computer. You will still be able to
 1. Tap **Mark messages as read on scroll**.
 
 1. Select **Always**, **Never** or **Only in
-   [conversation](/help/recent-conversations) views**.
+   [conversation](/help/reading-conversations) views**.
 
 {end_tabs}
 

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -3,7 +3,7 @@
 ## Composing to a different conversation
 
 When composing a message, Zulip lets you view a different
-[conversation](/help/recent-conversations) from the one you are composing to.
+[conversation](/help/reading-conversations) from the one you are composing to.
 For example, you can start a new topic without changing your view, send a
 direct message about the topic you're viewing, or look up a related discussion.
 
@@ -43,7 +43,7 @@ will be sent.
 
 ### Go to conversation
 
-Zulip lets you jump to the [conversation](/help/recent-conversations) you're
+Zulip lets you jump to the [conversation](/help/reading-conversations) you're
 currently composing to.
 
 {start_tabs}


### PR DESCRIPTION
Previously, links went to /help/recent-conversations.

After these changes, this returns no results: `git grep "conversation](/help/recent" help/ `.