### PR TITLE
Changed recent topics to recent. Fixes: #25781

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -480,7 +480,7 @@ def fetch_initial_state_data(
             id=0,
             default_language=spectator_requested_language,
             # Set home view to recent conversations for spectators regardless of default.
-            web_home_view="recent_topics",
+            web_home_view="recent",
         )
     if want("realm_user"):
         state["raw_users"] = get_users_for_api(

--- a/zerver/migrations/0311_userprofile_default_view.py
+++ b/zerver/migrations/0311_userprofile_default_view.py
@@ -12,6 +12,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="userprofile",
             name="default_view",
-            field=models.TextField(default="recent_topics"),
+            field=models.TextField(default="recent"),
         ),
     ]

--- a/zerver/migrations/0332_realmuserdefault.py
+++ b/zerver/migrations/0332_realmuserdefault.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ("enter_sends", models.BooleanField(null=True, default=False)),
                 ("left_side_userlist", models.BooleanField(default=False)),
                 ("default_language", models.CharField(default="en", max_length=50)),
-                ("default_view", models.TextField(default="recent_topics")),
+                ("default_view", models.TextField(default="recent")),
                 ("dense_mode", models.BooleanField(default=True)),
                 ("fluid_layout_width", models.BooleanField(default=False)),
                 ("high_contrast_mode", models.BooleanField(default=False)),

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3716,7 +3716,7 @@ class RealmPropertyActionTest(BaseAction):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_LEGACY],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_LEGACY],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent", "inbox", "all_messages"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,
@@ -3851,7 +3851,7 @@ class UserDisplayActionTest(BaseAction):
         test_changes: Dict[str, Any] = dict(
             emojiset=["twitter"],
             default_language=["es", "de", "en"],
-            web_home_view=["all_messages", "inbox", "recent_topics"],
+            web_home_view=["all_messages", "inbox", "recent"],
             demote_inactive_streams=[2, 3, 1],
             web_mark_read_on_scroll_policy=[2, 3, 1],
             user_list_style=[1, 2, 3],

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1582,7 +1582,7 @@ class RealmAPITest(ZulipTestCase):
             web_font_size_px=[UserProfile.WEB_FONT_SIZE_PX_LEGACY],
             web_line_height_percent=[UserProfile.WEB_LINE_HEIGHT_PERCENT_LEGACY],
             color_scheme=UserProfile.COLOR_SCHEME_CHOICES,
-            web_home_view=["recent_topics", "inbox", "all_messages"],
+            web_home_view=["recent", "inbox", "all_messages"],
             emojiset=[emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()],
             demote_inactive_streams=UserProfile.DEMOTE_STREAMS_CHOICES,
             web_mark_read_on_scroll_policy=UserProfile.WEB_MARK_READ_ON_SCROLL_POLICY_CHOICES,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1327,7 +1327,7 @@ class UserProfileTest(ZulipTestCase):
         realm = get_realm("zulip")
         realm_user_default = RealmUserDefault.objects.get(realm=realm)
 
-        realm_user_default.web_home_view = "recent_topics"
+        realm_user_default.web_home_view = "recent"
         realm_user_default.emojiset = "twitter"
         realm_user_default.color_scheme = UserProfile.COLOR_SCHEME_LIGHT
         realm_user_default.enable_offline_email_notifications = False
@@ -1342,7 +1342,7 @@ class UserProfileTest(ZulipTestCase):
         with self.capture_send_event_calls(expected_num_events=0):
             copy_default_settings(realm_user_default, cordelia)
 
-        self.assertEqual(cordelia.web_home_view, "recent_topics")
+        self.assertEqual(cordelia.web_home_view, "recent")
         self.assertEqual(cordelia.emojiset, "twitter")
         self.assertEqual(cordelia.color_scheme, UserProfile.COLOR_SCHEME_LIGHT)
         self.assertEqual(cordelia.enable_offline_email_notifications, False)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -506,7 +506,7 @@ def realm_reactivation(request: HttpRequest, confirmation_key: str) -> HttpRespo
 
 
 emojiset_choices = {emojiset["key"] for emojiset in RealmUserDefault.emojiset_choices()}
-web_home_view_options = ["recent_topics", "inbox", "all_messages"]
+web_home_view_options = ["recent", "inbox", "all_messages"]
 
 
 @require_realm_admin

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -155,7 +155,7 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
 
 
 emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices()}
-web_home_view_options = ["recent_topics", "inbox", "all_messages"]
+web_home_view_options = ["recent", "inbox", "all_messages"]
 
 
 def check_settings_values(


### PR DESCRIPTION
This PR renames the "recent_topics" field to "recent"

Fixes: #25781

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
