### PR TITLE
emails: Update text version of find team email to match HTML version.

### DIFF
--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -18,7 +18,7 @@
 
 {% else %}
 {% if corporate_enabled %}
-{{ _("You have requested a list of Zulip accounts for this email address.") }} {{ _("Unfortunately, no accounts in Zulip Cloud organizations were found.") }}
+{{ _("You have requested a list of Zulip accounts for this email address.") }} {{ _("Unfortunately, no Zulip Cloud accounts were found.") }}
 
 {% trans %}You can check for accounts with another email ({{ find_accounts_link }}), or try another way to find your account ({{ help_logging_in_link }}).{% endtrans %}
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4295,7 +4295,7 @@ class TestFindMyTeam(ZulipTestCase):
 
         self.assert_length(outbox, 1)
         message = outbox[0]
-        self.assertIn("Unfortunately, no accounts", message.body)
+        self.assertIn("Unfortunately, no Zulip Cloud accounts", message.body)
 
     def test_find_team_reject_invalid_email(self) -> None:
         result = self.client_post("/accounts/find/", dict(emails="invalid_string"))
@@ -4337,7 +4337,7 @@ class TestFindMyTeam(ZulipTestCase):
 
         self.assert_length(outbox, 1)
         message = outbox[0]
-        self.assertIn("Unfortunately, no accounts", message.body)
+        self.assertIn("Unfortunately, no Zulip Cloud accounts", message.body)
 
     def test_find_team_deactivated_realm(self) -> None:
         do_deactivate_realm(get_realm("zulip"), acting_user=None)
@@ -4348,7 +4348,7 @@ class TestFindMyTeam(ZulipTestCase):
 
         self.assert_length(outbox, 1)
         message = outbox[0]
-        self.assertIn("Unfortunately, no accounts", message.body)
+        self.assertIn("Unfortunately, no Zulip Cloud accounts", message.body)
 
     def test_find_team_bot_email(self) -> None:
         data = {"emails": self.example_email("webhook_bot")}
@@ -4358,7 +4358,7 @@ class TestFindMyTeam(ZulipTestCase):
 
         self.assert_length(outbox, 1)
         message = outbox[0]
-        self.assertIn("Unfortunately, no accounts", message.body)
+        self.assertIn("Unfortunately, no Zulip Cloud accounts", message.body)
 
     def test_find_team_more_than_ten_emails(self) -> None:
         data = {"emails": ",".join(f"hamlet-{i}@zulip.com" for i in range(11))}


### PR DESCRIPTION
Follow-up to #28598. The HTML version of this email was updated in commit 5410df2a7bc745.

Now both the HTML and text emails when no Zulip Cloud accounts are found read:

> You have requested a list of Zulip accounts for this email address.
> Unfortunately, no Zulip Cloud accounts were found.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
