### PR TITLE
scim: Add config option to disable initial streams for guests.

### DIFF
--- a/zerver/lib/scim.py
+++ b/zerver/lib/scim.py
@@ -296,6 +296,13 @@ class ZulipSCIMUser(SCIMUser):
 
         if self.is_new_user():
             assert full_name_new_value is not None
+            add_initial_stream_subscriptions = True
+            if (
+                self.config.get("create_guests_without_streams", False)
+                and role_new_value == UserProfile.ROLE_GUEST
+            ):
+                add_initial_stream_subscriptions = False
+
             self.obj = do_create_user(
                 email_new_value,
                 password,
@@ -303,6 +310,7 @@ class ZulipSCIMUser(SCIMUser):
                 full_name_new_value,
                 role=role_new_value,
                 tos_version=UserProfile.TOS_VERSION_BEFORE_FIRST_LOGIN,
+                add_initial_stream_subscriptions=add_initial_stream_subscriptions,
                 acting_user=None,
             )
             return

--- a/zproject/settings_types.py
+++ b/zproject/settings_types.py
@@ -37,7 +37,8 @@ class OIDCIdPConfigDict(TypedDict, total=False):
     auto_signup: bool
 
 
-class SCIMConfigDict(TypedDict):
+class SCIMConfigDict(TypedDict, total=False):
     bearer_token: str
     scim_client_name: str
     name_formatted_included: bool
+    create_guests_without_streams: bool


### PR DESCRIPTION
When an organization (without open ability for anyone to join) invites a guest user, the invitation prompts allows them to choose whether the guest should be added to default streams or not. This is useful, because since we don't have per-role default streams configs, they may want default streams to be for full Members.

SCIM provisioning doesn't have this control, since a newly provisioned user gets created via a direct do_create_user call, thus adding them to the organization's default streams, with no workaround possible aside of just getting rid of default streams in the organization.

To make provisioning guests in such an organization usable, we add a simple config option to create them with no streams. It's configured by adding
```
"create_guests_without_streams": True
```

to the config dict in settings.SCIM_CONFIG.

