### PR TITLE
portico: Clarify wording and policies on /self-hosting.

### DIFF
--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -40,12 +40,11 @@
             <div class="feature-half">
                 <div class="feature-text">
                     <h1>
-                        100% free and open-source software.
+                        100% open-source software.
                     </h1>
                     <p>
                         When you self-host Zulip, you get <a href="https://github.com/zulip/zulip#readme">
-                        the same software</a> as our <a href="/plans/">Zulip
-                        Cloud Standard</a> customers.
+                        the same software</a> as our <a href="/plans/">Zulip Cloud</a> customers.
                     </p>
                     <p>
                         Unlike the competition, you don't pay for
@@ -267,14 +266,15 @@
                         Amazing support experience.
                     </h1>
                     <p>
-                        <a href="mailto:sales@zulip.com">Contact Sales</a> to
-                        discuss Enterprise support offerings.
+                        We love getting feedback! Stop by <a href="/development-community/">our friendly
+                        development community</a> to ask for help or suggest
+                        improvements.
                     </p>
                     <p>
-                        We provide free, interactive support for the vast
-                        majority of questions about running a Zulip server. Stop by <a href="/development-community/">our friendly
-                        development community</a> to ask for help or suggest
-                        improvements!
+                        A variety of support services are available for Zulip
+                        Business and Zulip Enterprise customers. Contact <a
+                        href="mailto:sales@zulip.com">sales@zulip.com</a> with
+                        any questions.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Current: https://zulip.com/self-hosting/
<details>
<summary>
Updated
</summary>

<img width="693" alt="Screenshot 2024-04-02 at 2 44 35 PM" src="https://github.com/zulip/zulip/assets/2090066/53f301e0-a9c6-44e2-a831-60b26efd1d3d">


<img width="608" alt="Screenshot 2024-04-02 at 3 00 52 PM" src="https://github.com/zulip/zulip/assets/2090066/268cf845-0d85-4127-bbb4-2e79af58f6c1">


</details>