### PR TITLE
remote-support: Show deactivated servers in search results.

### DIFF
--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -44,8 +44,15 @@
         {% include 'corporate/support/push_status_details.html' %}
     {% endwith %}
 
-
-    {% if remote_realm.plan_type != SPONSORED_PLAN_TYPE %}
+    {% if remote_server_deactivated %}
+    <div class="remote-support-sponsorship-container">
+        {% with %}
+            {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
+            {% set format_discount = format_discount %}
+            {% include 'corporate/support/sponsorship_details.html' %}
+        {% endwith %}
+    </div>
+    {% elif remote_realm.plan_type != SPONSORED_PLAN_TYPE %}
     <div class="remote-support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
@@ -87,7 +94,7 @@
             {% include 'corporate/support/next_plan_details.html' %}
         {% endwith %}
     </div>
-    {% else %}
+    {% elif not remote_server_deactivated %}
     <div class="next-plan-container">
         {% with %}
             {% set is_current_plan_billable = support_data[remote_realm.id].plan_data.is_current_plan_billable %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -33,10 +33,15 @@
 
     <div id="remote-server-query-results">
         {% for remote_server in remote_servers %}
-        <div class="remote-support-query-result">
+        {% if remote_server.deactivated %}
+        {% set remote_server_query_result_class = "remote-support-query-result remote-server-deactivated" %}
+        {% else %}
+        {% set remote_server_query_result_class = "remote-support-query-result" %}
+        {% endif %}
+        <div class="{{ remote_server_query_result_class }}">
             <div class="remote-server-section">
                 <div class="remote-server-information">
-                    <span class="label">remote server</span>
+                    <span class="label">remote server{% if remote_server.deactivated %}: deactivated{% endif %}</span>
                     <h3>{{ remote_server.hostname }} {{ server_analytics_link(remote_server.id ) }}</h3>
                     {% if remote_server.plan_type == SPONSORED_PLAN_TYPE %}
                         <p class="support-section-header">On 100% sponsored Zulip Community plan 🎉</p>
@@ -81,7 +86,15 @@
                     {% include 'corporate/support/push_status_details.html' %}
                 {% endwith %}
 
-                {% if remote_server.plan_type != SPONSORED_PLAN_TYPE %}
+                {% if remote_server.deactivated %}
+                <div class="remote-support-sponsorship-container">
+                    {% with %}
+                        {% set sponsorship_data = remote_servers_support_data[remote_server.id].sponsorship_data %}
+                        {% set format_discount = format_discount %}
+                        {% include 'corporate/support/sponsorship_details.html' %}
+                    {% endwith %}
+                </div>
+                {% elif remote_server.plan_type != SPONSORED_PLAN_TYPE %}
                 <div class="remote-support-sponsorship-container">
                     {% with %}
                         {% set sponsorship_data = remote_servers_support_data[remote_server.id].sponsorship_data %}
@@ -123,7 +136,7 @@
                         {% include 'corporate/support/next_plan_details.html' %}
                     {% endwith %}
                 </div>
-                {% else %}
+                {% elif not remote_server.deactivated %}
                 <div class="next-plan-container">
                     {% with %}
                         {% set is_current_plan_billable = remote_servers_support_data[remote_server.id].plan_data.is_current_plan_billable %}
@@ -144,6 +157,7 @@
                 {% for remote_realm in remote_realms[remote_server.id] %}
                 <div>
                     {% with %}
+                        {% set remote_server_deactivated = remote_server.deactivated %}
                         {% set support_data = remote_realms_support_data %}
                         {% set get_plan_type_name = get_plan_type_name %}
                         {% set format_discount = format_discount %}

--- a/templates/corporate/support/sponsorship_details.html
+++ b/templates/corporate/support/sponsorship_details.html
@@ -1,0 +1,26 @@
+<div class="remote-sponsorship-details">
+    <p class="support-section-header">💸 Discount and sponsorship information:</p>
+    <b>Sponsorship pending</b>: {{ sponsorship_data.sponsorship_pending }}<br />
+    {% if sponsorship_data.default_discount %}
+        <b>Discount</b>: {{ format_discount(sponsorship_data.default_discount) }}%<br />
+    {% else %}
+        <b>Discount</b>: None<br />
+    {% endif %}
+    <b>Minimum licenses</b>: {{ sponsorship_data.minimum_licenses }}<br />
+    {% if sponsorship_data.required_plan_tier %}
+        {% for plan_tier in REMOTE_PLAN_TIERS %}
+            {% if sponsorship_data.required_plan_tier == plan_tier.value %}
+                <b>Required plan tier</b>: {{ plan_tier.name }}<br />
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        <b>Required plan tier</b>: None<br />
+    {% endif %}
+</div>
+
+{% if sponsorship_data.sponsorship_pending %}
+    {% with %}
+        {% set latest_sponsorship_request = sponsorship_data.latest_sponsorship_request %}
+        {% include 'corporate/support/sponsorship_request_details.html' %}
+    {% endwith %}
+{% endif %}

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -63,20 +63,8 @@
 </form>
 
 {% if sponsorship_data.sponsorship_pending %}
-<div class="">
-    <p class="support-section-header">Sponsorship request information:</p>
-    {% if sponsorship_data.latest_sponsorship_request %}
-    <ul>
-        <li><b>Organization type</b>: {{ sponsorship_data.latest_sponsorship_request.org_type }}</li>
-        <li><b>Organization website</b>: {{ sponsorship_data.latest_sponsorship_request.org_website }}</li>
-        <li><b>Organization description</b>: {{ sponsorship_data.latest_sponsorship_request.org_description }}</li>
-        <li><b>Estimated total users</b>: {{ sponsorship_data.latest_sponsorship_request.total_users }}</li>
-        <li><b>Paid staff</b>: {{ sponsorship_data.latest_sponsorship_request.paid_users }}</li>
-        <li><b>Description of paid staff</b>: {{ sponsorship_data.latest_sponsorship_request.paid_users_description }}</li>
-        <li><b>Requested plan</b>: {{ sponsorship_data.latest_sponsorship_request.requested_plan }}</li>
-    </ul>
-    {% else %}
-    <b>No sponsorship requests have been submitted.</b><br /><br />
-    {% endif %}
-</div>
+    {% with %}
+        {% set latest_sponsorship_request = sponsorship_data.latest_sponsorship_request %}
+        {% include 'corporate/support/sponsorship_request_details.html' %}
+    {% endwith %}
 {% endif %}

--- a/templates/corporate/support/sponsorship_request_details.html
+++ b/templates/corporate/support/sponsorship_request_details.html
@@ -1,0 +1,16 @@
+<div class="remote-sponsorship-details">
+    <p class="support-section-header">Sponsorship request information:</p>
+    {% if latest_sponsorship_request %}
+        <ul>
+            <li><b>Organization type</b>: {{ latest_sponsorship_request.org_type }}</li>
+            <li><b>Organization website</b>: {{ latest_sponsorship_request.org_website }}</li>
+            <li><b>Organization description</b>: {{ latest_sponsorship_request.org_description }}</li>
+            <li><b>Estimated total users</b>: {{ latest_sponsorship_request.total_users }}</li>
+            <li><b>Paid staff</b>: {{ latest_sponsorship_request.paid_users }}</li>
+            <li><b>Description of paid staff</b>: {{ latest_sponsorship_request.paid_users_description }}</li>
+            <li><b>Requested plan</b>: {{ latest_sponsorship_request.requested_plan }}</li>
+        </ul>
+    {% else %}
+        <b>No sponsorship requests have been submitted.</b>
+    {% endif %}
+</div>

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -260,6 +260,18 @@ tr.admin td:first-child {
     }
 }
 
+.remote-support-query-result.remote-server-deactivated {
+    background-color: hsl(2deg 64% 58%);
+
+    .remote-server-section {
+        background-color: hsl(22deg 100% 92%);
+    }
+
+    .remote-realms-section {
+        background-color: hsl(23deg 100% 95%);
+    }
+}
+
 .delete-user-form {
     margin: 8px 0;
 }
@@ -288,6 +300,7 @@ tr.admin td:first-child {
     top: -2px;
 }
 
+.remote-sponsorship-details,
 .support-form,
 .remote-form,
 .next-plan-information,


### PR DESCRIPTION
The remote support view now returns results for deactivated remote servers with those results sorted to the end and formatted to visually stand out.

**Notes**:
- Forms to change sponsorship and discount fields on the customer for the remote server or realm are not shown, but the data stored on the customer object is shown, including any sponsorship request information (if the customer had a sponsorship request pending when it was deactivated).
- Forms to schedule a plan are also not shown for deactivated servers and their associated remote realms.
- Forms and information for any current plan or scheduled plan, for either the deactivated remote server or its associated remote realms, are shown so that support staff can update those plans if necessary.
- Pulls out the information about the latest sponsorship request into a separate template. This will also help with adding this information to the Zulip Cloud support view.
- Deactivated servers are still not shown in the remote activity view. These changes only impact the remote support view.

**Screenshots and screen captures:**

<details>
<summary>Active remote server with these updates</summary>

![Screenshot from 2024-03-01 18-10-30](https://github.com/zulip/zulip/assets/63245456/4f98710b-05da-4e68-93b2-49a5638d0ed7)
</details>
<details>
<summary>Deactivated server that had some discount fields updated before they deactivated</summary>

![Screenshot from 2024-03-01 18-01-30](https://github.com/zulip/zulip/assets/63245456/9482329e-ef4d-425b-ae22-bef6f33544ba)
</details>
<details>
<summary>Deactivated server that had a pending sponsorship request when they deactivated</summary>

![Screenshot from 2024-03-01 18-02-02](https://github.com/zulip/zulip/assets/63245456/f6d368e3-08bc-4833-967e-82696e05e635)
</details>
<details>
<summary>Deactivated server that was on the Community plan when they deactivated</summary>

![Screenshot from 2024-03-01 18-08-48](https://github.com/zulip/zulip/assets/63245456/1781770d-4d3c-407c-a80e-60e82be9e6eb)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
