### PR TITLE
channel: Use TypeScript unions for AjaxRequestHandler.

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -100,7 +100,7 @@ function delete_attachments(attachment: string, file_name: string): void {
         id: "confirm_delete_file_modal",
         focus_submit_on_open: true,
         on_click() {
-            dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment);
+            dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment, {});
         },
         loading_spinner: true,
     });

--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -25,7 +25,7 @@ type PatchRequestData =
     | {processData: false; data: FormData}
     | {processData?: true; data: Record<string, unknown>};
 
-export type AjaxRequestHandler = typeof call;
+export type AjaxRequestHandler = typeof call | typeof patch;
 
 let password_change_in_progress = false;
 export let password_changes = 0;

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -229,7 +229,7 @@ export function launch(conf: DialogWidgetConfig): void {
 export function submit_api_request(
     request_method: AjaxRequestHandler,
     url: string,
-    data: Parameters<AjaxRequestHandler>[0]["data"] = {},
+    data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
     {
         failure_msg_html = $t_html({defaultMessage: "Failed"}),
         success_continuation,

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -156,7 +156,7 @@ export function set_up(): void {
             html_heading: $t_html({defaultMessage: "Delete data export?"}),
             html_body,
             on_click() {
-                dialog_widget.submit_api_request(channel.del, url);
+                dialog_widget.submit_api_request(channel.del, url, {});
             },
             loading_spinner: true,
         });

--- a/web/src/settings_linkifiers.js
+++ b/web/src/settings_linkifiers.js
@@ -192,7 +192,7 @@ export function build_page() {
             html_heading: $t_html({defaultMessage: "Delete linkifier?"}),
             html_body,
             id: "confirm_delete_linkifiers_modal",
-            on_click: () => dialog_widget.submit_api_request(channel.del, url),
+            on_click: () => dialog_widget.submit_api_request(channel.del, url, {}),
             loading_spinner: true,
         });
     });

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -98,7 +98,7 @@ function build_page(): void {
             html_body,
             id: "confirm_delete_code_playgrounds_modal",
             on_click() {
-                dialog_widget.submit_api_request(channel.del, url);
+                dialog_widget.submit_api_request(channel.del, url, {});
             },
             loading_spinner: true,
         });

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -34,7 +34,7 @@ export const strings = {
 export function do_settings_change(
     request_method: AjaxRequestHandler,
     url: string,
-    data: Parameters<AjaxRequestHandler>[0]["data"],
+    data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
     $status_element: JQuery,
     {
         success_msg_html = strings.success_html,

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -389,7 +389,7 @@ function handle_bot_deactivation($tbody) {
 
         function handle_confirm() {
             const url = "/json/bots/" + encodeURIComponent(bot_id);
-            dialog_widget.submit_api_request(channel.del, url);
+            dialog_widget.submit_api_request(channel.del, url, {});
         }
 
         user_deactivation_ui.confirm_bot_deactivation(bot_id, handle_confirm, true);

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -673,7 +673,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
             const bot_id = $("#bot-edit-form").data("user-id");
             function handle_confirm() {
                 const url = "/json/bots/" + encodeURIComponent(bot_id);
-                dialog_widget.submit_api_request(channel.del, url);
+                dialog_widget.submit_api_request(channel.del, url, {});
             }
             user_deactivation_ui.confirm_bot_deactivation(bot_id, handle_confirm, true);
         });
@@ -685,7 +685,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
             const user_id = $("#bot-edit-form").data("user-id");
             function handle_confirm() {
                 const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
-                dialog_widget.submit_api_request(channel.post, url);
+                dialog_widget.submit_api_request(channel.post, url, {});
             }
             user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
         });
@@ -785,7 +785,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         const user_id = $("#edit-user-form").data("user-id");
         function handle_confirm() {
             const url = "/json/users/" + encodeURIComponent(user_id);
-            dialog_widget.submit_api_request(channel.del, url);
+            dialog_widget.submit_api_request(channel.del, url, {});
         }
         user_deactivation_ui.confirm_deactivation(user_id, handle_confirm, true);
     });
@@ -797,7 +797,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         const user_id = $("#edit-user-form").data("user-id");
         function handle_confirm() {
             const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
-            dialog_widget.submit_api_request(channel.post, url);
+            dialog_widget.submit_api_request(channel.post, url, {});
         }
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });


### PR DESCRIPTION
[CZO discussion thread ](https://chat.zulip.org/#narrow/stream/6-frontend/topic/setting_ui.20do_settings_change)

Reason for 2nd Commit:
Since the type of request_method(`AjaxRequestHandler`) has
been extended in the previous commit.Consequently the 'data'
field of '`request_method`' has to be typed such that it
satisfies this change.

Because `request_method`'s type can also be `'typeof patch`' which
does not accept undefined '`data`' field, I haved '`omit`'-ted
'`undefined`' from 'data's type in function signature to satisfy
TypeScript.

Now ,in support of the changes I have made to two different function
sign(namely `setting_ui.do_settings_change` & `dialog_widget.submit_api_request`)
I am stating some points about `data` field inside these respective
function signs.

1.`settings_ui.do_settings_change`: For this '`data`' was actually never
`undefined`. Each function call has a '`data`' object passed( with one
or more fields).

2.`dialog_widget.submit_api_request`: For this case many function calls actually didn't have
'`data`' field (ie.'`data`' was undefined). BUT,[for those cases it was defaulted
to '{}'](https://github.com/zulip/zulip/blob/f4d109c289f614273b43b411cbd8d1fad128842e/web/src/dialog_widget.ts#L232)(see function sign). 
```
    export function submit_api_request(
    request_method: AjaxRequestHandler,
    url: string,
    data: Parameters<AjaxRequestHandler>[0]["data"] = {},
```
So effectively '`request_method`' didn't recieve
an `undefined` '`data`' for this case too. I have removed the defaulting
and passed '`{}'` in the function calls for those cases, which effectively
does the some job.But satisfies the type.

For both these cases 'data' field isn't undefined and hence `Omit` makes
sense IMO.