### PR TITLE
eslint: Fix no-jquery/no-append-html

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,6 +73,7 @@
         "no-implied-eval": "error",
         "no-inner-declarations": "off",
         "no-iterator": "error",
+        "no-jquery/no-append-html": "error",
         "no-jquery/no-constructor-attributes": "error",
         "no-jquery/no-parse-html-literal": "error",
         "no-label-var": "error",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
       "source-map@^0.6": "npm:source-map-js@1.0.1"
     },
     "patchedDependencies": {
-      "source-sans@3.46.0": "patches/source-sans@3.46.0.patch"
+      "source-sans@3.46.0": "patches/source-sans@3.46.0.patch",
+      "eslint-plugin-no-jquery@2.7.0": "patches/eslint-plugin-no-jquery@2.7.0.patch"
     }
   },
   "nyc": {

--- a/patches/eslint-plugin-no-jquery@2.7.0.patch
+++ b/patches/eslint-plugin-no-jquery@2.7.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/rules/no-append-html.js b/src/rules/no-append-html.js
+index 4dd1499f140d307433664b4aadec589473cd41fa..bcca359faf7d5a196bc58ad2fbda39992b012ec2 100644
+--- a/src/rules/no-append-html.js
++++ b/src/rules/no-append-html.js
+@@ -1,7 +1,7 @@
+ 'use strict';
+ 
+ const utils = require( '../utils.js' );
+-const methods = [ 'append', 'prepend', 'before', 'after', 'replaceWith' ];
++const methods = [ 'append', 'prepend', 'before', 'after', 'replaceWith', 'add', 'appendTo', 'prependTo' ];
+ 
+ function alljQueryOrEmpty( context, node ) {
+ 	if ( node.type === 'ConditionalExpression' ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   source-map@^0.6: npm:source-map-js@1.0.1
 
 patchedDependencies:
+  eslint-plugin-no-jquery@2.7.0:
+    hash: 3o6vd4atcpz6wln5ovpbrt3cea
+    path: patches/eslint-plugin-no-jquery@2.7.0.patch
   source-sans@3.46.0:
     hash: 4n7ij66tzyhzaqnxsenbilrxr4
     path: patches/source-sans@3.46.0.patch
@@ -392,7 +395,7 @@ devDependencies:
     version: 2.29.1(@typescript-eslint/parser@7.4.0)(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0)
   eslint-plugin-no-jquery:
     specifier: ^2.7.0
-    version: 2.7.0(eslint@8.57.0)
+    version: 2.7.0(patch_hash=3o6vd4atcpz6wln5ovpbrt3cea)(eslint@8.57.0)
   eslint-plugin-unicorn:
     specifier: ^51.0.1
     version: 51.0.1(eslint@8.57.0)
@@ -6234,13 +6237,14 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-no-jquery@2.7.0(eslint@8.57.0):
+  /eslint-plugin-no-jquery@2.7.0(patch_hash=3o6vd4atcpz6wln5ovpbrt3cea)(eslint@8.57.0):
     resolution: {integrity: sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==}
     peerDependencies:
       eslint: '>=2.3.0'
     dependencies:
       eslint: 8.57.0
     dev: true
+    patched: true
 
   /eslint-plugin-unicorn@51.0.1(eslint@8.57.0):
     resolution: {integrity: sha512-MuR/+9VuB0fydoI0nIn2RDA5WISRn4AsJyNSaNKLVwie9/ONvQhxOBbkfSICBPnzKrB77Fh6CZZXjgTt/4Latw==}

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -162,6 +162,12 @@ js_rules = RuleList(
                 "web/tests/",
                 "web/src/billing/",
             },
+            "exclude_line": {
+                (
+                    "web/src/common.ts",
+                    '$(this).before($("<kbd>").text("Fn"), $("<span>").text(" + ").contents());',
+                ),
+            },
         },
         {
             "pattern": r"""report.success\(["']""",

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 246
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (267, 0)
+PROVISION_VERSION = (267, 1)

--- a/web/src/about_zulip.ts
+++ b/web/src/about_zulip.ts
@@ -34,5 +34,5 @@ export function initialize(): void {
         zulip_merge_base: realm.zulip_merge_base,
         is_fork: realm.zulip_merge_base && realm.zulip_merge_base !== realm.zulip_version,
     });
-    $("#about-zulip-modal-container").append(rendered_about_zulip);
+    $("#about-zulip-modal-container").append($(rendered_about_zulip));
 }

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -89,8 +89,8 @@ export function render_empty_user_list_message_if_needed($container: JQuery): vo
         return;
     }
 
-    const empty_list_widget = render_empty_list_widget_for_list({empty_list_message});
-    $container.append(empty_list_widget);
+    const empty_list_widget_html = render_empty_list_widget_for_list({empty_list_message});
+    $container.append($(empty_list_widget_html));
 }
 
 export function build_user_sidebar(): number[] | undefined {

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -76,14 +76,16 @@ function insert_tip_box() {
     if (current_user.is_admin) {
         return;
     }
-    const tip_box = render_settings_organization_settings_tip({is_admin: current_user.is_admin});
+    const tip_box_html = render_settings_organization_settings_tip({
+        is_admin: current_user.is_admin,
+    });
     $(".organization-box")
         .find(".settings-section")
         .not("#emoji-settings")
         .not("#organization-auth-settings")
         .not("#admin-bot-list")
         .not("#admin-invites-list")
-        .prepend(tip_box);
+        .prepend($(tip_box_html));
 }
 
 function get_realm_level_notification_settings(options) {

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -238,7 +238,7 @@ class Typeahead<ItemType extends string | object> {
         this.sorter = options.sorter;
         this.highlighter_html = options.highlighter_html;
         this.updater = options.updater ?? ((items) => this.defaultUpdater(items));
-        this.$container = $(CONTAINER_HTML).appendTo(options.parentElement ?? "body");
+        this.$container = $(CONTAINER_HTML).appendTo($(options.parentElement ?? "body"));
         this.$menu = $(MENU_HTML).appendTo(this.$container);
         this.$header = $(HEADER_ELEMENT_HTML).appendTo(this.$container);
         this.source = options.source;
@@ -414,7 +414,7 @@ class Typeahead<ItemType extends string | object> {
             const option_label_html = this.option_label(matching_items, item);
 
             if (option_label_html) {
-                $item_html.append(option_label_html).addClass("typeahead-option-label");
+                $item_html.append($(option_label_html)).addClass("typeahead-option-label");
             }
             return $i;
         });

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -292,20 +292,18 @@ export class BuddyList extends BuddyListConf {
             matching_view_empty_list_message,
         );
         if ($("#buddy-list-users-matching-view .empty-list-message").length) {
-            const empty_list_widget = render_empty_list_widget_for_list({
+            const empty_list_widget_html = render_empty_list_widget_for_list({
                 matching_view_empty_list_message,
             });
-            $("#buddy-list-users-matching-view").empty();
-            $("#buddy-list-users-matching-view").append(empty_list_widget);
+            $("#buddy-list-users-matching-view").html(empty_list_widget_html);
         }
 
         $("#buddy-list-other-users").data("search-results-empty", other_users_empty_list_message);
         if ($("#buddy-list-other-users .empty-list-message").length) {
-            const empty_list_widget = render_empty_list_widget_for_list({
+            const empty_list_widget_html = render_empty_list_widget_for_list({
                 other_users_empty_list_message,
             });
-            $("#buddy-list-other-users").empty();
-            $("#buddy-list-other-users").append(empty_list_widget);
+            $("#buddy-list-other-users").html(empty_list_widget_html);
         }
     }
 
@@ -336,23 +334,27 @@ export class BuddyList extends BuddyListConf {
         }
 
         $("#buddy-list-users-matching-view-container .buddy-list-subsection-header").append(
-            render_section_header({
-                id: "buddy-list-users-matching-view-section-heading",
-                header_text,
-                user_count: get_formatted_sub_count(subscriber_count),
-                toggle_class: "toggle-users-matching-view",
-                is_collapsed: this.users_matching_view_is_collapsed,
-            }),
+            $(
+                render_section_header({
+                    id: "buddy-list-users-matching-view-section-heading",
+                    header_text,
+                    user_count: get_formatted_sub_count(subscriber_count),
+                    toggle_class: "toggle-users-matching-view",
+                    is_collapsed: this.users_matching_view_is_collapsed,
+                }),
+            ),
         );
 
         $("#buddy-list-other-users-container .buddy-list-subsection-header").append(
-            render_section_header({
-                id: "buddy-list-other-users-section-heading",
-                header_text: $t({defaultMessage: "Others"}),
-                user_count: get_formatted_sub_count(other_users_count),
-                toggle_class: "toggle-other-users",
-                is_collapsed: this.other_users_is_collapsed,
-            }),
+            $(
+                render_section_header({
+                    id: "buddy-list-other-users-section-heading",
+                    header_text: $t({defaultMessage: "Others"}),
+                    user_count: get_formatted_sub_count(other_users_count),
+                    toggle_class: "toggle-other-users",
+                    is_collapsed: this.other_users_is_collapsed,
+                }),
+            ),
         );
     }
 

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -437,7 +437,7 @@ export class BuddyList extends BuddyListConf {
             items: subscribed_users,
         });
         this.$users_matching_view_container = $(this.matching_view_list_selector);
-        this.$users_matching_view_container.append(subscribed_users_html);
+        this.$users_matching_view_container.append($(subscribed_users_html));
 
         // Remove the empty list message before adding users
         if (
@@ -450,7 +450,7 @@ export class BuddyList extends BuddyListConf {
             items: other_users,
         });
         this.$other_users_container = $(this.other_user_list_selector);
-        this.$other_users_container.append(other_users_html);
+        this.$other_users_container.append($(other_users_html));
 
         // Invariant: more_user_ids.length >= items.length.
         // (Usually they're the same, but occasionally user ids
@@ -477,16 +477,18 @@ export class BuddyList extends BuddyListConf {
         ) {
             const stream_edit_hash = hash_util.stream_edit_url(current_sub, "subscribers");
             $("#buddy-list-users-matching-view-container").append(
-                render_view_all_subscribers({
-                    stream_edit_hash,
-                }),
+                $(
+                    render_view_all_subscribers({
+                        stream_edit_hash,
+                    }),
+                ),
             );
         }
 
         // We give a link to view the list of all users to help reduce confusion about
         // there being hidden (inactive) "other" users.
         if (has_inactive_other_users) {
-            $("#buddy-list-other-users-container").append(render_view_all_users());
+            $("#buddy-list-other-users-container").append($(render_view_all_users()));
         }
     }
 
@@ -689,9 +691,9 @@ export class BuddyList extends BuddyListConf {
             if (new_pos_in_all_users === this.render_count) {
                 this.render_count += 1;
                 if (is_subscribed_user) {
-                    this.$users_matching_view_container.append(html);
+                    this.$users_matching_view_container.append($(html));
                 } else {
-                    this.$other_users_container.append(html);
+                    this.$other_users_container.append($(html));
                 }
                 this.update_padding();
             }
@@ -702,7 +704,7 @@ export class BuddyList extends BuddyListConf {
             this.render_count += 1;
             const $li = this.find_li({key: user_id_following_insertion});
             assert($li !== undefined);
-            $li.before(html);
+            $li.before($(html));
             this.update_padding();
         }
     }

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -65,7 +65,7 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         let key_text = $(this).text();
 
         if (fn_shortcuts.has(key_text)) {
-            $(this).before("<kbd>Fn</kbd> + ");
+            $(this).before($("<kbd>").text("Fn"), $("<span>").text(" + ").contents());
             $(this).addClass("arrow-key");
         }
 
@@ -88,7 +88,7 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         const following_key = $(this).attr("data-mac-following-key");
         if (following_key !== undefined) {
             const $kbd_elem = $("<kbd>").text(following_key);
-            $(this).after(" + ", $kbd_elem);
+            $(this).after($("<span>").text(" + ").contents(), $kbd_elem);
         }
     });
 }

--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -84,7 +84,7 @@ function construct_copy_div($div, start_id, end_id) {
         // so we have to add new recipient's bar to final copied message
         // and wouldn't forget to add start_recipient's bar at the beginning of final message
         if (recipient_row_id !== last_recipient_row_id) {
-            $div.append(construct_recipient_header($row));
+            construct_recipient_header($row).appendTo($div);
             last_recipient_row_id = recipient_row_id;
             should_include_start_recipient_header = true;
         }
@@ -99,7 +99,7 @@ function construct_copy_div($div, start_id, end_id) {
     }
 
     if (should_include_start_recipient_header) {
-        $div.prepend(construct_recipient_header($start_row));
+        construct_recipient_header($start_row).prependTo($div);
     }
 }
 

--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -64,7 +64,7 @@ export function append_custom_profile_fields(element_id, user_id) {
             for_manage_user_modal: element_id === "#edit-user-form .custom-profile-field-form",
             is_empty_required_field: field.required && !field_value.value,
         });
-        $(element_id).append(html);
+        $(element_id).append($(html));
     }
 }
 

--- a/web/src/demo_organizations_ui.js
+++ b/web/src/demo_organizations_ui.js
@@ -20,7 +20,7 @@ export function insert_demo_organization_warning() {
         is_owner: current_user.is_owner,
         days_remaining,
     });
-    $(".organization-box").find(".settings-section").prepend(rendered_demo_organization_warning);
+    $(".organization-box").find(".settings-section").prepend($(rendered_demo_organization_warning));
 }
 
 export function handle_demo_organization_conversion() {

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -161,7 +161,7 @@ export function launch() {
             draft_lifetime: drafts.DRAFT_LIFETIME,
         });
         const $drafts_table = $("#drafts_table");
-        $drafts_table.append(rendered);
+        $drafts_table.append($(rendered));
         if ($("#drafts_table .overlay-message-row").length > 0) {
             $("#drafts_table .no-drafts").hide();
             // Update possible dynamic elements.

--- a/web/src/hotspots.ts
+++ b/web/src/hotspots.ts
@@ -259,9 +259,9 @@ function insert_hotspot_into_DOM(hotspot: Hotspot): void {
 
     setTimeout(() => {
         if (!hotspot.has_trigger) {
-            $("body").prepend(hotspot_icon_HTML);
+            $("body").prepend($(hotspot_icon_HTML));
         }
-        $("body").prepend(hotspot_overlay_HTML);
+        $("body").prepend($(hotspot_overlay_HTML));
         if (hotspot.has_trigger || place_icon(hotspot)) {
             place_popover(hotspot);
         }

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -207,7 +207,7 @@ function insert_dms(keys_to_insert) {
     // If we need to insert at the top, we do it separately to avoid edge case in loop below.
     if (keys_to_insert.includes(sorted_keys[0])) {
         $("#inbox-direct-messages-container").prepend(
-            render_inbox_row(dms_dict.get(sorted_keys[0])),
+            $(render_inbox_row(dms_dict.get(sorted_keys[0]))),
         );
     }
 
@@ -218,7 +218,7 @@ function insert_dms(keys_to_insert) {
 
         if (keys_to_insert.includes(key)) {
             const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]);
-            $previous_row.after(render_inbox_row(dms_dict.get(key)));
+            $previous_row.after($(render_inbox_row(dms_dict.get(key))));
         }
     }
 }
@@ -241,7 +241,7 @@ function rerender_dm_inbox_row_if_needed(new_dm_data, old_dm_data, dm_keys_to_in
     for (const property in new_dm_data) {
         if (new_dm_data[property] !== old_dm_data[property]) {
             const $rendered_row = get_row_from_conversation_key(new_dm_data.conversation_key);
-            $rendered_row.replaceWith(render_inbox_row(new_dm_data));
+            $rendered_row.replaceWith($(render_inbox_row(new_dm_data)));
             return;
         }
     }
@@ -294,7 +294,7 @@ function rerender_stream_inbox_header_if_needed(new_stream_data, old_stream_data
     for (const property in new_stream_data) {
         if (new_stream_data[property] !== old_stream_data[property]) {
             const $rendered_row = get_stream_header_row(new_stream_data.stream_id);
-            $rendered_row.replaceWith(render_inbox_row(new_stream_data));
+            $rendered_row.replaceWith($(render_inbox_row(new_stream_data)));
             return;
         }
     }
@@ -333,7 +333,7 @@ function insert_stream(stream_id, topic_dict) {
     });
 
     if (stream_index === 0) {
-        $("#inbox-streams-container").prepend(rendered_stream);
+        $("#inbox-streams-container").prepend($(rendered_stream));
     } else {
         const previous_stream_key = sorted_stream_keys[stream_index - 1];
         $(rendered_stream).insertAfter(get_stream_container(previous_stream_key));
@@ -349,7 +349,7 @@ function insert_topics(keys, stream_key) {
         const $stream = get_stream_container(stream_key);
         $stream
             .find(".inbox-topic-container")
-            .prepend(render_inbox_row(stream_topics_data.get(sorted_keys[0])));
+            .prepend($(render_inbox_row(stream_topics_data.get(sorted_keys[0]))));
     }
 
     for (const [i, key] of sorted_keys.entries()) {
@@ -359,7 +359,7 @@ function insert_topics(keys, stream_key) {
 
         if (keys.includes(key)) {
             const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]);
-            $previous_row.after(render_inbox_row(stream_topics_data.get(key)));
+            $previous_row.after($(render_inbox_row(stream_topics_data.get(key))));
         }
     }
 }
@@ -380,7 +380,7 @@ function rerender_topic_inbox_row_if_needed(new_topic_data, old_topic_data, topi
     for (const property in new_topic_data) {
         if (new_topic_data[property] !== old_topic_data[property]) {
             const $rendered_row = get_row_from_conversation_key(new_topic_data.conversation_key);
-            $rendered_row.replaceWith(render_inbox_row(new_topic_data));
+            $rendered_row.replaceWith($(render_inbox_row(new_topic_data)));
             return;
         }
     }

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -121,10 +121,10 @@ export function show_generate_integration_url_modal(api_key: string): void {
                     };
                 });
                 events_with_ids?.sort((a, b) => a.event.localeCompare(b.event));
-                const events = render_integration_events({
+                const events_html = render_integration_events({
                     events: events_with_ids,
                 });
-                $("#integrations-event-options").empty().append(events);
+                $("#integrations-event-options").html(events_html);
             }
 
             const params = new URLSearchParams({api_key});

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -252,10 +252,9 @@ function display_image(payload: Payload): void {
     $(".image-preview, .media-actions, .media-description, .download, .lightbox-zoom-reset").show();
 
     const $img_container = $("#lightbox_overlay .image-preview > .zoom-element");
-    const img = new Image();
-    img.src = payload.source;
+    const $img = $("<img>").attr("src", payload.source);
     $img_container.empty();
-    $img_container.append(img).show();
+    $img_container.append($img).show();
 
     const filename = payload.url?.split("/").pop();
     $(".media-description .title")
@@ -561,7 +560,7 @@ function remove_video_players(): void {
 export function initialize(): void {
     // Renders the DOM for the lightbox.
     const rendered_lightbox_overlay = render_lightbox_overlay();
-    $("body").append(rendered_lightbox_overlay);
+    $("body").append($(rendered_lightbox_overlay));
 
     // Bind the pan/zoom control the newly created element.
     const pan_zoom_control = new PanZoomControl(

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -224,7 +224,7 @@ export function render_empty_list_message_if_needed(
         return;
     }
 
-    let empty_list_widget;
+    let empty_list_widget_html;
 
     if ($container.is("table, tbody")) {
         let $table = $container;
@@ -233,17 +233,17 @@ export function render_empty_list_message_if_needed(
         }
 
         const column_count = get_column_count_for_table($table);
-        empty_list_widget = render_empty_list_widget_for_table({
+        empty_list_widget_html = render_empty_list_widget_for_table({
             empty_list_message,
             column_count,
         });
     } else {
-        empty_list_widget = render_empty_list_widget_for_list({
+        empty_list_widget_html = render_empty_list_widget_for_list({
             empty_list_message,
         });
     }
 
-    $container.append(empty_list_widget);
+    $container.append($(empty_list_widget_html));
 }
 
 // @params
@@ -512,10 +512,10 @@ export function create<Key, Item = Key>(
                 const rendered_row = opts.modifier_html(item, meta.filter_value);
                 if (insert_index === meta.filtered_list.length - 1) {
                     const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]);
-                    $target_row.after(rendered_row);
+                    $target_row.after($(rendered_row));
                 } else {
                     const $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]);
-                    $target_row.before(rendered_row);
+                    $target_row.before($(rendered_row));
                 }
                 widget.increase_rendered_offset();
             }

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -378,7 +378,7 @@ export function create<Key, Item = Key>(
 
             // At this point, we have asserted we have all the information to replace
             // the html now.
-            $html_item.replaceWith(html);
+            $html_item.replaceWith($(html));
         },
 
         clear() {

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -94,8 +94,7 @@ function get_display_stream_name(stream_id: number): string {
 }
 
 export function fetch_and_render_message_history(message: Message): void {
-    $("#message-edit-history-overlay-container").empty();
-    $("#message-edit-history-overlay-container").append(render_message_history_overlay());
+    $("#message-edit-history-overlay-container").html(render_message_history_overlay());
     open_overlay();
     void channel.get({
         url: "/json/messages/" + message.id + "/history",
@@ -211,11 +210,11 @@ export function fetch_and_render_message_history(message: Message): void {
                     }
                 }
             }
-            const rendered_list: string = render_message_edit_history({
+            const rendered_list_html = render_message_edit_history({
                 edited_messages: content_edit_history,
             });
             $("#message-history-overlay").attr("data-message-id", message.id);
-            $("#message-history-overlay .overlay-messages-list").append(rendered_list);
+            $("#message-history-overlay .overlay-messages-list").append($(rendered_list_html));
 
             // Pass the history through rendered_markdown.ts
             // to update dynamic_elements in the content.

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -313,7 +313,9 @@ export class MessageListView {
     _RENDER_THRESHOLD = 50;
 
     _add_message_list_to_DOM() {
-        $("#message-lists-container").append(render_message_list({message_list_id: this.list.id}));
+        $("#message-lists-container").append(
+            $(render_message_list({message_list_id: this.list.id})),
+        );
     }
 
     _get_msg_timestring(message_container) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -745,7 +745,7 @@ export class MessageListView {
             $message_rows.find(".message_inline_image img").on("error", (e) => {
                 $(e.target)
                     .closest(".message_inline_image")
-                    .replaceWith(render_login_to_view_image_button());
+                    .replaceWith($(render_login_to_view_image_button()));
             });
         }
     }

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -90,7 +90,8 @@ export function all_rendered_message_lists(): MessageList[] {
 export function all_rendered_row_for_message_id(message_id: number): JQuery {
     let $rows = $();
     for (const msg_list of all_rendered_message_lists()) {
-        $rows = $rows.add(msg_list.get_row(message_id));
+        const $row = msg_list.get_row(message_id);
+        $rows = $rows.add($row);
     }
     return $rows;
 }

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -99,9 +99,7 @@ export function colorize_message_view_header(): void {
 
 function append_and_display_title_area(context: MessageViewHeaderContext): void {
     const $message_view_header_elem = $("#message_view_header");
-    $message_view_header_elem.empty();
-    const rendered = render_message_view_header(context);
-    $message_view_header_elem.append(rendered);
+    $message_view_header_elem.html(render_message_view_header(context));
     if (context.stream_settings_link) {
         colorize_message_view_header();
     }

--- a/web/src/poll_modal.ts
+++ b/web/src/poll_modal.ts
@@ -4,9 +4,9 @@ import SortableJS from "sortablejs";
 import render_poll_modal_option from "../templates/poll_modal_option.hbs";
 
 function create_option_row($last_option_row_input: JQuery): void {
-    const row = render_poll_modal_option();
+    const row_html = render_poll_modal_option();
     const $row_container = $last_option_row_input.closest(".simplebar-content");
-    $row_container.append(row);
+    $row_container.append($(row_html));
 }
 
 function add_option_row(e: JQuery.TriggeredEvent): void {

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -141,7 +141,7 @@ $(() => {
         errorPlacement($error: JQuery) {
             $(".email-frontend-error").empty();
             $("#send_confirm .alert.email-backend-error").remove();
-            $error.appendTo(".email-frontend-error").addClass("text-error");
+            $error.appendTo($(".email-frontend-error")).addClass("text-error");
         },
         success() {
             $("#errors").empty();

--- a/web/src/portico/team.ts
+++ b/web/src/portico/team.ts
@@ -158,11 +158,13 @@ export default function render_tabs(contributors: Contributor[]): void {
 
     $("#tab-total .contributors-grid").html(total_tab_html);
     $("#tab-total").prepend(
-        total_count_template({
-            contributor_count: contributors_list.length,
-            tab_name: "total",
-            hundred_plus_contributor_count: hundred_plus_total_contributors.length,
-        }),
+        $(
+            total_count_template({
+                contributor_count: contributors_list.length,
+                tab_name: "total",
+                hundred_plus_contributor_count: hundred_plus_total_contributors.length,
+            }),
+        ),
     );
 
     for (const tab_name of all_tab_names) {
@@ -215,12 +217,14 @@ export default function render_tabs(contributors: Contributor[]): void {
                     (repo_name) => `https://github.com/zulip/${repo_name}`,
                 );
                 $(`#tab-${CSS.escape(tab_name)}`).prepend(
-                    count_template({
-                        contributor_count,
-                        repo_list,
-                        repo_url_list,
-                        hundred_plus_contributor_count,
-                    }),
+                    $(
+                        count_template({
+                            contributor_count,
+                            repo_list,
+                            repo_url_list,
+                            hundred_plus_contributor_count,
+                        }),
+                    ),
                 );
 
                 loaded_tabs.push(tab_name);

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -8,7 +8,7 @@ import render_markdown_timestamp from "../templates/markdown_timestamp.hbs";
 
 import * as blueslip from "./blueslip";
 import {show_copied_confirmation} from "./copied_tooltip";
-import {$t, $t_html} from "./i18n";
+import {$t} from "./i18n";
 import * as message_store from "./message_store";
 import type {Message} from "./message_store";
 import * as people from "./people";
@@ -264,13 +264,13 @@ export const update_elements = ($content: JQuery): void => {
         // If a spoiler block has no header content, it should have a default header.
         // We do this client side to allow for i18n by the client.
         if ($(this).html().trim().length === 0) {
-            $(this).append(`<p>${$t_html({defaultMessage: "Spoiler"})}</p>`);
+            $(this).append($("<p>").text($t({defaultMessage: "Spoiler"})));
         }
 
         // Add the expand/collapse button to spoiler blocks
         const toggle_button_html =
             '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
-        $(this).prepend(toggle_button_html);
+        $(this).prepend($(toggle_button_html));
     });
 
     // Display the view-code-in-playground and the copy-to-clipboard button inside the div.codehilite element,

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -87,8 +87,7 @@ function format(scheduled_messages) {
 }
 
 export function launch() {
-    $("#scheduled_messages_overlay_container").empty();
-    $("#scheduled_messages_overlay_container").append(render_scheduled_messages_overlay());
+    $("#scheduled_messages_overlay_container").html(render_scheduled_messages_overlay());
     overlays.open_overlay({
         name: "scheduled",
         $overlay: $("#scheduled_messages_overlay"),
@@ -101,7 +100,7 @@ export function launch() {
         scheduled_messages_data: format(scheduled_messages.scheduled_messages_data),
     });
     const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
-    $messages_list.append(rendered_list);
+    $messages_list.append($(rendered_list));
 
     const first_element_id = keyboard_handling_context.get_items_ids()[0];
     messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
@@ -116,7 +115,7 @@ export function rerender() {
     });
     const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
     $messages_list.find(".scheduled-message-row").remove();
-    $messages_list.append(rendered_list);
+    $messages_list.append($(rendered_list));
 }
 
 export function remove_scheduled_message_id(scheduled_msg_id) {

--- a/web/src/scheduled_messages_popover.js
+++ b/web/src/scheduled_messages_popover.js
@@ -36,7 +36,7 @@ export function open_send_later_menu() {
     // Only show send later options that are possible today.
     const date = new Date();
     const filtered_send_opts = scheduled_messages.get_filtered_send_opts(date);
-    $("body").append(render_send_later_modal(filtered_send_opts));
+    $("body").append($(render_send_later_modal(filtered_send_opts)));
     let interval;
 
     modals.open("send_later_modal", {
@@ -232,6 +232,8 @@ export function update_send_later_options() {
     const now = new Date();
     if (should_update_send_later_options(now)) {
         const filtered_send_opts = scheduled_messages.get_filtered_send_opts(now);
-        $("#send_later_options").replaceWith(render_send_later_modal_options(filtered_send_opts));
+        $("#send_later_options").replaceWith(
+            $(render_send_later_modal_options(filtered_send_opts)),
+        );
     }
 }

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -174,7 +174,7 @@ export function initialize() {
         show_emoji_settings_lock: !settings_data.user_can_add_custom_emoji(),
         can_create_new_bots: settings_bots.can_create_new_bots(),
     });
-    $("#settings_overlay_container").append(rendered_settings_overlay);
+    $("#settings_overlay_container").append($(rendered_settings_overlay));
 
     $("#settings_overlay_container").on("click", (e) => {
         if (!modals.any_active()) {

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -360,7 +360,7 @@ export function set_up() {
     };
 
     $("#api_key_button").on("click", (e) => {
-        $("body").append(render_settings_api_key_modal());
+        $("body").append($(render_settings_api_key_modal()));
         setup_api_key_modal();
         $("#api_key_status").hide();
         modals.open("api_key_modal", {

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -353,7 +353,7 @@ export function set_up() {
         },
     });
 
-    $("#bot-settings .tab-container").prepend(toggler.get());
+    toggler.get().prependTo($("#bot-settings .tab-container"));
     toggler.goto("active-bots");
 
     render_bots();

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -818,7 +818,7 @@ export function save_discard_widget_status_handler(
             stream_id: sub.stream_id,
         };
         $("#stream_permission_settings .stream-permissions-warning-banner").append(
-            render_compose_banner(context),
+            $(render_compose_banner(context)),
         );
     } else {
         $("#stream_permission_settings .stream-permissions-warning-banner").empty();

--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -39,15 +39,17 @@ function rerender_ui() {
 
     for (const stream of unmatched_streams) {
         $unmatched_streams_table.append(
-            render_stream_specific_notification_row({
-                stream,
-                stream_specific_notification_settings:
-                    settings_config.stream_specific_notification_settings,
-                is_disabled:
-                    settings_config.all_notifications(user_settings)
-                        .show_push_notifications_tooltip,
-                muted: muted_stream_ids.includes(stream.stream_id),
-            }),
+            $(
+                render_stream_specific_notification_row({
+                    stream,
+                    stream_specific_notification_settings:
+                        settings_config.stream_specific_notification_settings,
+                    is_disabled:
+                        settings_config.all_notifications(user_settings)
+                            .show_push_notifications_tooltip,
+                    muted: muted_stream_ids.includes(stream.stream_id),
+                }),
+            ),
         );
     }
 

--- a/web/src/settings_profile_fields.js
+++ b/web/src/settings_profile_fields.js
@@ -681,23 +681,27 @@ export function do_populate_profile_fields(profile_fields_data) {
         const display_in_profile_summary = profile_field.display_in_profile_summary === true;
         const required = profile_field.required === true;
         $profile_fields_table.append(
-            render_admin_profile_field_list({
-                profile_field: {
-                    id: profile_field.id,
-                    name: profile_field.name,
-                    hint: profile_field.hint,
-                    type: field_type_id_to_string(profile_field.type),
-                    choices,
-                    is_select_field: profile_field.type === field_types.SELECT.id,
-                    is_external_account_field:
-                        profile_field.type === field_types.EXTERNAL_ACCOUNT.id,
-                    display_in_profile_summary,
-                    valid_to_display_in_summary: is_valid_to_display_in_summary(profile_field.type),
-                    required,
-                },
-                can_modify: current_user.is_admin,
-                realm_default_external_accounts: realm.realm_default_external_accounts,
-            }),
+            $(
+                render_admin_profile_field_list({
+                    profile_field: {
+                        id: profile_field.id,
+                        name: profile_field.name,
+                        hint: profile_field.hint,
+                        type: field_type_id_to_string(profile_field.type),
+                        choices,
+                        is_select_field: profile_field.type === field_types.SELECT.id,
+                        is_external_account_field:
+                            profile_field.type === field_types.EXTERNAL_ACCOUNT.id,
+                        display_in_profile_summary,
+                        valid_to_display_in_summary: is_valid_to_display_in_summary(
+                            profile_field.type,
+                        ),
+                        required,
+                    },
+                    can_modify: current_user.is_admin,
+                    realm_default_external_accounts: realm.realm_default_external_accounts,
+                }),
+            ),
         );
 
         // Keeping counts of all display_in_profile_summary profile fields, to keep track.

--- a/web/src/settings_profile_fields.js
+++ b/web/src/settings_profile_fields.js
@@ -158,8 +158,8 @@ function create_choice_row(container) {
         value: get_value_for_new_option(container),
         new_empty_choice_row: true,
     };
-    const row = render_settings_profile_field_choice(context);
-    $(container).append(row);
+    const row_html = render_settings_profile_field_choice(context);
+    $(container).append($(row_html));
 }
 
 function clear_form_data() {
@@ -417,10 +417,12 @@ function set_up_select_field_edit_form($profile_field_form, field_data) {
 
     for (const choice of choices_data) {
         $choice_list.append(
-            render_settings_profile_field_choice({
-                text: choice.text,
-                value: choice.value,
-            }),
+            $(
+                render_settings_profile_field_choice({
+                    text: choice.text,
+                    value: choice.value,
+                }),
+            ),
         );
     }
 

--- a/web/src/settings_realm_domains.ts
+++ b/web/src/settings_realm_domains.ts
@@ -25,9 +25,7 @@ export function populate_realm_domains_table(realm_domains: RealmDomain[]): void
 
     for (const realm_domain of realm_domains) {
         $realm_domains_table_body.append(
-            render_settings_admin_realm_domains_list({
-                realm_domain,
-            }),
+            $(render_settings_admin_realm_domains_list({realm_domain})),
         );
     }
 }

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -38,8 +38,8 @@ function create_choice_row() {
     const $container = $("#default-stream-choices");
     const value = settings_profile_fields.get_value_for_new_option("#default-stream-choices");
     const stream_dropdown_widget_name = `select_default_stream_${value}`;
-    const row = render_default_stream_choice({value, stream_dropdown_widget_name});
-    $container.append(row);
+    const row_html = render_default_stream_choice({value, stream_dropdown_widget_name});
+    $container.append($(row_html));
 
     // List of non-default streams that are not yet selected.
     function get_options() {

--- a/web/src/settings_toggle.js
+++ b/web/src/settings_toggle.js
@@ -30,7 +30,7 @@ export function initialize() {
 
     settings_panel_menu.set_key_handlers(toggler);
 
-    $("#settings_overlay_container .tab-container").append(toggler.get());
+    toggler.get().appendTo("#settings_overlay_container .tab-container");
 }
 
 // Handles the collapse/reveal of some tabs in the org settings for non-admins.

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -17,10 +17,10 @@ type RequestOpts = {
 };
 
 export function display_checkmark($elem: JQuery): void {
-    const check_mark = document.createElement("img");
-    check_mark.src = checkbox_image;
-    $elem.prepend(check_mark);
-    $(check_mark).css("width", "13px");
+    const $check_mark = $("<img>");
+    $check_mark.attr("src", checkbox_image);
+    $check_mark.css("width", "13px");
+    $elem.prepend($check_mark);
 }
 
 export const strings = {

--- a/web/src/spectators.ts
+++ b/web/src/spectators.ts
@@ -33,12 +33,14 @@ export function login_to_access(empty_narrow?: boolean): void {
     const realm_name = realm.realm_name;
 
     $("body").append(
-        render_login_to_access_modal({
-            signup_link: "/register/",
-            login_link,
-            empty_narrow,
-            realm_name,
-        }),
+        $(
+            render_login_to_access_modal({
+                signup_link: "/register/",
+                login_link,
+                empty_narrow,
+                realm_name,
+            }),
+        ),
     );
 
     modals.open("login_to_access_modal", {

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -260,7 +260,7 @@ export function show_settings_for(node) {
     });
     scroll_util.get_content_element($("#stream_settings")).html(html);
 
-    $("#stream_settings .tab-container").prepend(stream_edit_toggler.toggler.get());
+    stream_edit_toggler.toggler.get().prependTo("#stream_settings .tab-container");
     stream_ui_updates.set_up_right_panel_section(sub);
 
     const $edit_container = stream_settings_containers.get_edit_container(sub);

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -402,7 +402,7 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
         if (stream_id_for_elt($elt) === stream_id) {
             $elt.show();
             // Add search box for topics list.
-            $elt.children("div.bottom_left_row").append(render_filter_topics());
+            $elt.children("div.bottom_left_row").append($(render_filter_topics()));
             $("#filter-topic-input").trigger("focus");
             $("#clear_search_topic_button").hide();
         } else {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -329,7 +329,7 @@ export function build_stream_list(force_rerender: boolean): void {
         add_sidebar_li(stream_id);
     }
 
-    $parent.append(elems);
+    $parent.append(elems); // eslint-disable-line no-jquery/no-append-html
 }
 
 export function get_stream_li(stream_id: number): JQuery | undefined {

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -568,7 +568,7 @@ export function setup_page(callback) {
             },
         });
 
-        $("#streams_overlay_container .list-toggler-container").prepend(sort_toggler.get());
+        sort_toggler.get().prependTo("#streams_overlay_container .list-toggler-container");
 
         // Reset our internal state to reflect that we're initially in
         // the "Subscribed" tab if we're reopening "Stream settings".
@@ -633,7 +633,7 @@ export function setup_page(callback) {
         };
 
         const rendered = render_stream_settings_overlay(template_data);
-        $("#streams_overlay_container").append(rendered);
+        $("#streams_overlay_container").append($(rendered));
 
         render_left_panel_superset();
         initialize_components();

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -305,11 +305,13 @@ export function update_stream_privacy_icon_in_settings(sub) {
     const $stream_settings = stream_settings_containers.get_edit_container(sub);
 
     $stream_settings.find(".general_settings .large-icon").replaceWith(
-        render_stream_privacy_icon({
-            invite_only: sub.invite_only,
-            color: sub.color,
-            is_web_public: sub.is_web_public,
-        }),
+        $(
+            render_stream_privacy_icon({
+                invite_only: sub.invite_only,
+                color: sub.color,
+                is_web_public: sub.is_web_public,
+            }),
+        ),
     );
 }
 

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -7,7 +7,6 @@ import {
     parseISO,
 } from "date-fns";
 import $ from "jquery";
-import _ from "lodash";
 
 import render_markdown_time_tooltip from "../templates/markdown_time_tooltip.hbs";
 
@@ -343,8 +342,7 @@ function maybe_add_update_list_entry(entry: UpdateEntry): void {
 }
 
 function render_date_span($elem: JQuery, rendered_time: TimeRender): JQuery {
-    $elem.text("");
-    $elem.append(_.escape(rendered_time.time_str));
+    $elem.text(rendered_time.time_str);
     return $elem.attr("data-tippy-content", rendered_time.formal_time_str);
 }
 

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -208,7 +208,7 @@ export class TopicListWidget {
 
         const replace_content = (html: string): void => {
             this.remove();
-            this.$parent_elem.append(html);
+            this.$parent_elem.append($(html));
         };
 
         const find = (): JQuery => this.$parent_elem.find(".topic-list");

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -173,13 +173,15 @@ function initialize_navbar() {
 
 function initialize_compose_box() {
     $("#compose-container").append(
-        render_compose({
-            embedded: $("#compose").attr("data-embedded") === "",
-            file_upload_enabled: realm.max_file_upload_size_mib > 0,
-            giphy_enabled: giphy.is_giphy_enabled(),
-            max_stream_name_length: realm.max_stream_name_length,
-            max_topic_length: realm.max_topic_length,
-        }),
+        $(
+            render_compose({
+                embedded: $("#compose").attr("data-embedded") === "",
+                file_upload_enabled: realm.max_file_upload_size_mib > 0,
+                giphy_enabled: giphy.is_giphy_enabled(),
+                max_stream_name_length: realm.max_stream_name_length,
+                max_topic_length: realm.max_topic_length,
+            }),
+        ),
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();
     common.adjust_mac_kbd_tags(".open_enter_sends_dialog kbd");

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -352,11 +352,13 @@ function show_user_card_popover(
 
                 $popover.addClass(get_popover_classname(template_class));
                 $popover_title.append(
-                    render_user_card_popover_avatar({
-                        // See the load_medium_avatar comment for important background.
-                        user_avatar: people.small_avatar_url_for_person(user),
-                        user_is_guest: user.is_guest,
-                    }),
+                    $(
+                        render_user_card_popover_avatar({
+                            // See the load_medium_avatar comment for important background.
+                            user_avatar: people.small_avatar_url_for_person(user),
+                            user_is_guest: user.is_guest,
+                        }),
+                    ),
                 );
             },
             onHidden() {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -278,7 +278,7 @@ export function show_settings_for(group) {
         initialize_tooltip_for_membership_button(group.id);
     }
 
-    $("#user_group_settings .tab-container").prepend(toggler.get());
+    toggler.get().prependTo("#user_group_settings .tab-container");
     const $edit_container = get_edit_container(group);
     $(".nothing-selected").hide();
 
@@ -712,7 +712,7 @@ export function setup_page(callback) {
             },
         });
 
-        $("#groups_overlay_container .list-toggler-container").prepend(group_list_toggler.get());
+        group_list_toggler.get().prependTo("#groups_overlay_container .list-toggler-container");
     }
 
     function populate_and_fill() {
@@ -721,13 +721,12 @@ export function setup_page(callback) {
             max_user_group_name_length,
         };
 
-        const rendered = render_user_group_settings_overlay(template_data);
+        const groups_overlay_html = render_user_group_settings_overlay(template_data);
 
         const $groups_overlay_container = scroll_util.get_content_element(
             $("#groups_overlay_container"),
         );
-        $groups_overlay_container.empty();
-        $groups_overlay_container.append(rendered);
+        $groups_overlay_container.html(groups_overlay_html);
 
         // Initially as the overlay is build with empty right panel,
         // active_group_id is undefined.

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -351,7 +351,7 @@ function initialize_user_type_fields(user) {
 }
 
 export function show_user_profile_access_error_modal() {
-    $("body").append(render_profile_access_error_model());
+    $("body").append($(render_profile_access_error_model()));
 
     // This opens the model, referencing it by it's ID('profile_access_error_model)
     modals.open("profile_access_error_modal", {
@@ -526,7 +526,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
         current_bot_owner: bot.bot_owner_id,
         is_incoming_webhook_bot: bot.bot_type === INCOMING_WEBHOOK_BOT_TYPE,
     });
-    $container.append(html_body);
+    $container.append($(html_body));
     let avatar_widget;
 
     const bot_type = bot.bot_type.toString();
@@ -638,17 +638,21 @@ export function show_edit_bot_info_modal(user_id, $container) {
 
         if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
             $("#service_data").append(
-                render_settings_edit_outgoing_webhook_service({
-                    service,
-                }),
+                $(
+                    render_settings_edit_outgoing_webhook_service({
+                        service,
+                    }),
+                ),
             );
             $("#edit_service_interface").val(service.interface);
         }
         if (bot_type === EMBEDDED_BOT_TYPE) {
             $("#service_data").append(
-                render_settings_edit_embedded_bot_service({
-                    service,
-                }),
+                $(
+                    render_settings_edit_embedded_bot_service({
+                        service,
+                    }),
+                ),
             );
         }
 
@@ -749,7 +753,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         is_active,
     });
 
-    $container.append(html_body);
+    $container.append($(html_body));
     // Set role dropdown and fields user pills
     $("#user-role-select").val(person.role);
     if (!current_user.is_owner) {

--- a/web/src/vdom.ts
+++ b/web/src/vdom.ts
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import _ from "lodash";
 
 import * as blueslip from "./blueslip";
@@ -202,7 +203,7 @@ export function update<T>(
             continue;
         }
         const rendered_dom = new_node.render();
-        $child_elems.eq(i).replaceWith(rendered_dom);
+        $child_elems.eq(i).replaceWith($(rendered_dom));
     }
 
     update_attrs(find(), new_opts.attrs, old_opts.attrs);

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -237,6 +237,7 @@ test("presence_list_full_update", ({override, mock_template}) => {
     let presence_rows = [];
     mock_template("presence_rows.hbs", false, (data) => {
         presence_rows = [...presence_rows, ...data.presence_rows];
+        return "<presence-rows-stub>";
     });
 
     $("input.user-list-filter").trigger("focus");
@@ -288,7 +289,7 @@ test("direct_message_update_dom_counts", () => {
 test("handlers", ({override, override_rewire, mock_template}) => {
     let filter_key_handlers;
 
-    mock_template("presence_rows.hbs", false, noop);
+    mock_template("presence_rows.hbs", false, () => "<presence-rows-stub>");
 
     override(keydown_util, "handle", (opts) => {
         filter_key_handlers = opts.handlers;
@@ -402,7 +403,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
 
 test("first/prev/next", ({override, override_rewire, mock_template}) => {
     override_rewire(buddy_data, "user_matches_narrow", override_user_matches_narrow);
-    mock_template("presence_rows.hbs", false, noop);
+    mock_template("presence_rows.hbs", false, () => "<presence-rows-stub>");
     override(padded_widget, "update_padding", noop);
     stub_buddy_list_elements();
 
@@ -480,13 +481,13 @@ test("render_empty_user_list_message", ({override, mock_template}) => {
     const empty_list_message = "No matching users.";
     mock_template("empty_list_widget_for_list.hbs", false, (data) => {
         assert.equal(data.empty_list_message, empty_list_message);
-        return empty_list_message;
+        return "<empty-list-stub>";
     });
 
-    let appended_data;
+    let $appended_data;
     override(buddy_list, "$container", {
-        append(data) {
-            appended_data = data;
+        append($data) {
+            $appended_data = $data;
         },
         data() {
             return empty_list_message;
@@ -495,7 +496,7 @@ test("render_empty_user_list_message", ({override, mock_template}) => {
     });
 
     activity_ui.render_empty_user_list_message_if_needed(buddy_list.$container);
-    assert.equal(appended_data, empty_list_message);
+    assert.equal($appended_data.selector, "<empty-list-stub>");
 });
 
 test("insert_one_user_into_empty_list", ({override, mock_template}) => {
@@ -523,13 +524,13 @@ test("insert_one_user_into_empty_list", ({override, mock_template}) => {
         return html;
     });
 
-    let users_matching_view_appended_html;
-    override(buddy_list.$users_matching_view_container, "append", (html) => {
-        users_matching_view_appended_html = html;
+    let $users_matching_view_appended;
+    override(buddy_list.$users_matching_view_container, "append", ($element) => {
+        $users_matching_view_appended = $element;
     });
-    let other_users_appended_html;
-    override(buddy_list.$other_users_container, "append", (html) => {
-        other_users_appended_html = html;
+    let $other_users_appended;
+    override(buddy_list.$other_users_container, "append", ($element) => {
+        $other_users_appended = $element;
     });
 
     add_sub_and_set_as_current_narrow(rome_sub);
@@ -537,33 +538,33 @@ test("insert_one_user_into_empty_list", ({override, mock_template}) => {
     buddy_list_add_user_matching_view(alice.user_id, $alice_stub);
     peer_data.set_subscribers(rome_sub.stream_id, [alice.user_id]);
     activity_ui.redraw_user(alice.user_id);
-    assert.ok(users_matching_view_appended_html.includes('data-user-id="1"'));
-    assert.ok(users_matching_view_appended_html.includes("user_circle_green"));
+    assert.ok($users_matching_view_appended.selector.includes('data-user-id="1"'));
+    assert.ok($users_matching_view_appended.selector.includes("user_circle_green"));
 
     clear_buddy_list(buddy_list);
     buddy_list_add_other_user(alice.user_id, $alice_stub);
     peer_data.set_subscribers(rome_sub.stream_id, []);
     activity_ui.redraw_user(alice.user_id);
-    assert.ok(other_users_appended_html.includes('data-user-id="1"'));
-    assert.ok(other_users_appended_html.includes("user_circle_green"));
+    assert.ok($other_users_appended.selector.includes('data-user-id="1"'));
+    assert.ok($other_users_appended.selector.includes("user_circle_green"));
 });
 
 test("insert_alice_then_fred", ({override, mock_template}) => {
     mock_template("presence_row.hbs", true, (_data, html) => html);
 
-    let other_users_appended_html;
-    override(buddy_list.$other_users_container, "append", (html) => {
-        other_users_appended_html = html;
+    let $other_users_appended;
+    override(buddy_list.$other_users_container, "append", ($element) => {
+        $other_users_appended = $element;
     });
     override(padded_widget, "update_padding", noop);
 
     activity_ui.redraw_user(alice.user_id);
-    assert.ok(other_users_appended_html.includes('data-user-id="1"'));
-    assert.ok(other_users_appended_html.includes("user_circle_green"));
+    assert.ok($other_users_appended.selector.includes('data-user-id="1"'));
+    assert.ok($other_users_appended.selector.includes("user_circle_green"));
 
     activity_ui.redraw_user(fred.user_id);
-    assert.ok(other_users_appended_html.includes('data-user-id="2"'));
-    assert.ok(other_users_appended_html.includes("user_circle_green"));
+    assert.ok($other_users_appended.selector.includes('data-user-id="2"'));
+    assert.ok($other_users_appended.selector.includes("user_circle_green"));
 });
 
 test("insert_fred_then_alice_then_rename, both as users matching view", ({
@@ -575,21 +576,21 @@ test("insert_fred_then_alice_then_rename, both as users matching view", ({
     add_sub_and_set_as_current_narrow(rome_sub);
     peer_data.set_subscribers(rome_sub.stream_id, [alice.user_id, fred.user_id]);
 
-    let users_matching_view_appended_html;
-    override(buddy_list.$users_matching_view_container, "append", (html) => {
-        users_matching_view_appended_html = html;
+    let $users_matching_view_appended;
+    override(buddy_list.$users_matching_view_container, "append", ($element) => {
+        $users_matching_view_appended = $element;
     });
     override(padded_widget, "update_padding", noop);
     buddy_list_add_user_matching_view(alice.user_id, $alice_stub);
     buddy_list_add_user_matching_view(fred.user_id, $fred_stub);
 
     activity_ui.redraw_user(fred.user_id);
-    assert.ok(users_matching_view_appended_html.includes('data-user-id="2"'));
-    assert.ok(users_matching_view_appended_html.includes("user_circle_green"));
+    assert.ok($users_matching_view_appended.selector.includes('data-user-id="2"'));
+    assert.ok($users_matching_view_appended.selector.includes("user_circle_green"));
 
-    let inserted_html;
-    $fred_stub.before = (html) => {
-        inserted_html = html;
+    let $inserted;
+    $fred_stub.before = ($element) => {
+        $inserted = $element;
     };
 
     let fred_removed;
@@ -598,8 +599,8 @@ test("insert_fred_then_alice_then_rename, both as users matching view", ({
     };
 
     activity_ui.redraw_user(alice.user_id);
-    assert.ok(inserted_html.includes('data-user-id="1"'));
-    assert.ok(inserted_html.includes("user_circle_green"));
+    assert.ok($inserted.selector.includes('data-user-id="1"'));
+    assert.ok($inserted.selector.includes("user_circle_green"));
 
     // Next rename fred to Aaron.
     const fred_with_new_name = {
@@ -609,13 +610,13 @@ test("insert_fred_then_alice_then_rename, both as users matching view", ({
     };
     people.add_active_user(fred_with_new_name);
 
-    $alice_stub.before = (html) => {
-        inserted_html = html;
+    $alice_stub.before = ($element) => {
+        $inserted = $element;
     };
 
     activity_ui.redraw_user(fred_with_new_name.user_id);
     assert.ok(fred_removed);
-    assert.ok(users_matching_view_appended_html.includes('data-user-id="2"'));
+    assert.ok($users_matching_view_appended.selector.includes('data-user-id="2"'));
 
     // restore old Fred data
     people.add_active_user(fred);
@@ -627,9 +628,9 @@ test("insert_fred_then_alice_then_rename, both as other users", ({override, mock
     add_sub_and_set_as_current_narrow(rome_sub);
     peer_data.set_subscribers(rome_sub.stream_id, []);
 
-    let other_users_appended_html;
-    override(buddy_list.$other_users_container, "append", (html) => {
-        other_users_appended_html = html;
+    let $other_users_appended;
+    override(buddy_list.$other_users_container, "append", ($element) => {
+        $other_users_appended = $element;
     });
     override(padded_widget, "update_padding", noop);
 
@@ -637,12 +638,12 @@ test("insert_fred_then_alice_then_rename, both as other users", ({override, mock
     buddy_list_add_other_user(fred.user_id, $fred_stub);
 
     activity_ui.redraw_user(fred.user_id);
-    assert.ok(other_users_appended_html.includes('data-user-id="2"'));
-    assert.ok(other_users_appended_html.includes("user_circle_green"));
+    assert.ok($other_users_appended.selector.includes('data-user-id="2"'));
+    assert.ok($other_users_appended.selector.includes("user_circle_green"));
 
-    let inserted_html;
-    $fred_stub.before = (html) => {
-        inserted_html = html;
+    let $inserted;
+    $fred_stub.before = ($element) => {
+        $inserted = $element;
     };
 
     let fred_removed;
@@ -651,8 +652,8 @@ test("insert_fred_then_alice_then_rename, both as other users", ({override, mock
     };
 
     activity_ui.redraw_user(alice.user_id);
-    assert.ok(inserted_html.includes('data-user-id="1"'));
-    assert.ok(inserted_html.includes("user_circle_green"));
+    assert.ok($inserted.selector.includes('data-user-id="1"'));
+    assert.ok($inserted.selector.includes("user_circle_green"));
 
     // Next rename fred to Aaron.
     const fred_with_new_name = {
@@ -662,13 +663,13 @@ test("insert_fred_then_alice_then_rename, both as other users", ({override, mock
     };
     people.add_active_user(fred_with_new_name);
 
-    $alice_stub.before = (html) => {
-        inserted_html = html;
+    $alice_stub.before = ($element) => {
+        $inserted = $element;
     };
 
     activity_ui.redraw_user(fred_with_new_name.user_id);
     assert.ok(fred_removed);
-    assert.ok(other_users_appended_html.includes('data-user-id="2"'));
+    assert.ok($other_users_appended.selector.includes('data-user-id="2"'));
 
     // restore old Fred data
     people.add_active_user(fred);
@@ -769,7 +770,7 @@ test("initialize", ({override, mock_template}) => {
         buddy_list.$other_users_container = $("#buddy-list-other-users");
         buddy_list.$other_users_container.append = noop;
         stub_buddy_list_elements();
-        mock_template("empty_list_widget_for_list.hbs", false, noop);
+        mock_template("empty_list_widget_for_list.hbs", false, () => "<empty-list-stub>");
         clear_buddy_list(buddy_list);
         page_params.presences = {};
     }

--- a/web/tests/buddy_list.test.js
+++ b/web/tests/buddy_list.test.js
@@ -62,15 +62,15 @@ run_test("basics", ({override, mock_template}) => {
     const buddy_list = new BuddyList();
     init_simulated_scrolling();
 
-    override(buddy_list, "items_to_html", () => "html-stub");
+    override(buddy_list, "items_to_html", () => "<html-stub>");
     override(message_viewport, "height", () => 550);
     override(padded_widget, "update_padding", noop);
     stub_buddy_list_elements();
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
 
     let appended_to_users_matching_view;
-    $("#buddy-list-users-matching-view").append = (html) => {
-        assert.equal(html, "html-stub");
+    $("#buddy-list-users-matching-view").append = ($element) => {
+        assert.equal($element.selector, "<html-stub>");
         appended_to_users_matching_view = true;
     };
 
@@ -98,29 +98,29 @@ run_test("split list", ({override, override_rewire, mock_template}) => {
     const buddy_list = new BuddyList();
     init_simulated_scrolling();
     stub_buddy_list_elements();
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
 
     override_rewire(buddy_data, "user_matches_narrow", override_user_matches_narrow);
 
     override(buddy_list, "items_to_html", (opts) => {
         if (opts.items.length > 0) {
-            return "html-stub";
+            return "<html-stub>";
         }
-        return "empty-list";
+        return "<empty-list-stub>";
     });
     override(message_viewport, "height", () => 550);
     override(padded_widget, "update_padding", noop);
 
     let appended_to_users_matching_view = false;
-    $("#buddy-list-users-matching-view").append = (html) => {
-        if (html === "html-stub") {
+    $("#buddy-list-users-matching-view").append = ($element) => {
+        if ($element.selector === "<html-stub>") {
             appended_to_users_matching_view = true;
         }
     };
 
     let appended_to_other_users = false;
-    $("#buddy-list-other-users").append = (html) => {
-        if (html === "html-stub") {
+    $("#buddy-list-other-users").append = ($element) => {
+        if ($element.selector === "<html-stub>") {
             appended_to_other_users = true;
         }
     };
@@ -159,7 +159,7 @@ run_test("find_li", ({override, mock_template}) => {
     const buddy_list = new BuddyList();
 
     override(buddy_list, "fill_screen_with_content", noop);
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
     stub_buddy_list_elements();
 
     clear_buddy_list(buddy_list);
@@ -182,7 +182,7 @@ run_test("fill_screen_with_content early break on big list", ({override, mock_te
     const buddy_list = new BuddyList();
     const elem = init_simulated_scrolling();
     stub_buddy_list_elements();
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
 
     let chunks_inserted = 0;
     override(buddy_list, "render_more", () => {
@@ -224,12 +224,12 @@ run_test("big_list", ({override, override_rewire, mock_template}) => {
     override(padded_widget, "update_padding", noop);
     override(message_viewport, "height", () => 550);
     override_rewire(buddy_data, "user_matches_narrow", override_user_matches_narrow);
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
 
     let items_to_html_call_count = 0;
     override(buddy_list, "items_to_html", () => {
         items_to_html_call_count += 1;
-        return "html-stub";
+        return "<html-stub>";
     });
 
     const num_users = 300;
@@ -354,7 +354,7 @@ run_test("scrolling", ({override, mock_template}) => {
     override(buddy_list, "fill_screen_with_content", () => {
         tried_to_fill = true;
     });
-    mock_template("buddy_list/view_all_users.hbs", false, noop);
+    mock_template("buddy_list/view_all_users.hbs", false, () => "<view-all-users-stub>");
     stub_buddy_list_elements();
     init_simulated_scrolling();
     stub_buddy_list_elements();

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -98,9 +98,9 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
     ]);
 
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
-    const inserted_fn_key = "<kbd>Fn</kbd> + ";
 
     override(navigator, "platform", "MacIntel");
+    $("<span>").contents = () => $("<contents-stub>");
 
     const test_items = [];
     let key_no = 1;
@@ -112,13 +112,13 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
         assert.equal($stub.hasClass("arrow-key"), false);
         if (fn_shortcuts.has(old_key)) {
             $stub.before = ($elem) => {
-                assert.equal($elem, inserted_fn_key);
+                assert.equal($elem.selector, "<kbd>");
             };
         }
         if (old_key === "data-mac-following-key") {
             $stub.attr("data-mac-following-key", "⌥");
-            $stub.after = (plus, $elem) => {
-                assert.equal(plus, " + ");
+            $stub.after = ($plus, $elem) => {
+                assert.equal($plus.selector, "<contents-stub>");
                 assert.equal($elem.selector, "<kbd>");
                 assert.equal($elem.text(), $stub.attr("data-mac-following-key"));
             };

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -686,8 +686,8 @@ run_test("render item", () => {
             // Return a JQuery stub for the original HTML.
             // We want this to be called when we replace
             // the existing HTML with newly rendered HTML.
-            replaceWith(html) {
-                assert.equal(new_html, html);
+            replaceWith($element) {
+                assert.equal(new_html, $element.html());
                 called = true;
                 $container.$appended_data.replace(regex, new_html);
             },

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -37,7 +37,7 @@ let next_timestamp = 1500000000;
 function test(label, f) {
     run_test(label, ({override, mock_template}) => {
         muted_users.set_muted_users([]);
-        mock_template("message_list.hbs", false, noop);
+        mock_template("message_list.hbs", false, () => "<message-list-stub>");
         f({override, mock_template});
     });
 }
@@ -430,7 +430,7 @@ test("muted_message_vars", () => {
 });
 
 test("merge_message_groups", ({mock_template}) => {
-    mock_template("message_list.hbs", false, noop);
+    mock_template("message_list.hbs", false, () => "<message-list-stub>");
     // MessageListView has lots of DOM code, so we are going to test the message
     // group merging logic on its own.
 
@@ -714,7 +714,7 @@ test("merge_message_groups", ({mock_template}) => {
 });
 
 test("render_windows", ({mock_template}) => {
-    mock_template("message_list.hbs", false, noop);
+    mock_template("message_list.hbs", false, () => "<message-list-stub>");
     // We only render up to 400 messages at a time in our message list,
     // and we only change the window (which is a range, really, with
     // start/end) when the pointer moves outside of the window or close

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -2,6 +2,7 @@
 
 const {strict: assert} = require("assert");
 
+const {$t} = require("./lib/i18n");
 const {mock_cjs, mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
@@ -489,6 +490,10 @@ run_test("spoiler-header", () => {
     const $content = get_content_element();
     const $header = $.create("div.spoiler-header");
     $content.set_find_results("div.spoiler-header", $array([$header]));
+    let $prepended;
+    $header.prepend = ($element) => {
+        $prepended = $element;
+    };
 
     // Test that the show/hide button gets added to a spoiler header.
     const label = "My spoiler header";
@@ -496,7 +501,8 @@ run_test("spoiler-header", () => {
         '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
     $header.html(label);
     rm.update_elements($content);
-    assert.equal(toggle_button_html + label, $header.html());
+    assert.equal(label, $header.html());
+    assert.equal($prepended.selector, toggle_button_html);
 });
 
 run_test("spoiler-header-empty-fill", () => {
@@ -504,13 +510,23 @@ run_test("spoiler-header-empty-fill", () => {
     const $content = get_content_element();
     const $header = $.create("div.spoiler-header");
     $content.set_find_results("div.spoiler-header", $array([$header]));
+    let $appended;
+    $header.append = ($element) => {
+        $appended = $element;
+    };
+    let $prepended;
+    $header.prepend = ($element) => {
+        $prepended = $element;
+    };
 
     // Test that an empty header gets the default text applied (through i18n filter).
     const toggle_button_html =
         '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
     $header.empty();
     rm.update_elements($content);
-    assert.equal(toggle_button_html + "<p>translated HTML: Spoiler</p>", $header.html());
+    assert.equal($appended.selector, "<p>");
+    assert.equal($appended.text(), $t({defaultMessage: "Spoiler"}));
+    assert.equal($prepended.selector, toggle_button_html);
 });
 
 function assert_clipboard_setup() {

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -87,7 +87,7 @@ run_test("populate_profile_fields", ({mock_template}) => {
     const template_data = [];
     mock_template("settings/admin_profile_field_list.hbs", false, (data) => {
         template_data.push(data);
-        return "whatever";
+        return "<admin-profile-field-list-stub>";
     });
 
     const fields_data = [

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -375,11 +375,11 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     };
     stream_list.initialize_stream_cursor();
 
-    mock_template("filter_topics.hbs", false, () => "filter-topics-stub");
+    mock_template("filter_topics.hbs", false, () => "<filter-topics-stub>");
     let filter_topics_appended = false;
     $stream_li1.children = () => ({
-        append(html) {
-            assert.equal(html, "filter-topics-stub");
+        append($element) {
+            assert.equal($element.selector, "<filter-topics-stub>");
             filter_topics_appended = true;
         },
     });

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -350,7 +350,7 @@ run_test("render_date_renders_time_html", () => {
     MockDate.set(today.getTime());
 
     const message_time = today;
-    const expected_html = $t({defaultMessage: "Today"});
+    const expected_text = $t({defaultMessage: "Today"});
 
     const attrs = {};
     const $span_stub = $("<span>");
@@ -360,13 +360,8 @@ run_test("render_date_renders_time_html", () => {
         return $span_stub;
     };
 
-    $span_stub.append = (str) => {
-        $span_stub.html(str);
-        return $span_stub;
-    };
-
     const $actual = timerender.render_date(message_time);
-    assert.equal($actual.html(), expected_html);
+    assert.equal($actual.text(), expected_text);
     assert.equal(attrs["data-tippy-content"], "Friday, April 12, 2019");
     assert.equal(attrs.class, "timerender0");
 

--- a/web/tests/vdom.test.js
+++ b/web/tests/vdom.test.js
@@ -180,15 +180,15 @@ run_test("partial updates", () => {
         throw new Error("should not replace entire html");
     };
 
-    let patched_html;
+    let $patched;
 
     find = () => ({
         children: () => ({
             eq(i) {
                 assert.equal(i, 0);
                 return {
-                    replaceWith(html) {
-                        patched_html = html;
+                    replaceWith($element) {
+                        $patched = $element;
                     },
                 };
             },
@@ -206,7 +206,7 @@ run_test("partial updates", () => {
     const new_ul = vdom.ul(new_opts);
     vdom.update(replace_content, find, new_ul, ul);
 
-    assert.equal(patched_html, "<li>modified1</li>");
+    assert.equal($patched.selector, "<li>modified1</li>");
 });
 
 run_test("eq_array easy cases", () => {


### PR DESCRIPTION
Enable the lint rule that found

- #29601

Includes eslint-plugin-no-jquery patches merged upstream:

- wikimedia/eslint-plugin-no-jquery#309
- wikimedia/eslint-plugin-no-jquery#310