### PR TITLE
compose: Redesign the  arrow between stream and topic.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -229,6 +229,7 @@
     --color-compose-embedded-button-background-hover: hsl(
         231deg 100% 90% / 50%
     );
+    --color-compose-chevron-arrow: hsl(0deg 0% 58%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -177,14 +177,10 @@
                little layout shifts with pills. */
             flex: 0 0 auto;
             height: var(--compose-recipient-box-min-height);
-            /* Round up natural width to next whole pixel. */
-            width: 23px;
 
-            .fa-angle-right {
-                font-size: 0.9em;
-                -webkit-text-stroke: 0.05em;
-                align-self: center;
-                margin: 0 5px;
+            .zulip-icon-chevron-right {
+                font-size: 16px;
+                color: var(--color-compose-chevron-arrow);
             }
         }
 
@@ -1176,7 +1172,7 @@ textarea.new_message_textarea,
 
     .zulip-icon-chevron-down {
         padding-left: 5px;
-        color: hsl(0deg 0% 58%);
+        color: var(--color-compose-chevron-arrow);
         font-weight: lighter;
     }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -61,7 +61,7 @@
                             {{> dropdown_widget_wrapper
                               widget_name="compose_select_recipient"}}
                             <div class="topic-marker-container">
-                                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                                <i class="zulip-icon zulip-icon-chevron-right" aria-hidden="true"></i>
                             </div>
                             <div id="compose_recipient_box">
                                 <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />


### PR DESCRIPTION
The icon is now bigger, slimmer in stroke width and has less horizontal spacing around it.

Fixes: part of #28792.

### Screenshots and screen captures:
#### Light Mode
Before:
![image](https://github.com/zulip/zulip/assets/68962290/53f77603-932b-4509-948a-d28942b9b70a)
After:
![image](https://github.com/zulip/zulip/assets/68962290/4252fa91-c30e-4f17-b16e-a48cf01a1fc4)
Demo Design:
![image](https://github.com/zulip/zulip/assets/68962290/bcf108e5-e522-4ab0-a2b5-25c38dfa9f11)

#### Dark Mode:
Before:
![image](https://github.com/zulip/zulip/assets/68962290/93115838-f46d-4a73-8456-c138a9ded7ac)
After:
![image](https://github.com/zulip/zulip/assets/68962290/9fa75bb8-f53d-4825-b3fd-8bb32fc2c171)
Demo Design:
![image](https://github.com/zulip/zulip/assets/68962290/53559790-10bf-410d-9613-ee5e2d503d17)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
