### PR TITLE
Document user list + message search fixup

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -116,6 +116,7 @@
 * [Read receipts](/help/read-receipts)
 
 ## People
+* [User list](/help/user-list)
 * [Status and availability](/help/status-and-availability)
 * [User cards](/help/user-cards)
 * [View someone's profile](/help/view-someones-profile)

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -6,6 +6,24 @@ top of the app. There is a convenient [**search filters reference**](#search-fil
 in the Zulip app that you can use whenever you need a reminder of the search
 filters below.
 
+## Search for messages
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **search** (<i class="search_icon zulip-icon
+   zulip-icon-search"></i>) icon in the top bar to open the search box.
+
+1. Type your query, and press <kbd>Enter</kbd>.
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
+    keyboard shortcut to start searching messages.
+
+{end_tabs}
+
 ## Keyword search
 
 Zulip lets you search messages and topics by keyword. For example:

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -182,5 +182,6 @@ A summary of the search filters above is available in the Zulip app.
 ## Related articles
 
 * [Configure multi-language search](/help/configure-multi-language-search)
+* [Search people](/help/user-list#search-people)
 * [Link to a message or
   conversation](/help/link-to-a-message-or-conversation#link-to-zulip-from-anywhere)

--- a/help/user-list.md
+++ b/help/user-list.md
@@ -1,0 +1,59 @@
+# User list
+
+In the Zulip web and desktop app, the right sidebar shows a list of users in
+your organization. It shows
+[non-deactivated](/help/deactivate-or-reactivate-a-user) users, and does not
+include [bots](/help/bots-overview).
+
+In organizations with up to 600 users, everyone is shown. In larger organizations,
+only users who have been active in the last two weeks are listed. All users are
+included when you search for people.
+
+When you view a stream or a topic within a stream, subscribers to that stream
+are shown separately from other members of your organization. To avoid
+distraction, you can hide the user list any time.
+
+## Search people
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. If the user list in the right sidebar is hidden, click the **user list** (<i
+class="zulip-icon zulip-icon-triple-users"></i> ) icon in the upper right to
+show it.
+
+1. Click the **search** (<i class="search_icon zulip-icon
+   zulip-icon-search"></i>) icon at the top of the right sidebar to open the
+   search box.
+
+1. Type the name of the user you are looking for.
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>W</kbd> keyboard shortcut to start searching for
+    a person.
+
+{end_tabs}
+
+## Show or hide the user list
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **user list** (<i class="zulip-icon zulip-icon-triple-users"></i>
+) icon in the upper right.
+
+!!! keyboard_tip ""
+
+    The <kbd>W</kbd> keyboard shortcut to search people reveals the user list if
+    it is hidden.
+
+{end_tabs}
+
+## Related articles
+
+- [View someone's profile](/help/view-someones-profile)
+- [Status and availability](/help/status-and-availability)
+- [Searching for messages](/help/search-for-messages)


### PR DESCRIPTION
Current: https://zulip.com/help/search-for-messages
<details>
<summary>
Updated
</summary>

![Screenshot 2024-03-28 at 1 33 38 PM](https://github.com/zulip/zulip/assets/2090066/88654c76-2f0f-407c-8170-1dc310656713)

</details>

<details>
<summary>
User list (new page)
</summary>

![Screenshot 2024-03-28 at 1 36 55 PM](https://github.com/zulip/zulip/assets/2090066/d59f68c7-7f53-4b10-8095-cab2a310d9ab)


</details>

Sidebar:

![Screenshot 2024-03-28 at 1 35 49 PM](https://github.com/zulip/zulip/assets/2090066/32af3a7b-6495-48e1-a56b-fbfd193f090f)
