### PR TITLE
resolve_topic: Fix incorrect trigger of notification when moving message.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1039,20 +1039,12 @@ def do_update_message(
 
     resolved_topic_message_id = None
     resolved_topic_message_deleted = False
-    if topic_name is not None and content is None:
-        # When stream is changed and topic is marked as resolved or unresolved
-        # in the same API request, resolved or unresolved notification should
-        # be sent to "new_stream".
-        # In general, it is sent to "stream_being_edited".
-        stream_to_send_resolve_topic_notification = stream_being_edited
-        if new_stream is not None:
-            stream_to_send_resolve_topic_notification = new_stream
-
-        assert stream_to_send_resolve_topic_notification is not None
+    if topic_name is not None and content is None and new_stream is None:
+        assert stream_being_edited is not None
         resolved_topic_message_id, resolved_topic_message_deleted = (
             maybe_send_resolve_topic_notifications(
                 user_profile=user_profile,
-                stream=stream_to_send_resolve_topic_notification,
+                stream=stream_being_edited,
                 old_topic_name=orig_topic_name,
                 new_topic_name=topic_name,
                 changed_messages=changed_messages,

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -147,18 +147,21 @@ def maybe_send_resolve_topic_notifications(
     old_topic_name: str,
     new_topic_name: str,
     changed_messages: QuerySet[Message],
+    pre_truncation_new_topic_name: str,
 ) -> Tuple[Optional[int], bool]:
     """Returns resolved_topic_message_id if resolve topic notifications were in fact sent."""
     # Note that topics will have already been stripped in check_update_message.
-    #
-    # This logic is designed to treat removing a weird "✔ ✔✔ "
-    # prefix as unresolving the topic.
-    topic_resolved: bool = new_topic_name.startswith(
-        RESOLVED_TOPIC_PREFIX
-    ) and not old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-    topic_unresolved: bool = old_topic_name.startswith(
-        RESOLVED_TOPIC_PREFIX
-    ) and not new_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+    resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
+    topic_resolved: bool = (
+        new_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+        and not old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+        and pre_truncation_new_topic_name[resolved_prefix_len:] == old_topic_name
+    )
+    topic_unresolved: bool = (
+        old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+        and not new_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+        and old_topic_name.lstrip(RESOLVED_TOPIC_PREFIX) == new_topic_name
+    )
 
     if not topic_resolved and not topic_unresolved:
         # If there's some other weird topic that does not toggle the
@@ -171,7 +174,7 @@ def maybe_send_resolve_topic_notifications(
         # notifications in a row: one can send new messages to the
         # pre-resolve topic and then resolve the topic created that
         # way to get multiple in the resolved topic. And then an
-        # administrator can the messages in between. We consider this
+        # administrator can delete the messages in between. We consider this
         # to be a fundamental risk of irresponsible message deletion,
         # not a bug with the "resolve topics" feature.
         return None, False
@@ -1041,6 +1044,7 @@ def do_update_message(
     resolved_topic_message_deleted = False
     if topic_name is not None and content is None and new_stream is None:
         assert stream_being_edited is not None
+        assert pre_truncation_topic_name is not None
         resolved_topic_message_id, resolved_topic_message_deleted = (
             maybe_send_resolve_topic_notifications(
                 user_profile=user_profile,
@@ -1048,6 +1052,7 @@ def do_update_message(
                 old_topic_name=orig_topic_name,
                 new_topic_name=topic_name,
                 changed_messages=changed_messages,
+                pre_truncation_new_topic_name=pre_truncation_topic_name,
             )
         )
 

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1441,13 +1441,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, new_stream, new_topic_name)
-        self.assert_length(messages, 5)
+        self.assert_length(messages, 4)
         self.assertEqual(
             messages[3].content,
-            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as resolved.",
-        )
-        self.assertEqual(
-            messages[4].content,
             f"This topic was moved here from #**{first_stream.name}>test** by @_**{user_profile.full_name}|{user_profile.id}**.",
         )
 
@@ -1464,13 +1460,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, new_stream, new_topic_name)
-        self.assert_length(messages, 7)
+        self.assert_length(messages, 5)
         self.assertEqual(
-            messages[5].content,
-            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as unresolved.",
-        )
-        self.assertEqual(
-            messages[6].content,
+            messages[4].content,
             f"This topic was moved here from #**{second_stream.name}>✔ test** by @_**{user_profile.full_name}|{user_profile.id}**.",
         )
 

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -1456,13 +1456,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, stream, new_topic_name)
-        self.assert_length(messages, 4)
+        self.assert_length(messages, 3)
         self.assertEqual(
             messages[2].content,
-            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as unresolved.",
-        )
-        self.assertEqual(
-            messages[3].content,
             f"This topic was moved here from #**public stream>✔ test** by @_**{user_profile.full_name}|{user_profile.id}**.",
         )
 
@@ -1477,13 +1473,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, stream, new_resolved_topic_name)
-        self.assert_length(messages, 6)
+        self.assert_length(messages, 4)
         self.assertEqual(
-            messages[4].content,
-            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as resolved.",
-        )
-        self.assertEqual(
-            messages[5].content,
+            messages[3].content,
             f"This topic was moved here from #**public stream>{new_topic_name}** by @_**{user_profile.full_name}|{user_profile.id}**.",
         )
 
@@ -1752,6 +1744,7 @@ class MessageMoveTopicTest(ZulipTestCase):
             old_topic_name=original_topic,
             new_topic_name=resolve_topic,
             changed_messages=changed_messages,
+            pre_truncation_new_topic_name=resolve_topic,
         )
 
         topic_messages = get_topic_messages(admin_user, stream, resolve_topic)


### PR DESCRIPTION
This PR fixes the bug where the "topic unresolved" notification is wrongly triggered when moving a message between a resolved and unresolved topic.

To resolve this issue, this solution ensures that resolved/unresolved notifications are not sent if a message has been moved to a new topic. This is achieved by comparing the names of the old and new topics without considering the "resolved prefix". It also updates the code so that only the moved notification is triggered when moving a message between a resolved and unresolved topic in different streams or when moving a topic itself.

The PR also accounts for the scenario where `new_topic_name` has been truncated, indicating that it was resolved and the name had to change to accommodate the "resolved prefix".

This solution assumes that a stream cannot have two topics with the same name, even if one is resolved and another unresolved.

Fixes https://github.com/zulip/zulip/issues/29007.<br>

### Videos:

&bullet; Moving a message from a resolved topic to a unresolved topic
> Click the images below to play the videos.

| Before | After |
| --- | --- |
[![Video Thumbnail](https://github.com/zulip/zulip/assets/160421883/4fdf58c6-4407-450d-9878-a409d711de83)](https://github.com/zulip/zulip/assets/160421883/3a52507e-d386-401e-96e3-c07e3736fdf5) | [![Video Thumbnail](https://github.com/zulip/zulip/assets/160421883/ec714094-0e7d-436d-a8f7-3354ce37478e)](https://github.com/zulip/zulip/assets/160421883/ecc51052-98ad-4bbe-a1da-889c04e9fac8)


<br>&bullet; Understanding the usage of `pre_truncation_new_topic_name`


https://github.com/zulip/zulip/assets/160421883/e247e5d0-147b-4b39-a974-0f41504be871



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

