### PR TITLE
kandra: Enable per-object metrics from rabbitmq.

### DIFF
--- a/puppet/kandra/manifests/prometheus/rabbitmq.pp
+++ b/puppet/kandra/manifests/prometheus/rabbitmq.pp
@@ -10,5 +10,10 @@ class kandra::prometheus::rabbitmq {
     unless  => 'grep -q rabbitmq_prometheus /etc/rabbitmq/enabled_plugins',
     require => Service['rabbitmq-server'],
   }
+  exec { 'enable rabbitmq-prometheus-per-metric':
+    command => "rabbitmqctl eval 'application:set_env(rabbitmq_prometheus, return_per_object_metrics, true).'",
+    unless  => "rabbitmqctl eval 'application:get_env(rabbitmq_prometheus, return_per_object_metrics).' | grep -q true",
+    require => Exec['enable rabbitmq-prometheus'],
+  }
   kandra::firewall_allow { 'rabbitmq': port => '15692' }
 }


### PR DESCRIPTION
These default to off, because in situations with thousands of queues, consumers, and producers, they cause unreasonable overhead.  Our use case has few enough queues that we do want to be able to inspect them individually.

Enable per-object Prometheus metrics, per [1].

[1]: https://github.com/rabbitmq/rabbitmq-server/tree/78851828ecd1dddab2c890aaedfed7d6559dcd6e/deps/rabbitmq_prometheus#configuration

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
