### PR TITLE
tooltip: Hide scroll button tooltip on transition

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -177,4 +177,18 @@ export function initialize() {
             }
         }
     });
+
+    const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container").expectOne();
+    // Delete the tippy tooltip whenever the fadeout animation for
+    // this button is finished. This is necessary because the fading animation
+    // confuses Tippy's built-in `data-reference-hidden` feature.
+    $show_scroll_to_bottom_button.on("transitionend", (e) => {
+        if (e.propertyName === "visibility") {
+            const tooltip = $("#scroll-to-bottom-button-clickable-area")[0]._tippy;
+            // make sure the tooltip exists and the class is not currently showing
+            if (tooltip && !$show_scroll_to_bottom_button.hasClass("show")) {
+                tooltip.destroy();
+            }
+        }
+    });
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously, if the user hovered over the "scroll to bottom" button as it was disappearing and did not move the mouse, the tippy would remain visible even though the button was hidden.
Presently, the tippy is explicitly destroyed when the transition animation finishes.

This issue was also attempted in #28680, but the approach there involved the use of a timer to destroy the tippy, which could have led to inconsistent behavior. My approach differs in that I used the `transitionend` event to detect when the button is completely hidden.

Fixes #28656

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Old behaviour**

[Screencast from 09.03.2024 17:22:41.webm](https://github.com/zulip/zulip/assets/104032457/089b501a-3573-4ab5-85d3-58df26c507ba)

**New bevahoiur**

[Screencast from 09.03.2024 17:23:32.webm](https://github.com/zulip/zulip/assets/104032457/6a123a06-5cc8-4fb8-8d4e-35aae38802b9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
