### PR TITLE
Small bits of Python 3.8 → 3.10 modernization

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import operator
 import os
@@ -4599,11 +4600,11 @@ class BillingHelpersTest(ZulipTestCase):
         for i, boundary in enumerate(period_boundaries):
             self.assertEqual(add_months(anchor, i), boundary)
         # Test next_month for small values
-        for last, next_ in zip(period_boundaries[:-1], period_boundaries[1:]):
+        for last, next_ in itertools.pairwise(period_boundaries):
             self.assertEqual(next_month(anchor, last), next_)
         # Test next_month for large values
         period_boundaries = [dt.replace(year=dt.year + 100) for dt in period_boundaries]
-        for last, next_ in zip(period_boundaries[:-1], period_boundaries[1:]):
+        for last, next_ in itertools.pairwise(period_boundaries):
             self.assertEqual(next_month(anchor, last), next_)
 
     def test_compute_plan_parameters(self) -> None:

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -19,6 +19,8 @@ from datetime import datetime, timedelta
 from typing import IO, Any, Dict, List, Optional, Sequence, Set, Union, overload
 from urllib.parse import SplitResult
 
+import zoneinfo
+
 DEPLOYMENTS_DIR = "/home/zulip/deployments"
 LOCK_DIR = os.path.join(DEPLOYMENTS_DIR, "lock")
 TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
@@ -470,11 +472,6 @@ def os_families() -> Set[str]:
 
 
 def get_tzdata_zi() -> IO[str]:
-    if sys.version_info < (3, 9):  # nocoverage
-        from backports import zoneinfo
-    else:  # nocoverage
-        import zoneinfo
-
     for path in zoneinfo.TZPATH:
         filename = os.path.join(path, "tzdata.zi")
         if os.path.exists(filename):

--- a/tools/setup/build_timezone_values
+++ b/tools/setup/build_timezone_values
@@ -3,10 +3,7 @@ import json
 import os
 import sys
 
-if sys.version_info < (3, 9):
-    from backports import zoneinfo
-else:
-    import zoneinfo
+import zoneinfo
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 sys.path.insert(0, ZULIP_PATH)

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -12,6 +12,7 @@ from email.headerregistry import Address
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import lxml.html
+import zoneinfo
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.auth import get_backends
@@ -41,11 +42,6 @@ from zerver.models import Message, Realm, Recipient, Stream, UserMessage, UserPr
 from zerver.models.messages import get_context_for_message
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.users import get_user_profile_by_id
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
 
 logger = logging.getLogger(__name__)
 

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -14,7 +14,7 @@ import subprocess
 import tempfile
 from contextlib import suppress
 from datetime import datetime
-from functools import lru_cache
+from functools import cache
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, TypedDict
 
 import orjson
@@ -2232,7 +2232,7 @@ def chunkify(lst: List[int], chunk_size: int) -> List[List[int]]:
 def export_messages_single_user(
     user_profile: UserProfile, *, output_dir: Path, reaction_message_ids: Set[int]
 ) -> None:
-    @lru_cache(maxsize=None)
+    @cache
     def get_recipient(recipient_id: int) -> str:
         recipient = Recipient.objects.get(id=recipient_id)
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -7,7 +7,7 @@ import logging
 import re
 from dataclasses import dataclass
 from email.headerregistry import Address
-from functools import lru_cache
+from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -162,7 +162,7 @@ def has_apns_credentials() -> bool:
     return settings.APNS_TOKEN_KEY_FILE is not None or settings.APNS_CERT_FILE is not None
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_apns_context() -> Optional[APNsContext]:
     # We lazily do this import as part of optimizing Zulip's base
     # import time.

--- a/zerver/lib/timezone.py
+++ b/zerver/lib/timezone.py
@@ -1,10 +1,10 @@
-from functools import lru_cache
+from functools import cache
 from typing import Dict
 
 from scripts.lib.zulip_tools import get_tzdata_zi
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_canonical_timezone_map() -> Dict[str, str]:
     canonical = {}
     with get_tzdata_zi() as f:

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -29,7 +29,6 @@ for any particular type of object.
 """
 
 import re
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -52,6 +51,7 @@ from typing import (
 )
 
 import orjson
+import zoneinfo
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator, validate_email
 from django.utils.translation import gettext as _
@@ -62,11 +62,6 @@ from typing_extensions import override
 from zerver.lib.exceptions import InvalidJSONError, JsonableError
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.types import ProfileFieldData, Validator
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
 
 ResultT = TypeVar("ResultT")
 

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -1,6 +1,6 @@
-import sys
 from typing import Any, Optional
 
+import zoneinfo
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.dispatch import receiver
@@ -13,11 +13,6 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.models import UserProfile
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
 
 JUST_CREATED_THRESHOLD = 60
 

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -1,8 +1,8 @@
-import sys
 from datetime import datetime, timedelta, timezone
 from typing import Sequence
 
 import time_machine
+import zoneinfo
 from django.conf import settings
 from django.core import mail
 from django.test import override_settings
@@ -17,11 +17,6 @@ from zerver.lib.timezone import canonicalize_timezone
 from zerver.models import Message, Realm, Recipient, Stream, UserProfile
 from zerver.models.realms import get_realm
 from zerver.signals import JUST_CREATED_THRESHOLD, get_device_browser, get_device_os
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
 
 
 class SendLoginEmailTest(ZulipTestCase):

--- a/zerver/tests/test_timezone.py
+++ b/zerver/tests/test_timezone.py
@@ -1,15 +1,10 @@
-import sys
 from datetime import datetime, timezone
 
+import zoneinfo
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timezone import canonicalize_timezone, common_timezones
-
-if sys.version_info < (3, 9):  # nocoverage
-    from backports import zoneinfo
-else:  # nocoverage
-    import zoneinfo
 
 
 class TimeZoneTest(ZulipTestCase):

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -9,7 +9,7 @@ import traceback
 import uuid
 from collections import deque
 from contextlib import suppress
-from functools import lru_cache
+from functools import cache
 from typing import (
     AbstractSet,
     Any,
@@ -1110,7 +1110,7 @@ def process_message_event(
     recipient_type_name: str = wide_dict["type"]
     sending_client: str = wide_dict["client"]
 
-    @lru_cache(maxsize=None)
+    @cache
     def get_client_payload(
         apply_markdown: bool, client_gravatar: bool, can_access_sender: bool
     ) -> Dict[str, Any]:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -199,11 +199,7 @@ def retry_send_email_failures(
     def wrapper(worker: ConcreteQueueWorker, data: Dict[str, Any]) -> None:
         try:
             func(worker, data)
-        except (
-            socket.gaierror,
-            socket.timeout,
-            EmailNotDeliveredError,
-        ) as e:
+        except (socket.gaierror, TimeoutError, EmailNotDeliveredError) as e:
             error_class_name = type(e).__name__
 
             def on_failure(event: Dict[str, Any]) -> None:


### PR DESCRIPTION
Bumping `target-version = "py38"` to `"py310"` in `pyproject.yaml` will cause Ruff to enable new rules, fixes, and formatting. This is a subset that doesn’t include mass changes. Since we have not yet bumped `target-version`, they’re not yet lint-enforced.