### PR TITLE
docs: Fix typos in the Hindi translation guide.

### DIFF
--- a/docs/translating/hindi.md
+++ b/docs/translating/hindi.md
@@ -1,8 +1,8 @@
-# Hindi translation style guide(हिन्दी अनुवाद शैली मार्गदर्शक)
+# Hindi translation style guide (हिन्दी अनुवाद शैली मार्गदर्शक)
 
 Use informal Hindi for translation:
 
-- Informal "you" (_तु_) instead of formal form _आप_. Many top software
+- Informal "you" (_तू_) instead of formal form _आप_. Many top software
   companies (e.g. Google) use the informal one, because it's much more common in
   the daily language and avoids making translations look like they were written
   by machines.
@@ -23,7 +23,7 @@ Some terms are very tricky to translate, so be sure to communicate
 with other Hindi speakers in the community. It's all about making
 Zulip friendly and usable.
 
-## Terms(शर्तें)
+## Terms (शर्तें)
 
 - Message - **संदेश**
 - Private message (PM) - **निजी संदेश**
@@ -36,24 +36,22 @@ Zulip friendly and usable.
 - Bot - **बॉट**
 - Integration - **एकीकरण**
 - Notification - **अधिसूचना**
-- Alert word - **सतर्क शब्द**: this is only _alert_. Nonetheless, adding _word_ may
-  make the term confusing (something like _danger!_ could be a "चेतावनी के शब्द" as well).
-  Google Alerts uses "सतर्क शब्द" in its Hindi translation.
+- Alert word - **सतर्क शब्द**
 - View - **राय**
 - Filter - **छानना**: as used with narrowing (see below).
 - Home - **मुख पृष्ठ**: we never use the term "घर" (literally home) in Hindi.
 - Emoji - **इमोजी**
 
-## Phrases (वाक्यांशों)
+## Phrases (वाक्यांश)
 
 - Subscribe/Unsubscribe to a stream - **एक धारा में सदस्यता लें/सदस्यता समाप्त करें**
 - Narrow to - **अकेले फ़िल्टर करें**: this is _filter only_, because there's no other
   word that's common enough in Hindi for _to narrow_.
 - Mute/Unmute - **शांत/अशांत**
 - Deactivate/Reactivate - **निष्क्रिय करें / पुन: सक्रिय करें**
-- Search - **खोज करें/ढूंढे**
+- Search - **खोज करें/ढूंढें**
 - Pin - **ठीक करना**
-- Mention/@mention - **ज़िक्र करना / @ ज़िक्र करना**
+- Mention/@mention - **ज़िक्र करना / @ज़िक्र करना**
 - Invalid - **अमान्य**
 - Customization - **अनुकूलन**
 - I want - **मुझे चाहिए**
@@ -62,7 +60,7 @@ Zulip friendly and usable.
   "व्यक्ति", but when talking of _लोग_ referring to it as a crowd, we use
   "भीड़" instead.
 
-## Others(अन्य)
+## Others (अन्य)
 
 - You - **तुम**: also "आप" if it's in plural.
 - We - **हम**


### PR DESCRIPTION
I fixed some typos in the Hindi translation guide. I think more issues/typos remain, but I'm not sure what's the correct translation, so I haven't fixed them yet.