### PR TITLE
Updated uploaded files settings panel UI

### DIFF
--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
-        <h3>{{t "Uploaded files"}}</h3>
+        <h3>{{t "Your uploads"}}</h3>
         <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
     </div>
     <div class="clear-float"></div>

--- a/web/templates/settings/upload_space_stats.hbs
+++ b/web/templates/settings/upload_space_stats.hbs
@@ -1,9 +1,11 @@
 <span>
-    {{t "Organization using {percent_used}% of {upload_quota}." }}
     {{#if show_upgrade_message}}
-        {{#tr}}
-            <z-link>Upgrade</z-link> for more space.
-            {{#*inline "z-link"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-        {{/tr}}
+        <div class="upgrade-tip">
+            {{#tr}}
+                Available on Zulip Cloud Standard. <z-link>Upgrade</z-link> to access.
+                {{#*inline "z-link"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+            {{/tr}}
+        </div>
     {{/if}}
+    {{t "Your organization is using {percent_used}% of {upload_quota}." }}
 </span>


### PR DESCRIPTION
This Pull Request aims at updating the upload files settings panel UI. The issue has been mentioned in [Issue #29077](https://github.com/zulip/zulip/issues/29077)
 and reported by @alya. 

Changes have been made in `attachments_settings.hbs` and `upload_space_stats.hbs`.

Fixes: 
- [x] Rename the table to "Your uploads" to clarify that these are your files, not everyone's. All other strings can continue to say "uploaded files".
- [x] Change the text of the quota notice to:
      Your organization is using x% of your 5 GB file storage quota. Upgrade for more space.
- [x] Instead of a link on "Upgrade", put the whole notice into a clickable banner with a rocket icon, like ones elsewhere in settings:

Actions Taken:
Replaced "Updated Files" with "Your Uplaods" in `attachments_settings.hbs`.
Added new String Availabe on Zulip cloud storage. Upgrade to access and put it in a banner by moving it inside a div element with class 'upgrade-tip' which is also the class used for other similar banners.

I am not able to create demo organisation to login as organisation and test. So I have done testing by moving the code into different files and declaring some local variables. Here are the screenshots of the same.

Current UI
![Screenshot from 2024-03-21 19-53-25](https://github.com/zulip/zulip/assets/123956452/507bafae-d2ef-42b5-a0ee-cb3ff17fe83b)


After changes 
![Screenshot from 2024-03-21 19-07-42](https://github.com/zulip/zulip/assets/123956452/b684cc55-e972-4119-a1ac-aa5883bd8e70)

Self-review checklist

 - [x] Reviewed the changes to ensure clarity and maintainability, including variable names, code organization, and readability.
 - [x] Verified that variable names are descriptive and consistent with project conventions.
 - [x] Ensured that the code is modular and promotes reuse where applicable.
 - [x] Ensured that automated tests adequately verify the logic of the changes.
 - [x] Verified that each individual commit is prepared for review according to the project's commit discipline.
 - [x] Ensured that each commit represents a coherent idea or logical change.
 - [x] Reviewed commit messages to ensure they clearly explain the reasoning and motivation behind the changes.
 - [x] Evaluated the visual appearance of the changes.
 - [x] Checked how the changes impact the overall visual appearance, ensuring alignment with design guidelines.


