### PR TITLE
help: Add example playground URL templates.

### DIFF
--- a/help/code-blocks.md
+++ b/help/code-blocks.md
@@ -147,6 +147,19 @@ specified code playground.
     generate the URL. You can refer to parts of the documentation on URL
     templates from [adding a custom linkifier](/help/add-a-custom-linkifier).
 
+### Examples of playground URL templates
+
+Here is a list of playground URL templates you can use for some popular
+languages:
+
+* For Java: `https://pythontutor.com/java.html#code={code}` or
+  `https://cscircles.cemc.uwaterloo.ca/java_visualize/#code={code}`
+* For JavaScript: `https://pythontutor.com/javascript.html#code={code}`
+* For Python: `https://pythontutor.com/python-compiler.html#code={code}`
+* For C: `https://pythontutor.com/c.html#code={code}`
+* For C++: `https://pythontutor.com/cpp.html#code={code}`
+* For Rust: `https://play.rust-lang.org/?code={code}`
+
 ### Technical details
 
 * You can configure multiple playgrounds for a given language; if you do that,


### PR DESCRIPTION
Fixes #29067. Replaces #29166.

The playgrounds were tested successfully by @laurynmm .

![Screenshot 2024-03-13 at 12 09 15 AM](https://github.com/zulip/zulip/assets/2090066/051d320f-b338-4b86-8e77-06c24a838fba)

