### PR TITLE
Don't display x button in empty filter fields when field is not closeable

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -1553,9 +1553,18 @@ export function initialize({
         }, 300),
     );
 
+    $("body").on("input", "#recent_view_search", () => {
+        if ($("#recent_view_search").val()) {
+            $("#recent_view_search_clear").css("visibility", "visible");
+        } else {
+            $("#recent_view_search_clear").css("visibility", "hidden");
+        }
+    });
+
     $("body").on("click", "#recent_view_search_clear", (e) => {
         e.stopPropagation();
         $("#recent_view_search").val("");
+        $("#recent_view_search_clear").css("visibility", "hidden");
         update_filters_view();
     });
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -600,6 +600,10 @@ export function setup_page(callback) {
 
         // show the "Stream settings" header by default.
         $(".display-type #stream_settings_title").show();
+
+        if (!$("#stream_filter input[type='text']").val()) {
+            $("#clear_search_stream_name").css("visibility", "hidden");
+        }
     }
 
     function populate_and_fill() {
@@ -649,6 +653,11 @@ export function setup_page(callback) {
 
         const throttled_redraw_left_panel = _.throttle(redraw_left_panel, 50);
         $("#stream_filter input[type='text']").on("input", () => {
+            if (!$("#stream_filter input[type='text']").val()) {
+                $("#clear_search_stream_name").css("visibility", "hidden");
+            } else {
+                $("#clear_search_stream_name").css("visibility", "visible");
+            }
             // Debounce filtering in case a user is typing quickly
             throttled_redraw_left_panel();
         });
@@ -678,6 +687,7 @@ export function setup_page(callback) {
 
         $("#clear_search_stream_name").on("click", () => {
             $("#stream_filter input[type='text']").val("");
+            $("#clear_search_stream_name").css("visibility", "hidden");
             redraw_left_panel();
         });
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -168,6 +168,10 @@
             margin: 0 -27px 10px 0;
         }
 
+        #recent_view_search_clear {
+            visibility: hidden;
+        }
+
         #recent_view_search {
             flex-grow: 1;
             padding-right: 20px;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

In this pull request I have used css visibility property and jQuery's .css() helper to hide x button in a couple of filter fields when the filed is empty:

 - "Filter streams" in stream settings
 - "Filter topics" in Recent topics

For those fields, now it does not display the x button when field is empty.

I read that **zulip has a policy of not doing .css() instead of classes unless absolutely necessary** but here flex properties were growing input fields unnecessarily when there is no "x" button while using .hide() / .show(). That's why I have used .css() here. 

Fixes: #21297 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Light mode:

[Fix-x-button.webm](https://github.com/zulip/zulip/assets/113179991/cd1a3456-0d96-475d-a721-464f5d2376dd)

Dark mode:

[dark-mode-fix-x-button.webm](https://github.com/zulip/zulip/assets/113179991/eb504d23-bd63-4cd5-b9a9-af393de954b6)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] End-to-end functionality of buttons, interactions and flows.
</details>
