### PR TITLE
scripts: Use Apache Arrow from Groonga repository.

### DIFF
--- a/scripts/setup/apt-repos/zulip/custom.sh
+++ b/scripts/setup/apt-repos/zulip/custom.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
-    arrow_keyring=$(readlink -f "$LIST_PATH/apache-arrow-keyring.gpg")
     pgroonga_apt_sign_key=$(readlink -f "$LIST_PATH/pgroonga-packages.groonga.org.asc")
 
     remove_pgroonga_apt_tmp_dir() {
@@ -32,17 +31,6 @@ if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
             # PGroonga binaries are not yet provided for Ubuntu 24.04.
             exit
         fi
-
-        if [ "$distribution" = debian ] && [ "$release" = bookworm ]; then
-            # As of Debian 12, the Groonga repository depends on the
-            # Apache Arrow repository.
-            arrow_apt_source_deb="apache-arrow-apt-source-latest-$release.deb"
-            arrow_apt_source_deb_sign="$arrow_apt_source_deb.asc"
-            curl -fLO --retry 3 "https://apache.jfrog.io/artifactory/arrow/$distribution/$arrow_apt_source_deb"
-            curl -fLO --retry 3 "https://apache.jfrog.io/artifactory/arrow/$distribution/$arrow_apt_source_deb_sign"
-            gpgv --keyring="$arrow_keyring" "$arrow_apt_source_deb_sign" "$arrow_apt_source_deb"
-        fi
-
         groonga_apt_source_deb="groonga-apt-source-latest-$release.deb"
         groonga_apt_source_deb_sign="$groonga_apt_source_deb.asc.$pgroonga_apt_sign_key_fingerprint"
         curl -fLO --retry 3 "https://packages.groonga.org/$distribution/$groonga_apt_source_deb"
@@ -58,9 +46,6 @@ if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
         #   accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
         chown _apt .
 
-        if [ "$distribution" = debian ] && [ "$release" = bookworm ]; then
-            apt-get -y install "./$arrow_apt_source_deb"
-        fi
         apt-get -y install "./$groonga_apt_source_deb"
     }
     touch "$STAMP_FILE"


### PR DESCRIPTION
This lets us avoid CI failures related to that repository's signing key having expired. See https://github.com/apache/arrow/issues/40744.
