### PR TITLE
puppet: Only use the cron resource on Puppet 5.x.

### DIFF
--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -29,14 +29,16 @@ class zulip::postgresql_backups {
   # this in the postgres user's crontab, which was not discoverable.
   # Removed 2021-11 in version 5.0; these lines can be removed when we
   # drop support for upgrading from Zulip 4 or older.
-  cron { 'pg_backup_and_purge':
-    ensure      => absent,
-    command     => '/usr/local/bin/pg_backup_and_purge',
-    environment => 'PATH=/bin:/usr/bin:/usr/local/bin',
-    hour        => 2,
-    minute      => 0,
-    target      => 'postgres',
-    user        => 'postgres',
+  if $clientversion =~ /^5\./ {
+    cron { 'pg_backup_and_purge':
+      ensure      => absent,
+      command     => '/usr/local/bin/pg_backup_and_purge',
+      environment => 'PATH=/bin:/usr/bin:/usr/local/bin',
+      hour        => 2,
+      minute      => 0,
+      target      => 'postgres',
+      user        => 'postgres',
+    }
   }
   file { '/etc/cron.d/pg_backup_and_purge':
     ensure  => present,


### PR DESCRIPTION
Puppet 6.x and above moved the `cron` resource type out of core Puppet, into a "cron_core" module[^1]; thus Debian 12 and Ubuntu 24.04, with the newer Puppet, fail to compile if backups are configured:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Unknown resource type: 'cron' (file: /home/zulip/deployments/current/puppet/zulip/manifests/postgresql_backups.pp, line: 32, column: 3) on node zulip.example
```

However, we only use the `cron` package to assert that we no longer use it, for installs which are coming up from Zulip 4.x where it _was_ used.

Since Zulip 4.x does not support Ubuntu 24.04 or Debian 12, having Puppet >= 6.x means that the cron must have been previously removed in a previous upgrade, and we can skip the block.

In `main`, this block is removed entirely.

[^1]: https://forge.puppet.com/modules/puppetlabs/cron_core/readme
