### PR TITLE
rows: Make errors fatal in id, local_echo_id

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -232,11 +232,9 @@ export function initialize(): void {
         e.preventDefault();
 
         const message_id = rows.id($(e.currentTarget).closest(".message_row"));
-        assert(message_id !== undefined);
         assert(message_lists.current !== undefined);
         const $row = message_lists.current.get_row(message_id);
         const row_id = rows.id($row);
-        assert(row_id !== undefined);
         const message = message_lists.current.get(row_id);
         assert(message !== undefined);
 

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -297,7 +297,7 @@ export function visible_messages(require_fully_visible: boolean): Message[] {
 
     function row_to_id(row: HTMLElement): Message {
         assert(message_lists.current !== undefined);
-        return message_lists.current.get(rows.id($(row))!)!;
+        return message_lists.current.get(rows.id($(row)))!;
     }
 
     // Being simplistic about this, the smallest message is 25 px high.
@@ -512,7 +512,7 @@ export function keep_pointer_in_view(): void {
         adjust(message_is_far_enough_up, rows.prev_visible);
     }
 
-    message_lists.current.select_id(rows.id($next_row)!, {from_scroll: true});
+    message_lists.current.select_id(rows.id($next_row), {from_scroll: true});
 }
 
 export function scroll_to_selected(): void {

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -75,7 +75,6 @@ function get_message_for_message_content($content: JQuery): Message | undefined 
         return undefined;
     }
     const message_id = rows.id($message_row);
-    assert(message_id !== undefined);
     return message_store.get(message_id);
 }
 

--- a/web/src/rows.ts
+++ b/web/src/rows.ts
@@ -61,7 +61,7 @@ export function visible_range(start_id: number, end_id: number): JQuery[] {
     let $row = message_lists.current.get_row(start_id);
     let msg_id = id($row);
 
-    while (msg_id !== undefined && msg_id <= end_id) {
+    while (msg_id <= end_id) {
         rows.push($row);
 
         if (msg_id >= end_id) {
@@ -78,10 +78,9 @@ export function is_overlay_row($row: JQuery): boolean {
     return $row.closest(".overlay-message-row").length >= 1;
 }
 
-export function id($message_row: JQuery): number | undefined {
+export function id($message_row: JQuery): number {
     if (is_overlay_row($message_row)) {
-        blueslip.error("Drafts and scheduled messages have no message id.");
-        return undefined;
+        throw new Error("Drafts and scheduled messages have no message id.");
     }
 
     if ($message_row.length !== 1) {
@@ -97,12 +96,11 @@ export function id($message_row: JQuery): number | undefined {
     return Number.parseFloat(message_id);
 }
 
-export function local_echo_id($message_row: JQuery): string | undefined {
+export function local_echo_id($message_row: JQuery): string {
     const message_id = $message_row.attr("data-message-id");
 
     if (message_id === undefined) {
-        blueslip.error("Calling code passed rows.local_id a row with no `data-message-id` attr.");
-        return undefined;
+        throw new Error("Calling code passed rows.local_id a row with no `data-message-id` attr.");
     }
 
     if (!message_id.includes(".0")) {
@@ -112,7 +110,7 @@ export function local_echo_id($message_row: JQuery): string | undefined {
     return message_id;
 }
 
-export function get_message_id(elem: HTMLElement): number | undefined {
+export function get_message_id(elem: HTMLElement): number {
     // Gets the message_id for elem, where elem is a DOM
     // element inside a message.  This is typically used
     // in click handlers for things like the reaction button.
@@ -150,9 +148,6 @@ export function get_message_recipient_header($message_row: JQuery): JQuery {
 
 export function recipient_from_group(message_group: string): Message | undefined {
     const message_id = id($(message_group).children(".message_row").first().expectOne());
-    if (message_id === undefined) {
-        return undefined;
-    }
     return message_store.get(message_id);
 }
 
@@ -160,7 +155,7 @@ export function is_header_of_row_sticky($recipient_row: JQuery): boolean {
     return $recipient_row.find(".message_header").hasClass("sticky_header");
 }
 
-export function id_for_recipient_row($recipient_row: JQuery): number | undefined {
+export function id_for_recipient_row($recipient_row: JQuery): number {
     if (is_header_of_row_sticky($recipient_row)) {
         const msg_id = message_lists.current?.view.sticky_recipient_message_id;
         if (msg_id !== undefined) {

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -118,7 +118,6 @@ export function register_click_handlers(): void {
         const $elt = $(e.currentTarget);
         const $row = $elt.closest(".message_row");
         const message_id = rows.id($row);
-        assert(message_id !== undefined);
 
         assert(message_lists.current !== undefined);
         const message = message_lists.current.get(message_id);


### PR DESCRIPTION
This lets us simplify their types and remove dead error-handling code.