### PR TITLE
zulip_news: Wait for one day after sending group DM if stream is set.

### DIFF
--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -215,6 +215,14 @@ def send_zulip_update_announcements() -> None:
                 if not is_group_direct_message_sent_to_admins_within_days(realm, days=7):
                     new_zulip_update_announcements_level = latest_zulip_update_announcements_level
             else:
+                # Wait for 24 hours after sending group DM to allow admins to change the
+                # stream for zulip update announcements from it's default value if desired.
+                if (
+                    realm_zulip_update_announcements_level == 0
+                    and is_group_direct_message_sent_to_admins_within_days(realm, days=1)
+                ):
+                    continue
+
                 if realm.zulip_update_announcements_stream is not None:
                     messages = internal_prep_zulip_update_announcements_stream_messages(
                         current_level=realm_zulip_update_announcements_level,


### PR DESCRIPTION
* Update cron job to run daily instead of hourly.
* Wait for 24 hours after sending group DM to admins to publish Zulip updates in stream.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
