### PR TITLE
remote-support: Show remote realm matches if deactivated.

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -490,11 +490,9 @@ def get_remote_servers_for_support(
 
     if uuid_to_search:
         remote_servers_set = set(remote_servers_query.filter(uuid__iexact=uuid_to_search))
-        remote_realm_matches = (
-            RemoteRealm.objects.filter(uuid__iexact=uuid_to_search)
-            .exclude(realm_deactivated=True)
-            .select_related("server")
-        )
+        remote_realm_matches = RemoteRealm.objects.filter(
+            uuid__iexact=uuid_to_search
+        ).select_related("server")
         for remote_realm in remote_realm_matches:
             remote_servers_set.add(remote_realm.server)
         return list(remote_servers_set)
@@ -504,9 +502,7 @@ def get_remote_servers_for_support(
             remote_servers_query.filter(hostname__icontains=hostname_to_search)
         )
         remote_realm_matches = (
-            RemoteRealm.objects.filter(host__icontains=hostname_to_search).exclude(
-                realm_deactivated=True
-            )
+            RemoteRealm.objects.filter(host__icontains=hostname_to_search)
         ).select_related("server")
         for remote_realm in remote_realm_matches:
             remote_servers_set.add(remote_realm.server)


### PR DESCRIPTION
As a follow-up to commit d66b7ad853 (#29120), where we send internal emails when an active paid plan is on a locally deleted remote realm, we need search queries in the remote support view to return results for these deactivated remote realms, instead of excluding them. Particularly since the support URL generated for these emails uses the remote realm UUID as of #29125.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
