### PR TITLE
Message Area: Blur message behind copy button.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -635,7 +635,7 @@ li,
     outline-color: hsl(0deg 0% 73%);
     height: 18px;
     width: 10px;
-    padding: 6px;
+    padding: 10px;
     display: block;
     /* The below two avoids the padded element from displaying
     its own border and background color */
@@ -649,13 +649,20 @@ li,
     &:hover svg path {
         fill: var(--color-fill-hover-copy-icon);
     }
+    backdrop-filter: blur(4px);
+
+    mask-image: radial-gradient(
+        farthest-corner,
+        hsl(0deg 0% 0% / 100%),
+        hsl(0deg 0% 0% / 90%)
+    );
 }
 
 .copy_message {
     float: right;
     position: relative;
     cursor: pointer;
-    top: 30px;
+    top: 31px;
     /* To make sure the svg doesn't occupy any vertical space. */
     margin-top: -30px;
     right: 2px;


### PR DESCRIPTION
When on "View message source" (now "View original message") on many instances when the message is long the copy icon and message overlaps which makes it difficult to see both. This pr introduces a blur behind copy button so that it is visible in all scenarios.


Fixes: #29600 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Dark Mode:
![image](https://github.com/zulip/zulip/assets/91622060/9376116f-d79e-493b-9db9-a9858e83d7b2)
Light Mode:
![image](https://github.com/zulip/zulip/assets/91622060/b9cfdee5-775d-4b97-b628-00d69114ec0f)
When no message is behind the button
![image](https://github.com/zulip/zulip/assets/91622060/ba6d17fa-694d-45ba-8333-e108eee6d8d7)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
