### PR TITLE
Naming Convention Update: Changed Recipient's HUDDLE attribute to DIRECT_MESSAGE_GROUP.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -170,7 +170,7 @@ class AnalyticsTestCase(ZulipTestCase):
         for key, value in defaults.items():
             kwargs[key] = kwargs.get(key, value)
         huddle = Huddle.objects.create(**kwargs)
-        recipient = Recipient.objects.create(type_id=huddle.id, type=Recipient.HUDDLE)
+        recipient = Recipient.objects.create(type_id=huddle.id, type=Recipient.DIRECT_MESSAGE_GROUP)
         huddle.recipient = recipient
         huddle.save(update_fields=["recipient"])
         return huddle, recipient

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -372,7 +372,7 @@ def get_recipient_info(
                 )
             )
 
-    elif recipient.type == Recipient.HUDDLE:
+    elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         message_to_user_ids = get_huddle_user_ids(recipient)
 
     else:
@@ -738,7 +738,7 @@ def create_user_messages(
     base_flags = 0
     if rendering_result.mentions_stream_wildcard:
         base_flags |= UserMessage.flags.stream_wildcard_mentioned
-    if message.recipient.type in [Recipient.HUDDLE, Recipient.PERSONAL]:
+    if message.recipient.type in [Recipient.DIRECT_MESSAGE_GROUP, Recipient.PERSONAL]:
         base_flags |= UserMessage.flags.is_private
 
     # For long_term_idle (aka soft-deactivated) users, we are allowed
@@ -1222,7 +1222,7 @@ def do_send_messages(
 
 
 def already_sent_mirrored_message_id(message: Message) -> Optional[int]:
-    if message.recipient.type == Recipient.HUDDLE:
+    if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         # For huddle messages, we use a 10-second window because the
         # timestamps aren't guaranteed to actually match between two
         # copies of the same message.

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -589,7 +589,7 @@ def do_scrub_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
         *Stream.objects.filter(realm=realm).values_list("recipient_id", flat=True),
         *UserProfile.objects.filter(realm=realm).values_list("recipient_id", flat=True),
         *Subscription.objects.filter(
-            recipient__type=Recipient.HUDDLE, user_profile__realm=realm
+            recipient__type=Recipient.DIRECT_MESSAGE_GROUP, user_profile__realm=realm
         ).values_list("recipient_id", flat=True),
     ]
     cross_realm_bot_message_ids = list(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -65,7 +65,7 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: Optional[UserProfi
 
     subscribed_huddle_recipient_ids = set(
         Subscription.objects.filter(
-            user_profile=user_profile, recipient__type=Recipient.HUDDLE
+            user_profile=user_profile, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         ).values_list("recipient_id", flat=True)
     )
     user_id = user_profile.id
@@ -203,7 +203,7 @@ def do_delete_user_preserving_messages(user_profile: UserProfile) -> None:
             sender=temp_replacement_user
         )
         Subscription.objects.filter(
-            user_profile=user_profile, recipient__type=Recipient.HUDDLE
+            user_profile=user_profile, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         ).update(user_profile=temp_replacement_user)
         user_profile.delete()
 
@@ -229,7 +229,7 @@ def do_delete_user_preserving_messages(user_profile: UserProfile) -> None:
             sender=replacement_user
         )
         Subscription.objects.filter(
-            user_profile=temp_replacement_user, recipient__type=Recipient.HUDDLE
+            user_profile=temp_replacement_user, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         ).update(user_profile=replacement_user, is_user_active=replacement_user.is_active)
         temp_replacement_user.delete()
 
@@ -276,12 +276,12 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
     # separately.
     deactivated_user_subs = Subscription.objects.filter(
         user_profile=user_profile,
-        recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE],
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
         active=True,
     ).values_list("recipient_id", flat=True)
     subscribers_in_deactivated_user_subs = Subscription.objects.filter(
         recipient_id__in=list(deactivated_user_subs),
-        recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE],
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
         is_user_active=True,
         active=True,
     ).values_list("recipient__type", "user_profile_id")
@@ -289,7 +289,7 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
     subscribers_in_deactivated_user_streams = set()
     subscribers_in_deactivated_user_huddles = set()
     for recipient_type, user_id in subscribers_in_deactivated_user_subs:
-        if recipient_type == Recipient.HUDDLE:
+        if recipient_type == Recipient.DIRECT_MESSAGE_GROUP:
             subscribers_in_deactivated_user_huddles.add(user_id)
         else:
             subscribers_in_deactivated_user_streams.add(user_id)

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -257,7 +257,8 @@ def build_huddle_subscriptions(
     recipient_map = {
         recipient["id"]: recipient["type_id"]  # recipient_id -> stream_id
         for recipient in zerver_recipient
-        if recipient["type"] == Recipient.HUDDLE and recipient["type_id"] in huddle_ids
+        if recipient["type"] == Recipient.DIRECT_MESSAGE_GROUP
+        and recipient["type_id"] in huddle_ids
     }
 
     for recipient_id, huddle_id in recipient_map.items():
@@ -340,7 +341,7 @@ def build_recipients(
 
     for huddle in zerver_huddle:
         type_id = huddle["id"]
-        type = Recipient.HUDDLE
+        type = Recipient.DIRECT_MESSAGE_GROUP
         recipient = Recipient(
             type_id=type_id,
             id=NEXT_ID("recipient"),

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -459,7 +459,7 @@ def process_raw_message_batch(
             )
         elif "huddle_name" in raw_message:
             recipient_id = get_recipient_id_from_receiver_name(
-                raw_message["huddle_name"], Recipient.HUDDLE
+                raw_message["huddle_name"], Recipient.DIRECT_MESSAGE_GROUP
             )
         elif "pm_members" in raw_message:
             members = raw_message["pm_members"]
@@ -673,7 +673,7 @@ def write_message_data(
     for d in zerver_recipient:
         if d["type"] == Recipient.STREAM:
             stream_id_to_recipient_id[d["type_id"]] = d["id"]
-        elif d["type"] == Recipient.HUDDLE:
+        elif d["type"] == Recipient.DIRECT_MESSAGE_GROUP:
             huddle_id_to_recipient_id[d["type_id"]] = d["id"]
         if d["type"] == Recipient.PERSONAL:
             user_id_to_recipient_id[d["type_id"]] = d["id"]
@@ -682,7 +682,7 @@ def write_message_data(
         if recipient_type == Recipient.STREAM:
             receiver_id = stream_id_mapper.get(receiver_name)
             recipient_id = stream_id_to_recipient_id[receiver_id]
-        elif recipient_type == Recipient.HUDDLE:
+        elif recipient_type == Recipient.DIRECT_MESSAGE_GROUP:
             receiver_id = huddle_id_mapper.get(receiver_name)
             recipient_id = huddle_id_to_recipient_id[receiver_id]
         elif recipient_type == Recipient.PERSONAL:

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -880,7 +880,7 @@ def map_receiver_id_to_recipient_id(
     for recipient in zerver_recipient:
         if recipient["type"] == Recipient.STREAM:
             stream_id_to_recipient_id[recipient["type_id"]] = recipient["id"]
-        elif recipient["type"] == Recipient.HUDDLE:
+        elif recipient["type"] == Recipient.DIRECT_MESSAGE_GROUP:
             huddle_id_to_recipient_id[recipient["type_id"]] = recipient["id"]
         elif recipient["type"] == Recipient.PERSONAL:
             user_id_to_recipient_id[recipient["type_id"]] = recipient["id"]

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -611,7 +611,9 @@ def channels_to_zerver_stream(
 
             added_mpims[mpim["name"]] = (mpim["id"], huddle_id_count)
 
-            recipient = build_recipient(huddle_id_count, recipient_id_count, Recipient.HUDDLE)
+            recipient = build_recipient(
+                huddle_id_count, recipient_id_count, Recipient.DIRECT_MESSAGE_GROUP
+            )
             realm["zerver_recipient"].append(recipient)
             slack_recipient_name_to_zulip_recipient_id[mpim["name"]] = recipient_id_count
 

--- a/zerver/lib/display_recipient.py
+++ b/zerver/lib/display_recipient.py
@@ -144,7 +144,9 @@ def bulk_fetch_user_display_recipients(
     get_type = lambda tup: tup[1]
 
     personal_tuples = [tup for tup in recipient_tuples if get_type(tup) == Recipient.PERSONAL]
-    huddle_tuples = [tup for tup in recipient_tuples if get_type(tup) == Recipient.HUDDLE]
+    huddle_tuples = [
+        tup for tup in recipient_tuples if get_type(tup) == Recipient.DIRECT_MESSAGE_GROUP
+    ]
 
     huddle_recipient_ids = [get_recipient_id(tup) for tup in huddle_tuples]
     huddle_recipient_id_to_user_ids = bulk_get_huddle_user_ids(huddle_recipient_ids)

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -450,7 +450,7 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_user = get_user_profile_by_id(recipient_user_id)
         recipient_str = recipient_user.email
         internal_send_private_message(user_profile, recipient_user, body)
-    elif recipient.type == Recipient.HUDDLE:
+    elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(recipient)
         emails = [user_dict["email"] for user_dict in display_recipient]
         recipient_str = ", ".join(emails)

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -200,7 +200,7 @@ def build_message_list(
     messages_to_render: List[Dict[str, Any]] = []
 
     def sender_string(message: Message) -> str:
-        if message.recipient.type in (Recipient.STREAM, Recipient.HUDDLE):
+        if message.recipient.type in (Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP):
             return message.sender.full_name
         else:
             return ""
@@ -263,7 +263,7 @@ def build_message_list(
             )
             header = f"You and {message.sender.full_name}"
             header_html = f"<a style='color: #ffffff;' href='{narrow_link}'>{header}</a>"
-        elif message.recipient.type == Recipient.HUDDLE:
+        elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
             grouping = {"huddle": message.recipient_id}
             display_recipient = get_display_recipient(message.recipient)
             narrow_link = huddle_narrow_url(
@@ -470,7 +470,7 @@ def do_send_missedmessage_events_reply_in_zulip(
         reply_to_name = "Zulip"
 
     senders = list({m["message"].sender for m in missed_messages})
-    if missed_messages[0]["message"].recipient.type == Recipient.HUDDLE:
+    if missed_messages[0]["message"].recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(missed_messages[0]["message"].recipient)
         narrow_url = huddle_narrow_url(
             user=user_profile,

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1107,7 +1107,7 @@ def custom_fetch_huddle_objects(response: TableData, context: Context) -> None:
 
     # First we get all huddles involving someone in the realm.
     realm_huddle_subs = Subscription.objects.select_related("recipient").filter(
-        recipient__type=Recipient.HUDDLE, user_profile__in=user_profile_ids
+        recipient__type=Recipient.DIRECT_MESSAGE_GROUP, user_profile__in=user_profile_ids
     )
     realm_huddle_recipient_ids = {sub.recipient_id for sub in realm_huddle_subs}
 
@@ -2257,7 +2257,8 @@ def export_messages_single_user(
     )
 
     my_subscriptions = Subscription.objects.filter(
-        user_profile=user_profile, recipient__type__in=[Recipient.PERSONAL, Recipient.HUDDLE]
+        user_profile=user_profile,
+        recipient__type__in=[Recipient.PERSONAL, Recipient.DIRECT_MESSAGE_GROUP],
     )
     my_recipient_ids = [sub.recipient_id for sub in my_subscriptions]
     messages_to_me = Message.objects.filter(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1205,7 +1205,9 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         process_huddle_hash(data, "zerver_huddle")
         bulk_import_model(data, Huddle)
         for huddle in Huddle.objects.filter(recipient=None):
-            recipient = Recipient.objects.get(type=Recipient.HUDDLE, type_id=huddle.id)
+            recipient = Recipient.objects.get(
+                type=Recipient.DIRECT_MESSAGE_GROUP, type_id=huddle.id
+            )
             huddle.recipient = recipient
             huddle.save(update_fields=["recipient"])
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -490,7 +490,7 @@ def get_messages_with_usermessage_rows_for_user(
 def huddle_users(recipient_id: int) -> str:
     display_recipient: List[UserDisplayRecipient] = get_display_recipient_by_id(
         recipient_id,
-        Recipient.HUDDLE,
+        Recipient.DIRECT_MESSAGE_GROUP,
         None,
     )
 
@@ -672,7 +672,7 @@ def extract_unread_data_from_um_rows(
                 other_user_id=other_user_id,
             )
 
-        elif msg_type == Recipient.HUDDLE:
+        elif msg_type == Recipient.DIRECT_MESSAGE_GROUP:
             user_ids_string = get_huddle_users(recipient_id)
             huddle_dict[message_id] = dict(
                 user_ids_string=user_ids_string,

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -507,7 +507,7 @@ class MessageDict:
 
         if recipient_type == Recipient.STREAM:
             display_type = "stream"
-        elif recipient_type in (Recipient.HUDDLE, Recipient.PERSONAL):
+        elif recipient_type in (Recipient.DIRECT_MESSAGE_GROUP, Recipient.PERSONAL):
             assert not isinstance(display_recipient, str)
             display_type = "private"
             if len(display_recipient) == 1:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -576,7 +576,7 @@ class NarrowBuilder:
             raise BadNarrowOperatorError("unknown user in " + str(operand))
 
         # Group direct message
-        if recipient.type == Recipient.HUDDLE:
+        if recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
             cond = column("recipient_id", Integer) == recipient.id
             return query.where(maybe_negate(cond))
 
@@ -627,14 +627,14 @@ class NarrowBuilder:
             recipient_tuple["recipient_id"]
             for recipient_tuple in Subscription.objects.filter(
                 user_profile=self.user_profile,
-                recipient__type=Recipient.HUDDLE,
+                recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
             ).values("recipient_id")
         ]
         narrow_recipient_ids = [
             recipient_tuple["recipient_id"]
             for recipient_tuple in Subscription.objects.filter(
                 user_profile=other_user,
-                recipient__type=Recipient.HUDDLE,
+                recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
             ).values("recipient_id")
         ]
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -994,7 +994,7 @@ def get_message_payload(
         data["stream"] = get_message_stream_name_from_database(message)
         data["stream_id"] = message.recipient.type_id
         data["topic"] = message.topic_name()
-    elif message.recipient.type == Recipient.HUDDLE:
+    elif message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         data["recipient_type"] = "private"
         data["pm_users"] = huddle_users(message.recipient.id)
     else:  # Recipient.PERSONAL
@@ -1007,7 +1007,7 @@ def get_apns_alert_title(message: Message) -> str:
     """
     On an iOS notification, this is the first bolded line.
     """
-    if message.recipient.type == Recipient.HUDDLE:
+    if message.recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         recipients = get_display_recipient(message.recipient)
         assert isinstance(recipients, list)
         return ", ".join(sorted(r["full_name"] for r in recipients))

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -51,7 +51,7 @@ def get_recipient_from_user_profiles(
     huddle = get_or_create_huddle(user_ids)
     return Recipient(
         id=huddle.recipient_id,
-        type=Recipient.HUDDLE,
+        type=Recipient.DIRECT_MESSAGE_GROUP,
         type_id=huddle.id,
     )
 

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -224,7 +224,7 @@ def move_expired_personal_and_huddle_messages_to_archive(
     assert message_retention_days != -1
     check_date = timezone_now() - timedelta(days=message_retention_days)
 
-    recipient_types = (Recipient.PERSONAL, Recipient.HUDDLE)
+    recipient_types = (Recipient.PERSONAL, Recipient.DIRECT_MESSAGE_GROUP)
 
     # Archive expired personal and huddle Messages in the realm, including cross-realm messages.
     # Uses index: zerver_message_realm_recipient_date_sent

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -616,7 +616,7 @@ def use_db_models(
         Recipient = apps.get_model("zerver", "Recipient")
         Recipient.PERSONAL = 1
         Recipient.STREAM = 2
-        Recipient.HUDDLE = 3
+        Recipient.DIRECT_MESSAGE_GROUP = 3
         ScheduledEmail = apps.get_model("zerver", "ScheduledEmail")
         ScheduledMessage = apps.get_model("zerver", "ScheduledMessage")
         Service = apps.get_model("zerver", "Service")

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -582,7 +582,7 @@ def check_can_access_user(
     subscribed_recipient_ids = Subscription.objects.filter(
         user_profile=user_profile,
         active=True,
-        recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE],
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values_list("recipient_id", flat=True)
 
     if Subscription.objects.filter(
@@ -628,7 +628,7 @@ def get_inaccessible_user_ids(
     subscribed_recipient_ids = Subscription.objects.filter(
         user_profile=acting_user,
         active=True,
-        recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE],
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values_list("recipient_id", flat=True)
 
     common_subscription_user_ids = (
@@ -701,7 +701,7 @@ def get_subscribers_of_target_user_subscriptions(
         Subscription.objects.filter(
             user_profile__in=target_user_ids,
             active=True,
-            recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE],
+            recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
         )
         .order_by("user_profile_id")
         .values("user_profile_id", "recipient_id")
@@ -725,11 +725,12 @@ def get_subscribers_of_target_user_subscriptions(
     if include_deactivated_users_for_huddles:
         subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
             Q(recipient__type=Recipient.STREAM, is_user_active=True)
-            | Q(recipient__type=Recipient.HUDDLE)
+            | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP)
         )
     else:
         subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
-            recipient__type__in=[Recipient.STREAM, Recipient.HUDDLE], is_user_active=True
+            recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
+            is_user_active=True,
         )
 
     subs_in_target_user_subscriptions = subs_in_target_user_subscriptions_query.order_by(

--- a/zerver/migrations/0182_set_initial_value_is_private_flag.py
+++ b/zerver/migrations/0182_set_initial_value_is_private_flag.py
@@ -20,7 +20,7 @@ def set_initial_value_of_is_private_flag(
     print("\nStart setting initial value for is_private flag...", flush=True)
     while True:
         range_end = i + 10000
-        # Can't use [Recipient.PERSONAL, Recipient.HUDDLE] in migration files
+        # Can't use [Recipient.PERSONAL, Recipient.DIRECT_MESSAGE_GROUP] in migration files
         message_ids = list(
             Message.objects.filter(recipient__type__in=[1, 3], id__gt=i, id__lte=range_end)
             .values_list("id", flat=True)

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -47,13 +47,13 @@ class Recipient(models.Model):
     # The type for stream messages.
     STREAM = 2
     # The type group direct messages.
-    HUDDLE = 3
+    DIRECT_MESSAGE_GROUP = 3
 
     class Meta:
         unique_together = ("type", "type_id")
 
     # N.B. If we used Django's choice=... we would get this for free (kinda)
-    _type_names = {PERSONAL: "personal", STREAM: "stream", HUDDLE: "huddle"}
+    _type_names = {PERSONAL: "personal", STREAM: "stream", DIRECT_MESSAGE_GROUP: "huddle"}
 
     @override
     def __str__(self) -> str:
@@ -75,7 +75,7 @@ class Recipient(models.Model):
 def get_huddle_user_ids(recipient: Recipient) -> ValuesQuerySet["Subscription", int]:
     from zerver.models import Subscription
 
-    assert recipient.type == Recipient.HUDDLE
+    assert recipient.type == Recipient.DIRECT_MESSAGE_GROUP
 
     return (
         Subscription.objects.filter(
@@ -150,7 +150,9 @@ def get_or_create_huddle(id_list: List[int]) -> Huddle:
     with transaction.atomic():
         (huddle, created) = Huddle.objects.get_or_create(huddle_hash=huddle_hash)
         if created:
-            recipient = Recipient.objects.create(type_id=huddle.id, type=Recipient.HUDDLE)
+            recipient = Recipient.objects.create(
+                type_id=huddle.id, type=Recipient.DIRECT_MESSAGE_GROUP
+            )
             huddle.recipient = recipient
             huddle.save(update_fields=["recipient"])
             subs_to_create = [

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1081,7 +1081,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         self.assertEqual(message.content, "TestMissedHuddleMessageEmailMessages body")
         self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.HUDDLE)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
         # Confirm Othello received the message.
         user_profile = self.example_user("othello")
@@ -1089,7 +1089,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         self.assertEqual(message.content, "TestMissedHuddleMessageEmailMessages body")
         self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.HUDDLE)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -684,7 +684,7 @@ class RealmImportExportTest(ExportFile):
         # Third huddle is not exported since none of the members gave consent
         assert huddle_a is not None and huddle_b is not None
         huddle_recipients = Recipient.objects.filter(
-            type_id__in=[huddle_a.id, huddle_b.id], type=Recipient.HUDDLE
+            type_id__in=[huddle_a.id, huddle_b.id], type=Recipient.DIRECT_MESSAGE_GROUP
         )
         pm_query = Q(recipient__in=huddle_recipients) | Q(sender__in=consented_user_ids)
         exported_huddle_ids = (
@@ -984,7 +984,9 @@ class RealmImportExportTest(ExportFile):
             # Huddles don't have a realm column, so we just test all Huddles for simplicity.
             self.assertEqual(
                 huddle_object.recipient_id,
-                Recipient.objects.get(type=Recipient.HUDDLE, type_id=huddle_object.id).id,
+                Recipient.objects.get(
+                    type=Recipient.DIRECT_MESSAGE_GROUP, type_id=huddle_object.id
+                ).id,
             )
 
         self.assertEqual(ScheduledMessage.objects.filter(realm=imported_realm).count(), 1)

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -867,7 +867,9 @@ class MatterMostImporter(ZulipTestCase):
         self.assertFalse(stream_messages[3].has_image)
         self.assertTrue(stream_messages[3].has_link)
 
-        huddle_messages = messages.filter(recipient__type=Recipient.HUDDLE).order_by("date_sent")
+        huddle_messages = messages.filter(recipient__type=Recipient.DIRECT_MESSAGE_GROUP).order_by(
+            "date_sent"
+        )
         huddle_recipients = huddle_messages.values_list("recipient", flat=True)
         self.assert_length(huddle_messages, 3)
         self.assert_length(set(huddle_recipients), 1)

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -1021,7 +1021,9 @@ class RocketChatImporter(ZulipTestCase):
         self.assertTrue(stream_messages[23].has_image)
         self.assertTrue(stream_messages[23].has_link)
 
-        huddle_messages = messages.filter(recipient__type=Recipient.HUDDLE).order_by("date_sent")
+        huddle_messages = messages.filter(recipient__type=Recipient.DIRECT_MESSAGE_GROUP).order_by(
+            "date_sent"
+        )
         huddle_recipients = huddle_messages.values_list("recipient", flat=True)
         self.assert_length(huddle_messages, 4)
         self.assert_length(set(huddle_recipients), 1)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -2733,7 +2733,7 @@ class DeleteUserTest(ZulipTestCase):
 
         huddle_with_hamlet_recipient_ids = list(
             Subscription.objects.filter(
-                user_profile=hamlet, recipient__type=Recipient.HUDDLE
+                user_profile=hamlet, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
             ).values_list("recipient_id", flat=True)
         )
         self.assertGreater(len(huddle_with_hamlet_recipient_ids), 0)
@@ -2800,7 +2800,7 @@ class DeleteUserTest(ZulipTestCase):
 
         huddle_with_hamlet_recipient_ids = list(
             Subscription.objects.filter(
-                user_profile=hamlet, recipient__type=Recipient.HUDDLE
+                user_profile=hamlet, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
             ).values_list("recipient_id", flat=True)
         )
         self.assertGreater(len(huddle_with_hamlet_recipient_ids), 0)

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -45,7 +45,7 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
         )
 
         group_direct_messages = Message.objects.filter(
-            realm=realm, recipient__type=Recipient.HUDDLE
+            realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         )
         self.assertFalse(group_direct_messages.exists())
 
@@ -124,7 +124,7 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
         self.assertIsNotNone(realm.zulip_update_announcements_stream)
 
         group_direct_messages = Message.objects.filter(
-            realm=realm, recipient__type=Recipient.HUDDLE
+            realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
         )
         self.assertFalse(group_direct_messages.exists())
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1144,7 +1144,9 @@ def generate_and_send_messages(
         recipient.id
         for recipient in Recipient.objects.filter(type=Recipient.STREAM, type_id__in=stream_ids)
     ]
-    recipient_huddles: List[int] = [h.id for h in Recipient.objects.filter(type=Recipient.HUDDLE)]
+    recipient_huddles: List[int] = [
+        h.id for h in Recipient.objects.filter(type=Recipient.DIRECT_MESSAGE_GROUP)
+    ]
 
     huddle_members: Dict[int, List[int]] = {}
     for h in recipient_huddles:
@@ -1189,10 +1191,10 @@ def generate_and_send_messages(
             elif message_type == Recipient.STREAM:
                 message.subject = saved_data["subject"]
                 message.recipient = get_recipient_by_id(recipient_id)
-            elif message_type == Recipient.HUDDLE:
+            elif message_type == Recipient.DIRECT_MESSAGE_GROUP:
                 message.recipient = get_recipient_by_id(recipient_id)
         elif randkey <= random_max * options["percent_huddles"] / 100.0:
-            message_type = Recipient.HUDDLE
+            message_type = Recipient.DIRECT_MESSAGE_GROUP
             message.recipient = get_recipient_by_id(random.choice(recipient_huddles))
         elif (
             randkey
@@ -1205,7 +1207,7 @@ def generate_and_send_messages(
             message_type = Recipient.STREAM
             message.recipient = get_recipient_by_id(random.choice(recipient_streams))
 
-        if message_type == Recipient.HUDDLE:
+        if message_type == Recipient.DIRECT_MESSAGE_GROUP:
             sender_id = random.choice(huddle_members[message.recipient.id])
             message.sender = get_user_profile_by_id(sender_id)
         elif message_type == Recipient.PERSONAL:


### PR DESCRIPTION
Naming Convention Update: Changed Recipient's HUDDLE attribute to DIRECT_MESSAGE_GROUP

With VS Code's Search bar, I searched for all occurrences of "Recipient.HUDDLE" and manually changed it to "Recipient.DIRECT_MESSAGE_GROUP". Recipient_HUDDLE was left alone.

Fixes part of [#28640](https://github.com/zulip/zulip/pull/28640).