### PR TITLE
Improve sort order for @-mention typeahead

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -515,7 +515,11 @@ export function get_person_suggestions(query, opts) {
         // Exclude muted users from typeaheads.
         persons = muted_users.filter_muted_users(persons);
 
-        if (opts.want_broadcast) {
+        if (opts.want_broadcast && query !== "") {
+            // We don't want to show wildcards when user types: `@` in the
+            // composebox. It should be shown when relevant text is typed.
+            // This will make sure that wildcards are used only when user
+            // intends and we are not encouraging when user types: `@`.
             persons = [...persons, ...broadcast_mentions()];
         }
 

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -411,7 +411,10 @@ export function broadcast_mentions() {
         is_broadcast: true,
 
         // used for sorting
-        idx,
+        //
+        // We can safely assume that no user will ever have any
+        // negative user_id, so there is no risk of conflict.
+        user_id: -(wildcard_mention_array.length - idx),
     }));
 }
 

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1366,8 +1366,9 @@ export function get_mention_syntax(full_name: string, user_id: number, silent: b
     }
     if (
         (is_duplicate_full_name(full_name) || full_name_matches_wildcard_mention(full_name)) &&
-        user_id
+        user_id > 0
     ) {
+        // user_id > 0 => filters out the wildcards.
         mention += `|${user_id}`;
     }
     mention += "**";

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -239,7 +239,7 @@ export function compare_people_for_relevance(
     if (compose_state.get_message_type() !== "private") {
         if (person_a.is_broadcast) {
             if (person_b.is_broadcast) {
-                return person_a.idx - person_b.idx;
+                return person_a.user_id - person_b.user_id;
             }
             return -1;
         } else if (person_b.is_broadcast) {
@@ -248,7 +248,7 @@ export function compare_people_for_relevance(
     } else {
         if (person_a.is_broadcast) {
             if (person_b.is_broadcast) {
-                return person_a.idx - person_b.idx;
+                return person_a.user_id - person_b.user_id;
             }
             return 1;
         } else if (person_b.is_broadcast) {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -5,7 +5,6 @@ import * as typeahead from "../shared/src/typeahead";
 import render_typeahead_list_item from "../templates/typeahead_list_item.hbs";
 
 import * as buddy_data from "./buddy_data";
-import * as compose_state from "./compose_state";
 import * as people from "./people";
 import type {PseudoMentionUser, User} from "./people";
 import * as pm_conversations from "./pm_conversations";
@@ -215,7 +214,7 @@ export function compare_by_pms(user_a: User, user_b: User): number {
     } else if (user_a.is_bot && !user_b.is_bot) {
         return 1;
     }
-
+    
     // We use alpha sort as a tiebreaker, which might be helpful for
     // new users.
     if (user_a.full_name < user_b.full_name) {
@@ -226,53 +225,102 @@ export function compare_by_pms(user_a: User, user_b: User): number {
     return 1;
 }
 
+// TODO: Possibly rename function
 export function compare_people_for_relevance(
     person_a: UserOrMention,
     person_b: UserOrMention,
     tertiary_compare: (user_a: User, user_b: User) => number,
     current_stream_id?: number,
-): number {
+    ): number {
+    /**
+     * Typeahead sorting for stream-topic conversations
+     * has the order of priority is as follows:
+     *
+     * 1. Users who have sent messages to the current topic
+     *    over those who haven't sent to the current topic.
+     * 2. Users who have sent messages to the current stream
+     *    over those who haven't sent to the current stream.
+     * 3. Subscribers over non-subscribers.
+     * 4. Users have PMed with over users haven't PMed with.
+     * 5. Current user interaction with the rest of the users.
+     *
+     * Wildcards are given the following preference over:
+     * - non-subscribers
+     * - users who have not participated in topics
+     * - and the users with whom the current user hasn't PMed.
+     */
     // give preference to "all", "everyone" or "stream"
     // We use is_broadcast for a quick check.  It will
     // true for all/everyone/stream and undefined (falsy)
     // for actual people.
-    if (compose_state.get_message_type() !== "private") {
-        if (person_a.is_broadcast) {
-            if (person_b.is_broadcast) {
-                return person_a.user_id - person_b.user_id;
-            }
-            return -1;
-        } else if (person_b.is_broadcast) {
-            return 1;
-        }
-    } else {
-        if (person_a.is_broadcast) {
-            if (person_b.is_broadcast) {
-                return person_a.user_id - person_b.user_id;
-            }
-            return 1;
-        } else if (person_b.is_broadcast) {
-            return -1;
-        }
-    }
+    // TODO: merge conflict + old convention start
+    // if (compose_state.get_message_type() !== "private") {
+    //     if (person_a.is_broadcast) {
+    //         if (person_b.is_broadcast) {
+    //             return person_a.user_id - person_b.user_id;
+    //         }
+    //         return -1;
+    //     } else if (person_b.is_broadcast) {
+    //         return 1;
+    //     }
+    // } else {
+    //     if (person_a.is_broadcast) {
+    //         if (person_b.is_broadcast) {
+    //             return person_a.user_id - person_b.user_id;
+    //         }
+    //         return 1;
+    //     } else if (person_b.is_broadcast) {
+    //         return -1;
+    //     }
+    // }
 
-    // Now handle actual people users.
+    const a_is_sub = stream_data.is_user_subscribed(current_stream_id, person_a.user_id);
+    const b_is_sub = stream_data.is_user_subscribed(current_stream_id, person_b.user_id);
 
-    // give preference to subscribed users first
-    if (current_stream_id !== undefined) {
-        const a_is_sub = stream_data.is_user_subscribed(current_stream_id, person_a.user_id);
-        const b_is_sub = stream_data.is_user_subscribed(current_stream_id, person_b.user_id);
+    const a_is_sender_to_current_topic =
+        recent_senders.max_id_for_stream_topic_sender({
+            stream_id: current_stream_id,
+            topic: current_topic,
+            sender_id: person_a.user_id,
+        }) !== -1;
+    const b_is_sender_to_current_topic =
+        recent_senders.max_id_for_stream_topic_sender({
+            stream_id: current_stream_id,
+            topic: current_topic,
+            sender_id: person_b.user_id,
+        }) !== -1;
 
-        if (a_is_sub && !b_is_sub) {
-            return -1;
-        } else if (!a_is_sub && b_is_sub) {
-            return 1;
-        }
-    }
-
-    // give preference to direct message partners if both (are)/(are not) subscribers
+    // Give preference to pm partners if both (are)/(are not) subscribers.
     const a_is_partner = pm_conversations.is_partner(person_a.user_id);
     const b_is_partner = pm_conversations.is_partner(person_b.user_id);
+
+    // Handle wildcards
+    if (person_a.is_broadcast && person_b.is_broadcast) {
+        return person_a.user_id - person_b.user_id;
+    } else if (person_a.is_broadcast) {
+        if (!b_is_sender_to_current_topic || !b_is_sub || !b_is_partner) {
+            return -1;
+        }
+        return 1;
+    } else if (person_b.is_broadcast) {
+        if (!a_is_sender_to_current_topic || !a_is_sub || !a_is_partner) {
+            return 1;
+        }
+        return -1;
+    }
+
+    // Calls recent_senders.compare_by_recency
+    // Sort by recent senders in the topic (first preference) and stream (last preference).
+    const compare_value = tertiary_compare(person_a, person_b);
+    if (compare_value !== 0) {
+        return compare_value;
+    }
+
+    if (a_is_sub && !b_is_sub) {
+        return -1;
+    } else if (!a_is_sub && b_is_sub) {
+        return 1;
+    }
 
     if (a_is_partner && !b_is_partner) {
         return -1;
@@ -280,14 +328,85 @@ export function compare_people_for_relevance(
         return 1;
     }
 
+    return person_a.user_id - person_b.user_id;
+}
+// TODO: merge conflict end. old convention continues
+
+export function compare_people_for_pm_message(person_a, person_b, tertiary_compare) {
+    /**
+     * Typeahead sorting for PM conversations has the order of priority as follows:
+     * 1. Users who have PMed with each other over those who haven't.
+     * 2. Recipients with higher counts.
+     * 3. Normal users over bots.
+     * 4. Users with shorter names over those with longer names.
+     *
+     * Wildcards are given the following preference over the users with whom the current user hasn't PMed.
+     */
+
+    const a_is_partner = pm_conversations.is_partner(person_a.user_id);
+    const b_is_partner = pm_conversations.is_partner(person_b.user_id);
+
+    // Handle wildcards
+    if (person_a.is_broadcast && person_b.is_broadcast) {
+        return person_a.user_id - person_b.user_id;
+    } else if (person_a.is_broadcast) {
+        if (!b_is_partner) {
+            return -1;
+        }
+        return 1;
+    } else if (person_b.is_broadcast) {
+        if (!a_is_partner) {
+            return 1;
+        }
+        return -1;
+    }
+
+    if (a_is_partner && !b_is_partner) {
+        return -1;
+    } else if (!a_is_partner && b_is_partner) {
+        return 1;
+    }
+
+    // Calls compare_by_pms.
     return tertiary_compare(person_a, person_b);
 }
 
+// TODO: possibly rename function
 export function sort_people_for_relevance(
     objs: UserOrMention[],
     current_stream_id: number,
     current_topic: string,
 ): UserOrMention[] {
+export function compare_people_for_relevance(
+    person_a,
+    person_b,
+    tertiary_compare,
+    current_stream_id,
+    current_topic,
+) {
+    // It is very unlikely that user will try to mention themselves,
+    // so we keep the current user to the end of the list.
+    if (people.is_current_user(person_a.email)) {
+        return 1;
+    }
+
+    if (people.is_current_user(person_b.email)) {
+        return -1;
+    }
+
+    if (current_stream_id !== undefined) {
+        return compare_people_for_stream_message(
+            person_a,
+            person_b,
+            tertiary_compare,
+            current_stream_id,
+            current_topic,
+        );
+    }
+    return compare_people_for_pm_message(person_a, person_b, tertiary_compare);
+}
+
+export function sort_people_for_relevance(objs, current_stream_name, current_topic) {
     // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
     let current_stream = null;
     if (current_stream_id) {
@@ -298,20 +417,19 @@ export function sort_people_for_relevance(
             compare_people_for_relevance(person_a, person_b, compare_by_pms),
         );
     } else {
-        objs.sort((person_a, person_b) =>
-            compare_people_for_relevance(
+        const stream_id = current_stream.stream_id;
+
+        objs.sort((person_a, person_b) => {
+            const res = compare_people_for_relevance(
                 person_a,
                 person_b,
                 (user_a, user_b) =>
-                    recent_senders.compare_by_recency(
-                        user_a,
-                        user_b,
-                        current_stream_id,
-                        current_topic,
-                    ),
-                current_stream_id,
-            ),
-        );
+                    recent_senders.compare_by_recency(user_a, user_b, stream_id, current_topic),
+                stream_id,
+                current_topic,
+            );
+            return res;
+        });
     }
 
     return objs;

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1752,7 +1752,7 @@ test("typeahead_results", () => {
     assert_mentions_matches("oor ", []);
     assert_mentions_matches("oor o", []);
     assert_mentions_matches("oor of venice", []);
-    assert_mentions_matches("King ", [hamlet, lear]);
+    assert_mentions_matches("King ", [lear, hamlet]);
     assert_mentions_matches("King H", [hamlet]);
     assert_mentions_matches("King L", [lear]);
     assert_mentions_matches("delia lear", []);

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -443,7 +443,7 @@ test("sort_recipients all mention", () => {
     const all_obj = ct.broadcast_mentions()[0];
     assert.equal(all_obj.email, "all");
     assert.equal(all_obj.is_broadcast, true);
-    assert.equal(all_obj.idx, 0);
+    assert.equal(all_obj.user_id, -3);
 
     // Test person email is "all" or "everyone"
     const test_objs = [...matches, all_obj];


### PR DESCRIPTION
Completion for #19554 
Fixes #26838 

Rebased onto main and partially resolved some merge conflicts. Working on updating changes in the previous PR to adhere to the typescript conventions and changes over the year. 

This PR is **not** currently ready for preliminary review.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
