### PR TITLE
upgrade: Fix allowed free trails for ended legacy plans on server.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -4146,6 +4146,16 @@ class RemoteRealmBillingSession(BillingSession):
             CustomerPlan.TIER_SELF_HOSTED_BUSINESS,
         ):
             return PlanTierChangeType.UPGRADE
+        elif (
+            current_plan_tier == CustomerPlan.TIER_SELF_HOSTED_BASIC
+            and new_plan_tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
+        ):
+            return PlanTierChangeType.DOWNGRADE
+        elif (
+            current_plan_tier == CustomerPlan.TIER_SELF_HOSTED_BUSINESS
+            and new_plan_tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
+        ):
+            return PlanTierChangeType.DOWNGRADE
         else:
             assert current_plan_tier == CustomerPlan.TIER_SELF_HOSTED_BUSINESS
             assert new_plan_tier == CustomerPlan.TIER_SELF_HOSTED_BASIC

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -484,12 +484,6 @@ def get_current_plan_by_customer(customer: Customer) -> Optional[CustomerPlan]:
     ).first()
 
 
-def is_legacy_customer(customer: Customer) -> bool:
-    return CustomerPlan.objects.filter(
-        customer=customer, tier=CustomerPlan.TIER_SELF_HOSTED_LEGACY
-    ).exists()
-
-
 def get_current_plan_by_realm(realm: Realm) -> Optional[CustomerPlan]:
     customer = get_customer_by_realm(realm)
     if customer is None:

--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -21,12 +21,7 @@ from corporate.lib.stripe import (
     get_configured_fixed_price_plan_offer,
     get_free_trial_days,
 )
-from corporate.models import (
-    CustomerPlan,
-    get_current_plan_by_customer,
-    get_customer_by_realm,
-    is_legacy_customer,
-)
+from corporate.models import CustomerPlan, get_current_plan_by_customer, get_customer_by_realm
 from zerver.context_processors import get_realm_from_request, latest_info_context
 from zerver.decorator import add_google_analytics, zulip_login_required
 from zerver.lib.github import (
@@ -193,9 +188,9 @@ def remote_realm_plans_page(
                     status=CustomerPlan.NEVER_STARTED,
                 )
 
-        if is_legacy_customer(customer):
-            # Free trial is disabled for legacy customers.
-            context.free_trial_days = None
+    if billing_session.is_legacy_customer():
+        # Free trial is disabled for legacy customers.
+        context.free_trial_days = None
 
     context.is_new_customer = (
         not context.on_free_tier and context.customer_plan is None and not context.is_sponsored
@@ -256,7 +251,7 @@ def remote_server_plans_page(
                     status=CustomerPlan.NEVER_STARTED,
                 )
 
-        if is_legacy_customer(customer):
+        if billing_session.is_legacy_customer():
             # Free trial is disabled for legacy customers.
             context.free_trial_days = None
 


### PR DESCRIPTION
If the remote realm registered after the legacy plan on server ENDED, we never migrate the plan to the remote realm. So, we need to check the server of remote realm whenever we are check remote realm for legacy plan.

