### PR TITLE
stream_settings: Restructure stream creation panel.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -36,6 +36,8 @@ async function stream_name_error(page: Page): Promise<string> {
 
 async function click_create_new_stream(page: Page): Promise<void> {
     await page.click("#add_new_subscription .create_stream_button");
+    await page.type("#create_stream_name", "Test Stream 1");
+    await page.click("#stream_creation_go_to_subscribers");
     await page.waitForSelector(".finalize_create_stream", {visible: true});
 
     // sanity check that desdemona is the initial subsscriber
@@ -78,11 +80,17 @@ async function test_user_filter_ui(page: Page): Promise<void> {
 }
 
 async function create_stream(page: Page): Promise<void> {
-    await page.waitForSelector('xpath///*[text()="Create channel"]', {visible: true});
+    await page.click("#stream_creation_go_to_configure_channel_settings");
+    await page.waitForSelector('xpath///*[text()="Configure new channel settings"]', {
+        visible: true,
+    });
+
     await common.fill_form(page, "form#stream_creation_form", {
         stream_name: "Puppeteer",
         stream_description: "Everything Puppeteer",
     });
+    await page.click("#stream_creation_go_to_subscribers");
+    await page.type("#create_stream_name", "Test Stream 2");
     await page.click("form#stream_creation_form .finalize_create_stream");
     // an explanatory modal is shown for the first stream created
     await common.wait_for_micromodal_to_open(page);
@@ -117,16 +125,16 @@ async function test_streams_with_empty_names_cannot_be_created(page: Page): Prom
     await page.click("#add_new_subscription .create_stream_button");
     await page.waitForSelector("form#stream_creation_form", {visible: true});
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "  "});
-    await page.click("form#stream_creation_form button.finalize_create_stream");
+    await page.click("form#stream_creation_form button#stream_creation_go_to_subscribers");
     assert.strictEqual(await stream_name_error(page), "Choose a name for the new channel.");
 }
 
 async function test_streams_with_duplicate_names_cannot_be_created(page: Page): Promise<void> {
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "Puppeteer"});
-    await page.click("form#stream_creation_form button.finalize_create_stream");
+    await page.click("form#stream_creation_form button#stream_creation_go_to_subscribers");
     assert.strictEqual(await stream_name_error(page), "A channel with this name already exists.");
 
-    const cancel_button_selector = "form#stream_creation_form button.button.white";
+    const cancel_button_selector = "form#stream_creation_form button.create_stream_cancel";
     await page.click(cancel_button_selector);
 }
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -995,23 +995,21 @@ export const stream_privacy_policy_values = {
         name: $t({defaultMessage: "Web-public"}),
         description: $t({
             defaultMessage:
-                "Organization members can join (guests must be invited by a subscriber); anyone on the Internet can view complete message history without creating an account",
+                "Anyone on the internet can view messages; members of your organization can join.",
         }),
     },
     public: {
         code: "public",
         name: $t({defaultMessage: "Public"}),
         description: $t({
-            defaultMessage:
-                "Organization members can join (guests must be invited by a subscriber); organization members can view complete message history without joining",
+            defaultMessage: "Members of your organization can view messages and join",
         }),
     },
     private_with_public_history: {
         code: "invite-only-public-history",
         name: $t({defaultMessage: "Private, shared history"}),
         description: $t({
-            defaultMessage:
-                "Must be invited by a subscriber; new subscribers can view complete message history; hidden from non-administrator users",
+            defaultMessage: "Joining and viewing messages requires being added by a subscriber",
         }),
     },
     private: {
@@ -1019,7 +1017,7 @@ export const stream_privacy_policy_values = {
         name: $t({defaultMessage: "Private, protected history"}),
         description: $t({
             defaultMessage:
-                "Must be invited by a subscriber; new subscribers can only see messages sent after they join; hidden from non-administrator users",
+                "Joining and viewing messages requires being added by a subscriber; new subscribers cannot see messages sent before they joined",
         }),
     },
 };

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -122,6 +122,28 @@ class StreamNameError {
 }
 const stream_name_error = new StreamNameError();
 
+function toggle_advanced_configurations() {
+    const $advanced_configurations_view = $(".advanced-configurations-collapase-view");
+    const $toggle_button = $(".toggle-advanced-configurations-icon");
+
+    if ($advanced_configurations_view.is(":visible")) {
+        // Toggle into the condensed state
+        $advanced_configurations_view.addClass("hide");
+        $toggle_button.addClass("fa-caret-right");
+        $toggle_button.removeClass("fa-caret-down");
+    } else {
+        // Toggle into the expanded state
+        $advanced_configurations_view.removeClass("hide");
+        $toggle_button.addClass("fa-caret-down");
+        $toggle_button.removeClass("fa-caret-right");
+    }
+}
+
+$("body").on("click", ".advanced-configurations-container .advance-config-title-container", (e) => {
+    e.stopPropagation();
+    toggle_advanced_configurations();
+});
+
 // Stores the previous state of the stream creation checkbox.
 let stream_announce_previous_value;
 

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -139,6 +139,42 @@ function toggle_advanced_configurations() {
     }
 }
 
+$("body").on("click", ".settings-sticky-footer #stream_creation_go_to_subscribers", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const stream_name = $("#create_stream_name").val().trim();
+    const is_stream_name_valid = stream_name_error.validate_for_submit(stream_name);
+    const privacy_type = $("#stream_creation_form input[type=radio][name=privacy]:checked").val();
+    let invite_only = false;
+    let is_web_public = false;
+
+    if (is_stream_name_valid) {
+        if (privacy_type === "invite-only" || privacy_type === "invite-only-public-history") {
+            invite_only = true;
+        } else if (privacy_type === "web-public") {
+            is_web_public = true;
+        }
+
+        const sub = {
+            name: stream_name,
+            invite_only,
+            is_web_public,
+        };
+        stream_settings_components.show_subs_pane.create_stream("subscribers_container", sub);
+    }
+});
+
+$("body").on(
+    "click",
+    ".settings-sticky-footer #stream_creation_go_to_configure_channel_settings",
+    (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        stream_settings_components.show_subs_pane.create_stream("configure_channel_settings");
+    },
+);
+
 $("body").on("click", ".advanced-configurations-container .advance-config-title-container", (e) => {
     e.stopPropagation();
     toggle_advanced_configurations();
@@ -435,6 +471,7 @@ export function set_up_handlers() {
         const name_ok = stream_name_error.validate_for_submit(stream_name);
 
         if (!name_ok) {
+            stream_settings_components.show_subs_pane.create_stream("configure_channel_settings");
             return;
         }
 

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -223,7 +223,7 @@ function setup_dropdown(sub, slim_sub) {
             event.stopPropagation();
             can_remove_subscribers_group_widget.render();
             settings_components.save_discard_stream_settings_widget_status_handler(
-                $("#stream_permission_settings"),
+                $(".advanced-configurations-container"),
                 slim_sub,
             );
         },

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -45,12 +45,35 @@ export const show_subs_pane = {
         $(".settings").show();
         set_right_panel_title(sub);
     },
-    create_stream() {
+    create_stream(container_name = "configure_channel_settings", sub) {
+        $(".stream_creation_container").hide();
+        if (container_name === "configure_channel_settings") {
+            $("#subscription_overlay .stream-info-title").text(
+                $t({defaultMessage: "Configure new channel settings"}),
+            );
+        } else {
+            $("#subscription_overlay .stream-info-title").html(render_selected_stream_title({sub}));
+        }
+        update_footer_buttons(container_name);
+        $(`.${container_name}`).show();
         $(".nothing-selected, .settings, #stream-creation").hide();
         $("#stream-creation").show();
-        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create channel"}));
     },
 };
+
+export function update_footer_buttons(container_name) {
+    if (container_name === "subscribers_container") {
+        // Hide stream creation containers and show add subscriber container
+        $(".finalize_create_stream").show();
+        $("#stream_creation_go_to_subscribers").hide();
+        $("#stream_creation_go_to_configure_channel_settings").show();
+    } else {
+        // Hide add subscriber container and show stream creation containers
+        $(".finalize_create_stream").hide();
+        $("#stream_creation_go_to_subscribers").show();
+        $("#stream_creation_go_to_configure_channel_settings").hide();
+    }
+}
 
 export function get_active_data() {
     const $active_row = $("div.stream-row.active");

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -1,9 +1,12 @@
 import $ from "jquery";
 
 import * as dropdown_widget from "./dropdown_widget";
+import {$t_html} from "./i18n";
 import * as settings_components from "./settings_components";
 import * as user_groups from "./user_groups";
 import type {UserGroup} from "./user_groups";
+
+export let active_group_id: number | undefined;
 
 export function setup_permissions_dropdown(group: UserGroup, for_group_creation: boolean): void {
     let widget_name: string;
@@ -55,3 +58,36 @@ export function setup_permissions_dropdown(group: UserGroup, for_group_creation:
     }
     can_mention_group_widget.setup();
 }
+
+export function set_active_group_id(group_id: number): void {
+    active_group_id = group_id;
+}
+
+export function reset_active_group_id(): void {
+    active_group_id = undefined;
+}
+
+export const show_user_group_settings_pane = {
+    nothing_selected() {
+        $("#groups_overlay .settings, #user-group-creation").hide();
+        reset_active_group_id();
+        $("#groups_overlay .nothing-selected").show();
+        $("#groups_overlay .user-group-info-title").text(
+            $t_html({defaultMessage: "User group settings"}),
+        );
+    },
+    settings(group: UserGroup) {
+        $("#groups_overlay .nothing-selected, #user-group-creation").hide();
+        $("#groups_overlay .settings").show();
+        set_active_group_id(group.id);
+        $("#groups_overlay .user-group-info-title").text(group.name);
+    },
+    create_user_group() {
+        $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
+        reset_active_group_id();
+        $("#user-group-creation").show();
+        $("#groups_overlay .user-group-info-title").text(
+            $t_html({defaultMessage: "Create user group"}),
+        );
+    },
+};

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -82,12 +82,35 @@ export const show_user_group_settings_pane = {
         set_active_group_id(group.id);
         $("#groups_overlay .user-group-info-title").text(group.name);
     },
-    create_user_group() {
+    create_user_group(container_name = "configure_user_group_settings") {
+        $(".user_group_creation").hide();
+        if (container_name === "configure_user_group_settings") {
+            $("#groups_overlay .user-group-info-title").text(
+                $t_html({defaultMessage: "Create user group: configure settings"}),
+            );
+        } else {
+            $("#groups_overlay .user-group-info-title").text(
+                $t_html({defaultMessage: "Create user group: add members"}),
+            );
+        }
+        update_footer_buttons(container_name);
+        $(`.${container_name}`).show();
         $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
         reset_active_group_id();
         $("#user-group-creation").show();
-        $("#groups_overlay .user-group-info-title").text(
-            $t_html({defaultMessage: "Create user group"}),
-        );
     },
 };
+
+export function update_footer_buttons(container_name: string): void {
+    if (container_name === "user_group_members_container") {
+        // Hide user group creation containers and show add members container
+        $("#groups_overlay .finalize_create_user_group").show();
+        $("#groups_overlay #user_group_go_to_members").hide();
+        $("#groups_overlay #user_group_go_to_configure_settings").show();
+    } else {
+        // Hide add members container and show user group creation containers
+        $("#groups_overlay .finalize_create_user_group").hide();
+        $("#groups_overlay #user_group_go_to_members").show();
+        $("#groups_overlay #user_group_go_to_configure_settings").hide();
+    }
+}

--- a/web/src/user_group_create.js
+++ b/web/src/user_group_create.js
@@ -89,6 +89,28 @@ class UserGroupNameError {
 }
 const user_group_name_error = new UserGroupNameError();
 
+$("body").on("click", ".settings-sticky-footer #user_group_go_to_members", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const group_name = $("#create_user_group_name").val().trim();
+    const is_user_group_name_valid = user_group_name_error.validate_for_submit(group_name);
+
+    if (is_user_group_name_valid) {
+        user_group_components.show_user_group_settings_pane.create_user_group(
+            "user_group_members_container",
+        );
+    }
+});
+
+$("body").on("click", ".settings-sticky-footer #user_group_go_to_configure_settings", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    user_group_components.show_user_group_settings_pane.create_user_group(
+        "configure_user_group_settings",
+    );
+});
+
 function clear_error_display() {
     user_group_name_error.clear_errors();
     $(".user_group_create_info").hide();
@@ -170,6 +192,9 @@ export function set_up_handlers() {
         const name_ok = user_group_name_error.validate_for_submit(group_name);
 
         if (!name_ok) {
+            user_group_components.show_user_group_settings_pane.create_user_group(
+                "configure_user_group_settings",
+            );
             return;
         }
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -35,7 +35,6 @@ export let select_tab = "general";
 
 let group_list_widget;
 let group_list_toggler;
-let active_group_id;
 
 function get_user_group_id(target) {
     const $row = $(target).closest(
@@ -345,32 +344,9 @@ function hide_membership_toggle_spinner(group_row) {
     loading.destroy_indicator($spinner);
 }
 
-export const show_user_group_settings_pane = {
-    nothing_selected() {
-        $("#groups_overlay .settings, #user-group-creation").hide();
-        reset_active_group_id();
-        $("#groups_overlay .nothing-selected").show();
-        $("#groups_overlay .user-group-info-title").text(
-            $t({defaultMessage: "User group settings"}),
-        );
-    },
-    settings(group) {
-        $("#groups_overlay .nothing-selected, #user-group-creation").hide();
-        $("#groups_overlay .settings").show();
-        set_active_group_id(group.id);
-        $("#groups_overlay .user-group-info-title").text(group.name);
-    },
-    create_user_group() {
-        $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
-        reset_active_group_id();
-        $("#user-group-creation").show();
-        $("#groups_overlay .user-group-info-title").text($t({defaultMessage: "Create user group"}));
-    },
-};
-
 function empty_right_panel() {
     $(".group-row.active").removeClass("active");
-    show_user_group_settings_pane.nothing_selected();
+    user_group_components.show_user_group_settings_pane.nothing_selected();
 }
 
 function open_right_panel_empty() {
@@ -402,7 +378,7 @@ export function handle_deleted_group(group_id) {
 
 export function show_group_settings(group) {
     $(".group-row.active").removeClass("active");
-    show_user_group_settings_pane.settings(group);
+    user_group_components.show_user_group_settings_pane.settings(group);
     row_for_group_id(group.id).addClass("active");
     setup_group_settings(group);
 }
@@ -410,14 +386,6 @@ export function show_group_settings(group) {
 export function open_group_edit_panel_for_row(group_row) {
     const group = get_user_group_for_target(group_row);
     show_group_settings(group);
-}
-
-export function set_active_group_id(group_id) {
-    active_group_id = group_id;
-}
-
-export function reset_active_group_id() {
-    active_group_id = undefined;
 }
 
 // Ideally this should be included in page params.
@@ -442,7 +410,7 @@ export function set_up_click_handlers() {
 function create_user_group_clicked() {
     // this changes the tab switcher (settings/preview) which isn't necessary
     // to a add new stream title.
-    show_user_group_settings_pane.create_user_group();
+    user_group_components.show_user_group_settings_pane.create_user_group();
     $(".group-row.active").removeClass("active");
 
     user_group_create.show_new_user_group_modal();
@@ -472,8 +440,8 @@ export function is_group_already_present(group) {
 export function get_active_data() {
     const $active_tabs = $(".user-groups-container").find("div.ind-tab.selected");
     return {
-        $row: row_for_group_id(active_group_id),
-        id: active_group_id,
+        $row: row_for_group_id(user_group_components.active_group_id),
+        id: user_group_components.active_group_id,
         $tabs: $active_tabs,
     };
 }
@@ -580,7 +548,7 @@ export function change_state(section, left_side_tab, right_side_tab) {
         // group is being edited. We are always editing a group here
         // so its safe to call
         if (left_side_tab !== group_list_toggler.value()) {
-            set_active_group_id(group.id);
+            user_group_components.set_active_group_id(group.id);
             group_list_toggler.goto(left_side_tab);
         }
         switch_to_group_row(group);
@@ -658,13 +626,13 @@ export function add_or_remove_from_group(group, group_row) {
 }
 
 export function maybe_reset_right_panel(groups_list_data) {
-    if (active_group_id === undefined) {
+    if (user_group_components.active_group_id === undefined) {
         return;
     }
 
     const group_ids = new Set(groups_list_data.map((group) => group.id));
-    if (!group_ids.has(active_group_id)) {
-        show_user_group_settings_pane.nothing_selected();
+    if (!group_ids.has(user_group_components.active_group_id)) {
+        user_group_components.show_user_group_settings_pane.nothing_selected();
     }
 }
 
@@ -724,7 +692,7 @@ export function setup_page(callback) {
 
         // Initially as the overlay is build with empty right panel,
         // active_group_id is undefined.
-        reset_active_group_id();
+        user_group_components.reset_active_group_id();
 
         const $container = $("#groups_overlay_container .user-groups-list");
 
@@ -756,10 +724,14 @@ export function setup_page(callback) {
                     );
                 },
                 onupdate() {
-                    if (active_group_id !== undefined) {
-                        const active_group = user_groups.get_user_group_from_id(active_group_id);
+                    if (user_group_components.active_group_id !== undefined) {
+                        const active_group = user_groups.get_user_group_from_id(
+                            user_group_components.active_group_id,
+                        );
                         if (is_group_already_present(active_group)) {
-                            row_for_group_id(active_group_id).addClass("active");
+                            row_for_group_id(user_group_components.active_group_id).addClass(
+                                "active",
+                            );
                         }
                     }
                 },

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -525,6 +525,22 @@ input[type="checkbox"] {
     }
 }
 
+.advanced-configurations-container {
+    .advance-config-title-container {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+
+        .stream_setting_subsection_title {
+            margin: 4px 8px;
+        }
+
+        .toggle-advanced-configurations-icon {
+            font-size: 20px;
+        }
+    }
+}
+
 .organization-settings-parent > div:first-of-type {
     margin-top: 10px;
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -703,6 +703,13 @@ h4.user_group_setting_subsection_title {
 
 #groups_overlay,
 #subscription_overlay {
+    #stream-creation {
+        .settings-sticky-footer {
+            display: flex;
+            justify-content: space-between;
+        }
+    }
+
     #user-group-creation,
     #stream-creation {
         overflow: auto;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -703,13 +703,6 @@ h4.user_group_setting_subsection_title {
 
 #groups_overlay,
 #subscription_overlay {
-    #stream-creation {
-        .settings-sticky-footer {
-            display: flex;
-            justify-content: space-between;
-        }
-    }
-
     #user-group-creation,
     #stream-creation {
         overflow: auto;
@@ -738,6 +731,8 @@ h4.user_group_setting_subsection_title {
         }
 
         .settings-sticky-footer {
+            display: flex;
+            justify-content: space-between;
             position: absolute;
             bottom: 0;
             width: calc(100% - 27px);

--- a/web/templates/stream_settings/selected_stream_title.hbs
+++ b/web/templates/stream_settings/selected_stream_title.hbs
@@ -1,6 +1,7 @@
 <a {{#if preview_url}}class="tippy-zulip-delayed-tooltip" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}{{/if}}">
-    {{> stream_privacy_icon
-      invite_only=sub.invite_only
-      is_web_public=sub.is_web_public }}
-    <span class="stream-name-title">{{sub.name}}</span>
+{{#unless preview_url}}{{t "Add subscribers to "}}{{/unless}}
+{{> stream_privacy_icon
+  invite_only=sub.invite_only
+  is_web_public=sub.is_web_public }}
+<span class="stream-name-title">{{sub.name}}</span>
 </a>

--- a/web/templates/stream_settings/selected_stream_title.hbs
+++ b/web/templates/stream_settings/selected_stream_title.hbs
@@ -1,7 +1,6 @@
-<a class="tippy-zulip-delayed-tooltip" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}">
+<a {{#if preview_url}}class="tippy-zulip-delayed-tooltip" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}{{/if}}">
     {{> stream_privacy_icon
       invite_only=sub.invite_only
-      is_web_public=sub.is_web_public
-      color=title_icon_color }}
+      is_web_public=sub.is_web_public }}
     <span class="stream-name-title">{{sub.name}}</span>
 </a>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -5,42 +5,52 @@
             <div class="alert stream_create_info"></div>
             <div id="stream_creating_indicator"></div>
             <div class="stream-creation-body">
-                <section class="block">
-                    <label for="create_stream_name" class="settings-field-label">
-                        {{t "Channel name" }}
-                    </label>
-                    <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
-                      placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
-                    <div id="stream_name_error" class="stream_creation_error"></div>
-                </section>
-                <section class="block">
-                    <label for="create_stream_description" class="settings-field-label">
-                        {{t "Channel description" }}
-                        {{> ../help_link_widget link="/help/change-the-channel-description" }}
-                    </label>
-                    <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
-                      placeholder="{{t 'Channel description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
-                </section>
-                <section class="block" id="make-invite-only">
-                    <div class="stream-types">
-                        {{> stream_types
-                          stream_post_policy=stream_post_policy_values.everyone.code
-                          is_stream_edit=false
-                          can_remove_subscribers_setting_widget_name="new_stream_can_remove_subscribers_group" }}
-                    </div>
-                </section>
-                <section class="block">
-                    <label for="people_to_add">
-                        <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
-                    </label>
-                    <div id="stream_subscription_error" class="stream_creation_error"></div>
-                    <div class="controls" id="people_to_add"></div>
-                </section>
+                <div class="configure_channel_settings stream_creation_container">
+                    <section class="block create_stream_title_container">
+                        <label for="create_stream_name">
+                            {{t "Channel name" }}
+                        </label>
+                        <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
+                          placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
+                        <div id="stream_name_error" class="stream_creation_error"></div>
+                    </section>
+                    <section class="block create_stream_description_container">
+                        <label for="create_stream_description" class="settings-field-label">
+                            {{t "Channel description" }}
+                            {{> ../help_link_widget link="/help/change-the-channel-description" }}
+                        </label>
+                        <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
+                          placeholder="{{t 'Channel description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
+                    </section>
+                    <section class="block create_stream_types_container" id="make-invite-only">
+                        <div class="stream-types">
+                            {{> stream_types
+                              stream_post_policy=stream_post_policy_values.everyone.code
+                              is_stream_edit=false
+                              can_remove_subscribers_setting_widget_name="new_stream_can_remove_subscribers_group" }}
+                        </div>
+                    </section>
+                </div>
+                <div class="subscribers_container stream_creation_container">
+                    <section class="block stream_create_add_subscriber_container">
+                        <label for="people_to_add">
+                            <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
+                        </label>
+                        <div id="stream_subscription_error" class="stream_creation_error"></div>
+                        <div class="controls" id="people_to_add"></div>
+                    </section>
+                </div>
             </div>
         </div>
         <div class="settings-sticky-footer">
-            <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-            <button class="finalize_create_stream button small sea-green rounded" type="submit">{{t "Create" }}</button>
+            <div class="settings-sticky-footer-left">
+                <button id="stream_creation_go_to_configure_channel_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+            </div>
+            <div class="settings-sticky-footer-right">
+                <button class="create_stream_cancel button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+                <button class="finalize_create_stream button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
+                <button id="stream_creation_go_to_subscribers" class="button small sea-green rounded">{{t "Continue to add subscribers" }}</button>
+            </div>
         </div>
     </form>
 </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -21,14 +21,8 @@
                     <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
                       placeholder="{{t 'Channel description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
                 </section>
-                {{#if ask_to_announce_stream}}
-                    <div id="announce-new-stream">
-                        {{>announce_stream_checkbox }}
-                    </div>
-                {{/if}}
                 <section class="block" id="make-invite-only">
                     <div class="stream-types">
-                        <h3 class="stream_setting_subsection_title">{{t "Channel permissions" }}</h3>
                         {{> stream_types
                           stream_post_policy=stream_post_policy_values.everyone.code
                           is_stream_edit=false

--- a/web/templates/stream_settings/stream_privacy_icon.hbs
+++ b/web/templates/stream_settings/stream_privacy_icon.hbs
@@ -1,14 +1,14 @@
 {{! This controls whether the swatch next to streams in the stream edit page has a lock icon. }}
 {{#if invite_only}}
-<div class="large-icon" style="color: {{color}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
     <i class="zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 </div>
 {{else if is_web_public}}
-<div class="large-icon" style="color: {{color}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
     <i class="zulip-icon zulip-icon-globe" aria-hidden="true"></i>
 </div>
 {{else}}
-<div class="large-icon" style="color: {{color}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
     <i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i>
 </div>
 {{/if}}

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -53,27 +53,18 @@
                   rendered_description=rendered_description
                   }}
             </div>
-            <div class="stream-permissions settings-subsection-parent" id="stream_permission_settings">
-                <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title">{{t "Channel permissions" }}
-                    </h3>
-                    {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
-                </div>
-
-                <div class="stream-permissions-warning-banner"></div>
-
-                {{> stream_types
-                  stream_post_policy_values=../stream_post_policy_values
-                  stream_privacy_policy_values=../stream_privacy_policy_values
-                  stream_privacy_policy=../stream_privacy_policy
-                  check_default_stream=../check_default_stream
-                  zulip_plan_is_not_limited=../zulip_plan_is_not_limited
-                  upgrade_text_for_wide_organization_logo=../upgrade_text_for_wide_organization_logo
-                  is_business_type_org=../is_business_type_org
-                  org_level_message_retention_setting=../org_level_message_retention_setting
-                  is_stream_edit=true
-                  can_remove_subscribers_setting_widget_name="can_remove_subscribers_group" }}
-            </div>
+            {{> stream_types
+              stream_post_policy_values=../stream_post_policy_values
+              stream_privacy_policy_values=../stream_privacy_policy_values
+              stream_privacy_policy=../stream_privacy_policy
+              check_default_stream=../check_default_stream
+              zulip_plan_is_not_limited=../zulip_plan_is_not_limited
+              upgrade_text_for_wide_organization_logo=../upgrade_text_for_wide_organization_logo
+              is_business_type_org=../is_business_type_org
+              org_level_message_retention_setting=../org_level_message_retention_setting
+              is_stream_edit=true
+              can_remove_subscribers_setting_widget_name="can_remove_subscribers_group"
+              }}
             {{/with}}
             <div class="stream_details_box">
                 <div class="stream_details_box_header">

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -1,76 +1,105 @@
-<div class="input-group stream-privacy-values">
-    <div class="alert stream-privacy-status"></div>
-    <label>{{t 'Who can access the channel?'}}
-        {{> ../help_link_widget link="/help/channel-permissions" }}
-    </label>
+<div id="stream_permission_settings" class="stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
+    {{#if is_stream_edit}}
+        <div class="subsection-header">
+            <h3 class="stream_setting_subsection_title">{{t "Channel permissions" }}
+            </h3>
+            {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
+        </div>
+        <div class="stream-permissions-warning-banner"></div>
+    {{/if}}
 
-    <div class="stream-privacy_choices prop-element" id="id_stream_privacy" data-setting-widget-type="radio-group" data-setting-choice-type="string">
-        {{#each stream_privacy_policy_values}}
-            <div class="settings-radio-input-parent">
-                <label class="radio">
-                    <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
-                    <b>{{ this.name }}:</b> {{ this.description }}
-                </label>
-            </div>
-        {{/each}}
-    </div>
-</div>
-
-<div class="default-stream">
-    {{> ../settings/settings_checkbox
-      prefix="id_"
-      setting_name="is_default_stream"
-      is_checked=check_default_stream
-      label=(t "Default channel for new users")
-      help_link="/help/set-default-channels-for-new-users"
-      }}
-</div>
-
-<div class="input-group">
-    <label class="settings-field-label">{{t 'Who can post to the channel?'}}
-        {{> ../help_link_widget link="/help/channel-posting-policy" }}
-    </label>
-    <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
-        {{#each stream_post_policy_values}}
-            <option value="{{this.code}}" {{#if (eq this.code ../stream_post_policy) }}selected{{/if}}>
-                {{ this.description}}
-            </option>
-        {{/each}}
-    </select>
-</div>
-
-{{> ../dropdown_widget_with_label
-  widget_name=can_remove_subscribers_setting_widget_name
-  label=(t 'Who can unsubscribe others from this channel?')
-  value_type="number"}}
-
-{{#if (or is_owner is_stream_edit)}}
-<div>
-    <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-        <label class="settings-field-label">{{t "Message retention period" }}
-            {{> ../help_link_widget link="/help/message-retention-policy" }}
+    <div class="input-group stream-privacy-values">
+        <div class="alert stream-privacy-status"></div>
+        <label>{{t 'Who can access the channel?'}}
+            {{> ../help_link_widget link="/help/channel-permissions" }}
         </label>
 
-        {{> ../settings/upgrade_tip_widget}}
-
-        <select name="stream_message_retention_setting"
-          class="stream_message_retention_setting prop-element settings_select bootstrap-focus-style"
-          id="id_message_retention_days"
-          data-setting-widget-type="message-retention-setting">
-            <option value="realm_default">{{t "Use organization level settings {org_level_message_retention_setting}" }}</option>
-            <option value="unlimited">{{t 'Retain forever' }}</option>
-            <option value="custom_period">{{t 'Custom' }}</option>
-        </select>
-
-        <div class="dependent-settings-block stream-message-retention-days-input">
-            <label class="inline-block">
-                {{t 'Retention period (days)' }}:
-            </label>
-            <input type="text" autocomplete="off"
-              name="stream-message-retention-days"
-              class="stream-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
-              id="stream_message_retention_custom_input" />
+        <div class="stream-privacy_choices prop-element" id="id_stream_privacy" data-setting-widget-type="radio-group" data-setting-choice-type="string">
+            {{#each stream_privacy_policy_values}}
+                <div class="settings-radio-input-parent">
+                    <label class="radio">
+                        <input type="radio" name="privacy" value="{{ this.code }}" {{#if (eq this.code ../stream_privacy_policy) }}checked{{/if}} />
+                        <b>{{ this.name }}:</b> {{ this.description }}
+                    </label>
+                </div>
+            {{/each}}
         </div>
     </div>
+
+    {{#if ask_to_announce_stream}}
+        <div id="announce-new-stream">
+            {{>announce_stream_checkbox }}
+        </div>
+    {{/if}}
+
+    <div class="default-stream">
+        {{> ../settings/settings_checkbox
+          prefix="id_"
+          setting_name="is_default_stream"
+          is_checked=check_default_stream
+          label=(t "Default channel for new users")
+          help_link="/help/set-default-channels-for-new-users"
+          }}
+    </div>
 </div>
-{{/if}}
+
+<div class="advanced-configurations-container stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
+    <div class="advance-config-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
+        <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
+        <h4 class="stream_setting_subsection_title"><span>{{t 'Advanced configurations' }}</span></h4>
+        {{#if is_stream_edit}}
+            {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
+        {{/if}}
+    </div>
+    <div class="advanced-configurations-collapase-view hide">
+
+        <div class="input-group">
+            <label class="dropdown-title">{{t 'Who can post to the channel?'}}
+                {{> ../help_link_widget link="/help/stream-sending-policy" }}
+            </label>
+            <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
+                {{#each stream_post_policy_values}}
+                    <option value="{{this.code}}" {{#if (eq this.code ../stream_post_policy) }}selected{{/if}}>
+                        {{ this.description}}
+                    </option>
+                {{/each}}
+            </select>
+        </div>
+
+        {{> ../dropdown_widget_with_label
+          widget_name=can_remove_subscribers_setting_widget_name
+          label=(t 'Who can unsubscribe others from this channel?')
+          value_type="number"}}
+
+        {{#if (or is_owner is_stream_edit)}}
+            <div>
+                <div class="input-group inline-block message-retention-setting-group time-limit-setting">
+                    <label class="dropdown-title">{{t "Message retention period" }}
+                        {{> ../help_link_widget link="/help/message-retention-policy" }}
+                    </label>
+
+                    {{> ../settings/upgrade_tip_widget}}
+
+                    <select name="stream_message_retention_setting"
+                      class="stream_message_retention_setting prop-element settings_select bootstrap-focus-style"
+                      id="id_message_retention_days"
+                      data-setting-widget-type="message-retention-setting">
+                        <option value="realm_default">{{t "Use organization level settings {org_level_message_retention_setting}" }}</option>
+                        <option value="unlimited">{{t 'Retain forever' }}</option>
+                        <option value="custom_period">{{t 'Custom' }}</option>
+                    </select>
+
+                    <div class="dependent-settings-block stream-message-retention-days-input">
+                        <label class="inline-block">
+                            {{t 'Retention period (days)' }}:
+                        </label>
+                        <input type="text" autocomplete="off"
+                          name="stream-message-retention-days"
+                          class="stream-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
+                          id="stream_message_retention_custom_input" />
+                    </div>
+                </div>
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -5,43 +5,53 @@
             <div class="alert user_group_create_info"></div>
             <div id="user_group_creating_indicator"></div>
             <div class="user-group-creation-body">
-                <section class="block">
-                    <label for="create_user_group_name" class="settings-field-label">
-                        {{t "User group name" }}
-                    </label>
-                    <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
-                      placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
-                    <div id="user_group_name_error" class="user_group_creation_error"></div>
-                </section>
-                <section class="block">
-                    <label for="create_user_group_description" class="settings-field-label">
-                        {{t "User group description" }}
-                    </label>
-                    <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"
-                      placeholder="{{t 'User group description' }}" value="" autocomplete="off" />
-                </section>
-                <section class="block">
-                    <div class="group-permissions settings-subsection-parent" id="new_group_permission_settings">
-                        <div class="subsection-header">
-                            <h3 class="user_group_setting_subsection_title">{{t "Group permissions" }}
-                            </h3>
-                        </div>
+                <div class="configure_user_group_settings user_group_creation">
+                    <section id="user-group-name-container" class="block">
+                        <label for="create_user_group_name" class="settings-field-label">
+                            {{t "User group name" }}
+                        </label>
+                        <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
+                          placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
+                        <div id="user_group_name_error" class="user_group_creation_error"></div>
+                    </section>
+                    <section id="user-group-description-container" class="block">
+                        <label for="create_user_group_description" class="settings-field-label">
+                            {{t "User group description" }}
+                        </label>
+                        <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"
+                          placeholder="{{t 'User group description' }}" value="" autocomplete="off" />
+                    </section>
+                    <section id="user-group-permission-container" class="block">
+                        <div class="group-permissions settings-subsection-parent" id="new_group_permission_settings">
+                            <div class="subsection-header">
+                                <h3 class="user_group_setting_subsection_title">{{t "Group permissions" }}
+                                </h3>
+                            </div>
 
-                        {{> group_permissions can_mention_group_widget_name="new_group_can_mention_group"}}
-                    </div>
-                </section>
-                <section class="block">
-                    <label for="people_to_add_in_group">
-                        <h4 class="user_group_setting_subsection_title">{{t "Choose members" }}</h4>
-                    </label>
-                    <div id="user_group_membership_error" class="user_group_creation_error"></div>
-                    <div class="controls" id="people_to_add_in_group"></div>
-                </section>
+                            {{> group_permissions can_mention_group_widget_name="new_group_can_mention_group"}}
+                        </div>
+                    </section>
+                </div>
+                <div class="user_group_members_container user_group_creation">
+                    <section id="choose_member_section" class="block">
+                        <label for="people_to_add_in_group">
+                            <h4 class="user_group_setting_subsection_title">{{t "Choose members" }}</h4>
+                        </label>
+                        <div id="user_group_membership_error" class="user_group_creation_error"></div>
+                        <div class="controls" id="people_to_add_in_group"></div>
+                    </section>
+                </div>
             </div>
         </div>
         <div class="settings-sticky-footer">
-            <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-            <button class="finalize_create_user_group button small sea-green rounded" type="submit">{{t "Create" }}</button>
+            <div class="settings-sticky-footer-left">
+                <button id="user_group_go_to_configure_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+            </div>
+            <div class="settings-sticky-footer-right">
+                <button class="create_user_group_cancel button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+                <button class="finalize_create_user_group button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
+                <button id="user_group_go_to_members" class="button small sea-green rounded">{{t "Continue to add members" }}</button>
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
## User group section 

| panel 1 | panel 2 |
| -------- | -------- |
| ![image](https://github.com/zulip/zulip/assets/73663475/cb6b0513-3951-4c7d-8ae2-62d28f1b0cf0) | ![image](https://github.com/zulip/zulip/assets/73663475/1abbadf1-1bf1-426a-8c54-7e6461a033ef)|


-----

## Channel creation section
| panel 1 | panel 2 |
| -------- | -------- |
| ![image](https://github.com/zulip/zulip/assets/73663475/a41b64ab-6c8d-4d6b-b8ee-64bfe595a557) | ![image](https://github.com/zulip/zulip/assets/73663475/d092addf-6a6e-4765-a915-34800f422641) |

- ###  Advance configuration:
| img | img |
| -------- | -------- |
| ![image](https://github.com/zulip/zulip/assets/73663475/8fc8a08d-3c40-471d-a559-7bb196a3a7c3) | ![image](https://github.com/zulip/zulip/assets/73663475/edf94696-9fc4-4e40-ba86-aaa5f3447907) |

-----
### Notes

- The issue description doesn't include a mention of a "Configure Settings" button. While implementing these changes, I realized that users might need to revisit the configuration settings to modify certain details, such as the stream name. Therefore, I added a button for navigating back to the configuration settings when needed.
 
- Also the color of the button should be different I guess please provide feedback on both of this.

-----

Fixes part of #29403.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
