### PR TITLE
tooltips: Hide scroll button tooltip under transition.

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -183,7 +183,7 @@ export function initialize() {
     // this button is finished. This is necessary because the fading animation
     // confuses Tippy's built-in `data-reference-hidden` feature.
     $show_scroll_to_bottom_button.on("transitionend", (e) => {
-        if (e.propertyName === "visibility") {
+        if (e.originalEvent.propertyName === "visibility") {
             const tooltip = $("#scroll-to-bottom-button-clickable-area")[0]._tippy;
             // make sure the tooltip exists and the class is not currently showing
             if (tooltip && !$show_scroll_to_bottom_button.hasClass("show")) {


### PR DESCRIPTION
This PR fixes the bug where the scroll button tooltip does not hide even after the button is dissapeared. This is because the fading animation confuses the `data-referrence-hidden` property of tippy.

This issue has been resolved in #29253. But presently the jquery wraps the native event object in it's own event object as a wrapper. Hence we would need to bypass the jquery wrapper to access a specific property.
This PR uses the `originalEvent` key to bypass the jquery wrapper and directly access the `propertyName` property from the jquery event object.

Fixes: #28656

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screen Recording 2024-03-26 at 10 43 43 PM](https://github.com/zulip/zulip/assets/97145463/4ecb75b1-74b1-4fa1-bdab-1393d2a0cf6d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
