### PR TITLE
docs: Update documentation on narrows to include ``is:unread``

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -45,6 +45,12 @@ operator, search the current user's personal message history. See
 [searching shared history](/help/search-for-messages#searching-shared-history)
 for details.
 
+Clients should note that the `is:unread` filter takes advantage of the
+fact that there is a database index for unread messages, which can be an
+important optimization when fetching messages in certain cases (e.g.
+when [adding the `read` flag to a user's personal
+messages](/api/update-message-flags-for-narrow)).
+
 **Changes**: In Zulip 7.0 (feature level 177), support was added
 for three filters related to direct messages: `is:dm`, `dm` and
 `dm-including`. The `dm` operator replaced and deprecated the

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7043,6 +7043,11 @@ paths:
                     The narrow you want update flags within. See how to
                     [construct a narrow](/api/construct-narrow).
 
+                    Note that, when adding the `read` flag to messages, clients should
+                    consider including a narrow with the `is:unread` filter as an
+                    optimization. Including that filter takes advantage of the fact that
+                    the server has a database index for unread messages.
+
                     **Changes**: In Zulip 7.0 (feature level 177), narrows gained support
                     for three new filters related to direct messages: `is:dm`, `dm` and
                     `dm-including`; replacing and deprecating `is:private`, `pm-with` and


### PR DESCRIPTION
``is:unread`` is an important feature which offers an alternative to searching in narrows, and I have included it in documentation on [personal message flags](https://zulip.com/api/update-message-flags-for-narrow) and [narrow construction](https://zulip.com/api/construct-narrow) related to narrows.

Here are pictures of what they would look like now:
![image](https://github.com/zulip/zulip/assets/87673068/f8b16571-da0c-4114-bb93-478fece0e905)
![image](https://github.com/zulip/zulip/assets/87673068/faf95a68-bd57-4289-aa98-278cbef54cc4)



fixes #28328.