### PR TITLE
typeahead: Update activity score computation algorithm for streams.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -567,19 +567,28 @@ export function sort_slash_commands(matches: SlashCommand[], query: string): Sla
     return [...results.matches, ...results.rest];
 }
 
-// Gives stream a score from 0 to 3 based on its activity
 function activity_score(sub: StreamSubscription): number {
-    let stream_score = 0;
+    // We assign the highest score to the stream being composed
+    // to, and the lowest score to unsubscribed streams. For others,
+    // we prioritise pinned unmuted streams > unpinned unmuted streams
+    // > pinned muted streams > unpinned muted streams, using recent
+    // activity as a tiebreaker.
+    if (sub.name === compose_state.stream_name()) {
+        return 8;
+    }
     if (!sub.subscribed) {
-        stream_score = -1;
-    } else {
-        if (sub.pin_to_top) {
-            stream_score += 2;
-        }
-        // Note: A pinned stream may accumulate a 3rd point if it has recent activity.
-        if (stream_list_sort.has_recent_activity(sub)) {
-            stream_score += 1;
-        }
+        return -1;
+    }
+
+    let stream_score = 0;
+    if (!sub.is_muted) {
+        stream_score += 4;
+    }
+    if (sub.pin_to_top) {
+        stream_score += 2;
+    }
+    if (stream_list_sort.has_recent_activity(sub)) {
+        stream_score += 1;
     }
     return stream_score;
 }

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -122,7 +122,7 @@ function test(label, f) {
     });
 }
 
-test("sort_streams", ({override}) => {
+test("sort_streams", ({override, override_rewire}) => {
     let test_streams = [
         {
             stream_id: 101,
@@ -130,6 +130,7 @@ test("sort_streams", ({override}) => {
             pin_to_top: false,
             stream_weekly_traffic: 0,
             subscribed: true,
+            is_muted: false,
         },
         {
             stream_id: 102,
@@ -137,6 +138,7 @@ test("sort_streams", ({override}) => {
             pin_to_top: false,
             stream_weekly_traffic: 100,
             subscribed: true,
+            is_muted: false,
         },
         {
             stream_id: 103,
@@ -144,6 +146,7 @@ test("sort_streams", ({override}) => {
             pin_to_top: false,
             stream_weekly_traffic: 0,
             subscribed: true,
+            is_muted: true,
         },
         {
             stream_id: 104,
@@ -151,6 +154,7 @@ test("sort_streams", ({override}) => {
             pin_to_top: true,
             stream_weekly_traffic: 100,
             subscribed: true,
+            is_muted: false,
         },
         {
             stream_id: 105,
@@ -158,6 +162,15 @@ test("sort_streams", ({override}) => {
             pin_to_top: false,
             stream_weekly_traffic: 0,
             subscribed: true,
+            is_muted: false,
+        },
+        {
+            stream_id: 106,
+            name: "dead (almost)",
+            pin_to_top: false,
+            stream_weekly_traffic: 2,
+            subscribed: true,
+            is_muted: false,
         },
     ];
 
@@ -173,14 +186,17 @@ test("sort_streams", ({override}) => {
         "stream_has_topics",
         (stream_id) => ![105, 205].includes(stream_id),
     );
+    override_rewire(compose_state, "stream_name", () => "Dev");
 
     test_streams = th.sort_streams(test_streams, "d");
-    assert.deepEqual(test_streams[0].name, "Denmark"); // Pinned streams first
-    assert.deepEqual(test_streams[1].name, "Docs"); // Active streams next
-    assert.deepEqual(test_streams[2].name, "Derp"); // Less subscribers
-    assert.deepEqual(test_streams[3].name, "Dev"); // Alphabetically last
-    assert.deepEqual(test_streams[4].name, "dead"); // Inactive streams last
+    assert.deepEqual(test_streams[0].name, "Dev"); // Stream being composed to
+    assert.deepEqual(test_streams[1].name, "Denmark"); // Pinned stream
+    assert.deepEqual(test_streams[2].name, "Docs"); // Active stream
+    assert.deepEqual(test_streams[3].name, "dead (almost)"); // Relatively inactive stream
+    assert.deepEqual(test_streams[4].name, "dead"); // Completely inactive stream
+    assert.deepEqual(test_streams[5].name, "Derp"); // Muted stream last
 
+    override_rewire(compose_state, "stream_name", () => "Different");
     // Test sort streams with description
     test_streams = [
         {


### PR DESCRIPTION
Earlier, streams were prioritised like this: pinned streams > subscribed streams > other streams, with message volume serving as the tie breaker.

Now we prioritise them like: stream being composed to > pinned unmuted streams > unpinned unmuted streams > pinned muted streams > unpinned muted streams > unsubscribed streams, with the same tie breaker.

Fixes: #20618.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
