### PR TITLE
base_page_params: Restore google_analytics_id

### DIFF
--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -9,6 +9,7 @@ const t1 = performance.now();
 const default_params_schema = z.object({
     page_type: z.literal("default"),
     development_environment: z.boolean(),
+    google_analytics_id: z.optional(z.string()),
     realm_sentry_key: z.optional(z.string()),
     request_language: z.string(),
     server_sentry_dsn: z.nullable(z.string()),


### PR DESCRIPTION
This was broken in commit a4938d3760d5d9c67fb3c4f72274d8f775321931 (#28971).