### PR TITLE
parse_client: Migrate has_request_variables to typed_endpoint.

### DIFF
--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -22,7 +22,7 @@ from django.utils.translation import gettext as _
 from django_scim.middleware import SCIMAuthCheckMiddleware
 from django_scim.settings import scim_settings
 from sentry_sdk import set_tag
-from typing_extensions import Concatenate, ParamSpec, override
+from typing_extensions import Annotated, Concatenate, ParamSpec, override
 
 from zerver.lib.cache import get_remote_cache_requests, get_remote_cache_time
 from zerver.lib.db import reset_queries
@@ -32,7 +32,7 @@ from zerver.lib.html_to_text import get_content_description
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.rate_limiter import RateLimitResult
-from zerver.lib.request import REQ, RequestNotes, has_request_variables
+from zerver.lib.request import RequestNotes
 from zerver.lib.response import (
     AsynchronousResponse,
     json_response,
@@ -40,6 +40,7 @@ from zerver.lib.response import (
     json_unauthorized,
 )
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.typed_endpoint import INTENTIONALLY_UNDOCUMENTED, ApiParamConfig, typed_endpoint
 from zerver.lib.user_agent import parse_user_agent
 from zerver.models import Realm
 from zerver.models.realms import get_realm
@@ -226,15 +227,18 @@ def write_log_line(
         logger.info("status=%3d, data=%s, uid=%s", status_code, error_data, requester_for_logs)
 
 
-# We take advantage of `has_request_variables` being called multiple times
+# We take advantage of `typed_endpoint` being called multiple times
 # when processing a request in order to process any `client` parameter that
 # may have been sent in the request content.
-@has_request_variables
+@typed_endpoint
 def parse_client(
     request: HttpRequest,
     # As `client` is a common element to all API endpoints, we choose
     # not to document on every endpoint's individual parameters.
-    req_client: Optional[str] = REQ("client", default=None, intentionally_undocumented=True),
+    *,
+    req_client: Annotated[
+        Optional[str], ApiParamConfig("client", documentation_status=INTENTIONALLY_UNDOCUMENTED)
+    ] = None,
 ) -> Tuple[str, Optional[str]]:
     # If the API request specified a client in the request content,
     # that has priority. Otherwise, extract the client from the


### PR DESCRIPTION
Refactor `parse_client` view to use `typed_endpoint` decorator instead of `has_request_variables`. This change improves code consistency and enhances codebase comprehension.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
