### PR TITLE
compose_recipient: Add character limit in DM recipients box.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -355,6 +355,19 @@ export function initialize(): void {
         update_on_recipient_change();
         compose_state.set_recipient_edited_manually(true);
     });
+    // enforce character limit when pasting long texts
+    $("#private_message_recipient").on("input", () => {
+        const currentText = $("#private_message_recipient").text();
+        if (currentText.length > realm.max_topic_length) {
+            $("#private_message_recipient").text(currentText.slice(0, 60));
+        }
+    });
+    // enforce character limit on character input
+    $("#private_message_recipient").on("keypress", (e) => {
+        if ($("#private_message_recipient").text().length === 60) {
+            e.preventDefault();
+        }
+    });
 }
 
 export function update_placeholder_text(): void {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -204,6 +204,8 @@
 
     #compose-direct-recipient {
         flex-grow: 1;
+        position: relative;
+        overflow: hidden;
     }
 
     .message_header {
@@ -831,6 +833,8 @@ textarea.new_message_textarea,
 
 #private_message_recipient.recipient_box {
     width: 100%;
+    height: auto;
+    overflow: hidden;
 }
 
 .compose-send-or-save-button {


### PR DESCRIPTION
Previously, the DM recipients box lacked a character limit, allowing character overflow. This fix
addresses the issue by manually imposing a
character limit on both paste and character
keypress events.

Fixes zulip#27688.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
Implemented a fix for issue https://github.com/zulip/zulip/issues/27688 by introducing a character cutoff mechanism at the maximum length of a name in Zulip and I changed the compose css file to correct the deformatting that occurred when there was a change in the size of the web page.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
before:
![image](https://github.com/zulip/zulip/assets/106839691/34fd3d87-0c81-4af9-8c6e-36c17949f6b0)
after:
![image](https://github.com/zulip/zulip/assets/106839691/8f55c7b2-4189-4564-ab5a-aed0b0942254)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
