### PR TITLE
django: Skip running config and database checks on process start.

### DIFF
--- a/puppet/zulip/templates/supervisor/zulip-once.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip-once.conf.template.erb
@@ -1,5 +1,5 @@
 [program:zulip_deliver_scheduled_emails]
-command=nice -n15 /home/zulip/deployments/current/manage.py deliver_scheduled_emails
+command=nice -n15 /home/zulip/deployments/current/manage.py deliver_scheduled_emails --skip-checks
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
@@ -14,7 +14,7 @@ stdout_logfile_backups=3     ; # of stdout logfile backups (default 10)
 directory=/home/zulip/deployments/current/
 
 [program:zulip_deliver_scheduled_messages]
-command=nice -n15 /home/zulip/deployments/current/manage.py deliver_scheduled_messages
+command=nice -n15 /home/zulip/deployments/current/manage.py deliver_scheduled_messages --skip-checks
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)

--- a/puppet/zulip/templates/supervisor/zulip.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip.conf.template.erb
@@ -26,7 +26,7 @@ directory=/home/zulip/deployments/current/
 
 <% if @tornado_ports.length > 1 -%>
 [program:zulip-tornado]
-command=/home/zulip/deployments/current/manage.py runtornado 127.0.0.1:98%(process_num)02d
+command=/home/zulip/deployments/current/manage.py runtornado 127.0.0.1:98%(process_num)02d --skip-checks
 process_name=zulip-tornado-port-98%(process_num)02d
 environment=PYTHONUNBUFFERED=1,HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=200                   ; the relative start priority (default 999)
@@ -43,7 +43,7 @@ directory=/home/zulip/deployments/current/
 numprocs=<%= @tornado_ports.length %>
 <% else -%>
 [program:zulip-tornado]
-command=/home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9800
+command=/home/zulip/deployments/current/manage.py runtornado 127.0.0.1:9800 --skip-checks
 environment=PYTHONUNBUFFERED=1,HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
@@ -61,7 +61,7 @@ directory=/home/zulip/deployments/current/
 <% if @queues_multiprocess %>
 <% @queues.each do |queue| -%>
 [program:zulip_events_<%= queue %>]
-command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %>
+command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
@@ -77,7 +77,7 @@ directory=/home/zulip/deployments/current/
 <% end -%>
 <% else %>
 [program:zulip_events]
-command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --multi_threaded <%= @queues.join(' ') %>
+command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --multi_threaded <%= @queues.join(' ') %> --skip-checks
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=300                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)


### PR DESCRIPTION
The process of running Django's built-in database and config checks can be very heavy-weight, potentially taking multiple seconds:

```
$ hyperfine './manage.py print_initial_password iago@zulip.com'  './manage.py print_initial_password iago@zulip.com --skip-checks'
Benchmark 1: ./manage.py print_initial_password iago@zulip.com
  Time (mean ± σ):      4.943 s ±  0.722 s    [User: 4.434 s, System: 0.311 s]
  Range (min … max):    4.415 s …  6.835 s    10 runs

Benchmark 2: ./manage.py print_initial_password iago@zulip.com --skip-checks
  Time (mean ± σ):      1.786 s ±  0.113 s    [User: 1.598 s, System: 0.162 s]
  Range (min … max):    1.576 s …  1.999 s    10 runs

Summary
  './manage.py print_initial_password iago@zulip.com --skip-checks' ran
    2.77 ± 0.44 times faster than './manage.py print_initial_password iago@zulip.com'
```

This extends the window during which nginx is forced to serve 502's to clients.  f5f6a3789baf added an explicit `manage.py check` during server restarts, and fa77be6e6c2b added one during upgrades; as such, we expect that any check failures will already have been caught when performing a restart or upgrade, and there is no point in running them on process startup.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
