### PR TITLE
Clean message reactions during initial processing.

### DIFF
--- a/web/src/message_helper.js
+++ b/web/src/message_helper.js
@@ -3,6 +3,7 @@ import * as message_store from "./message_store";
 import * as message_user_ids from "./message_user_ids";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
+import * as reactions from "./reactions";
 import * as recent_senders from "./recent_senders";
 import * as stream_topic_history from "./stream_topic_history";
 import * as user_status from "./user_status";
@@ -23,8 +24,16 @@ export function process_new_message(message) {
         return cached_msg;
     }
 
+    if (!message.reactions) {
+        message.reactions = [];
+    }
+
     message_store.set_message_booleans(message);
     message.sent_by_me = people.is_current_user(message.sender_email);
+
+    // Cleaning message_reactions during initial message processing
+    // to avoid message_reactions being undefined during rendering
+    message.message_reactions = reactions.get_message_reactions(message);
 
     people.extract_people_from_message(message);
     people.maybe_incr_recipient_count(message);
@@ -74,9 +83,7 @@ export function process_new_message(message) {
     }
 
     alert_words.process_message(message);
-    if (!message.reactions) {
-        message.reactions = [];
-    }
+
     message_store.update_message_cache(message);
     return message;
 }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -26,7 +26,6 @@ import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as popovers from "./popovers";
-import * as reactions from "./reactions";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
 import * as sidebar_ui from "./sidebar_ui";
@@ -525,8 +524,6 @@ export class MessageListView {
         };
 
         for (const message_container of message_containers) {
-            const message_reactions = reactions.get_message_reactions(message_container.msg);
-            message_container.msg.message_reactions = message_reactions;
             message_container.include_recipient = false;
 
             if (
@@ -778,8 +775,6 @@ export class MessageListView {
     }
 
     _get_message_template(message_container) {
-        const msg_reactions = reactions.get_message_reactions(message_container.msg);
-        message_container.msg.message_reactions = msg_reactions;
         const msg_to_render = {
             ...message_container,
             message_list_id: this.list.id,

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -146,6 +146,8 @@ people.add_active_user(me);
 people.add_active_user(test_user);
 people.initialize_current_user(me.user_id);
 
+// process_new_messages calls get_message_reactions, so we need to stub it.
+reactions.get_message_reactions = (message) => message.reactions;
 message_helper.process_new_message(test_message);
 
 const realm_emoji = {};

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -124,6 +124,7 @@ run_test("update_messages", () => {
         {
             alerted: false,
             collapsed: false,
+            clean_reactions: new Map(),
             content: "<b>new content</b>",
             display_recipient: denmark.name,
             historical: false,
@@ -134,8 +135,8 @@ run_test("update_messages", () => {
             stream_wildcard_mentioned: false,
             topic_wildcard_mentioned: false,
             mentioned_me_directly: false,
+            message_reactions: [],
             raw_content: "**new content**",
-            reactions: [],
             reply_to: alice.email,
             sender_email: alice.email,
             sender_full_name: alice.full_name,


### PR DESCRIPTION
Prerequisite to [PR #29109 ](https://github.com/zulip/zulip/pull/29109)

Clean reactions and set `message_reactions` in `process_new_message`. Earlier, `message_reactions` was being set
after the predicate for the narrow was built,
as a result functions that require the reactions while building the predicate.

Also attempted to clean up and simplify  `type Message`, but ran into tsc lint errors.
Please give feedback on how relevant changes that can be made to simplify the `type Message` with or without affecting the other functions that use `Message`

