### PR TITLE
click_handlers: Don't handle clicks with meta / ctrl keypress.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -483,6 +483,10 @@ export function initialize() {
 
     // SIDEBARS
     $(".buddy-list-section").on("click", ".selectable_sidebar_block", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         const $li = $(e.target).parents("li");
 
         activity_ui.narrow_for_user({$li});
@@ -841,6 +845,10 @@ export function initialize() {
     });
 
     $("body").on("click", "#header-container .brand", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         e.preventDefault();
         e.stopPropagation();
 

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -1270,6 +1270,10 @@ export function initialize() {
     );
 
     $("body").on("keydown", ".inbox-header", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         if (keydown_util.is_enter_event(e)) {
             e.preventDefault();
             e.stopPropagation();
@@ -1289,6 +1293,10 @@ export function initialize() {
     });
 
     $("body").on("keydown", ".inbox-row", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         if (keydown_util.is_enter_event(e)) {
             e.preventDefault();
             e.stopPropagation();
@@ -1299,6 +1307,10 @@ export function initialize() {
     });
 
     $("body").on("click", "#inbox-list .inbox-left-part-wrapper", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         const $elt = $(e.currentTarget);
         col_focus = COLUMNS.RECIPIENT;
         focus_clicked_list_element($elt);

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -1548,6 +1548,10 @@ export function initialize({
     });
 
     $("body").on("click", "td.recent_topic_stream", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         e.stopPropagation();
         const topic_row_index = $(e.target).closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.stream);
@@ -1555,6 +1559,10 @@ export function initialize({
     });
 
     $("body").on("click", "td.recent_topic_name", (e) => {
+        if (e.metaKey || e.ctrlKey) {
+            return;
+        }
+
         e.stopPropagation();
         // The element's parent may re-render while it is being passed to
         // other functions, so, we get topic_key first.


### PR DESCRIPTION
Fixes #17935

This allows users to ctrl + click a link to open it in new tab without changing the state in the current tab.
