### PR TITLE
navbar: Add navigate to home view tooltip to the organization logo.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -3,11 +3,13 @@ import assert from "minimalistic-assert";
 import tippy, {delegate} from "tippy.js";
 
 import render_buddy_list_title_tooltip from "../templates/buddy_list/title_tooltip.hbs";
+import render_org_logo_tooltip from "../templates/org_logo_tooltip.hbs";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
 import {$t} from "./i18n";
 import * as people from "./people";
 import * as popovers from "./popovers";
+import * as settings_config from "./settings_config";
 import * as ui_util from "./ui_util";
 import {user_settings} from "./user_settings";
 
@@ -572,6 +574,22 @@ export function initialize(): void {
             const total_user_count = people.get_active_human_count();
             instance.setContent(
                 ui_util.parse_html(render_buddy_list_title_tooltip({total_user_count})),
+            );
+        },
+    });
+
+    delegate("body", {
+        target: "#realm-logo",
+        placement: "right",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const escape_navigates_to_home_view = user_settings.web_escape_navigates_to_home_view;
+            const home_view =
+                settings_config.web_home_view_values[user_settings.web_home_view].description;
+            instance.setContent(
+                ui_util.parse_html(
+                    render_org_logo_tooltip({home_view, escape_navigates_to_home_view}),
+                ),
             );
         },
     });

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -26,7 +26,7 @@ export type UserSettings = (StreamNotificationSettings &
     FollowedTopicNotificationSettings) & {
     color_scheme: number;
     default_language: string;
-    web_home_view: string;
+    web_home_view: "inbox" | "recent_topics" | "all_messages";
     desktop_icon_count_display: number;
     demote_inactive_streams: number;
     dense_mode: boolean;

--- a/web/templates/org_logo_tooltip.hbs
+++ b/web/templates/org_logo_tooltip.hbs
@@ -1,0 +1,8 @@
+<div>
+    <div>{{t "Go to home view"}} ({{home_view}})</div>
+</div>
+{{#if escape_navigates_to_home_view}}
+    {{tooltip_hotkey_hints "Esc"}}
+{{else}}
+    {{tooltip_hotkey_hints "Ctrl" "["}}
+{{/if}}


### PR DESCRIPTION
The organization logo in the upper left navigates to the user's home view. We add a tooltip to make this easier to discover.

We show `Esc` as the keyboard shortcut here, unless the user has disabled it, in which case we show the alt shortcut `Ctrl` + `[`.

Fixes: #29185.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>When ` Escape key navigates to home view` is disabled</summary>
<p>

![image](https://github.com/zulip/zulip/assets/82862779/d686d835-af71-415f-8b20-13c748c76c92)

</p>
</details> 

<details><summary>When ` Escape key navigates to home view` is enabled</summary>
<p>

![image](https://github.com/zulip/zulip/assets/82862779/2d6aa028-3db3-4b04-a977-213f40ab3106)

![image](https://github.com/zulip/zulip/assets/82862779/309e89d6-e7b1-44aa-8a8d-205fc5860a03)

![image](https://github.com/zulip/zulip/assets/82862779/2e4f4f36-02a3-4080-840a-0cecdca9e870)


</p>
</details> 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
