### PR TITLE
compose: Scroll cursor at message's end into view when restoring draft.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -302,11 +302,12 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
         opts.private_message_recipient.replaceAll(/,\s*/g, ", "),
     );
 
-    // If the user opens the compose box, types some text, and then clicks on a
-    // different stream/topic, we want to keep the text in the compose box
     if (opts.content !== undefined) {
         compose_ui.insert_and_scroll_into_view(opts.content, $("textarea#compose-textarea"), true);
         $(".compose_control_button_container:has(.add-poll)").addClass("disabled-on-hover");
+        // If we were provided with message content, we might need to
+        // display that it's too long.
+        compose_validate.check_overflow_text();
     }
 
     compose_state.set_message_type(opts.message_type);
@@ -316,12 +317,6 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
 
     if (opts.draft_id) {
         $("textarea#compose-textarea").data("draft-id", opts.draft_id);
-    }
-
-    if (opts.content !== undefined) {
-        // If we were provided with message content, we might need to
-        // display that it's too long.
-        compose_validate.check_overflow_text();
     }
 
     const $clear_topic_button = $("#recipient_box_clear_topic_button");

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -305,7 +305,7 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
     // If the user opens the compose box, types some text, and then clicks on a
     // different stream/topic, we want to keep the text in the compose box
     if (opts.content !== undefined) {
-        compose_state.message_content(opts.content);
+        compose_ui.insert_and_scroll_into_view(opts.content, $("textarea#compose-textarea"), true);
         $(".compose_control_button_container:has(.add-poll)").addClass("disabled-on-hover");
     }
 
@@ -320,8 +320,7 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
 
     if (opts.content !== undefined) {
         // If we were provided with message content, we might need to
-        // resize the compose box, or display that it's too long.
-        compose_ui.autosize_textarea($("textarea#compose-textarea"));
+        // display that it's too long.
         compose_validate.check_overflow_text();
     }
 

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -124,6 +124,10 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     let compose_defaults;
     override(narrow_state, "set_compose_defaults", () => compose_defaults);
+    override(compose_ui, "insert_and_scroll_into_view", (content, $textarea, replace_all) => {
+        $textarea.val(content);
+        assert.ok(replace_all);
+    });
 
     // Start stream message
     compose_defaults = {


### PR DESCRIPTION
When a long message is restored from a draft (or scheduled messages), its end, and the cursor placed there, used to be out of view, giving the impression that the message was not focused, when it actually was.

This is fixed by always scrolling the cursor into view.

Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/position.20when.20restoring.20draft/near/1756940)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
