### PR TITLE
popovers: Fix cancel button style issue.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -145,6 +145,13 @@
     &:hover {
         background: var(--color-exit-button-background-interactive);
     }
+
+    &:disabled {
+        cursor: not-allowed;
+        filter: saturate(0);
+        background-color: hsl(0deg 0% 93%);
+        color: hsl(0deg 3% 52%);
+    }
 }
 
 .dialog_submit_button {


### PR DESCRIPTION
The "Cancel" button in the dialog widget was not visually disabled in the light theme despite being functionally disabled. The same thing didn't happen in the dark theme.

Added CSS styling to fix this, more specifically made changes to modal.css to consider when this button is disabled in .dialog_exit_button.

Fixes: zulip#28803

**Screenshots and screen captures:**

- Light theme before changes:

     ![Captura de ecrã 2024-03-30 180819](https://github.com/zulip/zulip/assets/115926737/0f376534-6e18-45a0-b943-16e4a02307fe)

- Light theme after changes:

     ![Captura de ecrã 2024-03-30 181538](https://github.com/zulip/zulip/assets/115926737/0f0c6f1b-65d1-4a4f-b6d7-3eca5c75f2fb)

- Dark theme after changes:

     ![Captura de ecrã 2024-03-30 175521](https://github.com/zulip/zulip/assets/115926737/6a2050f6-7add-4aca-9cb0-e5115d392e23)


<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
