### PR TITLE
migrations: Match dependencies from 8.x branch.

### DIFF
--- a/zerver/migrations/0501_delete_dangling_usermessages.py
+++ b/zerver/migrations/0501_delete_dangling_usermessages.py
@@ -196,7 +196,7 @@ class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ("zerver", "0500_realm_zulip_update_announcements_stream"),
+        ("zerver", "0496_alter_scheduledmessage_read_by_sender"),
     ]
 
     operations = [


### PR DESCRIPTION
The `zerver/0501_delete_dangling_usermessages` was backported to the `8.x` branch (and the 8.3 release) in 3db1733310dd.  However, because `main` contained migrations which `8.x` did not, it was backported with a different `dependencies`:

```
    dependencies = [
        ("zerver", "0496_alter_scheduledmessage_read_by_sender"),
    ]
```

...as opposed to in `main`:

```
    dependencies = [
        ("zerver", "0500_realm_zulip_update_announcements_stream"),
    ]
```

This causes upgrades from 8.3 to `main` to fail:
```
django.db.migrations.exceptions.InconsistentMigrationHistory:
Migration zerver.0501_delete_dangling_usermessages is applied before
its dependency zerver.0500_realm_zulip_update_announcements_stream on
database 'default'.
```

Adjust the dependencies in `main` to match those in `8.x` where many deploys will first have encountered the migration.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
