### PR TITLE
remote-support: Use remote server or realm UUID in support URL.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3781,7 +3781,7 @@ class RemoteRealmBillingSession(BillingSession):
 
     @override
     def support_url(self) -> str:  # nocoverage
-        return build_support_url("remote_servers_support", self.remote_realm.server.hostname)
+        return build_support_url("remote_servers_support", str(self.remote_realm.uuid))
 
     @override
     def get_customer(self) -> Optional[Customer]:
@@ -4212,7 +4212,7 @@ class RemoteServerBillingSession(BillingSession):
 
     @override
     def support_url(self) -> str:  # nocoverage
-        return build_support_url("remote_servers_support", self.remote_server.hostname)
+        return build_support_url("remote_servers_support", str(self.remote_server.uuid))
 
     @override
     def get_customer(self) -> Optional[Customer]:

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -6985,7 +6985,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertIn("Zulip sponsorship request <noreply-", self.email_display_from(message))
         self.assertIn(
-            "Support URL: http://zulip.testserver/activity/remote/support?q=demo.example.com",
+            f"Support URL: http://zulip.testserver/activity/remote/support?q={remote_realm.uuid!s}",
             message.body,
         )
         self.assertIn("Website: https://infinispan.org", message.body)
@@ -7596,7 +7596,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertIn("Zulip sponsorship request <noreply-", self.email_display_from(message))
         self.assertIn(
-            "Support URL: http://zulip.testserver/activity/remote/support?q=demo.example.com",
+            f"Support URL: http://zulip.testserver/activity/remote/support?q={self.remote_server.uuid!s}",
             message.body,
         )
         self.assertIn("Website: https://infinispan.org", message.body)

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -27,6 +27,8 @@
         {% endif %}
         <br />
         <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
+        <b>UUID</b>: {{ remote_realm.uuid }}<br />
+        <br />
         <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
         <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />
         <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />


### PR DESCRIPTION
Because the remote support page now supports searching by UUID, the support URL for remote billing entities, which is used for sponsorship request emails and overdue invoice emails, can now use the remote server or realm UUID.

Adds the remote realm UUID to the remote support view information.

**Screenshots and screen captures:**

<details>
<summary>Example sponsorship request email from remote realm</summary>

![Screenshot from 2024-02-29 18-05-53](https://github.com/zulip/zulip/assets/63245456/b76b6625-5af9-485c-8e14-1a6dacf2d582)
</details>
<details>
<summary>Remote support view from sponsorship request email link - scrolled down to see remote realm</summary>

![Screenshot from 2024-02-29 18-03-24](https://github.com/zulip/zulip/assets/63245456/788147f7-775e-4181-86fb-30a23f62e1f4)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
