### PR TITLE
left sidebar: Navigation area library rewrite.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -76,16 +76,21 @@ export function update_dom_with_unread_counts(
 // TODO: Rewrite how we handle activation of narrows when doing the redesign.
 // We don't want to adjust class for all the buttons when switching narrows.
 
-function remove($elem: JQuery): void {
+function deactivate_narrow($elem: JQuery): void {
     $elem.removeClass("top-left-active-filter");
 }
 
-function deselect_top_left_corner_items(): void {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_mentions"));
-    remove($(".top_left_recent_view"));
-    remove($(".top_left_inbox"));
+/**
+ * Deselects narrows in the top left corner except the specified narrow if provided.
+ * If no narrow is provided, deselects all narrows.
+ * @param narrow_to_activate The narrow to exclude from deselection.
+ */
+function deselect_top_left_corner_items(narrow_to_activate = ""): void {
+    deactivate_narrow($(".top-left-active-filter"));
+
+    if (narrow_to_activate !== "") {
+        $(narrow_to_activate).addClass("top-left-active-filter");
+    }
 }
 
 export function handle_narrow_activated(filter: Filter): void {
@@ -158,27 +163,24 @@ function do_new_messages_animation($li: JQuery): void {
 }
 
 export function highlight_inbox_view(): void {
-    deselect_top_left_corner_items();
+    deselect_top_left_corner_items(".top_left_inbox");
 
-    $(".top_left_inbox").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
 }
 
 export function highlight_recent_view(): void {
-    deselect_top_left_corner_items();
+    deselect_top_left_corner_items(".top_left_recent_view");
 
-    $(".top_left_recent_view").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
 }
 
 export function highlight_all_messages_view(): void {
-    deselect_top_left_corner_items();
+    deselect_top_left_corner_items(".top_left_all_messages");
 
-    $(".top_left_all_messages").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -77,7 +77,7 @@ export function update_dom_with_unread_counts(
 // We don't want to adjust class for all the buttons when switching narrows.
 
 function remove($elem: JQuery): void {
-    $elem.removeClass("active-filter active-sub-filter");
+    $elem.removeClass("top-left-active-filter");
 }
 
 function deselect_top_left_corner_items(): void {
@@ -108,10 +108,10 @@ export function handle_narrow_activated(filter: Filter): void {
         filter_name = ops[0];
         if (filter_name === "starred") {
             $filter_li = $(".top_left_starred_messages");
-            $filter_li.addClass("active-filter");
+            $filter_li.addClass("top-left-active-filter");
         } else if (filter_name === "mentioned") {
             $filter_li = $(".top_left_mentions");
-            $filter_li.addClass("active-filter");
+            $filter_li.addClass("top-left-active-filter");
         }
     }
 }
@@ -160,7 +160,7 @@ function do_new_messages_animation($li: JQuery): void {
 export function highlight_inbox_view(): void {
     deselect_top_left_corner_items();
 
-    $(".top_left_inbox").addClass("active-filter");
+    $(".top_left_inbox").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
@@ -169,7 +169,7 @@ export function highlight_inbox_view(): void {
 export function highlight_recent_view(): void {
     deselect_top_left_corner_items();
 
-    $(".top_left_recent_view").addClass("active-filter");
+    $(".top_left_recent_view").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
@@ -178,7 +178,7 @@ export function highlight_recent_view(): void {
 export function highlight_all_messages_view(): void {
     deselect_top_left_corner_items();
 
-    $(".top_left_all_messages").addClass("active-filter");
+    $(".top_left_all_messages").addClass("top-left-active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -193,7 +193,7 @@ li.show-more-topics {
         }
     }
 
-    .inactive_stream:not(.active-filter) {
+    .inactive_stream:not(.top-left-active-filter) {
         opacity: 0.5;
     }
 
@@ -386,11 +386,11 @@ li.show-more-topics {
 }
 
 #stream_filters .narrow-filter.highlighted_stream {
-    &.active-filter > .bottom_left_row {
+    &.top-left-active-filter > .bottom_left_row {
         background-color: var(--color-background-hover-narrow-filter);
     }
 
-    &.active-filter .topic-list .bottom_left_row {
+    &.top-left-active-filter .topic-list .bottom_left_row {
         background-color: var(--color-background-active-narrow-filter);
     }
 
@@ -522,7 +522,7 @@ ul.filters {
     }
 }
 
-li.active-filter,
+li.top-left-active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
     position: relative;
@@ -530,7 +530,7 @@ li.active-sub-filter {
     background-color: var(--color-background-active-narrow-filter);
 }
 
-#stream_filters .narrow-filter.active-filter {
+#stream_filters .narrow-filter.top-left-active-filter {
     .topic-list .filter-topics,
     > .bottom_left_row {
         background-color: var(--color-background-active-narrow-filter);
@@ -596,7 +596,7 @@ li.active-sub-filter {
         }
     }
 
-    .active-filter {
+    .top-left-active-filter {
         /* Don't display a background on condensed icons. */
         background: unset;
     }
@@ -835,7 +835,7 @@ li.top_left_scheduled_messages {
             }
             /* ...except when there is an active filter in place:
                that row should still be shown. */
-            & .top_left_row.active-filter {
+            & .top_left_row.top-left-active-filter {
                 display: grid;
             }
         }

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, set_global, zrequire} = require("./lib/namespace");
+const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
@@ -14,60 +14,7 @@ const scheduled_messages = mock_esm("../src/scheduled_messages");
 
 scheduled_messages.get_count = () => 555;
 
-const {Filter} = zrequire("../src/filter");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
-
-run_test("narrowing", () => {
-    let filter = new Filter([{operator: "is", operand: "mentioned"}]);
-
-    // activating narrow
-
-    left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_mentions").hasClass("active-filter"));
-
-    filter = new Filter([{operator: "is", operand: "starred"}]);
-    left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_starred_messages").hasClass("active-filter"));
-
-    filter = new Filter([{operator: "in", operand: "home"}]);
-    left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
-
-    // deactivating narrow
-
-    left_sidebar_navigation_area.handle_narrow_activated(new Filter([]));
-
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
-
-    set_global("setTimeout", (f) => {
-        f();
-    });
-    left_sidebar_navigation_area.highlight_recent_view();
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
-    assert.ok($(".top_left_recent_view").hasClass("active-filter"));
-
-    left_sidebar_navigation_area.handle_narrow_activated(new Filter([]));
-    left_sidebar_navigation_area.highlight_inbox_view();
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok($(".top_left_inbox").hasClass("active-filter"));
-
-    left_sidebar_navigation_area.highlight_all_messages_view();
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
-    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
-});
 
 run_test("update_count_in_dom", () => {
     function make_elem($elem, count_selector) {


### PR DESCRIPTION
Now we don't individually adjust the classes for all the narrow buttons when switching narrows. Multiple calls to function have been replaced by a single call as noted in https://github.com/zulip/zulip/pull/26586#discussion_r1308046455. The **remove** function is also renamed to **deactivate_narrow** function which matches its purpose.

<!-- Describe your pull request here.-->

Fixes: #26686 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Working in dark mode:

[switching_narrows_dark_mode.webm](https://github.com/zulip/zulip/assets/113179991/719f73a3-22b4-4676-8741-98a07370c68c)

Working in light mode:

[switching_narrrows_light_mode.webm](https://github.com/zulip/zulip/assets/113179991/6a85874b-e474-4430-bbac-734760e2d29e)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
