### PR TITLE
Left Sidebar: Rename All messages to Combined Feed without changing hash.

### DIFF
--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -266,7 +266,7 @@ Some scenarios to consider:
 
 - Try clicking on any interactive elements, multiple times, in a variety of orders.
 - If the feature affects the **message view**, try it out in different types of
-  narrows: topic, stream, All messages, direct messages.
+  narrows: topic, stream, Combined feed, direct messages.
 - If the feature affects the **compose box** in the web app, try both ways of
   [resizing the compose box](https://zulip.com/help/resize-the-compose-box).
   Test both stream messages and direct messages.

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -280,7 +280,7 @@ self-explanatory names.
 
 - **ellipsis**: A small vertical three dot icon (technically called
   as ellipsis-v), present in sidebars as a menu icon.
-  It offers contextual options for global filters (All messages
+  It offers contextual options for global filters (Combined feed
   and Starred messages), stream filters and topics in left
   sidebar and users in right sidebar. To avoid visual clutter
   ellipsis only appears in the web UI upon hover.

--- a/docs/subsystems/pointer.md
+++ b/docs/subsystems/pointer.md
@@ -54,11 +54,11 @@ streams.)
 ### Unnarrow: previous sequence
 
 When you unnarrow using e.g. the `a` key, you will automatically be
-taken to the same message that was selected in the All messages view before
+taken to the same message that was selected in the Combined feed view before
 you narrowed, unless in the narrow you read new messages, in which
 case you will be jumped forward to the first unread and non-muted
-message in the All messages view (or the bottom of the feed if there is
-none). This makes for a nice experience reading threads via the All messages
+message in the Combined feed view (or the bottom of the feed if there is
+none). This makes for a nice experience reading threads via the Combined feed
 view in sequence.
 
 ### Forced reload: state preservation

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -53,7 +53,7 @@ Try using all the navigation hotkeys:
 Try narrowing from the message view:
 
 - Hotkeys
-  - use a to go to All messages
+  - use a to go to Combined feed
   - use s to narrow to a stream (select message first
     and verify in sidebar)
   - use S to narrow to the topic (and verify in sidebar)
@@ -184,7 +184,7 @@ For each of the above types of messages, you will want to cycle
 through the following views for Cordelia (and have Hamlet send new
 messages after each narrow):
 
-- Go to All messages view.
+- Go to Combined feed view.
 - Go to All direct messages view.
 - Go to Direct messages w/Hamlet.
 - Go to Direct messages w/Hamlet and Othello.

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -185,7 +185,7 @@ through the following views for Cordelia (and have Hamlet send new
 messages after each narrow):
 
 - Go to Combined feed view.
-- Go to All direct messages view.
+- Go to Direct message feed view.
 - Go to Direct messages w/Hamlet.
 - Go to Direct messages w/Hamlet and Othello.
 - Go to Verona view.
@@ -217,9 +217,9 @@ populated and where the focus is placed.
 - Buttons
 
   - Narrow to a stream and click on "New topic"
-  - Narrow "All direct messages" and click on "New topic"
+  - Narrow to "Direct message feed" and click on "New topic"
   - Narrow to a stream and click on "New direct message"
-  - Narrow "All direct messages" and click on "New direct message"
+  - Narrow to "Direct message feed" and click on "New direct message"
 
 - Topics
 

--- a/docs/translating/polish.md
+++ b/docs/translating/polish.md
@@ -48,11 +48,11 @@ You can set your own alert words for Zulip messages.
 
 > Możesz ustawić powiadomienia dla wybranych fraz w Zulipie.
 
-**All messages**: wszystkie wiadomości
+**Combined feed**: wszystkie wiadomości
 
 example:
 
-You can see all messages in unmuted streams and topics with "All messages".
+You can see all messages in unmuted streams and topics with "Combined feed".
 
 > Możesz zobaczyć pełną listę wiadomości poprzez widok "Wszystkie wiadomości".
 

--- a/help/all-messages.md
+++ b/help/all-messages.md
@@ -1,4 +1,4 @@
-# All messages
+# Combined feed
 
 {!all-messages.md!}
 
@@ -6,7 +6,7 @@
 
     Use <kbd>S</kbd> (go to stream) or <kbd>Shift</kbd> +
     <kbd>S</kbd> (go to conversation) to zoom in, and <kbd>A</kbd> to
-    get back to **All messages**.
+    get back to **Combined feed**.
 
 
 ## Related articles

--- a/help/archive-a-stream.md
+++ b/help/archive-a-stream.md
@@ -4,7 +4,7 @@
 
 Archiving a stream will immediately unsubscribe all users from the stream,
 remove the stream from search and other typeaheads, and remove the stream's
-messages from **All messages**.
+messages from **Combined feed**.
 
 Archiving a stream does not delete a stream's messages. Users will still be
 able to find any given message by searching for it. However, links to

--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -27,7 +27,7 @@ preference settings, including the following:
     * [Home view](/help/configure-home-view)
       ([Inbox](/help/inbox) vs.
       [Recent conversations](/help/recent-conversations) vs.
-      [All messages](/help/reading-strategies#all-messages))
+      [Combined feed](/help/reading-strategies#combined-feed))
 
 * Notification settings:
     * What types of messages [trigger notifications][default-notifications]

--- a/help/configure-home-view.md
+++ b/help/configure-home-view.md
@@ -7,7 +7,7 @@ keyboard shortcuts.
 The home views available in Zulip are
 [**Inbox**](/help/inbox),
 [Recent conversations](/help/recent-conversations), and
-[All messages](/help/all-messages). See
+[Combined feed](/help/all-messages). See
 [Reading strategies](/help/reading-strategies) for recommendations
 on how to use these views.
 
@@ -22,14 +22,14 @@ Organization administrators can [configure the home view for their
 organization](/help/configure-default-new-user-settings) to
 [**Inbox**](/help/inbox),
 [**Recent conversations**](/help/recent-conversations), or
-[**All messages**](/help/all-messages).
+[**Combined feed**](/help/all-messages).
 
 - The **Inbox** view works best if you regularly clear all unread messages in
 streams you follow.
 
 - **Recent conversations** works well for getting an overview of recent activity.
 
-- **All messages** is convenient for low-traffic organizations, or for skimming
+- **Combined feed** is convenient for low-traffic organizations, or for skimming
   messages as they come in.
 
 You can customize your personal home view regardless of
@@ -80,5 +80,5 @@ shortcut.
 
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
-* [All messages](/help/all-messages)
+* [Combined feed](/help/all-messages)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -51,7 +51,7 @@ In the web app, you can control whether the **Inbox** includes all topics, just
 
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
-* [All messages](/help/all-messages)
+* [Combined feed](/help/all-messages)
 * [Mute or unmute a stream](/help/mute-a-stream)
 * [Mute or unmute a topic](/help/mute-a-topic)
 * [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)

--- a/help/include/all-messages.md
+++ b/help/include/all-messages.md
@@ -1,8 +1,8 @@
-The **All messages** view is a feed of all the unmuted messages you have
+The **Combined feed** view is a feed of all the unmuted messages you have
 received, which combines stream messages and direct messages. It's a great way
 to see new messages as they come in.
 
-You can configure **All messages** to be the [home
+You can configure **Combined feed** to be the [home
 view](/help/configure-home-view#configure-home-view) for the Zulip web app.
 
 {start_tabs}
@@ -13,7 +13,7 @@ view](/help/configure-home-view#configure-home-view) for the Zulip web app.
 
 {tab|mobile}
 
-1. Tap the **All messages**
+1. Tap the **Combined feed**
    (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="help-center-icon"/>)
    tab in the upper left corner of the app.
 

--- a/help/include/go-to-all-messages.md
+++ b/help/include/go-to-all-messages.md
@@ -1,4 +1,4 @@
-1. Click on <i class="zulip-icon zulip-icon-all-messages"></i> **All messages**
+1. Click on <i class="zulip-icon zulip-icon-all-messages"></i> **Combined feed**
    (or <i class="zulip-icon zulip-icon-all-messages"></i> if the **views**
    section is collapsed) in the left sidebar,
    or use the <kbd>A</kbd> keyboard shortcut.

--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -8,7 +8,7 @@ Muting has the following effects:
 - Messages in muted topics do not generate notifications (including [alert
   word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
   you are [mentioned](/help/mention-a-user-or-group).
-- Messages in muted topics do not appear in the [**All messages**
+- Messages in muted topics do not appear in the [**Combined feed**
   view](/help/all-messages) or the mobile **Inbox** view.
 - Muted topics appear in the [**Recent conversations**
   view](/help/recent-conversations) only if the **Include muted** filter is

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -96,7 +96,7 @@
 * [Reading strategies](/help/reading-strategies)
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
-* [All messages](/help/all-messages)
+* [Combined feed](/help/all-messages)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -51,9 +51,9 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Toggle keyboard shortcuts view**: <kbd>?</kbd>
 
-* **Go to home view**: <kbd>Ctrl</kbd> + <kbd>[</kbd> (or
+* **Go to your home view**: <kbd>Ctrl</kbd> + <kbd>[</kbd> (or
   <kbd>Esc</kbd>, [if enabled][disable-escape])
-  until you are in the [home view](/help/configure-home-view).
+  until you are in your [home view](/help/configure-home-view).
 
 [disable-escape]: /help/configure-home-view#configure-whether-esc-navigates-to-the-home-view
 ## Search

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -103,7 +103,7 @@ in the Zulip app to add more to your repertoire as needed.
 * **Cycle between stream views**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
-* **Go to All messages**: <kbd>A</kbd> — Shows all unmuted messages.
+* **Go to Combined feed**: <kbd>A</kbd> — Shows all unmuted messages.
 
 * **Go to the conversation you are composing to**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -96,7 +96,7 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Go to stream from topic view**: <kbd>S</kbd>
 
-* **Go to all direct messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
+* **Go to your direct message feed**: <kbd>Shift</kbd> + <kbd>P</kbd>
 
 * **Zoom to message in conversation context**: <kbd>Z</kbd> — This view does not mark messages as read.
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -69,7 +69,7 @@ stream or topic as read**.
 
 {tab|via-left-sidebar}
 
-1. Hover over a stream, topic, or **All messages** in the left sidebar.
+1. Hover over a stream, topic, or **Combined feed** in the left sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
 
@@ -100,7 +100,7 @@ stream or topic as read**.
 
 {tab|mobile}
 
-1. Tap a stream, topic, or the **All messages**
+1. Tap a stream, topic, or the **Combined feed**
    (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="help-center-icon"/>)
    tab.
 

--- a/help/mute-a-user.md
+++ b/help/mute-a-user.md
@@ -8,11 +8,11 @@
 You can mute any user you do not wish to interact with. Muting someone will
 have the following effects:
 
-* All messages sent by a muted user will automatically be [marked as
+* Combined feed sent by a muted user will automatically be [marked as
   read](/help/marking-messages-as-read) for you, and will never
   generate any desktop, email, or mobile push notifications.
 
-* All messages sent by muted users, including the name, profile
+* Combined feed sent by muted users, including the name, profile
   picture, and message content, are hidden behind a **Click here to
   reveal** banner. A revealed message can later be [re-hidden](/help/mute-a-user#re-hide-a-message-that-has-been-revealed).
 

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -45,7 +45,7 @@ workflows:
 
 ## Combined views
 
-### All messages
+### Combined feed
 
 {!all-messages.md!}
 

--- a/help/reading-strategies.md
+++ b/help/reading-strategies.md
@@ -49,7 +49,7 @@ workflows:
 
 {!all-messages.md!}
 
-### All direct messages
+### Direct message feed
 
 You can see all your direct messages in one place.
 
@@ -57,7 +57,7 @@ You can see all your direct messages in one place.
 
 {tab|desktop-web}
 
-1. Click on the **All direct messages** (<i class="fa fa-align-right"></i>)
+1. Click on the **Direct message feed** (<i class="fa fa-align-right"></i>)
    icon next to **DIRECT MESSAGES** in the left sidebar.
 
 1. Read your direct messages, starting from your first unread message. You can
@@ -69,7 +69,7 @@ You can see all your direct messages in one place.
 !!! keyboard_tip ""
 
     Use the <kbd>Shift</kbd> + <kbd>P</kbd> keyboard shortcut to go to
-    **All direct messages**.
+    **Direct message feed**.
 
 {end_tabs}
 

--- a/help/recent-conversations.md
+++ b/help/recent-conversations.md
@@ -37,5 +37,5 @@ containing the most recent messages.
 * [Reading conversations](/help/reading-conversations)
 * [Reading strategies](/help/reading-strategies)
 * [Inbox](/help/inbox)
-* [All messages](/help/all-messages)
+* [Combined feed](/help/all-messages)
 * [Configure home view](/help/configure-home-view)

--- a/templates/corporate/case-studies/end-point-case-study.md
+++ b/templates/corporate/case-studies/end-point-case-study.md
@@ -52,7 +52,7 @@ explored all the leading open-source team chat products. They found that while
 Mattermost and Rocket.Chat were similar to Slack (but felt less polished), Zulip
 stood out. “Zulip had all the modern features we were looking for, like
 reliable, flexible notifications. At the same time, the [extensive keyboard
-shortcuts](/help/keyboard-shortcuts) and the ‘All messages’
+shortcuts](/help/keyboard-shortcuts) and the ‘Combined feed’
 view offered a UI that the IRC fans loved.”
 
 When End Point moved to Zulip, it was an immediate improvement over the
@@ -118,7 +118,7 @@ Jensen](https://www.endpointdev.com/team/jon-jensen/) has experienced them all.
 “It is amazing that companies would use Teams in its current state,” Jon says, a
 bit exasperated. “The UI is slow and inconsistent, and you have to do so much
 clicking to get anywhere. Compared to Zulip, it’s missing key features like the
-‘All messages’ view and topics.”
+‘Combined feed’ view and topics.”
 
 > “It is amazing that companies would use Teams in its current state. The UI is
 > slow and inconsistent, and compared to Zulip, it’s missing key features.”

--- a/templates/corporate/case-studies/gut-contact-case-study.md
+++ b/templates/corporate/case-studies/gut-contact-case-study.md
@@ -79,7 +79,7 @@ customer, where team leaders post daily updates.
 For agents, may of whom are not fully comfortable with modern software, Zulip
 being easy to use is invaluable. "We checked out Microsoft Teams and Mattermost,
 and most of our users didn’t like these programs, because they didn’t know how
-to work with them,” Erik says. “In Zulip, agents love the “All messages” view,”
+to work with them,” Erik says. “In Zulip, agents love the “Combined feed” view,”
 which combines direct messages and stream messages into a single feed. “Unlike
 other chat apps, you don’t have to click on each channel separately to see
 unreads,” Erik explains.

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -135,7 +135,7 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
         content: multiple_recipients_pm,
     });
 
-    // Go back to all messages view and make sure all messages are loaded.
+    // Go back to the combined feed view and make sure all messages are loaded.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
 
     await page.waitForSelector(".message-list .message_row", {visible: true});

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -110,7 +110,7 @@ async function un_narrow(page: Page): Promise<void> {
     await page.waitForSelector(".message-list .message_row", {visible: true});
     // Assert that there is only one message list.
     assert.equal((await page.$$(".message-list")).length, 1);
-    assert.strictEqual(await page.title(), "All messages - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "Combined feed - Zulip Dev - Zulip");
 }
 
 async function un_narrow_by_clicking_org_icon(page: Page): Promise<void> {

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -304,7 +304,7 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "#new_conversation_button"),
         "Start new conversation",
     );
-    assert.strictEqual(await page.title(), "All direct messages - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "Direct message feed - Zulip Dev - Zulip");
 }
 
 async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {

--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -32,7 +32,7 @@ async function test_narrow_to_starred_messages(page: Page): Promise<void> {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [["Verona > stars", [message]]]);
 
-    // Go back to all messages narrow.
+    // Go back to the combined feed view.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
 }

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -777,7 +777,7 @@ export function initialize() {
         ".direct-messages-container.zoom-out #private_messages_section_header",
         (e) => {
             if ($(e.target).closest("#show_all_private_messages").length === 1) {
-                // Let the browser handle the "all direct messages" widget.
+                // Let the browser handle the "direct message feed" widget.
                 return;
             }
 

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -175,7 +175,7 @@ export function initialize() {
     $(document).on("message_selected.zulip", () => {
         if (narrow_state.is_message_feed_visible()) {
             // message_selected events can occur with Recent Conversations
-            // open due to "All messages" loading in the background,
+            // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
             update_reply_recipient_label();
         }

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -162,7 +162,9 @@ export function initialize(): void {
             let display_current_view;
             if (narrow_state.is_message_feed_visible()) {
                 if (narrow_filter === undefined) {
-                    display_current_view = $t({defaultMessage: "Currently viewing all messages."});
+                    display_current_view = $t({
+                        defaultMessage: "Currently viewing your combined feed.",
+                    });
                 } else if (
                     _.isEqual(narrow_filter.sorted_term_types(), ["channel"]) &&
                     compose_state.get_message_type() === "stream" &&

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -574,7 +574,7 @@ export class Filter {
         const parts: Part[] = [];
 
         if (terms.length === 0) {
-            parts.push({type: "plain_text", content: "all messages"});
+            parts.push({type: "plain_text", content: "combined feed"});
             return parts;
         }
 
@@ -712,7 +712,7 @@ export class Filter {
     }
 
     is_in_home(): boolean {
-        // All messages view.
+        // Combined feed view
         return this._terms.length === 1 && this.has_operand("in", "home");
     }
 
@@ -852,7 +852,7 @@ export class Filter {
     // This is used to control the behaviour for "exiting search"
     // within a narrow (E.g. a stream/topic + search) to bring you to
     // the containing common narrow (stream/topic, in the example)
-    // rather than "All messages".
+    // rather than the "Combined feed" view.
     //
     // Note from tabbott: The slug-based approach may not be ideal; we
     // may be able to do better another way.
@@ -1023,7 +1023,7 @@ export class Filter {
         if (term_types.length === 1) {
             switch (term_types[0]) {
                 case "in-home":
-                    return $t({defaultMessage: "All messages"});
+                    return $t({defaultMessage: "Combined feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted streams"});
                 case "channels-public":

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1033,7 +1033,7 @@ export class Filter {
                 case "is-mentioned":
                     return $t({defaultMessage: "Mentions"});
                 case "is-dm":
-                    return $t({defaultMessage: "All direct messages"});
+                    return $t({defaultMessage: "Direct message feed"});
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
                 // These cases return false for is_common_narrow, and therefore are not

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -146,7 +146,7 @@ export function initialize() {
         },
     });
 
-    // All messages popover
+    // Combined feed popover
     popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -304,7 +304,7 @@ export function load_messages(opts, attempt = 1) {
         const web_public_narrow = {negated: false, operator: "channels", operand: "web-public"};
 
         if (!data.narrow) {
-            /* For the "All messages" feed, this will be the only operator. */
+            /* For the combined feed, this will be the only operator. */
             data.narrow = JSON.stringify([web_public_narrow]);
         } else {
             // Otherwise, we append the operator.  This logic is not

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -49,7 +49,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     }
     if (filter === undefined) {
         return {
-            title: $t({defaultMessage: "All messages"}),
+            title: $t({defaultMessage: "Combined feed"}),
             zulip_icon: "all-messages",
         };
     }

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -1055,7 +1055,7 @@ export function to_compose_target() {
         const emails = util.extract_pm_recipients(recipient_string);
         const invalid = emails.filter((email) => !people.is_valid_email_for_compose(email));
         // If there are no recipients or any recipient is
-        // invalid, narrow to all direct messages.
+        // invalid, narrow to your direct message feed.
         if (emails.length === 0 || invalid.length > 0) {
             by("is", "dm", opts);
             return;

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -11,7 +11,7 @@ import * as unread from "./unread";
 export let has_shown_message_list_view = false;
 
 export function filter(): Filter | undefined {
-    // `All messages`, `Recent Conversations` and `Inbox` return undefined;
+    // `Combined feed`, `Recent Conversations` and `Inbox` return undefined;
     if (message_lists.current === undefined || message_lists.current.data.filter.is_in_home()) {
         return undefined;
     }

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -318,8 +318,8 @@ export function _possible_unread_message_ids(
     return undefined;
 }
 
-// Are we narrowed to direct messages: all direct messages
-// or direct messages with particular people.
+// Are we narrowed to direct messages: the direct message feed or a
+// specific direct message conversation.
 export function narrowed_to_pms(current_filter: Filter | undefined = filter()): boolean {
     if (current_filter === undefined) {
         return false;

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -16,8 +16,7 @@ export let narrow_title = "home";
 
 export function compute_narrow_title(filter?: Filter): string {
     if (filter === undefined) {
-        // "All messages" and "Recent conversations" views have
-        // an `undefined` filter.
+        // Views without a message feed in the center pane.
         if (recent_view_util.is_visible()) {
             return $t({defaultMessage: "Recent conversations"});
         }

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -99,7 +99,7 @@ export const web_home_view_values = {
     },
     all_messages: {
         code: "all_messages",
-        description: $t({defaultMessage: "All messages"}),
+        description: $t({defaultMessage: "Combined feed"}),
     },
 };
 

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -137,9 +137,8 @@ export class TaskData {
             },
 
             inbound: (sender_id, data) => {
-                // All messages readers may add tasks.
-                // for legacy reasons, the inbound idx is
-                // called key in the event
+                // All readers may add tasks. For legacy reasons, the
+                // inbound idx is called key in the event.
                 const idx = data.key;
                 const task = data.task;
                 const desc = data.desc;

--- a/web/src/user_topics_ui.js
+++ b/web/src/user_topics_ui.js
@@ -47,7 +47,7 @@ export function handle_topic_updates(user_topic_event) {
     }
 
     setTimeout(0, () => {
-        /* Rerender "all messages" if necessary, but defer until after
+        /* Rerender the combined feed view if necessary, but defer until after
          * the browser has rendered the DOM updates scheduled above. */
         if (message_lists.current !== message_lists.home) {
             message_lists.home.update_muting_and_rerender();

--- a/web/src/widgetize.ts
+++ b/web/src/widgetize.ts
@@ -50,7 +50,7 @@ function set_widget_in_message($row: JQuery, $widget_elem: JQuery): void {
 
     // Avoid adding the $widget_elem if it already exists.
     // This can happen when the app loads in the "Recent Conversations"
-    // view and the user changes the view to "All messages".
+    // view and the user changes the view to "Combined feed".
     // This is important since jQuery removes all the event handlers
     // on `empty()`ing an element.
     if ($content_holder.find(".widget-content").length === 0) {

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -65,7 +65,7 @@
                     <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to home view' }}</td>
+                    <td class="definition">{{t 'Go to your home view' }}</td>
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>[</kbd><span id="go-to-home-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
                 </tr>
             </table>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -148,7 +148,7 @@
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to all direct messages' }}</td>
+                    <td class="definition">{{t 'Go to your direct message feed' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
                 </tr>
                 <tr>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -140,7 +140,7 @@
                 <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
-                        <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
+                        <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
                     </a>
                     <span class="unread_count"></span>
                 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -81,7 +81,7 @@
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Combined feed' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">

--- a/web/templates/popovers/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar_all_messages_popover.hbs
@@ -13,7 +13,7 @@
         <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
             <i class="fa fa-home" aria-hidden="true"></i>
             {{#tr}}
-                Make <b>all messages</b> my home view
+                Make <b>combined feed</b> my home view
             {{/tr}}
         </a>
     </li>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -117,7 +117,7 @@
     {{tooltip_hotkey_hints "D"}}
 </template>
 <template id="show-all-pms-template">
-    {{t 'All direct messages' }}
+    {{t 'Direct message feed' }}
     {{tooltip_hotkey_hints "Shift" "P"}}
 </template>
 <template id="mentions-tooltip-template">

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -93,7 +93,7 @@
 </template>
 <template id="all-message-tooltip-template">
     <div class="views-tooltip-container" data-view-code="all_messages">
-        <div>{{t 'All messages' }}</div>
+        <div>{{t 'Combined feed' }}</div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "A"}}

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1696,7 +1696,7 @@ test("navbar_helpers", () => {
             terms: is_dm,
             is_common_narrow: true,
             icon: "envelope",
-            title: "translated: All direct messages",
+            title: "translated: Direct message feed",
             redirect_url_with_search: "/#narrow/is/dm",
         },
         {

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1360,7 +1360,7 @@ test("describe", ({mock_template}) => {
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [];
-    string = "all messages";
+    string = "combined feed";
     assert.equal(Filter.search_description_as_html(narrow), string);
 });
 
@@ -1682,7 +1682,7 @@ test("navbar_helpers", () => {
             terms: in_home,
             is_common_narrow: true,
             icon: "home",
-            title: "translated: All messages",
+            title: "translated: Combined feed",
             redirect_url_with_search: "#",
         },
         {

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -22,7 +22,7 @@ const $ = require("./lib/zjquery");
 // Future work includes making sure it actually does call `ui.foo()`.
 
 // Since all the tests here are based on narrow starting with all_messages.
-// We set our default narrow to all messages here.
+// We set our default narrow to the combined feed here.
 window.location.hash = "#all_messages";
 
 set_global("navigator", {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -789,7 +789,7 @@ run_test("narrow_compute_title", () => {
 
     inbox_util.set_visible(false);
     filter = new Filter([{operator: "in", operand: "home"}]);
-    assert.equal(narrow_title.compute_narrow_title(filter), "translated: All messages");
+    assert.equal(narrow_title.compute_narrow_title(filter), "translated: Combined feed");
 
     // Search & uncommon narrows
     filter = new Filter([{operator: "search", operand: "potato"}]);

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -154,7 +154,7 @@ test("excludes_muted_topics", () => {
     let filter = set_filter([["stream", "devel"]]);
     assert.ok(filter.excludes_muted_topics());
 
-    // All messages view.
+    // Combined feed view.
     filter = set_filter([["in", "home"]]);
     assert.ok(filter.excludes_muted_topics());
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -166,7 +166,7 @@ starred_instructions = """
 """
 
 direct_instructions = """
-1. In the left sidebar, click the **All direct messages**
+1. In the left sidebar, click the **Direct message feed**
    (<i class="fa fa-align-right"></i>) icon to the right of the
    **Direct messages** label, or use the <kbd>Shift</kbd> + <kbd>P</kbd>
    keyboard shortcut.
@@ -183,7 +183,7 @@ message_info = {
     "recent": ["Recent conversations", "/#recent", recent_instructions],
     "all": ["Combined feed", "/#all_messages", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
-    "direct": ["All direct messages", "/#narrow/is/dm", direct_instructions],
+    "direct": ["Direct message feed", "/#narrow/is/dm", direct_instructions],
     "inbox": ["Inbox", "/#inbox", inbox_instructions],
 }
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -156,7 +156,7 @@ recent_instructions = """
 """
 
 all_instructions = """
-1. Click on <i class="fa fa-align-left"></i> **All messages** in the left
+1. Click on <i class="fa fa-align-left"></i> **Combined feed** in the left
    sidebar, or use the <kbd>A</kbd> keyboard shortcut.
 """
 
@@ -181,7 +181,7 @@ message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
     "recent": ["Recent conversations", "/#recent", recent_instructions],
-    "all": ["All messages", "/#all_messages", all_instructions],
+    "all": ["Combined feed", "/#all_messages", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
     "direct": ["All direct messages", "/#narrow/is/dm", direct_instructions],
     "inbox": ["Inbox", "/#inbox", inbox_instructions],

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10681,7 +10681,7 @@ paths:
 
                     - "recent_topics" - Recent conversations view
                     - "inbox" - Inbox view
-                    - "all_messages" - All messages view
+                    - "all_messages" - Combined feed view
 
                     **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                     called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -13464,7 +13464,7 @@ paths:
 
                               - "recent_topics" - Recent conversations view
                               - "inbox" - Inbox view
-                              - "all_messages" - All messages view
+                              - "all_messages" - Combined feed view
 
                               **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -15787,7 +15787,7 @@ paths:
 
                               - "recent_topics" - Recent conversations view
                               - "inbox" - Inbox view
-                              - "all_messages" - All messages view
+                              - "all_messages" - Combined feed view
 
                               **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                               called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -16922,7 +16922,7 @@ paths:
 
                     - "recent_topics" - Recent conversations view
                     - "inbox" - Inbox view
-                    - "all_messages" - All messages view
+                    - "all_messages" - Combined feed view
 
                     **Changes**: New in Zulip 8.0 (feature level 219). Previously, this was
                     called `default_view`, which was new in Zulip 4.0 (feature level 42).
@@ -19972,8 +19972,8 @@ components:
           type: boolean
           description: |
             Whether the user has muted the stream. Muted streams do
-            not count towards your total unread count and do not show up in
-            `All messages` view (previously known as `Home` view).
+            not count towards your total unread count and do not show
+            up in the `Combined feed` view (previously known as `All messages`).
 
             **Changes**: Prior to Zulip 2.1.0, this feature was
             represented by the more confusingly named `in_home_view` (with the


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This pr is based on #27841 and changes "All messages" to "Combined Feed" in left sidebar, title and help center (without changing it's hash). 
Changes `All direct messages` tooltip to `DM feed`.
I've attached screenshots of some major changes.

Fixes part of #27802.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/91622060/fe90581a-d866-4103-b9ff-148056015a5c)

![image](https://github.com/zulip/zulip/assets/91622060/f4cf30fa-6813-40dc-98c0-d9c4920d6bbe)
![image](https://github.com/zulip/zulip/assets/91622060/d57e5ebd-f157-4366-8ffa-70aedf09011e)
![image](https://github.com/zulip/zulip/assets/91622060/7fab2b30-2652-42db-ae5f-bc97c845be43)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
