### PR TITLE
people: Update get_mention_syntax to better account for wildcards.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1353,7 +1353,7 @@ export function is_duplicate_full_name(full_name: string): boolean {
     return ids !== undefined && ids.size > 1;
 }
 
-export function get_mention_syntax(full_name: string, user_id: number, silent: boolean): string {
+export function get_mention_syntax(full_name: string, user_id?: number, silent = false): string {
     let mention = "";
     if (silent) {
         mention += "@_**";
@@ -1361,13 +1361,11 @@ export function get_mention_syntax(full_name: string, user_id: number, silent: b
         mention += "@**";
     }
     mention += full_name;
-    if (!user_id) {
+    const wildcard_match = full_name_matches_wildcard_mention(full_name);
+    if (user_id === undefined && !wildcard_match) {
         blueslip.warn("get_mention_syntax called without user_id.");
     }
-    if (
-        (is_duplicate_full_name(full_name) || full_name_matches_wildcard_mention(full_name)) &&
-        user_id
-    ) {
+    if ((is_duplicate_full_name(full_name) || wildcard_match) && user_id !== undefined) {
         mention += `|${user_id}`;
     }
     mention += "**";
@@ -1375,7 +1373,7 @@ export function get_mention_syntax(full_name: string, user_id: number, silent: b
 }
 
 function full_name_matches_wildcard_mention(full_name: string): boolean {
-    return ["all", "everyone", "stream"].includes(full_name);
+    return ["all", "everyone", "stream", "topic"].includes(full_name);
 }
 
 export function _add_user(person: User): void {

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -1150,6 +1150,12 @@ test_people("track_duplicate_full_names", () => {
 });
 
 test_people("get_mention_syntax", () => {
+    // blueslip warning is not raised for wildcard mentions without a user_id
+    assert.equal(people.get_mention_syntax("all"), "@**all**");
+    assert.equal(people.get_mention_syntax("everyone", undefined, true), "@_**everyone**");
+    assert.equal(people.get_mention_syntax("stream"), "@**stream**");
+    assert.equal(people.get_mention_syntax("topic"), "@**topic**");
+
     people.add_active_user(stephen1);
     people.add_active_user(stephen2);
     people.add_active_user(maria);
@@ -1161,7 +1167,7 @@ test_people("get_mention_syntax", () => {
     blueslip.reset();
 
     assert.equal(people.get_mention_syntax("Stephen King", 601), "@**Stephen King|601**");
-    assert.equal(people.get_mention_syntax("Stephen King", 602), "@**Stephen King|602**");
+    assert.equal(people.get_mention_syntax("Stephen King", 602, true), "@_**Stephen King|602**");
     assert.equal(people.get_mention_syntax("Maria Athens", 603), "@**Maria Athens**");
 
     // Following tests handle a special case when `full_name` matches with a wildcard.
@@ -1172,7 +1178,8 @@ test_people("get_mention_syntax", () => {
     assert.equal(people.get_mention_syntax("all", 1202), "@**all|1202**");
 
     people.add_active_user(all2);
-    assert.equal(people.get_mention_syntax("all", 1203), "@**all|1203**");
+    assert.ok(people.is_duplicate_full_name("all"));
+    assert.equal(people.get_mention_syntax("all", 1203, true), "@_**all|1203**");
 });
 
 test_people("initialize", () => {


### PR DESCRIPTION
In `composebox_typeahead`, it is completely possible to call `people.get_mention_syntax` for a wildcard mention, which will not have a `user_id`.

Updates `get_mention_syntax` to not raise a blueslip error if the mention syntax is for a wildcard mention.

Adds "topic" to the array of possible wildcard mention strings.

Tightens the types for the parameters for `get_mention_syntax`, by setting `user_id` to be number or undefined, and by setting `silent` to default to false (which is expected in a number of modules where this function is called).

```console
$ git grep get_mention_syntax web/src
web/src/compose_reply.js:    const mention = people.get_mention_syntax(message.sender_full_name, message.sender_id);
web/src/compose_validate.ts:    const silent_mention_text = people.get_mention_syntax(full_name, user_id, true);
web/src/composebox_typeahead.js:                let mention_text = people.get_mention_syntax(
web/src/people.ts:export function get_mention_syntax(full_name: string, user_id?: number, silent = false): string {
web/src/people.ts:        blueslip.warn("get_mention_syntax called without user_id.");
web/src/transmit.js:        const mention = people.get_mention_syntax(message.sender_full_name, message.sender_id);
web/src/user_card_popover.js:        user_mention_syntax: people.get_mention_syntax(user.full_name, user.user_id, !is_active),
web/src/user_card_popover.js:        const mention = people.get_mention_syntax(name, user_id);
web/src/user_card_popover.js:        const mention = people.get_mention_syntax(name, user_id, !is_active);
```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
