### PR TITLE
remote-support: Add ability to deactivate and reactivate remote servers.

### DIFF
--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -146,6 +146,22 @@
                     {% endwith %}
                 </div>
                 {% endif %}
+
+                {% if remote_server.deactivated %}
+                <form method="POST" class="reactivate-remote-server-form">
+                    {{ csrf_input }}
+                    <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
+                    <input type="hidden" name="remote_server_status" value="active" />
+                    <button class="reactivate-remote-server-button"><b>Reactivate</b>: {{ remote_server.hostname }}</button>
+                </form>
+                {% else %}
+                <form method="POST" class="deactivate-remote-server-form">
+                    {{ csrf_input }}
+                    <input type="hidden" name="remote_server_id" value="{{ remote_server.id }}" />
+                    <input type="hidden" name="remote_server_status" value="deactivated" />
+                    <button class="deactivate-remote-server-button"><b>Deactivate</b>: {{ remote_server.hostname }}</button>
+                </form>
+                {% endif %}
             </div>
             <div class="remote-realms-section">
                 {% if remote_realms[remote_server.id] == [] %}

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -171,6 +171,8 @@ tr.admin td:first-child {
     }
 }
 
+.reactivate-remote-server-button,
+.deactivate-remote-server-button,
 .delete-next-fixed-price-plan-button,
 .approve-sponsorship-button,
 .support-search-button,
@@ -243,6 +245,7 @@ tr.admin td:first-child {
     }
 }
 
+.deactivate-remote-server-button,
 .delete-next-fixed-price-plan-button,
 .delete-user-button,
 .scrub-realm-button {
@@ -258,6 +261,30 @@ tr.admin td:first-child {
         background-color: hsl(2deg 65% 50%);
         border: 1px solid hsl(2deg 65% 41%);
     }
+}
+
+.reactivate-remote-server-button {
+    color: hsl(0deg 0% 100%);
+    background-color: hsl(35deg 70% 56%);
+    border: 1px solid hsl(35deg 70% 50%);
+    border-radius: 2px;
+
+    &:hover,
+    &:focus,
+    &:active {
+        color: hsl(0deg 0% 100%);
+        background-color: hsl(35deg 82% 40%);
+        border: 1px solid hsl(35deg 82% 30%);
+    }
+}
+
+.reactivate-remote-server-button,
+.deactivate-remote-server-button {
+    font-size: 15px;
+    line-height: 1.8;
+    max-width: 550px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .remote-support-query-result.remote-server-deactivated {
@@ -280,6 +307,8 @@ tr.admin td:first-child {
     text-align: center;
 }
 
+.reactivate-remote-server-form,
+.deactivate-remote-server-form,
 .realm-support-information,
 .remote-server-information,
 .remote-realm-information {


### PR DESCRIPTION
In the remote support view:
- Adds a deactivate button for remote servers that are active.
- Adds a reactivate button for remote servers that are deactivated.

**Notes**:
- Uses the utility functions in `stripe.py` for deactivating and reactivating the remote server.
- When deactivating, if a `ServerDeactivateWithExistingPlanError` is raised, then an error message is shown in the support view and the remote server is not deactivated.
- Note that remote servers (and associated remote realms) with a `CustomerPlanOffer` configured can be deactivated, but the support admin can still delete that configured plan when the remote server is deactivated.
- Positioned the buttons at the bottom of the remote server section and included the hostname on the button text. The button does have a max-width set and any text overflow will be hidden with an ellipsis. These buttons have a slightly bigger font-size so that they stand out more than the other buttons in the support view.

---

**Screenshots and screen captures:**

<details>
<summary>Remote server with realms with active plans - cannot be deactivated</summary>

![Screenshot from 2024-03-07 13-21-32](https://github.com/zulip/zulip/assets/63245456/c11859d6-994f-42e5-91ce-9b82bbccdd31)
</details>
<details>
<summary>Remote server with active plan - cannot be deactivated</summary>

![Screenshot from 2024-03-06 18-26-24](https://github.com/zulip/zulip/assets/63245456/89c29caa-84a2-4cb7-b4c4-523424e897ec)
</details>
<details>
<summary>Remote server with plan scheduled - cannot be deactivated</summary>

![Screenshot from 2024-03-06 18-25-09](https://github.com/zulip/zulip/assets/63245456/de493366-b818-403d-b442-bf6c98a726b5)
</details>
<details>
<summary>Remote server on legacy plan - can be deactivated</summary>

![Screenshot from 2024-03-06 18-25-40](https://github.com/zulip/zulip/assets/63245456/ea74c0f9-6d95-4c14-af2b-c2be0f11af31)
</details>
<details>
<summary>Reactivated remote server from screenshot above (legacy plan)</summary>

![Screenshot from 2024-03-06 18-25-54](https://github.com/zulip/zulip/assets/63245456/6d8b80ea-7a89-4fa9-afeb-18a1f7b29333)
</details>
<details>
<summary>Remote server on community plan - can be deactivated</summary>

![Screenshot from 2024-03-06 18-26-45](https://github.com/zulip/zulip/assets/63245456/78fb34d4-8a1b-45a3-9ba9-10b07b1f96c8)
</details>
<details>
<summary>Reactivated remote server from screenshot above (community plan)</summary>

![Screenshot from 2024-03-06 18-27-06](https://github.com/zulip/zulip/assets/63245456/82b0affb-ffc0-4428-ab7f-34e082d0d305)
</details>
<details>
<summary>Remote server with remote realms and no active/scheduled plans - can be deactivated</summary>

![Screenshot from 2024-03-06 18-27-53](https://github.com/zulip/zulip/assets/63245456/19807024-9671-48c7-b112-71b4fe7a7031)
</details>
<details>
<summary>Reactivated remote server from screenshot above (remote realms and no plans)</summary>

![Screenshot from 2024-03-06 18-28-04](https://github.com/zulip/zulip/assets/63245456/0b768df0-f2a4-4891-afdf-615fb3a2195e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

