### PR TITLE
integrations: Restructure documentation pages.

### DIFF
--- a/api_docs/incoming-webhooks-overview.md
+++ b/api_docs/incoming-webhooks-overview.md
@@ -189,10 +189,18 @@ Parameters accepted in the URL include:
   [URL-encoded][url-encoder]. By default the integration will have a
   topic configured for stream messages.
 
-* `only_events`, `exclude_events`: Some incoming webhook integrations
-  support these parameters to filter which events will trigger a
-  notification. For details, see the integration's [integration
-  documentation](/integrations) page.
+* `only_events`, `exclude_events`: Some incoming webhook integrations support
+  these parameters to filter which events will trigger a notification. You can
+  append either `&only_events=["event_a","event_b"]` or
+  `&exclude_events=["event_a","event_b"]` (or both, with different events) to
+  the URL, with an arbitrary number of supported events. You can use UNIX-style
+  wildcards like `*` to include multiple events. For example, `test*` matches
+  every event that starts with `test`.
+
+    !!! tip ""
+
+        For a list of supported events, see the integration's [integration
+        documentation](/integrations) page.
 
 [browse-streams]: /help/browse-and-subscribe-to-streams
 [add-bot]: /help/add-a-bot-or-integration

--- a/api_docs/incoming-webhooks-overview.md
+++ b/api_docs/incoming-webhooks-overview.md
@@ -156,51 +156,61 @@ below are for a webhook named `MyWebHook`.
   spot why something isn't working or if the service is using custom HTTP
   headers.
 
-## URLs
+## URL specification
 
-The base URL for an incoming webhook integration bot is
-`{{ api_url }}/v1/external/INTEGRATION_NAME?api_key=API_KEY` where
+The base URL for an incoming webhook integration bot, where
 `INTEGRATION_NAME` is the name of the specific webhook integration and
 `API_KEY` is the API key of the bot created by the user for the
-integration.
+integration, is:
 
-The list of existing webhook integrations can be found in
-`zerver/lib/integrations.py` (at `WEBHOOK_INTEGRATIONS`) or by browsing
-the [Integrations documentation](/integrations/).
+```
+{{ api_url }}/v1/external/INTEGRATION_NAME?api_key=API_KEY
+```
+
+The list of existing webhook integrations can be found by browsing the
+[Integrations documentation](/integrations/) or in
+`zerver/lib/integrations.py` at `WEBHOOK_INTEGRATIONS`.
 
 Parameters accepted in the URL include:
 
-* `api_key`: **Required**. The API key of the bot created by the user
-  for the integration. To get a bot's API key, see the [API
-  keys](/api/api-keys) documentation.
+### api_key *(required)*
 
-* `stream`: The stream for the integration to send notifications to.
-  Can be either the stream ID or the [URL-encoded][url-encoder] stream
-  name. By default the integration will send direct messages to the
-  bot's owner.
+The API key of the bot created by the user for the integration. To get a
+bot's API key, see the [API keys](/api/api-keys) documentation.
 
-    !!! tip ""
+### stream
 
-        A stream ID can be found when [browsing streams][browse-streams]
-        in the web app via the URL.
+The stream for the integration to send notifications to. Can be either
+the stream ID or the [URL-encoded][url-encoder] stream name. By default
+the integration will send direct messages to the bot's owner.
 
-* `topic`: The topic in the specified stream for the integration to
-  send notifications to. The topic should also be
-  [URL-encoded][url-encoder]. By default the integration will have a
-  topic configured for stream messages.
+!!! tip ""
 
-* `only_events`, `exclude_events`: Some incoming webhook integrations support
-  these parameters to filter which events will trigger a notification. You can
-  append either `&only_events=["event_a","event_b"]` or
-  `&exclude_events=["event_a","event_b"]` (or both, with different events) to
-  the URL, with an arbitrary number of supported events. You can use UNIX-style
-  wildcards like `*` to include multiple events. For example, `test*` matches
-  every event that starts with `test`.
+    A stream ID can be found when [browsing streams][browse-streams]
+    in the web app via the URL.
 
-    !!! tip ""
+### topic
 
-        For a list of supported events, see the integration's [integration
-        documentation](/integrations) page.
+The topic in the specified stream for the integration to send
+notifications to. The topic should also be [URL-encoded][url-encoder].
+By default the integration will have a topic configured for stream
+messages.
+
+### only_events, exclude_events
+
+Some incoming webhook integrations support these parameters to filter
+which events will trigger a notification. You can append either
+`&only_events=["event_a","event_b"]` or
+`&exclude_events=["event_a","event_b"]` (or both, with different events)
+to the URL, with an arbitrary number of supported events.
+
+You can use UNIX-style wildcards like `*` to include multiple events.
+For example, `test*` matches every event that starts with `test`.
+
+!!! tip ""
+
+    For a list of supported events, see a specific [integration's
+    documentation](/integrations) page.
 
 [browse-streams]: /help/browse-and-subscribe-to-streams
 [add-bot]: /help/add-a-bot-or-integration

--- a/templates/zerver/integrations/include/congrats.md
+++ b/templates/zerver/integrations/include/congrats.md
@@ -1,3 +1,2 @@
-**Congratulations! You're done!**
-
-Your {{ integration_display_name }} notifications may look like:
+You're done! Your {{ integration_display_name }} notifications may look like
+this:

--- a/templates/zerver/integrations/include/event-filtering-additional-feature.md
+++ b/templates/zerver/integrations/include/event-filtering-additional-feature.md
@@ -1,0 +1,8 @@
+### Filtering incoming events
+
+The {{ integration_display_name }} integration supports filtering for
+the following events:
+
+{% set comma = joiner(", ") %}
+
+{% for event_type in all_event_types -%} {{- comma() -}} `{{ event_type }}` {%- endfor %}

--- a/templates/zerver/integrations/include/event-filtering-additional-feature.md
+++ b/templates/zerver/integrations/include/event-filtering-additional-feature.md
@@ -1,8 +1,10 @@
 ### Filtering incoming events
 
-The {{ integration_display_name }} integration supports filtering for
-the following events:
+The {{ integration_display_name }} integration supports
+[filtering][event-filters] for the following events:
 
 {% set comma = joiner(", ") %}
 
 {% for event_type in all_event_types -%} {{- comma() -}} `{{ event_type }}` {%- endfor %}
+
+[event-filters]: /api/incoming-webhooks-overview#only_events-exclude_events

--- a/templates/zerver/integrations/include/generate-integration-url.md
+++ b/templates/zerver/integrations/include/generate-integration-url.md
@@ -15,4 +15,4 @@ The generated URL will look something like this:
 see [the webhook URLs specification][incoming-webhook-urls].*
 
 [generate-url]: /help/generate-integration-url
-[incoming-webhook-urls]: /api/incoming-webhooks-overview#urls
+[incoming-webhook-urls]: /api/incoming-webhooks-overview#url-specification

--- a/templates/zerver/integrations/include/generate-webhook-url-basic.md
+++ b/templates/zerver/integrations/include/generate-webhook-url-basic.md
@@ -1,0 +1,4 @@
+[Generate the URL][generate-url] for your {{ integration_display_name }}
+integration.
+
+[generate-url]: /help/generate-integration-url

--- a/templates/zerver/integrations/include/git-branches-additional-feature.md
+++ b/templates/zerver/integrations/include/git-branches-additional-feature.md
@@ -1,0 +1,3 @@
+* You can limit the branches you receive notifications for by
+  specifying them in a comma-separated list appended to the generated
+  URL, e.g. `&branches=main,development`.

--- a/templates/zerver/integrations/include/webhooks-url-specification.md
+++ b/templates/zerver/integrations/include/webhooks-url-specification.md
@@ -1,3 +1,3 @@
 * [Webhook URLs specification][incoming-webhook-urls]
 
-[incoming-webhook-urls]: /api/incoming-webhooks-overview#urls
+[incoming-webhook-urls]: /api/incoming-webhooks-overview#url-specification

--- a/templates/zerver/integrations/include/webhooks-url-specification.md
+++ b/templates/zerver/integrations/include/webhooks-url-specification.md
@@ -1,0 +1,3 @@
+* [Webhook URLs specification][incoming-webhook-urls]
+
+[incoming-webhook-urls]: /api/incoming-webhooks-overview#urls

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -68,10 +68,6 @@ $category-text: hsl(219deg 23% 33%);
         list-style: none;
     }
 
-    & ul li {
-        list-style: circle;
-    }
-
     .integration-main-text {
         padding: 0 15px;
     }
@@ -561,10 +557,6 @@ $category-text: hsl(219deg 23% 33%);
         }
 
         .integration-instructions {
-            .help-content h3 {
-                margin: 20px 0;
-            }
-
             .logos_disclaimer {
                 font-size: 14px;
                 font-style: italic;

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -152,12 +152,6 @@
             & > ul {
                 margin-bottom: 5px;
             }
-
-            .warn,
-            .tip,
-            .keyboard_tip {
-                margin: 5px 25px;
-            }
         }
 
         @media (width <= 500px) {

--- a/zerver/webhooks/airbrake/doc.md
+++ b/zerver/webhooks/airbrake/doc.md
@@ -1,17 +1,27 @@
+# Zulip Airbrake integration
+
 Get Zulip notifications for your Airbrake bug tracker!
+
+{start_tabs}
 
 1. {!create-stream.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
+1. {!generate-webhook-url-basic.md!}
 
 1. Go to your project's settings on the Airbrake site. Click on the
    **Integration** section, and select **Webhook**.
 
-1. Enter the URL constructed above, and check **Enabled**.
+1. Enter the URL you generated, and check **Enabled**.
    Click **Save**.
+
+{end_tabs}
 
 {!congrats.md!}
 
 ![](/static/images/integrations/airbrake/001.png)
+
+### Related documentation
+
+{!webhooks-url-specification.md!}

--- a/zerver/webhooks/azuredevops/doc.md
+++ b/zerver/webhooks/azuredevops/doc.md
@@ -1,30 +1,43 @@
-Get Azure Devops notifications in Zulip!
+# Zulip Azure DevOps integration
+
+Get Azure DevOps notifications in Zulip!
+
+{start_tabs}
 
 1. {!create-stream.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
+1. {!generate-webhook-url-basic.md!}
 
-    {!git-webhook-url-with-branches.md!}
+1. Go to your project on Azure DevOps, click on the **Project
+   settings** in the bottom left corner and select **Service
+   hooks**. Click on **Create subscription**, select
+   **Web hooks**, and click **Next**.
 
-1. Go to your project on Azure DevOps and click on the **Project
-   settings** in the bottom left corner. Select **Service
-   hooks**. Click on **Create subscription**. Select **Web hooks** and
-   then **Next**.
+1. Select the [events](#filtering-incoming-events) you would like to receive
+   notifications for, and click **Next**.
 
-1. Select the events you would like to receive notifications for and
-   then click **Next**. This integration supports the following
-   events:
-    * Code pushed
-    * Pull request created
-    * Pull request updated
-    * Pull request merge attempted
-
-1. Set **URL** to the URL constructed above. Ensure that **Resource
+1. Set **URL** to the URL you generated. Ensure that **Resource
    details to send** and **Detailed messages to send** are set to
    **All**. Click **Finish**.
+
+{end_tabs}
 
 {!congrats.md!}
 
 ![](/static/images/integrations/azuredevops/001.png)
+
+{% if all_event_types is defined %}
+
+{!event-filtering-additional-feature.md!}
+
+{% endif %}
+
+### Configuration options
+
+{!git-branches-additional-feature.md!}
+
+### Related documentation
+
+{!webhooks-url-specification.md!}

--- a/zerver/webhooks/gitlab/doc.md
+++ b/zerver/webhooks/gitlab/doc.md
@@ -1,34 +1,52 @@
+# Zulip GitLab integration
+
 Receive GitLab notifications in Zulip!
+
+{start_tabs}
 
 1. {!create-stream.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
-
-    By default, the Zulip topics for merge requests will contain the
-    title of the GitLab merge request.  You can change the topic format to
-    just contain the merge request ID by adding
-    `&use_merge_request_title=false` at the end of the URL.
-
-    {!git-webhook-url-with-branches.md!}
+1. {!generate-webhook-url-basic.md!}
 
 1. Go to your repository on GitLab and click **Settings** on the left
    sidebar.  Click on **Integrations**.
 
-1. Set **URL** to the URL constructed above. Select the events you
-   you would like to receive notifications for, and click
-   **Add Webhook**.
+1. Set **URL** to the URL you generated. Select the
+   [events](#filtering-incoming-events) you you would like to receive
+   notifications for, and click **Add Webhook**.
 
-{!congrats.md!}
+!!! warn ""
 
-![](/static/images/integrations/gitlab/001.png)
-
-!!! tip ""
-
-    If your GitLab server and your Zulip server are on a local network
+    **Note**: If your GitLab server and your Zulip server are on a local network
     together, and you're running GitLab 10.5 or newer, you may need to enable
     GitLab's "Allow requests to the local network from hooks and
     services" setting (by default, recent GitLab versions refuse to post
     webhook events to servers on the local network).  You can find this
     setting near the bottom of the GitLab "Settings" page in the "Admin area".
+
+{end_tabs}
+
+{!congrats.md!}
+
+![](/static/images/integrations/gitlab/001.png)
+
+{% if all_event_types is defined %}
+
+{!event-filtering-additional-feature.md!}
+
+{% endif %}
+
+### Configuration options
+
+* By default, the Zulip topics for merge requests will contain the title
+  of the GitLab merge request. You can change the topic format to just
+  contain the merge request ID by adding `&use_merge_request_title=false`
+  to the generated URL.
+
+{!git-branches-additional-feature.md!}
+
+### Related documentation
+
+{!webhooks-url-specification.md!}


### PR DESCRIPTION
Proposal based on #29348. My changes are in a separate commit.

Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/updating.20event.20filtering.20in.20integration.20docs.2C.20.2328294/near/1759249).

These changes use the GitLab, Airbrake and Azure Devops integrations as examples.

**Screenshots and screen captures:**

<details>
<summary>Updated GitLab integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/gitlab)


![Screenshot 2024-03-20 at 11 42 39 PM](https://github.com/zulip/zulip/assets/2090066/d2c9666b-4e50-4915-8b35-ccfa58716919)

</details>
<details>
<summary>Updated Airbrake integration</summary>

[Current documentation](https://zulip.com/integrations/doc/airbrake)
![Screenshot 2024-03-19 at 11 35 11 PM](https://github.com/zulip/zulip/assets/2090066/f9f42b34-1718-4bee-a514-fd70c74c3b8e)



</details>
<details>
<summary>Updated Azure Devops integration</summary>

[Current documentation](https://zulip.com/integrations/doc/azuredevops)
![Screenshot 2024-03-20 at 11 41 56 PM](https://github.com/zulip/zulip/assets/2090066/aa6a2dd1-84da-4f1d-8f62-2382e2b4c134)


</details>

<details>
<summary>API doc</summary>

[Current documentation](https://zulip.com/api/incoming-webhooks-overview#urls)
![Screenshot 2024-03-20 at 11 41 03 PM](https://github.com/zulip/zulip/assets/2090066/9483b3f9-66df-47b1-8f53-53c041136eae)



</details>