### PR TITLE
typeahead: Redesign the function compare_people_for_relevance.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -210,6 +210,20 @@ export function compare_by_pms(user_a: User, user_b: User): number {
         return 1;
     }
 
+    const a_is_partner = pm_conversations.is_partner(user_a.user_id);
+    const b_is_partner = pm_conversations.is_partner(user_b.user_id);
+
+    // This code will never run except in the rare case that one has no
+    // recent DM message history with a user, but does have some older
+    // message history that's outside the "recent messages only"
+    // data set powering people.get_recipient_count.
+    /* istanbul ignore next */
+    if (a_is_partner && !b_is_partner) {
+        return -1;
+    } else if (!a_is_partner && b_is_partner) {
+        return 1;
+    }
+
     if (!user_a.is_bot && user_b.is_bot) {
         return -1;
     } else if (user_a.is_bot && !user_b.is_bot) {

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -565,6 +565,7 @@ test("sort_recipients dup alls direct message", () => {
 
 test("sort_recipients subscribers", () => {
     // b_user_2 is a subscriber and b_user_1 is not.
+    peer_data.add_subscriber(dev_sub.stream_id, b_user_2.user_id);
     const small_matches = [b_user_2, b_user_1];
     const recipients = th.sort_recipients({
         users: small_matches,
@@ -580,6 +581,7 @@ test("sort_recipients subscribers", () => {
 test("sort_recipients pm partners", () => {
     // b_user_3 is a pm partner and b_user_2 is not and
     // both are not subscribed to the stream Linux.
+    pm_conversations.set_partner(b_user_3.user_id);
     const small_matches = [b_user_3, b_user_2];
     const recipients = th.sort_recipients({
         users: small_matches,


### PR DESCRIPTION
typeahead: Redesign the function `compare_people_for_relevance`.

We make the following changes:

- Remove the dm partnership check before calling the comparator passed by the caller, and instead have the more thorough `compare_by_pms` be the final tie breaker. This deprioritization of dms fixes the bug where dm partners would be prioritized even if they had not participated in a stream conversation over recent senders who are not dm partners.

- Make the passed comparator optional, since the tie breaker is same as the comparator that was passed so far for dms, and only pass it in case of a stream conversation.

tests: Add missing setup to typeahead_helper tests passing as a fluke.

typeahead: Add check for all time dm partners to `compare_by_pms`.

For the rare case where there is no recent recipient count for a pair of users when sorting, we now check if either has been a dm conversation partner ever before.

Fixes: [Issue reported on CZO here](https://chat.zulip.org/#narrow/stream/9-issues/topic/typeahead.20priority.20for.20mentions/near/1763643)

**Screenshots and screen captures:**
(conversation participants who are not dm partners at top of suggestions:)
![image](https://github.com/zulip/zulip/assets/68962290/e3a6eba9-a7f5-450e-99d3-7e71b17f0802)

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
