### PR TITLE
apt-repos: Disallow libmagic1 1:5.45-2 (Ubuntu 24.04) again

### DIFF
--- a/scripts/setup/apt-repos/zulip/zulip.pref
+++ b/scripts/setup/apt-repos/zulip/zulip.pref
@@ -7,3 +7,8 @@ Pin-Priority: 501
 Package: nginx-common nginx-full
 Pin: version 1.24.0-2ubuntu4
 Pin-Priority: 501
+
+# https://bugs.launchpad.net/ubuntu/+source/file/+bug/2059723
+Package: libmagic1
+Pin: version 1:5.45-2
+Pin-Priority: -1


### PR DESCRIPTION
- Reprise of #29502.