### PR TITLE
help: Improve documentation for Shift+M keyboard shortcut.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -176,9 +176,10 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Collapse/show message**: <kbd>-</kbd>
 
-* **Toggle topic mute**: <kbd>Shift</kbd> + <kbd>M</kbd> — Muted topics
-  don't show up in any views (including **All messages**), and don't contribute
-  to unread counts. Read more about [muting or unmuting topics](/help/mute-a-topic).
+* **Toggle topic mute**: <kbd>Shift</kbd> + <kbd>M</kbd>. This works in both
+  message views and views that list topics (e.g., [inbox](/help/inbox), [recent
+  conversations](/help/recent-conversations)). Learn about [muted
+  topics](/help/mute-a-topic).
 
 ## Recent conversations
 

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -6,6 +6,11 @@
 
 {!configure-topic-notifications.md!}
 
+!!! keyboard_tip ""
+
+    You can also use the <kbd>Shift</kbd> + <kbd>M</kbd> [keyboard
+    shortcut](/help/keyboard-shortcuts) to mute or unmute a topic.
+
 ## Automatically unmute topics in muted streams
 
 {!automatically-unmute-topics-in-muted-streams.md!}


### PR DESCRIPTION
Current: https://zulip.com/help/mute-a-topic
Updated:

![Screenshot 2024-03-19 at 3 45 44 PM](https://github.com/zulip/zulip/assets/2090066/0c771787-017c-4866-8597-c1cfb9a7f881)

Note: I would have put the keyboard tip inside the Desktop/Web instruction block, but we're currently reusing that block for followed topics, and I'm not sure it's worth it to split out the two use cases.

---

Current: https://zulip.com/help/keyboard-shortcuts#for-a-selected-message-outlined-in-blue

Updated:

![Screenshot 2024-03-19 at 3 46 47 PM](https://github.com/zulip/zulip/assets/2090066/fce11332-89f9-4504-aac1-f8a6798b5e68)

Note: It's a bit weird for this to be in the "For selected message" section, but probably OK? I removed random bits of description of what a muted topic is, since I think it's better to direct folks to the page that explains them in detail.