### PR TITLE
compose: Trigger language typeahead on using code formatting button.

### DIFF
--- a/web/src/bootstrap_typeahead.js
+++ b/web/src/bootstrap_typeahead.js
@@ -573,7 +573,10 @@ Typeahead.prototype = {
             return;
         }
         setTimeout(() => {
-            if (!this.$container.is(":hover")) {
+            if (!this.$container.is(":hover") && !this.$element.is(":focus")) {
+                // We do not hide the typeahead in case it is being hovered over,
+                // or if the focus is immediately back in the input field (likely
+                // when using compose formatting buttons).
                 this.hide();
             } else if (this.shown) {
                 // refocus the input if the user clicked on the typeahead

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -585,7 +585,7 @@ export function format_text(
         }
     };
 
-    const format = (syntax_start: string, syntax_end = syntax_start): void => {
+    const format = (syntax_start: string, syntax_end = syntax_start): boolean => {
         let linebreak_start = "";
         let linebreak_end = "";
         if (syntax_start.startsWith("\n")) {
@@ -606,7 +606,7 @@ export function format_text(
                 range.start - syntax_start.length,
                 range.end - syntax_start.length,
             );
-            return;
+            return false;
         } else if (is_inner_text_formatted(syntax_start, syntax_end)) {
             // Remove syntax inside the selection, if present.
             text =
@@ -620,11 +620,12 @@ export function format_text(
                 range.start,
                 range.end - syntax_start.length - syntax_end.length,
             );
-            return;
+            return false;
         }
 
         // Otherwise, we don't have syntax within or around, so we add it.
         wrapFieldSelection(field, syntax_start, syntax_end);
+        return true;
     };
 
     const format_spoiler = (): void => {

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -46,7 +46,12 @@ type SelectedLinesSections = {
 
 export let compose_spinner_visible = false;
 export let shift_pressed = false; // true or false
+export let code_formatting_button_triggered = false; // true or false
 let full_size_status = false; // true or false
+
+export function set_code_formatting_button_triggered(value: boolean): void {
+    code_formatting_button_triggered = value;
+}
 
 // Some functions to handle the full size status explicitly
 export function set_full_size(is_full: boolean): void {
@@ -1011,7 +1016,15 @@ export function format_text(
                 if (range.end < text.length && text[range.end] !== "\n") {
                     block_code_syntax_end = block_code_syntax_end + "\n";
                 }
-                format(block_code_syntax_start, block_code_syntax_end);
+                const added_fence = format(block_code_syntax_start, block_code_syntax_end);
+                if (added_fence) {
+                    const cursor_after_opening_fence =
+                        range.start + block_code_syntax_start.length - 1;
+                    field.setSelectionRange(cursor_after_opening_fence, cursor_after_opening_fence);
+                    set_code_formatting_button_triggered(true);
+                    // Trigger typeahead lookup with a click.
+                    field.click();
+                }
             } else {
                 format(inline_code_syntax);
             }

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -677,13 +677,15 @@ export function get_candidates(query) {
     const syntax_token = current_token.slice(0, 3);
     if (this.options.completions.syntax && (syntax_token === "```" || syntax_token === "~~~")) {
         // Only autocomplete if user starts typing a language after ```
-        if (current_token.length === 3) {
+        // unless the fence was added via the code formatting button.
+        if (current_token.length === 3 && !compose_ui.code_formatting_button_triggered) {
             return false;
         }
 
         // If the only input is a space, don't autocomplete
         current_token = current_token.slice(3);
         if (current_token === " ") {
+            compose_ui.set_code_formatting_button_triggered(false);
             return false;
         }
 
@@ -693,7 +695,13 @@ export function get_candidates(query) {
         }
         this.completing = "syntax";
         this.token = current_token;
-        return realm_playground.get_pygments_typeahead_list_for_composebox();
+        // If the code formatting button was triggered, we want to show a blank option
+        // to improve the discoverability of the possibility of specifying a language.
+        const language_list = compose_ui.code_formatting_button_triggered
+            ? ["", ...realm_playground.get_pygments_typeahead_list_for_composebox()]
+            : realm_playground.get_pygments_typeahead_list_for_composebox();
+        compose_ui.set_code_formatting_button_triggered(false);
+        return language_list;
     }
 
     // Only start the emoji autocompleter if : is directly after one

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -798,6 +798,14 @@ strong {
             color: hsl(0deg 0% 20%);
             white-space: nowrap;
 
+            /* hidden text just to maintain line height for a blank option */
+            strong:empty {
+                &::after {
+                    content: ".";
+                    visibility: hidden;
+                }
+            }
+
             &:hover {
                 text-decoration: none;
             }

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -508,6 +508,7 @@ $textarea.get = () => ({
             length: end - start,
         });
     },
+    click() {},
 });
 
 // The argument `text_representation` is a string representing the text
@@ -859,17 +860,17 @@ run_test("format_text - code", ({override, override_rewire}) => {
     compose_ui.format_text($textarea, "code");
     assert.equal(
         get_textarea_state(),
-        "Before\nBefore \n```\n<this should\nbe code>\n```\n After\nAfter",
+        "Before\nBefore \n```|\nthis should\nbe code\n```\n After\nAfter",
     );
 
     init_textarea_state("<abc\ndef>");
     compose_ui.format_text($textarea, "code");
-    assert.equal(get_textarea_state(), "```\n<abc\ndef>\n```");
+    assert.equal(get_textarea_state(), "```|\nabc\ndef\n```");
 
     // Code, no selection
     init_textarea_state("|");
     compose_ui.format_text($textarea, "code");
-    assert.equal(get_textarea_state(), "```\n|\n```");
+    assert.equal(get_textarea_state(), "```|\n\n```");
 
     // Undo code selected text, syntax not selected
     init_textarea_state("before `<abc>` after");

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -16,6 +16,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
         autosize_called = true;
     },
     cursor_inside_code_block: () => false,
+    set_code_formatting_button_triggered: noop,
 });
 const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,


### PR DESCRIPTION
To increase the discoverability of the possibility of specifying the language for a code block, we trigger the language typeahead when code syntax is added using the code formatting button. A blank option is shown preselected in the typeahead, so that pressing enter will not mistakenly add a language to the code block.

We only trigger the typeahead on empty opening fences when added by the button, by setting a state variable to true when adding the syntax using the button, checking for this state when sourcing languages for the code typeahead, and then resetting the state variable to false.

Fixes: #29150.

typeahead: Don't hide typeahead on blur if focus is back in the input.

Now we don't hide the typeahead if the focus is back in the input within 150 ms. This is common when using the compose formatting buttons, which only momentarily take the focus away from the input.

This is a prep commit for the next, to show typeahead on adding code syntax with the code formatting button.

compose: Refactor `format` function to return a boolean.

The inline `format` function defined in `format_text` function` now returns true if formatting was added rather than removed, else false.

This is a prep commit for the upcoming change to show typeahead on using the code formatting button to add code formatting to any selected text.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/c514b419-8278-4fa3-854e-62509c507517)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
