### PR TITLE
compose_state: Remove incorrect recipient_has_topics helper.

### DIFF
--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -49,10 +49,6 @@ export function has_recipient_viewed_topic_resolved_banner(): boolean {
     return recipient_viewed_topic_resolved_banner;
 }
 
-export function recipient_has_topics(): boolean {
-    return message_type !== "stream";
-}
-
 export function composing(): boolean {
     // This is very similar to get_message_type(), but it returns
     // a boolean.

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -245,17 +245,19 @@ export function clear_topic_resolved_warning() {
 }
 
 export function warn_if_topic_resolved(topic_changed) {
-    if (compose_state.recipient_has_topics()) {
-        return;
-    }
     // This function is called with topic_changed=false on every
     // keypress when typing a message, so it should not do anything
     // expensive in that case.
     //
     // Pass topic_changed=true if this function was called in response
     // to a topic being edited.
-    const topic_name = compose_state.topic();
 
+    const stream_id = compose_state.stream_id();
+    if (stream_id === undefined) {
+        return;
+    }
+
+    const topic_name = compose_state.topic();
     if (!topic_changed && !resolved_topic.is_resolved(topic_name)) {
         // The resolved topic warning will only ever appear when
         // composing to a resolve topic, so we return early without
@@ -263,10 +265,8 @@ export function warn_if_topic_resolved(topic_changed) {
         return;
     }
 
-    const stream_id = compose_state.stream_id();
     const message_content = compose_state.message_content();
     const sub = stream_data.get_sub_by_id(stream_id);
-
     if (sub && message_content !== "" && resolved_topic.is_resolved(topic_name)) {
         if (compose_state.has_recipient_viewed_topic_resolved_banner()) {
             // We display the resolved topic banner at most once per narrow.


### PR DESCRIPTION
This function was introduced in
99d1c5a1f3e5e3f1ec71161f562e8eab1d718df7 and always has the opposite value from what its name suggests. It worked OK because the caller also expected it to have an incorrect value.

It's cleaner in this context to just use the `stream_id` helper, so just delete the bad code and use that.

Fix the docstring comment having been incorrectly pushed down while we're addressing this.

@evykassirer FYI.