### PR TITLE
Replace "Unknown" with something better for inactive users.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -169,7 +169,11 @@ function get_last_active(user) {
     const last_active_date = presence.last_active_date(user.user_id);
 
     if (!last_active_date) {
+<<<<<<< Updated upstream
         return $t({defaultMessage: "Unknown"});
+=======
+        return $t({defaultMessage: "1+ year ago"});
+>>>>>>> Stashed changes
     }
     return timerender.render_now(last_active_date).time_str;
 }

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -155,10 +155,17 @@ def get_presence_for_user(
 def get_presence_dict_by_realm(
     realm: Realm, slim_presence: bool = False, requesting_user_profile: Optional[UserProfile] = None
 ) -> Dict[str, Dict[str, Any]]:
+<<<<<<< Updated upstream
     two_weeks_ago = timezone_now() - timedelta(weeks=2)
     query = UserPresence.objects.filter(
         realm_id=realm.id,
         last_connected_time__gte=two_weeks_ago,
+=======
+    fiftytwo_weeks_ago = timezone_now() - timedelta(weeks=52)
+    query = UserPresence.objects.filter(
+        realm_id=realm.id,
+        last_connected_time__gte=fiftytwo_weeks_ago,
+>>>>>>> Stashed changes
         user_profile__is_active=True,
         user_profile__is_bot=False,
     )


### PR DESCRIPTION
#8432  

Description:


Current status about last active for users and problems with it:    on #organization/user-list-admin (Organization settings -> Users) we use "Unknown" to denote the last active time more than two weeks ago and for people who were active under two weeks, the actual last active dates are being used.

 What we aim to do: We will provide actual last active dates for these users for 1 year and if inactive time exceeds 1 year last active will change to 1+ year ago.

Why we are choosing to tell the actual last active dates only till 1 year? : 

Its because the code used in python file ( zerver/lib/presence.py  ) does not show the year alongside date that might lead to confusion ( for eg 3 march but of  which year 2023 or 2022 ) so it turns out the max amount of time you can show actual dates without confusion is till 1 year and then  i made code to change last active  to  " 1+ years ago."


 for eg 

case 1 : inactive time is within one year .--------------

 eg.-if a user is inactive for 3 weeks 

before: last active would show "unknown"

now: last active would show " 12 March "

case 2 : inactive time is more than 1 year--------------

eg. if a user  is inactive for 1.5 years 

before :" unknown"

now : "1+ years ago"

if someone want to work on the code  responsible for last active date  in future here is the code snippet from  python file :

Fixes: #8432  changes activity status from "unknown" to something better for inactive users .

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
