### PR TITLE
Show empty conversation in left sidebar when viewed.

### DIFF
--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -51,6 +51,13 @@ export function get_conversations(): DisplayObject[] {
     // The user_ids_string for the current view, if any.
     const active_user_ids_string = get_active_user_ids_string();
 
+    if (
+        active_user_ids_string !== undefined &&
+        !private_messages.map((obj) => obj.user_ids_string).includes(active_user_ids_string)
+    ) {
+        private_messages.unshift({user_ids_string: active_user_ids_string, max_message_id: -1});
+    }
+
     for (const conversation of private_messages) {
         const user_ids_string = conversation.user_ids_string;
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -153,6 +153,7 @@ export function get_list_info(
     zoomed: boolean,
     search_term: string,
 ): TopicListInfo {
+    const narrowed_topic = narrow_state.topic();
     const topic_choice_state: TopicChoiceState = {
         items: [],
         topics_selected: 0,
@@ -169,6 +170,15 @@ export function get_list_info(
     const stream_muted = sub.is_muted;
 
     let topic_names = stream_topic_history.get_recent_topic_names(stream_id);
+
+    if (
+        stream_id === narrow_state.stream_id() &&
+        narrowed_topic &&
+        !topic_names.includes(narrowed_topic)
+    ) {
+        topic_names.unshift(narrowed_topic);
+    }
+
     if (zoomed) {
         topic_names = util.filter_by_word_prefix_match(topic_names, search_term, (item) => item);
     }

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -143,6 +143,22 @@ test("get_conversations", ({override}) => {
 
     pm_data = pm_list_data.get_conversations();
     assert.deepEqual(pm_data, expected_data);
+
+    expected_data.unshift({
+        recipients: "Iago",
+        user_ids_string: "106",
+        unread: 0,
+        is_zero: true,
+        is_active: true,
+        url: "#narrow/dm/106-Iago",
+        status_emoji_info: {emoji_code: "20"},
+        user_circle_class: "user_circle_empty",
+        is_group: false,
+        is_bot: false,
+    });
+    set_pm_with_filter("iago@zulip.com");
+    pm_data = pm_list_data.get_conversations();
+    assert.deepEqual(pm_data, expected_data);
 });
 
 test("get_conversations bot", ({override}) => {

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -28,6 +28,7 @@ const user_topics = mock_esm("../src/user_topics", {
 });
 const narrow_state = mock_esm("../src/narrow_state", {
     topic() {},
+    stream_id() {},
 });
 
 const stream_data = zrequire("stream_data");
@@ -85,6 +86,28 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         }
         add_topic_message(topic_name + i, 1000 + i);
     }
+
+    override(narrow_state, "topic", () => "topic 11");
+    override(narrow_state, "stream_id", () => 556);
+
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 8);
+    assert.equal(list_info.more_topics_unreads, 0);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, false);
+    assert.equal(list_info.num_possible_topics, 11);
+    assert.deepEqual(list_info.items[0], {
+        topic_name: "topic 11",
+        topic_resolved_prefix: "",
+        topic_display_name: "topic 11",
+        unread: 0,
+        is_zero: true,
+        is_muted: false,
+        is_followed: false,
+        is_unmuted_or_followed: false,
+        is_active_topic: true,
+        url: "#narrow/stream/556-general/topic/topic.2011",
+        contains_unread_mention: false,
+    });
 
     override(narrow_state, "topic", () => "topic 6");
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds a PM thread/Topic entry in the left sidebar when narrowed down to an empty conversation.
It also disappears if the user navigates away without starting the conversation.

For PM list, it checks if the narrowed user string(s) is already available in `pm_conversations.recent` or else adds on top of it.
Since it just adds it for rendering purpose, it doesn't mess with the `pm_conversations.recent` history and will get removed on unnarrowed.

In topic list too, `get_list_info` checks if the narrowed topic is available in the `stream_topic_history.get_recent_topic_names`, and renders the topic entry if needed.

Fixes: zulip#22769

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 04-03-24 05:12:19 PM IST.webm](https://github.com/zulip/zulip/assets/33497322/c81872bd-06fe-45cc-8478-618ba3072195)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
