### PR TITLE
types: Migrated copy_and_paste.js to copy_and_paste.ts.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -85,7 +85,7 @@ EXEMPT_FILES = make_set(
         "web/src/condense.ts",
         "web/src/confirm_dialog.ts",
         "web/src/copied_tooltip.ts",
-        "web/src/copy_and_paste.js",
+        "web/src/copy_and_paste.ts",
         "web/src/csrf.ts",
         "web/src/css_variables.d.ts",
         "web/src/css_variables.js",

--- a/web/src/is-url.d.ts
+++ b/web/src/is-url.d.ts
@@ -1,0 +1,3 @@
+declare module "is-url" {
+    export default function isUrl(url: string): boolean;
+}

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -274,7 +274,7 @@ export const update_elements = ($content: JQuery): void => {
     });
 
     // Display the view-code-in-playground and the copy-to-clipboard button inside the div.codehilite element,
-    // and add a `zulip-code-block` class to it to detect it easily in `copy_and_paste.js`.
+    // and add a `zulip-code-block` class to it to detect it easily in `copy_and_paste.ts`.
     $content.find("div.codehilite").each(function (): void {
         const $codehilite = $(this);
         const $pre = $codehilite.find("pre");


### PR DESCRIPTION
- Migrated the `copy_and_paste.js` to TypeScript for improved type safety and maintainability.
- File extension modified in `tests-js-with-node` and `rendered_markdown.ts`. 
- `is-url.d.ts` added to enable type definition for the module `is-url`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
