### PR TITLE
landing_navbar: Add `Semsee` case study link in mobile navbar.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -7,6 +7,7 @@
 {% endif %}
 
 {% if not isolated_page %}
+<!-- We have separate copies of the navbar list for web and mobile. Please update both the versions when making changes. -->
 <nav class="top-menu">
     <div class="top-menu-container">
         <a class="top-menu-logo nav-zulip-logo" href="https://zulip.com" tabindex="1"></a>
@@ -73,7 +74,7 @@
                                 </a>
                             </li>
                             <li class="top-menu-submenu-list-item">
-                                <a href="/case-studies/semsee/">
+                                <a href="https://zulip.com/case-studies/semsee/">
                                 More efficient communication than Slack at Semsee
                                 </a>
                             </li>
@@ -181,6 +182,7 @@
     <div id='top-menu-submenu-backdrop' class="top-menu-submenu-backdrop"></div>
     <label class="top-menu-tab-label-unselect nav-menu-label" for="top-menu-tab-close" tabindex="0"></label>
 </nav>
+<!-- We have separate copies of the navbar list for web and mobile. Please update both the versions when making changes. -->
 <details class="top-menu-mobile">
     <summary class="top-menu-mobile-summary">
         <a class="top-menu-logo nav-zulip-logo" href="https://zulip.com"></a>
@@ -238,6 +240,11 @@
                     <li class="top-menu-submenu-list-item">
                         <a href="https://zulip.com/case-studies/end-point/">
                         Managing hundreds of projects at End Point Dev
+                        </a>
+                    </li>
+                    <li class="top-menu-submenu-list-item">
+                        <a href="https://zulip.com/case-studies/semsee/">
+                        More efficient communication than Slack at Semsee
                         </a>
                     </li>
                     <li class="top-menu-submenu-list-item">


### PR DESCRIPTION
This was missed in #29019.

![image](https://github.com/zulip/zulip/assets/25124304/64a87db1-9e56-426b-8028-e355317ac7ea)
