### PR TITLE
css: Fix css styling in "profile-settings-form".

### DIFF
--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -141,7 +141,7 @@ export const update_person = function update(person) {
                 const $custom_user_field = $(
                     `.profile-settings-form .custom_user_field[data-field-id="${CSS.escape(field_id)}"]`,
                 );
-                const $field = $custom_user_field.find(".field");
+                const $field = $custom_user_field.find(".settings-profile-user-field");
                 const $required_symbol = $custom_user_field.find(".required-symbol");
                 if (!field_value) {
                     if (!$field.hasClass("empty-required-field")) {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -482,7 +482,7 @@
         border-width: 1px;
     }
 
-    .field {
+    .settings-profile-user-field {
         border-color: hsl(3deg 73% 74%);
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1924,6 +1924,7 @@ $option_title_width: 180px;
     .settings_textarea,
     .pill-container {
         border-color: hsl(0deg 0% 100%);
+        margin-bottom: 0;
 
         &:focus {
             border-color: hsl(206deg 80% 62% / 80%);


### PR DESCRIPTION
This is a follow-up for #28924 to fix css issues related to border around required custom-profile-fields.

This styling issue occurred after ```.field``` was renamed to ```.settings-profile-user-field``` to make it globally unique but it was left unchanged in some positions. See [here](https://github.com/zulip/zulip/pull/28924#discussion_r1532798749) for discussion.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
|![Screenshot 2024-03-25 144143](https://github.com/zulip/zulip/assets/119798962/24fe7cc7-2f7f-4dd2-bba8-7f846d7aaf6a)|![Screenshot 2024-03-25 121331](https://github.com/zulip/zulip/assets/119798962/31996288-e7cf-4f3f-8b20-69a2a4d1c280)|
|![Screenshot 2024-03-25 144502](https://github.com/zulip/zulip/assets/119798962/9eb1cf00-aa1d-4a5a-aa09-dd1933ae4d75)|![Screenshot 2024-03-25 121347](https://github.com/zulip/zulip/assets/119798962/3f76f6a1-034a-496c-8649-5320136cd49e)| 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
