### PR TITLE
input_pill: Add edit input_pill feature.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -288,6 +288,10 @@ export class Typeahead<ItemType extends string | object> {
             // Empty text after the change event handler
             // converts the input text to html elements.
             this.input_element.$element.text("");
+            if (this.input_element.$element.hasClass("editable-pill")) {
+                this.input_element.$element.siblings(".input").trigger("focus");
+                this.input_element.$element.remove();
+            }
         } else {
             const after_text = this.updater(val, this.query, this.input_element, e) ?? "";
             const element_val = this.input_element.$element.val();

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1280,47 +1280,9 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
     );
 }
 
-export function initialize({
-    on_enter_send,
-}: {
-    on_enter_send: (scheduling_message?: boolean) => boolean | undefined;
-}): void {
-    // These handlers are at the "form" level so that they are called after typeahead
-    $("form#send_message_form").on("keydown", (e) => {
-        handle_keydown(e, on_enter_send);
-    });
-    $("form#send_message_form").on("keyup", handle_keyup);
-
-    const stream_message_typeahead_input: TypeaheadInputElement = {
-        $element: $("input#stream_message_recipient_topic"),
-        type: "input",
-    };
-    new Typeahead(stream_message_typeahead_input, {
-        source(): string[] {
-            return topics_seen_for(compose_state.stream_id());
-        },
-        items: 3,
-        highlighter_html(item: string): string {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
-        sorter(items: string[], query: string): string[] {
-            const sorted = typeahead_helper.sorter(query, items, (x) => x);
-            if (sorted.length > 0 && !sorted.includes(query)) {
-                sorted.unshift(query);
-            }
-            return sorted;
-        },
-        option_label(matching_items: string[], item: string): string | false {
-            if (!matching_items.includes(item)) {
-                return `<em>${$t({defaultMessage: "New"})}</em>`;
-            }
-            return false;
-        },
-        header_html: render_topic_typeahead_hint,
-    });
-
+export function initialize_pm_typeahead($element: JQuery): void {
     const private_message_typeahead_input: TypeaheadInputElement = {
-        $element: $("#private_message_recipient"),
+        $element,
         type: "contenteditable",
     };
     new Typeahead(private_message_typeahead_input, {
@@ -1363,6 +1325,49 @@ export function initialize({
         },
         stopAdvance: true, // Do not advance to the next field on a Tab or Enter
     });
+}
+
+export function initialize({
+    on_enter_send,
+}: {
+    on_enter_send: (scheduling_message?: boolean) => boolean | undefined;
+}): void {
+    // These handlers are at the "form" level so that they are called after typeahead
+    $("form#send_message_form").on("keydown", (e) => {
+        handle_keydown(e, on_enter_send);
+    });
+    $("form#send_message_form").on("keyup", handle_keyup);
+
+    const stream_message_typeahead_input: TypeaheadInputElement = {
+        $element: $("input#stream_message_recipient_topic"),
+        type: "input",
+    };
+    new Typeahead(stream_message_typeahead_input, {
+        source(): string[] {
+            return topics_seen_for(compose_state.stream_id());
+        },
+        items: 3,
+        highlighter_html(item: string): string {
+            return typeahead_helper.render_typeahead_item({primary: item});
+        },
+        sorter(items: string[], query: string): string[] {
+            const sorted = typeahead_helper.sorter(query, items, (x) => x);
+            if (sorted.length > 0 && !sorted.includes(query)) {
+                sorted.unshift(query);
+            }
+            return sorted;
+        },
+        option_label(matching_items: string[], item: string): string | false {
+            if (!matching_items.includes(item)) {
+                return `<em>${$t({defaultMessage: "New"})}</em>`;
+            }
+            return false;
+        },
+        header_html: render_topic_typeahead_hint,
+    });
+
+    compose_pm_pill.widget.addSetupTypeahead(initialize_pm_typeahead);
+    initialize_pm_typeahead($("#private_message_recipient"));
 
     initialize_compose_typeahead($("textarea#compose-textarea"));
 }

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -4,11 +4,10 @@ import * as blueslip from "./blueslip";
 import {Typeahead} from "./bootstrap_typeahead";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead";
 import * as people from "./people";
-import type {User} from "./people";
 import * as stream_pill from "./stream_pill";
 import type {StreamPillData} from "./stream_pill";
 import * as typeahead_helper from "./typeahead_helper";
-import type {CombinedPillContainer} from "./typeahead_helper";
+import type {CombinedPillContainer, TypeaheadOptions} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import type {UserGroupPillData} from "./user_group_pill";
 import * as user_pill from "./user_pill";
@@ -26,22 +25,18 @@ function group_matcher(query: string, item: UserGroupPillData): boolean {
 
 type TypeaheadItem = UserGroupPillData | StreamPillData | UserPillData;
 
-export function set_up(
-    $input: JQuery,
-    pills: CombinedPillContainer,
-    opts: {
-        user: boolean;
-        user_group?: boolean;
-        stream?: boolean;
-        user_source?: () => User[];
-        exclude_bots?: boolean;
-        update_func?: () => void;
-    },
-): void {
+export function set_up($input: JQuery, pills: CombinedPillContainer, opts: TypeaheadOptions): void {
+    if (!$input) {
+        return;
+    }
     if (!opts.user && !opts.user_group && !opts.stream) {
         blueslip.error("Unspecified possible item types");
         return;
     }
+    pills.addSetupTypeahead(($input) => {
+        set_up($input, pills, opts);
+    });
+
     const include_streams = (query: string): boolean =>
         opts.stream !== undefined && query.trim().startsWith("#");
     const include_user_groups = opts.user_group;

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -39,6 +39,17 @@ export type CombinedPillItem =
     | InputPillItem<UserGroupPill>
     | InputPillItem<StreamPill>;
 
+export type TypeaheadOptions = {
+    user: boolean;
+    user_group?: boolean;
+    stream?: boolean;
+    user_source?: () => User[];
+    exclude_bots?: boolean;
+    update_func?: () => void;
+};
+
+export type SetupTypeahead = ($input: JQuery) => void;
+
 export function build_highlight_regex(query: string): RegExp {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");
     return regex;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -119,6 +119,19 @@
             perspective: 1000px;
         }
     }
+
+    .editable-pill {
+        display: block;
+        max-width: 100%;
+        min-width: 0;
+        padding: 0 4px;
+
+        min-height: 20px;
+        margin: 2px;
+
+        border-radius: 4px;
+        border: 1px solid hsl(176deg 78% 28%);
+    }
 }
 
 #compose-direct-recipient .pill-container {

--- a/web/templates/editable_pill.hbs
+++ b/web/templates/editable_pill.hbs
@@ -1,0 +1,2 @@
+<div class='input editable-pill' contenteditable="true">
+</div>

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -124,6 +124,7 @@ test_ui("validate", ({mock_template}) => {
         $("#private_message_recipient")[0] = {};
         $("#private_message_recipient").set_parent($pm_pill_container);
         $pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
+        $pm_pill_container.set_find_results(".editable-pill", {remove: noop});
         $("#private_message_recipient").before = noop;
 
         compose_pm_pill.initialize({

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -845,6 +845,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         appendValidatedData(item) {
             appended_names.push(item.display_value);
         },
+        addSetupTypeahead(_) {},
     }));
     compose_pm_pill.initialize({
         on_pill_create_or_remove: compose_recipient.update_placeholder_text,

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -337,6 +337,8 @@ run_test("set_up", ({mock_template, override, override_rewire}) => {
 
     function test_pill_typeahead(opts) {
         pill_typeahead.set_up($fake_input, $pill_widget, opts);
+        const setup_typeahead = $pill_widget._get_setup_typeahead_for_testing();
+        setup_typeahead(null);
         assert.ok(input_pill_typeahead_called);
     }
 


### PR DESCRIPTION
Here's a quick overview of what each commit does:

1. Edit input_pills in place by

    - Double clicking on a pill
    - Focusing on a pill (via arrow keys) and then pressing enter

2. Show typeahead for pills in composebox DM recipient box.

Fixes part (3) of #29510 

**Screenshots:**

Edit pill example:

1. By double clicking

![case1](https://github.com/zulip/zulip/assets/78212328/b767ec65-95ca-4ae9-a5a3-8bca7a0333cb)

2. Using the Arrow keys + Enter key

![case2](https://github.com/zulip/zulip/assets/78212328/ccd7d267-f034-48bc-b7b0-89bcee6fb9a6)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
