### PR TITLE
message_body: Calculate width of timestamp column.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -241,7 +241,7 @@ export function initialize(): void {
         },
     });
 
-    message_list_tooltip(".message-list .message_time", {
+    message_list_tooltip(".message-list .message-time", {
         onShow(instance) {
             const $time_elem = $(instance.reference);
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -746,6 +746,8 @@ export function dispatch_normal_event(event) {
                 }
             }
             if (event.property === "twenty_four_hour_time") {
+                // Recalculate timestamp column width
+                message_lists.calculate_timestamp_widths();
                 // Rerender the whole message list UI
                 for (const msg_list of message_lists.all_rendered_message_lists()) {
                     msg_list.rerender();

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -69,6 +69,9 @@
     --message-box-line-height: 1.214;
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;
+    /* This width is updated with an exact pixel
+       width upon UI initialization. */
+    --message-box-timestamp-column-width: 42px;
 
     /*
     Reaction container UI scaling.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -71,7 +71,7 @@
     --message-box-icon-height: 25px;
     /* This width is updated with an exact pixel
        width upon UI initialization. */
-    --message-box-timestamp-column-width: 42px;
+    --message-box-timestamp-column-width: 0;
 
     /*
     Reaction container UI scaling.

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -525,10 +525,6 @@
         color: hsl(0deg 0% 42% / 90%) !important;
     }
 
-    .message_time:hover {
-        color: var(--color-message-action-interactive);
-    }
-
     & input[type="text"]:focus,
     input[type="email"]:focus,
     input[type="number"]:focus,

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -194,7 +194,7 @@ $time_column_min_width: 42px; /* + padding */
             grid-area: edited;
         }
 
-        .message_time {
+        .message-time {
             justify-self: end;
             padding-right: 5px;
             /* Maintain first-line baseline regardless of
@@ -419,7 +419,7 @@ $time_column_min_width: 42px; /* + padding */
                 grid-area: message;
             }
 
-            .message_time {
+            .message-time {
                 grid-area: time;
                 /* Don't adjust the line-height for collapsed or
                    edited/source messages when there's a sender,
@@ -476,9 +476,9 @@ $time_column_min_width: 42px; /* + padding */
     }
 
     /* Locally echoed messages. */
-    &.locally-echoed .message_time {
+    &.locally-echoed .message-time {
         opacity: 0;
-        /* Don't show pointer when message_time doesn't has a link. */
+        /* Don't show pointer when message-time doesn't have a link. */
         cursor: default;
     }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -190,39 +190,6 @@ $message_box_margin: 3px;
             grid-area: edited;
         }
 
-        .message-time {
-            justify-self: end;
-            padding-right: 5px;
-            /* Maintain first-line baseline regardless of
-               what happens in the message-content area (e.g., a
-               collapsed message, or source/edit view). This
-               line-height also keeps EDITED/MOVED messages
-               in place, care of their baseline-group participation
-               within the grid.
-
-               That said, 28px is a bit of a magical number.
-               In theory, this should be 27px. That's the height
-               of a single-message row without a sender. (See the
-               calculations for the height of a single-line,
-               sender-less message row in the message box grid.)
-               But when shifting into collapsed or source views,
-               28px is necessary to maintain the vertical alignment
-               of the EDITED messages, hover controls, and
-               timestamp. It's possible that this is also due to a
-               a rounding error, given how --message-box-line-height
-               is expressed as a unitless decimal. */
-            line-height: 28px;
-            text-align: end;
-            grid-area: time;
-
-            &.notvisible {
-                /* This happens when message failed to send. We don't want to
-                   display time but still want it to occupy space. */
-                width: 45px !important;
-                position: unset !important;
-            }
-        }
-
         .slow-send-spinner {
             display: none;
             justify-self: end;
@@ -416,7 +383,6 @@ $message_box_margin: 3px;
             }
 
             .message-time {
-                grid-area: time;
                 /* Don't adjust the line-height for collapsed or
                    edited/source messages when there's a sender,
                    as the sender text is always visible. */
@@ -540,6 +506,50 @@ $message_box_margin: 3px;
         &:hover {
             background: var(--color-exit-button-background-interactive);
         }
+    }
+}
+
+.message-time {
+    justify-self: end;
+    padding-right: 5px;
+    /* Maintain first-line baseline regardless of
+       what happens in the message-content area (e.g., a
+       collapsed message, or source/edit view). This
+       line-height also keeps EDITED/MOVED messages
+       in place, care of their baseline-group participation
+       within the grid.
+
+       That said, 28px is a bit of a magical number.
+       In theory, this should be 27px. That's the height
+       of a single-message row without a sender. (See the
+       calculations for the height of a single-line,
+       sender-less message row in the message box grid.)
+       But when shifting into collapsed or source views,
+       28px is necessary to maintain the vertical alignment
+       of the EDITED messages, hover controls, and
+       timestamp. It's possible that this is also due to a
+       a rounding error, given how --message-box-line-height
+       is expressed as a unitless decimal. */
+    line-height: 28px;
+    grid-area: time;
+    display: block;
+    font-size: 13px;
+    font-weight: 350;
+    text-align: end;
+    opacity: 0.8;
+    color: var(--color-text-default);
+    letter-spacing: 0.02em;
+    /* Disable blue link styling for the message timestamp link. */
+    &:hover {
+        text-decoration: none;
+        color: var(--color-message-action-interactive);
+    }
+
+    &.notvisible {
+        /* This happens when message failed to send. We don't want to
+           display time but still want it to occupy space. */
+        width: 45px !important;
+        position: unset !important;
     }
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -3,18 +3,6 @@ $distance_of_text_elements_from_message_box_top: 8.5px;
 $distance_of_non_text_elements_from_message_box: 6px;
 $message_box_margin: 3px;
 
-/* The time column usually just needs enough space to display the
-   timestamp. The minimum width here is enough for "22:22 PM", which
-   is roughly the widest this will be in English; this is nice as the
-   timestamps and message controls will be vertically aligned.
-
-   But in some locales, the time encoding is wider, (especially where
-   the "PM" abbreviation is longer), so we allow the column to be
-   wider for individual messages if required, up to `max-content`, to
-   prevent ugly line-wrapping. In practice, it's unlikely we'll see
-   anything wider than 60px. */
-$time_column_min_width: 42px; /* + padding */
-
 .message_row {
     display: grid;
     /* Prevent the messagebox column from overflowing the 1fr
@@ -144,13 +132,18 @@ $time_column_min_width: 42px; /* + padding */
         /* Prevent the message column from overflowing the 1fr
            space allotted by specifying `minmax(0,1fr)`, which
            sets 0 as the minimum size, not the grid default of
-           `auto`. */
+           `auto`.
+
+            The calculated `--message-box-timestamp-column-width`
+            should match `max-content` exactly, but `max-content`
+            ensures the timestamp will always have enough space
+            in the column. */
         grid-template:
             var(--message-box-icon-height) repeat(3, auto) /
             $avatar_column_width minmax(0, 1fr) calc(
                 3 * var(--message-box-icon-width)
             )
-            8px minmax($time_column_min_width, max-content);
+            8px minmax(var(--message-box-timestamp-column-width), max-content);
         /* Named grid areas provide flexibility for positioning grid items
            reliably, even if the row or column definitions of the grid change. */
         grid-template-areas:
@@ -164,7 +157,7 @@ $time_column_min_width: 42px; /* + padding */
             /* Set the controls area to 0 to give more space
                to the edit/source view area. */
             grid-template-columns: $avatar_column_width minmax(0, 1fr) 0 8px minmax(
-                    $time_column_min_width,
+                    var(--message-box-timestamp-column-width),
                     max-content
                 );
         }
@@ -174,7 +167,10 @@ $time_column_min_width: 42px; /* + padding */
                 $avatar_column_width minmax(0, 1fr) calc(
                     2 * var(--message-box-icon-width)
                 )
-                8px minmax($time_column_min_width, max-content);
+                8px minmax(
+                    var(--message-box-timestamp-column-width),
+                    max-content
+                );
         }
 
         .message_controls {

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -63,7 +63,7 @@
 
     .messagebox-content {
         .message_edit_notice,
-        .message_time {
+        .message-time {
             /* Firefox seems to have a bug that fuzzes out
                small text with opacity; this unsets that
                value, and replaces with a matching gray. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -888,7 +888,7 @@ td.pointer {
     transition: all 3s ease-in-out;
 }
 
-.messagebox-content .message_time {
+.messagebox-content .message-time {
     display: block;
     font-size: 13px;
     font-weight: 350;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -912,10 +912,6 @@ td.pointer {
     animation: rotate 1s infinite linear;
 }
 
-.status-time {
-    top: 8px !important;
-}
-
 .message_controls {
     display: flex;
     align-items: baseline;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -888,21 +888,6 @@ td.pointer {
     transition: all 3s ease-in-out;
 }
 
-.messagebox-content .message-time {
-    display: block;
-    font-size: 13px;
-    font-weight: 350;
-    text-align: right;
-    opacity: 0.8;
-    color: var(--color-text-default);
-    letter-spacing: 0.02em;
-    /* Disable blue link styling for the message timestamp link. */
-    &:hover {
-        text-decoration: none;
-        color: var(--color-message-action-interactive);
-    }
-}
-
 .messagebox-content .slow-send-spinner {
     display: block;
     font-size: 12px;

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -26,7 +26,7 @@
     {{/if}}
 </span>
 
-<a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message_time{{#if status_message}} status-time{{/if}}">
+<a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message_time">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>
     {{/unless}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -26,7 +26,7 @@
     {{/if}}
 </span>
 
-<a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message_time">
+<a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message-time">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>
     {{/unless}}

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -872,6 +872,7 @@ run_test("user_settings", ({override}) => {
     let event = event_fixtures.user_settings__default_language;
     user_settings.default_language = "en";
     override(settings_preferences, "update_page", noop);
+    override(message_lists, "calculate_timestamp_widths", noop);
     override(overlays, "settings_open", () => true);
     dispatch(event);
     assert_same(user_settings.default_language, "fr");

--- a/web/tests/lib/zjquery.js
+++ b/web/tests/lib/zjquery.js
@@ -18,6 +18,7 @@ function verify_selector_for_zulip(selector) {
         selector === "document-stub" ||
         selector === "body" ||
         selector === "html" ||
+        selector === ":root" ||
         selector.location ||
         selector.includes("#") ||
         selector.includes(".") ||

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const $ = require("./lib/zjquery");
 const {page_params, realm} = require("./lib/zpage_params");
 
 const {Filter} = zrequire("filter");
@@ -121,6 +122,12 @@ function set_page_params_no_edit_restrictions() {
 // Test init function
 function test(label, f) {
     run_test(label, (helpers) => {
+        // Stubs for calculate_timestamp_widths()
+        $("<div>").css = noop;
+        $(":root").css = noop;
+        $("<div>").width = noop;
+        $("<div>").remove = noop;
+
         // Clear stuff for testing environment
         add_initialize_users();
         message_lists.initialize();


### PR DESCRIPTION
In addition to cleaning up some structural and CSS matters around message timestamps, this PR calculates a shared width for all timestamp columns, based on the largest possible timestamp for a given language/locale and time format (12 and 24).

This ensures that the timestamp column is always the same size between messages, leading to more consistent appearance of the star icon and hover controls.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Star.20icon.20alignment/near/1660398)

Fixes: #26970

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![timestamps-before](https://github.com/zulip/zulip/assets/170719/be0627b5-33c8-4cc1-9fda-4bd3a2a75041) | ![timestamps-after](https://github.com/zulip/zulip/assets/170719/aa7a8362-9f75-4a30-bd77-286fdf81e019) |

_Internationalization examples:_

| Chinese| Persian | Portuguese |
| --- | --- | --- |
| ![timestamps-chinese-after](https://github.com/zulip/zulip/assets/170719/1de5a77c-b8a1-4191-9368-f3bb66ec21d4) | ![timestamps-persian-after](https://github.com/zulip/zulip/assets/170719/898ad4ac-d5e7-4c51-9ae3-ef7a3ba1db39) | ![timestamps-portuguese-after](https://github.com/zulip/zulip/assets/170719/4de34502-2e3a-4873-abb2-22a3c650aa36) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>