### PR TITLE
Modify tooltips to clarify draft saving.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -8,7 +8,6 @@ import render_message_edit_notice_tooltip from "../templates/message_edit_notice
 import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
 import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 
-import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as popover_menus from "./popover_menus";
 import * as reactions from "./reactions";
@@ -221,12 +220,6 @@ export function initialize(): void {
 
     message_list_tooltip(".slow-send-spinner", {
         onShow(instance) {
-            instance.setContent(
-                $t({
-                    defaultMessage:
-                        "Your message is taking longer than expected to be sent. Sending…",
-                }),
-            );
             const $elem = $(instance.reference);
 
             // We need to check for removal of local class from message_row since

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -34,7 +34,7 @@
 </a>
 
 {{#if (and (not msg/failed_request) msg/locally_echoed)}}
-    <span class="fa fa-circle-o-notch slow-send-spinner{{#unless msg/show_slow_send_spinner }} hidden{{/unless}}"></span>
+    <span data-tooltip-template-id="slow-send-spinner-tooltip-template" class="fa fa-circle-o-notch slow-send-spinner{{#unless msg/show_slow_send_spinner }} hidden{{/unless}}"></span>
 {{/if}}
 
 {{> message_controls}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -22,8 +22,8 @@
             <i class="fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
         </div>
 
-        <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Cancel' }}">
-            <i class="fa fa-times-circle remove-failed-message" aria-label="{{t 'Cancel' }}" role="button" tabindex="0"></i>
+        <div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
+            <i class="fa fa-times-circle remove-failed-message" aria-label="{{t 'Dismiss' }}" role="button" tabindex="0"></i>
         </div>
     </div>
 

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -154,6 +154,22 @@
     {{t "Message actions" }}
     {{tooltip_hotkey_hints "I"}}
 </template>
+<template id="dismiss-failed-send-button-tooltip-template">
+    <div>
+        <div>{{t "Dismiss failed message" }}</div>
+        <div class="italic tooltip-inner-content">
+            {{t "This content remains saved in your drafts." }}
+        </div>
+    </div>
+</template>
+<template id="slow-send-spinner-tooltip-template">
+    <div>
+        <div>{{t "Sending…" }}</div>
+        <div class="italic">
+            {{t "This message will remain saved in your drafts until it is successfully sent." }}
+        </div>
+    </div>
+</template>
 <template id="star-message-tooltip-template">
     <div class="starred-status">{{t "Star this message" }}</div>
     {{tooltip_hotkey_hints "Ctrl" "S"}}


### PR DESCRIPTION
Modified tooltips for both the Cancel button and the in-progress sending spinner to provide clearer guidance to users. Now, if the message fails to send successfully, the tooltip includes an additional line explicitly stating: `If the message is not sent successfully, it will be saved as a draft.` 

Additionally, it's worth noting that in my development environment, I noticed that the loading spinner was not displayed, which may be related to the changes introduced in [this commit](https://github.com/zulip/zulip/commit/7463f561f1a38b2afd6da9e84163ee1dda6dd283). Despite this, I proceeded with adding tooltips for both the Cancel button and the spinner, as demonstrated in the attached screenshot.

Fixes part of #29100.

**Screenshots and screen captures:**
## Cancel:
![image](https://github.com/zulip/zulip/assets/73663475/32546807-8c81-4418-8d44-7a0cff87f85e)



## Spinner:

![image](https://github.com/zulip/zulip/assets/73663475/207f2147-7d2c-4d29-b62c-e417bad49429)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
