### PR TITLE
hooks: Add a send_zulip_update_announcements post deploy hook.

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -13,7 +13,15 @@ log][commit-log] for an up-to-date list of all changes.
 
 #### Upgrade notes for 9.0
 
-- None yet.
+- This release introduces a new [Zulip updates](https://zulip.com/help/configure-automated-notices#zulip-update-announcements) feature, which
+  announces significant product changes and new features via automated
+  messages to a configurable stream. Generally, these announcements will
+  be sent automatically when upgrading to the new release. However, when
+  you first upgrade to the 9.x series, they will be sent with a delay
+  (explained in an automated direct message to organization administrators)
+  to give time to potentially reconfigure which stream to use. You can
+  override the delay by running `./manage.py send_zulip_update_announcements --skip-delay`
+  once you've done any necessary configuration updates.
 
 ## Zulip Server 8.x series
 

--- a/puppet/zulip/files/hooks/post-deploy.d/send_zulip_update_announcements.hook
+++ b/puppet/zulip/files/hooks/post-deploy.d/send_zulip_update_announcements.hook
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+/home/zulip/deployments/current/manage.py send_zulip_update_announcements

--- a/puppet/zulip/manifests/app_frontend_once.pp
+++ b/puppet/zulip/manifests/app_frontend_once.pp
@@ -2,6 +2,8 @@
 # in a cluster.
 
 class zulip::app_frontend_once {
+  include zulip::hooks::send_zulip_update_announcements
+
   $proxy_host = zulipconf('http_proxy', 'host', 'localhost')
   $proxy_port = zulipconf('http_proxy', 'port', '4750')
   if $proxy_host != '' and $proxy_port != '' {

--- a/puppet/zulip/manifests/hooks/send_zulip_update_announcements.pp
+++ b/puppet/zulip/manifests/hooks/send_zulip_update_announcements.pp
@@ -1,0 +1,9 @@
+# @summary Send zuip update announcements after deploy
+#
+class zulip::hooks::send_zulip_update_announcements {
+  include zulip::hooks::base
+
+  zulip::hooks::file { [
+    'post-deploy.d/send_zulip_update_announcements.hook',
+  ]: }
+}

--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -182,7 +182,7 @@ def send_messages_and_update_level(
     realm.save(update_fields=["zulip_update_announcements_level"])
 
 
-def send_zulip_update_announcements() -> None:
+def send_zulip_update_announcements(skip_delay: bool) -> None:
     latest_zulip_update_announcements_level = get_latest_zulip_update_announcements_level()
 
     realms = get_realms_behind_zulip_update_announcements_level(
@@ -220,6 +220,7 @@ def send_zulip_update_announcements() -> None:
                 if (
                     realm_zulip_update_announcements_level == 0
                     and is_group_direct_message_sent_to_admins_within_days(realm, days=1)
+                    and not skip_delay
                 ):
                     continue
 

--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -45,14 +45,16 @@ announcements, they can be disabled. [Learn more]({zulip_update_announcements_he
     ZulipUpdateAnnouncement(
         level=2,
         message="""
+**Web and desktop updates**
+
 - When you paste content into the compose box, Zulip will now do its best to preserve
-  the formatting, including links, bulleted lists, bold, italics, and more.
-  Pasting as plain text remains an alternative option. [Learn
-  more]({keyboard_shortcuts_basics_help_url}).
+the formatting, including links, bulleted lists, bold, italics, and more.
+Pasting as plain text remains an alternative option. [Learn
+more]({keyboard_shortcuts_basics_help_url}).
 - To [quote and reply]({quote_and_reply_help_url}) to part of a message, you can
-  now select the part that you want to quote.
+now select the part that you want to quote.
 - You can now hide the user list in the right sidebar to reduce distraction.
-  [Learn more]({user_list_help_url}).
+[Learn more]({user_list_help_url}).
 """.format(
             keyboard_shortcuts_basics_help_url="/help/keyboard-shortcuts#the-basics",
             user_list_help_url="/help/user-list",

--- a/zerver/management/commands/send_zulip_update_announcements.py
+++ b/zerver/management/commands/send_zulip_update_announcements.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from typing import Any
 
 from typing_extensions import override
@@ -10,5 +11,13 @@ class Command(ZulipBaseCommand):
     help = """Script to send zulip update announcements to realms."""
 
     @override
-    def handle(self, *args: Any, **options: str) -> None:
-        send_zulip_update_announcements()
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--skip-delay",
+            action="store_true",
+            help="Immediately send updates if 'zulip_update_announcements_stream' is configured.",
+        )
+
+    @override
+    def handle(self, *args: Any, **options: Any) -> None:
+        send_zulip_update_announcements(skip_delay=options["skip_delay"])

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -4,6 +4,7 @@ from unittest import mock
 import time_machine
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
+from typing_extensions import override
 
 from zerver.lib.message import remove_single_newlines
 from zerver.lib.test_classes import ZulipTestCase
@@ -17,171 +18,181 @@ from zerver.models.recipients import Recipient, get_huddle_user_ids
 from zerver.models.streams import get_stream
 from zerver.models.users import get_system_bot
 
-test_zulip_update_announcements = [
-    ZulipUpdateAnnouncement(
-        level=1,
-        message="Announcement message 1.",
-    ),
-    ZulipUpdateAnnouncement(
-        level=2,
-        message="Announcement message 2.",
-    ),
-]
-
 
 class ZulipUpdateAnnouncementsTest(ZulipTestCase):
-    @mock.patch(
-        "zerver.lib.zulip_update_announcements.zulip_update_announcements",
-        test_zulip_update_announcements,
-    )
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.zulip_update_announcements = [
+            ZulipUpdateAnnouncement(
+                level=1,
+                message="Announcement message 1.",
+            ),
+            ZulipUpdateAnnouncement(
+                level=2,
+                message="Announcement message 2.",
+            ),
+        ]
+
     def test_send_zulip_update_announcements(self) -> None:
-        realm = get_realm("zulip")
+        with mock.patch(
+            "zerver.lib.zulip_update_announcements.zulip_update_announcements",
+            self.zulip_update_announcements,
+        ):
+            realm = get_realm("zulip")
 
-        # realm predates the "zulip updates" feature with the
-        # zulip_update_announcements_stream set to None.
-        realm.zulip_update_announcements_level = None
-        realm.zulip_update_announcements_stream = None
-        realm.save(
-            update_fields=["zulip_update_announcements_level", "zulip_update_announcements_stream"]
-        )
+            # realm predates the "zulip updates" feature with the
+            # zulip_update_announcements_stream set to None.
+            realm.zulip_update_announcements_level = None
+            realm.zulip_update_announcements_stream = None
+            realm.save(
+                update_fields=[
+                    "zulip_update_announcements_level",
+                    "zulip_update_announcements_stream",
+                ]
+            )
 
-        group_direct_messages = Message.objects.filter(
-            realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
-        )
-        self.assertFalse(group_direct_messages.exists())
+            group_direct_messages = Message.objects.filter(
+                realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
+            )
+            self.assertFalse(group_direct_messages.exists())
 
-        admin_user_ids = set(realm.get_human_admin_users().values_list("id", flat=True))
-        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
-        expected_group_direct_message_user_ids = admin_user_ids | {notification_bot.id}
+            admin_user_ids = set(realm.get_human_admin_users().values_list("id", flat=True))
+            notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+            expected_group_direct_message_user_ids = admin_user_ids | {notification_bot.id}
 
-        now = timezone_now()
-        with time_machine.travel(now, tick=False):
-            send_zulip_update_announcements()
+            now = timezone_now()
+            with time_machine.travel(now, tick=False):
+                send_zulip_update_announcements()
 
-        realm.refresh_from_db()
-        group_direct_message = group_direct_messages.first()
-        assert group_direct_message is not None
-        self.assertEqual(group_direct_message.sender, notification_bot)
-        self.assertEqual(group_direct_message.date_sent, now)
-        self.assertEqual(
-            set(get_huddle_user_ids(group_direct_message.recipient)),
-            expected_group_direct_message_user_ids,
-        )
-        self.assertEqual(realm.zulip_update_announcements_level, 0)
-        self.assertIn(
-            "These notifications are currently turned off in your organization.",
-            group_direct_message.content,
-        )
+            realm.refresh_from_db()
+            group_direct_message = group_direct_messages.first()
+            assert group_direct_message is not None
+            self.assertEqual(group_direct_message.sender, notification_bot)
+            self.assertEqual(group_direct_message.date_sent, now)
+            self.assertEqual(
+                set(get_huddle_user_ids(group_direct_message.recipient)),
+                expected_group_direct_message_user_ids,
+            )
+            self.assertEqual(realm.zulip_update_announcements_level, 0)
+            self.assertIn(
+                "These notifications are currently turned off in your organization.",
+                group_direct_message.content,
+            )
 
-        # Wait for one week before starting to skip sending updates.
-        with time_machine.travel(now + timedelta(days=2), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        self.assertEqual(realm.zulip_update_announcements_level, 0)
+            # Wait for one week before starting to skip sending updates.
+            with time_machine.travel(now + timedelta(days=2), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            self.assertEqual(realm.zulip_update_announcements_level, 0)
 
-        with time_machine.travel(now + timedelta(days=8), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        self.assertEqual(realm.zulip_update_announcements_level, 2)
+            with time_machine.travel(now + timedelta(days=8), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            self.assertEqual(realm.zulip_update_announcements_level, 2)
 
-        # Configure a stream. Two new updates added.
-        verona = get_stream("verona", realm)
-        realm.zulip_update_announcements_stream = verona
-        realm.save(update_fields=["zulip_update_announcements_stream"])
-        new_updates = [
-            ZulipUpdateAnnouncement(
-                level=3,
-                message="Announcement message 3.",
-            ),
-            ZulipUpdateAnnouncement(
-                level=4,
-                message="Announcement message 4.",
-            ),
-        ]
-        test_zulip_update_announcements.extend(new_updates)
+            # Configure a stream. Two new updates added.
+            verona = get_stream("verona", realm)
+            realm.zulip_update_announcements_stream = verona
+            realm.save(update_fields=["zulip_update_announcements_stream"])
+            new_updates = [
+                ZulipUpdateAnnouncement(
+                    level=3,
+                    message="Announcement message 3.",
+                ),
+                ZulipUpdateAnnouncement(
+                    level=4,
+                    message="Announcement message 4.",
+                ),
+            ]
+            self.zulip_update_announcements.extend(new_updates)
 
-        # verify zulip update announcements sent to configured stream.
-        with time_machine.travel(now + timedelta(days=10), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        stream_messages = Message.objects.filter(
-            realm=realm,
-            sender=notification_bot,
-            recipient__type_id=verona.id,
-            date_sent__gte=now + timedelta(days=10),
-        ).order_by("id")
-        self.assert_length(stream_messages, 2)
-        self.assertEqual(stream_messages[0].content, "Announcement message 3.")
-        self.assertEqual(stream_messages[1].content, "Announcement message 4.")
-        self.assertEqual(realm.zulip_update_announcements_level, 4)
+            # verify zulip update announcements sent to configured stream.
+            with time_machine.travel(now + timedelta(days=10), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            stream_messages = Message.objects.filter(
+                realm=realm,
+                sender=notification_bot,
+                recipient__type_id=verona.id,
+                date_sent__gte=now + timedelta(days=10),
+            ).order_by("id")
+            self.assert_length(stream_messages, 2)
+            self.assertEqual(stream_messages[0].content, "Announcement message 3.")
+            self.assertEqual(stream_messages[1].content, "Announcement message 4.")
+            self.assertEqual(realm.zulip_update_announcements_level, 4)
 
-    @mock.patch(
-        "zerver.lib.zulip_update_announcements.zulip_update_announcements",
-        test_zulip_update_announcements,
-    )
     def test_send_zulip_update_announcements_with_stream_configured(self) -> None:
-        realm = get_realm("zulip")
+        with mock.patch(
+            "zerver.lib.zulip_update_announcements.zulip_update_announcements",
+            self.zulip_update_announcements,
+        ):
+            realm = get_realm("zulip")
 
-        # realm predates the "zulip updates" feature with the
-        # zulip_update_announcements_stream configured.
-        realm.zulip_update_announcements_level = None
-        realm.zulip_update_announcements_stream = get_stream("verona", realm)
-        realm.save(
-            update_fields=["zulip_update_announcements_level", "zulip_update_announcements_stream"]
-        )
+            # realm predates the "zulip updates" feature with the
+            # zulip_update_announcements_stream configured.
+            realm.zulip_update_announcements_level = None
+            realm.zulip_update_announcements_stream = get_stream("verona", realm)
+            realm.save(
+                update_fields=[
+                    "zulip_update_announcements_level",
+                    "zulip_update_announcements_stream",
+                ]
+            )
 
-        group_direct_messages = Message.objects.filter(
-            realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
-        )
-        self.assertFalse(group_direct_messages.exists())
+            group_direct_messages = Message.objects.filter(
+                realm=realm, recipient__type=Recipient.DIRECT_MESSAGE_GROUP
+            )
+            self.assertFalse(group_direct_messages.exists())
 
-        now = timezone_now()
-        with time_machine.travel(now, tick=False):
-            send_zulip_update_announcements()
+            now = timezone_now()
+            with time_machine.travel(now, tick=False):
+                send_zulip_update_announcements()
 
-        realm.refresh_from_db()
-        self.assertTrue(group_direct_messages.exists())
-        self.assertEqual(realm.zulip_update_announcements_level, 0)
+            realm.refresh_from_db()
+            self.assertTrue(group_direct_messages.exists())
+            self.assertEqual(realm.zulip_update_announcements_level, 0)
 
-        # Wait for 24 hours before starting to send updates.
-        with time_machine.travel(now + timedelta(hours=10), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        self.assertEqual(realm.zulip_update_announcements_level, 0)
+            # Wait for 24 hours before starting to send updates.
+            with time_machine.travel(now + timedelta(hours=10), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            self.assertEqual(realm.zulip_update_announcements_level, 0)
 
-        with time_machine.travel(now + timedelta(days=1), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        self.assertEqual(realm.zulip_update_announcements_level, 4)
+            with time_machine.travel(now + timedelta(days=1), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            self.assertEqual(realm.zulip_update_announcements_level, 2)
 
-        # Two new updates added.
-        new_updates = [
-            ZulipUpdateAnnouncement(
-                level=5,
-                message="Announcement message 5.",
-            ),
-            ZulipUpdateAnnouncement(
-                level=6,
-                message="Announcement message 6.",
-            ),
-        ]
-        test_zulip_update_announcements.extend(new_updates)
+            # Two new updates added.
+            new_updates = [
+                ZulipUpdateAnnouncement(
+                    level=3,
+                    message="Announcement message 3.",
+                ),
+                ZulipUpdateAnnouncement(
+                    level=4,
+                    message="Announcement message 4.",
+                ),
+            ]
+            self.zulip_update_announcements.extend(new_updates)
 
-        # verify zulip update announcements sent to configured stream.
-        with time_machine.travel(now + timedelta(days=2), tick=False):
-            send_zulip_update_announcements()
-        realm.refresh_from_db()
-        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
-        stream_messages = Message.objects.filter(
-            realm=realm,
-            sender=notification_bot,
-            recipient__type_id=realm.zulip_update_announcements_stream.id,
-            date_sent__gte=now + timedelta(days=2),
-        ).order_by("id")
-        self.assert_length(stream_messages, 2)
-        self.assertEqual(stream_messages[0].content, "Announcement message 5.")
-        self.assertEqual(stream_messages[1].content, "Announcement message 6.")
-        self.assertEqual(realm.zulip_update_announcements_level, 6)
+            # verify zulip update announcements sent to configured stream.
+            with time_machine.travel(now + timedelta(days=2), tick=False):
+                send_zulip_update_announcements()
+            realm.refresh_from_db()
+            notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+            stream_messages = Message.objects.filter(
+                realm=realm,
+                sender=notification_bot,
+                recipient__type_id=realm.zulip_update_announcements_stream.id,
+                date_sent__gte=now + timedelta(days=2),
+            ).order_by("id")
+            self.assert_length(stream_messages, 2)
+            self.assertEqual(stream_messages[0].content, "Announcement message 3.")
+            self.assertEqual(stream_messages[1].content, "Announcement message 4.")
+            self.assertEqual(realm.zulip_update_announcements_level, 4)
 
     def test_group_direct_message_with_zulip_updates_stream_set(self) -> None:
         realm = get_realm("zulip")


### PR DESCRIPTION
[CZO Discussion:](https://chat.zulip.org/#narrow/stream/101-design/topic/New.20feature.20notification.20system.20.2328604/near/1771998)

> What I'm imagining for self-hosted servers, in that in a post-9.0 release, they'll already have the DMs, and for the 9.0 release, we can just offer a documented option in the management command for how to skip the delay, and put that in the "upgrade notes" section of the changelog.

For 9.0 upgrade:
* post upgrade tooling will send the group DM.
* Upgrade notes suggests to run `./manage.py send_zulip_update_announcements --skip-delay` to send updates immediately. (Stream should be configured)
<details><summary>Upgrade notes</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/cc48ec9c-fc61-43a0-89ac-825f202087e8">
</img>
</details> 


For post 9.0 upgrades:
* post upgrade tooling will send the update messages.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
