### PR TITLE
Upload Settings UI Fix PR

### DIFF
--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
-        <h3>{{t "Uploaded files"}}</h3>
+        <h3>{{t "Your Uploads"}}</h3>
         <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
     </div>
     <div class="clear-float"></div>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
-        <h3>{{t "Your Uploads"}}</h3>
+        <h3>{{t "Your uploads"}}</h3>
         <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
     </div>
     <div class="clear-float"></div>

--- a/web/templates/settings/upload_space_stats.hbs
+++ b/web/templates/settings/upload_space_stats.hbs
@@ -1,9 +1,11 @@
 <span>
-    {{t "Organization using {percent_used}% of {upload_quota}." }}
+    {{t "Your organization is using {percent_used}% of your {upload_quota} file storage quota." }}
     {{#if show_upgrade_message}}
-        {{#tr}}
-            <z-link>Upgrade</z-link> for more space.
-            {{#*inline "z-link"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-        {{/tr}}
+        <div class="upgrade-tip">
+            {{#tr}}
+                <z-link>Upgrade</z-link> for more space.
+                {{#*inline "z-link"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+            {{/tr}}
+        </div>
     {{/if}}
 </span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Improvements made to the uploaded files settings panel UI. Only minor changes made to the `upload_space_stats.hbs` and `attachment_settings.hbs` files. These include nesting the upgrade message in the appropriate `div`, inserting required text where necessary, and changing the header text from "Uploaded Files" to "Your Uploads"

Some updates will need to be made to existing translations to match English version

Fixes: <!-- Issue link, or clear description.-->
issue #29077 by author @alya 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
- [x] Rename the table to "Your uploads" to clarify that these are your files, not everyone's. All other strings can continue to say "uploaded files"
- [x] Change the text of the quota notice to:

> Your organization is using x% of your 5 GB file storage quota. Upgrade for more space.

- [x]  Instead of a link on "Upgrade", put the whole notice into a clickable banner with a rocket icon, like ones elsewhere

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/92211625/af706b95-df4d-4d64-b5c6-1219b7027c72)


![image](https://github.com/zulip/zulip/assets/92211625/20705809-4856-419f-9764-af6d6857c6be)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
