### PR TITLE
organization_settings: Convert name to pills.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -143,6 +143,7 @@ function bot_info(bot_user_id) {
     info.full_name = bot_user.full_name;
     info.bot_owner_id = owner_id;
     info.user_role_text = people.get_user_type(bot_user_id);
+    info.img_src = people.small_avatar_url_for_person(bot_user);
 
     // Convert bot type id to string for viewing to the users.
     info.bot_type = settings_data.bot_type_id_to_string(bot_user.bot_type);
@@ -161,6 +162,10 @@ function bot_info(bot_user_id) {
 
     // It's always safe to show the real email addresses for bot users
     info.display_email = bot_user.email;
+
+    if (owner_id) {
+        info.owner_img_src = people.small_avatar_url_for_person(people.get_by_user_id(owner_id));
+    }
 
     return info;
 }
@@ -188,6 +193,7 @@ function human_info(person) {
     info.is_current_user = people.is_my_user_id(person.user_id);
     info.cannot_deactivate = info.is_current_user || (person.is_owner && !current_user.is_owner);
     info.display_email = person.delivery_email;
+    info.img_src = people.small_avatar_url_for_person(person);
 
     if (info.is_active) {
         // TODO: We might just want to show this

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1165,7 +1165,7 @@
         }
     }
 
-    .panel_subscriber_member_list > .pill-container {
+    .panel_user_list > .pill-container {
         &:hover {
             color: inherit;
         }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -160,7 +160,7 @@
     }
 }
 
-.panel_subscriber_member_list > .pill-container {
+.panel_user_list > .pill-container {
     background-color: hsl(0deg 0% 0% / 7%);
 
     &:hover {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -214,6 +214,7 @@ $user_status_emoji_width: 24px;
 
 .my_user_status {
     opacity: 0.5;
+    white-space: nowrap;
 }
 
 .selectable_sidebar_block {

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -1,13 +1,6 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
-    <td>
-        <span class="user_name" >
-            <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>
-            {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
-        {{#if is_bot}}
-        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Bot is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
-        {{else}}
-        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
-        {{/if}}
+    <td class="panel_user_list">
+        {{> ../user_display_only_pill display_value=full_name user_id=user_id img_src=img_src}}
     </td>
     {{#if display_email}}
     <td>
@@ -23,11 +16,12 @@
     </td>
     {{#if is_bot}}
     <td class="user_role">
-        <span class="owner">
+        <span class="owner panel_user_list">
             {{#if no_owner }}
             {{bot_owner_full_name}}
             {{else}}
-            <a data-user-id="{{bot_owner_id}}" class="view_user_profile" tabindex="0">{{bot_owner_full_name}}</a>
+            {{> ../user_display_only_pill display_value=bot_owner_full_name user_id=bot_owner_id img_src=owner_img_src is_active=true}}
+
             {{/if}}
         </span>
     </td>

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -1,5 +1,5 @@
 <tr>
-    <td class="panel_subscriber_member_list">
+    <td class="panel_user_list">
         {{> ../user_display_only_pill display_value=full_name}}
     </td>
     {{#if email}}

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -1,6 +1,6 @@
 <tr>
     <td class="panel_user_list">
-        {{> ../user_display_only_pill display_value=full_name}}
+        {{> ../user_display_only_pill display_value=full_name is_active=true}}
     </td>
     {{#if email}}
         <td class="subscriber-email">{{email}}</td>

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -1,5 +1,5 @@
 <tr data-subscriber-id="{{user_id}}">
-    <td class="subscriber-name panel_subscriber_member_list">
+    <td class="subscriber-name panel_user_list">
         {{> ../user_display_only_pill display_value=name}}
     </td>
     {{#if email}}

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -1,6 +1,6 @@
 <tr data-subscriber-id="{{user_id}}">
     <td class="subscriber-name panel_user_list">
-        {{> ../user_display_only_pill display_value=name}}
+        {{> ../user_display_only_pill display_value=name  is_active=true}}
     </td>
     {{#if email}}
     <td class="subscriber-email">{{email}}</td>

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -1,14 +1,17 @@
 <span class="pill-container">
     <a data-user-id="{{user_id}}" class="view_user_profile pill" tabindex="0">
         {{#if img_src}}
-        <img class="pill-image" src="{{img_src}}" />
+            <img class="pill-image" src="{{img_src}}" />
         {{/if}}
         <span class="pill-value">{{display_value}}</span>
-        {{#if is_current_user}} <span class="my_user_status">{{t "(you)"}}</span>{{/if}}
+        {{#unless is_active}}
+            <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{#if is_bot}}{{t 'Bot is deactivated' }}{{else}}{{t 'User is deactivated' }}{{/if}}"></i>
+        {{/unless}}
+        {{#if is_current_user}}
+            <span class="my_user_status">{{t "(you)"}}</span>
+        {{/if}}
         {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
         {{~#if deactivated}}&nbsp;({{t 'deactivated'}}){{~/if~}}
-        {{~#if has_status~}}
-        {{~> status_emoji status_emoji_info~}}
-        {{~/if~}}
+        {{~#if has_status~}}{{~> status_emoji status_emoji_info~}}{{~/if~}}
     </a>
 </span>

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -1,5 +1,5 @@
 <span class="pill-container">
-    <a data-user-id="{{user_id}}" class="view_user_profile pill" tabindex="0">
+    <a data-user-id="{{user_id}}" class="view_user_profile pill tippy-zulip-delayed-tooltip" data-tippy-content="{{display_value}}" tabindex="0">
         {{#if img_src}}
             <img class="pill-image" src="{{img_src}}" />
         {{/if}}


### PR DESCRIPTION
Converting plain links to pills for user and bot names across the User groups, Users, and Deactivated users panels. The conversion includes both bot names and their respective owner names. used same `user_display_only_pill.hbs` template to convert name to pills in the organization settings 

- Updated `user_display_only_pill.hbs` to utilize the newly created user_pill.hbs partial for displaying user and bot names as pills.
- Implemented the `user_pill.hbs` partial to encapsulate the common structure and styling of the pills, reducing code repetition.
- Added tooltip so that long names can seen from tooltip

Fixes #24229.

## Users

| Dark | Light |
|--------|-------|
| ![image](https://github.com/zulip/zulip/assets/73663475/0ed2103a-24c9-4d75-b3ee-ffef312531dd) | ![image](https://github.com/zulip/zulip/assets/73663475/4ad7cf3b-7672-43f2-852f-a8ab773cf3b6) |

## Bots
| Dark | Light |
|--------|-------|
| ![image](https://github.com/zulip/zulip/assets/73663475/f2e84a5b-06ee-4cbb-8983-011166a3cc7a) | ![image](https://github.com/zulip/zulip/assets/73663475/363caf04-e312-466d-81a6-3344f8daba77) |

## Deactivated users

| Dark | Light |
|--------|-------|
| ![image](https://github.com/zulip/zulip/assets/73663475/6634b6bf-9d07-4f4c-87e3-4b9131c68cd8) | ![image](https://github.com/zulip/zulip/assets/73663475/72d4bc09-bf4d-452d-9660-bd24013e043e) |

## tooltip
| tooltip | 
|--------|
| ![image](https://github.com/zulip/zulip/assets/73663475/199a17c3-ec4d-4198-9ab9-293ddca3e73f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
