### PR TITLE
settings: Adjust label and field-hint layout.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -171,6 +171,10 @@
     */
     --stream-subscriber-list-max-height: 100%;
 
+    /*
+      Reusable dimensions and offsets.
+    */
+    --margin-bottom-field-description: 3px;
     /* Gap between tabs in the tab picker */
     --grid-gap-tab-picker: 2px;
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -360,6 +360,10 @@
     }
 }
 
+.modal-field-label {
+    margin-bottom: var(--margin-bottom-field-description);
+}
+
 .dropdown-widget-button {
     width: 206px;
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -540,18 +540,12 @@ input[type="checkbox"] {
     margin-top: 10px;
 }
 
-.language_selection_widget {
-    .title {
-        margin-bottom: var(--margin-bottom-field-description);
-    }
+.language_selection_widget .language_selection_button {
+    text-decoration: none;
+    color: hsl(0deg 0% 20%);
 
-    .language_selection_button {
-        text-decoration: none;
-        color: hsl(0deg 0% 20%);
-
-        .fa.fa-pencil {
-            margin-left: 5px;
-        }
+    .fa.fa-pencil {
+        margin-left: 5px;
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -542,7 +542,7 @@ input[type="checkbox"] {
 
 .language_selection_widget {
     .title {
-        margin-bottom: 3px;
+        margin-bottom: var(--margin-bottom-field-description);
     }
 
     .language_selection_button {
@@ -1488,7 +1488,7 @@ $option_title_width: 180px;
     gap: 15px;
 
     .jitsi_server_url_custom_input_label {
-        margin-bottom: 3px;
+        margin-bottom: var(--margin-bottom-field-description);
     }
 }
 
@@ -1597,7 +1597,7 @@ $option_title_width: 180px;
 }
 
 .dropdown-title {
-    margin-bottom: 3px;
+    margin-bottom: var(--margin-bottom-field-description);
 }
 
 .profile-field-choices {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1589,12 +1589,27 @@ $option_title_width: 180px;
     }
 }
 
+/* TODO: Remove .dropdown-title once the more
+   generic and reusable .settings-field-label has
+   been placed throughout the settings modals. */
+.settings-field-label,
 .dropdown-title {
     margin-bottom: var(--margin-bottom-field-description);
 }
 
 .settings-profile-user-field-hint {
     color: var(--color-text-settings-field-hint);
+    /* We effectively eliminate the margin-bottom on
+       .settings-field-label by pulling .field-hint
+       up a corresponding negative value. This cinches
+       things up a little tighter, given the generous
+       line-height (20px) on <label> elements, though
+       note well that that comes care of Bootstrap. */
+    margin-top: calc(var(--margin-bottom-field-description) * -1.5);
+    /* Maintain the same margin-bottom value as appears
+       with .settings-field-label to display text-input
+       combinations uniformly throughout the settings UI. */
+    margin-bottom: var(--margin-bottom-field-description);
 }
 
 .profile-field-choices {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1589,11 +1589,7 @@ $option_title_width: 180px;
     }
 }
 
-/* TODO: Remove .dropdown-title once the more
-   generic and reusable .settings-field-label has
-   been placed throughout the settings modals. */
-.settings-field-label,
-.dropdown-title {
+.settings-field-label {
     margin-bottom: var(--margin-bottom-field-description);
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1536,7 +1536,7 @@ $option_title_width: 180px;
 
     .custom_user_field,
     .user-name-section {
-        .settings-profile-field-user-hint {
+        .settings-profile-user-field-hint {
             color: var(--color-text-settings-field-hint);
         }
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1533,13 +1533,6 @@ $option_title_width: 180px;
         padding-left: 2px;
         vertical-align: middle;
     }
-
-    .custom_user_field,
-    .user-name-section {
-        .settings-profile-user-field-hint {
-            color: var(--color-text-settings-field-hint);
-        }
-    }
 }
 
 #edit-user-form {
@@ -1598,6 +1591,10 @@ $option_title_width: 180px;
 
 .dropdown-title {
     margin-bottom: var(--margin-bottom-field-description);
+}
+
+.settings-profile-user-field-hint {
+    color: var(--color-text-settings-field-hint);
 }
 
 .profile-field-choices {

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,4 @@
 <form id="change_email_form" class="new-style">
-    <label for="email">{{t "New email" }}</label>
+    <label for="email" class="modal-field-label">{{t "New email" }}</label>
     <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/demo_organization_add_email_modal.hbs
+++ b/web/templates/demo_organization_add_email_modal.hbs
@@ -1,11 +1,11 @@
 <form id="demo_organization_add_email_form" class="new-style">
     <div class="tip">{{t "If you haven't updated your name, it's a good idea to do so before inviting other users to join you!" }}</div>
     <div class="input-group">
-        <label for="demo_organization_add_email">{{t "Email" }}</label>
+        <label for="demo_organization_add_email" class="modal-field-label">{{t "Email" }}</label>
         <input id="demo_organization_add_email" type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
     </div>
     <div class="input-group">
-        <label for="demo_organization_update_full_name">{{t "Name" }}</label>
+        <label for="demo_organization_update_full_name" class="modal-field-label">{{t "Name" }}</label>
         <input id="demo_organization_update_full_name" name="full_name" type="text" class="modal_text_input" value="{{full_name}}" maxlength="60" />
     </div>
 </form>

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -1,6 +1,6 @@
 <form id="change_password_container">
     <div class="password-div">
-        <label for="old_password" class="dropdown-title">{{t "Old password" }}</label>
+        <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
         <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
         <div class="settings-forgot-password">
@@ -8,7 +8,7 @@
         </div>
     </div>
     <div class="password-div">
-        <label for="new_password" class="dropdown-title">{{t "New password" }}</label>
+        <label for="new_password" class="modal-field-label">{{t "New password" }}</label>
         <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block modal_password_input" value=""
           data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>

--- a/web/templates/dropdown_widget_with_label.hbs
+++ b/web/templates/dropdown_widget_with_label.hbs
@@ -1,5 +1,5 @@
 <div class="input-group" id="{{widget_name}}_widget_container">
-    <label class="dropdown-title" for="{{widget_name}}_widget">{{label}}
+    <label class="settings-field-label" for="{{widget_name}}_widget">{{label}}
         {{#if help_link}}{{> help_link_widget link=help_link }}{{/if}}
     </label>
     <span class="prop-element hide" id="id_{{widget_name}}" data-setting-widget-type="dropdown-list-widget" {{#if value_type}}data-setting-value-type="{{value_type}}"{{/if}}></span>

--- a/web/templates/embedded_bot_config_item.hbs
+++ b/web/templates/embedded_bot_config_item.hbs
@@ -1,5 +1,5 @@
 <div class="input-group" name="{{botname}}" id="{{botname}}_{{key}}">
-    <label for="{{botname}}_{{key}}_input">{{key}}</label>
+    <label for="{{botname}}_{{key}}_input" class="modal-field-label">{{key}}</label>
     <input type="text" name="{{key}}" id="{{botname}}_{{key}}_input" class="modal_text_input"
       maxlength=1000 placeholder="{{value}}" value="" />
 </div>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -14,14 +14,14 @@
     <div class="input-group">
         <div id="invite_users_option_tabs_container" class="new-style"></div>
         <div id="invitee_emails_container">
-            <label for="invitee_emails">{{t "Emails (one on each line or comma-separated)" }}</label>
+            <label for="invitee_emails" class="modal-field-label">{{t "Emails (one on each line or comma-separated)" }}</label>
             <div class="pill-container">
                 <div class="input" contenteditable="true"></div>
             </div>
         </div>
     </div>
     <div class="input-group">
-        <label for="expires_in">{{t "Invitation expires after" }}</label>
+        <label for="expires_in" class="modal-field-label">{{t "Invitation expires after" }}</label>
         <select id="expires_in" class="invite-expires-in modal_select bootstrap-focus-style">
             {{#each expires_in_options}}
                 <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
@@ -29,7 +29,7 @@
         </select>
         <p id="expires_on"></p>
         <div id="custom-invite-expiration-time" class="dependent-settings-block">
-            <label for="expires_in">{{t "Custom time" }}</label>
+            <label for="expires_in" class="modal-field-label">{{t "Custom time" }}</label>
             <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="" maxlength="3"/>
             <select class="custom-expiration-time modal_select bootstrap-focus-style" id="custom-expiration-time-unit">
                 {{#each time_choices}}
@@ -40,7 +40,7 @@
         </div>
     </div>
     <div class="input-group">
-        <label for="invite_as">{{t "Users join as" }}
+        <label for="invite_as" class="modal-field-label">{{t "Users join as" }}
             {{> help_link_widget link="/help/roles-and-permissions" }}
         </label>
         <select id="invite_as" class="invite-as modal_select bootstrap-focus-style">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -99,7 +99,7 @@
                   prefix="user_"}}
             </div>
             <div class="input-group">
-                <label for="email_address_visibility" class="dropdown-title">{{t "Who can access your email address" }}
+                <label for="email_address_visibility" class="settings-field-label">{{t "Who can access your email address" }}
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
                 <div id="user_email_address_dropdown_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">

--- a/web/templates/settings/add_alert_word.hbs
+++ b/web/templates/settings/add_alert_word.hbs
@@ -1,4 +1,4 @@
 <form id="add-alert-word-form">
-    <label for="add-alert-word-name">{{t "Alert word" }}</label>
+    <label for="add-alert-word-name" class="modal-field-label">{{t "Alert word" }}</label>
     <input type="text" name="alert-word-name" id="add-alert-word-name" class="required modal_text_input" maxlength=100 placeholder="{{t 'Alert word' }}" value="" />
 </form>

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -11,7 +11,7 @@
     </div>
     <div id="emoji_file_input_error" class="text-error"></div>
     <div class="emoji_name_input">
-        <label for="emoji_name">{{t "Emoji name" }}</label>
+        <label for="emoji_name" class="modal-field-label">{{t "Emoji name" }}</label>
         <input type="text" name="name" id="emoji_name" class="modal_text_input" placeholder="{{t 'leafy green vegetable' }}" />
     </div>
 </form>

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -1,7 +1,7 @@
 <form id="create_bot_form" class="new-style">
     <div class="new-bot-form">
         <div class="input-group">
-            <label for="bot_type">
+            <label for="bot_type" class="modal-field-label">
                 {{t "Bot type" }}
                 {{> ../help_link_widget link="/help/bots-overview#bot-type" }}
             </label>
@@ -14,7 +14,7 @@
             </select>
         </div>
         <div class="input-group" id="service_name_list">
-            <label for="select_service_name">{{t "Bot"}}</label>
+            <label for="select_service_name" class="modal-field-label">{{t "Bot"}}</label>
             <select name="service_name" id="select_service_name" class="modal_select bootstrap-focus-style">
                 {{#each realm_embedded_bots}}
                     <option value="{{this.name}}">{{this.name}}</option>
@@ -22,13 +22,13 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="create_bot_name">{{t "Name" }}</label>
+            <label for="create_bot_name" class="modal-field-label">{{t "Name" }}</label>
             <input type="text" name="bot_name" id="create_bot_name" class="required modal_text_input"
               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="input-group">
-            <label for="bot_short_name">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
+            <label for="bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"
               placeholder="{{t 'cookie' }}" value="" />
             -bot@{{ realm_bot_domain }}
@@ -38,13 +38,13 @@
         </div>
         <div id="payload_url_inputbox">
             <div class="input-group">
-                <label for="create_payload_url">{{t "Endpoint URL" }}</label>
+                <label for="create_payload_url" class="modal-field-label">{{t "Endpoint URL" }}</label>
                 <input type="text" name="payload_url" id="create_payload_url" class="modal_text_input"
                   maxlength=2083 placeholder="https://hostname.example.com" value="" />
                 <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
             </div>
             <div class="input-group">
-                <label for="interface_type">{{t "Outgoing webhook message format" }}</label>
+                <label for="interface_type" class="modal-field-label">{{t "Outgoing webhook message format" }}</label>
                 <select name="interface_type" id="create_interface_type" class="modal_select bootstrap-focus-style">
                     <option value="1">Zulip</option>
                     <option value="2">{{t "Slack compatible" }}</option>
@@ -60,7 +60,7 @@
             {{/each}}
         </div>
         <div class="input-group">
-            <label for="bot_avatar_file_input">{{t "Avatar" }}</label>
+            <label for="bot_avatar_file_input" class="modal-field-label">{{t "Avatar" }}</label>
             <div id="bot_avatar_file"></div>
             <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
             <div id="add_bot_preview_text">

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -1,7 +1,7 @@
 <form class="admin-profile-field-form new-style" id="add-new-custom-profile-field-form">
     <div class="new-profile-field-form wrapper">
         <div class="input-group">
-            <label for="profile_field_type" >{{t "Type" }}</label>
+            <label for="profile_field_type" class="modal-field-label">{{t "Type" }}</label>
             <select id="profile_field_type" name="field_type" class="modal_select bootstrap-focus-style">
                 {{#each custom_profile_field_types}}
                     <option value='{{this.id}}'>{{this.name}}</option>
@@ -9,7 +9,7 @@
             </select>
         </div>
         <div class="input-group" id="profile_field_external_accounts">
-            <label for="profile_field_external_accounts_type" >{{t "External account type" }}</label>
+            <label for="profile_field_external_accounts_type" class="modal-field-label">{{t "External account type" }}</label>
             <select id="profile_field_external_accounts_type" name="external_acc_field_type" class="modal_select bootstrap-focus-style">
                 {{#each realm_default_external_accounts}}
                     <option value='{{@key}}'>{{this.text}}</option>
@@ -18,22 +18,22 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="profile_field_name" >{{t "Label" }}</label>
+            <label for="profile_field_name" class="modal-field-label">{{t "Label" }}</label>
             <input type="text" id="profile_field_name" class="modal_text_input" name="name" autocomplete="off" maxlength="40" />
         </div>
         <div class="input-group">
-            <label for="profile_field_hint" >{{t "Hint (up to 80 characters)" }}</label>
+            <label for="profile_field_hint" class="modal-field-label">{{t "Hint (up to 80 characters)" }}</label>
             <input type="text" id="profile_field_hint" class="modal_text_input" name="hint" autocomplete="off" maxlength="80" />
             <div class="alert" id="admin-profile-field-hint-status"></div>
         </div>
         <div class="input-group" id="profile_field_choices_row">
-            <label for="profile_field_choices" >{{t "Field choices" }}</label>
+            <label for="profile_field_choices" class="modal-field-label">{{t "Field choices" }}</label>
             <table class="profile_field_choices_table">
                 <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
             </table>
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">
-            <label for="custom_field_url_pattern" >{{t "URL pattern" }}</label>
+            <label for="custom_field_url_pattern" class="modal-field-label">{{t "URL pattern" }}</label>
             <input type="url" id="custom_field_url_pattern" class="modal_url_input" name="url_pattern" autocomplete="off" maxlength="1024" placeholder="https://example.com/path/%(username)s"/>
         </div>
         <div class="input-group">

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -17,7 +17,7 @@
             <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>
         </div>
         <div class="input-group">
-            <label class="input-label" for="user-role-select">{{t 'User role' }}
+            <label for="user-role-select">{{t 'User role' }}
                 {{> ../help_link_widget link="/help/roles-and-permissions" }}
             </label>
             <select name="user-role-select" class="bootstrap-focus-style modal_select" id="user-role-select" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -3,21 +3,21 @@
         <div class="alert" id="edit-user-form-error"></div>
         <input type="hidden" name="is_full_name" value="true" />
         <div class="input-group name_change_container">
-            <label for="edit_user_full_name">{{t "Name" }}</label>
+            <label for="edit_user_full_name" class="modal-field-label">{{t "Name" }}</label>
             <input type="text" autocomplete="off" name="full_name" id="edit_user_full_name" class="modal_text_input" value="{{ full_name }}" />
         </div>
         {{#if email}}
         <div class="input-group email_change_container">
-            <label for="email">{{t "Email" }}</label>
+            <label for="email" class="modal-field-label">{{t "Email" }}</label>
             <input type="text" autocomplete="off" name="email" class="modal_text_input" value="{{ email }}" readonly/>
         </div>
         {{/if}}
         <div class="input-group user_id_container">
-            <label for="user_id">{{t "User ID" }}</label>
+            <label for="user_id" class="modal-field-label">{{t "User ID" }}</label>
             <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>
         </div>
         <div class="input-group">
-            <label for="user-role-select">{{t 'User role' }}
+            <label for="user-role-select" class="modal-field-label">{{t 'User role' }}
                 {{> ../help_link_widget link="/help/roles-and-permissions" }}
             </label>
             <select name="user-role-select" class="bootstrap-focus-style modal_select" id="user-role-select" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>

--- a/web/templates/settings/admin_linkifier_edit_form.hbs
+++ b/web/templates/settings/admin_linkifier_edit_form.hbs
@@ -1,12 +1,12 @@
 <div id="edit-linkifier-form">
     <form class="linkifier-edit-form">
         <div class="input-group name_change_container">
-            <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
+            <label for="edit-linkifier-pattern" class="modal-field-label">{{t "Pattern" }}</label>
             <input type="text" autocomplete="off" id="edit-linkifier-pattern" class="modal_text_input" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
             <div class="alert" id="edit-linkifier-pattern-status"></div>
         </div>
         <div class="input-group name_change_container">
-            <label for="edit-linkifier-url-template" >{{t "URL template" }}</label>
+            <label for="edit-linkifier-url-template" class="modal-field-label">{{t "URL template" }}</label>
             <input type="text" autocomplete="off" id="edit-linkifier-url-template" class="modal_text_input" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" value="{{ url_template }}" />
             <div class="alert" id="edit-linkifier-template-status"></div>
         </div>

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -13,7 +13,7 @@
                     <div id="api_key_form">
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
                         <div class="password-div">
-                            <label for="password">{{t "Your password" }}</label>
+                            <label for="password" class="modal-field-label">{{t "Your password" }}</label>
                             <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
                             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
                         </div>

--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -23,7 +23,7 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="string_id" class="title inline-block">{{t "Organization URL" }}</label>
+            <label for="string_id" class="inline-block">{{t "Organization URL" }}</label>
             <div id="subdomain_input_container">
                 <input id="new_subdomain" type="text" class="modal_text_input" autocomplete="off" name="string_id" placeholder="{{t 'acme' }}"/>
                 <label for="string_id" class="domain_label">.{{ realm_domain }}</label>

--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -23,7 +23,7 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="string_id" class="inline-block">{{t "Organization URL" }}</label>
+            <label for="string_id" class="inline-block modal-field-label">{{t "Organization URL" }}</label>
             <div id="subdomain_input_container">
                 <input id="new_subdomain" type="text" class="modal_text_input" autocomplete="off" name="string_id" placeholder="{{t 'acme' }}"/>
                 <label for="string_id" class="domain_label">.{{ realm_domain }}</label>

--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -13,7 +13,7 @@
     <p>{{t "You can convert this demo organization to a permanent Zulip organization. All users and message history will be preserved." }}</p>
     <form class="subdomain-setting">
         <div class="input-group">
-            <label for="organization_type" class="dropdown-title">{{t "Organization type" }}
+            <label for="organization_type" class="modal-field-label">{{t "Organization type" }}
                 {{> ../help_link_widget link="/help/organization-type" }}
             </label>
             <select name="organization_type" id="add_organization_type" class="modal_select bootstrap-focus-style">

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,6 +1,6 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <span class="custom-user-field-label-wrapper {{#if field.required}}required-field-wrapper{{/if}}">
-        <label class="inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
+        <label class="settings-field-label inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -4,7 +4,7 @@
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>
-    <div class="settings-profile-field-user-hint">{{ field.hint }}</div>
+    <div class="settings-profile-user-field-hint">{{ field.hint }}</div>
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}}">
         {{#if is_long_text_field}}
         <textarea maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -15,7 +15,7 @@
         {{/unless}}
 
         <div class="input-group">
-            <label for="twenty_four_hour_time" class="dropdown-title">{{ settings_label.twenty_four_hour_time }}</label>
+            <label for="twenty_four_hour_time" class="settings-field-label">{{ settings_label.twenty_four_hour_time }}</label>
             <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
                 {{#each twenty_four_hour_time_values}}
                     <option value='{{ this.value }}'>{{ this.description }}</option>
@@ -23,7 +23,7 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="color_scheme" class="dropdown-title">{{t "Theme" }}</label>
+            <label for="color_scheme" class="settings-field-label">{{t "Theme" }}</label>
             <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=color_scheme_values}}
             </select>
@@ -85,7 +85,7 @@
         </div>
 
         <div class="input-group">
-            <label for="web_mark_read_on_scroll_policy" class="dropdown-title">{{t "Automatically mark messages as read" }}
+            <label for="web_mark_read_on_scroll_policy" class="settings-field-label">{{t "Automatically mark messages as read" }}
                 {{> ../help_link_widget link="/help/marking-messages-as-read" }}
             </label>
             <select name="web_mark_read_on_scroll_policy" class="setting_web_mark_read_on_scroll_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_mark_read_on_scroll_policy"  data-setting-widget-type="number">
@@ -125,7 +125,7 @@
         </div>
 
         <div class="input-group thinner setting-next-is-related">
-            <label for="web_home_view" class="dropdown-title">{{t "Home view" }}
+            <label for="web_home_view" class="settings-field-label">{{t "Home view" }}
                 {{> ../help_link_widget link="/help/configure-home-view" }}
             </label>
             <select name="web_home_view" class="setting_web_home_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_home_view" data-setting-widget-type="string">
@@ -140,7 +140,7 @@
           prefix=prefix}}
 
         <div class="input-group">
-            <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive channels" }}
+            <label for="demote_inactive_streams" class="settings-field-label">{{t "Demote inactive channels" }}
                 {{> ../help_link_widget link="/help/manage-inactive-streams" }}
             </label>
             <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element settings_select bootstrap-focus-style" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">
@@ -149,7 +149,7 @@
         </div>
 
         <div class="input-group">
-            <label for="web_stream_unreads_count_display_policy" class="dropdown-title">{{t "Show unread counts for" }}</label>
+            <label for="web_stream_unreads_count_display_policy" class="settings-field-label">{{t "Show unread counts for" }}</label>
             <select name="web_stream_unreads_count_display_policy" class="setting_web_stream_unreads_count_display_policy prop-element bootstrap-focus-style settings_select" id="{{prefix}}web_stream_unreads_count_display_policy"  data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=web_stream_unreads_count_display_policy_values}}
             </select>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -37,7 +37,7 @@
         </div>
 
         <div class="input-group">
-            <label class="emoji-theme title">{{t "Emoji theme" }}</label>
+            <label>{{t "Emoji theme" }}</label>
             <div class="emojiset_choices grey-box prop-element" id="{{prefix}}emojiset" data-setting-widget-type="radio-group" data-setting-choice-type="string">
                 {{#each settings_object.emojiset_choices}}
                     <label class="preferences-radio-choice-label">
@@ -94,7 +94,7 @@
         </div>
 
         <div class="input-group">
-            <label class="title">{{t "User list style" }}</label>
+            <label>{{t "User list style" }}</label>
             <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
                 {{#each user_list_style_values}}
                     <label class="preferences-radio-choice-label">

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -37,7 +37,7 @@
         </div>
 
         <div class="input-group">
-            <label>{{t "Emoji theme" }}</label>
+            <label class="settings-field-label">{{t "Emoji theme" }}</label>
             <div class="emojiset_choices grey-box prop-element" id="{{prefix}}emojiset" data-setting-widget-type="radio-group" data-setting-choice-type="string">
                 {{#each settings_object.emojiset_choices}}
                     <label class="preferences-radio-choice-label">
@@ -94,7 +94,7 @@
         </div>
 
         <div class="input-group">
-            <label>{{t "User list style" }}</label>
+            <label class="settings-field-label">{{t "User list style" }}</label>
             <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
                 {{#each user_list_style_values}}
                     <label class="preferences-radio-choice-label">

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -15,7 +15,7 @@
             <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>
         </div>
         <div class="input-group">
-            <label class="input-label" for="bot-role-select">{{t 'Role' }}
+            <label for="bot-role-select">{{t 'Role' }}
                 {{> ../help_link_widget link="/help/roles-and-permissions" }}
             </label>
             <select name="bot-role-select" id="bot-role-select" class="modal_select bootstrap-focus-style" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -2,20 +2,20 @@
     <form class="new-style edit_bot_form name-setting">
         <div class="alert" id="bot-edit-form-error"></div>
         <div class="input-group name_change_container">
-            <label for="edit_bot_full_name">{{t "Name" }}</label>
+            <label for="edit_bot_full_name" class="modal-field-label">{{t "Name" }}</label>
             <input type="text" autocomplete="off" name="full_name" id="edit_bot_full_name" class="modal_text_input" value="{{ full_name }}" />
         </div>
         <input type="hidden" name="is_full_name" value="true" />
         <div class="input-group email_change_container">
-            <label for="email">{{t "Email" }}</label>
+            <label for="email" class="modal-field-label">{{t "Email" }}</label>
             <input type="text" autocomplete="off" name="email" class="modal_text_input" value="{{ email }}" readonly/>
         </div>
         <div class="input-group user_id_container">
-            <label for="user_id">{{t "User ID" }}</label>
+            <label for="user_id" class="modal-field-label">{{t "User ID" }}</label>
             <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>
         </div>
         <div class="input-group">
-            <label for="bot-role-select">{{t 'Role' }}
+            <label for="bot-role-select" class="modal-field-label">{{t 'Role' }}
                 {{> ../help_link_widget link="/help/roles-and-permissions" }}
             </label>
             <select name="bot-role-select" id="bot-role-select" class="modal_select bootstrap-focus-style" data-setting-widget-type="number" {{#if disable_role_dropdown}}disabled{{/if}}>
@@ -29,7 +29,7 @@
         <div id="service_data">
         </div>
         <div class="input-group edit-avatar-section">
-            <label>{{t "Avatar" }}</label>
+            <label class="modal-field-label">{{t "Avatar" }}</label>
             {{!-- Shows the current avatar --}}
             <img src="{{bot_avatar_url}}" id="current_bot_avatar_image" />
             <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -1,16 +1,16 @@
 {{#with profile_field_info}}
 <form class="name-setting profile-field-form new-style" id="edit-custom-profile-field-form-{{id}}" data-profile-field-id="{{id}}">
     <div class="input-group">
-        <label for="name">{{t "Label" }}</label>
+        <label for="name" class="modal-field-label">{{t "Label" }}</label>
         <input type="text" name="name" id="id-custom-profile-field-name" class="modal_text_input prop-element" value="{{ name }}" maxlength="40" data-setting-widget-type="string" />
     </div>
     <div class="input-group hint_change_container">
-        <label for="hint">{{t "Hint" }}</label>
+        <label for="hint" class="modal-field-label">{{t "Hint" }}</label>
         <input type="text" name="hint" id="id-custom-profile-field-hint" class="modal_text_input prop-element" value="{{ hint }}" maxlength="80" data-setting-widget-type="string" />
     </div>
     {{#if is_select_field }}
     <div class="input-group prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
-        <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
+        <label for="profile_field_choices_edit" class="modal-field-label">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
             <div class="edit_profile_field_choices_container">
                 {{#each choices}}
@@ -22,7 +22,7 @@
     {{else if is_external_account_field}}
     <div class="prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
         <div class="input-group profile_field_external_accounts_edit" >
-            <label for="external_acc_field_type">{{t "External account type" }}</label>
+            <label for="external_acc_field_type" class="modal-field-label">{{t "External account type" }}</label>
             <select name="external_acc_field_type" class="modal_select" disabled>
                 {{#each ../realm_default_external_accounts}}
                     <option value='{{@key}}'>{{this.text}}</option>
@@ -31,7 +31,7 @@
             </select>
         </div>
         <div class="input-group custom_external_account_detail">
-            <label for="url_pattern">{{t "URL pattern" }}</label>
+            <label for="url_pattern" class="modal-field-label">{{t "URL pattern" }}</label>
             <input type="url" class="modal_url_input" name="url_pattern" autocomplete="off" maxlength="80" />
         </div>
     </div>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -12,7 +12,6 @@
     <div class="input-group prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
         <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
-            <hr />
             <div class="edit_profile_field_choices_container">
                 {{#each choices}}
                     {{> profile_field_choice }}

--- a/web/templates/settings/edit_embedded_bot_service.hbs
+++ b/web/templates/settings/edit_embedded_bot_service.hbs
@@ -1,7 +1,7 @@
 <div id="config_edit_inputbox">
     {{#each service.config_data}}
         <div class="input-group">
-            <label for="embedded_bot_{{@key}}_edit">{{@key}}</label>
+            <label for="embedded_bot_{{@key}}_edit" class="modal-field-label">{{@key}}</label>
             <input type="text" name="{{@key}}" id="embedded_bot_{{@key}}_edit" class="modal_text_input"
               maxlength=1000 value="{{this}}" />
         </div>

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -23,7 +23,7 @@
         </label>
     </div>
     <div class="input-group hide">
-        <label for="integration-url-topic-input">{{t "Topic"}}</label>
+        <label for="integration-url-topic-input" class="modal-label-field">{{t "Topic"}}</label>
         <input type="text" id="integration-url-topic-input" class="modal_text_input integration-url-parameter" maxlength="{{ max_topic_length }}" />
     </div>
     <div id="integration-events-parameter" class="input-group hide">

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -1,5 +1,5 @@
 <div class="language_selection_widget input-group prop-element" id="id_{{section_name}}">
-    <label class="title">
+    <label class="settings-field-label">
         {{section_title}}
         {{#if help_link_widget_link}}
         {{> ../help_link_widget link=help_link_widget_link }}

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -65,7 +65,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_follow_topics_policy" class="dropdown-title">{{ settings_label.automatically_follow_topics_policy }}</label>
+            <label for="automatically_follow_topics_policy" class="settings-field-label">{{ settings_label.automatically_follow_topics_policy }}</label>
             <select name="automatically_follow_topics_policy" class="setting_automatically_follow_topics_policy prop-element settings_select bootstrap-focus-style"
               id="{{prefix}}automatically_follow_topics_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=automatically_follow_topics_policy_values}}
@@ -73,7 +73,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_unmute_topics_in_muted_streams_policy" class="dropdown-title">{{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}</label>
+            <label for="automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">{{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}</label>
             <select name="automatically_unmute_topics_in_muted_streams_policy" class="setting_automatically_unmute_topics_in_muted_streams_policy prop-element settings_select bootstrap-focus-style"
               id="{{prefix}}automatically_unmute_topics_in_muted_streams_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=automatically_unmute_topics_in_muted_streams_policy_values}}
@@ -128,7 +128,7 @@
         </div>
 
         <div class="input-group">
-            <label for="desktop_icon_count_display" class="dropdown-title">{{ settings_label.desktop_icon_count_display }}</label>
+            <label for="desktop_icon_count_display" class="settings-field-label">{{ settings_label.desktop_icon_count_display }}</label>
             <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element settings_select bootstrap-focus-style" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
             </select>
@@ -195,7 +195,7 @@
         </div>
 
         <div class="input-group">
-            <label for="realm_name_in_email_notifications_policy" class="dropdown-title">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
+            <label for="realm_name_in_email_notifications_policy" class="settings-field-label">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
             <select name="realm_name_in_email_notifications_policy" class="setting_realm_name_in_email_notifications_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}realm_name_in_email_notifications_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=realm_name_in_email_notifications_policy_values}}
             </select>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -173,7 +173,7 @@
 
         <div class="input-group time-limit-setting">
 
-            <label for="email_notifications_batching_period">
+            <label for="email_notifications_batching_period" class="settings-field-label">
                 {{t "Delay before sending message notification emails" }}
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element settings_select bootstrap-focus-style" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -186,7 +186,7 @@
             </div>
 
             <div class="input-group">
-                <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another channel" }}
+                <label for="realm_move_messages_between_streams_policy" class="settings-field-label">{{t "Who can move messages to another channel" }}
                 </label>
                 <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element bootstrap-focus-style move-message-policy-setting settings_select" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
@@ -318,7 +318,7 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_bot_creation_policy">{{t "Who can add bots" }}</label>
+                    <label for="realm_bot_creation_policy" class="settings-field-label">{{t "Who can add bots" }}</label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_bot_creation_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=bot_creation_policy_values}}
                     </select>
@@ -339,7 +339,7 @@
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_private_message_policy">{{t "Who can use direct messages" }} ({{t "beta" }})
+                    <label for="realm_private_message_policy" class="settings-field-label">{{t "Who can use direct messages" }} ({{t "beta" }})
                         {{> ../help_link_widget link="/help/restrict-direct-messages" }}
                     </label>
                     <select name="realm_private_message_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_private_message_policy" data-setting-widget-type="number">

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -16,7 +16,7 @@
                       prefix="id_"
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
-                    <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can send email invitations to new users" }}
+                    <label for="realm_invite_to_realm_policy" class="settings-field-label">{{t "Who can send email invitations to new users" }}
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -29,7 +29,7 @@
                   value_type="number"}}
 
                 <div class="input-group">
-                    <label for="realm_org_join_restrictions" class="dropdown-title">{{t "Restrict email domains of new users?" }}</label>
+                    <label for="realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users?" }}</label>
                     <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style">
                         <option value="no_restriction">{{t "No restrictions" }}</option>
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
@@ -43,7 +43,7 @@
                     </div>
                 </div>
                 <div class="input-group time-limit-setting">
-                    <label for="realm_waiting_period_threshold" class="dropdown-title">
+                    <label for="realm_waiting_period_threshold" class="settings-field-label">
                         {{t "Waiting period before new members turn into full members" }}
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
@@ -69,7 +69,7 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_create_public_stream_policy" class="dropdown-title">{{t "Who can create public channels" }}</label>
+                    <label for="realm_create_public_stream_policy" class="settings-field-label">{{t "Who can create public channels" }}</label>
                     <select name="realm_create_public_stream_policy" id="id_realm_create_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
@@ -83,25 +83,25 @@
                   is_disabled=disable_enable_spectator_access_setting
                   help_link="/help/public-access-option"}}
                 <div class="input-group realm_create_web_public_stream_policy">
-                    <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public channels" }}</label>
+                    <label for="realm_create_web_public_stream_policy" class="settings-field-label">{{t "Who can create web-public channels" }}</label>
                     <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=create_web_public_stream_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private channels" }}</label>
+                    <label for="realm_create_private_stream_policy" class="settings-field-label">{{t "Who can create private channels" }}</label>
                     <select name="realm_create_private_stream_policy" id="id_realm_create_private_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to channels" }}</label>
+                    <label for="realm_invite_to_stream_policy" class="settings-field-label">{{t "Who can add users to channels" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="dropdown-title">{{t "Who can notify a large number of users with a wildcard mention" }}
+                    <label for="realm_wildcard_mention_policy" class="settings-field-label">{{t "Who can notify a large number of users with a wildcard mention" }}
                         {{> ../help_link_widget link="/help/restrict-wildcard-mentions" }}
                     </label>
                     <select name="realm_wildcard_mention_policy" id="id_realm_wildcard_mention_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -132,7 +132,7 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
+                    <label for="realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
@@ -161,14 +161,14 @@
                 {{> settings_save_discard_widget section_name="moving-msgs" }}
             </div>
             <div class="input-group">
-                <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
+                <label for="realm_edit_topic_policy" class="settings-field-label">{{t "Who can move messages to another topic" }}</label>
                 <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element move-message-policy-setting settings_select bootstrap-focus-style" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=edit_topic_policy_values}}
                 </select>
             </div>
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_within_stream_limit_seconds" class="dropdown-title">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="realm_move_messages_within_stream_limit_seconds" class="settings-field-label">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_within_stream_limit_seconds" id="id_realm_move_messages_within_stream_limit_seconds" class="prop-element settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
@@ -194,7 +194,7 @@
             </div>
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="dropdown-title">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="realm_move_messages_between_streams_limit_seconds" class="settings-field-label">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_between_streams_limit_seconds" id="id_realm_move_messages_between_streams_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
@@ -224,7 +224,7 @@
                     {{t "Administrators can delete any message." }}
                 </label>
                 <div class="input-group">
-                    <label for="realm_delete_own_message_policy" class="dropdown-title">
+                    <label for="realm_delete_own_message_policy" class="settings-field-label">
                         {{t "Who can delete their own messages" }}
                     </label>
                     <select name="realm_delete_own_message_policy" id="id_realm_delete_own_message_policy" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="number">
@@ -233,7 +233,7 @@
                 </div>
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_delete_limit_seconds" class="dropdown-title">
+                    <label for="realm_message_content_delete_limit_seconds" class="settings-field-label">
                         {{t "Time limit for deleting messages" }} <i>({{t "does not apply to administrators" }})</i>
                     </label>
                     <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
@@ -325,14 +325,14 @@
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_user_group_edit_policy" class="dropdown-title">{{t "Who can create and manage user groups" }}</label>
+                    <label for="realm_user_group_edit_policy" class="settings-field-label">{{t "Who can create and manage user groups" }}</label>
                     <select name="realm_user_group_edit_policy" id="id_realm_user_group_edit_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_add_custom_emoji_policy" class="dropdown-title">{{t "Who can add custom emoji" }}</label>
+                    <label for="realm_add_custom_emoji_policy" class="settings-field-label">{{t "Who can add custom emoji" }}</label>
                     <select name="realm_add_custom_emoji_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_add_custom_emoji_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -18,7 +18,7 @@
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
-                    <label for="realm_org_type" class="dropdown-title">{{t "Organization type" }}
+                    <label for="realm_org_type" class="settings-field-label">{{t "Organization type" }}
                         {{> ../help_link_widget link="/help/organization-type" }}
                     </label>
                     <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -12,7 +12,7 @@
 
             <div class="organization-settings-parent">
                 <div class="input-group admin-realm">
-                    <label for="id_realm_name">{{t "Organization name" }}</label>
+                    <label for="id_realm_name" class="settings-field-label">{{t "Organization name" }}</label>
                     <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name setting-widget prop-element settings_text_input"
                       autocomplete="off" data-setting-widget-type="string"
                       value="{{ realm_name }}" maxlength="40" />
@@ -33,7 +33,7 @@
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
                 <div class="input-group admin-realm">
-                    <label for="realm_description">{{t "Organization description" }}</label>
+                    <label for="realm_description" class="settings-field-label">{{t "Organization description" }}</label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings_textarea"
                       maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
                 </div>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -50,7 +50,7 @@
                   label=admin_settings_label.realm_digest_emails_enabled}}
                 {{/if}}
                 <div class="input-group">
-                    <label for="realm_digest_weekday" class="dropdown-title">{{t "Day of the week to send digests" }}</label>
+                    <label for="realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
                     <select name="realm_digest_weekday"
                       id="id_realm_digest_weekday"
                       class="setting-widget prop-element settings_select bootstrap-focus-style"
@@ -79,7 +79,7 @@
 
             <div class="inline-block organization-settings-parent">
                 <div class="input-group time-limit-setting">
-                    <label for="id_realm_message_retention_days" class="dropdown-title">{{t "Message retention period" }}
+                    <label for="id_realm_message_retention_days" class="settings-field-label">{{t "Message retention period" }}
                     </label>
                     <select name="realm_message_retention_days"
                       id="id_realm_message_retention_days" class="prop-element settings_select bootstrap-focus-style"
@@ -110,7 +110,7 @@
             </div>
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
-                    <label for="realm_video_chat_provider" class="dropdown-title">
+                    <label for="realm_video_chat_provider" class="settings-field-label">
                         {{t 'Call provider' }}
                         {{> ../help_link_widget link="/help/start-a-call" }}
                     </label>
@@ -122,7 +122,7 @@
 
                     <div class="dependent-settings-block" id="realm_jitsi_server_url_setting">
                         <div>
-                            <label for="id_realm_jitsi_server_url" class="dropdown-title">
+                            <label for="id_realm_jitsi_server_url" class="settings-field-label">
                                 {{t "Jitsi server URL" }}
                                 {{> ../help_link_widget link="/help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet" }}
                             </label>
@@ -148,7 +148,7 @@
                     </div>
                 </div>
                 <div class="input-group">
-                    <label for="realm_giphy_rating" class="dropdown-title">
+                    <label for="realm_giphy_rating" class="settings-field-label">
                         {{t 'GIPHY integration' }}
                         {{> ../help_link_widget link=giphy_help_link }}
                     </label>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -40,7 +40,7 @@
           help_link="/help/read-receipts"}}
 
         <div class="input-group">
-            <label for="email_address_visibility" class="dropdown-title">{{t "Who can access user's email address" }}
+            <label for="email_address_visibility" class="settings-field-label">{{t "Who can access user's email address" }}
                 {{> ../help_link_widget link="/help/configure-email-visibility" }}
             </label>
             <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -8,7 +8,7 @@
                         <div class="user-name-section inline-block">
                             <label for="full_name" class="title inline-block">{{t "Name" }}</label>
                             <div class="alert-notification full-name-status"></div>
-                            <div class="field_hint">{{t "How your account is displayed in Zulip." }}</div>
+                            <div class="settings-profile-user-field-hint">{{t "How your account is displayed in Zulip." }}</div>
                             <div id="full_name_input_container" {{#unless user_can_change_name}}class="disabled_setting_tooltip"{{/unless}}>
                                 <input id="full_name" name="full_name" class="settings_text_input" type="text" value="{{ current_user.full_name }}" {{#unless user_can_change_name}}disabled="disabled"{{/unless}} maxlength="60" />
                             </div>

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -6,7 +6,7 @@
                 <div class="full-name-change-container">
                     <div class="input-group inline-block grid user-name-parent">
                         <div class="user-name-section inline-block">
-                            <label for="full_name" class="title inline-block">{{t "Name" }}</label>
+                            <label for="full_name" class="settings-field-label inline-block">{{t "Name" }}</label>
                             <div class="alert-notification full-name-status"></div>
                             <div class="settings-profile-user-field-hint">{{t "How your account is displayed in Zulip." }}</div>
                             <div id="full_name_input_container" {{#unless user_can_change_name}}class="disabled_setting_tooltip"{{/unless}}>
@@ -18,7 +18,7 @@
 
                 <form class="timezone-setting-form">
                     <div class="input-group grid">
-                        <label for="timezone" class="dropdown-title inline-block">{{t "Time zone" }}</label>
+                        <label for="timezone" class="settings-field-label inline-block">{{t "Time zone" }}</label>
                         <div class="alert-notification timezone-setting-status"></div>
                         <div class="timezone-input">
                             <select name="timezone" id="user_timezone" class="bootstrap-focus-style settings_select">

--- a/web/templates/stream_settings/change_stream_info_modal.hbs
+++ b/web/templates/stream_settings/change_stream_info_modal.hbs
@@ -1,11 +1,11 @@
 <div>
-    <label for="change_stream_name">
+    <label for="change_stream_name" class="modal-field-label">
         {{t 'Channel name' }}
     </label>
     <input type="text" id="change_stream_name" class="modal_text_input" name="stream_name" value="{{ stream_name }}" maxlength="{{ max_stream_name_length }}" />
 </div>
 <div>
-    <label for="change_stream_description">
+    <label for="change_stream_description" class="modal-field-label">
         {{t 'Description' }}
         {{> ../help_link_widget link="/help/change-the-stream-description" }}
     </label>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -6,7 +6,7 @@
             <div id="stream_creating_indicator"></div>
             <div class="stream-creation-body">
                 <section class="block">
-                    <label for="create_stream_name">
+                    <label for="create_stream_name" class="settings-field-label">
                         {{t "Channel name" }}
                     </label>
                     <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
@@ -14,7 +14,7 @@
                     <div id="stream_name_error" class="stream_creation_error"></div>
                 </section>
                 <section class="block">
-                    <label for="create_stream_description">
+                    <label for="create_stream_description" class="settings-field-label">
                         {{t "Channel description" }}
                         {{> ../help_link_widget link="/help/change-the-stream-description" }}
                     </label>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -144,7 +144,7 @@
                     </div>
                 {{/each}}
                 <div class="input-group">
-                    <label for="streamcolor">{{t "Channel color" }}</label>
+                    <label for="streamcolor" class="settings-field-label">{{t "Channel color" }}</label>
                     <span class="sub_setting_control">
                         <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
                     </span>

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -27,7 +27,7 @@
 </div>
 
 <div class="input-group">
-    <label class="dropdown-title">{{t 'Who can post to the channel?'}}
+    <label class="settings-field-label">{{t 'Who can post to the channel?'}}
         {{> ../help_link_widget link="/help/stream-sending-policy" }}
     </label>
     <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
@@ -47,7 +47,7 @@
 {{#if (or is_owner is_stream_edit)}}
 <div>
     <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-        <label class="dropdown-title">{{t "Message retention period" }}
+        <label class="settings-field-label">{{t "Message retention period" }}
             {{> ../help_link_widget link="/help/message-retention-policy" }}
         </label>
 

--- a/web/templates/user_group_settings/change_user_group_info_modal.hbs
+++ b/web/templates/user_group_settings/change_user_group_info_modal.hbs
@@ -1,11 +1,11 @@
 <div>
-    <label for="change_user_group_name">
+    <label for="change_user_group_name" class="modal-field-label">
         {{t 'User group name' }}
     </label>
     <input type="text" id="change_user_group_name" class="modal_text_input" name="user_group_name" value="{{ group_name }}" maxlength="{{max_user_group_name_length}}" />
 </div>
 <div>
-    <label for="change_user_group_description">
+    <label for="change_user_group_description" class="modal-field-label">
         {{t 'User group description' }}
     </label>
     <textarea id="change_user_group_description" class="settings_textarea" name="user_group_description">{{ group_description }}</textarea>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -6,7 +6,7 @@
             <div id="user_group_creating_indicator"></div>
             <div class="user-group-creation-body">
                 <section class="block">
-                    <label for="create_user_group_name">
+                    <label for="create_user_group_name" class="settings-field-label">
                         {{t "User group name" }}
                     </label>
                     <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
@@ -14,7 +14,7 @@
                     <div id="user_group_name_error" class="user_group_creation_error"></div>
                 </section>
                 <section class="block">
-                    <label for="create_user_group_description">
+                    <label for="create_user_group_description" class="settings-field-label">
                         {{t "User group description" }}
                     </label>
                     <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"


### PR DESCRIPTION
This draft PR displays non-checkbox labels and field hints, where present, spaced equally from the inputs that follow them.

Thoughts, questions, & to-dos:

- [x] There are labels with a `title` class, but no associated style with them. (E.g., on the Emoji theme label); only the Language field has it styled, and that could probably be cleaned up and restyled with the new, shared label class anyway
- [x] Replace the `dropdown-title` class as I go, but save cleanup of the CSS until all instances are accounted for
- [x] `<label>` inherits a generous 20px line-height for its diminutive 14px font-size, so conceivably we could do a negative top-margin on field hint of `-4.5px` (multiply the value by `-1.5`), though that would likely need to be rethought on any future line-height work

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/field.20label.20and.20hint.20positions/near/1758968)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Profile labels and hints_

| Before | After |
| --- | --- |
| ![settings-label-before](https://github.com/zulip/zulip/assets/170719/5fcf1aec-fa07-4f81-a58b-3089e432186d) | ![settings-label-after](https://github.com/zulip/zulip/assets/170719/1e78cb1e-1067-43b7-94f3-7917b59d7ac9) |

_Profile labels, errors, and hints_

| Before | After |
| --- | --- |
| ![settings-label-with-error-before](https://github.com/zulip/zulip/assets/170719/172c801e-e4dd-4edc-bffd-b124adee8284) | ![settings-label-with-error-after](https://github.com/zulip/zulip/assets/170719/5152937c-5ea0-4c9f-967a-ed7f75e8cd1c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
