### PR TITLE
settings: Fix dropdown menu for pronouns.

### DIFF
--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -2,12 +2,9 @@ import $ from "jquery";
 
 import render_settings_custom_user_profile_field from "../templates/settings/custom_user_profile_field.hbs";
 
-import * as bootstrap_typeahead from "./bootstrap_typeahead";
-import {$t} from "./i18n";
 import * as people from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import {realm} from "./state_data";
-import * as typeahead_helper from "./typeahead_helper";
 import * as user_pill from "./user_pill";
 
 export function append_custom_profile_fields(element_id, user_id) {
@@ -156,23 +153,4 @@ export function initialize_custom_date_type_fields(element_id) {
         .on("click", function () {
             $(this).parent().find(".custom_user_field_value").val("");
         });
-}
-
-export function initialize_custom_pronouns_type_fields(element_id) {
-    const commonly_used_pronouns = [
-        $t({defaultMessage: "he/him"}),
-        $t({defaultMessage: "she/her"}),
-        $t({defaultMessage: "they/them"}),
-    ];
-    bootstrap_typeahead.create($(element_id).find(".pronouns_type_field"), {
-        items: 3,
-        fixed: true,
-        helpOnEmptyStrings: true,
-        source() {
-            return commonly_used_pronouns;
-        },
-        highlighter_html(item) {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
-    });
 }

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -241,7 +241,6 @@ export function add_custom_profile_fields_to_settings() {
         pill_update_handler,
     );
     custom_profile_fields_ui.initialize_custom_date_type_fields(element_id);
-    custom_profile_fields_ui.initialize_custom_pronouns_type_fields(element_id);
 }
 
 export function hide_confirm_email_banner() {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -764,9 +764,6 @@ export function show_edit_user_info_modal(user_id, $container) {
         user_id,
     );
     custom_profile_fields_ui.initialize_custom_date_type_fields(custom_profile_field_form_selector);
-    custom_profile_fields_ui.initialize_custom_pronouns_type_fields(
-        custom_profile_field_form_selector,
-    );
     const fields_user_pills = custom_profile_fields_ui.initialize_custom_user_type_fields(
         custom_profile_field_form_selector,
         user_id,

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -23,9 +23,14 @@
         {{else if is_url_field }}
         <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" list="pronoun-options" />
         {{else}}
         <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{/if}}
+        <datalist id="pronoun-options">
+            <option value="She/her"></option>
+            <option value="He/him"></option>
+            <option value="They/them"></option>
+        </datalist>
     </div>
 </div>


### PR DESCRIPTION
Replaced Boostrap Typehead with a native HTML <datalist>. 

Typehead demonstrated a sticky like behavior when scrolling with the list open. The suggested fix was to replace Typehead with datalist. This fixes the issue on all non-chromium based browsers, however the chromium based browsers do demonstrate a similar behavior even with datalist.  

**Screenshots and screen captures:**

From Safari: 

https://github.com/zulip/zulip/assets/63150791/91cd73d6-1b9b-48c8-a0c8-ae3b47e0e907

From Chrome:

https://github.com/zulip/zulip/assets/63150791/b5e384e3-55d3-41b4-9eaa-30cb721a41ee

Fixes: https://github.com/zulip/zulip/issues/29303

Fixes #29303 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ x ] Explains differences from previous plans (e.g., issue description).
- [ x ] Highlights technical choices and bugs encountered.
- [ x ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x ] Each commit is a coherent idea.
- [ x ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x ] Visual appearance of the changes.
- [ x ] Responsiveness and internationalization.
- [ x ] Strings and tooltips.
- [ x ] End-to-end functionality of buttons, interactions and flows.
- [ x ] Corner cases, error conditions, and easily imagined bugs.
</details>
