### PR TITLE
css: Make pills' content collapse according to width available.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -963,6 +963,7 @@ textarea.new_message_textarea,
       `align-self: center` to center only
       themselves, where necessary. */
     min-height: var(--compose-recipient-box-min-height);
+    min-width: 0;
 }
 
 .compose-control-buttons-container {

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -1,6 +1,7 @@
 .pill-container {
     display: inline-flex;
     flex-wrap: wrap;
+    min-width: 0;
 
     padding: 2px;
     border: 1px solid hsl(0deg 0% 0% / 15%);
@@ -13,6 +14,7 @@
         display: inline-flex;
         align-items: center;
         max-width: 100%;
+        min-width: 0;
 
         height: 20px;
         margin: 1px 2px;


### PR DESCRIPTION
We set `min-width: 0` on all nested flex containers for pills, not just the pills label, which allows the label content to collapse as much as needed with ellipsis when overflowing.

Fixes: #27205.

**Screenshots and screen captures:**
Before:
![image](https://github.com/zulip/zulip/assets/68962290/2919d856-35c0-4ba0-8876-c245d0cf00c2)
![image](https://github.com/zulip/zulip/assets/68962290/ffe7def1-d87d-4c51-b9bb-9f0e91f36d24)

After:
![image](https://github.com/zulip/zulip/assets/68962290/ea64509b-a6e9-4e8e-b3d4-e01473e7524e)
![image](https://github.com/zulip/zulip/assets/68962290/6321d79f-00ba-4587-b878-54c6263a29dd)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
