### PR TITLE
message_view: Fix error thrown on deleting stream and searching for it.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -340,8 +340,8 @@ export class MessageList {
         let just_unsubscribed = false;
         const subscribed = stream_data.is_subscribed_by_name(stream_name);
         const sub = stream_data.get_sub(stream_name);
-        const invite_only = sub.invite_only;
-        const is_web_public = sub.is_web_public;
+        const invite_only = sub && sub.invite_only;
+        const is_web_public = sub && sub.is_web_public;
         const can_toggle_subscription =
             sub !== undefined && stream_data.can_toggle_subscription(sub);
         if (sub === undefined) {


### PR DESCRIPTION
Previously, when a stream is deleted and the deleted stream is looked up in the search bar, then an error is thrown.

This is because, when the StreamSubscription object of the deleted stream is fetched we try to access its properties -- invite_only and is_web_public, despite it being undefined.

This is fixed by accessing the properties only when the object is not undefined.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/error.20when.20deleting.20a.20stream.20and.20searching.20for.20it)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
