### PR TITLE
tests: Downgrade deprecated SHA1PasswordHasher to MD5PasswordHasher

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -415,20 +415,21 @@ LANGUAGE_COOKIE_SAMESITE: Final = "Lax"
 if DEVELOPMENT:
     # Use fast password hashing for creating testing users when not
     # PRODUCTION.  Saves a bunch of time.
-    PASSWORD_HASHERS = (
+    PASSWORD_HASHERS = [
+        "django.contrib.auth.hashers.MD5PasswordHasher",
         "django.contrib.auth.hashers.SHA1PasswordHasher",
         "django.contrib.auth.hashers.PBKDF2PasswordHasher",
-    )
+    ]
     # Also we auto-generate passwords for the default users which you
     # can query using ./manage.py print_initial_password
     INITIAL_PASSWORD_SALT = get_secret("initial_password_salt")
 else:
     # For production, use the best password hashing algorithm: Argon2
     # Zulip was originally on PBKDF2 so we need it for compatibility
-    PASSWORD_HASHERS = (
+    PASSWORD_HASHERS = [
         "django.contrib.auth.hashers.Argon2PasswordHasher",
         "django.contrib.auth.hashers.PBKDF2PasswordHasher",
-    )
+    ]
 
 ########################################################################
 # API/BOT SETTINGS


### PR DESCRIPTION
`SHA1PasswordHasher` will be [removed in Django 5.1](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-5-1). `MD5PasswordHasher` will [remain](https://github.com/django/django/pull/15871#issuecomment-1193110581) for exactly this purpose of [speeding up tests](https://docs.djangoproject.com/en/5.0/topics/testing/overview/#password-hashing).

Use `MD5PasswordHasher` by default, but leave `SHA1PasswordHasher` in the list for compatibility with test databases that have already been generated.  Once some other change forces test databases to be rebuilt, we can remove `SHA1PasswordHasher`.

(For my future reference, my current `db_files_hash_for_test` is `4e8367bf77e8466c407fffc9c5fb325463b8e441`.)