### PR TITLE
user_topic_popover: Use new sliding tab for topic visibility switcher.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -97,6 +97,14 @@ export function get_topic_menu_popover(): tippy.Instance | null {
     return popover_instances.topics_menu;
 }
 
+export function is_topic_menu_popover_displayed(): boolean | undefined {
+    return popover_instances.topics_menu?.state.isVisible;
+}
+
+export function is_visibility_policy_popover_displayed(): boolean | undefined {
+    return popover_instances.change_visibility_policy?.state.isVisible;
+}
+
 export function get_scheduled_messages_popover(): tippy.Instance | null {
     return popover_instances.send_later;
 }

--- a/web/src/topic_popover.js
+++ b/web/src/topic_popover.js
@@ -108,42 +108,6 @@ export function initialize() {
                     );
                 });
 
-                $popper.one("click", ".sidebar-popover-unmute-topic", () => {
-                    user_topics.set_user_topic_visibility_policy(
-                        stream_id,
-                        topic_name,
-                        user_topics.all_visibility_policies.UNMUTED,
-                    );
-                    popover_menus.hide_current_popover_if_visible(instance);
-                });
-
-                $popper.one("click", ".sidebar-popover-remove-unmute", () => {
-                    user_topics.set_user_topic_visibility_policy(
-                        stream_id,
-                        topic_name,
-                        user_topics.all_visibility_policies.INHERIT,
-                    );
-                    popover_menus.hide_current_popover_if_visible(instance);
-                });
-
-                $popper.one("click", ".sidebar-popover-mute-topic", () => {
-                    user_topics.set_user_topic_visibility_policy(
-                        stream_id,
-                        topic_name,
-                        user_topics.all_visibility_policies.MUTED,
-                    );
-                    popover_menus.hide_current_popover_if_visible(instance);
-                });
-
-                $popper.one("click", ".sidebar-popover-remove-mute", () => {
-                    user_topics.set_user_topic_visibility_policy(
-                        stream_id,
-                        topic_name,
-                        user_topics.all_visibility_policies.INHERIT,
-                    );
-                    popover_menus.hide_current_popover_if_visible(instance);
-                });
-
                 $popper.one("click", ".sidebar-popover-unstar-all-in-topic", () => {
                     starred_messages_ui.confirm_unstar_all_messages_in_topic(
                         Number.parseInt(stream_id, 10),

--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -49,10 +49,7 @@ export function initialize() {
             }
 
             // TODO: Figure out a good way to offer feedback if this request fails.
-            $popper.on("click", ".visibility_policy_option", (e) => {
-                $(".visibility_policy_option").removeClass("selected_visibility_policy");
-                $(e.currentTarget).addClass("selected_visibility_policy");
-
+            $popper.on("change", "input[name='visibility-policy-select']", (e) => {
                 const visibility_policy = $(e.currentTarget).attr("data-visibility-policy");
                 user_topics.set_user_topic_visibility_policy(
                     stream_id,

--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -6,6 +6,7 @@ import * as popover_menus from "./popover_menus";
 import * as popover_menus_data from "./popover_menus_data";
 import {parse_html} from "./ui_util";
 import * as user_topics from "./user_topics";
+import * as util from "./util";
 
 export function initialize() {
     popover_menus.register_popover_menu(".change_visibility_policy", {
@@ -50,13 +51,30 @@ export function initialize() {
 
             // TODO: Figure out a good way to offer feedback if this request fails.
             $popper.on("change", "input[name='visibility-policy-select']", (e) => {
-                const visibility_policy = $(e.currentTarget).attr("data-visibility-policy");
+                const start_time = Date.now();
+                const visibility_policy = Number.parseInt(
+                    $(e.currentTarget).attr("data-visibility-policy"),
+                    10,
+                );
+
+                const success_cb = () => {
+                    setTimeout(
+                        () => {
+                            popover_menus.hide_current_popover_if_visible(instance);
+                        },
+                        util.get_remaining_time(start_time, 500),
+                    );
+                };
+
                 user_topics.set_user_topic_visibility_policy(
                     stream_id,
                     topic_name,
                     visibility_policy,
+                    false,
+                    false,
+                    undefined,
+                    success_cb,
                 );
-                popover_menus.hide_current_popover_if_visible(instance);
             });
         },
         onHidden(instance) {

--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -49,9 +49,9 @@ export function initialize() {
                 return;
             }
 
-            // TODO: Figure out a good way to offer feedback if this request fails.
             $popper.on("change", "input[name='visibility-policy-select']", (e) => {
                 const start_time = Date.now();
+
                 const visibility_policy = Number.parseInt(
                     $(e.currentTarget).attr("data-visibility-policy"),
                     10,
@@ -66,6 +66,22 @@ export function initialize() {
                     );
                 };
 
+                const error_cb = () => {
+                    const prev_visibility_policy = user_topics.get_topic_visibility_policy(
+                        stream_id,
+                        topic_name,
+                    );
+                    const $prev_visibility_policy_input = $(e.currentTarget)
+                        .parent()
+                        .find(`input[data-visibility-policy="${prev_visibility_policy}"]`);
+                    setTimeout(
+                        () => {
+                            $prev_visibility_policy_input.prop("checked", true);
+                        },
+                        util.get_remaining_time(start_time, 500),
+                    );
+                };
+
                 user_topics.set_user_topic_visibility_policy(
                     stream_id,
                     topic_name,
@@ -74,6 +90,7 @@ export function initialize() {
                     false,
                     undefined,
                     success_cb,
+                    error_cb,
                 );
             });
         },

--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -123,6 +123,7 @@ export function set_user_topic_visibility_policy(
     from_hotkey?: boolean,
     from_banner?: boolean,
     $status_element?: JQuery,
+    success_cb?: () => void,
 ): void {
     const data = {
         stream_id,
@@ -141,6 +142,10 @@ export function set_user_topic_visibility_policy(
         url: "/json/user_topics",
         data,
         success() {
+            if (success_cb) {
+                success_cb();
+            }
+
             if ($status_element) {
                 const remove_after = 1000;
                 const appear_after = 500;

--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -124,6 +124,7 @@ export function set_user_topic_visibility_policy(
     from_banner?: boolean,
     $status_element?: JQuery,
     success_cb?: () => void,
+    error_cb?: () => void,
 ): void {
     const data = {
         stream_id,
@@ -194,6 +195,11 @@ export function set_user_topic_visibility_policy(
                     title_text: $t({defaultMessage: "Topic muted"}),
                     undo_button_text: $t({defaultMessage: "Undo mute"}),
                 });
+            }
+        },
+        error() {
+            if (error_cb) {
+                error_cb();
             }
         },
     });

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -533,3 +533,8 @@ export function format_array_as_list(
     // Return the formatted string.
     return list_formatter.format(array);
 }
+
+// Returns the remaining time in milliseconds from the start_time and duration.
+export function get_remaining_time(start_time: number, duration: number): number {
+    return Math.max(0, start_time + duration - Date.now());
+}

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1150,55 +1150,6 @@ div.overlay {
     }
 }
 
-/* Icon-based tab picker used for topics popover. */
-.tabs-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    padding: 1px;
-    margin: 0 10px;
-    height: 33px;
-    gap: 2px;
-    background-color: var(--color-background-tab-picker-container);
-    border-radius: 5px;
-
-    & i {
-        z-index: 2;
-        color: var(--color-tab-picker-icon);
-        font-size: 16px;
-    }
-
-    .selected-tab {
-        background-color: var(--color-background-tab-picker-selected-tab);
-        outline: 1px solid var(--color-outline-tab-picker-tab-option);
-        outline-offset: -1px;
-        z-index: 1;
-    }
-
-    .tab-option {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        box-sizing: border-box;
-        width: 100%;
-        height: 31px;
-        cursor: pointer;
-        border-radius: 5px;
-
-        &:hover:not(.selected-tab) {
-            background-color: var(
-                --color-background-tab-picker-tab-option-hover
-            );
-        }
-
-        &:active:not(.selected-tab) {
-            outline: 1px solid var(--color-outline-tab-picker-tab-option);
-            outline-offset: -1px;
-        }
-    }
-}
-
 /**
  * Use the "tab-picker-vertical" class in conjunction
  * for a vertical tab picker.

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1069,50 +1069,15 @@ ul {
 
 .visibility_policy_popover {
     padding: 0 4px;
+}
 
-    .visibility_policy_popover_container {
-        display: flex;
-        flex-direction: column;
-        gap: 1px;
-        padding: 1px;
-        background-color: var(--color-background-tab-picker-container);
-        border-radius: 5px;
-    }
-
-    .visibility_policy_option {
+.recipient-bar-topic-visibility-switcher {
+    .tab-option-content {
+        font-size: 15px;
+        color: var(--color-text-popover-menu);
+        gap: 10px;
+        justify-content: flex-start;
         padding: 2px 13px;
-        border-radius: 4px;
-        cursor: pointer;
-
-        .icon_and_text {
-            display: flex;
-            align-items: center;
-            text-decoration: none;
-            color: var(--color-tab-picker-icon);
-            gap: 10px;
-
-            &i {
-                font-size: 16px;
-            }
-        }
-
-        &:hover:not(.selected_visibility_policy) {
-            background-color: var(
-                --color-background-tab-picker-tab-option-hover
-            );
-        }
-
-        &:active:not(.selected_visibility_policy) {
-            outline: 1px solid var(--color-outline-tab-picker-tab-option);
-            outline-offset: -1px;
-        }
-    }
-
-    .selected_visibility_policy {
-        background-color: var(--color-background-tab-picker-selected-tab);
-        outline: 1px solid var(--color-outline-tab-picker-tab-option);
-        outline-offset: -1px;
-        z-index: 1;
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -307,7 +307,7 @@ ul {
             margin-right: 3px;
         }
 
-        &.zulip-icon:not(.tab-option > .zulip-icon) {
+        &.zulip-icon {
             /* These icons are different from font awesome icons,
                 so they need to be aligned separately. */
             line-height: 14px;
@@ -1428,7 +1428,8 @@ ul.popover-menu-list {
     }
 }
 
-#theme-switcher {
+#theme-switcher,
+.sidebar-topic-visibility-switcher {
     margin: 0 10px;
 
     .tab-option-content:focus-visible {

--- a/web/templates/popovers/change_visibility_policy_popover.hbs
+++ b/web/templates/popovers/change_visibility_policy_popover.hbs
@@ -1,34 +1,27 @@
 <ul class="nav nav-list visibility_policy_popover hidden-for-spectators">
-    <div class="visibility_policy_popover_container">
-        <li class="visibility_policy_option {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected_visibility_policy{{/if}}"
-          data-visibility-policy="{{ all_visibility_policies.MUTED }}">
-            <a tabindex="0" class="icon_and_text">
-                <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-                {{t "Mute"}}
-            </a>
-        </li>
-        <li class="visibility_policy_option {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}selected_visibility_policy{{/if}}"
-          data-visibility-policy="{{ all_visibility_policies.INHERIT }}">
-            <a tabindex="0" class="icon_and_text">
-                <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
-                {{t "Default"}}
-            </a>
-        </li>
+    <div class="recipient-bar-topic-visibility-switcher tab-picker tab-picker-vertical">
+        <input type="radio" id="select-muted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
+        <label class="tab-option-content" for="select-muted-policy" tabindex="0">
+            <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
+            {{t "Mute"}}
+        </label>
+        <input type="radio" id="select-inherit-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
+        <label class="tab-option-content" for="select-inherit-policy" tabindex="0">
+            <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
+            {{t "Default"}}
+        </label>
         {{#if (or stream_muted topic_unmuted)}}
-            <li class="visibility_policy_option {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}selected_visibility_policy{{/if}}"
-              data-visibility-policy="{{ all_visibility_policies.UNMUTED }}">
-                <a tabindex="0" class="icon_and_text">
-                    <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-                    {{t "Unmute"}}
-                </a>
-            </li>
+        <input type="radio" id="select-unmuted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
+        <label class="tab-option-content" for="select-unmuted-policy" tabindex="0">
+            <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
+            {{t "Unmute"}}
+        </label>
         {{/if}}
-        <li class="visibility_policy_option {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}selected_visibility_policy{{/if}}"
-          data-visibility-policy="{{ all_visibility_policies.FOLLOWED }}">
-            <a tabindex="0" class="icon_and_text">
-                <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
-                {{t "Follow"}}
-            </a>
-        </li>
+        <input type="radio" id="select-followed-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
+        <label class="tab-option-content" for="select-followed-policy" tabindex="0">
+            <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
+            {{t "Follow"}}
+        </label>
+        <span class="slider"></span>
     </div>
 </ul>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -6,22 +6,27 @@
         {{!-- Group 1 --}}
         {{#unless is_spectator}}
         <li role="separator" class="popover-menu-separator"></li>
-        <li role="none" class="popover-menu-list-item hidden-for-spectators">
-            <div role="group" class="tabs-container" aria-label="{{t 'Topic visibility' }}">
-                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
+        <li role="none" class="popover-menu-list-item">
+            <div role="group" class="sidebar-topic-visibility-switcher tab-picker" aria-label="{{t 'Topic visibility' }}">
+                <input type="radio" id="sidebar-topic-muted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-muted-policy" aria-label="{{t 'Mute' }}" data-tippy-content="{{t 'Mute' }}" tabindex="0">
                     <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-                </div>
-                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.INHERIT}}" data-tippy-content="{{t 'Default' }}" aria-label="{{t 'Default' }}">
+                </label>
+                <input type="radio" id="sidebar-topic-inherit-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-inherit-policy" aria-label="{{t 'Default' }}" data-tippy-content="{{t 'Default' }}" tabindex="0">
                     <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
-                </div>
+                </label>
                 {{#if (or stream_muted topic_unmuted)}}
-                    <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" data-tippy-content="{{t 'Unmute' }}" aria-label="{{t 'Unmute' }}">
-                        <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-                    </div>
+                <input type="radio" id="sidebar-topic-unmuted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-unmuted-policy" aria-label="{{t 'Unmute' }}" data-tippy-content="{{t 'Unmute' }}" tabindex="0">
+                    <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
+                </label>
                 {{/if}}
-                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" data-tippy-content="{{t 'Follow' }}" aria-label="{{t 'Follow' }}">
+                <input type="radio" id="sidebar-topic-followed-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-followed-policy" aria-label="{{t 'Follow' }}" data-tippy-content="{{t 'Follow' }}" tabindex="0">
                     <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
-                </div>
+                </label>
+                <span class="slider"></span>
             </div>
         </li>
         {{/unless}}

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const _ = require("lodash");
+const MockDate = require("mockdate");
 
 const {set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
@@ -388,4 +389,23 @@ run_test("format_array_as_list", () => {
     // when Intl.ListFormat does not exist
     global.Intl.ListFormat = undefined;
     assert.equal(util.format_array_as_list(array, "long", "conjunction"), "apple, banana, orange");
+});
+
+run_test("get_remaining_time", () => {
+    // When current time is less than start time
+    // Set a random start time
+    const start_time = new Date(1000).getTime();
+    // Set current time to 400ms ahead of the start time
+    MockDate.set(start_time + 400);
+    const duration = 500;
+    let expected_remaining_time = 100;
+    assert.equal(util.get_remaining_time(start_time, duration), expected_remaining_time);
+
+    // When current time is greater than start time + duration
+    // Set current time to 100ms after the start time + duration
+    MockDate.set(start_time + duration + 100);
+    expected_remaining_time = 0;
+    assert.equal(util.get_remaining_time(start_time, duration), expected_remaining_time);
+
+    MockDate.reset();
 });


### PR DESCRIPTION
This PR adds the new sliding tab animation to the topic visibility switchers (one situated in the message header topic visibility popover, and the other one situated in the sidebar topic actions), along with some functionality changes, such as:
- Hiding the popover, only when the mute topic request gets completed successfully.
- Adding visual feedback via the same sliding animation, on request failure.

Fixes: [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20theme.20switcher.20.2322803/near/1766900)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Light Mode</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/82862779/254813a0-bdc4-423e-97fc-09565314a6ef) | ![image](https://github.com/zulip/zulip/assets/82862779/6ef10c85-d9e5-40ec-a358-4dbe069f0fd2) | 

</details>

<details>
<summary>Light Mode (Sidebar topic actions popover)</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/82862779/b49ed3e2-5d6f-4b41-adb0-8f9008c65b83) | ![image](https://github.com/zulip/zulip/assets/82862779/5040db02-321f-4b26-a987-15edc3d9b645) | 

</details>

<details>
<summary>Dark Mode</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/82862779/5a44892a-84ca-4ae2-bde6-8a1984840bdb) | ![image](https://github.com/zulip/zulip/assets/82862779/bf6aab51-d3b2-44ee-b196-a95cbe19e670) | 

</details>

<details>
<summary>Dark Mode (Sidebar topic actions popover)</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/82862779/3b17c702-d2f2-49fa-a6d2-c1a089c396a1) | ![image](https://github.com/zulip/zulip/assets/82862779/2827fb45-64c1-414e-992b-efeb43c4b2ff) | 

</details>

<details>
<summary>General Usage</summary>

[general-usage.webm](https://github.com/zulip/zulip/assets/82862779/6ad998bd-c487-4ed9-b3ce-43dbe22a05ef)

[topic-vis-popover-working.webm](https://github.com/zulip/zulip/assets/82862779/39185559-30f8-4b8c-9075-e78bedc0df4c)


</details>

<details>
<summary>Request error feedback</summary>

[sidebar-topic-vis-error-handling.webm](https://github.com/zulip/zulip/assets/82862779/2265ad0d-8683-442e-b436-4c6ad549e23e)

[error-handling-topic-vis-popover.webm](https://github.com/zulip/zulip/assets/82862779/3a6d5ebb-170e-4f04-ace9-2692bd37061d)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
