### PR TITLE
settings: Scroll save button into view when a change made needs saving.

### DIFF
--- a/web/src/settings_components.js
+++ b/web/src/settings_components.js
@@ -6,6 +6,7 @@ import * as blueslip from "./blueslip";
 import * as compose_banner from "./compose_banner";
 import {$t} from "./i18n";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
+import * as scroll_util from "./scroll_util";
 import * as settings_config from "./settings_config";
 import {realm} from "./state_data";
 import * as stream_data from "./stream_data";
@@ -404,6 +405,12 @@ export function change_save_button_state($element, state) {
     $textEl.text(button_text);
     $saveBtn.attr("data-status", data_status);
     if (state === "unsaved") {
+        // Ensure the save button is visible when the state is "unsaved",
+        // so the user does not miss saving their changes.
+        scroll_util.scroll_element_into_container(
+            $element.parent(".subsection-header"),
+            $("#settings_content"),
+        );
         enable_or_disable_save_button($element.closest(".settings-subsection-parent"));
     }
     show_hide_element($element, is_show, 800);

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -18,6 +18,7 @@ mock_esm("../src/loading", {
     make_indicator: noop,
     destroy_indicator: noop,
 });
+mock_esm("../src/scroll_util", {scroll_element_into_container: noop});
 
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");


### PR DESCRIPTION
Whenever a setting that needs confirmation to save is tweaked, and the save button is not visible, we scroll it into view, to ensure the user does not mistake it for an automatically saved change and misses saving their change.

Fixes: #29290.

**Screenshots and screen captures:**
Before toggling off the checkbox under the pointer:
![image](https://github.com/zulip/zulip/assets/68962290/09a7cfd9-e273-47ff-84da-2dea6bb9e9c1)

After clicking:
![image](https://github.com/zulip/zulip/assets/68962290/42047b8a-a83c-4ef6-82e1-bd577a8cc272)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
