### PR TITLE
apt-repos: Temporarily work around Ubuntu 24.04 non-installable gnupg

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -86,6 +86,12 @@ fi
 # Hash to check if the configuration is changed by the script later.
 hashes=$(sha256sum "$SOURCES_FILE" "$PREF_FILE" 2>/dev/null || true)
 
+if [ -e "$LIST_PATH/$LIST.pref" ]; then
+    cp "$LIST_PATH/$LIST.pref" "$PREF_FILE"
+else
+    rm -f "$PREF_FILE"
+fi
+
 pre_setup_deps=(apt-transport-https ca-certificates gnupg curl)
 if ! apt-get -dy install "${pre_setup_deps[@]}"; then
     apt-get update
@@ -94,12 +100,6 @@ apt-get -y install "${pre_setup_deps[@]}"
 
 apt-key add "$LIST_PATH/"*.asc
 cp "$LIST_PATH/$release.list" "$SOURCES_FILE"
-
-if [ -e "$LIST_PATH/$LIST.pref" ]; then
-    cp "$LIST_PATH/$LIST.pref" "$PREF_FILE"
-else
-    rm -f "$PREF_FILE"
-fi
 
 if [ -e "$LIST_PATH/custom.sh" ]; then
     export LIST_PATH

--- a/scripts/setup/apt-repos/zulip/zulip.pref
+++ b/scripts/setup/apt-repos/zulip/zulip.pref
@@ -1,0 +1,9 @@
+# Temporary workaround for
+# https://discourse.ubuntu.com/t/whats-happening-in-noble-repositories/43729/7
+Package: gnupg
+Pin: version 2.4.4-2ubuntu7
+Pin-Priority: 501
+
+Package: nginx-common nginx-full
+Pin: version 1.24.0-2ubuntu4
+Pin-Priority: 501


### PR DESCRIPTION
[Discussion](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/libmagic1.20not.20available.20error.20on.20Ubuntu24/near/1771274).