### PR TITLE
message_edit: Fix local echo of message edit.

### DIFF
--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -315,10 +315,10 @@ export function edit_locally(message, request) {
             // all flags, so we need to restore those flags that are
             // properties of how the user has interacted with the
             // message, and not its rendering.
-            message = {
-                ...message,
-                ...markdown.render(message.raw_content),
-            };
+            const {content, flags, is_me_message} = markdown.render(message.raw_content);
+            message.content = content;
+            message.flags = flags;
+            message.is_me_message = is_me_message;
             if (request.starred !== undefined) {
                 message.starred = request.starred;
             }


### PR DESCRIPTION
Previously, when a message is edited, it is locally echoed with its
pre-edit content.

This is because previously, when we tried to render the edited
message of the edit box during local echo, in order to update
the content, flags, and is_me_message properties of the message
object with that of those returned is markdown.render(), we used
the spread operator and created a new message object, and updated
the existing message object with this new one.

This was misconverted, since edit_locally() method already has a
fully-rendered message object to start with, and is just doing a
rerendering, it should be mutating what message it received, rather
than constructing a new local variable.

<!-- Describe your pull request here.-->
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/view.20message.20source.20appearing.20during.20edit.20save/near/1760398)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![brave_54ij6LYfVT](https://github.com/zulip/zulip/assets/97049524/8c1c3206-c3de-4b47-aaf9-583e7a7a9533)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
