### PR TITLE
Documentation Update: Add instructions to Status and Availability.

### DIFF
--- a/help/include/clear-status.md
+++ b/help/include/clear-status.md
@@ -1,0 +1,2 @@
+1. Click on the <i class="zulip-icon zulip-icon-x-circle"></i> to the
+   right of your current status.

--- a/help/include/self-user-card.md
+++ b/help/include/self-user-card.md
@@ -1,4 +1,4 @@
 1. Hover over your name in the right sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
-   to open your **user card**.
+   to open your [**user card**](/help/user-cards).

--- a/help/include/set-status.md
+++ b/help/include/set-status.md
@@ -1,0 +1,6 @@
+1. Click **Set status**.
+
+1. Click to select one of the common statuses, *or* choose any emoji and/or
+   write a short message.
+
+1. Click **Save**.

--- a/help/status-and-availability.md
+++ b/help/status-and-availability.md
@@ -21,25 +21,56 @@ You can set a status emoji, status message, or both.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-user-card}
 
 {!self-user-card.md!}
 
-1. Click **Set a status**.
+{!set-status.md!}
 
-1. Click to select one of the common statuses, *or* choose any emoji and/or
-   write a short message.
+{tab|via-personal-settings}
 
-1. Click **Save**.
+{!personal-menu.md!}
+
+{!set-status.md!}
 
 {tab|mobile}
 
 {!mobile-profile-menu.md!}
 
-1. Tap **Set a status**.
+1. Tap **Set your status**.
 
 1. Tap to select one of the common statuses, *or* choose any emoji and/or
    write a short message.
+
+1. Tap **Save**.
+
+{end_tabs}
+
+### Clear a status
+
+{start_tabs}
+
+{tab|via-user-card}
+
+{!self-user-card.md!}
+
+{!clear-status.md!}
+
+{tab|via-personal-settings}
+
+{!personal-menu.md!}
+
+{!clear-status.md!}
+
+{tab|mobile}
+
+{!mobile-profile-menu.md!}
+
+1. Tap **Set your status**.
+
+1. Tap the **x**
+   (<img src="/static/images/help/mobile-x-icon.svg" alt="x" class="help-center-icon"/>)
+   to the right of your current status.
 
 1. Tap **Save**.
 

--- a/static/images/help/mobile-x-icon.svg
+++ b/static/images/help/mobile-x-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>


### PR DESCRIPTION
Fixes #29415.

- Added a "Via Personal Settings" tab.
- Added relative link in self-user-card.md.
- Added "Clear a Status", where the user is told to press the X button.

Here's what the new documentation would be as opposed to the [old documentation](https://zulip.com/help/status-and-availability#statuses):