### PR TITLE
Web: Making keyboard Navigation work for login/signin buttons.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -821,7 +821,7 @@ export function process_hotkey(e, hotkey) {
 
     // Handle hotkeys for active popovers here which can handle keys other than `menu_dropdown_hotkeys`.
     if (
-        navbar_menus.is_navbar_menus_displayed() &&
+        (navbar_menus.is_navbar_menus_displayed() || navbar_menus.can_handle_navigation_hotkey()) &&
         navbar_menus.handle_keyboard_events(event_name)
     ) {
         return true;

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -4,6 +4,11 @@ import {page_params} from "./page_params";
 import * as personal_menu_popover from "./personal_menu_popover";
 import * as popover_menus from "./popover_menus";
 
+// Available menu options based on user type
+const popover_menus_options = page_params.is_spectator
+    ? ["signup_button", "login_button", "navbar_help_menu", "gear_menu"]
+    : ["navbar_help_menu", "gear_menu", "personal_menu"];
+
 export function is_navbar_menus_displayed() {
     return (
         popover_menus.is_personal_menu_popover_displayed() ||
@@ -12,46 +17,91 @@ export function is_navbar_menus_displayed() {
     );
 }
 
+export function can_handle_navigation_hotkey() {
+    return (
+        document.activeElement &&
+        (document.activeElement.classList.contains("signup_button") ||
+            document.activeElement.classList.contains("login_button"))
+    );
+}
+
+// Handle keyboard events for navigation
 export function handle_keyboard_events(event_name) {
-    // We don't need to process arrow keys in navbar menus for spectators
-    // since they only have gear menu present.
-    if (
-        popover_menus.is_personal_menu_popover_displayed() &&
-        (event_name === "left_arrow" || event_name === "gear_menu") &&
-        !page_params.is_spectator
-    ) {
-        // Open gear menu popover on left arrow.
-        personal_menu_popover.toggle();
-        gear_menu.toggle();
-        return true;
-    }
+    const index = popover_menus_options.findIndex((menu) => is_menu_displayed(menu));
 
-    if (
-        popover_menus.is_help_menu_popover_displayed() &&
-        (event_name === "right_arrow" || event_name === "gear_menu")
-    ) {
-        // Open gear menu popover on right arrow.
-        navbar_help_menu.toggle();
-        gear_menu.toggle();
-        return true;
-    }
-
-    if (popover_menus.is_gear_menu_popover_displayed()) {
-        if (event_name === "gear_menu") {
-            gear_menu.toggle();
-            return true;
-        } else if (event_name === "right_arrow" && !page_params.is_spectator) {
-            // Open personal menu popover on g + right arrow.
-            gear_menu.toggle();
-            personal_menu_popover.toggle();
-            return true;
-        } else if (event_name === "left_arrow") {
-            // Open help menu popover on g + left arrow.
-            gear_menu.toggle();
-            navbar_help_menu.toggle();
-            return true;
-        }
+    if (index !== -1) {
+        return handle_menu_event(popover_menus_options[index], event_name, index);
     }
 
     return false;
+}
+
+// Check if a specific menu is displayed
+function is_menu_displayed(selected_popover_menu) {
+    switch (selected_popover_menu) {
+        case "signup_button":
+            return document.activeElement.classList.contains("signup_button");
+        case "login_button":
+            return document.activeElement.classList.contains("login_button");
+        case "navbar_help_menu":
+            return popover_menus.is_help_menu_popover_displayed();
+        case "gear_menu":
+            return popover_menus.is_gear_menu_popover_displayed();
+        case "personal_menu":
+            return popover_menus.is_personal_menu_popover_displayed();
+    }
+    return false;
+}
+
+// Handle navigation events for specific menus
+function handle_menu_event(selected_popover_menu, event_name, index) {
+    switch (event_name) {
+        case "gear_menu":
+            toggle_menu(selected_popover_menu);
+            return true;
+        case "left_arrow":
+            if (index > 0) {
+                toggle_menu(selected_popover_menu);
+                toggle_menu(popover_menus_options[index - 1]);
+                return true;
+            }
+            break;
+        case "right_arrow":
+            if (index < popover_menus_options.length - 1) {
+                toggle_menu(selected_popover_menu);
+                toggle_menu(popover_menus_options[index + 1]);
+                return true;
+            }
+            break;
+    }
+    return false;
+}
+
+// Toggle the display state of a specific menu
+function toggle_menu(selected_popover_menu) {
+    switch (selected_popover_menu) {
+        case "signup_button":
+        case "login_button":
+            toggle_button_focus(selected_popover_menu);
+            break;
+        case "navbar_help_menu":
+            navbar_help_menu.toggle();
+            break;
+        case "gear_menu":
+            gear_menu.toggle();
+            break;
+        case "personal_menu":
+            personal_menu_popover.toggle();
+            break;
+    }
+}
+
+// Toggle the focus state of a button
+function toggle_button_focus(selected_popover_menu) {
+    const selected_element = document.querySelector("." + selected_popover_menu);
+    if (document.activeElement.classList.contains(selected_popover_menu)) {
+        selected_element.blur();
+    } else {
+        selected_element.focus();
+    }
 }

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -112,7 +112,9 @@ export function is_in_focus() {
         !sidebar_ui.any_sidebar_expanded_as_overlay() &&
         !overlays.any_active() &&
         !modals.any_active() &&
-        !$(".home-page-input").is(":focus")
+        !document.activeElement.classList.contains("signup_button") &&
+        !document.activeElement.classList.contains("login_button") &&
+        !document.activeElement.classList.contains(".home-page-input")
     );
 }
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -59,10 +59,12 @@ export function hide_all(): void {
 }
 
 export function initialize(): void {
-    $("body").on("click", ".login_button", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        window.location.href = spectators.build_login_link();
+    $("body").on("click keydown", ".login_button", (e) => {
+        if (e.type === "click" || (e.type === "keydown" && e.key === "Enter")) {
+            e.preventDefault();
+            e.stopPropagation();
+            window.location.href = spectators.build_login_link();
+        }
     });
 
     $("#userlist-toggle-button").on("click", (e) => {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -444,12 +444,13 @@ body.has-overlay-scrollbar {
                 --color-navbar-spectator-low-attention-brand-button-background
             );
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: var(
                     --color-navbar-spectator-low-attention-brand-button-text
                 );
                 background-color: var(
-                    --color-navbar-spectator-low-attention-brand-button-background-hover
+                    --color-navbar-spectator-medium-attention-brand-button-background-hover
                 );
             }
 
@@ -471,7 +472,8 @@ body.has-overlay-scrollbar {
                 --color-navbar-spectator-medium-attention-brand-button-background
             );
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: var(
                     --color-navbar-spectator-medium-attention-brand-button-text
                 );

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -33,7 +33,7 @@
                 <a href="/register/"  class="signup_button">
                     {{t 'Sign up' }}
                 </a>
-                <a class="login_button">
+                <a tabindex="0" class="login_button">
                     {{t 'Log in' }}
                 </a>
             </div>


### PR DESCRIPTION
It is a continuation/completion of the PR #28074, made by @sethdivyansh.
Fixes: #28037

<!-- Describe your pull request here.-->
 
 In this PR, We have refactored the ```navbar_menus.js``` with it's basic functionality of how it works, as before there was multiple duplicative code. Now it works on the basis of list system, and options can be visited with left and right press of arrow keys.
 
 Now after pressing ```G``` Hotkey, in the spectator mode, and then travelling with arrow keys, will take you to login/signup button also.
 
**Screenshots and screen captures:**

 **Steps can be seen in the video capture.**
                                      1. Changed focus to ```login button``` from ```Help menu``` on pressing ```left arrow key```.
                                      2. Changed focus from ```login button``` to ```signup button``` on pressing ```left arrow key```.
                                      3. Changed focus from ```signup button``` to ```login button``` on pressing ```right arrow key```.
                                      4. Changed focus from ```login button``` to ```Help menu``` on pressing ```right arrow key```.


**Dark**

https://github.com/zulip/zulip/assets/91906953/c0f6181e-f127-40eb-8299-b2d5129b2108


**Light**

https://github.com/zulip/zulip/assets/91906953/4f26f04d-f741-4052-99a2-77e5b6db8738


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
