### PR TITLE
click_handlers: Show add reaction button on message select

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -217,13 +217,13 @@ export function initialize() {
         $("#main_div").on("click", ".messagebox", select_message_function);
         // on the other hand, on mobile it should be done with a long tap.
     } else {
-        const show_reaction_button = () => {
-            // To get the current visibility of the reaction_button
-            const visibility = $(".reaction_button").css("visibility");
+        const show_reaction_button = (e) => {
+            $(".reaction_button").css("visibility", "hidden");
 
-            // To set the visibility of the reaction_button
-            if (visibility === "hidden") {
-                $(".reaction_button").css("visibility", "visible");
+            const $reactionButton = $(e.currentTarget).find(".reaction_button");
+
+            if ($reactionButton.css("visibility") === "hidden") {
+                $reactionButton.css("visibility", "visible");
             }
         };
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -217,6 +217,18 @@ export function initialize() {
         $("#main_div").on("click", ".messagebox", select_message_function);
         // on the other hand, on mobile it should be done with a long tap.
     } else {
+        const show_reaction_button = () => {
+            // To get the current visibility of the reaction_button
+            const visibility = $(".reaction_button").css("visibility");
+
+            // To set the visibility of the reaction_button
+            if (visibility === "hidden") {
+                $(".reaction_button").css("visibility", "visible");
+            }
+        };
+
+        $("#main_div").on("click", ".messagebox", show_reaction_button);
+
         $("#main_div").on("longtap", ".messagebox", function (e) {
             const sel = window.getSelection();
             // if one matches, remove the current selections.


### PR DESCRIPTION
This PR modifies `web/src/click_handlers.js` to show the add reaction button when a message is selected on mobile web browsers. This is achieved by updating the mobile condition to include a new function `show_reaction_button` and an event handler that calls this on a `click` event.

The issue also mentions changing the compose message functionality, but on mobile devices this is triggered by a longtap, not a click, so that may not be needed.

Fixes: #29529 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://github.com/zulip/zulip/assets/87996659/26746f21-5061-450e-b049-6fde58b54939

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
