### PR TITLE
stream_settings: Show disabled create stream button and text.

### DIFF
--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -420,6 +420,17 @@ export function update_empty_left_panel_message() {
     } else {
         has_streams = stream_data.get_unsorted_subs().length;
     }
+
+    const has_hidden_streams =
+        $("#channels_overlay_container .stream-row:not(.notdisplayed)").length === 0;
+    const has_search_query = $("#stream_filter input[type='text']").val().trim() !== "";
+    // Show "no channels match" text if all channels are hidden and there's a search query.
+    if (has_hidden_streams && has_search_query) {
+        $(".no-streams-to-show").children().hide();
+        $(".no_stream_match_filter_empty_text").show();
+        $(".no-streams-to-show").show();
+        return;
+    }
     if (has_streams) {
         $(".no-streams-to-show").hide();
         return;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -693,6 +693,11 @@ div.overlay {
         box-shadow: 0 1px 4px 0 hsl(235deg 18% 7%);
         outline: none;
     }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
 }
 
 .color_animated_button {

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -41,6 +41,11 @@
                             <a href="#channels/all">{{t 'View all channels'}}</a>
                         </span>
                     </div>
+                    <div class="no_stream_match_filter_empty_text">
+                        <span class="settings-empty-option-text">
+                            {{t 'No channels match your filter.'}}
+                        </span>
+                    </div>
                     <div class="all_streams_tab_empty_text">
                         <span class="settings-empty-option-text">
                             {{t 'There are no channels you can view in this organization.'}}

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -58,13 +58,17 @@
                     <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
                 </div>
                 <div class="nothing-selected">
+                    <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
                     {{#if can_create_streams}}
-                    <button type="button" class="create_stream_button animated-purple-button">{{t 'Create channel' }}</button>
                     <span class="settings-empty-option-text">
                         {{#tr}}
                             First time? Read our <z-link>guidelines</z-link> for creating and naming channels.
                             {{#*inline "z-link"}}<a href="/help/getting-your-organization-started-with-zulip#create-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                         {{/tr}}
+                    </span>
+                    {{else}}
+                    <span class="settings-empty-option-text">
+                        {{t 'You do not have permission to create channels in this organization.' }}
                     </span>
                     {{/if}}
                 </div>


### PR DESCRIPTION
- [x] Now user who don't have permission can see disabled stream create button with message.
- [x] If user types in a streams filter query with no matches this text will shown **No channels match your filter**.

fixes #18332.

## user without the create stream permission:

### First commit
| Dark | Light |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/1cf9a28f-1f84-4dd8-8b7a-3520927efd89) | ![image](https://github.com/user-attachments/assets/bf101471-82f4-45d7-ab0b-8cf64ed22b26) |

### Second commit
- At the time the issue was opened, the **Not Subscribed** tab was not available. However, it is now present, so the text will be displayed in **Not Subscribed** tab too.

| when no channel match filter query | when there is no channel |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/0564c76c-fd79-4ca4-b99c-478f5896e971) | ![image](https://github.com/user-attachments/assets/0c1be636-5d31-4767-b8b9-308e6502c846) |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
