### PR TITLE
right_sidebar: Hide underline from user-list toggle button in navbar.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -19,14 +19,11 @@ export let right_sidebar_expanded_as_overlay = false;
 
 export function hide_userlist_sidebar(): void {
     $(".app-main .column-right").removeClass("expanded");
-    $("body").removeClass("right-sidebar-expanded");
     right_sidebar_expanded_as_overlay = false;
 }
 
 export function show_userlist_sidebar(): void {
-    // TODO: Refactor to only use class added to body.
     $(".app-main .column-right").addClass("expanded");
-    $("body").addClass("right-sidebar-expanded");
     resize.resize_page_components();
     right_sidebar_expanded_as_overlay = true;
 }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -300,13 +300,6 @@ $user_status_emoji_width: 24px;
     }
 }
 
-/* This makes a play on specificity for displaying box-shadow. */
-#userlist-toggle-button,
-body.right-sidebar-expanded #userlist-toggle-button {
-    /* Same color as icon but a bit darker. */
-    box-shadow: inset 0 -2px 0 hsl(241.36deg 27.48% 37.73%);
-}
-
 .right-sidebar-items:first-of-type #userlist-header {
     border-top: none;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2453,10 +2453,6 @@ select.invite-as {
             }
         }
     }
-
-    #userlist-toggle-button {
-        box-shadow: none;
-    }
 }
 
 .hide-right-sidebar {


### PR DESCRIPTION
![image](https://github.com/zulip/zulip/assets/25124304/dcbed7d7-e034-4d31-b695-1864366edc45)
![image](https://github.com/zulip/zulip/assets/25124304/9f5159a5-09aa-424c-b100-a70fe9481bee)

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/Hide.20right.20sidebar