### PR TITLE
i18n-test: Update translated strings in test_email_translation.

### DIFF
--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -24,7 +24,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         def check_translation(phrase: str, request_type: str, *args: Any, **kwargs: Any) -> None:
             if request_type == "post":
                 self.client_post(*args, **kwargs)
-            elif request_type == "patch":  # nocoverage: see comment below
+            elif request_type == "patch":
                 self.client_patch(*args, **kwargs)
 
             email_message = mail.outbox[0]
@@ -43,10 +43,12 @@ class EmailTranslationTestCase(ZulipTestCase):
         invite_expires_in_minutes = 2 * 24 * 60
         self.login_user(hamlet)
 
-        # TODO: Uncomment and replace with translation once we have German translations for the strings
-        # in confirm_new_email.txt.
-        # Also remove the "nocoverage" from check_translation above.
-        # check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
+        check_translation(
+            "Wir haben eine Anfrage erhalten",
+            "patch",
+            "/json/settings",
+            {"email": "hamlets-new@zulip.com"},
+        )
         check_translation(
             "Incrível!",
             "post",
@@ -70,9 +72,7 @@ class EmailTranslationTestCase(ZulipTestCase):
 
         with self.settings(DEVELOPMENT_LOG_EMAILS=True):
             enqueue_welcome_emails(hamlet)
-        # TODO: Uncomment and replace with translation once we have German translations for the strings
-        # in account_registered emails.
-        # check_translation("Viele Grüße", "")
+        check_translation("Hier findest du einige Tipps", "")
 
 
 class TranslationTestCase(ZulipTestCase):


### PR DESCRIPTION
Updates the check email translation test for updated email text in confirm_new_email.html and onboarding_zulip_topics.html for current translated strings in German.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
