### PR TITLE
message_list: Fix delayed events finding current msg list undefined.

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -35,12 +35,28 @@ const store_message_list_instances_plugin = {
     },
 };
 
-function message_list_tooltip(target, props) {
+function message_list_tooltip(target, props = {}) {
+    const {onShow, ...other_props} = props;
     delegate("body", {
         target,
         appendTo: () => document.body,
         plugins: [store_message_list_instances_plugin],
-        ...props,
+        onShow(instance) {
+            if (message_lists.current === undefined) {
+                // Since tooltips is called with a delay, it is possible that the
+                // message feed is not visible when the tooltip is shown.
+                return false;
+            }
+
+            if (onShow !== undefined && onShow(instance) === false) {
+                // Only return false if `onShow` returns false. We don't want to hide
+                // tooltip if `onShow` returns `undefined`.
+                return false;
+            }
+
+            return true;
+        },
+        ...other_props,
     });
 }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -196,6 +196,12 @@ export function initialize_kitchen_sink_stuff() {
     //      specific-purpose modules like message_viewport.ts.
 
     const throttled_mousewheelhandler = _.throttle((_e, delta) => {
+        if (!narrow_state.is_message_feed_visible()) {
+            // Since this function is called with a delay, it's
+            // possible that message list was hidden before we reached here.
+            return;
+        }
+
         // Most of the mouse wheel's work will be handled by the
         // scroll handler, but when we're at the top or bottom of the
         // page, the pointer may still need to move.


### PR DESCRIPTION
Events that are called after a delay can find message_lists.current to be undefined if user has moved to non-message list view.

