### PR TITLE
Fix invite scrolling

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -19,7 +19,6 @@ import * as email_pill from "./email_pill";
 import {$t, $t_html} from "./i18n";
 import * as input_pill from "./input_pill";
 import {page_params} from "./page_params";
-import * as scroll_util from "./scroll_util";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import {current_user, realm} from "./state_data";
@@ -194,7 +193,7 @@ function submit_invitation_form(): void {
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
             $<HTMLTextAreaElement>("textarea#invitee_emails").trigger("focus");
-            scroll_util.get_scroll_element($("#invite-user-modal"))[0].scrollTop = 0;
+            $invite_status[0].scrollIntoView();
         },
     });
 }
@@ -231,7 +230,7 @@ function generate_multiuse_invite(): void {
             );
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
-            scroll_util.get_scroll_element($("#invite-user-modal"))[0].scrollTop = 0;
+            $invite_status[0].scrollIntoView();
         },
     });
 }


### PR DESCRIPTION
"When a user invites someone to join Zulip and then clicks on the invite button,a success
message is displayed in a popover. However, the current placement of the success message
at the top of the popover may not be easily visible to the user, making it unclear whether
the invitation has been sent successfully.
To make the confirmation banner visible, changed the code to  scroll the invitation modal
to the top when a user sends invites or generates an invite link."

The problem was related to the way the scrolling was implemented. We were scrolling to the invite dialog element what did not work as the dialog was already in view. Changed the code to scroll to the Sucess message (both link and mail invite).

Fixes: #28906

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/97690818/6018987c-8323-4da9-a57c-1b82a175848b