### PR TITLE
integration: Split 'opened_or_update_pull_request' event type into multiple event type.

### DIFF
--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -829,7 +829,8 @@ EVENT_FUNCTION_MAPPER: Dict[str, Callable[[Helper], str]] = {
     "issues": get_issue_body,
     "member": get_member_body,
     "membership": get_membership_body,
-    "opened_or_update_pull_request": get_opened_or_update_pull_request_body,
+    "opened_pull_request": get_opened_or_update_pull_request_body,
+    "updated_pull_request": get_opened_or_update_pull_request_body,
     "assigned_or_unassigned_pull_request": get_assigned_or_unassigned_pull_request_body,
     "page_build": get_page_build_body,
     "ping": get_ping_body,
@@ -951,8 +952,10 @@ def get_zulip_event_name(
     """
     if header_event == "pull_request":
         action = payload["action"].tame(check_string)
-        if action in ("opened", "synchronize", "reopened", "edited"):
-            return "opened_or_update_pull_request"
+        if action in ("opened", "reopened"):
+            return "opened_pull_request"
+        elif action in ("synchronize", "edited"):
+            return "updated_pull_request"
         if action in ("assigned", "unassigned"):
             return "assigned_or_unassigned_pull_request"
         if action == "closed":


### PR DESCRIPTION
>GSoC`2024 participant.

Modified the 'get_zulip_event_name' function to
differentiate between 'opened' and 'updated' actions for pull requests within the 'pull_request' event type. Created separate event types for 'opened_pull_request' and 'updated_pull_request'. Updated the 'EVENT_FUNCTION_MAPPER' dictionary to include handlers for these new event types. Adjusted the'get_opened_or_update_pull_request_body' function to handle both 'opened' and 'updated' actions appropriately.

Fixes #29594.

### Docs:
![Screenshot 2024-04-06 172919](https://github.com/zulip/zulip/assets/73663475/b8f07561-6fc7-46d6-a4cf-1cadaee511b2)

### Event filtering option:
![image](https://github.com/zulip/zulip/assets/73663475/d4a21ee9-4a01-4f77-a991-6c79b56c386d)

![image](https://github.com/zulip/zulip/assets/73663475/51587145-4777-4f1c-8ed0-86a6fa4181e7)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
