### PR TITLE
Update topic & content of Grafana webhook

### DIFF
--- a/zerver/webhooks/grafana/fixtures/alert_new.json
+++ b/zerver/webhooks/grafana/fixtures/alert_new.json
@@ -18,7 +18,10 @@
         "silenceURL": "https://zuliptestingwh2.grafana.net/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTestAlert&matcher=instance%3DGrafana",
         "dashboardURL": "",
         "panelURL": "",
-        "valueString": "[ metric='foo' labels={instance=bar} value=10 ]"
+        "values": {
+          "foo": 10
+        },
+        "imageURL": "https://grafana.com/assets/img/blog/mixed_styles.png"
       }
     ],
     "groupLabels": {},

--- a/zerver/webhooks/grafana/fixtures/alert_new_multiple.json
+++ b/zerver/webhooks/grafana/fixtures/alert_new_multiple.json
@@ -22,7 +22,10 @@
         "silenceURL": "https://play.grafana.org/alerting/silence/new?alertmanager=grafana&matchers=alertname%3DT2%2Cteam%3Dblue%2Czone%3Dus-1",
         "dashboardURL": "",
         "panelURL": "",
-        "valueString": "[ metric='' labels={} value=14151.331895396988 ]"
+        "values": {
+          "B": 44.23943737541908,
+          "C": 1
+        }
       },
       {
         "status": "firing",
@@ -43,7 +46,10 @@
         "silenceURL": "https://play.grafana.org/alerting/silence/new?alertmanager=grafana&matchers=alertname%3DT1%2Cteam%3Dblue%2Czone%3Deu-1",
         "dashboardURL": "",
         "panelURL": "",
-        "valueString": "[ metric='' labels={} value=47043.702386305304 ]"
+        "values": {
+          "B": 44.23943737541908,
+          "C": 1
+        }
       }
     ],
     "groupLabels": {},

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -137,14 +137,11 @@ Someone is testing the alert notification within grafana.
         )
 
     def test_alert_new(self) -> None:
-        expected_topic_name = "[RESOLVED:1]"
+        expected_topic_name = "[TestAlert]"
         expected_message = """
 :checkbox: **RESOLVED**
 
-Webhook test message.
-
----
-**Alert 1**: TestAlert.
+**TestAlert**
 
 This alert was fired at <time:2022-08-31T05:54:04.52289368Z>.
 
@@ -154,10 +151,14 @@ Labels:
 - alertname: TestAlert
 - instance: Grafana
 
+Values:
+- foo: 10
+
 Annotations:
 - summary: Notification test
 
-1 alert(s) truncated.
+[Silence](https://zuliptestingwh2.grafana.net/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTestAlert&matcher=instance%3DGrafana)
+[Image](https://grafana.com/assets/img/blog/mixed_styles.png)
 """.strip()
 
         self.check_webhook(
@@ -167,46 +168,98 @@ Annotations:
             content_type="application/x-www-form-urlencoded",
         )
 
-    def test_alert_new_multiple(self) -> None:
-        expected_topic_name = "[FIRING:2]"
+    def test_alert_new_no_labels(self) -> None:
+        expected_topic_name = "[57c6d9296de2ad39]"  # fingerprint
         expected_message = """
+:checkbox: **RESOLVED**
+
+This alert was fired at <time:2022-08-31T05:54:04.52289368Z>.
+
+This alert was resolved at <time:2022-08-31T10:30:00.52288431Z>.
+
+""".strip()
+
+        self.check_webhook(
+            "alert_new_no_labels",
+            expected_topic_name,
+            expected_message,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_alert_new_multiple(self) -> None:
+        expected_topic_name_1 = "[High memory usage]"
+        expected_topic_name_2 = "[High CPU usage]"
+        expected_message_1 = """
 :alert: **FIRING**
 
-Webhook test message.
-
----
-**Alert 1**: High memory usage.
+**High memory usage**
 
 This alert was fired at <time:2021-10-12T09:51:03.157076+02:00>.
+
 Labels:
 - alertname: High memory usage
 - team: blue
 - zone: us-1
+
+Values:
+- B: 44.23943737541908
+- C: 1
 
 Annotations:
 - description: The system has high memory usage
 - runbook_url: https://myrunbook.com/runbook/1234
 - summary: This alert was triggered for zone us-1
 
+[Generator](https://play.grafana.org/alerting/1afz29v7z/edit)
+[Silence](https://play.grafana.org/alerting/silence/new?alertmanager=grafana&matchers=alertname%3DT2%2Cteam%3Dblue%2Czone%3Dus-1)
+""".strip()
+        expected_message_2 = """
+:alert: **FIRING**
 
----
-**Alert 2**: High CPU usage.
+**High CPU usage**
 
 This alert was fired at <time:2021-10-12T09:56:03.157076+02:00>.
+
 Labels:
 - alertname: High CPU usage
 - team: blue
 - zone: eu-1
 
+Values:
+- B: 44.23943737541908
+- C: 1
+
 Annotations:
 - description: The system has high CPU usage
 - runbook_url: https://myrunbook.com/runbook/1234
 - summary: This alert was triggered for zone eu-1
+
+[Generator](https://play.grafana.org/alerting/d1rdpdv7k/edit)
+[Silence](https://play.grafana.org/alerting/silence/new?alertmanager=grafana&matchers=alertname%3DT1%2Cteam%3Dblue%2Czone%3Deu-1)
 """.strip()
 
-        self.check_webhook(
-            "alert_new_multiple",
-            expected_topic_name,
-            expected_message,
-            content_type="application/x-www-form-urlencoded",
+        self.subscribe(self.test_user, self.STREAM_NAME)
+        payload = self.get_body("alert_new_multiple")
+
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            payload,
+            content_type="application/json",
+        )
+
+        msg = self.get_second_to_last_message()
+        self.assert_stream_message(
+            message=msg,
+            stream_name=self.STREAM_NAME,
+            topic_name=expected_topic_name_1,
+            content=expected_message_1,
+        )
+
+        msg = self.get_last_message()
+        self.assert_stream_message(
+            message=msg,
+            stream_name=self.STREAM_NAME,
+            topic_name=expected_topic_name_2,
+            content=expected_message_2,
         )


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR attempts to improve the Grafana integration by making the assigned topic more intuitive, as well as adding some additional information to the body of the message.

Previously, the Grafana webhooks would be assigned a topic that looked something like `[FIRING:3]` indicating that 3 alerts were received and they were in the state "firing". Later when that alert was resolved, it would go into a topic such as `[RESOLVED:1]`, if say one of the alerts had been resolved. This caused topics to contain unrelated alerts. The same alert could end up in multiple topics, depending on the number of other alerts that happened to be sent at the same time.

My proposed new behavior will send a separate message for each individual alert, to a topic with the alert's name. So previously where we had a single message go to topic `[FIRING:3]` , we will now have 3 messages go to topics `[My alert]`, `[My other alert]`, and `[My 3rd alert]`, respectively. Then, when you get the resolved message for any one of them it will go to the same topic that the firing message went to.

There were also a few updates to the body of the message, including:
- print a bulleted list of all the values
- add a link to the alert generator
- add a link to the attached screenshot, if it exists

Fixes: initial issue was raised [here](https://chat.zulip.org/#narrow/stream/127-integrations/topic/Customizing.20Grafana.20topic) <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
