### PR TITLE
shortcut : made Shift + M work in Recent conversations and Inbox

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -971,6 +971,18 @@ export function process_hotkey(e, hotkey) {
         case "all_messages":
             browser_history.go_to_location("#all_messages");
             return true;
+        case "toggle_topic_visibility_policy":
+            if (recent_view_ui.is_in_focus()) {
+                const recent_msg = recent_view_ui.get_focused_row_message();
+                if (recent_msg !== undefined && recent_msg.type === "stream") {
+                    user_topics_ui.toggle_topic_visibility_policy(recent_msg);
+                    return true;
+                }
+                return false;
+            }
+            if (inbox_ui.is_in_focus()) {
+                return inbox_ui.toggle_topic_visibility_policy();
+            }
     }
 
     // Shortcuts that are useful with an empty message feed, like opening compose.

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -28,6 +28,7 @@ import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as user_status from "./user_status";
 import * as user_topics from "./user_topics";
+import * as user_topics_ui from "./user_topics_ui";
 import * as util from "./util";
 import * as views_util from "./views_util";
 
@@ -739,6 +740,21 @@ export function get_focused_row_message() {
     }
 
     return {message};
+}
+
+export function toggle_topic_visibility_policy() {
+    const inbox_message = get_focused_row_message();
+    if (inbox_message.message !== undefined) {
+        user_topics_ui.toggle_topic_visibility_policy(inbox_message.message);
+        if (inbox_message.message.type === "stream") {
+            // means mute/unmute action is taken
+            const $elt = $(".inbox-header"); // Select the element with class "inbox-header"
+            const $focusElement = $elt.find(get_focus_class_for_header()).first();
+            focus_clicked_list_element($focusElement);
+            return true;
+        }
+    }
+    return false;
 }
 
 function is_row_a_header($row) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Earlier Shift + M shortcut is working only in messages to mute/unmute topic in messages part

This PR enables shortcut Shift + M work in recent conversations and the inbox view.It achieves this by utilizing the existing function toggle_topic_visibility_policy in user_topics_ui.The focused row message of the recent_view_ui is passed to mute/unmute the selected topic in the recent_view_ui, and the same process is applied to the inbox_ui but the logic of muting/unmuting the topic is kept in inbox_ui which uses function toggle_topic_visibility_policy in user_topics_ui.

The function toggle_topic_visibility_policy is called in both cases based on specific conditions to prevent the shortcut from affecting other parts of the page, thus avoiding errors.

Fixes: #27741 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
</details>
