### PR TITLE
adding pasting documentation to the keyboard-shortcats.md

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -23,6 +23,9 @@ in the Zulip app to add more to your repertoire as needed.
   stream.
 
 * **New direct message**: <kbd>X</kbd>
+  * **Paste formatted text**: <kbd>Ctrl/Cmd + V</kbd> — Paste text with formatting.
+  * **Paste as plain text**: <kbd>Ctrl+Shift+V</kbd> (or <kbd>Command-Option-Shift-V</kbd> on a Mac) — Paste text without formatting.
+
 
 * **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
   <kbd>[</kbd> — Close the compose box and save the unsent message as a


### PR DESCRIPTION
 This pull request addresses the issue #29209, which requests adding documentation for copy-pasting into the Zulip help center. The goal is to document the two ways of pasting into Zulip: pasting formatted text (Ctrl/Cmd + V) and pasting as plain text (Ctrl+Shift+V / Command-Option-Shift-V on a Mac).


Fixes:  (https://github.com/zulip/zulip/issues/29209)

