### PR TITLE
register_server: Check write access to secrets file when rotate_key.

### DIFF
--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from argparse import ArgumentParser
 from typing import Any, Dict
@@ -80,6 +81,8 @@ class Command(ZulipBaseCommand):
             "contact_email": settings.ZULIP_ADMINISTRATOR,
         }
         if options["rotate_key"]:
+            if not os.access(SECRETS_FILENAME, os.W_OK):
+                raise CommandError(f"{SECRETS_FILENAME} is not writable by the current user.")
             request["new_org_key"] = get_random_string(64)
 
         print(


### PR DESCRIPTION
Using --rotate-key without write access to the secrets file is currently quite painful, since you end up rotating your registration's secret with no local record of it; so effectively you lose your registration and need help from support. We should just prevent this failure mode.

