### PR TITLE
buddy_list: Ensure users are visible when hide_headers is true.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -248,7 +248,15 @@ export class BuddyList extends BuddyListConf {
         }
 
         this.render_section_headers();
-        if (!this.render_data.hide_headers) {
+        if (this.render_data.hide_headers) {
+            // Ensure the section isn't collapsed, because we're hiding its header
+            // so there's no way to collapse or uncollapse the list in this view.
+            $("#buddy-list-other-users-container").toggleClass("collapsed", false);
+        } else {
+            $("#buddy-list-other-users-container").toggleClass(
+                "collapsed",
+                this.other_users_is_collapsed,
+            );
             this.update_empty_list_placeholders();
         }
     }


### PR DESCRIPTION
Discussion on [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/User.20list.20behaviour/near/1761900)

Essentially, when `hide_headers` is true (when we're not showing a separate users list for the current narrow) we're actually still showing the "other users" section, just without its header. But the code that ensured that collapsed sections stay collapsed between narrows ended up hiding the list of users in the `hide_headers` view, which caused this bug. This adds some logic to make sure the list is always shown in these situations.