### PR TITLE
corporate: Use `next_invoice_date` as the event_time in invoice_plan.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2918,7 +2918,7 @@ class StripeTest(StripeTestCase):
         for key, value in monthly_plan_invoice_item_params.items():
             self.assertEqual(invoice_item0[key], value)
 
-        with time_machine.travel(self.now, tick=False):
+        with time_machine.travel(self.next_year, tick=False):
             response = self.client_get("/billing/")
         self.assert_not_in_success_response(
             ["Your plan will switch to annual billing on February 2, 2012"], response
@@ -3368,7 +3368,8 @@ class StripeTest(StripeTestCase):
 
         invoice_plans_as_needed(self.next_year)
 
-        response = self.client_get("/billing/")
+        with time_machine.travel(self.next_year, tick=False):
+            response = self.client_get("/billing/")
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/plans/", response["Location"])
 
@@ -4901,9 +4902,10 @@ class LicenseLedgerTest(StripeTestCase):
         billing_session.update_license_ledger_if_needed(self.now)
         self.assertFalse(LicenseLedger.objects.exists())
         # Test plan not automanaged
-        self.local_upgrade(
-            self.seat_count + 1, False, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
-        )
+        with time_machine.travel(self.now, tick=False):
+            self.local_upgrade(
+                self.seat_count + 1, False, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
+            )
         plan = CustomerPlan.objects.get()
         self.assertEqual(LicenseLedger.objects.count(), 1)
         self.assertEqual(plan.licenses(), self.seat_count + 1)
@@ -6011,7 +6013,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         assert latest_ledger is not None
         self.assertEqual(latest_ledger.licenses, min_licenses + 10)
 
-        with time_machine.travel(self.now + timedelta(days=1), tick=False):
+        with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )
@@ -6160,7 +6162,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             assert latest_ledger is not None
             self.assertEqual(latest_ledger.licenses, min_licenses + 10)
 
-            with time_machine.travel(self.now + timedelta(days=1), tick=False):
+            with time_machine.travel(self.now + timedelta(days=3), tick=False):
                 response = self.client_get(
                     f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
                 )
@@ -6280,7 +6282,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         assert latest_ledger is not None
         self.assertEqual(latest_ledger.licenses, min_licenses + 10)
 
-        with time_machine.travel(self.now + timedelta(days=1), tick=False):
+        with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )
@@ -7939,7 +7941,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
             assert latest_ledger is not None
             self.assertEqual(latest_ledger.licenses, 28)
 
-            with time_machine.travel(self.now + timedelta(days=1), tick=False):
+            with time_machine.travel(self.now + timedelta(days=3), tick=False):
                 response = self.client_get(
                     f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
                 )
@@ -8059,7 +8061,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         assert latest_ledger is not None
         self.assertEqual(latest_ledger.licenses, 28)
 
-        with time_machine.travel(self.now + timedelta(days=1), tick=False):
+        with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -662,7 +662,7 @@ class TestSupportEndpoint(ZulipTestCase):
         LicenseLedger.objects.create(
             licenses=10,
             licenses_at_next_renewal=10,
-            event_time=timezone_now(),
+            event_time=now,
             is_renewal=True,
             plan=plan,
         )


### PR DESCRIPTION

* PR to use `next_invoice_date` as the event_time in invoice_plan.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
