### PR TITLE
fix: Added a try/except case when trying to execute the astimezone function.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1417,7 +1417,15 @@ class Timestamp(markdown.inlinepatterns.Pattern):
         # Use HTML5 <time> element for valid timestamps.
         time_element = Element("time")
         if timestamp.tzinfo:
-            timestamp = timestamp.astimezone(timezone.utc)
+            try:
+                timestamp = timestamp.astimezone(timezone.utc)
+            except ValueError:
+                error_element = Element("span")
+                error_element.set("class", "timestamp-error")
+                error_element.text = markdown.util.AtomicString(
+                    f"Invalid time format: {time_input_string}"
+                )
+                return error_element
         else:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
         time_element.set("datetime", timestamp.isoformat().replace("+00:00", "Z"))

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -839,6 +839,13 @@
       "text_content": "Invalid time format: **hello world**"
     },
     {
+      "name": "timestamp_invalid_timezone",
+      "input": "<time:1969-12-31T00:00:00+32:00>",
+      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 1969-12-31T00:00:00+32:00</span></p>",
+      "marked_expected_output": "<p><span>1969-12-31T00:00:00+32:00</span></p>",
+      "text_content": "Invalid time format: 1969-12-31T00:00:00+32:00"
+    },
+    {
       "name": "timestamp_unix",
       "input": "Let's meet at <time:1496701800>.",
       "expected_output": "<p>Let's meet at <time datetime=\"2017-06-05T22:30:00Z\">1496701800</time>.</p>",


### PR DESCRIPTION
In file zerver/lib/Markdown/__init__.py we try to atler timestamp using the astimezone function. However, if an incorrect timezone (such as +32h) was provided, this function would produce an error and the message would not be sent. 

The try/except fixes the python error and allows the message to be sent, saying `Incorrect Date Format: [time]`, much like trying to send a message with `<time:abc>`. This approach was chosen to make the website more coherent.

Also created two tests which verify that the request is successful, when the timezone is valid and invalid. 

Fixes zulip#19658

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Before:
![exemplo3](https://github.com/zulip/zulip/assets/91789565/479d89b8-8d89-4298-9654-ce01a4b5ac2c)

- After:
![exemplo4](https://github.com/zulip/zulip/assets/91789565/14b51167-79fa-43ef-bd4e-c8de1343cb35)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] End-to-end functionality of buttons, interactions and flows.
</details>
