### PR TITLE
release: Fix changelog output.

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -111,7 +111,7 @@ gh auth status \
 
 # Extract the changelog, print it
 changelog_anchor="zulip-server-${version//./-}"
-changelog=$(VERSION="$version" perl -nle '$v=quotemeta($ENV{VERSION}); print if $rc = /^### $v/ .. /^#{1,3} (?!$v)/ and $rc !~ /E0/' docs/overview/changelog.md)
+changelog=$(VERSION="$version" perl -nle '$v=quotemeta($ENV{VERSION}); print if $rc = /^### Zulip Server $v/ .. /^#{1,3} Zulip Server (?!$v)/ and $rc !~ /E0/' docs/overview/changelog.md)
 echo "$changelog"
 
 echo -e "\n\n(pausing for 15s, ^C to cancel)"


### PR DESCRIPTION
9bd340957ff8 changed the headers; while we no longer store the changelog text in the Github release object, we should still output the changelog to STDOUT correctly.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
