### PR TITLE
right-sidebar: Remove duplicate search people tooltip.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -245,7 +245,6 @@ export function initialize(): void {
     delegate("body", {
         target: [
             "#streams_header .streams-tooltip-target",
-            "#user_filter_icon",
             "#scroll-to-bottom-button-clickable-area",
             ".spectator_narrow_login_button",
             "#stream-specific-notify-table .unmute_stream",

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -5,10 +5,7 @@
                 <h4 class='right-sidebar-title' id='userlist-title'>
                     {{t 'USERS' }}
                 </h4>
-                <i id="user_filter_icon" class="fa fa-search"
-                  aria-hidden="true" aria-label="{{t 'Search people' }}"
-                  data-tooltip-template-id="search-people-tooltip-template">
-                </i>
+                <i id="user_filter_icon" class="fa fa-search"></i>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
                 <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -184,10 +184,6 @@
     {{t "Mute topic" }}
     {{tooltip_hotkey_hints "Shift" "M"}}
 </template>
-<template id="search-people-tooltip-template">
-    {{t 'Search people' }}
-    {{tooltip_hotkey_hints "W"}}
-</template>
 <template id="restore-scheduled-message-tooltip-template">
     {{t 'Edit and reschedule message' }}
     {{tooltip_hotkey_hints "Enter"}}


### PR DESCRIPTION
The buddy list redesign introduced a new, more detailed tooltip, and neglected to remove the previous one.
