### PR TITLE
api_docs: Fix "/invites" enpoint documentation.

### DIFF
--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -319,7 +319,7 @@ def send_invitations(client: Client) -> None:
     # Send invitations
     request = {
         "invitee_emails": "example@zulip.com, logan@zulip.com",
-        "invite_expires_in_minutes": 14400,
+        "invite_expires_in_minutes": 60 * 24 * 10,  # 10 days
         "invite_as": 400,
         "stream_ids": [1, 8, 9],
     }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11878,7 +11878,8 @@ paths:
                   description: |
                     The number of minutes before the invitation will expire. If `null`, the
                     invitation will never expire. If unspecified, the server will use a default
-                    value (`INVITATION_LINK_VALIDITY_MINUTES`) for when the invitation will expire.
+                    value (based on the `INVITATION_LINK_VALIDITY_MINUTES` server setting, which
+                    defaults to 10) for when the invitation will expire.
 
                     **Changes**: New in Zulip 6.0 (feature level 126). Previously, there was an
                     `invite_expires_in_days` parameter, which specified the duration in days instead
@@ -11890,6 +11891,13 @@ paths:
                   description: |
                     The [organization-level role](/api/roles-and-permissions) of the user that is
                     created when the invitation is accepted.
+                    Possible values are:
+
+                    - 100 = Organization owner
+                    - 200 = Organization administrator
+                    - 300 = Organization moderator
+                    - 400 = Member
+                    - 600 = Guest
 
                     Users can only send invitations for
                     [roles with equal or stricter restrictions](/api/roles-and-permissions#permission-levels)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR makes small revisions in "/invites" API documentation.
Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
