### PR TITLE
email_page: Migrate has_request_variables to typed_endpoint.

### DIFF
--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -14,8 +14,8 @@ from zerver.actions.realm_settings import do_send_realm_reactivation_email
 from zerver.actions.user_settings import do_change_user_delivery_email
 from zerver.actions.users import change_user_is_active
 from zerver.lib.email_notifications import enqueue_welcome_emails, send_account_registered_email
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import Realm
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_realm_stream
@@ -26,10 +26,8 @@ from zproject.email_backends import get_forward_address, set_forward_address
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 
 
-@has_request_variables
-def email_page(
-    request: HttpRequest, forward_address: Optional[str] = REQ(default=None)
-) -> HttpResponse:
+@typed_endpoint
+def email_page(request: HttpRequest, *, forward_address: Optional[str] = None) -> HttpResponse:
     if request.method == "POST":
         assert forward_address is not None
         set_forward_address(forward_address)


### PR DESCRIPTION
Refactor `email_page` view to use `typed_endpoint` decorator instead of `has_request_variables`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
