### PR TITLE
modal: Fix invite link overflow in mobile view

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -666,6 +666,14 @@ li,
     }
 }
 
+#copy_generated_link_container {
+    display: flex;
+    width: 100%;
+    margin-right: -32px;
+    gap: 4px;
+    align-items: center;
+}
+
 #copy_generated_invite_link {
     position: relative;
     margin-right: -32px;

--- a/web/templates/copy_invite_link.hbs
+++ b/web/templates/copy_invite_link.hbs
@@ -1,7 +1,9 @@
-{{t "Link:" }}
-<a href="{{ invite_link }}" id="multiuse_invite_link">{{ invite_link }}</a>
-&nbsp;
 <a class="btn copy_button_base" data-tippy-content="{{t 'Copy link' }}" data-tippy-placement="top" aria-label="{{t 'Copy link' }}"
   id='copy_generated_invite_link' data-clipboard-text="{{ invite_link }}">
     {{> copy_to_clipboard_svg }}
 </a>
+
+<div id="copy_generated_link_container">
+    <span>{{t "Link:" }}</span>
+    <a href="{{ invite_link }}" id="multiuse_invite_link">{{ invite_link }}</a>
+</div>


### PR DESCRIPTION
Fixed overflow of invite link in the invite users modal for mobile view.

Fixes zulip#29524.



**Screenshots:**

![image](https://github.com/zulip/zulip/assets/78212328/ff8d5cc1-384d-4191-9aa8-14900dbcb7a3)
