### PR TITLE
stream_settings: Update feedback message to include user name.

### DIFF
--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -233,7 +233,16 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
         if (data.removed.length > 0) {
             // Remove the user from the subscriber list.
             $list_entry.remove();
-            message = $t({defaultMessage: "Unsubscribed successfully!"});
+
+            const user_name = people.get_full_name(target_user_id);
+            if (target_user_id === current_user.user_id) {
+                message = $t({defaultMessage: "Unsubscribed yourself successfully!"});
+            } else {
+                message = $t(
+                    {defaultMessage: "Unsubscribed {user_name} successfully!"},
+                    {user_name},
+                );
+            }
             // The rest of the work is done via the subscription -> remove event we will get
         } else {
             message = $t({defaultMessage: "User is already not subscribed."});


### PR DESCRIPTION
Add user name in feedback message so that it is more clear which user is unsubscribe.

![image](https://github.com/zulip/zulip/assets/73663475/0159a779-799a-456e-aa23-1895f3408520)






https://github.com/zulip/zulip/assets/73663475/df816098-2397-460b-b861-89276b939865












Fixes #19165.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
