### PR TITLE
ui: Go to top topic instead of interleaved view.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -321,11 +321,10 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
 async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {
     console.log("Narrowing with left sidebar");
 
-    await page.click((await get_stream_li(page, "Verona")) + " a");
-    await expect_verona_stream(page);
-
     await page.click((await get_stream_li(page, "Verona")) + " .stream-name");
     await expect_verona_stream_top_topic(page);
+
+    console.log("THIS THING IS DONE");
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages a");
     await expect_home(page);

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -26,6 +26,17 @@ async function expect_home(page: Page): Promise<void> {
     ]);
 }
 
+async function expect_verona_stream_top_topic(page: Page): Promise<void> {
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
+        visible: true,
+    });
+    await common.check_messages_sent(page, message_list_id, [
+        ["Verona > test", ["verona test a", "verona test b", "verona test d"]],
+    ]);
+    assert.strictEqual(await page.title(), "#Verona > test - Zulip Dev - Zulip");
+}
+
 async function expect_verona_stream(page: Page): Promise<void> {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
@@ -313,6 +324,9 @@ async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<voi
     await page.click((await get_stream_li(page, "Verona")) + " a");
     await expect_verona_stream(page);
 
+    await page.click((await get_stream_li(page, "Verona")) + " .stream-name");
+    await expect_verona_stream_top_topic(page);
+
     await page.click("#left-sidebar-navigation-list .top_left_all_messages a");
     await expect_home(page);
 
@@ -410,7 +424,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
-    await expect_verona_stream(page);
+    await expect_verona_stream_top_topic(page);
     assert.strictEqual(
         await common.get_text_from_selector(page, ".stream-list-filter"),
         "",

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -6,7 +6,8 @@ import * as common from "./lib/common";
 
 async function navigate_using_left_sidebar(page: Page, click_target: string): Promise<void> {
     console.log("Visiting #" + click_target);
-    await page.click(`#left-sidebar span.stream-name`);
+    // await page.click(`#left-sidebar span.stream-name`);
+    await page.click('#left-sidebar .subscription_block .stream-markers-and-controls .interleaved-icon');
     await page.waitForSelector(`#message_feed_container`, {visible: true});
 }
 
@@ -107,8 +108,6 @@ async function navigation_tests(page: Page): Promise<void> {
     await navigate_using_left_sidebar(page, verona_narrow);
 
     await test_reload_hash(page);
-
-    console.log("We are done till here");
 
     // Verify that we're narrowed to the target stream
     await page.waitForSelector(

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -108,7 +108,7 @@ async function navigation_tests(page: Page): Promise<void> {
 
     await test_reload_hash(page);
 
-    console.log("We are done till heree");
+    console.log("We are done till here");
 
     // Verify that we're narrowed to the target stream
     await page.waitForSelector(

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -7,7 +7,9 @@ import * as common from "./lib/common";
 async function navigate_using_left_sidebar(page: Page, click_target: string): Promise<void> {
     console.log("Visiting #" + click_target);
     // await page.click(`#left-sidebar span.stream-name`);
-    await page.click('#left-sidebar .subscription_block .stream-markers-and-controls .interleaved-icon');
+    await page.click(
+        "#left-sidebar .subscription_block .stream-markers-and-controls .interleaved-icon",
+    );
     await page.waitForSelector(`#message_feed_container`, {visible: true});
 }
 

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -6,7 +6,7 @@ import * as common from "./lib/common";
 
 async function navigate_using_left_sidebar(page: Page, click_target: string): Promise<void> {
     console.log("Visiting #" + click_target);
-    await page.click(`#left-sidebar a[href='#${CSS.escape(click_target)}']`);
+    await page.click(`#left-sidebar span.stream-name`);
     await page.waitForSelector(`#message_feed_container`, {visible: true});
 }
 
@@ -107,6 +107,8 @@ async function navigation_tests(page: Page): Promise<void> {
     await navigate_using_left_sidebar(page, verona_narrow);
 
     await test_reload_hash(page);
+
+    console.log("We are done till heree");
 
     // Verify that we're narrowed to the target stream
     await page.waitForSelector(

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -8,7 +8,7 @@ async function navigate_using_left_sidebar(page: Page, click_target: string): Pr
     console.log("Visiting #" + click_target);
     // await page.click(`#left-sidebar span.stream-name`);
     await page.click(
-        "#left-sidebar .subscription_block .stream-markers-and-controls .interleaved-icon",
+        "#left-sidebar .subscription_block .stream-markers-and-controls a[href='#${CSS.escape(click_target)}']",
     );
     await page.waitForSelector(`#message_feed_container`, {visible: true});
 }

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -825,7 +825,7 @@ export function set_event_handlers({
 }: {
     on_stream_click: (stream_id: number, trigger: string) => void;
 }): void {
-    $("#stream_filters").on("click", "li .subscription_block", (e) => {
+    $("#stream_filters").on("click", "li .subscription_block a", (e) => {
         if (e.metaKey || e.ctrlKey) {
             return;
         }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -972,6 +972,21 @@ li.top_left_scheduled_messages {
            definition. */
         height: auto;
     }
+
+    .interleaved-icon {
+        display: none;
+    }
+}
+
+.bottom_left_row:hover .stream-markers-and-controls {
+    .interleaved-icon {
+        display: flex;
+        color: var(--color-left-sidebar-navigation-icon);
+
+        &:hover {
+            color: var(--color-text-message-header);
+        }
+    }
 }
 
 .bottom_left_row .sidebar-menu-icon {

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -11,6 +11,7 @@
             <span title="{{name}}" class="stream-name">{{name}}</span>
 
             <div class="stream-markers-and-controls">
+                <a href="{{url}}" class="interleaved-icon fa fa-align-right"></a>
                 <span class="unread_mention_info"></span>
                 <span class="unread_count"></span>
                 <span class="masked_unread_count"></span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
+            <span title="{{name}}" class="stream-name">{{name}}</span>
 
             <div class="stream-markers-and-controls">
                 <span class="unread_mention_info"></span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
It is a completion PR for the original PR #27614, by @emmawitt.
The credit for solution is all @emmawitt. I have addressed all the concerned feedbacks.

This is an UI-experiment that contains:

- Added click event in stream_list event handlers so that clicking on the name of a stream in the left sidebar goes to the top topic in the left sidebar view of that stream, rather than an interleaved view.
- Added an "interleaved" button to the stream header row in the left sidebar, as well as a click event so that clicking the interleaved button leads to an interleaved view of that stream.

Fixes: #26937 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Dark Mode</summary>

Without Hover --------------------------------------- Hover on Stream Name
![image](https://github.com/zulip/zulip/assets/91906953/0b57ab2b-05c3-40fd-99ef-095be592dc77)                  ![image](https://github.com/zulip/zulip/assets/91906953/9435d51a-a51d-4ba2-a7a5-b1ea7b92d4cd)

On Clicking Stream Name
![image](https://github.com/zulip/zulip/assets/91906953/656dad8a-10dc-4291-bd53-8ef3876ec92b)

On Clicking the interleaved button
![image](https://github.com/zulip/zulip/assets/91906953/11277f1c-5112-41b1-97c3-dc8b91a31f6a)
</details>


<details>
<summary>Light Mode</summary>

Without Hover --------------------------------------- Hover on Stream Name
![image](https://github.com/zulip/zulip/assets/91906953/cdd734ab-e3c7-4f61-8eb7-8b34940c3d81)                ![image](https://github.com/zulip/zulip/assets/91906953/3a46a3de-a47e-4881-a8c3-9c529c85b23f)

On Clicking Stream Name
![image](https://github.com/zulip/zulip/assets/91906953/6bd7abf5-99be-4f49-a322-46c73cafce40)

On Clicking the interleaved button
![image](https://github.com/zulip/zulip/assets/91906953/197c4167-1612-49b7-923c-a73542bc498f)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
