### PR TITLE
css: Redesign message source textarea and close / cancel buttons.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -768,9 +768,8 @@
 
     /* Button colors on modals and message editing. */
     --color-exit-button-text: hsl(0deg 0% 100%);
-    --color-exit-button-border: hsl(0deg 0% 0% / 60%);
-    --color-exit-button-background: hsl(211deg 29% 14%);
-    --color-exit-button-background-interactive: hsl(211deg 29% 17%);
+    --color-exit-button-background: hsl(226deg 1% 30% / 50%);
+    --color-exit-button-background-interactive: hsl(226deg 1% 30% / 65%);
 
     /* Emoji-picker colors */
     --color-background-emoji-picker-popover: hsl(0deg 0% 0% / 20%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1110,14 +1110,7 @@ textarea.new_message_textarea,
 
         & button {
             pointer-events: none;
-        }
-
-        #compose-send-button {
-            background-color: hsl(0deg 0% 65%);
-        }
-
-        #send_later {
-            color: hsl(0deg 0% 65%);
+            opacity: 0.5;
         }
     }
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -104,11 +104,6 @@
         }
     }
 
-    .modal__btn:disabled {
-        opacity: 1;
-        background-color: hsl(0deg 0% 83% / 50%);
-    }
-
     & table.table-striped thead.table-sticky-headers th {
         background-color: hsl(0deg 0% 0%);
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -104,8 +104,7 @@
         }
     }
 
-    .modal__btn:disabled,
-    .disabled-message-send-controls button {
+    .modal__btn:disabled {
         opacity: 1;
         background-color: hsl(0deg 0% 83% / 50%);
     }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -589,8 +589,13 @@
     &:read-only,
     &:disabled {
         cursor: not-allowed;
-        background-color: hsl(0deg 0% 93%);
     }
+}
+
+/* The selector needs to be written this way to override the specificity
+of the base style defined for a read-only textarea in dark mode. */
+.message_edit_form .edit-controls textarea.message_edit_content:read-only {
+    opacity: 1;
 }
 
 .message_edit_countdown_timer {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -512,7 +512,6 @@
     .message_edit_close {
         color: var(--color-exit-button-text);
         background: var(--color-exit-button-background);
-        border: 1px solid var(--color-exit-button-border);
 
         &:hover {
             background: var(--color-exit-button-background-interactive);

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -503,7 +503,6 @@
             /* Replicate the `.new-style` disabled values,
                without any color shifts. */
             cursor: not-allowed;
-            filter: saturate(0);
             opacity: 0.5;
         }
     }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -4,8 +4,8 @@
        other "Nah, forget it" actions. */
     --color-exit-button-text: hsl(0deg 0% 0%);
     --color-exit-button-border: hsl(300deg 2% 11% / 30%);
-    --color-exit-button-background: hsl(0deg 0% 100%);
-    --color-exit-button-background-interactive: hsl(0deg 0% 97%);
+    --color-exit-button-background: hsl(226deg 1% 42% / 20%);
+    --color-exit-button-background-interactive: hsl(226deg 1% 42% / 27%);
 }
 
 .modal__overlay {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -129,6 +129,7 @@
 
     &:disabled {
         cursor: not-allowed;
+        opacity: 0.5;
     }
 }
 
@@ -151,10 +152,6 @@
     margin-left: 12px;
     background-color: hsl(240deg 96% 68%);
     color: hsl(0deg 0% 100%) !important;
-
-    &:disabled {
-        background-color: hsl(0deg 0% 65%);
-    }
 }
 
 #read_receipts_error,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -641,10 +641,6 @@ li,
     its own border and background color */
     border: none;
     background-clip: content-box;
-    /* The z-index here ensures that the copy-message
-    icon is clickable and is needed because of reduced
-    opacity of readonly textarea */
-    z-index: 2;
 
     &:hover svg path {
         fill: var(--color-fill-hover-copy-icon);


### PR DESCRIPTION
css: Make all modal buttons half opaque when disabled, instead of grey.

Earlier, the primary modal button always turned grey on being disabled, while other modal buttons remained as is in light mode, and grey in dark mode. Now the styling is made consistent across all modal buttons, by giving them all 50% opacity when disabled.

css: Make message send / save buttons half opaque when disabled.

So far, the Send buttons area would turn grey when the message could not be sent. The Save button when editing a message would also turn grey when the message could not be edited anymore. Now we simply make the buttons half opaque instead of turning them grey in a disabled state.

css: Redesign exit / close buttons.

We change the background colors for the close / cancel / exit buttons in modals and messages (when editing them or viewing their source). The border is also removed for those buttons in messages.

message_edit: Show message source in full opacity.

When viewing the source of a message when not editable, the opacity of the read-only textarea would be reduced to 0.5, like for any other read- only textarea. This was unnecessary for viewing message source, so the opacity for this case is now set to 1.

Fixes: #28701.

### Screenshots and screen captures:
#### Light:
**Message edit / source**
![image](https://github.com/zulip/zulip/assets/68962290/6b5ad7e9-8759-459d-8274-230dd84200ea)
**Modal (both enabled buttons)**
![image](https://github.com/zulip/zulip/assets/68962290/54fb256d-80a9-4f26-9594-10e965d18255)
**Modal (both disabled buttons)**
![image](https://github.com/zulip/zulip/assets/68962290/d3ad6ca6-10dd-482b-beca-062cdbc2332b)
**Disabled Send button**
![image](https://github.com/zulip/zulip/assets/68962290/f53fd318-aa97-400b-8ed2-19c995fa9016)


#### Dark:
**Message edit / source**
![image](https://github.com/zulip/zulip/assets/68962290/499a93bd-eac9-4ac7-8f59-a3f28b27aa5e)
**Modal (both enabled buttons)**
![image](https://github.com/zulip/zulip/assets/68962290/445c30a3-0c46-4730-96d1-155b0561e395)
**Modal (both disabled buttons)**
![image](https://github.com/zulip/zulip/assets/68962290/1832cb5a-fd0e-4ae6-9013-0baffda93021)
**Disabled Send button**
![image](https://github.com/zulip/zulip/assets/68962290/37864d7f-2650-4b63-950d-ee12b36e44b2)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
