### PR TITLE
dev-vagrant-docker: Upgrade docker-systemctl-replacement to 1.5.8066

### DIFF
--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -31,8 +31,8 @@ RUN \
     # managed by systemd start within Docker, which breaks normal
     # operation of systemd.
     dpkg-divert --add --rename /bin/systemctl \
-    && curl -fLsS --retry 3 -o /bin/systemctl 'https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/v1.5.7106/files/docker/systemctl3.py' \
-    && echo '7479f4cd0d1604e5c5eb5329f0a6a3a80fea811e2f9889e3083c2c29b229ff99  /bin/systemctl' | sha256sum -c \
+    && curl -fLsS --retry 3 -o /bin/systemctl 'https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/v1.5.8066/files/docker/systemctl3.py' \
+    && echo 'f8736b56299374a316a958e5e949be73e657e2f7069691381664d94950c645c9  /bin/systemctl' | sha256sum -c \
     && chmod +x /bin/systemctl \
     && ln -nsf /bin/true /usr/sbin/policy-rc.d \
     && mkdir -p /run/sshd \


### PR DESCRIPTION
https://github.com/gdraheim/docker-systemctl-replacement/compare/v1.5.7106...v1.5.8066