### PR TITLE
right_sidebar: Rename invite modal label.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -487,7 +487,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
     }
 
     dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Invite users to Zulip"}),
+        html_heading: $t_html({defaultMessage: "Invite users to organization"}),
         html_body,
         html_submit_button: $t_html({defaultMessage: "Invite"}),
         id: "invite-user-modal",

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -26,7 +26,7 @@
             </div>
         </div>
         <div class="right-sidebar-shortcuts">
-            <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t 'Invite more users' }}</a>
+            <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t 'Invite users to organization' }}</a>
             {{#if realm_rendered_description}}
             <div class="only-visible-for-spectators">
                 <div class="realm-description">

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -3,7 +3,7 @@
     {{#unless is_admin }}
     <div class="tip">{{t "You can only view or manage invitations that you sent." }}</div>
     {{/unless}}
-    <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t "Invite more users" }}</a>
+    <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t "Invite users to organization" }}</a>
 
     <div class="settings_panel_list_header">
         <h3>{{t "Invites"}}</h3>


### PR DESCRIPTION
This PR updates the user invitation terminology by :

- Renaming "Invite more users" -> "Invite users to organization" in the right sidebar.

- Renaming "Invite users to Zulip" -> "Invite users to organization" in the modal title.

Fixes #29582


**Screenshots and screen captures:**

**right sidebar:**
![Screenshot from 2024-04-03 09-49-35-imageonline co-merged](https://github.com/zulip/zulip/assets/128511266/e71b668e-c030-4b0e-b795-e8135f61a0ed)




**user invitation modal:**
![userinvite](https://github.com/zulip/zulip/assets/128511266/7bd8862e-3d4a-49ff-b8c1-ae94ef641dea)



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
