### PR TITLE
compose: Fix topics required banner closing on enter to send.

### DIFF
--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -324,10 +324,10 @@ export function initialize() {
         on_hidden_callback,
     }).setup();
 
-    // `keyup` isn't relevant for streams since it registers as a change only
+    // `input` isn't relevant for streams since it registers as a change only
     // when an item in the dropdown is selected.
     $("#stream_message_recipient_topic,#private_message_recipient").on(
-        "keyup",
+        "input",
         update_on_recipient_change,
     );
     // changes for the stream dropdown are handled in on_compose_select_recipient_update


### PR DESCRIPTION
We were updating the compose banners on every `keyup` event on the topic input. Since, `keyup` also gets triggered for the modifier and non-printing keys such as "Enter", this lead to banner for topic required being closed via the `check_posting_policy_for_compose_box` when pressing "Enter" to send a message with no topic.

This bug was probably introduced in 5c993f0, which moved additional logic into `update_on_recipient_change`.

To solve this issue, we use the `input` event instead of the `keyup` event to update the compose banners only when the value inside the input element changes.

This also as a side effect solves two other issues:
1. Prevents the the compose banner from being closed when we only press modifier keys - such as Shift/Caps.
2. Fixes the flashing "Direct messages are disabled in this organization." message

<!-- Describe your pull request here.-->

Fixes: [Issue reported at CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/topics.20required.20banner.20disappears.20.5BCZO.5D/near/1751187)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Description | Before | After |
|--------|--------|--------|
| No topics banner hidden on enter | ![no-topics-banner-on-enter-before](https://github.com/zulip/zulip/assets/82862779/20dfae96-a726-4f32-b1c9-c28456d1353c) | ![no-topics-banner-on-enter-after](https://github.com/zulip/zulip/assets/82862779/8ab1f7c1-aa60-4831-8546-007cc4636ae3) |
| When pressing a modifier key closes the banner | ![no-topics-banner-on-mod-before](https://github.com/zulip/zulip/assets/82862779/08039eb0-87a8-4c17-adfd-988f227b9f68) | ![no-topics-banner-on-mod-after](https://github.com/zulip/zulip/assets/82862779/0d8febf6-bcbb-4bf4-844c-27d866dd4015) |
| Flashing "Direct messages are disabled in this organization." message | ![dm-banner-shuffle-before](https://github.com/zulip/zulip/assets/82862779/087e4fe6-6b77-49a0-8b72-f90b115284b1) | ![dm-banner-shuffle-after](https://github.com/zulip/zulip/assets/82862779/f6efe350-79cb-4811-9133-66eabf6d0774) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
