### PR TITLE
message_view: For message sent by current user, always scroll into view.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1005,13 +1005,17 @@ export class MessageListView {
         }
 
         if (list === message_lists.current && messages_are_new) {
+            let sent_by_me = false;
+            if (messages.some((message) => message.sent_by_me)) {
+                sent_by_me = true;
+            }
             if (started_scrolled_up) {
                 return {
                     need_user_to_scroll: true,
                 };
             }
             const new_messages_height = this._new_messages_height(new_dom_elements);
-            const need_user_to_scroll = this._maybe_autoscroll(new_messages_height);
+            const need_user_to_scroll = this._maybe_autoscroll(new_messages_height, sent_by_me);
 
             if (need_user_to_scroll) {
                 return {
@@ -1055,10 +1059,11 @@ export class MessageListView {
         return scroll_limit;
     }
 
-    _maybe_autoscroll(new_messages_height) {
+    _maybe_autoscroll(new_messages_height, sent_by_me) {
         // If we are near the bottom of our feed (the bottom is visible) and can
         // scroll up without moving the pointer out of the viewport, do so, by
-        // up to the amount taken up by the new message.
+        // up to the amount taken up by the new message. For messages sent by
+        // the current user, we scroll it into view.
         //
         // returns `true` if we need the user to scroll
 
@@ -1090,6 +1095,13 @@ export class MessageListView {
             // If a popover is active, then we are pretty sure the
             // incoming message is not from the user themselves, so
             // we don't need to tell users to scroll down.
+            return false;
+        }
+
+        if (sent_by_me) {
+            // For messages sent by the current user we always autoscroll,
+            // updating the selected row if needed.
+            message_viewport.system_initiated_animate_scroll(new_messages_height, true);
             return false;
         }
 

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -358,8 +358,11 @@ export function stop_auto_scrolling(): void {
     }
 }
 
-export function system_initiated_animate_scroll(scroll_amount: number): void {
-    message_scroll_state.set_update_selection_on_next_scroll(false);
+export function system_initiated_animate_scroll(
+    scroll_amount: number,
+    update_selection_on_scroll = false,
+): void {
+    message_scroll_state.set_update_selection_on_next_scroll(update_selection_on_scroll);
     const viewport_offset = scrollTop();
     in_stoppable_autoscroll = true;
     $scroll_container.animate({


### PR DESCRIPTION
Now whenever the bottom of the feed is visible, we always scroll to the message/s just sent by the current user, updating the selected message if necessary.

Scroll behaviour for messages sent by other users remains unchanged.

Fixes: #23298.

**Screenshots and screen captures:**
Before sending:
![image](https://github.com/zulip/zulip/assets/68962290/4d0855ad-eb4f-4013-a98e-2e99afabe926)

New message scrolled into view on sending:
![image](https://github.com/zulip/zulip/assets/68962290/a675bc43-e82d-463b-9fb9-f847a1024ce5)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
