### PR TITLE
puppet: Add a daily cron-job to send zulip update announcements.

### DIFF
--- a/puppet/zulip/files/cron.d/send_zulip_update_announcements
+++ b/puppet/zulip/files/cron.d/send_zulip_update_announcements
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+USER=zulip
+
+# Cron job to send zulip update announcements hourly, if there are any.
+47 * * * * zulip /home/zulip/deployments/current/manage.py send_zulip_update_announcements

--- a/puppet/zulip/manifests/app_frontend_once.pp
+++ b/puppet/zulip/manifests/app_frontend_once.pp
@@ -74,4 +74,12 @@ class zulip::app_frontend_once {
     mode   => '0644',
     source => 'puppet:///modules/zulip/cron.d/clearsessions',
   }
+
+  file { '/etc/cron.d/send_zulip_update_announcements':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/zulip/cron.d/send_zulip_update_announcements',
+  }
 }

--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -74,21 +74,22 @@ def internal_prep_group_direct_message_for_old_realm(
         topic_name = str(realm.ZULIP_UPDATE_ANNOUNCEMENTS_TOPIC_NAME)
     if realm.zulip_update_announcements_stream is None:
         content = """\
-You can now [configure]({organization_settings_url}) a stream where Zulip \
-will send [updates]({zulip_update_announcements_help_url}) about new Zulip features. \
-These notifications are currently turned off in your organization.
+Zulip now supports [configuring]({organization_settings_url}) a stream where Zulip will \
+send [updates]({zulip_update_announcements_help_url}) about new Zulip features. \
+These notifications are currently turned off in your organization. If you configure \
+a stream within one week, your organization will not miss any update messages.
 """.format(
             zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
             organization_settings_url="/#organization/organization-settings",
         )
     else:
         content = """\
-Users in your organization will now receive [updates]({zulip_update_announcements_help_url}) \
+Starting tomorrow, users in your organization will receive [updates]({zulip_update_announcements_help_url}) \
 about new Zulip features in #**{zulip_update_announcements_stream}>{topic_name}**.
 
 If you like, you can [configure]({organization_settings_url}) a different stream for \
-these updates (and [move]({move_content_another_stream_help_url}) the initial updates there), \
-or [turn this feature off]({organization_settings_url}) altogether.
+these updates (and [move]({move_content_another_stream_help_url}) any updates sent before the \
+configuration change), or [turn this feature off]({organization_settings_url}) altogether.
 """.format(
             zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
             zulip_update_announcements_stream=realm.zulip_update_announcements_stream.name,

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -147,7 +147,7 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
         )
         self.assertEqual(realm.zulip_update_announcements_level, 0)
         self.assertIn(
-            "Users in your organization will now receive "
+            "Starting tomorrow, users in your organization will receive "
             "[updates](/help/configure-automated-notices#zulip-update-announcements) about new Zulip features in "
             f"#**{realm.zulip_update_announcements_stream}>{realm.ZULIP_UPDATE_ANNOUNCEMENTS_TOPIC_NAME}**",
             group_direct_message.content,


### PR DESCRIPTION
Commit 1: Group DM text update.
Commit 2: A daily cron job is configured to run the `send_zulip_update_announcements` management command.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
