### PR TITLE
remote-support: Include billing entity name in internal billing notice.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -4942,6 +4942,7 @@ def invoice_plans_as_needed(event_time: Optional[datetime] = None) -> None:
                     if last_audit_log_update is not None:
                         last_audit_log_update_string = last_audit_log_update.strftime("%Y-%m-%d")
                     context = {
+                        "billing_entity": billing_session.billing_entity_display_name,
                         "support_url": billing_session.support_url(),
                         "last_audit_log_update": last_audit_log_update_string,
                         "notice_reason": "invoice_overdue",

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -7131,6 +7131,14 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             f"Support URL: {self.billing_session.support_url()}",
             message.body,
         )
+        self.assertIn(
+            f"Internal billing notice for {self.billing_session.billing_entity_display_name}.",
+            message.body,
+        )
+        self.assertIn(
+            "Reminder to re-evaluate the pricing and configure a new fixed-price plan accordingly.",
+            message.body,
+        )
         self.assertEqual(
             f"Fixed-price plan for {billing_entity} ends on {end_date.strftime('%Y-%m-%d')}",
             message.subject,
@@ -7514,11 +7522,19 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         message = outbox[-1]
         self.assert_length(message.to, 1)
         self.assertEqual(message.to[0], "sales@zulip.com")
-        self.assertEqual(message.subject, "Invoice overdue due to stale data")
+        self.assertEqual(
+            message.subject,
+            f"Invoice overdue for {self.billing_session.billing_entity_display_name} due to stale data",
+        )
         self.assertIn(
             f"Support URL: {self.billing_session.support_url()}",
             message.body,
         )
+        self.assertIn(
+            f"Internal billing notice for {self.billing_session.billing_entity_display_name}.",
+            message.body,
+        )
+        self.assertIn("Recent invoice is overdue for payment.", message.body)
         self.assertIn(
             f"Last data upload: {last_audit_log_update.strftime('%Y-%m-%d')}", message.body
         )
@@ -8979,11 +8995,19 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         message = outbox[-1]
         self.assert_length(message.to, 1)
         self.assertEqual(message.to[0], "sales@zulip.com")
-        self.assertEqual(message.subject, "Invoice overdue due to stale data")
+        self.assertEqual(
+            message.subject,
+            f"Invoice overdue for {self.billing_session.billing_entity_display_name} due to stale data",
+        )
         self.assertIn(
             f"Support URL: {self.billing_session.support_url()}",
             message.body,
         )
+        self.assertIn(
+            f"Internal billing notice for {self.billing_session.billing_entity_display_name}.",
+            message.body,
+        )
+        self.assertIn("Recent invoice is overdue for payment.", message.body)
         self.assertIn(
             f"Last data upload: {last_audit_log_upload.strftime('%Y-%m-%d')}", message.body
         )

--- a/templates/zerver/emails/internal_billing_notice.html
+++ b/templates/zerver/emails/internal_billing_notice.html
@@ -2,12 +2,15 @@
 
 {% block content %}
 
+<p>Internal billing notice for {{ billing_entity }}.</p>
+
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
 <p>Reminder to re-evaluate the pricing and configure a new fixed-price plan accordingly.</p>
 {% elif notice_reason == "invoice_overdue" %}
+<p>Recent invoice is overdue for payment.</p>
 <b>Last data upload</b>: {{ last_audit_log_update }}
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}
-<p>Investigate the reason for {{billing_entity}} on paid plan marked as locally deleted.</p>
+<p>Investigate why remote realm is marked as locally deleted when it's on a paid plan.</p>
 {% endif %}
 
 <br /><br />

--- a/templates/zerver/emails/internal_billing_notice.subject.txt
+++ b/templates/zerver/emails/internal_billing_notice.subject.txt
@@ -1,7 +1,7 @@
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
-Fixed-price plan for {{billing_entity}} ends on {{end_date}}
+Fixed-price plan for {{ billing_entity }} ends on {{ end_date }}
 {% elif notice_reason == "invoice_overdue" %}
-Invoice overdue due to stale data
+Invoice overdue for {{ billing_entity }} due to stale data
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}
-{{billing_entity}} on paid plan marked as locally deleted
+{{ billing_entity }} on paid plan marked as locally deleted
 {% endif %}

--- a/templates/zerver/emails/internal_billing_notice.txt
+++ b/templates/zerver/emails/internal_billing_notice.txt
@@ -1,9 +1,13 @@
+Internal billing notice for {{ billing_entity }}.
+
 {% if notice_reason == "fixed_price_plan_ends_soon" %}
 Reminder to re-evaluate the pricing and configure a new fixed-price plan accordingly.
 {% elif notice_reason == "invoice_overdue" %}
+Recent invoice is overdue for payment.
+
 Last data upload: {{ last_audit_log_update }}
 {% elif notice_reason == "locally_deleted_realm_on_paid_plan" %}
-Investigate the reason for {{billing_entity}} on paid plan marked as locally deleted.
+Investigate why remote realm is marked as locally deleted when it's on a paid plan.
 {% endif %}
 
 Support URL: {{ support_url }}

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2591,6 +2591,14 @@ class AnalyticsBouncerTest(BouncerTestCase):
             f"Support URL: {billing_session.support_url()}",
             email.body,
         )
+        self.assertIn(
+            f"Internal billing notice for {billing_session.billing_entity_display_name}.",
+            email.body,
+        )
+        self.assertIn(
+            "Investigate why remote realm is marked as locally deleted when it's on a paid plan.",
+            email.body,
+        )
         self.assertEqual(
             f"{billing_session.billing_entity_display_name} on paid plan marked as locally deleted",
             email.subject,


### PR DESCRIPTION
**Updates**:
- Adds a line to the top of the `internal_billing_notice` email with the billing entity's display name.
- Makes sure all existing `internal_billng_notice` email subjects also include the billing entity's display name.
- Makes small updates to the notice text for some cases.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
