### PR TITLE
Update Onboarding Email Links and Use Cases Heading

### DIFF
--- a/templates/corporate/for/use-cases.md
+++ b/templates/corporate/for/use-cases.md
@@ -1,4 +1,4 @@
-## Use cases
+## Guides for popular use cases
 
 * [Business](/for/business/)
 * [Education](/for/education/)

--- a/templates/zerver/emails/onboarding_zulip_guide.html
+++ b/templates/zerver/emails/onboarding_zulip_guide.html
@@ -6,7 +6,11 @@
 
 {% block content %}
 
-<p>{{ _("As you are getting started with Zulip, we'd love to help you discover how it can work best for your needs. Check out this guide to key Zulip features for organizations like yours!") }}</p>
+{% if organization_type in ["government", "political_group", "personal", "other"] %}
+    <p>{{ _("As you are getting started with Zulip, we'd love to help you discover how it can work best for your needs. Check out our guides to key Zulip features!") }}</p>
+{% else %}
+    <p>{{ _("As you are getting started with Zulip, we'd love to help you discover how it can work best for your needs. Check out this guide to key Zulip features.") }}</p>
+{% endif %}
 
 
 {% if organization_type == "business" %}
@@ -23,6 +27,16 @@
 <a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide for non-profits") }}</a>
 {% elif organization_type == "community" %}
 <a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide for communities") }}</a>
+{% elif organization_type == "unspecified" %}
+<a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide") }}</a>
+{% elif organization_type == "government" %}
+<a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide") }}</a>
+{% elif organization_type == "political_group" %}
+<a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide") }}</a>
+{% elif organization_type == "personal" %}
+<a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide") }}</a>
+{% elif organization_type == "other" %}
+<a class="button" href="{{ zulip_guide_link }}">{{ _("View Zulip guide") }}</a>
 {% endif %}
 
 <p>

--- a/templates/zerver/emails/onboarding_zulip_guide.subject.txt
+++ b/templates/zerver/emails/onboarding_zulip_guide.subject.txt
@@ -12,4 +12,14 @@
 {{ _("Zulip guide for non-profits") }}
 {% elif organization_type == "community" %}
 {{ _("Zulip guide for communities") }}
+{% elif organization_type == "unspecified" %}
+{{ _("Zulip guide") }}
+{% elif organization_type == "government" %}
+{{ _("Zulip guide") }}
+{% elif organization_type == "political_group" %}
+{{ _("Zulip guide") }}
+{% elif organization_type == "personal" %}
+{{ _("Zulip guide") }}
+{% elif organization_type == "other" %}
+{{ _("Zulip guide") }}
 {% endif %}

--- a/templates/zerver/emails/onboarding_zulip_guide.txt
+++ b/templates/zerver/emails/onboarding_zulip_guide.txt
@@ -14,6 +14,16 @@
 {{ _("View Zulip guide for non-profits") }}:
 {% elif organization_type == "community" %}
 {{ _("View Zulip guide for communities") }}:
+{% elif organization_type == "unspecified" %}
+{{ _("View Zulip guide") }}:
+{% elif organization_type == "government" %}
+{{ _("View Zulip guide") }}:
+{% elif organization_type == "political_group" %}
+{{ _("View Zulip guide") }}:
+{% elif organization_type == "personal" %}
+{{ _("View Zulip guide") }}:
+{% elif organization_type == "other" %}
+{{ _("View Zulip guide") }}:
 {% endif %}
 <{{ zulip_guide_link }}>
 

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -379,7 +379,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
             "id": OrgTypeEnum.Unspecified.value,
             "hidden": True,
             "display_order": 0,
-            "onboarding_zulip_guide_url": None,
+            "onboarding_zulip_guide_url": "https://zulip.com/use-cases/",
         },
         "business": {
             "name": "Business",
@@ -435,14 +435,14 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
             "id": OrgTypeEnum.Government.value,
             "hidden": False,
             "display_order": 8,
-            "onboarding_zulip_guide_url": None,
+            "onboarding_zulip_guide_url": "https://zulip.com/use-cases/",
         },
         "political_group": {
             "name": "Political group",
             "id": OrgTypeEnum.PoliticalGroup.value,
             "hidden": False,
             "display_order": 9,
-            "onboarding_zulip_guide_url": None,
+            "onboarding_zulip_guide_url": "https://zulip.com/use-cases/",
         },
         "community": {
             "name": "Community",
@@ -456,14 +456,14 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
             "id": OrgTypeEnum.Personal.value,
             "hidden": False,
             "display_order": 100,
-            "onboarding_zulip_guide_url": None,
+            "onboarding_zulip_guide_url": "https://zulip.com/use-cases/",
         },
         "other": {
             "name": "Other",
             "id": OrgTypeEnum.Other.value,
             "hidden": False,
             "display_order": 1000,
-            "onboarding_zulip_guide_url": None,
+            "onboarding_zulip_guide_url": "https://zulip.com/use-cases/",
         },
     }
 


### PR DESCRIPTION
**Changes:**
- Updated the onboarding_zulip_guide email to include a link to https://zulip.com/use-cases/ when there is no specific page for the organization's type.
- Modified the "Use cases" heading on https://zulip.com/use-cases/ to "Guides for popular use cases" for clarity.

![image](https://github.com/zulip/zulip/assets/73663475/51698a21-bf87-4753-9d61-f1d9df2ee925)
![onboarding_email_02](https://github.com/zulip/zulip/assets/73663475/50bf7b20-ec39-4549-bf82-e413a5c0c017)

Fixes #26868 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
