### PR TITLE
Make more use of `bulk_insert_all_ums`, removing race conditions

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -67,24 +67,6 @@ MAX_NUM_ONBOARDING_UNREAD_MESSAGES = 20
 # several weeks old and still be a good place to start.
 ONBOARDING_RECENT_TIMEDELTA = timedelta(weeks=12)
 
-DEFAULT_HISTORICAL_FLAGS = UserMessage.flags.historical | UserMessage.flags.read
-
-
-def create_historical_user_messages(
-    *, user_id: int, message_ids: Iterable[int], flags: int = DEFAULT_HISTORICAL_FLAGS
-) -> None:
-    # Users can see and interact with messages sent to streams with
-    # public history for which they do not have a UserMessage because
-    # they were not a subscriber at the time the message was sent.
-    # In order to add emoji reactions or mutate message flags for
-    # those messages, we create UserMessage objects for those messages;
-    # these have the special historical flag which keeps track of the
-    # fact that the user did not receive the message at the time it was sent.
-    UserMessage.objects.bulk_create(
-        UserMessage(user_profile_id=user_id, message_id=message_id, flags=flags)
-        for message_id in message_ids
-    )
-
 
 def send_message_to_signup_notification_stream(
     sender: UserProfile, realm: Realm, message: str

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -338,8 +338,9 @@ def do_update_message_flags(
 
             create_historical_user_messages(
                 user_id=user_profile.id,
-                message_ids=historical_message_ids,
-                flags=(DEFAULT_HISTORICAL_FLAGS & ~flagattr) | flag_target,
+                message_ids=list(historical_message_ids),
+                flagattr=flagattr,
+                flag_target=flag_target,
             )
 
         to_update = UserMessage.objects.filter(

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -8,7 +8,6 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
-from zerver.actions.create_user import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import (
     bulk_access_messages,
@@ -18,6 +17,7 @@ from zerver.lib.message import (
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.stream_subscription import get_subscribed_stream_recipient_ids_for_user
 from zerver.lib.topic import filter_by_topic_name_via_message
+from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import Message, Recipient, UserMessage, UserProfile
 from zerver.tornado.django_api import send_event
 

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 
-from zerver.actions.create_user import create_historical_user_messages
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
 from zerver.lib.exceptions import ReactionExistsError
@@ -13,6 +12,7 @@ from zerver.lib.message import (
 from zerver.lib.message_cache import update_message_cache
 from zerver.lib.stream_subscription import subscriber_ids_with_stream_history_access
 from zerver.lib.streams import access_stream_by_id
+from zerver.lib.user_message import create_historical_user_messages
 from zerver.models import Message, Reaction, Recipient, Stream, UserMessage, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 


### PR DESCRIPTION
Helps with #22396, by making it faster and not causing user-visible 500's during login.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
