### PR TITLE
emails: Add infrastructure to prevent double-sending of custom emails

### DIFF
--- a/zerver/models/realm_audit_logs.py
+++ b/zerver/models/realm_audit_logs.py
@@ -125,6 +125,8 @@ class AbstractRealmAuditLog(models.Model):
     USER_GROUP_DESCRIPTION_CHANGED = 721
     USER_GROUP_GROUP_BASED_SETTING_CHANGED = 722
 
+    CUSTOM_EMAIL_SENT = 800
+
     # The following values are only for RemoteZulipServerAuditLog
     # Values should be exactly 10000 greater than the corresponding
     # value used for the same purpose in RealmAuditLog (e.g.


### PR DESCRIPTION
Followed Tim's comments in Issue #19529 to implement a new event type of CUSTOM_EMAIL_SENT to prevent double-sending of customer emails.

After an email is sent, an event of type CUSTOM_EMAIL_SENT is logged in RealmAuditLog.
RealmAuditLog's (realm, event_type, acting_user_id) is set to (realm, CUSTOM_EMAIL_SENT, recipient's user id).
RealmAuditLog's extra_data is set to {"email_id": {email_id}} where {email_id} is the digest of the email template's content.
Before sending an email, check in RealAuditLog if any row with the same {email_id} and recipient's {user_id} exists; if it exists, we skip sending the email.  

[discussion link](
https://chat.zulip.org/#narrow/stream/3-backend/topic/Add.20CUSTOM_EMAIL_SENT.20event.20to.20prevent.20duplicate.20email)

Fixes: issue #19529

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
