### PR TITLE
streams: Message users when someone unsubscribes them from stream(s). (#29272)

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -849,6 +849,7 @@ def do_send_messages(
     send_message_requests_maybe_none: Sequence[Optional[SendMessageRequest]],
     *,
     mark_as_read: Sequence[int] = [],
+    is_channel_unsubscription_notification: bool = False,
 ) -> List[SentMessageResult]:
     """See
     https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
@@ -1014,7 +1015,11 @@ def do_send_messages(
 
         # Deliver events to the real-time push system, as well as
         # enqueuing any additional processing triggered by the message.
-        wide_message_dict = MessageDict.wide_dict(send_request.message, realm_id)
+        wide_message_dict = MessageDict.wide_dict(
+            send_request.message,
+            realm_id,
+            is_channel_unsubscription_notification=is_channel_unsubscription_notification,
+        )
 
         user_flags = user_message_flags.get(send_request.message.id, {})
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -679,7 +679,11 @@ def to_dict_cache_key_id(message_id: int) -> str:
     return f"message_dict:{message_id}"
 
 
-def to_dict_cache_key(message: "Message", realm_id: Optional[int] = None) -> str:
+def to_dict_cache_key(
+    message: "Message",
+    realm_id: Optional[int] = None,
+    is_channel_unsubscription_notification: bool = False,
+) -> str:
     return to_dict_cache_key_id(message.id)
 
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -125,7 +125,7 @@ def add_emoji_to_message() -> Dict[str, object]:
 
     # The message ID here is hardcoded based on the corresponding value
     # for the example message IDs we use in zulip.yaml.
-    message_id = 47
+    message_id = 48
     emoji_name = "octopus"
     emoji_code = "1f419"
     reaction_type = "unicode_emoji"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22612,7 +22612,7 @@ components:
         The target message's ID.
       schema:
         type: integer
-      example: 43
+      example: 44
       required: true
     UserId:
       name: user_id

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -103,7 +103,7 @@ class OpenAPIToolsTest(ZulipTestCase):
             description="The target message's ID.\n",
             json_encoded=False,
             value_schema={"type": "integer"},
-            example=43,
+            example=44,
             required=True,
             deprecated=False,
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -6097,7 +6097,7 @@ class GetSubscribersTest(ZulipTestCase):
             )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the following channels:
+            @_**King Hamlet|{hamlet.id}** subscribed you to the following streams:
 
             * #**stream_0**
             * #**stream_1**
@@ -6132,7 +6132,7 @@ class GetSubscribersTest(ZulipTestCase):
         )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the channel #**stream_invite_only_1**.
+            @_**King Hamlet|{hamlet.id}** subscribed you to the stream #**stream_invite_only_1**.
             """
         for user in [cordelia, othello, polonius]:
             self.assert_user_got_subscription_notification(user, msg)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -514,14 +514,14 @@ def you_were_just_subscribed_message(
     subscriptions = sorted(stream_names)
     if len(subscriptions) == 1:
         with override_language(recipient_user.default_language):
-            return _("{user_full_name} subscribed you to the channel {channel_name}.").format(
-                user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
-                channel_name=f"#**{subscriptions[0]}**",
+            return _("{user_full_name} subscribed you to the stream {stream_name}.").format(
+                user_full_name=silent_mention_syntax_for_user(acting_user),
+                stream_name=f"#**{subscriptions[0]}**",
             )
 
     with override_language(recipient_user.default_language):
-        message = _("{user_full_name} subscribed you to the following channels:").format(
-            user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
+        message = _("{user_full_name} subscribed you to the following streams:").format(
+            user_full_name=silent_mention_syntax_for_user(acting_user),
         )
     message += "\n\n"
     for channel_name in subscriptions:


### PR DESCRIPTION
These "you were unsubscribed" messages are supposed to mirror "you were subscribed" messages we already send. So, **we dont message when unsubcriptions occur from management commands, archiving streams, etc**. We only message when someone unsubscribes the user from the api endpoint.

I **did not test** bulk unsubscribe as i do not know of a way to do that from the ui, without archiving the stream.

<!-- Describe your pull request here.-->

Fixes: #29272 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/133781250/23faadfb-5692-4774-aa2a-b3abe26a8cfb)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
