### PR TITLE
web: Fix usage of .replace with variable replacement

### DIFF
--- a/web/src/settings_profile_fields.js
+++ b/web/src/settings_profile_fields.js
@@ -781,7 +781,7 @@ export function get_external_account_link(field) {
     } else {
         field_url_pattern = realm.realm_default_external_accounts[field_subtype].url_pattern;
     }
-    return field_url_pattern.replace("%(username)s", field.value);
+    return field_url_pattern.replace("%(username)s", () => field.value);
 }
 
 export function set_up() {

--- a/web/third/marked/lib/marked.js
+++ b/web/third/marked/lib/marked.js
@@ -1188,7 +1188,7 @@ Parser.prototype.parse = function(src) {
     if (!safe) {
       html = escape(html);
     }
-    output = output.replace('<p>' + key + '</p>', html)
+    output = output.replace('<p>' + key + '</p>', () => html)
   }
   return output;
  };


### PR DESCRIPTION
`String.prototype.replace` and `String.prototype.replaceAll` interpret certain sequences such as `$$` within a string provided as the replacement argument. Avoid this interpretation by providing a function.