### PR TITLE
compose: Unresolve empty topics followup

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -18,6 +18,7 @@ import * as flatpickr from "./flatpickr";
 import {$t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_view from "./message_view";
+import * as narrow_state from "./narrow_state";
 import * as onboarding_steps from "./onboarding_steps";
 import {page_params} from "./page_params";
 import * as poll_modal from "./poll_modal";
@@ -182,9 +183,23 @@ export function initialize() {
                     // user-triggered edit to that field.
                     $input.trigger("input");
 
-                    // TODO: Probably this should also renarrow to the
-                    // new topic, if we were currently viewing the old
-                    // topic, just as if a message edit had occurred.
+                    // Renarrow to the unresolved topic if currently viewing the resolved topic.
+                    const current_filter = narrow_state.filter();
+                    const channel_name = sub_store.maybe_get_stream_name(stream_id);
+                    if (
+                        current_filter &&
+                        (current_filter.is_conversation_view() ||
+                            current_filter.is_conversation_view_with_near()) &&
+                        current_filter.has_topic(channel_name, topic_name)
+                    ) {
+                        message_view.show(
+                            [
+                                {operator: "channel", operand: channel_name},
+                                {operator: "topic", operand: new_topic},
+                            ],
+                            {},
+                        );
+                    }
                 } else {
                     message_edit.toggle_resolve_topic(message_id, topic_name, true);
                 }


### PR DESCRIPTION
Renarrow to the unresolved topic for better UX.

This PR is a followup to PR #29225. It addresses the TODO comment on that PR:

```
        // TODO: Probably this should also renarrow to the
        // new topic, if we were currently viewing the old
        // topic, just as if a message edit had occurred.
```

When a user tries to send a message to an empty resolved topic, the `Unresolve topic` button marks the topic as unresolved instead of giving an error. (done in #29225).
In this PR, it also renarrows to the now unresolved topic.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

![chrome_0VVQCKzRie](https://github.com/zulip/zulip/assets/88523649/66015a69-8394-4422-a002-218220385429)

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
