### PR TITLE
Add links to manage deactivated users

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -70,7 +70,6 @@ export function update_view_on_deactivate(user_id) {
 
     const $button = $row.find("button.deactivate");
     $button.prop("disabled", false);
-    $row.find("button.open-user-form").hide();
     $row.find("i.deactivated-user-icon").show();
     $button.addClass("btn-warning reactivate");
     $button.removeClass("deactivate btn-danger");
@@ -81,7 +80,6 @@ export function update_view_on_deactivate(user_id) {
 
 function update_view_on_reactivate($row) {
     const $button = $row.find("button.reactivate");
-    $row.find("button.open-user-form").show();
     $row.find("i.deactivated-user-icon").hide();
     $button.addClass("btn-danger deactivate");
     $button.removeClass("btn-warning reactivate");

--- a/web/templates/popovers/user_card/user_card_popover_manage_menu.hbs
+++ b/web/templates/popovers/user_card/user_card_popover_manage_menu.hbs
@@ -14,18 +14,17 @@
     </li>
     {{/if}}
     {{#if can_manage_user}}
-        {{#if is_active}}
         <li>
             <a tabindex="0" class="sidebar-popover-manage-user">
                 <i class="fa fa-edit" aria-hidden="true"></i> {{#if is_bot}}{{t "Manage this bot" }}{{else}}{{t "Manage this user" }}{{/if}}
             </a>
         </li>
-        {{else}}
+        {{#unless is_active}}
         <li>
             <a tabindex="0" class="sidebar-popover-reactivate-user">
                 <i class="fa fa-user-plus" aria-hidden="true"></i> {{#if is_bot}}{{t "Reactivate this bot" }}{{else}}{{t "Reactivate this user" }}{{/if}}
             </a>
         </li>
-        {{/if}}
+        {{/unless}}
     {{/if}}
 </ul>

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -43,7 +43,7 @@
     <td class="actions">
         <span class="user-status-settings">
             <span {{#if (and is_bot cannot_edit)}}class="tippy-zulip-tooltip"{{/if}} {{#if (and is_bot cannot_edit)}}data-tippy-content="{{t 'This bot cannot be edited.'}}"{{/if}}>
-                <button class="button rounded small btn-warning open-user-form tippy-zulip-delayed-tooltip" {{#unless is_active}}style="display: none;"{{/unless}} data-tippy-content="{{#if is_bot}}{{#unless cannot_edit}}{{t 'Edit bot' }}{{/unless}}{{else}}{{t 'Edit user' }}{{/if}}" data-user-id="{{user_id}}" {{#if cannot_edit}}disabled="disabled"{{/if}}>
+                <button class="button rounded small btn-warning open-user-form tippy-zulip-delayed-tooltip" data-tippy-content="{{#if is_bot}}{{#unless cannot_edit}}{{t 'Edit bot' }}{{/unless}}{{else}}{{t 'Edit user' }}{{/if}}" data-user-id="{{user_id}}" {{#if cannot_edit}}disabled="disabled"{{/if}}>
                     <i class="fa fa-pencil" aria-hidden="true"></i>
                 </button>
             </span>


### PR DESCRIPTION
Organization settings: add links to manage deactivated users.

Display manage this user in the three-dot menu on the user card regardless of user is_active. Similarly, display edit user icon in deactivated users list. Do not hide edit button when user is deactivated.

Fixes: #29486 

UI Changes:
![image](https://github.com/zulip/zulip/assets/29176437/ef28e011-090d-48d0-a29a-5242e8c30275)
![image](https://github.com/zulip/zulip/assets/29176437/635cd2fa-17df-4935-a4f0-70af597e2955)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
