### PR TITLE
compose: Redesign Drafts button, especially at smaller widths.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1320,7 +1320,7 @@ textarea.new_message_textarea,
        the 8px from the negative left margin. */
     max-width: calc(100% + 8px);
     display: flex;
-    gap: 1px;
+    gap: 2px;
 
     .compose-drafts-text {
         /* Set an ellipsis when the translated

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1333,13 +1333,13 @@ textarea.new_message_textarea,
     }
 
     @media (width < $mc_min) {
-        margin-left: 0;
-        /* With no negative left margin,
-           hold the max width to 100%. */
-        max-width: 100%;
+        /* Reduce the padding on the sides so the
+        button's edge isn't too close to the textarea */
+        margin-left: -3px;
+        max-width: calc(100% + 3px);
         /* Align the `Drafts` text with the
            send icon below. */
-        padding: 0 5px;
+        padding: 0 3px;
     }
 }
 


### PR DESCRIPTION
compose: Increase gap between Draft button's text and the counter.

compose: Adjust alignment and size of Drafts button at smaller widths.

The padding on the sides of the Drafts button is reduced from 5 to 3px
at smaller width, so that it's not right up against the textareas when
hovered.

The text is also aligned to the Send button's edge, like at larger
widths.

Fixes: [Issue report on CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20drafts.20button.20and.20counter.20in.20compose.20box/near/1769156)

**Screenshots and screen captures:**
Light:
![image](https://github.com/zulip/zulip/assets/68962290/88e1faa9-c682-4be0-bc42-67ccba6f8f55)

Dark:
![image](https://github.com/zulip/zulip/assets/68962290/98b4c7bd-f89c-44cc-98b0-408731be6f7b)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
