### PR TITLE
compose_fade: Convert module to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -69,7 +69,7 @@ EXEMPT_FILES = make_set(
         "web/src/compose_banner.ts",
         "web/src/compose_call_ui.js",
         "web/src/compose_closed_ui.js",
-        "web/src/compose_fade.js",
+        "web/src/compose_fade.ts",
         "web/src/compose_notifications.ts",
         "web/src/compose_popovers.js",
         "web/src/compose_recipient.js",

--- a/web/src/compose_fade.js
+++ b/web/src/compose_fade.js
@@ -68,7 +68,7 @@ function fade_messages() {
 
     // Update the visible messages first, before the compose box opens
     for (i = 0; i < visible_groups.length; i += 1) {
-        $first_row = rows.first_message_in_group(visible_groups[i]);
+        $first_row = rows.first_message_in_group($(visible_groups[i]));
         first_message = message_lists.current.get(rows.id($first_row));
         should_fade_group = compose_fade_helper.should_fade_message(first_message);
 

--- a/web/src/compose_fade.js
+++ b/web/src/compose_fade.js
@@ -18,22 +18,27 @@ export function set_focused_recipient(msg_type) {
 
     // Construct focused_recipient as a mocked up element which has all the
     // fields of a message used by util.same_recipient()
-    const focused_recipient = {
-        type: msg_type,
-    };
-
-    if (focused_recipient.type === "stream") {
+    let focused_recipient;
+    if (msg_type === "stream") {
         const stream_id = compose_state.stream_id();
-        focused_recipient.topic = compose_state.topic();
+        const topic = compose_state.topic();
         if (stream_id) {
-            focused_recipient.stream_id = stream_id;
+            focused_recipient = {
+                type: msg_type,
+                stream_id,
+                topic,
+            };
         }
-    } else {
+    } else if (msg_type === "private") {
         // Normalize the recipient list so it matches the one used when
         // adding the message (see message_helper.process_new_message()).
         const reply_to = util.normalize_recipients(compose_state.private_message_recipient());
-        focused_recipient.reply_to = reply_to;
-        focused_recipient.to_user_ids = people.reply_to_to_user_ids_string(reply_to);
+        const to_user_ids = people.reply_to_to_user_ids_string(reply_to);
+        focused_recipient = {
+            type: msg_type,
+            reply_to,
+            to_user_ids,
+        };
     }
 
     compose_fade_helper.set_focused_recipient(focused_recipient);

--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -1,17 +1,83 @@
 import $ from "jquery";
 import _ from "lodash";
+import assert from "minimalistic-assert";
 
 import * as compose_fade_helper from "./compose_fade_helper";
 import * as compose_state from "./compose_state";
 import * as message_lists from "./message_lists";
+import type {Message} from "./message_store";
 import * as message_viewport from "./message_viewport";
 import * as people from "./people";
 import * as rows from "./rows";
+import type {TopicLink} from "./types";
 import * as util from "./util";
+
+type AllVisibilityPolicies = {
+    INHERIT: 0;
+    MUTED: 1;
+    UNMUTED: 2;
+    FOLLOWED: 3;
+};
+
+// TODO/TypeScript: Move this to message_list_view.js when it's migrated to TypeScript.
+type MessageContainer = {
+    background_color: string;
+    date_divider_html?: string;
+    edited_alongside_sender: boolean;
+    edited_in_left_col: boolean;
+    edited_status_msg: boolean;
+    include_recipient: boolean;
+    include_sender: boolean;
+    is_hidden: boolean;
+    mention_classname: string | null;
+    message_edited_notices_alongside_sender: boolean;
+    message_edited_notices_for_status_message: boolean;
+    message_edit_notices_in_left_col: boolean;
+    msg: Message;
+    sender_is_bot: boolean;
+    sender_is_guest: boolean;
+    should_add_guest_indicator_for_sender: boolean;
+    small_avatar_url: string;
+    status_message: boolean;
+    stream_url?: string;
+    subscribed?: boolean;
+    timestr: string;
+    topic_url?: string;
+    unsubscribed?: boolean;
+    want_date_divider: boolean;
+};
+
+// TODO/TypeScript: Move this to message_list_view.js when it's migrated to TypeScript.
+type MessageGroup = {
+    all_visibility_policies: AllVisibilityPolicies;
+    always_visible_topic_edit: boolean;
+    date: string;
+    date_unchanged: boolean;
+    display_recipient: string;
+    invite_only: boolean;
+    is_private?: boolean;
+    is_stream: boolean;
+    is_subscribed: boolean;
+    is_web_public: boolean;
+    match_topic?: string;
+    message_containers: MessageContainer[];
+    message_group_id: string;
+    on_hover_topic_edit: boolean;
+    recipient_bar_color: string;
+    stream_id: number;
+    stream_privacy_icon_color: string;
+    stream_url: string;
+    topic: string;
+    topic_is_resolved: boolean;
+    topic_links: TopicLink[];
+    topic_url: string;
+    user_can_resolve_topic: boolean;
+    visibility_policy: number;
+};
 
 let normal_display = false;
 
-export function set_focused_recipient(msg_type) {
+export function set_focused_recipient(msg_type?: "private" | "stream"): void {
     if (msg_type === undefined) {
         compose_fade_helper.clear_focused_recipient();
     }
@@ -44,13 +110,13 @@ export function set_focused_recipient(msg_type) {
     compose_fade_helper.set_focused_recipient(focused_recipient);
 }
 
-function display_messages_normally() {
+function display_messages_normally(): void {
     message_lists.current?.view.$list.find(".recipient_row").removeClass("message-fade");
 
     normal_display = true;
 }
 
-function change_fade_state($elt, should_fade_group) {
+function change_fade_state($elt: JQuery, should_fade_group: boolean): void {
     if (should_fade_group) {
         $elt.addClass("message-fade");
     } else {
@@ -58,7 +124,7 @@ function change_fade_state($elt, should_fade_group) {
     }
 }
 
-function fade_messages() {
+function fade_messages(): void {
     if (message_lists.current === undefined) {
         return;
     }
@@ -75,6 +141,7 @@ function fade_messages() {
     for (i = 0; i < visible_groups.length; i += 1) {
         $first_row = rows.first_message_in_group($(visible_groups[i]));
         first_message = message_lists.current.get(rows.id($first_row));
+        assert(first_message !== undefined);
         should_fade_group = compose_fade_helper.should_fade_message(first_message);
 
         change_fade_state($(visible_groups[i]), should_fade_group);
@@ -98,7 +165,7 @@ function fade_messages() {
             for (i = 0; i < $all_groups.length; i += 1) {
                 const $group_elt = $($all_groups[i]);
                 should_fade_group = compose_fade_helper.should_fade_message(
-                    rows.recipient_from_group($group_elt),
+                    rows.recipient_from_group($group_elt)!,
                 );
                 change_fade_state($group_elt, should_fade_group);
             }
@@ -109,7 +176,7 @@ function fade_messages() {
     );
 }
 
-function do_update_all() {
+function do_update_all(): void {
     if (compose_fade_helper.want_normal_display()) {
         if (!normal_display) {
             display_messages_normally();
@@ -122,17 +189,17 @@ function do_update_all() {
 // This gets called on keyup events, hence the throttling.
 export const update_all = _.debounce(do_update_all, 50);
 
-export function start_compose(msg_type) {
+export function start_compose(msg_type?: "private" | "stream"): void {
     set_focused_recipient(msg_type);
     do_update_all();
 }
 
-export function clear_compose() {
+export function clear_compose(): void {
     compose_fade_helper.clear_focused_recipient();
     display_messages_normally();
 }
 
-export function update_message_list() {
+export function update_message_list(): void {
     if (compose_fade_helper.want_normal_display()) {
         display_messages_normally();
     } else {
@@ -140,7 +207,10 @@ export function update_message_list() {
     }
 }
 
-export function update_rendered_message_groups(message_groups, get_element) {
+export function update_rendered_message_groups(
+    message_groups: MessageGroup[],
+    get_element: (message_group: MessageGroup) => JQuery,
+): void {
     if (compose_fade_helper.want_normal_display()) {
         return;
     }

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -185,13 +185,13 @@ function add_to_visible<T>(
     top_of_feed: number,
     bottom_of_feed: number,
     require_fully_visible: boolean,
-    row_to_id: ($row: HTMLElement) => T,
+    row_to_output: ($row: HTMLElement) => T,
 ): void {
     for (const row of $candidates) {
         const row_rect = row.getBoundingClientRect();
         // Mark very tall messages as read once we've gotten past them
         if (in_viewport_or_tall(row_rect, top_of_feed, bottom_of_feed, require_fully_visible)) {
-            visible.push(row_to_id(row));
+            visible.push(row_to_output(row));
         } else {
             break;
         }

--- a/web/src/rows.ts
+++ b/web/src/rows.ts
@@ -146,8 +146,8 @@ export function get_message_recipient_header($message_row: JQuery): JQuery {
     return $message_row.parent(".recipient_row").find(".message_header").expectOne();
 }
 
-export function recipient_from_group(message_group: string): Message | undefined {
-    const message_id = id($(message_group).children(".message_row").first().expectOne());
+export function recipient_from_group($message_group: JQuery): Message | undefined {
+    const message_id = id($message_group.children(".message_row").first().expectOne());
     return message_store.get(message_id);
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

[Commit-3](https://github.com/zulip/zulip/commit/95fd0fe87a31562d6006183477b0401f8c6e046d): Previously we  declared the 'focused_recipient' object
with an initial field of 'msg_type' and progressively added
fields by mutating the object(depending on the 'msg_type' ie. 'stream'
or 'private'). This was not TypeScript friendly and the compiler threw.

Now, we first fetch those fields into variables and then create the 'focused_recipient'
object depending on the value of 'msg_type' field.

