### PR TITLE
portico: Remove All plans tab at mobile scale.

### DIFF
--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -624,6 +624,12 @@
     }
 }
 
+@media (width <= 460px) {
+    .zulip-plans-comparison .comparison-tab-all {
+        display: none;
+    }
+}
+
 @media (width <= 356px) {
     .zulip-plans-comparison
         .comparison-table


### PR DESCRIPTION
This PR removes the tab for All plans at mobile scales below 460px, the point at which the All plans features-comparison table cannot comfortably fit within a narrow viewport.

Note that this does not attempt to catch edge cases like where All tabs might be selected and then the viewport shifts smaller (e.g., on an orientation shift from landscape to portrait.

**Screenshots and screen captures:**

| 460px wide, Before | 460px wide, After |
| --- | --- |
| ![460-wide-before](https://github.com/zulip/zulip/assets/170719/153cb8fe-adbe-439d-a7d6-f3ae9d420659) | ![460-wide-after](https://github.com/zulip/zulip/assets/170719/f9b20c29-a4ce-4a4e-b5b3-fdae6dd11d3f) |

| 470px wide, Before | 470px wide, After (no change) |
| --- | --- |
| ![470-wide-before](https://github.com/zulip/zulip/assets/170719/90cf5185-48fd-4ad3-82eb-b179c6cb65f3) | ![470-wide-after](https://github.com/zulip/zulip/assets/170719/6a618d2d-7600-4d14-930a-99b2353cf0af) |
