### PR TITLE
docs: Remove flush memcached command as it's auto-done by migration.

### DIFF
--- a/docs/subsystems/schema-migrations.md
+++ b/docs/subsystems/schema-migrations.md
@@ -180,12 +180,17 @@ If you follow the processes described above, `tools/provision` and
 migrations and run migrations on (`./manage.py migrate`) or rebuild
 the relevant database automatically as appropriate.
 
-While developing migrations, you may accidentally corrupt
-your databases while debugging your new code.
-You can always rebuild these databases from scratch.
+Notably, both `manage.py migrate` (`git grep post_migrate.connect` for
+details) and restarting `tools/run-dev` will flush `memcached`, so you
+shouldn't have to worry about cached objects from a previous database
+schema.
 
-Use `tools/rebuild-test-database` to rebuild the database
-used for `test-backend` and other automated tests.
+While developing migrations, you may accidentally corrupt your
+databases while debugging your new code. You can always rebuild these
+databases from scratch:
 
-Use `tools/rebuild-dev-database` to rebuild the database
-used in [manual testing](../development/using.md).
+- Use `tools/rebuild-test-database` to rebuild the database
+  used for `test-backend` and other automated tests.
+
+- Use `tools/rebuild-dev-database` to rebuild the database
+  used in [manual testing](../development/using.md).

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -83,14 +83,13 @@ following commands:
 ./manage.py migrate
 ```
 
-You can read our
+It's highly recommended to read our
 [database migration documentation](../subsystems/schema-migrations.md)
 to learn more about creating and applying database migrations.
 
-**Test your changes:** Once you've run the migration, flush memcached
-on your development server (`./scripts/setup/flush-memcached`) and then
-[restart the development server](../development/remote.md#running-the-development-server)
-to avoid interacting with cached objects.
+**Test your changes:** Once you've run the migration, [restart the
+development
+server](../development/remote.md#running-the-development-server).
 
 ### Backend changes
 
@@ -262,9 +261,8 @@ Running migrations:
   Applying zerver.NNNN_realm_mandatory_topics... OK
 ```
 
-Once you've run the migration, flush memcached on your development
-server (`./scripts/setup/flush-memcached`) and then [restart the development server](../development/remote.md#running-the-development-server)
-to avoid interacting with cached objects.
+Once you've run the migration, [restart the development
+server](../development/remote.md#running-the-development-server).
 
 ### Handle database interactions
 


### PR DESCRIPTION
It turns out `./manage.py migrate` auto flushes memcached resulting in clearing the cache, so no need to tell the developer to manually type the command to flush .

[relevant CZO topic](https://chat.zulip.org/#narrow/stream/3-backend/topic/flush.20vs.20restart.20memcached) 

<summary>Rendered updated text : </summary>

![Screenshot from 2024-03-23 10-20-52](https://github.com/zulip/zulip/assets/64221784/be0c5064-1cc5-4f84-99f2-371082f1b89c)

see [updated doc](https://zulip--29427.org.readthedocs.build/en/29427/tutorials/new-feature-tutorial.html)
see [original doc](https://zulip.readthedocs.io/en/latest/tutorials/new-feature-tutorial.html)