### PR TITLE
requirements: Move pip and zoneinfo forks to zulip organization

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -85,7 +85,7 @@ django-bmemcached
 python-dateutil
 
 # Needed for time zone work
-https://github.com/andersk/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9"  # https://github.com/pganssle/zoneinfo/pull/126
+https://github.com/zulip/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9"  # https://github.com/pganssle/zoneinfo/pull/126
 
 # Needed for Redis
 redis

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -182,7 +182,7 @@ backoff==2.2.1 \
     --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
     --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
     # via -r requirements/common.in
-https://github.com/andersk/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9" \
+https://github.com/zulip/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9" \
     --hash=sha256:23938590401ee45d88f37a5caa538b410ffa827169965a0bcf387da13b695450
     # via
     #   -r requirements/common.in
@@ -3456,7 +3456,7 @@ zxcvbn==4.4.28 \
     # via -r requirements/common.in
 
 # The following packages are considered to be unsafe in a requirements file:
-https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+https://github.com/zulip/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
     --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
     # via
     #   -r requirements/pip.in

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,3 +1,3 @@
-https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git  # Our hack for installing specific commits from Git requires --use-deprecated=legacy-resolver: https://github.com/pypa/pip/issues/5780
+https://github.com/zulip/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git  # Our hack for installing specific commits from Git requires --use-deprecated=legacy-resolver: https://github.com/pypa/pip/issues/5780
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -13,7 +13,7 @@ wheel==0.42.0 \
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+https://github.com/zulip/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
     --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
     # via -r requirements/pip.in
 setuptools==69.1.1 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -160,7 +160,7 @@ backoff==2.2.1 \
     --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
     --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
     # via -r requirements/common.in
-https://github.com/andersk/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9" \
+https://github.com/zulip/zoneinfo/archive/f9687abaea8453be1c8d0e21544bd557d65af933.zip#egg=backports.zoneinfo==0.2.1+git ; python_version < "3.9" \
     --hash=sha256:23938590401ee45d88f37a5caa538b410ffa827169965a0bcf387da13b695450
     # via
     #   -r requirements/common.in
@@ -2413,7 +2413,7 @@ zxcvbn==4.4.28 \
     # via -r requirements/common.in
 
 # The following packages are considered to be unsafe in a requirements file:
-https://github.com/andersk/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
+https://github.com/zulip/pip/archive/6642149c44297200f44dfe215b1cb7954d47ed77.zip#egg=pip==20.3.4+git \
     --hash=sha256:4dfbc892b80b32091921c7cead7c4aff06c726e520633ac89bc463137e0fd27d
     # via
     #   -r requirements/pip.in


### PR DESCRIPTION
- https://github.com/zulip/zulip/pull/29234#discussion_r1516958975

For permanence, I copied these tags into the forks:

- https://github.com/zulip/pip/releases/tag/zulip-29074
- https://github.com/zulip/zoneinfo/releases/tag/zulip-24573
