### PR TITLE
rendered_markdown: Correct and modernize presentation of REPL and Copy buttons.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -679,8 +679,7 @@
         display: block;
         border-radius: 4px;
 
-        &:hover .copy_codeblock,
-        &:hover .code_external_link {
+        &:hover .code-buttons-container {
             visibility: visible;
         }
     }
@@ -710,14 +709,52 @@
         border-radius: 3px;
     }
 
-    /* Style copy-to-clipboard button inside code blocks */
-    .copy_codeblock {
-        visibility: hidden;
+    /* Container for buttons inside code blocks. */
+    .code-buttons-container {
+        /* Break white-space treatment inherited from <pre> */
+        white-space: collapse;
+        /* Present buttons in a flexbox layout. */
+        display: flex;
+        align-items: center;
+        gap: 3px;
         /* Having absolute positioning here ensures that the element
         doesn't scroll along with the code div in narrow windows */
         position: absolute;
-        right: 20px;
-        margin-top: -4px;
+        top: 2px;
+        right: 0;
+        padding: 0 4px;
+        /* Invisible unless <pre> is hovered. */
+        visibility: hidden;
+
+        #clipboard_image {
+            /* Zero out legacy negative margins */
+            margin: 0;
+        }
+    }
+
+    /* Style copy-to-clipboard button inside code blocks */
+    .copy_codeblock {
+        display: flex;
+        align-content: center;
+        /* Push back on legacy styles from .copy_button_base,
+           which are not necessary in the flex setting established
+           on the .code-buttons-container. */
+        height: auto;
+        width: auto;
+        background-clip: unset;
+        /* Don't let the default button color appear
+           behind the icon. Regrettably, !important
+           is necessary for a thorny selector-specificity
+           issue in dark mode. */
+        background-color: transparent !important;
+        /* Square off the box around the copy-to-clipboard icon. */
+        padding: 0 2px 0 4px;
+
+        &:hover {
+            /* Regrettably, !important is necessary for a thorny
+               selector-specificity issue in dark mode. */
+            background-color: transparent !important;
+        }
 
         /* Remove the outline when clicking on the copy-to-clipboard button */
         &:focus {
@@ -726,17 +763,23 @@
     }
 
     .code_external_link {
-        visibility: hidden;
-        position: absolute;
-        right: 23px;
-        margin-top: -3px;
-        font-size: 17px;
+        /* Match the apparent size of the playground icon
+           to the copy-to-clipboard icon. */
+        font-size: 16px;
+        /* Center the icon vertically in the link container. */
+        display: flex;
+        align-content: center;
+        /* The font-icon footprint still requires 2px of
+           top padding to get better alignment with the
+           copy-to-clipboard icon. */
+        padding-top: 2px;
         /* The default icon and on-hover colors are inherited from <a> tag.
         so we set our own to match the copy-to-clipbord icon */
         color: hsl(0deg 0% 47%);
 
         &:hover {
             color: hsl(200deg 100% 40%);
+            text-decoration: none;
         }
     }
 }
@@ -819,6 +862,12 @@
     display: block !important;
     border: none !important;
     background: none !important;
+
+    /* Set a relative positioning context to more precisely
+       position .code-buttons-container. This eliminates
+       problems with positioning shifts associated with
+       code blocks in spoilers, too. */
+    position: relative;
 
     & pre {
         color: var(--color-markdown-pre-text);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -725,6 +725,24 @@
         padding: 0 4px;
         /* Invisible unless <pre> is hovered. */
         visibility: hidden;
+        z-index: 0;
+
+        &::after {
+            content: " ";
+            position: absolute;
+            height: 100%;
+            width: 100%;
+            z-index: -1;
+            /* Blur the background behind the button container */
+            backdrop-filter: blur(5px);
+            /* Use a radial gradient to avoid obvious hard edges
+               to the blur. */
+            mask-image: radial-gradient(
+                farthest-corner,
+                hsl(0deg 0% 0% / 100%),
+                hsl(0deg 0% 0% / 50%)
+            );
+        }
 
         #clipboard_image {
             /* Zero out legacy negative margins */

--- a/web/templates/code_buttons_container.hbs
+++ b/web/templates/code_buttons_container.hbs
@@ -1,0 +1,6 @@
+<div class="code-buttons-container">
+    {{~> copy_code_button~}}
+    {{~#if show_playground_button~}}
+    {{~> view_code_in_playground~}}
+    {{~/if~}}
+</div>

--- a/web/templates/copy_code_button.hbs
+++ b/web/templates/copy_code_button.hbs
@@ -1,3 +1,3 @@
-<button class="btn copy_button_base copy_codeblock" data-tippy-content="{{t 'Copy code' }}" data-tippy-trigger="mouseenter" aria-label="{{t 'Copy code' }}">
+<button class="copy_button_base copy_codeblock" data-tippy-content="{{t 'Copy code' }}" data-tippy-trigger="mouseenter" aria-label="{{t 'Copy code' }}">
     {{> copy_to_clipboard_svg }}
 </button>

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -536,10 +536,16 @@ function test_code_playground(mock_template, viewing_code) {
 
     $hilite.data("code-language", "javascript");
 
+    const $code_buttons_container = $.create("code_buttons_container", {
+        children: ["copy-code-stub", "view-code-stub"],
+    });
     const $copy_code_button = $.create("copy_code_button", {children: ["copy-code-stub"]});
     const $view_code_in_playground = $.create("view_code_in_playground");
 
-    // The code playground code prepends a few buttons
+    $code_buttons_container.set_find_results(".copy_codeblock", $copy_code_button);
+    $code_buttons_container.set_find_results(".code_external_link", $view_code_in_playground);
+
+    // The code playground code prepends a button container
     // to the <pre> section of a highlighted piece of code.
     // The args to prepend should be jQuery objects (or in
     // our case "fake" zjquery objects).
@@ -549,15 +555,15 @@ function test_code_playground(mock_template, viewing_code) {
         prepends.push(arg);
     };
 
-    mock_template("copy_code_button.hbs", false, (data) => {
-        assert.equal(data, undefined);
-        return {to_$: () => $copy_code_button};
-    });
-
     if (viewing_code) {
-        mock_template("view_code_in_playground.hbs", false, (data) => {
-            assert.equal(data, undefined);
-            return {to_$: () => $view_code_in_playground};
+        mock_template("code_buttons_container.hbs", true, (data) => {
+            assert.equal(data.show_playground_button, true);
+            return {to_$: () => $code_buttons_container};
+        });
+    } else {
+        mock_template("code_buttons_container.hbs", true, (data) => {
+            assert.equal(data.show_playground_button, false);
+            return {to_$: () => $code_buttons_container};
         });
     }
 
@@ -565,6 +571,7 @@ function test_code_playground(mock_template, viewing_code) {
 
     return {
         prepends,
+        $button_container: $code_buttons_container,
         $copy_code: $copy_code_button,
         $view_code: $view_code_in_playground,
     };
@@ -578,8 +585,8 @@ run_test("code playground none", ({override, mock_template}) => {
 
     override(copied_tooltip, "show_copied_confirmation", noop);
 
-    const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, false);
-    assert.deepEqual(prepends, [$copy_code]);
+    const {prepends, $button_container, $view_code} = test_code_playground(mock_template, false);
+    assert.deepEqual(prepends, [$button_container]);
     assert_clipboard_setup();
 
     assert.equal($view_code.attr("data-tippy-content"), undefined);
@@ -594,8 +601,8 @@ run_test("code playground single", ({override, mock_template}) => {
 
     override(copied_tooltip, "show_copied_confirmation", noop);
 
-    const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
-    assert.deepEqual(prepends, [$view_code, $copy_code]);
+    const {prepends, $button_container, $view_code} = test_code_playground(mock_template, true);
+    assert.deepEqual(prepends, [$button_container]);
     assert_clipboard_setup();
 
     assert.equal(
@@ -614,8 +621,8 @@ run_test("code playground multiple", ({override, mock_template}) => {
 
     override(copied_tooltip, "show_copied_confirmation", noop);
 
-    const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
-    assert.deepEqual(prepends, [$view_code, $copy_code]);
+    const {prepends, $button_container, $view_code} = test_code_playground(mock_template, true);
+    assert.deepEqual(prepends, [$button_container]);
     assert_clipboard_setup();
 
     assert.equal($view_code.attr("data-tippy-content"), "translated: View in playground");


### PR DESCRIPTION
This PR corrects the overlap problem described in #29165. Additionally, to shore up the code in this area, the PR:

1. Makes a containing template with logic for displaying the REPL button only when a code playground is available
2. Cleans up the JavaScript for readability
3. Sets a `position: relative` context on `.codehilite` blocks, to more accurately position the button-container overlay, and make the overlay's position agnostic toward whether or note the code block is inside a spoiler (issue #20712, whose fix introduced the overlap regression here)
4. Positions the REPL and Copy buttons to a similar righthand edge as can be seen on the similar Copy icon in message-source view
5. Prepares a flexbox-based layout for the REPL and Copy buttons, providing better target areas and reliable presentation of the buttons when hovered
6. Cleans up a bunch of legacy CSS
7. Introduces a blurred background behind the buttons, so that underlying code appears blurred when the button container appears

[CZO discussion: issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22view.20in.20repl.22.20and.20.22copy.20code.22.20icons.20of.20code.20block/near/1753186)

[CZO discussion: blurred code filter](https://chat.zulip.org/#narrow/stream/101-design/topic/code.20block.20hover.20icons/near/1754588)

Fixes: #29165 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Complete layout with blur effect:_

| Light mode | Dark mode |
| --- | --- |
| ![light-mode-layout-blur](https://github.com/zulip/zulip/assets/170719/9d8747b8-f978-4746-9196-f033b596d6b3) | ![dark-mode-layout-blur](https://github.com/zulip/zulip/assets/170719/e7912f91-4abb-40cc-a246-3c309c3c458d) |

_Interactions:_

| Light mode | Dark mode |
| --- | --- |
| ![code-buttons-light-interactive](https://github.com/zulip/zulip/assets/170719/53f99eed-2a94-4c44-852a-a77ebe1206a5) | ![code-buttons-dark-interactive](https://github.com/zulip/zulip/assets/170719/80c950a5-02b7-4a1e-8f43-643e0dbf8017) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>