### PR TITLE
docs: Fix broken Markdown links from recent reorganization.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -212,6 +212,9 @@ directory if you want to customize. A good example of doing this is
 in the [kandra Puppet configuration][zulipchat-puppet] that we use
 as part of managing chat.zulip.org and zulip.com.
 
+[standalone.pp]: https://github.com/zulip/zulip/blob/main/puppet/zulip/manifests/profile/standalone.pp
+[zulipchat-puppet]: https://github.com/zulip/zulip/tree/main/puppet/kandra/manifests
+
 ### Using Zulip with Amazon RDS as the database
 
 You can use DBaaS services like Amazon RDS for the Zulip database.

--- a/docs/production/reverse-proxies.md
+++ b/docs/production/reverse-proxies.md
@@ -127,10 +127,6 @@ that your Zulip server sits at `https://10.10.10.10:443`; see
    `ssl_certificate_key` and `proxy_pass` with the appropriate values
    for your deployment.
 
-[nginx-proxy-longpolling-config]: https://github.com/zulip/zulip/blob/main/puppet/zulip/files/nginx/zulip-include-common/proxy_longpolling
-[standalone.pp]: https://github.com/zulip/zulip/blob/main/puppet/zulip/manifests/profile/standalone.pp
-[zulipchat-puppet]: https://github.com/zulip/zulip/tree/main/puppet/kandra/manifests
-
 ### Apache2 configuration
 
 Below is a working example of a full Apache2 configuration. It assumes
@@ -275,3 +271,5 @@ things you need to be careful about when configuring it:
    unexpectedly (e.g. pointing to a DNS name that you haven't configured
    with multiple IPs for your Zulip machine; sometimes this happens with
    IPv6 configuration).
+
+[nginx-proxy-longpolling-config]: https://github.com/zulip/zulip/blob/main/puppet/zulip/files/nginx/zulip-include-common/proxy_longpolling


### PR DESCRIPTION
Introduced in 2b9506840684ceb9e27ba5b509561be509d7059d.
