### PR TITLE
Revert "ci: Disable 8.0 upgrade suite to unbreak CI."

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -262,10 +262,9 @@ jobs:
           - docker_image: zulip/ci:bookworm-7.0
             name: 7.0 Version Upgrade
             os: bookworm
-          # Temporarily disabled so CI passes pending https://github.com/apache/arrow/issues/40744.
-          # - docker_image: zulip/ci:bookworm-8.0
-          #   name: 8.0 Version Upgrade
-          #   os: bookworm
+          - docker_image: zulip/ci:bookworm-8.0
+            name: 8.0 Version Upgrade
+            os: bookworm
 
     name: ${{ matrix.name  }}
     container:


### PR DESCRIPTION
This reverts commit 51773d55ed1b71bb1e679997e283109513d213ed.

Supposedly https://github.com/apache/arrow/issues/40744 is fixed.

