### PR TITLE
apt-repos: Disallow libmagic1 1:5.45-2 (Ubuntu 24.04)

### DIFF
--- a/scripts/setup/apt-repos/zulip/zulip.pref
+++ b/scripts/setup/apt-repos/zulip/zulip.pref
@@ -1,0 +1,4 @@
+# https://bugs.launchpad.net/ubuntu/+source/file/+bug/2059723
+Package: libmagic1
+Pin: version 1:5.45-2
+Pin-Priority: -1


### PR DESCRIPTION
This package is replaced by libmagic1t64 1:5.45-3 for the Ubuntu 64-bit time_t transition, but hasn’t been deleted from the archive yet.

[Discussion](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/CI.20and.20production.20suite.20failure.20Ubuntu.2024.2E04/near/1768953).