### PR TITLE
wildcard-mentions: Add "channel" as a stream wildcard option.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 247**
+
+* [Markdown message formatting](/api/message-formatting#mentions):
+  Added `channel` to the supported options for [wildcard
+  mentions](/help/mention-a-user-or-group#mention-everyone-on-a-stream).
+
 **Feature level 246**
 
 * [`POST /register`](/api/register-queue), [`POST

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1795,10 +1795,10 @@ field with an integer field `invite_to_realm_policy`.
 
 **Feature level 33**
 
-* Markdown code blocks now have a `data-code-language` attribute
-  attached to the outer `div` element, recording the programming
-  language that was selecting for syntax highlighting.  This field
-  supports the upcoming "view in playground" feature for code blocks.
+* [Markdown message formatting](/api/message-formatting#code-blocks):
+  [Code blocks](/help/code-blocks) now have a `data-code-language`
+  attribute attached to the outer HTML `div` element, recording the
+  programming language that was selected for syntax highlighting.
 
 **Feature level 32**
 
@@ -1854,9 +1854,9 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 24**
 
-* The `!avatar()` and `!gravatar()` Markdown syntax, which was never
-  documented, had inconsistent syntax, and was rarely used, was
-  removed.
+* [Markdown message formatting](/api/message-formatting#removed-features):
+  The rarely used `!avatar()` and `!gravatar()` markup syntax, which
+  was never documented and had inconsistent syntax, was removed.
 
 **Feature level 23**
 
@@ -1921,8 +1921,8 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 15**
 
-* Added [spoilers](/help/format-your-message-using-markdown#spoilers)
-  to supported Markdown features.
+* [Markdown message formatting](/api/message-formatting#spoilers): Added
+  [spoilers](/help/spoilers) to supported message formatting features.
 
 **Feature level 14**
 
@@ -1984,8 +1984,9 @@ No changes; feature level used for Zulip 3.0 release.
 * [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user)
   and [`GET /users/me`](/api/get-own-user): User objects now contain the
   `is_owner` field as well.
-* Added [time mentions](/help/format-your-message-using-markdown#mention-a-time)
-  to supported Markdown features.
+* [Markdown message formatting](/api/message-formatting#global-times):
+  Added [global times](/help/global-times) to supported message
+  formatting features.
 
 **Feature level 7**
 

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -1,0 +1,47 @@
+# Message formatting
+
+Zulip supports an extended version of Markdown for messages, as well as
+some HTML level special behavior. The Zulip help center article on [message
+formatting](/help/format-your-message-using-markdown) is the primary
+documentation for Zulip's markup features. This article is currently a
+changelog for updates to these features.
+
+The [render a message](/api/render-message) endpoint can be used to get
+the current HTML version of any Markdown syntax for message content.
+
+## Code blocks
+
+**Changes**: As of Zulip 4.0 (feature level 33), [code blocks][help-code]
+can have a `data-code-language` attribute attached to the outer HTML
+`div` element, which records the programming language that was selected
+for syntax highlighting. This field is used in the
+[playgrounds][help-playgrounds] feature for code blocks.
+
+## Global times
+
+**Changes**: In Zulip 3.0 (feature level 8), added [global time
+mentions][help-global-time] to supported Markdown message formatting
+features.
+
+## Spoilers
+
+**Changes**: In Zulip 3.0 (feature level 15), added
+[spoilers][help-spoilers] to supported Markdown message formatting
+features.
+
+## Removed features
+
+**Changes**: In Zulip 4.0 (feature level 24), the rarely used `!avatar()`
+and `!gravatar()` markup syntax, which was never documented and had an
+inconsistent syntax, were removed.
+
+## Related articles
+
+* [Markdown formatting](/help/format-your-message-using-markdown)
+* [Send a message](/api/send-message)
+* [Render a message](/api/render-message)
+
+[help-code]: /help/code-blocks
+[help-playgrounds]: /help/code-blocks#code-playgrounds
+[help-spoilers]: /help/spoilers
+[help-global-time]: /help/global-times

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -23,6 +23,12 @@ for syntax highlighting. This field is used in the
 mentions][help-global-time] to supported Markdown message formatting
 features.
 
+## Mentions
+
+**Changes**: In Zulip 9.0 (feature level 247), `channel` was added
+to the supported [wildcard][help-mention-all] options used in the
+[mentions][help-mentions] Markdown message formatting feature.
+
 ## Spoilers
 
 **Changes**: In Zulip 3.0 (feature level 15), added
@@ -45,3 +51,5 @@ inconsistent syntax, were removed.
 [help-playgrounds]: /help/code-blocks#code-playgrounds
 [help-spoilers]: /help/spoilers
 [help-global-time]: /help/global-times
+[help-mentions]: /help/mention-a-user-or-group
+[help-mention-all]: /help/mention-a-user-or-group#mention-everyone-on-a-stream

--- a/api_docs/sidebar_index.md
+++ b/api_docs/sidebar_index.md
@@ -21,6 +21,7 @@
 * [HTTP headers](/api/http-headers)
 * [Error handling](/api/rest-error-handling)
 * [Roles and permissions](/api/roles-and-permissions)
+* [Message formatting](/api/message-formatting)
 * [Client libraries](/api/client-libraries)
 * [API changelog](/api/changelog)
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 246
+API_FEATURE_LEVEL = 247
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -411,7 +411,7 @@ export function broadcast_mentions() {
     if (compose_state.get_message_type() === "private") {
         wildcard_mention_array = ["all", "everyone"];
     } else if (compose_validate.stream_wildcard_mention_allowed()) {
-        wildcard_mention_array = ["all", "everyone", "stream", "topic"];
+        wildcard_mention_array = ["all", "everyone", "stream", "channel", "topic"];
     } else if (compose_validate.topic_wildcard_mention_allowed()) {
         wildcard_mention_array = ["topic"];
     }

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -191,7 +191,12 @@ function parse_with_options(
     const marked_options = {
         ...options,
         userMentionHandler(mention: string, silently: boolean): string | undefined {
-            if (mention === "all" || mention === "everyone" || mention === "stream") {
+            if (
+                mention === "all" ||
+                mention === "everyone" ||
+                mention === "stream" ||
+                mention === "channel"
+            ) {
                 let classes;
                 let display_text;
                 if (silently) {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1373,7 +1373,7 @@ export function get_mention_syntax(full_name: string, user_id?: number, silent =
 }
 
 function full_name_matches_wildcard_mention(full_name: string): boolean {
-    return ["all", "everyone", "stream", "topic"].includes(full_name);
+    return ["all", "everyone", "stream", "channel", "topic"].includes(full_name);
 }
 
 export function _add_user(person: User): void {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1360,8 +1360,13 @@ export function get_mention_syntax(full_name: string, user_id?: number, silent =
     } else {
         mention += "@**";
     }
-    mention += full_name;
     const wildcard_match = full_name_matches_wildcard_mention(full_name);
+    if (wildcard_match && user_id === undefined) {
+        mention += util.canonicalize_stream_synonym(full_name);
+    } else {
+        mention += full_name;
+    }
+
     if (user_id === undefined && !wildcard_match) {
         blueslip.warn("get_mention_syntax called without user_id.");
     }

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -275,6 +275,19 @@ export function convert_message_topic(message: Message): void {
     }
 }
 
+// TODO: When "stream" is renamed to "channel", update these stream
+// synonym helper functions for the reverse logic.
+export function is_stream_synonym(text: string): boolean {
+    return text === "channel";
+}
+
+export function canonicalize_stream_synonym(text: string): string {
+    if (is_stream_synonym(text.toLowerCase())) {
+        return "stream";
+    }
+    return text;
+}
+
 let inertDocument: Document | undefined;
 
 export function clean_user_content_links(html: string): string {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -195,10 +195,12 @@ export class CachedValue<T> {
 }
 
 export function find_stream_wildcard_mentions(message_content: string): string | null {
-    // We cannot use the exact same regex as the server side users (in zerver/lib/mention.py)
+    // We cannot use the exact same regex as the server side uses (in zerver/lib/mention.py)
     // because Safari < 16.4 does not support look-behind assertions.  Reframe the lookbehind of a
     // negative character class as a start-of-string or positive character class.
-    const mention = message_content.match(/(?:^|[\s"'(/<[{])(@\*{2}(all|everyone|stream)\*{2})/);
+    const mention = message_content.match(
+        /(?:^|[\s"'(/<[{])(@\*{2}(all|everyone|stream|channel)\*{2})/,
+    );
     if (mention === null) {
         return null;
     }

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -65,19 +65,23 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     const mention_all = ct.broadcast_mentions()[0];
     const mention_everyone = ct.broadcast_mentions()[1];
     const mention_stream = ct.broadcast_mentions()[2];
-    const mention_topic = ct.broadcast_mentions()[3];
+    const mention_channel = ct.broadcast_mentions()[3];
+    const mention_topic = ct.broadcast_mentions()[4];
     assert.equal(mention_all.email, "all");
     assert.equal(mention_all.full_name, "all");
     assert.equal(mention_everyone.email, "everyone");
     assert.equal(mention_everyone.full_name, "everyone");
     assert.equal(mention_stream.email, "stream");
     assert.equal(mention_stream.full_name, "stream");
+    assert.equal(mention_channel.email, "channel");
+    assert.equal(mention_channel.full_name, "channel");
     assert.equal(mention_topic.email, "topic");
     assert.equal(mention_topic.full_name, "topic");
 
     assert.equal(mention_all.special_item_text, "all (translated: Notify stream)");
     assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify stream)");
     assert.equal(mention_stream.special_item_text, "stream (translated: Notify stream)");
+    assert.equal(mention_channel.special_item_text, "channel (translated: Notify stream)");
     assert.equal(mention_topic.special_item_text, "topic (translated: Notify topic)");
 
     compose_validate.stream_wildcard_mention_allowed = () => false;
@@ -1788,7 +1792,7 @@ test("typeahead_results", () => {
 
     // Verify we suggest both 'the first matching stream wildcard' and
     // 'topic wildcard' mentions. Not only one matching wildcard mention.
-    const mention_topic = ct.broadcast_mentions()[3];
+    const mention_topic = ct.broadcast_mentions()[4];
     // Here, we suggest both "everyone" and "topic".
     assert_mentions_matches("o", [othello, mention_everyone, mention_topic, cordelia]);
 

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -781,6 +781,17 @@ test("message_flags", () => {
     assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
     assert.equal(message.flags.includes("mentioned"), false);
 
+    input = "test @**channel**";
+    message = {topic: "No links here", raw_content: input};
+    message = {
+        ...message,
+        ...markdown.render(message.raw_content),
+    };
+    assert.equal(message.is_me_message, false);
+    assert.equal(message.flags.includes("stream_wildcard_mentioned"), true);
+    assert.equal(message.flags.includes("topic_wildcard_mentioned"), false);
+    assert.equal(message.flags.includes("mentioned"), false);
+
     input = "test @**topic**";
     message = {topic: "No links here", raw_content: input};
     message = {

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -1154,6 +1154,7 @@ test_people("get_mention_syntax", () => {
     assert.equal(people.get_mention_syntax("all"), "@**all**");
     assert.equal(people.get_mention_syntax("everyone", undefined, true), "@_**everyone**");
     assert.equal(people.get_mention_syntax("stream"), "@**stream**");
+    assert.equal(people.get_mention_syntax("channel"), "@**stream**");
     assert.equal(people.get_mention_syntax("topic"), "@**topic**");
 
     people.add_active_user(stephen1);

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -602,7 +602,7 @@ test("sort broadcast mentions for stream message type", () => {
 
     assert.deepEqual(
         results.map((r) => r.email),
-        ["all", "everyone", "stream", "topic"],
+        ["all", "everyone", "stream", "channel", "topic"],
     );
 
     // Reverse the list to test actual sorting
@@ -616,7 +616,7 @@ test("sort broadcast mentions for stream message type", () => {
 
     assert.deepEqual(
         results2.map((r) => r.email),
-        ["all", "everyone", "stream", "topic", a_user.email, zman.email],
+        ["all", "everyone", "stream", "channel", "topic", a_user.email, zman.email],
     );
 });
 

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -184,6 +184,13 @@ run_test("wildcard_mentions_regexp", () => {
         "some text before only @**stream**",
     ];
 
+    const messages_with_channel_mentions = [
+        "@**channel**",
+        "some text before @**channel** some text after",
+        "@**channel** some text after only",
+        "some text before only @**channel**",
+    ];
+
     const messages_with_topic_mentions = [
         "@**topic**",
         "some text before @**topic** some text after",
@@ -218,6 +225,15 @@ run_test("wildcard_mentions_regexp", () => {
         "some_email@**stream**.com",
     ];
 
+    const messages_without_channel_mentions = [
+        "some text before @channel some text after",
+        "@channel",
+        "`@channel`",
+        "some_email@channel.com",
+        "`@**channel**`",
+        "some_email@**channel**.com",
+    ];
+
     let i;
     for (i = 0; i < messages_with_all_mentions.length; i += 1) {
         assert.ok(util.find_stream_wildcard_mentions(messages_with_all_mentions[i]));
@@ -229,6 +245,10 @@ run_test("wildcard_mentions_regexp", () => {
 
     for (i = 0; i < messages_with_stream_mentions.length; i += 1) {
         assert.ok(util.find_stream_wildcard_mentions(messages_with_stream_mentions[i]));
+    }
+
+    for (i = 0; i < messages_with_channel_mentions.length; i += 1) {
+        assert.ok(util.find_stream_wildcard_mentions(messages_with_channel_mentions[i]));
     }
 
     for (i = 0; i < messages_with_topic_mentions.length; i += 1) {
@@ -245,6 +265,10 @@ run_test("wildcard_mentions_regexp", () => {
 
     for (i = 0; i < messages_without_stream_mentions.length; i += 1) {
         assert.ok(!util.find_stream_wildcard_mentions(messages_without_stream_mentions[i]));
+    }
+
+    for (i = 0; i < messages_without_channel_mentions.length; i += 1) {
+        assert.ok(!util.find_stream_wildcard_mentions(messages_without_channel_mentions[i]));
     }
 });
 

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -22,7 +22,7 @@ USER_GROUP_MENTIONS_RE = re.compile(
 )
 
 topic_wildcards = frozenset(["topic"])
-stream_wildcards = frozenset(["all", "everyone", "stream"])
+stream_wildcards = frozenset(["all", "everyone", "stream", "channel"])
 
 
 @dataclass

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -791,7 +791,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
         othello = self.example_user("othello")
 
         stream_wildcard_mentioned_in_followed_topic_message_id = self.send_stream_message(
-            othello, "Denmark", "@**stream**"
+            othello, "Denmark", "@**all**"
         )
         topic_wildcard_mentioned_in_followed_topic_message_id = self.send_stream_message(
             othello, "Denmark", "@**topic**"
@@ -810,7 +810,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
         )
 
         expected_email_include = [
-            "Othello, the Moor of Venice: > @**stream** > @**topic** -- ",
+            "Othello, the Moor of Venice: > @**all** > @**topic** -- ",
             "You are receiving this because all topic participants were mentioned in #Denmark > test.",
         ]
 

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -4,6 +4,7 @@ from unittest import mock
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.alert_words import do_add_alert_words
+from zerver.lib.mention import stream_wildcards
 from zerver.lib.soft_deactivation import (
     add_missing_messages,
     do_auto_soft_deactivate_users,
@@ -747,15 +748,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
 
         # Test UserMessage row is created while user is deactivated if
         # there is a stream wildcard mention such as @all or @everyone
-        assert_stream_message_sent_to_idle_user(
-            "Test @**all** mention", possible_stream_wildcard_mention=True
-        )
-        assert_stream_message_sent_to_idle_user(
-            "Test @**everyone** mention", possible_stream_wildcard_mention=True
-        )
-        assert_stream_message_sent_to_idle_user(
-            "Test @**stream** mention", possible_stream_wildcard_mention=True
-        )
+        for stream_wildcard in stream_wildcards:
+            assert_stream_message_sent_to_idle_user(
+                f"Test @**{stream_wildcard}** mention", possible_stream_wildcard_mention=True
+            )
         assert_stream_message_not_sent_to_idle_user("Test @**bogus** mention")
 
         # Test UserMessage row is created while user is deactivated if


### PR DESCRIPTION
Adds "channel" as one of the stream wildcard mention strings on the backend and implements it on the web app frontend.

Still to do as part of (or follow-ups to) these changes:
- Remove "stream" from typeahead, but still support it in the web app if someone manually types it in the compose box.
- Update the help center docs (replace "stream" with "channel" in the stream wildcard mentions).
- Figure out API changelog update - currently the wildcard strings are not documented in the API docs directly.

---

Part of the work towards #28468 (Rename "stream" to "channel").

Relevant CZO discussions:
- [#api design - stream/channel rename: stream wildcard mention](https://chat.zulip.org/#narrow/stream/378-api-design/topic/stream.2Fchannel.20rename.3A.20.40stream.20wildcard.20mention/near/1752174)
- [#release management - overall discussion](https://chat.zulip.org/#narrow/stream/438-release-management/topic/rename.20.22stream.22.20to.20.22channel.22.20project.2C.20.2328468/near/1758864)

---

**Screenshots and screen captures:**

<details>
<summary>typeahead options in composebox</summary>

![Screenshot from 2024-03-15 12-37-17](https://github.com/zulip/zulip/assets/63245456/d61779f4-8cf5-4a6d-9ada-461fc5e9e8a4)
![Screenshot from 2024-03-15 12-37-30](https://github.com/zulip/zulip/assets/63245456/f386ac8e-9a56-49d8-b8fd-3837ac91f1bb)
![Screenshot from 2024-03-15 12-37-50](https://github.com/zulip/zulip/assets/63245456/7a1139f1-9ad1-4c71-92b0-4b4cd5cdbf73)
</details>
<details>
<summary>preview mode in compose box</summary>

![Screenshot from 2024-03-15 13-40-03](https://github.com/zulip/zulip/assets/63245456/c727c456-af8e-4462-9ae8-10e0fc4fb5f0)
</details>
<details>
<summary>Aaron's view of test message from Iago in subscribed stream</summary>

![Screenshot from 2024-03-15 12-40-30](https://github.com/zulip/zulip/assets/63245456/b632a618-5dbc-4509-a844-33a56c77d454)
![Screenshot from 2024-03-15 12-40-13](https://github.com/zulip/zulip/assets/63245456/973691e3-5f8a-4f69-9e25-6106861a5e36)
![Screenshot from 2024-03-15 12-39-11](https://github.com/zulip/zulip/assets/63245456/a8128f46-235d-48a5-bde1-9e6a84718277)
</details>
<details>
<summary>test message in stream where Aaron is subscribed and Iago is not</summary>

**Aaron viewing the message:**
![Screenshot from 2024-03-15 12-42-33](https://github.com/zulip/zulip/assets/63245456/0ccd5073-e215-4a42-a98d-f01bdea6db70)

**Iago viewing the message:**
![Screenshot from 2024-03-15 12-42-09](https://github.com/zulip/zulip/assets/63245456/227a5382-f183-491c-9b4b-d12aab88b73a)
</details>
<details>
<summary>dev environment email notifications for the above messages</summary>

![Screenshot from 2024-03-15 12-43-08](https://github.com/zulip/zulip/assets/63245456/ce5b9d14-ba07-4ffd-88ba-59b8d5b18f62)
![Screenshot from 2024-03-15 12-45-10](https://github.com/zulip/zulip/assets/63245456/be6dd0b8-2310-466f-9e3e-3a45a4e6af5b)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
