### PR TITLE
inbox: Add icon for default topic visibility policy.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -448,10 +448,15 @@
             &:focus,
             &:focus-within,
             &:hover {
+                .inbox-row-visibility-policy-inherit,
                 .inbox-action-button {
                     opacity: 1;
                 }
             }
+        }
+
+        .inbox-row-visibility-policy-inherit {
+            opacity: 0;
         }
 
         .inbox-action-button {

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -47,7 +47,8 @@
             <div class="inbox-right-part-wrapper">
                 <div class="inbox-right-part">
                     {{#if is_topic}}
-                        <span class="visibility-policy-indicator change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0">
+                        <span class="visibility-policy-indicator change_visibility_policy hidden-for-spectators{{#if (eq visibility_policy all_visibility_policies.INHERIT)}} inbox-row-visibility-policy-inherit{{/if}}"
+                          data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                                 <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
@@ -57,6 +58,9 @@
                             {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
                                 <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
+                            {{else if (eq visibility_policy all_visibility_policies.INHERIT)}}
+                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'Default'}}"
+                                  role="button" aria-haspopup="true" aria-label="{{t 'Default' }}"></i>
                             {{/if}}
                         </span>
                     {{/if}}


### PR DESCRIPTION
This bug occurred when we added `INHERIT` visibility policy for topics but forgot to handle that case here.

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/inbox-view.20focus


<img width="639" alt="Screenshot 2024-03-14 at 8 39 41 PM" src="https://github.com/zulip/zulip/assets/25124304/31469431-7052-4aa1-844e-e089fc1511bf">

