### PR TITLE
util: Do not use look-behind in wildcard mention checks.

### DIFF
--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -195,7 +195,10 @@ export class CachedValue<T> {
 }
 
 export function find_stream_wildcard_mentions(message_content: string): string | null {
-    const mention = message_content.match(/(?<![^\s"'(/<[{])(@\*{2}(all|everyone|stream)\*{2})/);
+    // We cannot use the exact same regex as the server side users (in zerver/lib/mention.py)
+    // because Safari < 16.4 does not support look-behind assertions.  Reframe the lookbehind of a
+    // negative character class as a start-of-string or positive character class.
+    const mention = message_content.match(/(?:^|[\s"'(/<[{])(@\*{2}(all|everyone|stream)\*{2})/);
     if (mention === null) {
         return null;
     }

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -170,6 +170,8 @@ run_test("wildcard_mentions_regexp", () => {
         "@**everyone**",
         '"@**everyone**"',
         "@**everyone**: Look at this!",
+        "The <@**everyone**> channel",
+        'I have to say "@**everyone**" to ding the bell',
         "some text before @**everyone** some text after",
         "@**everyone** some text after only",
         "some text before only @**everyone**",


### PR DESCRIPTION
92fa9ee78c78 switched this regex to match the server-side regex, but Safari < 16.4 does not support look-behind in regexes.

Switch to matching on start-of-string or a positive character class.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
