### PR TITLE
:Renamed Display settings to preferences

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1346,7 +1346,7 @@ No changes; feature level used for Zulip 5.0 release.
 
 * [`GET /events`](/api/get-events): Introduced the `user_settings`
   event type, unifying and replacing the previous
-  `update_display_settings` and `update_global_notifications` event
+  `update_preferences` and `update_global_notifications` event
   types. The legacy event types are still supported for backwards
   compatibility, but will be removed in a future release.
 * [`POST /register`](/api/register-queue): Added `user_settings` field
@@ -1358,7 +1358,7 @@ No changes; feature level used for Zulip 5.0 release.
   `user_settings_object` property to supported `client_capabilities`.
   When enabled, the server will not include a duplicate copy of
   personal settings in the top-level response.
-* [`GET /events`](/api/get-events): `update_display_settings` and
+* [`GET /events`](/api/get-events): `update_preferences` and
   `update_global_notifications` events now only sent to clients that
   did not include `user_settings_object` in their
   `client_capabilities` when the event queue was created.
@@ -1381,7 +1381,7 @@ No changes; feature level used for Zulip 5.0 release.
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue):
   Added new `enable_drafts_synchronization` setting under
-  `update_display_settings`.
+  `update_preferences`.
 
 * [`GET /drafts`](/api/get-drafts): Added new endpoint to fetch user's
   synced drafts from the server.
@@ -2103,7 +2103,7 @@ No changes; feature level used for Zulip 3.0 release.
   `create_stream_policy`, `digest_emails_enabled`, `digest_weekday`,
   `user_group_edit_policy`, and `avatar_changes_disabled` organization settings.
 * Added `fluid_layout_width`, `desktop_icon_count_display`, and
-  `demote_inactive_streams` display settings.
+  `demote_inactive_streams` preferences.
 * `enable_stream_sounds` was renamed to
   `enable_stream_audible_notifications`.
 * [`POST /users/me/subscriptions/properties`](/api/update-subscription-settings):

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -173,7 +173,7 @@ _Released 2023-12-15_
   support an upcoming mobile feature. Realms now have a UUID sent to
   the push notifications service to simplify migrating via
   export/import into a different server.
-- Display settings was renamed to Preferences.
+- preferences was renamed to Preferences.
 - "Default view" was renamed to "home view".
 - The manage streams UI has a cleaner design for changing
   subscriptions, can now directly manage default streams, and has
@@ -1589,7 +1589,7 @@ _Released 2021-05-13_
 - "Recent topics" is no longer beta, no longer an overlay, supports
   composing messages, and is now the default view. The previous
   default view, "All messages", is still available, and the default
-  view can now be configured via "Display settings".
+  view can now be configured via "preferences".
 - Completed API documentation for Zulip's real-time events system. It
   is now possible to write a decent Zulip client with minimal
   interaction with the Zulip server development team.
@@ -3551,7 +3551,7 @@ _Released 2016-08-25_
   Zulip.
 - Added support for using Ubuntu 16.04 in production.
 - Added a powerful and complete realm import/export tool.
-- Added nice UI for selecting a default language to display settings.
+- Added nice UI for selecting a default language to preferences.
 - Added UI for searching streams in left sidebar with hotkeys.
 - Added Semaphore, Bitbucket, and HelloWorld (example) integrations.
 - Added new webhook-based integration for Trello.

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -189,7 +189,7 @@ export function build_page() {
         color_scheme_values: settings_config.color_scheme_values,
         web_home_view_values: settings_config.web_home_view_values,
         settings_object: realm_user_settings_defaults,
-        display_settings: settings_config.get_all_preferences(),
+        preferences: settings_config.get_all_preferences(),
         settings_label: settings_config.realm_user_settings_defaults_labels,
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         enable_sound_select:

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -229,9 +229,9 @@ function do_hashchange_overlay(old_hash) {
     }
 
     const coming_from_overlay = hash_parser.is_overlay_hash(old_hash);
-    if (section === "display-settings") {
-        // Since display-settings was deprecated and replaced with preferences
-        // #settings/display-settings is being redirected to #settings/preferences.
+    if (section === "preferences") {
+        // Since preferences was deprecated and replaced with preferences
+        // #settings/preferences is being redirected to #settings/preferences.
         section = "preferences";
     }
     if ((base === "settings" || base === "organization") && !section) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -690,7 +690,7 @@ export function dispatch_normal_event(event) {
                 break;
             }
 
-            const user_display_settings = [
+            const user_preferences = [
                 "color_scheme",
                 "default_language",
                 "web_home_view",
@@ -714,7 +714,7 @@ export function dispatch_normal_event(event) {
             ];
 
             const original_home_view = user_settings.web_home_view;
-            if (user_display_settings.includes(event.property)) {
+            if (user_preferences.includes(event.property)) {
                 user_settings[event.property] = event.value;
             }
             if (event.property === "default_language") {

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -118,7 +118,7 @@ export function build_page() {
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
         show_push_notifications_tooltip:
             settings_config.all_notifications(user_settings).show_push_notifications_tooltip,
-        display_settings: settings_config.get_all_preferences(),
+        preferences: settings_config.get_all_preferences(),
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
         user_can_change_email: settings_data.user_can_change_email(),

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -131,7 +131,7 @@ export const twenty_four_hour_time_values = {
 
 export type DisplaySettings = {
     settings: {
-        user_display_settings: string[];
+        user_preferences: string[];
     };
     render_only: {
         high_contrast_mode: boolean;
@@ -142,7 +142,7 @@ export type DisplaySettings = {
 /* istanbul ignore next */
 export const get_all_preferences = (): DisplaySettings => ({
     settings: {
-        user_display_settings: [
+        user_preferences: [
             "dense_mode",
             "high_contrast_mode",
             "fluid_layout_width",

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -155,12 +155,12 @@
             </select>
         </div>
 
-        {{#each display_settings.settings.user_display_settings}}
+        {{#each preferences.settings.user_preferences}}
             {{> settings_checkbox
               setting_name=this
               is_checked=(lookup ../settings_object this)
               label=(lookup ../settings_label this)
-              render_only=(lookup ../display_settings.render_only this)
+              render_only=(lookup ../preferences.render_only this)
               prefix=../prefix}}
         {{/each}}
 

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -6,7 +6,7 @@
             {{#*inline "z-link"}}<a href="/help/configure-default-new-user-settings" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
         {{/tr}}
     </div>
-    {{> display_settings prefix="realm_" for_realm_settings=true full_name=full_name}}
+    {{> preferences prefix="realm_" for_realm_settings=true full_name=full_name}}
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
 

--- a/web/templates/settings/user_display_settings.hbs
+++ b/web/templates/settings/user_display_settings.hbs
@@ -1,3 +1,3 @@
 <div id="user-preferences" class="settings-section" data-name="preferences">
-    {{> display_settings prefix="user_" for_realm_settings=false}}
+    {{> preferences prefix="user_" for_realm_settings=false}}
 </div>

--- a/web/templates/settings_tab.hbs
+++ b/web/templates/settings_tab.hbs
@@ -3,7 +3,7 @@
 
     {{> settings/account_settings }}
 
-    {{> settings/user_display_settings }}
+    {{> settings/user_preferences }}
 
     {{> settings/user_notification_settings }}
 

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -89,7 +89,7 @@ run_test("tr_tag", ({mock_template}) => {
     const args = {
         botserverrc: "botserverrc",
         date_joined_text: "Mar 21, 2022",
-        display_settings: {
+        preferences: {
             settings: {},
         },
         notification_settings: {},

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -480,12 +480,12 @@ def do_change_user_setting(
         }
         send_event_on_commit(user_profile.realm, legacy_event, [user_profile.id])
 
-    if setting_name in UserProfile.display_settings_legacy or setting_name == "timezone":
+    if setting_name in UserProfile.preferences_legacy or setting_name == "timezone":
         # This legacy event format is for backwards-compatibility with
         # clients that don't support the new user_settings event type.
         # We only send this for settings added before Feature level 89.
         legacy_event = {
-            "type": "update_display_settings",
+            "type": "update_preferences",
             "user": user_profile.email,
             "setting_name": setting_name,
             "setting": setting_value,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1518,9 +1518,9 @@ typing_stop_event = event_dict_type(
 )
 check_typing_stop = make_checker(typing_stop_event)
 
-update_display_settings_event = event_dict_type(
+update_preferences_event = event_dict_type(
     required_keys=[
-        ("type", Equals("update_display_settings")),
+        ("type", Equals("update_preferences")),
         ("setting_name", str),
         ("setting", value_type),
         ("user", str),
@@ -1529,7 +1529,7 @@ update_display_settings_event = event_dict_type(
         ("language_name", str),
     ],
 )
-_check_update_display_settings = make_checker(update_display_settings_event)
+_check_update_preferences = make_checker(update_preferences_event)
 
 user_settings_update_event = event_dict_type(
     required_keys=[
@@ -1546,7 +1546,7 @@ user_settings_update_event = event_dict_type(
 _check_user_settings_update = make_checker(user_settings_update_event)
 
 
-def check_update_display_settings(
+def check_update_preferences(
     var_name: str,
     event: Dict[str, object],
 ) -> None:
@@ -1555,7 +1555,7 @@ def check_update_display_settings(
     is more specifically typed according to the
     UserProfile.property_types dictionary.
     """
-    _check_update_display_settings(var_name, event)
+    _check_update_preferences(var_name, event)
     setting_name = event["setting_name"]
     setting = event["setting"]
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -642,8 +642,8 @@ def fetch_initial_state_data(
     if want("stop_words"):
         state["stop_words"] = read_stop_words()
 
-    if want("update_display_settings") and not user_settings_object:
-        for prop in UserProfile.display_settings_legacy:
+    if want("update_preferences") and not user_settings_object:
+        for prop in UserProfile.preferences_legacy:
             state[prop] = getattr(settings_user, prop)
         state["emojiset_choices"] = UserProfile.emojiset_choices()
         state["timezone"] = canonicalize_timezone(settings_user.timezone)
@@ -1405,9 +1405,9 @@ def apply_event(
             state["realm_linkifiers"] = event["realm_linkifiers"]
     elif event["type"] == "realm_playgrounds":
         state["realm_playgrounds"] = event["realm_playgrounds"]
-    elif event["type"] == "update_display_settings":
+    elif event["type"] == "update_preferences":
         if event["setting_name"] != "timezone":
-            assert event["setting_name"] in UserProfile.display_settings_legacy
+            assert event["setting_name"] in UserProfile.preferences_legacy
         state[event["setting_name"]] = event["setting"]
     elif event["type"] == "update_global_notifications":
         assert event["notification_name"] in UserProfile.notification_settings_legacy
@@ -1418,7 +1418,7 @@ def apply_event(
         if event["property"] != "timezone":
             assert event["property"] in UserProfile.property_types
         if event["property"] in {
-            **UserProfile.display_settings_legacy,
+            **UserProfile.preferences_legacy,
             **UserProfile.notification_settings_legacy,
         }:
             state[event["property"]] = event["value"]

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -259,7 +259,7 @@ class UserBaseSettings(models.Model):
 
     EMAIL_ADDRESS_VISIBILITY_TYPES = list(EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.keys())
 
-    display_settings_legacy = dict(
+    preferences_legacy = dict(
         # Don't add anything new to this legacy dict.
         # Instead, see `modern_settings` below.
         color_scheme=int,
@@ -335,7 +335,7 @@ class UserBaseSettings(models.Model):
 
     # Define the types of the various automatically managed properties
     property_types = {
-        **display_settings_legacy,
+        **preferences_legacy,
         **notification_setting_types,
         **modern_settings,
     }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -251,7 +251,7 @@ paths:
                             - type: object
                               description: |
                                 Event sent to clients that have requested the
-                                `update_display_settings` event type and did not include
+                                `update_preferences` event type and did not include
                                 `user_settings_object` in their `client_capabilities` when
                                 registering the event queue.
 
@@ -266,7 +266,7 @@ paths:
                                   allOf:
                                     - $ref: "#/components/schemas/EventTypeSchema"
                                     - enum:
-                                        - update_display_settings
+                                        - update_preferences
                                 user:
                                   type: string
                                   description: |
@@ -291,7 +291,7 @@ paths:
                               additionalProperties: false
                               example:
                                 {
-                                  "type": "update_display_settings",
+                                  "type": "update_preferences",
                                   "user": "iago@zulip.com",
                                   "setting_name": "high_contrast_mode",
                                   "setting": false,
@@ -347,7 +347,7 @@ paths:
                                 have changed.
 
                                 **Changes**: New in Zulip 5.0 (feature level 89), replacing the
-                                previous `update_display_settings` and `update_global_notifications`
+                                previous `update_preferences` and `update_global_notifications`
                                 event types, which are still present for backwards compatibility reasons.
                               properties:
                                 id:
@@ -11917,14 +11917,14 @@ paths:
 
                     - `user_settings_object`: Boolean for whether the client supports the modern
                       `user_settings` event type. If false, the server will additionally send the
-                      legacy `update_global_notifications` and `update_display_settings` event
+                      legacy `update_global_notifications` and `update_preferences` event
                       types.
                       <br />
                       **Changes**: New in Zulip 5.0 (feature level 89). This capability is for
                       backwards-compatibility; it will be removed in a future server release.
                       Because the feature level 89 API changes were merged together, clients can
                       safely make a request with this client capability and also request all three
-                      event types (`user_settings`, `update_display_settings`,
+                      event types (`user_settings`, `update_preferences`,
                       `update_global_notifications`), and get exactly one copy of settings data on
                       any server version. Clients can then use the `zulip_feature_level` in the
                       `/register` response or the presence/absence of a `user_settings` key to
@@ -13744,7 +13744,7 @@ paths:
                         deprecated: true
                         type: integer
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13762,7 +13762,7 @@ paths:
                         deprecated: true
                         type: string
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13780,7 +13780,7 @@ paths:
                         deprecated: true
                         type: integer
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13798,7 +13798,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13817,7 +13817,7 @@ paths:
                         deprecated: true
                         type: string
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13835,7 +13835,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13856,7 +13856,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13874,7 +13874,7 @@ paths:
                         deprecated: true
                         type: string
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13898,7 +13898,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13916,7 +13916,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13936,7 +13936,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13955,7 +13955,7 @@ paths:
                         deprecated: true
                         type: string
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13974,7 +13974,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -13993,7 +13993,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -14012,7 +14012,7 @@ paths:
                         deprecated: true
                         type: boolean
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
@@ -14025,14 +14025,14 @@ paths:
 
                           Prior to Zulip 5.0 (feature level 84), this field was present
                           in response if `realm_user` was present in `fetch_event_types`, not
-                          `update_display_settings`.
+                          `update_preferences`.
 
                           [capabilities]: /api/register-queue#parameter-client_capabilities
                           [set-enter-send]: /help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message
                       emojiset_choices:
                         deprecated: true
                         description: |
-                          Present if `update_display_settings` is present in `fetch_event_types`
+                          Present if `update_preferences` is present in `fetch_event_types`
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -756,7 +756,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
         self.assertIn("user_settings", result)
         for prop in UserProfile.property_types:
             if prop in {
-                **UserProfile.display_settings_legacy,
+                **UserProfile.preferences_legacy,
                 **UserProfile.notification_settings_legacy,
             }:
                 # Only legacy settings are included in the top level.
@@ -1187,7 +1187,7 @@ class FetchQueriesTest(ZulipTestCase):
             stream=3,
             stop_words=0,
             subscription=4,
-            update_display_settings=0,
+            update_preferences=0,
             update_global_notifications=0,
             update_message_flags=5,
             user_settings=0,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -185,7 +185,7 @@ from zerver.lib.event_schema import (
     check_subscription_update,
     check_typing_start,
     check_typing_stop,
-    check_update_preferences,
+    check_update_display_settings,
     check_update_global_notifications,
     check_update_message,
     check_update_message_flags_add,
@@ -3861,10 +3861,10 @@ class UserDisplayActionTest(BaseAction):
         user_settings_object = True
         num_events = 1
 
-        legacy_setting = setting_name in UserProfile.preferences_legacy
+        legacy_setting = setting_name in UserProfile.display_settings_legacy
         if legacy_setting:
-            # Two events:`update_preferences` and `user_settings`.
-            # `update_preferences` is only sent for settings added
+            # Two events:`update_display_settings` and `user_settings`.
+            # `update_display_settings` is only sent for settings added
             # before feature level 89 which introduced `user_settings`.
             # We send both events so that older clients that do not
             # rely on `user_settings` don't break.
@@ -3914,7 +3914,7 @@ class UserDisplayActionTest(BaseAction):
                 # Only settings added before feature level 89
                 # generate this event.
                 self.assert_length(events, 2)
-                check_update_preferences("events[1]", events[1])
+                check_update_display_settings("events[1]", events[1])
 
     def test_change_user_settings(self) -> None:
         for prop in UserProfile.property_types:
@@ -3940,7 +3940,7 @@ class UserDisplayActionTest(BaseAction):
             )
 
             check_user_settings_update("events[0]", events[0])
-            check_update_preferences("events[1]", events[1])
+            check_update_display_settings("events[1]", events[1])
             check_realm_user_update("events[2]", events[2], "timezone")
 
     def test_delivery_email_events_on_changing_email_address_visibility(self) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -185,7 +185,7 @@ from zerver.lib.event_schema import (
     check_subscription_update,
     check_typing_start,
     check_typing_stop,
-    check_update_display_settings,
+    check_update_preferences,
     check_update_global_notifications,
     check_update_message,
     check_update_message_flags_add,
@@ -3861,10 +3861,10 @@ class UserDisplayActionTest(BaseAction):
         user_settings_object = True
         num_events = 1
 
-        legacy_setting = setting_name in UserProfile.display_settings_legacy
+        legacy_setting = setting_name in UserProfile.preferences_legacy
         if legacy_setting:
-            # Two events:`update_display_settings` and `user_settings`.
-            # `update_display_settings` is only sent for settings added
+            # Two events:`update_preferences` and `user_settings`.
+            # `update_preferences` is only sent for settings added
             # before feature level 89 which introduced `user_settings`.
             # We send both events so that older clients that do not
             # rely on `user_settings` don't break.
@@ -3914,7 +3914,7 @@ class UserDisplayActionTest(BaseAction):
                 # Only settings added before feature level 89
                 # generate this event.
                 self.assert_length(events, 2)
-                check_update_display_settings("events[1]", events[1])
+                check_update_preferences("events[1]", events[1])
 
     def test_change_user_settings(self) -> None:
         for prop in UserProfile.property_types:
@@ -3940,7 +3940,7 @@ class UserDisplayActionTest(BaseAction):
             )
 
             check_user_settings_update("events[0]", events[0])
-            check_update_display_settings("events[1]", events[1])
+            check_update_preferences("events[1]", events[1])
             check_realm_user_update("events[2]", events[2], "timezone")
 
     def test_delivery_email_events_on_changing_email_address_visibility(self) -> None:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -241,10 +241,10 @@ class ClientDescriptor:
             # client_capability is enabled, for backwards compatibility.
             return self.stream_typing_notifications
         if self.user_settings_object and event["type"] in [
-            "update_display_settings",
+            "update_preferences",
             "update_global_notifications",
         ]:
-            # 'update_display_settings' and 'update_global_notifications'
+            # 'update_preferences' and 'update_global_notifications'
             # events are sent only if user_settings_object is False,
             # otherwise only 'user_settings' event is sent.
             return False


### PR DESCRIPTION
<!-- Describe your pull request here.--> I have renamed the display setting as mentioned in the below thread, to preferences.

Fixes: <!-- Issue link, or clear description.--> https://github.com/zulip/zulip/issues/26874

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ yes] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [yes ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ yes] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ yes] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ yes] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
