### PR TITLE
Add a default password to Zoom meetings

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -78,6 +78,7 @@ class TestVideoCall(ZulipTestCase):
                     "host_video": True,
                     "participant_video": True,
                 },
+                "default_password": True,
             },
         )
         self.assertEqual(
@@ -113,6 +114,7 @@ class TestVideoCall(ZulipTestCase):
                     "host_video": False,
                     "participant_video": False,
                 },
+                "default_password": True,
             },
         )
         self.assertEqual(

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -162,7 +162,14 @@ def make_zoom_video_call(
         "settings": {
             "host_video": is_video_call,
             "participant_video": is_video_call,
-        }
+        },
+        # Generate a default password depending on the user settings. This will
+        # result in the password being appended to the returned Join URL.
+        #
+        # If we don't request a password to be set, the waiting room will be
+        # forcibly enabled in Zoom organizations that require some kind of
+        # authentication for all meetings.
+        "default_password": True,
     }
 
     try:


### PR DESCRIPTION
When a Zoom organization is configured to always require authentication in meetings, not generating a meeting password implies the use of the waiting room feature, which is annoying for example when sending a DM to a colleague with a Zoom link.

This changes how we call the Zoom API to have Zoom generate a meeting password, using the settings in the user's Zoom account. The password will be included in the meeting link, users won't have to type it in manually. Example of the newly generated URLs:

```
https://DOMAIN.zoom.us/j/MEETING_NUMBER?pwd=ENCODED_PASSWORD
```

Fixes: https://chat.zulip.org/#narrow/stream/137-feedback/topic/default.20password.20for.20zoom

**Screenshots and screen captures:**

![zulip-zoom](https://github.com/zulip/zulip/assets/2299951/4dd38784-53ba-4450-aacc-4dc289c8425a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
