### PR TITLE
alert_words: Fix incorrect highlighting of alert words.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -87,5 +87,5 @@ export function notifies(message: Message): boolean {
 }
 
 export const initialize = (params: {alert_words: string[]}): void => {
-    my_alert_words = params.alert_words;
+    set_words(params.alert_words);
 };

--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -8,7 +8,12 @@ import * as people from "./people";
 let my_alert_words: string[] = [];
 
 export function set_words(words: string[]): void {
+    // This module's highlighting algorithm of greedily created
+    // highlight spans cannot correctly handle overlapping alert word
+    // clauses, but processing in order from longest-to-shortest
+    // reduces some symptoms of this. See #28415 for details.
     my_alert_words = words;
+    my_alert_words.sort((a, b) => b.length - a.length);
 }
 
 export function get_word_list(): {word: string}[] {

--- a/web/tests/alert_words.test.js
+++ b/web/tests/alert_words.test.js
@@ -116,7 +116,18 @@ run_test("notifications", () => {
 
 run_test("munging", () => {
     alert_words.initialize(params);
-
+    assert.deepEqual(alert_words.get_word_list(), [
+        {word: "alertthree"},
+        {word: "alertone"},
+        {word: "alerttwo"},
+        {word: "al*rt.*s"},
+        {word: "emoji"},
+        {word: `5'11"`},
+        {word: "FD&C"},
+        {word: ".+"},
+        {word: "<3"},
+        {word: ">8"},
+    ]);
     let saved_content = regular_message.content;
     alert_words.process_message(regular_message);
     assert.equal(saved_content, regular_message.content);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -160,7 +160,7 @@ run_test("alert_words", ({override}) => {
     const event = event_fixtures.alert_words;
     dispatch(event);
 
-    assert.deepEqual(alert_words.get_word_list(), [{word: "fire"}, {word: "lunch"}]);
+    assert.deepEqual(alert_words.get_word_list(), [{word: "lunch"}, {word: "fire"}]);
     assert.ok(alert_words.has_alert_word("fire"));
     assert.ok(alert_words.has_alert_word("lunch"));
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

If the overlapping alert words are configured , only the overlapped part of it seems to be highlighted.
The expected behaviour should be that anything which is a part of alert word should be highlighted.

This approach modifies the approach of processing alert words by sorting the words based on their size. 
It initially checks for the larger words and hence resolve the incorrect highlighting.

Fixes: #28415
Completion PR for - #28431

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Previously - 

<img width="182" alt="Screenshot 2024-03-19 at 4 11 16 PM" src="https://github.com/zulip/zulip/assets/97145463/5d363958-34a9-4035-b1e5-a8203dc6f925">

Presently - 

<img width="187" alt="Screenshot 2024-03-19 at 4 10 55 PM" src="https://github.com/zulip/zulip/assets/97145463/852935bc-c3e2-49ce-8ca6-2b844a345e39">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
