### PR TITLE
docs and help: Update text of no-content mobile notifications.

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -180,8 +180,8 @@ and privacy in mind:
 
   There's a `PUSH_NOTIFICATION_REDACT_CONTENT` setting available to
   disable any message content being sent via the push notification
-  bouncer (i.e. message content will be replaced with
-  `***REDACTED***`). Note that this setting makes push notifications
+  bouncer (i.e., message content will be replaced with
+  `New message`). Note that this setting makes push notifications
   significantly less usable.
 
   We plan to

--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -206,6 +206,12 @@ notification settings.
 
 {end_tabs}
 
+### Why am I seeing “New message” in place of message text?
+
+Administrators of self-hosted Zulip servers can
+[configure](https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#security-and-privacy)
+push notifications not to include any message content.
+
 ### Contacting Zulip support
 
 If you are still having trouble with your push notifications, you can send an


### PR DESCRIPTION
Documentation follow-up to d9c5eb1280ddaf0f010e52e4584a4fe3822af995.

New help section in https://zulip.com/help/mobile-notifications#troubleshooting-mobile-notifications:

 
<img width="806" alt="Screenshot 2024-03-22 at 4 52 26 PM" src="https://github.com/zulip/zulip/assets/2090066/e2921eab-53d6-449f-935a-06f3039a9608">
