### PR TITLE
compose_ui: Add auto-surround for brackets and quotes.

### DIFF
--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -1140,6 +1140,8 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
     override_rewire(compose_ui, "format_text", (_$textarea, type) => {
         format_text_type = type;
     });
+    // Simulate text selection
+    $("textarea#compose-textarea").range = () => ({text: "Some text"});
 
     const event = {
         key: "b",
@@ -1178,6 +1180,14 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
         event.shiftKey = true;
         compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
         assert.equal(format_text_type, "link");
+        format_text_type = undefined;
+
+        // Test auto-surround:
+        // Auto-surround keys = ( [ { " ' `
+        event.key = "[";
+        event.shiftKey = false;
+        compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
+        assert.equal(format_text_type, "auto-surround");
         format_text_type = undefined;
     }
 


### PR DESCRIPTION
Add auto-surround for ( [ { ` " '. This change does not auto-close when there is no selection.

One caveat in the implementation that was not discussed in this [CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Bracket.2Fquote.20auto-surround.20in.20compose.20box/near/1766937): we do not support auto-surrounding with the same character multiple times for the same selections. For example: "this is _some_ text" with _some_ selected, would produce "this is [_some_] text" when "[" is pressed the first time and go back to "this is _some_ text" when "[" is pressed again with the same selection. This is consistent with the behaviour for the rest of the markdown shortcuts (bold, italics, link) and makes sense semantically since adding something like "{{{ }}}}" around text is not very meaningful.

Fixes #29482 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] <del>Explains differences from previous plans (e.g., issue description).
- [ ] <del>Highlights technical choices and bugs encountered.
- [ ] <del>Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] <del>Strings and tooltips.
- [ ] <del>End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
