### PR TITLE
emoji_picker: Improve CSS and correct light bleedthrough in dark theme.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -426,6 +426,17 @@
     /* Don't define light theme colors for modal here
        since the modal is also used on billing pages and
        this file is not imported on billing pages. */
+
+    /* Emoji-picker colors */
+    --color-background-emoji-picker-popover: hsl(0deg 0% 93%);
+    --color-background-emoji-picker-popover-tab-item-active: hsl(
+        0deg 0% 100% / 20%
+    );
+    --color-background-emoji-picker-emoji-focus: hsl(0deg 0% 93%);
+    --color-box-shadow-emoji-picker-emoji-focus: transparent;
+    --color-background-emoji-picker-emoji-reacted: hsl(195deg 50% 95%);
+    --color-border-emoji-picker-emoji-reacted: hsl(195deg 52% 79%);
+    --color-background-emoji-picker-emoji-reacted-focus: hsl(195deg 55% 88%);
 }
 
 %dark-theme {
@@ -704,6 +715,17 @@
     --color-exit-button-border: hsl(0deg 0% 0% / 60%);
     --color-exit-button-background: hsl(211deg 29% 14%);
     --color-exit-button-background-interactive: hsl(211deg 29% 17%);
+
+    /* Emoji-picker colors */
+    --color-background-emoji-picker-popover: hsl(0deg 0% 0% / 20%);
+    --color-background-emoji-picker-popover-tab-item-active: hsl(
+        0deg 0% 0% / 50%
+    );
+    --color-background-emoji-picker-emoji-focus: hsl(212deg 28% 8% / 75%);
+    --color-box-shadow-emoji-picker-emoji-focus: hsl(0deg 0% 98%);
+    --color-background-emoji-picker-emoji-reacted: hsl(0deg 0% 0% / 50%);
+    --color-border-emoji-picker-emoji-reacted: hsl(0deg 0% 0% / 90%);
+    --color-background-emoji-picker-emoji-reacted-focus: hsl(0deg 0% 20% / 70%);
 }
 
 @media screen {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -520,31 +520,6 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
-    .emoji-picker-popover .emoji-showcase-container,
-    .emoji-picker-popover .emoji-popover .emoji-popover-category-tabs,
-    .emoji-picker-popover .emoji-popover .emoji-popover-top {
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-
-    .emoji-picker-popover
-        .emoji-popover
-        .emoji-popover-category-tabs
-        .emoji-popover-tab-item.active {
-        background-color: hsl(0deg 0% 0% / 50%);
-    }
-
-    .emoji-popover-emoji {
-        &:focus {
-            background-color: hsl(212deg 28% 8% / 75%);
-            box-shadow: 0 0 1px hsl(0deg 0% 98%);
-        }
-
-        &.reacted {
-            background-color: hsl(0deg 0% 0% / 50%);
-            border-color: hsl(0deg 0% 0% / 90%);
-        }
-    }
-
     .new-style .tab-switcher .ind-tab.selected,
     div.message_content thead,
     .table-striped thead th {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -191,7 +191,7 @@
             padding: 8px 10px;
             margin-bottom: 0;
 
-            background-color: hsl(0deg 0% 93%);
+            background-color: var(--color-background-emoji-picker-popover);
 
             border-radius: 3px 3px 0 0;
 
@@ -214,7 +214,7 @@
         .emoji-popover-category-tabs {
             /* Flex needed here to work around #7511 (90% zoom issues in firefox) */
             display: flex;
-            background-color: hsl(0deg 0% 93%);
+            background-color: var(--color-background-emoji-picker-popover);
             width: 100%;
             box-sizing: border-box;
             overflow: hidden;
@@ -231,7 +231,9 @@
                 flex-grow: 1;
 
                 &.active {
-                    background-color: hsl(0deg 0% 100% / 20%);
+                    background-color: var(
+                        --color-background-emoji-picker-popover-tab-item-active
+                    );
                 }
             }
         }
@@ -265,17 +267,27 @@
             width: 25px;
 
             &:focus {
-                background-color: hsl(0deg 0% 93%);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-focus
+                );
+                /* Only dark mode takes a box shadow on
+                   the emoji-picker's focused emoji. */
+                box-shadow: 0 0 1px
+                    var(--color-box-shadow-emoji-picker-emoji-focus);
                 outline: none;
             }
 
             &.reacted {
-                background-color: hsl(195deg 50% 95%);
-                border-color: hsl(195deg 52% 79%);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-reacted
+                );
+                border-color: var(--color-border-emoji-picker-emoji-reacted);
             }
 
             &.reacted:focus {
-                background-color: hsl(195deg 55% 88%);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-reacted-focus
+                );
             }
 
             &.hide {
@@ -300,7 +312,7 @@
 
     .emoji-showcase-container {
         position: relative;
-        background-color: hsl(0deg 0% 93%);
+        background-color: var(--color-background-emoji-picker-popover);
         min-height: 44px;
         width: 250px;
         border-radius: 0 0 3px 3px;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -246,16 +246,6 @@
             padding-left: 3px;
         }
 
-        .emoji-search-results-container {
-            height: 283px;
-
-            .emoji-popover-results-heading {
-                font-weight: 600;
-                padding: 5px 3px 3px 5px;
-                font-size: 17px;
-            }
-        }
-
         .emoji-popover-emoji-map {
             height: 250px;
 
@@ -294,6 +284,16 @@
 
             .emoji {
                 top: 6px;
+            }
+        }
+
+        .emoji-search-results-container {
+            height: 283px;
+
+            .emoji-popover-results-heading {
+                font-weight: 600;
+                padding: 5px 3px 3px 5px;
+                font-size: 17px;
             }
         }
     }

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -182,14 +182,6 @@
     height: 370px;
     user-select: none;
 
-    &.bottom .arrow {
-        border-bottom-color: hsl(0deg 0% 93%);
-    }
-
-    &.top .arrow {
-        border-top-color: hsl(0deg 0% 93%);
-    }
-
     .emoji-popover {
         width: 250px;
 


### PR DESCRIPTION
This PR improves the CSS around the emoji picker:

1. It removes a few stale selectors leftover from before the picker's implementation in Tippy
2. It reorders a selector to make it easier to cross-reference the CSS with HTML order in templates
3. It creates variables for emoji picker background, border, and box-shadow colors
4. It eliminates all separate emoji-picker references from `dark_theme.css`

It also introduces a previously missing dark-theme color for the `:focus` state on a reacted emoji.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/emoji.20picker.20dark.20theme/near/1745800)

**Screenshots and screen captures:**

_Showing focus on reacted emoji_

| Before | After |
| --- | --- |
| ![light-mode-reacted-emoji-focused-before](https://github.com/zulip/zulip/assets/170719/674f2b6f-3d81-42bb-beab-00c33aee9e0f) | ![light-mode-reacted-emoji-focused-after](https://github.com/zulip/zulip/assets/170719/797bdec9-d071-49f8-a161-1e113a2f3f29) |
| ![dark-mode-reacted-emoji-focused-before](https://github.com/zulip/zulip/assets/170719/7572e143-2687-42fd-8b55-92684f469654) | ![dark-mode-reacted-emoji-focused-after](https://github.com/zulip/zulip/assets/170719/19481315-4759-4ad8-ab3d-c9b69edaae66) |

_Showing focus on other emoji (with reacted emoji indicated)_

| Before | After (no changes) |
| --- | --- |
| ![light-mode-other-emoji-focused-before](https://github.com/zulip/zulip/assets/170719/0dcc1b70-f4ea-4043-a251-ab3e9c7e6aa9) | ![light-mode-other-emoji-focused-after](https://github.com/zulip/zulip/assets/170719/8c3ee9d8-56ca-4e0e-b3d7-093aee7f9fa0) |
| ![dark-mode-other-emoji-focused-before](https://github.com/zulip/zulip/assets/170719/d3b19148-ef29-41fe-9d7f-868f674b86c8) | ![dark-mode-other-emoji-focused-after](https://github.com/zulip/zulip/assets/170719/2dcef16e-14e3-4ccf-a542-ea4eba873031) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>