### PR TITLE
Fix extraneous shadow at bottom of link preview

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -349,7 +349,7 @@
     .message_embed .data-container::after {
         background: linear-gradient(
             0deg,
-            hsl(212deg 28% 18%),
+            var(--color-background-stream-message-content),
             transparent 100%
         );
     }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -629,7 +629,7 @@
 
             background: linear-gradient(
                 0deg,
-                hsl(0deg 0% 100%),
+                var(--color-background-stream-message-content),
                 transparent 100%
             );
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1362,6 +1362,14 @@ td.pointer {
     .date_row {
         background-color: var(--color-background-private-message-content);
     }
+
+    .message_content .message_embed .data-container::after {
+        background: linear-gradient(
+            0deg,
+            var(--color-background-private-message-content),
+            transparent 100%
+        );
+    }
 }
 
 .selected_message {


### PR DESCRIPTION
<!-- Describe your pull request here.--> 
The issue talks about a extraneous shadow at the bottom of link preview in stream messages in dark theme but this problem is present not only there but in private messages in both themes (dark and light) aswell ([comment on issue](https://github.com/zulip/zulip/issues/28853#issuecomment-1999771610)).

The solution consists of applying the same color, used in the background, to the shadow. There are CSS variables that hold the values of the background color, which I use to apply to the shadow.

Fixes: #28853<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
```
$ git grep 'data-container::after'
web/styles/dark_theme.css:    .message_embed .data-container::after {
web/styles/rendered_markdown.css:        .data-container::after {
web/styles/zulip.css:    .message_content .message_embed .data-container::after {
```
**Screenshots:**
- **Stream** messages in **DARK THEME**

| Before | After |
| --- | --- |
|![DARK_STREAM_BEFORE](https://github.com/zulip/zulip/assets/92178181/fac421a1-7592-40fa-9a66-22519766d3cb) | ![DARK_STREAM_AFTER](https://github.com/zulip/zulip/assets/92178181/967a818f-c9b3-4631-81f0-8a90e2ea271c) |

- **Private** messages in **DARK THEME**

| Before | After |
| --- | --- |
| ![DARK_PRIVATE_AFTER_](https://github.com/zulip/zulip/assets/92178181/d673fcb9-88a7-4093-84ec-215250ad16e1) | ![DARK_PRIVATE_AFTER_](https://github.com/zulip/zulip/assets/92178181/a232b094-f50a-46d1-a79d-4ffe7f715daf) |

- **Private** messages in **LIGHT THEME**

| Before | After |
| --- | --- |
| ![LIGHT_PRIVATE_BEFORE](https://github.com/zulip/zulip/assets/92178181/d3f5e3c5-9975-4c39-9f7a-26aa1011831a) | ![LIGHT_PRIVATE_AFTER](https://github.com/zulip/zulip/assets/92178181/0234c0a5-9412-43c5-9c89-0959d08ae73a) |

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/shadow.20at.20bottom.20of.20link.20preview/near/1605298)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
