### PR TITLE
create-database: Treat "zulip" db without "zerver_messages" as empty.

### DIFF
--- a/scripts/setup/create-database
+++ b/scripts/setup/create-database
@@ -15,7 +15,7 @@ DATABASE_NAME=$(crudini --get /etc/zulip/zulip.conf postgresql database_name 2>/
 DATABASE_USER=$(crudini --get /etc/zulip/zulip.conf postgresql database_user 2>/dev/null || echo zulip)
 
 if [ "$(su "$POSTGRES_USER" -c "cd / && psql -v ON_ERROR_STOP=1 -Atc \"SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME';\"")" = "1" ]; then
-    records="$(su "$POSTGRES_USER" -c "cd / && psql -v ON_ERROR_STOP=1 -Atc 'SELECT COUNT(*) FROM $DATABASE_NAME.zerver_message;' $DATABASE_USER")"
+    records="$(su "$POSTGRES_USER" -c "cd / && psql -v ON_ERROR_STOP=1 -Atc 'SELECT COUNT(*) FROM $DATABASE_NAME.zerver_message;' $DATABASE_USER" || echo 0)"
     if [ "$records" -gt 200 ]; then
         set +x
         echo "WARNING: This will delete your Zulip database which currently contains $records messages."


### PR DESCRIPTION
A user who somehow got an empty `zulip` database, but without a `zerver_messages` table in it, would get stuck in the installer at:

```
++ su postgres -c 'cd / && psql -v ON_ERROR_STOP=1 -Atc '\''SELECT COUNT(*) FROM zulip.zerver_message;'\'' zulip'
ERROR:  relation "zulip.zerver_message" does not exist
LINE 1: SELECT COUNT(*) FROM zulip.zerver_message;
                             ^
+ records=
```

Treat a failure to select from `zerver_messages` as having 0 messages, and continue with the `DROP DATABASE IF EXISTS` / `CREATE DATABASE` that `create-db.sql` usually does.

Fixes: #29110.
