### PR TITLE
puppet: Remove all purged/absent blocks known to have run already.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -118,16 +118,6 @@ class zulip::app_frontend_base {
     source  => 'puppet:///modules/zulip/nginx/zulip-include-frontend/uploads-internal.conf',
   }
 
-  file { [
-    # TODO/compatibility: Removed 2021-04 in Zulip 4.0; these lines can
-    # be removed once one must have upgraded through Zulip 4.0 or higher
-    # to get to the next release.
-    '/etc/nginx/zulip-include/uploads.route',
-    '/etc/nginx/zulip-include/app.d/thumbor.conf',
-  ]:
-    ensure => absent,
-  }
-
   # This determines whether we run queue processors multithreaded or
   # multiprocess.  Multiprocess scales much better, but requires more
   # RAM; we just auto-detect based on available system RAM.

--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -25,19 +25,6 @@ class zulip::postgresql_backups {
     ],
   }
 
-  # Zulip 4.x and before used the `cron` resource here, which placed
-  # this in the postgres user's crontab, which was not discoverable.
-  # Removed 2021-11 in version 5.0; these lines can be removed when we
-  # drop support for upgrading from Zulip 4 or older.
-  cron { 'pg_backup_and_purge':
-    ensure      => absent,
-    command     => '/usr/local/bin/pg_backup_and_purge',
-    environment => 'PATH=/bin:/usr/bin:/usr/local/bin',
-    hour        => 2,
-    minute      => 0,
-    target      => 'postgres',
-    user        => 'postgres',
-  }
   file { '/etc/cron.d/pg_backup_and_purge':
     ensure  => present,
     owner   => 'root',

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -75,13 +75,6 @@ class zulip::postgresql_base {
   $pgroonga = zulipconf('machine', 'pgroonga', false)
   if $pgroonga {
     # Needed for optional our full text search system
-
-    # Removed 2020-12 in version 4.0; these lines can be removed when
-    # we drop support for upgrading from Zulip 3 or older.
-    package{"${postgresql}-pgroonga":
-      ensure => purged,
-    }
-
     package{"${postgresql}-pgdg-pgroonga":
       ensure  => latest,
       require => [

--- a/puppet/zulip/manifests/profile/rabbitmq.pp
+++ b/puppet/zulip/manifests/profile/rabbitmq.pp
@@ -8,12 +8,6 @@ class zulip::profile::rabbitmq {
     $erlang,
     'rabbitmq-server',
   ]
-  # Removed 2020-09 in version 4.0; these lines can be removed in
-  # Zulip version 5.0 and later.
-  file { ['/etc/cron.d/rabbitmq-queuesize', '/etc/cron.d/rabbitmq-numconsumers']:
-    ensure => absent,
-  }
-
 
   group { 'rabbitmq':
     ensure => present,

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -25,20 +25,6 @@ class zulip::supervisor {
     notify  => Service[$supervisor_service],
   }
 
-  # These files were moved from /etc/supervisor/conf.d/ into a zulip/
-  # subdirectory in 2020-10 in version 4.0; these lines can be removed
-  # in Zulip version 5.0 and later.
-  file { [
-    "${system_conf_dir}/cron.conf",
-    "${system_conf_dir}/nginx.conf",
-    "${system_conf_dir}/smokescreen.conf",
-    "${system_conf_dir}/thumbor.conf",
-    "${system_conf_dir}/zulip.conf",
-    "${system_conf_dir}/zulip_db.conf",
-    ]:
-    ensure => absent,
-  }
-
   # In the docker environment, we don't want/need supervisor to be
   # started/stopped /bin/true is used as a decoy command, to maintain
   # compatibility with other code using the supervisor service.


### PR DESCRIPTION
It is not possible to have upgraded from 4.x to this version without having run puppet at least once, since there are no shared OS versions in between them.  Remove these `absent`/`purged` blocks which we know to have already been run.

----

Compare #29572 in `8.x`.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
