### PR TITLE
puppet: Install the same version of postgres-client as the server.

### DIFF
--- a/docs/production/postgresql.md
+++ b/docs/production/postgresql.md
@@ -48,6 +48,14 @@ PostgreSQL documentation):
     overhead. I want to be sure that I connect to a server I trust,
     and that it's the one I specify.
 
+Set the remote server's PostgreSQL version in `/etc/zulip/zulip.conf`:
+
+```ini
+[postgresql]
+# Set this to match the version running on your remote PostgreSQL server
+version = 16
+```
+
 Then you should specify the password of the user zulip for the
 database in /etc/zulip/zulip-secrets.conf:
 

--- a/puppet/kandra/manifests/prometheus/postgresql.pp
+++ b/puppet/kandra/manifests/prometheus/postgresql.pp
@@ -49,7 +49,7 @@ class kandra::prometheus::postgresql {
 
   include zulip::postgresql_client
   exec { 'create prometheus postgres user':
-    require => Package['postgresql-client'],
+    require => Class['zulip::postgresql_client'],
     command => '/usr/bin/createuser -g pg_monitor prometheus',
     unless  => 'test -f /usr/bin/psql && /usr/bin/psql -tAc "select usename from pg_user" | /bin/grep -xq prometheus',
     user    => 'postgres',

--- a/puppet/zulip/manifests/postgresql_client.pp
+++ b/puppet/zulip/manifests/postgresql_client.pp
@@ -1,8 +1,6 @@
 class zulip::postgresql_client {
-  # This may get us a more recent client than the database server is
-  # configured to be, ($zulip::postgresql_common::version), but
-  # they're compatible.
-  package { 'postgresql-client':
+  include zulip::postgresql_common
+  package { "postgresql-client-${zulip::postgresql_common::version}":
     ensure => installed,
   }
 }


### PR DESCRIPTION
We require a `pg_dump` whose version matches the version of the server we are configured against (see 3a8b4b020509).  Installing the latest `postgresql-client` does not guarantee that we have such a binary present.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
