### PR TITLE
types: Migrated add_stream_options_popover to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -46,7 +46,7 @@ EXEMPT_FILES = make_set(
     [
         "web/shared/src/poll_data.ts",
         "web/src/about_zulip.ts",
-        "web/src/add_stream_options_popover.js",
+        "web/src/add_stream_options_popover.ts",
         "web/src/add_subscribers_pill.js",
         "web/src/admin.js",
         "web/src/alert_popup.ts",

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -1,4 +1,6 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
+import type {ReferenceElement} from "tippy.js";
 
 import render_left_sidebar_stream_setting_popover from "../templates/popovers/left_sidebar_stream_setting_popover.hbs";
 
@@ -6,7 +8,7 @@ import * as popover_menus from "./popover_menus";
 import * as settings_data from "./settings_data";
 import {parse_html} from "./ui_util";
 
-export function initialize() {
+export function initialize(): void {
     popover_menus.register_popover_menu("#streams_inline_icon", {
         onShow(instance) {
             const can_create_streams =
@@ -31,32 +33,41 @@ export function initialize() {
             //  When showing the popover menu, we want the
             // "Add streams" and the "Filter streams" tooltip
             //  to appear below the "Add streams" icon.
-            const add_streams_tooltip = $("#add_streams_tooltip").get(0);
+            const add_streams_tooltip: ReferenceElement | undefined =
+                $("#add_streams_tooltip").get(0);
+            assert(add_streams_tooltip !== undefined);
             add_streams_tooltip._tippy?.setProps({
                 placement: "bottom",
             });
-            const filter_streams_tooltip = $("#filter_streams_tooltip").get(0);
+
+            const filter_streams_tooltip: (ReferenceElement & HTMLElement) | undefined =
+                $("#filter_streams_tooltip").get(0);
             // If `filter_streams_tooltip` is not triggered yet, this will set its initial placement.
+            assert(filter_streams_tooltip !== undefined);
             filter_streams_tooltip.dataset.tippyPlacement = "bottom";
             filter_streams_tooltip._tippy?.setProps({
                 placement: "bottom",
             });
 
-            // The linter complains about unbalanced returns
-            return true;
+            return undefined;
         },
         onHidden(instance) {
             instance.destroy();
-            popover_menus.popover_instances.stream_settings = undefined;
+            popover_menus.popover_instances.stream_settings = null;
             //  After the popover menu is closed, we want the
             //  "Add streams" and the "Filter streams" tooltip
             //  to appear at it's original position that is
             //  above the "Add streams" icon.
-            const add_streams_tooltip = $("#add_streams_tooltip").get(0);
+            const add_streams_tooltip: ReferenceElement | undefined =
+                $("#add_streams_tooltip").get(0);
+            assert(add_streams_tooltip !== undefined);
             add_streams_tooltip._tippy?.setProps({
                 placement: "top",
             });
-            const filter_streams_tooltip = $("#filter_streams_tooltip").get(0);
+
+            const filter_streams_tooltip: (ReferenceElement & HTMLElement) | undefined =
+                $("#filter_streams_tooltip").get(0);
+            assert(filter_streams_tooltip !== undefined);
             filter_streams_tooltip.dataset.tippyPlacement = "top";
             filter_streams_tooltip._tippy?.setProps({
                 placement: "top",


### PR DESCRIPTION
- Migrated the `add_stream_options_popover.js` to TypeScript. 
- File extension is modified in test-js-with-node.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
