### PR TITLE
compose: Fix bug where inserted content would not be scrolled into view.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -68,9 +68,15 @@ export function autosize_textarea($textarea: JQuery<HTMLTextAreaElement>): void 
 export function insert_and_scroll_into_view(
     content: string,
     $textarea: JQuery<HTMLTextAreaElement>,
+    replace_all = false,
 ): void {
-    insertTextIntoField($textarea[0], content);
-    // Blurring and refocusing ensures the cursor / selection is in view.
+    if (replace_all) {
+        setFieldText($textarea[0], content);
+    } else {
+        insertTextIntoField($textarea[0], content);
+    }
+    // Blurring and refocusing ensures the cursor / selection is in view
+    // in chromium browsers.
     $textarea.trigger("blur");
     $textarea.trigger("focus");
     autosize_textarea($textarea);

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -569,7 +569,7 @@ export function format_text(
             after_lines = "\n" + after_lines;
         }
         text = before_lines + selected_lines + after_lines;
-        setFieldText(field, text);
+        insert_and_scroll_into_view(text, $textarea, true);
         // If no text was selected, that is, marking was added to the line with the
         // cursor, nothing will be selected and the cursor will remain as it was.
         if (selected_text === "") {
@@ -601,7 +601,7 @@ export function format_text(
                 text.slice(range.start, range.end) +
                 linebreak_end +
                 text.slice(range.end + syntax_end.length);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start - syntax_start.length,
                 range.end - syntax_start.length,
@@ -615,7 +615,7 @@ export function format_text(
                 text.slice(range.start + syntax_start.length, range.end - syntax_end.length) +
                 linebreak_end +
                 text.slice(range.end);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start,
                 range.end - syntax_start.length - syntax_end.length,
@@ -644,7 +644,7 @@ export function format_text(
             if (text.startsWith("\n")) {
                 text = text.slice(1);
             }
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start,
                 range.end - spoiler_syntax_start.length - spoiler_syntax_end.length,
@@ -664,7 +664,7 @@ export function format_text(
             if (text.startsWith("\n")) {
                 text = text.slice(1);
             }
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start,
                 range.end - spoiler_syntax_start_without_break.length - spoiler_syntax_end.length,
@@ -678,7 +678,7 @@ export function format_text(
                 text.slice(0, range.start - spoiler_syntax_start_without_break.length) +
                 selected_text +
                 text.slice(range.end + spoiler_syntax_end.length);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start - spoiler_syntax_start_without_break.length,
                 range.end - spoiler_syntax_start_without_break.length,
@@ -692,7 +692,7 @@ export function format_text(
                 text.slice(0, range.start - spoiler_syntax_start.length) +
                 selected_text +
                 text.slice(range.end + spoiler_syntax_end.length);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start - spoiler_syntax_start.length,
                 range.end - spoiler_syntax_start.length,
@@ -722,7 +722,7 @@ export function format_text(
                 ) +
                 selected_text +
                 text.slice(range.end + spoiler_syntax_end.length);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 new_selection_start,
                 range.end - spoiler_syntax_start_without_break.length,
@@ -746,7 +746,7 @@ export function format_text(
                 text.slice(0, range.start - spoiler_syntax_start_without_break.length) +
                 text.slice(new_range_start, new_range_end) +
                 text.slice(new_range_end + spoiler_syntax_end.length);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 new_range_start - spoiler_syntax_start_without_break.length - (header ? 0 : 1),
                 new_range_end - spoiler_syntax_start_without_break.length - (header ? 0 : 1),
@@ -813,7 +813,7 @@ export function format_text(
                 space_between_description_and_url(description, url) +
                 url +
                 text.slice(range.end + 1);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start - 3 + space_between_description_and_url(description, url).length,
                 range.start -
@@ -846,7 +846,7 @@ export function format_text(
                 space_between_description_and_url(selected_text, url) +
                 url +
                 text.slice(text.indexOf(")", range.end) + 1);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(range.start - 1, range.end - 1);
             return;
         }
@@ -870,7 +870,7 @@ export function format_text(
                 space_between_description_and_url(description, url) +
                 url +
                 text.slice(range.end);
-            setFieldText(field, text);
+            insert_and_scroll_into_view(text, $textarea, true);
             field.setSelectionRange(
                 range.start,
                 range.start +
@@ -940,7 +940,7 @@ export function format_text(
                     text.slice(0, range.start - italic_syntax.length) +
                     text.slice(range.start, range.end) +
                     text.slice(range.end + italic_syntax.length);
-                setFieldText(field, text);
+                insert_and_scroll_into_view(text, $textarea, true);
                 field.setSelectionRange(
                     range.start - italic_syntax.length,
                     range.end - italic_syntax.length,
@@ -976,7 +976,7 @@ export function format_text(
                         range.end - italic_syntax.length,
                     ) +
                     text.slice(range.end);
-                setFieldText(field, text);
+                insert_and_scroll_into_view(text, $textarea, true);
                 field.setSelectionRange(range.start, range.end - italic_syntax.length * 2);
                 break;
             }

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -544,10 +544,15 @@ function get_textarea_state() {
     return before_text + selected_text + after_text;
 }
 
-run_test("format_text - bold and italic", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - bold and italic", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(
         text_field_edit,
         "wrapFieldSelection",
@@ -634,10 +639,15 @@ run_test("format_text - bold and italic", ({override}) => {
     assert.equal(get_textarea_state(), "before <**abc**> after");
 });
 
-run_test("format_text - bulleted and numbered lists", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
 
     // Toggling on bulleted list
     init_textarea_state("<first_item\nsecond_item>");
@@ -686,10 +696,15 @@ run_test("format_text - bulleted and numbered lists", ({override}) => {
     assert.equal(get_textarea_state(), "<first_item\nsecond_item>");
 });
 
-run_test("format_text - strikethrough", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - strikethrough", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +
@@ -733,10 +748,15 @@ run_test("format_text - strikethrough", ({override}) => {
     assert.equal(get_textarea_state(), "before <abc> after");
 });
 
-run_test("format_text - latex", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - latex", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +
@@ -799,10 +819,15 @@ run_test("format_text - latex", ({override}) => {
     assert.equal(get_textarea_state(), "Before\n<abc\ndef>\nAfter");
 });
 
-run_test("format_text - code", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - code", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +
@@ -865,10 +890,15 @@ run_test("format_text - code", ({override}) => {
     assert.equal(get_textarea_state(), "before\n<abc\ndef>\nafter");
 });
 
-run_test("format_text - quote", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - quote", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +
@@ -924,10 +954,15 @@ run_test("format_text - quote", ({override}) => {
     assert.equal(get_textarea_state(), "before\n<abc\ndef>\nafter");
 });
 
-run_test("format_text - spoiler", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - spoiler", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +
@@ -991,10 +1026,15 @@ run_test("format_text - spoiler", ({override}) => {
     assert.equal(get_textarea_state(), "before\n<abc>\nafter");
 });
 
-run_test("format_text - link", ({override}) => {
-    override(text_field_edit, "setFieldText", (_field, text) => {
-        $textarea.val = () => text;
-    });
+run_test("format_text - link", ({override, override_rewire}) => {
+    override_rewire(
+        compose_ui,
+        "insert_and_scroll_into_view",
+        (content, _textarea, replace_all) => {
+            assert.ok(replace_all);
+            $textarea.val = () => content;
+        },
+    );
     override(text_field_edit, "wrapFieldSelection", (_field, syntax_start, syntax_end) => {
         const new_val =
             $textarea.val().slice(0, $textarea.range().start) +


### PR DESCRIPTION
compose: Fix bug where inserted content would not be scrolled into view.

On chromium browsers, the scroll position is not restored when the text in a textarea is replaced. So instead of directly replacing the text, we call the `insert_and_scroll_into_view` function with `replace_all` set to true.

compose: Add parameter `replace_all` to `insert_and_scroll_into_view`.

We refactor the `insert_and_scroll_into_view` function to accept a new parameter, `replace_all`, defaulting to false, that when set to `true`, will replace all existing content of the textarea with the new content, instead of inserting the new content at the current cursor position.

This is a prep commit for the next commit, which will set this new flag.

Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Using.20list.20in.20compose.20box.2E/near/1749433)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
