### PR TITLE
typeahead: Convert from a jQuery plugin to a normal exported function.

### DIFF
--- a/web/src/bootstrap_typeahead.js
+++ b/web/src/bootstrap_typeahead.js
@@ -152,9 +152,27 @@ function get_pseudo_keycode(event) {
 const header_element_html =
     '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>';
 
+const defaults = {
+    source: [],
+    items: 8,
+    container: '<div class="typeahead dropdown-menu"></div>',
+    menu: '<ul class="typeahead-menu"></ul>',
+    item: "<li><a></a></li>",
+    minLength: 1,
+    stopAdvance: false,
+    dropup: false,
+    advanceKeyCodes: [],
+    openInputFieldOnKeyUp: null,
+    closeInputFieldOnHide: null,
+    tabIsEnter: true,
+};
+
 const Typeahead = function (element, options) {
     this.$element = $(element);
-    this.options = $.extend({}, $.fn.typeahead.defaults, options);
+    this.options = {
+        ...defaults,
+        ...options,
+    };
     this.matcher = this.options.matcher ?? this.matcher;
     this.sorter = this.options.sorter ?? this.sorter;
     this.highlighter_html = this.options.highlighter_html;
@@ -633,33 +651,11 @@ Typeahead.prototype = {
 /* TYPEAHEAD PLUGIN DEFINITION
  * =========================== */
 
-$.fn.typeahead = function (option) {
-    return this.each(function () {
-        const $this = $(this);
-        let data = $this.data("typeahead");
-        const options = typeof option === "object" && option;
-        if (!data) {
-            $this.data("typeahead", (data = new Typeahead(this, options)));
-        }
-        if (typeof option === "string") {
-            data[option]();
-        }
-    });
-};
+export function create($element, options) {
+    $element.data("typeahead", new Typeahead($element, options));
+}
 
-$.fn.typeahead.defaults = {
-    source: [],
-    items: 8,
-    container: '<div class="typeahead dropdown-menu"></div>',
-    menu: '<ul class="typeahead-menu"></ul>',
-    item: "<li><a></a></li>",
-    minLength: 1,
-    stopAdvance: false,
-    dropup: false,
-    advanceKeyCodes: [],
-    openInputFieldOnKeyUp: null,
-    closeInputFieldOnHide: null,
-    tabIsEnter: true,
-};
-
-$.fn.typeahead.Constructor = Typeahead;
+export function lookup($element) {
+    const typeahead = $element.data("typeahead");
+    typeahead.lookup();
+}

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import * as typeahead from "../shared/src/typeahead";
 import render_topic_typeahead_hint from "../templates/topic_typeahead_hint.hbs";
 
+import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
@@ -1093,7 +1094,7 @@ export function initialize_topic_edit_typeahead(form_field, stream_name, dropup)
         },
         items: 5,
     };
-    form_field.typeahead(options);
+    bootstrap_typeahead.create(form_field, options);
 }
 
 function get_header_html() {
@@ -1131,8 +1132,7 @@ export function initialize_compose_typeahead(selector) {
         topic: true,
         timestamp: true,
     };
-
-    $(selector).typeahead({
+    bootstrap_typeahead.create($(selector), {
         items: max_num_items,
         dropup: true,
         fixed: true,
@@ -1164,7 +1164,7 @@ export function initialize({on_enter_send}) {
     $("form#send_message_form").on("keydown", (e) => handle_keydown(e, {on_enter_send}));
     $("form#send_message_form").on("keyup", handle_keyup);
 
-    $("input#stream_message_recipient_topic").typeahead({
+    bootstrap_typeahead.create($("input#stream_message_recipient_topic"), {
         source() {
             return topics_seen_for(compose_state.stream_id());
         },
@@ -1189,7 +1189,7 @@ export function initialize({on_enter_send}) {
         header_html: render_topic_typeahead_hint,
     });
 
-    $("#private_message_recipient").typeahead({
+    bootstrap_typeahead.create($("#private_message_recipient"), {
         source: get_pm_people,
         items: max_num_items,
         dropup: true,

--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_settings_custom_user_profile_field from "../templates/settings/custom_user_profile_field.hbs";
 
+import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import {$t} from "./i18n";
 import * as people from "./people";
 import * as pill_typeahead from "./pill_typeahead";
@@ -163,17 +164,15 @@ export function initialize_custom_pronouns_type_fields(element_id) {
         $t({defaultMessage: "she/her"}),
         $t({defaultMessage: "they/them"}),
     ];
-    $(element_id)
-        .find(".pronouns_type_field")
-        .typeahead({
-            items: 3,
-            fixed: true,
-            helpOnEmptyStrings: true,
-            source() {
-                return commonly_used_pronouns;
-            },
-            highlighter_html(item) {
-                return typeahead_helper.render_typeahead_item({primary: item});
-            },
-        });
+    bootstrap_typeahead.create($(element_id).find(".pronouns_type_field"), {
+        items: 3,
+        fixed: true,
+        helpOnEmptyStrings: true,
+        source() {
+            return commonly_used_pronouns;
+        },
+        highlighter_html(item) {
+            return typeahead_helper.render_typeahead_item({primary: item});
+        },
+    });
 }

--- a/web/src/pill_typeahead.js
+++ b/web/src/pill_typeahead.js
@@ -1,4 +1,5 @@
 import * as blueslip from "./blueslip";
+import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as people from "./people";
 import * as stream_pill from "./stream_pill";
@@ -31,7 +32,7 @@ export function set_up($input, pills, opts) {
     const include_users = opts.user;
     const exclude_bots = opts.exclude_bots;
 
-    $input.typeahead({
+    bootstrap_typeahead.create($input, {
         items: 5,
         fixed: true,
         dropup: true,

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_search_list_item from "../templates/search_list_item.hbs";
 
+import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import {Filter} from "./filter";
 import * as keydown_util from "./keydown_util";
 import * as narrow_state from "./narrow_state";
@@ -56,7 +57,7 @@ export function initialize({on_narrow_search}) {
     // just represents the key of the hash, so it's redundant.)
     let search_map = new Map();
 
-    $search_query_box.typeahead({
+    bootstrap_typeahead.create($search_query_box, {
         source(query) {
             const suggestions = search_suggestion.get_suggestions(query);
             // Update our global search_map hash
@@ -195,7 +196,8 @@ export function initiate_search() {
     // Open the typeahead after opening the search bar, so that we don't
     // get a weird visual jump where the typeahead results are narrow
     // before the search bar expands and then wider it expands.
-    $("#search_query").typeahead("lookup").trigger("select");
+    bootstrap_typeahead.lookup($("#search_query"));
+    $("#search_query").trigger("select");
 }
 
 // This is what the default searchbox text would be for this narrow,

--- a/web/src/settings_playgrounds.js
+++ b/web/src/settings_playgrounds.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import render_confirm_delete_playground from "../templates/confirm_dialog/confirm_delete_playground.hbs";
 import render_admin_playground_list from "../templates/settings/admin_playground_list.hbs";
 
+import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
@@ -151,7 +152,7 @@ function build_page() {
     const $search_pygments_box = $("#playground_pygments_language");
     let language_labels = new Map();
 
-    $search_pygments_box.typeahead({
+    bootstrap_typeahead.create($search_pygments_box, {
         source(query) {
             language_labels = realm_playground.get_pygments_typeahead_list_for_settings(query);
             return [...language_labels.keys()];
@@ -167,7 +168,8 @@ function build_page() {
     });
 
     $search_pygments_box.on("click", (e) => {
-        $search_pygments_box.typeahead("lookup").trigger("select");
+        bootstrap_typeahead.lookup($search_pygments_box);
+        $search_pygments_box.trigger("select");
         e.preventDefault();
         e.stopPropagation();
     });

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -36,6 +36,7 @@ set_global("setTimeout", (f, time) => {
 });
 set_global("document", "document-stub");
 
+const bootstrap_typeahead = zrequire("bootstrap_typeahead");
 const typeahead = zrequire("../shared/src/typeahead");
 const stream_topic_history = zrequire("stream_topic_history");
 const compose_state = zrequire("compose_state");
@@ -756,390 +757,402 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     override(stream_topic_history_util, "get_server_history", noop);
 
     let topic_typeahead_called = false;
-    $("input#stream_message_recipient_topic").typeahead = (options) => {
-        override_rewire(stream_topic_history, "get_recent_topic_names", (stream_id) => {
-            assert.equal(stream_id, sweden_stream.stream_id);
-            return sweden_topics_to_show;
-        });
-
-        compose_state.set_stream_id(sweden_stream.stream_id);
-        let actual_value = options.source();
-        // Topics should be sorted alphabetically, not by addition order.
-        let expected_value = sweden_topics_to_show;
-        assert.deepEqual(actual_value, expected_value);
-
-        // options.highlighter_html()
-        options.query = "Kro";
-        actual_value = options.highlighter_html("kronor");
-        expected_value = "<strong>kronor</strong>";
-        assert.equal(actual_value, expected_value);
-
-        // Highlighted content should be escaped.
-        options.query = "<";
-        actual_value = options.highlighter_html("<&>");
-        expected_value = "<strong>&lt;&amp;&gt;</strong>";
-        assert.equal(actual_value, expected_value);
-
-        options.query = "even m";
-        actual_value = options.highlighter_html("even more ice");
-        expected_value = "<strong>even more ice</strong>";
-        assert.equal(actual_value, expected_value);
-
-        // options.sorter()
-        //
-        // Notice that alphabetical sorting isn't managed by this sorter,
-        // it is a result of the topics already being sorted after adding
-        // them with add_topic().
-        options.query = "furniture";
-        actual_value = options.sorter(["furniture"]);
-        expected_value = ["furniture"];
-        assert.deepEqual(actual_value, expected_value);
-
-        // A literal match at the beginning of an element puts it at the top.
-        options.query = "ice";
-        actual_value = options.sorter(["even more ice", "ice", "more ice"]);
-        expected_value = ["ice", "even more ice", "more ice"];
-        assert.deepEqual(actual_value, expected_value);
-
-        // The sorter should return the query as the first element if there
-        // isn't a topic with such name.
-        // This only happens if typeahead is providing other suggestions.
-        options.query = "e"; // Letter present in "furniture" and "ice"
-        actual_value = options.sorter(["furniture", "ice"]);
-        expected_value = ["e", "furniture", "ice"];
-        assert.deepEqual(actual_value, expected_value);
-
-        // Suggest the query if this query doesn't match any existing topic.
-        options.query = "non-existing-topic";
-        actual_value = options.sorter([]);
-        expected_value = [];
-        assert.deepEqual(actual_value, expected_value);
-
-        topic_typeahead_called = true;
-
-        // Unset the stream.
-        compose_state.set_stream_id("");
-    };
-
     let pm_recipient_typeahead_called = false;
-    $("#private_message_recipient").typeahead = (options) => {
-        pill_items = [];
-
-        // This should match the users added at the beginning of this test file.
-        let actual_value = options.source("");
-        let expected_value = [
-            ali,
-            alice,
-            cordelia,
-            hal,
-            gael,
-            harry,
-            hamlet,
-            lear,
-            twin1,
-            twin2,
-            othello,
-            hamletcharacters,
-            backend,
-            call_center,
-        ];
-        actual_value.sort((a, b) => a.user_id - b.user_id);
-        expected_value.sort((a, b) => a.user_id - b.user_id);
-        assert.deepEqual(actual_value, expected_value);
-
-        function matcher(query, person) {
-            query = typeahead.clean_query_lowercase(query);
-            return ct.query_matches_person(query, person);
-        }
-
-        let query;
-        query = "el"; // Matches both "othELlo" and "cordELia"
-        assert.equal(matcher(query, othello), true);
-        assert.equal(matcher(query, cordelia), true);
-
-        query = "bender"; // Doesn't exist
-        assert.equal(matcher(query, othello), false);
-        assert.equal(matcher(query, cordelia), false);
-
-        query = "gael";
-        assert.equal(matcher(query, gael), true);
-
-        query = "Gaël";
-        assert.equal(matcher(query, gael), true);
-
-        query = "gaël";
-        assert.equal(matcher(query, gael), true);
-
-        // Don't make suggestions if the last name only has whitespaces
-        // (we're between typing names).
-        query = "othello@zulip.com,     ";
-        assert.equal(matcher(query, othello), false);
-        assert.equal(matcher(query, cordelia), false);
-
-        // query = 'othello@zulip.com,, , cord';
-        query = "cord";
-        assert.equal(matcher(query, othello), false);
-        assert.equal(matcher(query, cordelia), true);
-
-        // If the user is already in the list, typeahead doesn't include it
-        // again.
-        query = "cordelia@zulip.com, cord";
-        assert.equal(matcher(query, othello), false);
-        assert.equal(matcher(query, cordelia), false);
-
-        query = "oth";
-        deactivated_user.delivery_email = null;
-        assert.equal(matcher(query, deactivated_user), false);
-
-        deactivated_user.delivery_email = "other@zulip.com";
-        assert.equal(matcher(query, deactivated_user), true);
-
-        function sorter(query, people) {
-            return typeahead_helper.sort_recipients({
-                users: people,
-                query,
-                current_stream_id: compose_state.stream_id(),
-                current_topic: compose_state.topic(),
-            });
-        }
-
-        // The sorter's output has the items that match the query from the
-        // beginning first, and then the rest of them in REVERSE order of
-        // the input.
-        query = "othello";
-        actual_value = sorter(query, [othello]);
-        expected_value = [othello];
-        assert.deepEqual(actual_value, expected_value);
-
-        query = "Ali";
-        actual_value = sorter(query, [alice, ali]);
-        expected_value = [ali, alice];
-        assert.deepEqual(actual_value, expected_value);
-
-        // A literal match at the beginning of an element puts it at the top.
-        query = "co"; // Matches everything ("x@zulip.COm")
-        actual_value = sorter(query, [othello, deactivated_user, cordelia]);
-        expected_value = [cordelia, deactivated_user, othello];
-        actual_value.sort((a, b) => a.user_id - b.user_id);
-        expected_value.sort((a, b) => a.user_id - b.user_id);
-        assert.deepEqual(actual_value, expected_value);
-
-        query = "non-existing-user";
-        actual_value = sorter(query, []);
-        expected_value = [];
-        assert.deepEqual(actual_value, expected_value);
-
-        // Adds a `no break-space` at the end. This should fail
-        // if there wasn't any logic replacing `no break-space`
-        // with normal space.
-        query = "cordelia, lear's\u00A0";
-        assert.equal(matcher(query, cordelia), true);
-        assert.equal(matcher(query, othello), false);
-
-        const event = {
-            target: "#doesnotmatter",
-        };
-
-        // options.updater()
-        options.query = "othello";
-        appended_names = [];
-        options.updater(othello, event);
-        assert.deepEqual(appended_names, ["Othello, the Moor of Venice"]);
-
-        options.query = "othello@zulip.com, cor";
-        appended_names = [];
-        actual_value = options.updater(cordelia, event);
-        assert.deepEqual(appended_names, ["Cordelia, Lear's daughter"]);
-
-        const click_event = {type: "click", target: "#doesnotmatter"};
-        options.query = "othello";
-        // Focus lost (caused by the click event in the typeahead list)
-        $("#private_message_recipient").trigger("blur");
-        appended_names = [];
-        actual_value = options.updater(othello, click_event);
-        assert.deepEqual(appended_names, ["Othello, the Moor of Venice"]);
-
-        cleared = false;
-        options.query = "hamletchar";
-        appended_names = [];
-        options.updater(hamletcharacters, event);
-        assert.deepEqual(appended_names, ["King Lear"]);
-        assert.ok(cleared);
-
-        pill_items = [{user_id: lear.user_id}];
-        appended_names = [];
-        cleared = false;
-        options.updater(hamletcharacters, event);
-        assert.deepEqual(appended_names, []);
-        assert.ok(cleared);
-
-        pm_recipient_typeahead_called = true;
-    };
-
     let compose_textarea_typeahead_called = false;
-    $("textarea#compose-textarea").typeahead = (options) => {
-        // options.source()
-        //
-        // For now we only test that get_sorted_filtered_items has been
-        // properly set as the .source(). All its features are tested later on
-        // in test_begins_typeahead().
-        let fake_this = {
-            $element: {},
-        };
-        let caret_called = false;
-        fake_this.$element.caret = () => {
-            caret_called = true;
-            return 7;
-        };
-        fake_this.$element.closest = () => [];
-        fake_this.options = options;
-        let actual_value = options.source.call(fake_this, "test #s");
-        assert.deepEqual(sorted_names_from(actual_value), ["Sweden", "The Netherlands"]);
-        assert.ok(caret_called);
+    override_rewire(bootstrap_typeahead, "create", ($element, options) => {
+        switch ($element) {
+            case $("input#stream_message_recipient_topic"): {
+                override_rewire(stream_topic_history, "get_recent_topic_names", (stream_id) => {
+                    assert.equal(stream_id, sweden_stream.stream_id);
+                    return sweden_topics_to_show;
+                });
 
-        othello.delivery_email = "othello@zulip.com";
-        // options.highlighter_html()
-        //
-        // Again, here we only verify that the highlighter has been set to
-        // content_highlighter_html.
-        fake_this = {completing: "mention", token: "othello"};
-        actual_value = options.highlighter_html.call(fake_this, othello);
-        expected_value =
-            `    <span class="user_circle_empty user_circle"></span>\n` +
-            `    <img class="typeahead-image" src="http://zulip.zulipdev.com/avatar/${othello.user_id}?s&#x3D;50" />\n` +
-            `<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
-            `<small class="autocomplete_secondary">othello@zulip.com</small>\n`;
-        assert.equal(actual_value, expected_value);
-        // Reset the email such that this does not affect further tests.
-        othello.delivery_email = null;
+                compose_state.set_stream_id(sweden_stream.stream_id);
+                let actual_value = options.source();
+                // Topics should be sorted alphabetically, not by addition order.
+                let expected_value = sweden_topics_to_show;
+                assert.deepEqual(actual_value, expected_value);
 
-        fake_this = {completing: "mention", token: "hamletcharacters"};
-        actual_value = options.highlighter_html.call(fake_this, hamletcharacters);
-        expected_value =
-            '    <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
-        assert.equal(actual_value, expected_value);
+                // options.highlighter_html()
+                options.query = "Kro";
+                actual_value = options.highlighter_html("kronor");
+                expected_value = "<strong>kronor</strong>";
+                assert.equal(actual_value, expected_value);
 
-        // matching
+                // Highlighted content should be escaped.
+                options.query = "<";
+                actual_value = options.highlighter_html("<&>");
+                expected_value = "<strong>&lt;&amp;&gt;</strong>";
+                assert.equal(actual_value, expected_value);
 
-        function match(fake_this, item) {
-            const token = fake_this.token;
-            const completing = fake_this.completing;
+                options.query = "even m";
+                actual_value = options.highlighter_html("even more ice");
+                expected_value = "<strong>even more ice</strong>";
+                assert.equal(actual_value, expected_value);
 
-            return ct.compose_content_matcher(completing, token)(item);
+                // options.sorter()
+                //
+                // Notice that alphabetical sorting isn't managed by this sorter,
+                // it is a result of the topics already being sorted after adding
+                // them with add_topic().
+                options.query = "furniture";
+                actual_value = options.sorter(["furniture"]);
+                expected_value = ["furniture"];
+                assert.deepEqual(actual_value, expected_value);
+
+                // A literal match at the beginning of an element puts it at the top.
+                options.query = "ice";
+                actual_value = options.sorter(["even more ice", "ice", "more ice"]);
+                expected_value = ["ice", "even more ice", "more ice"];
+                assert.deepEqual(actual_value, expected_value);
+
+                // The sorter should return the query as the first element if there
+                // isn't a topic with such name.
+                // This only happens if typeahead is providing other suggestions.
+                options.query = "e"; // Letter present in "furniture" and "ice"
+                actual_value = options.sorter(["furniture", "ice"]);
+                expected_value = ["e", "furniture", "ice"];
+                assert.deepEqual(actual_value, expected_value);
+
+                // Suggest the query if this query doesn't match any existing topic.
+                options.query = "non-existing-topic";
+                actual_value = options.sorter([]);
+                expected_value = [];
+                assert.deepEqual(actual_value, expected_value);
+
+                topic_typeahead_called = true;
+
+                // Unset the stream.
+                compose_state.set_stream_id("");
+
+                break;
+            }
+            case $("#private_message_recipient"): {
+                pill_items = [];
+
+                // This should match the users added at the beginning of this test file.
+                let actual_value = options.source("");
+                let expected_value = [
+                    ali,
+                    alice,
+                    cordelia,
+                    hal,
+                    gael,
+                    harry,
+                    hamlet,
+                    lear,
+                    twin1,
+                    twin2,
+                    othello,
+                    hamletcharacters,
+                    backend,
+                    call_center,
+                ];
+                actual_value.sort((a, b) => a.user_id - b.user_id);
+                expected_value.sort((a, b) => a.user_id - b.user_id);
+                assert.deepEqual(actual_value, expected_value);
+
+                function matcher(query, person) {
+                    query = typeahead.clean_query_lowercase(query);
+                    return ct.query_matches_person(query, person);
+                }
+
+                let query;
+                query = "el"; // Matches both "othELlo" and "cordELia"
+                assert.equal(matcher(query, othello), true);
+                assert.equal(matcher(query, cordelia), true);
+
+                query = "bender"; // Doesn't exist
+                assert.equal(matcher(query, othello), false);
+                assert.equal(matcher(query, cordelia), false);
+
+                query = "gael";
+                assert.equal(matcher(query, gael), true);
+
+                query = "Gaël";
+                assert.equal(matcher(query, gael), true);
+
+                query = "gaël";
+                assert.equal(matcher(query, gael), true);
+
+                // Don't make suggestions if the last name only has whitespaces
+                // (we're between typing names).
+                query = "othello@zulip.com,     ";
+                assert.equal(matcher(query, othello), false);
+                assert.equal(matcher(query, cordelia), false);
+
+                // query = 'othello@zulip.com,, , cord';
+                query = "cord";
+                assert.equal(matcher(query, othello), false);
+                assert.equal(matcher(query, cordelia), true);
+
+                // If the user is already in the list, typeahead doesn't include it
+                // again.
+                query = "cordelia@zulip.com, cord";
+                assert.equal(matcher(query, othello), false);
+                assert.equal(matcher(query, cordelia), false);
+
+                query = "oth";
+                deactivated_user.delivery_email = null;
+                assert.equal(matcher(query, deactivated_user), false);
+
+                deactivated_user.delivery_email = "other@zulip.com";
+                assert.equal(matcher(query, deactivated_user), true);
+
+                function sorter(query, people) {
+                    return typeahead_helper.sort_recipients({
+                        users: people,
+                        query,
+                        current_stream_id: compose_state.stream_id(),
+                        current_topic: compose_state.topic(),
+                    });
+                }
+
+                // The sorter's output has the items that match the query from the
+                // beginning first, and then the rest of them in REVERSE order of
+                // the input.
+                query = "othello";
+                actual_value = sorter(query, [othello]);
+                expected_value = [othello];
+                assert.deepEqual(actual_value, expected_value);
+
+                query = "Ali";
+                actual_value = sorter(query, [alice, ali]);
+                expected_value = [ali, alice];
+                assert.deepEqual(actual_value, expected_value);
+
+                // A literal match at the beginning of an element puts it at the top.
+                query = "co"; // Matches everything ("x@zulip.COm")
+                actual_value = sorter(query, [othello, deactivated_user, cordelia]);
+                expected_value = [cordelia, deactivated_user, othello];
+                actual_value.sort((a, b) => a.user_id - b.user_id);
+                expected_value.sort((a, b) => a.user_id - b.user_id);
+                assert.deepEqual(actual_value, expected_value);
+
+                query = "non-existing-user";
+                actual_value = sorter(query, []);
+                expected_value = [];
+                assert.deepEqual(actual_value, expected_value);
+
+                // Adds a `no break-space` at the end. This should fail
+                // if there wasn't any logic replacing `no break-space`
+                // with normal space.
+                query = "cordelia, lear's\u00A0";
+                assert.equal(matcher(query, cordelia), true);
+                assert.equal(matcher(query, othello), false);
+
+                const event = {
+                    target: "#doesnotmatter",
+                };
+
+                // options.updater()
+                options.query = "othello";
+                appended_names = [];
+                options.updater(othello, event);
+                assert.deepEqual(appended_names, ["Othello, the Moor of Venice"]);
+
+                options.query = "othello@zulip.com, cor";
+                appended_names = [];
+                actual_value = options.updater(cordelia, event);
+                assert.deepEqual(appended_names, ["Cordelia, Lear's daughter"]);
+
+                const click_event = {type: "click", target: "#doesnotmatter"};
+                options.query = "othello";
+                // Focus lost (caused by the click event in the typeahead list)
+                $("#private_message_recipient").trigger("blur");
+                appended_names = [];
+                actual_value = options.updater(othello, click_event);
+                assert.deepEqual(appended_names, ["Othello, the Moor of Venice"]);
+
+                cleared = false;
+                options.query = "hamletchar";
+                appended_names = [];
+                options.updater(hamletcharacters, event);
+                assert.deepEqual(appended_names, ["King Lear"]);
+                assert.ok(cleared);
+
+                pill_items = [{user_id: lear.user_id}];
+                appended_names = [];
+                cleared = false;
+                options.updater(hamletcharacters, event);
+                assert.deepEqual(appended_names, []);
+                assert.ok(cleared);
+
+                pm_recipient_typeahead_called = true;
+
+                break;
+            }
+            case $("textarea#compose-textarea"): {
+                // options.source()
+                //
+                // For now we only test that get_sorted_filtered_items has been
+                // properly set as the .source(). All its features are tested later on
+                // in test_begins_typeahead().
+                let fake_this = {
+                    $element: {},
+                };
+                let caret_called = false;
+                fake_this.$element.caret = () => {
+                    caret_called = true;
+                    return 7;
+                };
+                fake_this.$element.closest = () => [];
+                fake_this.options = options;
+                let actual_value = options.source.call(fake_this, "test #s");
+                assert.deepEqual(sorted_names_from(actual_value), ["Sweden", "The Netherlands"]);
+                assert.ok(caret_called);
+
+                othello.delivery_email = "othello@zulip.com";
+                // options.highlighter_html()
+                //
+                // Again, here we only verify that the highlighter has been set to
+                // content_highlighter_html.
+                fake_this = {completing: "mention", token: "othello"};
+                actual_value = options.highlighter_html.call(fake_this, othello);
+                expected_value =
+                    `    <span class="user_circle_empty user_circle"></span>\n` +
+                    `    <img class="typeahead-image" src="http://zulip.zulipdev.com/avatar/${othello.user_id}?s&#x3D;50" />\n` +
+                    `<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
+                    `<small class="autocomplete_secondary">othello@zulip.com</small>\n`;
+                assert.equal(actual_value, expected_value);
+                // Reset the email such that this does not affect further tests.
+                othello.delivery_email = null;
+
+                fake_this = {completing: "mention", token: "hamletcharacters"};
+                actual_value = options.highlighter_html.call(fake_this, hamletcharacters);
+                expected_value =
+                    '    <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+                assert.equal(actual_value, expected_value);
+
+                // matching
+
+                function match(fake_this, item) {
+                    const token = fake_this.token;
+                    const completing = fake_this.completing;
+
+                    return ct.compose_content_matcher(completing, token)(item);
+                }
+
+                fake_this = {completing: "emoji", token: "ta"};
+                assert.equal(match(fake_this, make_emoji(emoji_tada)), true);
+                assert.equal(match(fake_this, make_emoji(emoji_moneybag)), false);
+
+                fake_this = {completing: "stream", token: "swed"};
+                assert.equal(match(fake_this, sweden_stream), true);
+                assert.equal(match(fake_this, denmark_stream), false);
+
+                fake_this = {completing: "syntax", token: "py"};
+                assert.equal(match(fake_this, "python"), true);
+                assert.equal(match(fake_this, "javascript"), false);
+
+                fake_this = {completing: "non-existing-completion"};
+                assert.equal(match(fake_this), undefined);
+
+                function sort_items(fake_this, item) {
+                    const token = fake_this.token;
+                    const completing = fake_this.completing;
+
+                    return ct.sort_results(completing, item, token);
+                }
+
+                // options.sorter()
+                fake_this = {completing: "emoji", token: "ta"};
+                actual_value = sort_items(fake_this, [
+                    make_emoji(emoji_stadium),
+                    make_emoji(emoji_tada),
+                ]);
+                expected_value = [make_emoji(emoji_tada), make_emoji(emoji_stadium)];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "emoji", token: "th"};
+                actual_value = sort_items(fake_this, [
+                    make_emoji(emoji_thermometer),
+                    make_emoji(emoji_thumbs_up),
+                ]);
+                expected_value = [make_emoji(emoji_thumbs_up), make_emoji(emoji_thermometer)];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "emoji", token: "he"};
+                actual_value = sort_items(fake_this, [
+                    make_emoji(emoji_headphones),
+                    make_emoji(emoji_heart),
+                ]);
+                expected_value = [make_emoji(emoji_heart), make_emoji(emoji_headphones)];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "slash", token: "m"};
+                actual_value = sort_items(fake_this, [my_slash, me_slash]);
+                expected_value = [me_slash, my_slash];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "slash", token: "da"};
+                actual_value = sort_items(fake_this, [dark_slash, light_slash]);
+                expected_value = [dark_slash, light_slash];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "stream", token: "de"};
+                actual_value = sort_items(fake_this, [sweden_stream, denmark_stream]);
+                expected_value = [denmark_stream, sweden_stream];
+                assert.deepEqual(actual_value, expected_value);
+
+                // Matches in the descriptions affect the order as well.
+                // Testing "co" for "cold", in both streams' description. It's at the
+                // beginning of Sweden's description, so that one should go first.
+                fake_this = {completing: "stream", token: "co"};
+                actual_value = sort_items(fake_this, [denmark_stream, sweden_stream]);
+                expected_value = [sweden_stream, denmark_stream];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "syntax", token: "ap"};
+                actual_value = sort_items(fake_this, ["abap", "applescript"]);
+                expected_value = ["applescript", "abap"];
+                assert.deepEqual(actual_value, expected_value);
+
+                const serbia_stream = {
+                    name: "Serbia",
+                    description: "Snow and cold",
+                    stream_id: 3,
+                    subscribed: false,
+                };
+                // Subscribed stream is active
+                override(
+                    user_settings,
+                    "demote_inactive_streams",
+                    settings_config.demote_inactive_streams_values.never.code,
+                );
+
+                stream_list_sort.set_filter_out_inactives();
+                fake_this = {completing: "stream", token: "s"};
+                actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
+                expected_value = [sweden_stream, serbia_stream];
+                assert.deepEqual(actual_value, expected_value);
+                // Subscribed stream is inactive
+                override(
+                    user_settings,
+                    "demote_inactive_streams",
+                    settings_config.demote_inactive_streams_values.always.code,
+                );
+
+                stream_list_sort.set_filter_out_inactives();
+                actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
+                expected_value = [sweden_stream, serbia_stream];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "stream", token: "ser"};
+                actual_value = sort_items(fake_this, [denmark_stream, serbia_stream]);
+                expected_value = [serbia_stream, denmark_stream];
+                assert.deepEqual(actual_value, expected_value);
+
+                fake_this = {completing: "non-existing-completion"};
+                assert.equal(sort_items(fake_this), undefined);
+
+                compose_textarea_typeahead_called = true;
+
+                break;
+            }
+            // No default
         }
-
-        fake_this = {completing: "emoji", token: "ta"};
-        assert.equal(match(fake_this, make_emoji(emoji_tada)), true);
-        assert.equal(match(fake_this, make_emoji(emoji_moneybag)), false);
-
-        fake_this = {completing: "stream", token: "swed"};
-        assert.equal(match(fake_this, sweden_stream), true);
-        assert.equal(match(fake_this, denmark_stream), false);
-
-        fake_this = {completing: "syntax", token: "py"};
-        assert.equal(match(fake_this, "python"), true);
-        assert.equal(match(fake_this, "javascript"), false);
-
-        fake_this = {completing: "non-existing-completion"};
-        assert.equal(match(fake_this), undefined);
-
-        function sort_items(fake_this, item) {
-            const token = fake_this.token;
-            const completing = fake_this.completing;
-
-            return ct.sort_results(completing, item, token);
-        }
-
-        // options.sorter()
-        fake_this = {completing: "emoji", token: "ta"};
-        actual_value = sort_items(fake_this, [make_emoji(emoji_stadium), make_emoji(emoji_tada)]);
-        expected_value = [make_emoji(emoji_tada), make_emoji(emoji_stadium)];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "emoji", token: "th"};
-        actual_value = sort_items(fake_this, [
-            make_emoji(emoji_thermometer),
-            make_emoji(emoji_thumbs_up),
-        ]);
-        expected_value = [make_emoji(emoji_thumbs_up), make_emoji(emoji_thermometer)];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "emoji", token: "he"};
-        actual_value = sort_items(fake_this, [
-            make_emoji(emoji_headphones),
-            make_emoji(emoji_heart),
-        ]);
-        expected_value = [make_emoji(emoji_heart), make_emoji(emoji_headphones)];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "slash", token: "m"};
-        actual_value = sort_items(fake_this, [my_slash, me_slash]);
-        expected_value = [me_slash, my_slash];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "slash", token: "da"};
-        actual_value = sort_items(fake_this, [dark_slash, light_slash]);
-        expected_value = [dark_slash, light_slash];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "stream", token: "de"};
-        actual_value = sort_items(fake_this, [sweden_stream, denmark_stream]);
-        expected_value = [denmark_stream, sweden_stream];
-        assert.deepEqual(actual_value, expected_value);
-
-        // Matches in the descriptions affect the order as well.
-        // Testing "co" for "cold", in both streams' description. It's at the
-        // beginning of Sweden's description, so that one should go first.
-        fake_this = {completing: "stream", token: "co"};
-        actual_value = sort_items(fake_this, [denmark_stream, sweden_stream]);
-        expected_value = [sweden_stream, denmark_stream];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "syntax", token: "ap"};
-        actual_value = sort_items(fake_this, ["abap", "applescript"]);
-        expected_value = ["applescript", "abap"];
-        assert.deepEqual(actual_value, expected_value);
-
-        const serbia_stream = {
-            name: "Serbia",
-            description: "Snow and cold",
-            stream_id: 3,
-            subscribed: false,
-        };
-        // Subscribed stream is active
-        override(
-            user_settings,
-            "demote_inactive_streams",
-            settings_config.demote_inactive_streams_values.never.code,
-        );
-
-        stream_list_sort.set_filter_out_inactives();
-        fake_this = {completing: "stream", token: "s"};
-        actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
-        expected_value = [sweden_stream, serbia_stream];
-        assert.deepEqual(actual_value, expected_value);
-        // Subscribed stream is inactive
-        override(
-            user_settings,
-            "demote_inactive_streams",
-            settings_config.demote_inactive_streams_values.always.code,
-        );
-
-        stream_list_sort.set_filter_out_inactives();
-        actual_value = sort_items(fake_this, [sweden_stream, serbia_stream]);
-        expected_value = [sweden_stream, serbia_stream];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "stream", token: "ser"};
-        actual_value = sort_items(fake_this, [denmark_stream, serbia_stream]);
-        expected_value = [serbia_stream, denmark_stream];
-        assert.deepEqual(actual_value, expected_value);
-
-        fake_this = {completing: "non-existing-completion"};
-        assert.equal(sort_items(fake_this), undefined);
-
-        compose_textarea_typeahead_called = true;
-    };
+    });
 
     user_settings.enter_sends = false;
     let compose_finish_called = false;

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -11,6 +11,7 @@ const input_pill = zrequire("input_pill");
 const pill_typeahead = zrequire("pill_typeahead");
 const noop = function () {};
 
+const bootstrap_typeahead = zrequire("bootstrap_typeahead");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
@@ -105,7 +106,7 @@ for (const sub of subs) {
     stream_data.add_sub(sub);
 }
 
-run_test("set_up", ({mock_template}) => {
+run_test("set_up", ({mock_template, override_rewire}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
         assert.equal(typeof data.has_image, "boolean");
@@ -130,7 +131,8 @@ run_test("set_up", ({mock_template}) => {
     }
 
     let opts = {};
-    $fake_input.typeahead = (config) => {
+    override_rewire(bootstrap_typeahead, "create", ($element, config) => {
+        assert.equal($element, $fake_input);
         assert.equal(config.items, 5);
         assert.ok(config.fixed);
         assert.ok(config.dropup);
@@ -316,7 +318,7 @@ run_test("set_up", ({mock_template}) => {
         // input_pill_typeahead_called is set true if
         // no exception occurs in pill_typeahead.set_up.
         input_pill_typeahead_called = true;
-    };
+    });
 
     function test_pill_typeahead(opts) {
         pill_typeahead.set_up($fake_input, $pill_widget, opts);

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -16,6 +16,7 @@ mock_esm("../src/filter", {
 });
 
 const search = zrequire("search");
+const bootstrap_typeahead = zrequire("bootstrap_typeahead");
 
 run_test("initialize", ({override_rewire, mock_template}) => {
     const $search_query_box = $("#search_query");
@@ -35,7 +36,8 @@ run_test("initialize", ({override_rewire, mock_template}) => {
     search_suggestion.max_num_of_search_results = 999;
     let terms;
 
-    $search_query_box.typeahead = (opts) => {
+    override_rewire(bootstrap_typeahead, "create", ($element, opts) => {
+        assert.equal($element, $search_query_box);
         assert.equal(opts.items, 999);
         assert.equal(opts.naturalSearch, true);
         assert.equal(opts.helpOnEmptyStrings, true);
@@ -206,7 +208,7 @@ run_test("initialize", ({override_rewire, mock_template}) => {
             $search_query_box.off("blur");
         }
         return {};
-    };
+    });
 
     search.initialize({
         on_narrow_search(raw_terms, options) {
@@ -304,7 +306,7 @@ run_test("initialize", ({override_rewire, mock_template}) => {
     assert.ok(is_blurred);
 });
 
-run_test("initiate_search", () => {
+run_test("initiate_search", ({override_rewire}) => {
     // open typeahead and select text when navbar is open
     // this implicitly expects the code to used the chained
     // function calls, which is something to keep in mind if
@@ -312,12 +314,9 @@ run_test("initiate_search", () => {
     narrow_state.filter = () => ({is_keyword_search: () => false});
     let typeahead_forced_open = false;
     let is_searchbox_text_selected = false;
-    $("#search_query").typeahead = (lookup) => {
-        if (lookup === "lookup") {
-            typeahead_forced_open = true;
-        }
-        return $("#search_query");
-    };
+    override_rewire(bootstrap_typeahead, "lookup", () => {
+        typeahead_forced_open = true;
+    });
     $("#search_query").on("select", () => {
         is_searchbox_text_selected = true;
     });


### PR DESCRIPTION
Part of an effort towards converting the typeahead to typescript.