### PR TITLE
stripe: Remove unused do_change_remote_server_plan_type.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -4747,19 +4747,6 @@ def ensure_customer_does_not_have_active_plan(customer: Customer) -> None:
 
 
 @transaction.atomic
-def do_change_remote_server_plan_type(remote_server: RemoteZulipServer, plan_type: int) -> None:
-    old_value = remote_server.plan_type
-    remote_server.plan_type = plan_type
-    remote_server.save(update_fields=["plan_type"])
-    RemoteZulipServerAuditLog.objects.create(
-        event_type=RealmAuditLog.REMOTE_SERVER_PLAN_TYPE_CHANGED,
-        server=remote_server,
-        event_time=timezone_now(),
-        extra_data={"old_value": old_value, "new_value": plan_type},
-    )
-
-
-@transaction.atomic
 def do_reactivate_remote_server(remote_server: RemoteZulipServer) -> None:
     """
     Utility function for reactivating deactivated registrations.


### PR DESCRIPTION
This was implemented instead as part of the `BillingSession` class with the `do_change_plan_type` method.

[CODE link](https://github.com/zulip/zulip/blob/d98580ab14452c838a58f389402bf9eca2e39582/corporate/lib/stripe.py#L4371-L4398)
```python
class RemoteServerBillingSession(BillingSession):

...

    @override
    @transaction.atomic
    def do_change_plan_type(
        self, *, tier: Optional[int], is_sponsored: bool = False, background_update: bool = False
    ) -> None:
        # This function needs to translate between the different
        # formats of CustomerPlan.tier and RealmZulipServer.plan_type.
        if is_sponsored:
            plan_type = RemoteZulipServer.PLAN_TYPE_COMMUNITY
            self.add_customer_to_community_plan()
        elif tier == CustomerPlan.TIER_SELF_HOSTED_BASIC:
            plan_type = RemoteZulipServer.PLAN_TYPE_BASIC
        elif tier == CustomerPlan.TIER_SELF_HOSTED_BUSINESS:
            plan_type = RemoteZulipServer.PLAN_TYPE_BUSINESS
        elif tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY:
            plan_type = RemoteZulipServer.PLAN_TYPE_SELF_MANAGED_LEGACY
        else:
            raise AssertionError("Unexpected tier")

        old_plan_type = self.remote_server.plan_type
        self.remote_server.plan_type = plan_type
        self.remote_server.save(update_fields=["plan_type"])
        self.write_to_audit_log(
            event_type=AuditLogEventType.BILLING_ENTITY_PLAN_TYPE_CHANGED,
            event_time=timezone_now(),
            extra_data={"old_value": old_plan_type, "new_value": plan_type},
            background_update=background_update,
        )
```


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
