### PR TITLE
Fix DM row highlight linger in left siderbar.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -146,6 +146,7 @@ export function handle_narrow_activated(filter: Filter): void {
     const active_filter = filter;
     const is_all_private_message_view = _.isEqual(active_filter.sorted_term_types(), ["is-dm"]);
     const narrow_to_private_messages_section = active_filter.operands("dm").length !== 0;
+    const is_private_messages_in_view = active_filter.has_operator("dm");
 
     if (is_all_private_message_view) {
         // In theory, this should get expanded when we scroll to the
@@ -165,6 +166,8 @@ export function handle_narrow_activated(filter: Filter): void {
             );
             scroll_pm_into_view($active_filter_li);
         }
+        update_private_messages();
+    } else if (!is_private_messages_in_view) {
         update_private_messages();
     }
 }

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -69,17 +69,17 @@ export function show(opts) {
         return;
     }
 
-    // Hide selected elements in the left sidebar.
-    opts.highlight_view_in_left_sidebar();
-    stream_list.handle_message_view_deactivated();
-    pm_list.handle_message_view_deactivated();
-
     // Hide "middle-column" which has html for rendering
     // a messages narrow. We hide it and show the view.
     $("#message_feed_container").hide();
     opts.$view.show();
     message_lists.update_current_message_list(undefined);
     opts.set_visible(true);
+
+    // Hide selected elements in the left sidebar.
+    opts.highlight_view_in_left_sidebar();
+    stream_list.handle_message_view_deactivated();
+    pm_list.handle_message_view_deactivated();
 
     unread_ui.hide_unread_banner();
     opts.update_compose();


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the behaviour of DM row highlight lingering on view changed.

PR fixes two sub issues

- When user navigates away from selected DM row to recents or inbox, the dm remains highlighted because `update_private_message` builds the dm list again from `pm_list_data` with `is_active` set as true for the last DM which should actually be set to false. `get_active_user_ids_string()` is returning last selected DM row since `message_lists.current` wasn't updating to return `undefined`. We fix it by updating `current` before updating the DM list again.
- When the user navigates away to other left sidebar narrows, the DM highlight lingers as the `handle_narrow_activated` isn't calling `update_private_message`. We fix it by updating the dm list again on unnarrowed.


Fixes: zulip#27698.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 26-03-24 02:01:23 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/e31dac61-3384-424a-9aaa-bfccc56490bb)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
