### PR TITLE
invite_user_modal: Replaced email text_area with input_pill

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -102,6 +102,7 @@ EXEMPT_FILES = make_set(
         "web/src/dropdown_widget.ts",
         "web/src/echo.js",
         "web/src/electron_bridge.d.ts",
+        "web/src/email_pill.ts",
         "web/src/emoji_picker.js",
         "web/src/emojisets.ts",
         "web/src/favicon.ts",

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,0 +1,57 @@
+import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
+import * as input_pill from "./input_pill";
+
+type EmailPill = {
+    email: string;
+};
+
+export type EmailPillWidget = InputPillContainer<EmailPill>;
+
+const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function create_item_from_email(
+    email: string,
+    current_items: InputPillItem<EmailPill>[],
+): InputPillItem<EmailPill> | undefined {
+    if (!email_regex.test(email)) {
+        return undefined;
+    }
+
+    const existing_emails = current_items.map((item) => item.email);
+    if (existing_emails.includes(email)) {
+        return undefined;
+    }
+
+    return {
+        type: "email",
+        display_value: email,
+        email,
+    };
+}
+
+export function get_email_from_item(item: InputPillItem<EmailPill>): string {
+    return item.email;
+}
+
+export function get_current_email(
+    pill_container: input_pill.InputPillContainer<EmailPill>,
+): string | null {
+    const current_text = pill_container.getCurrentText();
+    if (current_text !== null && email_regex.test(current_text)) {
+        return current_text;
+    }
+    return null;
+}
+
+export function create_pills(
+    $pill_container: JQuery,
+    pill_config?: InputPillConfig | undefined,
+): input_pill.InputPillContainer<EmailPill> {
+    const pill_container = input_pill.create({
+        $container: $pill_container,
+        pill_config,
+        create_item_from_text: create_item_from_email,
+        get_text_from_item: get_email_from_item,
+    });
+    return pill_container;
+}

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -50,7 +50,7 @@ type InputPillStore<T> = {
     create_item_from_text: InputPillCreateOptions<T>["create_item_from_text"];
     get_text_from_item: InputPillCreateOptions<T>["get_text_from_item"];
     onPillCreate?: () => void;
-    removePillFunction?: (pill: InputPill<T>) => void;
+    onPillRemove?: (pill: InputPill<T>) => void;
     createPillonPaste?: () => void;
 };
 
@@ -214,8 +214,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             if (idx !== undefined) {
                 store.pills[idx].$element.remove();
                 const pill = store.pills.splice(idx, 1);
-                if (store.removePillFunction !== undefined) {
-                    store.removePillFunction(pill[0]);
+                if (store.onPillRemove !== undefined) {
+                    store.onPillRemove(pill[0]);
                 }
 
                 // This is needed to run the "change" event handler registered in
@@ -240,8 +240,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
             if (pill) {
                 pill.$element.remove();
-                if (!quiet && store.removePillFunction !== undefined) {
-                    store.removePillFunction(pill);
+                if (!quiet && store.onPillRemove !== undefined) {
+                    store.onPillRemove(pill);
                 }
             }
         },
@@ -452,7 +452,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         },
 
         onPillRemove(callback) {
-            store.removePillFunction = callback;
+            store.onPillRemove = callback;
         },
 
         createPillonPaste(callback) {

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -43,6 +43,7 @@ type InputPill<T> = {
 };
 
 type InputPillStore<T> = {
+    onTextInputHook?: () => void;
     pills: InputPill<T>[];
     pill_config: InputPillCreateOptions<T>["pill_config"];
     $parent: JQuery;
@@ -72,9 +73,11 @@ export type InputPillContainer<T> = {
     items: () => InputPillItem<T>[];
     onPillCreate: (callback: () => void) => void;
     onPillRemove: (callback: (pill: InputPill<T>) => void) => void;
+    onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
     clear: () => void;
     clear_text: () => void;
+    getCurrentText: () => string | null;
     is_pending: () => boolean;
     _get_pills_for_testing: () => InputPill<T>[];
 };
@@ -107,6 +110,10 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
         clear_text() {
             store.$input.text("");
+        },
+
+        getCurrentText() {
+            return store.$input.text();
         },
 
         is_pending() {
@@ -328,7 +335,6 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
                 return;
             }
-
             const selection = window.getSelection();
             // If no text is selected, and the cursor is just to the
             // right of the last pill (with or without text in the
@@ -364,6 +370,8 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
                 return;
             }
+
+            store.onTextInputHook?.();
         });
 
         // handle events while hovering on ".pill" elements.
@@ -403,7 +411,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
             // get text representation of clipboard
             assert(e.originalEvent instanceof ClipboardEvent);
-            const text = e.originalEvent.clipboardData?.getData("text/plain");
+            const text = e.originalEvent.clipboardData?.getData("text/plain").replaceAll("\n", ",");
 
             // insert text manually
             document.execCommand("insertText", false, text);
@@ -445,6 +453,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         appendValidatedData: funcs.appendValidatedData.bind(funcs),
 
         getByElement: funcs.getByElement.bind(funcs),
+        getCurrentText: funcs.getCurrentText.bind(funcs),
         items: funcs.items.bind(funcs),
 
         onPillCreate(callback) {
@@ -453,6 +462,10 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
         onPillRemove(callback) {
             store.onPillRemove = callback;
+        },
+
+        onTextInputHook(callback) {
+            store.onTextInputHook = callback;
         },
 
         createPillonPaste(callback) {

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -168,7 +168,7 @@ function submit_invitation_form(): void {
                     has_billing_access: current_user.is_owner || current_user.is_billing_admin,
                     daily_limit_reached: response_body.daily_limit_reached,
                 });
-                ui_report.message(error_response, $invite_status, "alert-warning");
+                ui_report.message(error_response, $invite_status, "alert-error");
 
                 if (response_body.sent_invitations) {
                     $invitee_emails.val(invitee_emails_errored.join("\n"));

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -141,6 +141,10 @@
     }
 }
 
+#invitee_emails_container .pill-container {
+    width: 100%;
+}
+
 .deactivated-pill {
     background-color: hsl(0deg 86% 86%) !important;
 }

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -29,7 +29,9 @@
         </div>
         <div id="invitee_emails_container">
             <label for="invitee_emails">{{t "Emails (one on each line or comma-separated)" }}</label>
-            <textarea rows="2" id="invitee_emails" name="invitee_emails" class="invitee_emails" placeholder="{{t 'One or more email addresses...' }}"></textarea>
+            <div class="pill-container">
+                <div class="input" contenteditable="true"></div>
+            </div>
         </div>
     </div>
     <div class="input-group">

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -639,3 +639,40 @@ run_test("appendValue/clear", ({mock_template}) => {
     assert.deepEqual(removed_colors, ["blue", "yellow", "red"]);
     assert.equal($pill_input[0].textContent, "");
 });
+
+run_test("getCurrentText/onTextInputHook", ({mock_template}) => {
+    mock_template("input_pill.hbs", true, (data, html) => {
+        assert.equal(typeof data.display_value, "string");
+        return html;
+    });
+
+    const info = set_up();
+    const config = info.config;
+    const items = info.items;
+    const $pill_input = info.$pill_input;
+    const $container = info.$container;
+
+    const widget = input_pill.create(config);
+    widget.appendValue("blue,red");
+    assert.deepEqual(widget.items(), [items.blue, items.red]);
+
+    const onTextInputHook = () => {
+        assert.deepEqual(widget.items(), [items.blue, items.red]);
+    };
+    widget.onTextInputHook(onTextInputHook);
+
+    $pill_input.text("yellow");
+    assert.equal(widget.getCurrentText(), "yellow");
+
+    const key_handler = $container.get_on_handler("keydown", ".input");
+    key_handler({
+        key: " ",
+        preventDefault: noop,
+    });
+    key_handler({
+        key: ",",
+        preventDefault: noop,
+    });
+
+    assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
+});


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Replaces the "emails" text area in **invite new users modal** with an **input_pill** component.

Implemented email based pills utilizing the /web/src/input_pill.ts component. 

Features:

- Supports pasting comma separated emails
- Allow valid, non-duplicate emails
- Displays errored emails

Fixes: #29391

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>

<summary>Screenshots</summary>

1. Invite new users modal initial state:
   ![Invite Modal](https://github.com/zulip/zulip/assets/78212328/a5ac3be6-68f1-4a11-a04f-a353466b4a6b)

2. Input_pill component with pasted emails:
   ![Input Pill](https://github.com/zulip/zulip/assets/78212328/e0ab757a-bed6-4a38-be90-b0972232c851)

3. Success message on inviting:
   ![Success](https://github.com/zulip/zulip/assets/78212328/07cf5dd9-3186-4407-8965-24bc6f89b675)

4. On server side error:
   ![image](https://github.com/zulip/zulip/assets/78212328/03edfb88-d136-48a6-8e67-079dde940212)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
