### PR TITLE
people: Don't refetch user when we already have it.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1234,17 +1234,11 @@ export function filter_people_by_search_terms(
     // Loop through users and populate filtered_users only
     // if they include search_terms
     for (const user of users) {
-        const person = get_by_email(user.email);
-        // Get person object (and ignore errors)
-        if (!person?.full_name) {
-            continue;
-        }
-
         // Return user emails that include search terms
         const match = matchers.some((matcher) => matcher(user));
 
         if (match) {
-            filtered_users.set(person.user_id, true);
+            filtered_users.set(user.user_id, true);
         }
     }
 

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -758,13 +758,6 @@ test_people("filtered_users", () => {
     filtered_people = people.filter_people_by_search_terms(users, ["ëm"]);
     assert.equal(filtered_people.size, 1);
     assert.ok(filtered_people.has(noah.user_id));
-
-    // Test filtering with undefined user
-    users.push(invalid_user);
-
-    filtered_people = people.filter_people_by_search_terms(users, ["ltorv"]);
-    assert.equal(filtered_people.size, 1);
-    assert.ok(filtered_people.has(linus.user_id));
 });
 
 test_people("multi_user_methods", () => {


### PR DESCRIPTION
CZO discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/buddy.20list.20split.20users.20.2326717/near/1742798

I double checked that `filter_people_by_search_terms` can only be called with defined users, and so I removed the undefined user test.