### PR TITLE
notifications: Update string for redacted body notifications

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -922,13 +922,7 @@ def get_mobile_push_content(rendered_content: str) -> str:
         return plain_text
 
     if settings.PUSH_NOTIFICATION_REDACT_CONTENT:
-        return (
-            "*"
-            + _(
-                "This organization has disabled including message content in mobile push notifications"
-            )
-            + "*"
-        )
+        return _("New message")
 
     elem = lxml.html.fragment_fromstring(rendered_content, create_parent=True)
     change_katex_to_raw_latex(elem)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -4109,7 +4109,7 @@ class TestGetAPNsPayload(PushNotificationTest):
             "alert": {
                 "title": "Cordelia, Lear's daughter, King Hamlet, Othello, the Moor of Venice",
                 "subtitle": "King Hamlet:",
-                "body": "*This organization has disabled including message content in mobile push notifications*",
+                "body": "New message",
             },
             "sound": "default",
             "badge": 0,
@@ -4305,7 +4305,7 @@ class TestGetGCMPayload(PushNotificationTest):
                 "event": "message",
                 "zulip_message_id": message.id,
                 "time": datetime_to_timestamp(message.date_sent),
-                "content": "*This organization has disabled including message content in mobile push notifications*",
+                "content": "New message",
                 "content_truncated": False,
                 "server": settings.EXTERNAL_HOST,
                 "realm_id": hamlet.realm.id,


### PR DESCRIPTION
Current solution: replace the long string for organisations that have notification body/content disabled (settings.PUSH_NOTIFICATION_REDACT_CONTENT set to true) with "New message".

Resolves #29152 

This solution replaces the previous redacted push notification body string ("\*This organization has disabled including message content in mobile push notifications\*") with "New message". This is done in favour of setting up a notification string encoding convention and frontend push notification parsing logic to italicise the new text. The redundant asterisks have also been removed based on the solution discussion CZO thread linked in the next comment.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] <del>Calls out remaining decisions and concerns.</del>
- [ ] <del>Automated tests verify logic where appropriate.</del>

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] <del>Visual appearance of the changes.</del>
- [ ] <del>Responsiveness and internationalization.</del>
- [ ] <del>Strings and tooltips.</del>
- [ ] <del>End-to-end functionality of buttons, interactions and flows.</del>
- [ ] <del>Corner cases, error conditions, and easily imagined bugs.</del>
</details>
