### PR TITLE
Compose Box: Unresolve empty topics.

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import {unresolve_name} from "../shared/src/resolved_topic";
 import render_add_poll_modal from "../templates/add_poll_modal.hbs";
 
 import * as compose from "./compose";
@@ -168,7 +169,22 @@ export function initialize() {
             const topic_name = $target.attr("data-topic-name");
 
             message_edit.with_first_message_id(stream_id, topic_name, (message_id) => {
-                message_edit.toggle_resolve_topic(message_id, topic_name, true);
+                if (message_id === undefined) {
+                    // There is no message in the topic, so it is sufficient to
+                    // just remove the topic resolved prefix (✔) from the topic name.
+                    const $input = $("input#stream_message_recipient_topic");
+                    const new_topic = unresolve_name(topic_name);
+                    $input.val(new_topic);
+                    // Trigger an input event, since this is a form of
+                    // user-triggered edit to that field.
+                    $input.trigger("input");
+
+                    // TODO: Probably this should also renarrow to the
+                    // new topic, if we were currently viewing the old
+                    // topic, just as if a message edit had occurred.
+                } else {
+                    message_edit.toggle_resolve_topic(message_id, topic_name, true);
+                }
                 compose_validate.clear_topic_resolved_warning(true);
             });
         },

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1375,7 +1375,7 @@ export function with_first_message_id(stream_id, topic_name, success_cb, error_c
         url: "/json/messages",
         data,
         success(data) {
-            const message_id = data.messages[0].id;
+            const message_id = data.messages[0]?.id;
             success_cb(message_id);
         },
         error: error_cb,


### PR DESCRIPTION
In case of empty topics, only the compose box
topic is changed to remove the tick-prefix from it.

The function `with_first_message_id` may return
undefined when no message is found, instead of
throwing an error.

Fixes #29182

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Instead of an error, unresolving an empty topic and then sending a message in it now results in:

![image](https://github.com/zulip/zulip/assets/88523649/d7153e79-337b-4e95-ae85-a63118445731)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
