### PR TITLE
docs: Revised performance.md for more clarity.

### DIFF
--- a/docs/subsystems/performance.md
+++ b/docs/subsystems/performance.md
@@ -73,9 +73,10 @@ to thoughtfully implement the data fetch code path for every feature.
 Furthermore, a snappy user interface is one of Zulip's design goals, and
 so we care about the performance of any user-facing code path, even
 though many of them are not material to scalability of the server.
-But only with regard to the requests detailed below, is it worth considering
-optimizations which save a few milliseconds that would be invisible to the end user,
-if they carry any cost in code readability.
+But when an optimization only saves a few milliseconds that would be
+invisible to the end user, and carries any cost in code readability,
+the optimization is worth considering only if it applies to
+the major endpoints listed below.
 
 In Zulip's documentation, our general rule is to primarily write facts
 that are likely to remain true for a long time. While the numbers


### PR DESCRIPTION
Some people (including me) get confused reading this part, so this is a more simple way of delivering the same meaning. 

[revised message](https://chat.zulip.org/#narrow/stream/19-documentation/topic/Request.20Volume/near/1755646) from CZO

<details>
<summary>Rendered updated text : </summary>

![Screenshot from 2024-03-11 23-23-33](https://github.com/zulip/zulip/assets/64221784/004c427d-96e9-4f63-8a97-82a094bbe0aa)
</details>

see [updated doc](https://zulip--29260.org.readthedocs.build/en/29260/subsystems/performance.html#major-zulip-endpoints)
see [original doc](https://zulip.readthedocs.io/en/latest/subsystems/performance.html)