### PR TITLE
tools: Fix broken link in check-frontend-i18n

### DIFF
--- a/tools/check-frontend-i18n
+++ b/tools/check-frontend-i18n
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     print(
         WARNING
-        + "See https://zulip.readthedocs.io/en/latest/translating/translating.html#frontend-translations "
+        + "See https://zulip.readthedocs.io/en/latest/translating/internationalization.html#frontend-translations "
         "on how you can insert variables in the frontend translatable "
         "strings." + ENDC
     )


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/ci.3A.20broken.20link.20in.20tools.2Fcheck-frontend-i18n)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details> 