### PR TITLE
dev_urls: Make requests to /docs redirect to the index.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -505,6 +505,7 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "config-error/(?P<error_name>[^/]+)",
             "confirmation_key/",
             "node-coverage/(?P<path>.+)",
+            "docs/",
             "docs/(?P<path>.+)",
             "casper/(?P<path>.+)",
             "static/(?P<path>.+)",

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -7,7 +7,7 @@ from django.contrib.staticfiles.views import serve as staticfiles_serve
 from django.http.request import HttpRequest
 from django.http.response import FileResponse
 from django.urls import path
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 from django.views.static import serve
 
 from zerver.views.auth import login_page
@@ -52,6 +52,7 @@ urls = [
             "show_indexes": True,
         },
     ),
+    path("docs/", RedirectView.as_view(url="/docs/index.html")),
     path(
         "docs/<path:path>",
         serve,


### PR DESCRIPTION
This makes it easier to browse to the docs in development mode, and more closely matches ReadTheDocs production.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
