### PR TITLE
stream_menu: Fix Stream Menu Viewport Width Issue

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1125,7 +1125,7 @@ div.settings-radio-input-parent {
 
    Longer-term we should extract this logic two-column-overlay class
    to read more naturally. */
-   @media (calc($md_min - 1px) < width < calc($md_min + 113px)) {
+@media (calc($md_min - 1px) < width < calc($md_min + 113px)) {
     .user-groups-container .right,
     .subscriptions-container .right {
         position: absolute;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1125,6 +1125,34 @@ div.settings-radio-input-parent {
 
    Longer-term we should extract this logic two-column-overlay class
    to read more naturally. */
+   @media (calc($md_min - 1px) < width < calc($md_min + 113px)) {
+    .user-groups-container .right,
+    .subscriptions-container .right {
+        position: absolute;
+        left: 50% !important;
+        top: 45px;
+        background-color: var(--color-background-modal) !important;
+        border-top: none !important;
+        transition: all 0.3s ease;
+        z-index: 10 !important;
+        width: 50% !important;
+        display: block;
+        margin: 0;
+        height: calc(100% - 45px);
+        border-left: 1px solid hsl(0deg 0% 0% / 20%);
+    }
+
+    .user-groups-container .left,
+    .subscriptions-container .left {
+        position: absolute;
+        display: block;
+        margin: 0;
+        width: 50% !important;
+        height: calc(100% - 45px);
+        border-right: 1px solid hsl(0deg 0% 0% / 20%);
+    }
+}
+
 @media (width < $md_min) {
     .user-groups-container,
     .subscriptions-container {


### PR DESCRIPTION
Address the issue of the left panel layout getting distorted and creating a second
line of options on top when the screen width is between 768px and 881px. The problem
was caused by a gap in the media query coverage in this range.

These changes ensure a smooth transition of styles across different screen widths and
prevent the layout from breaking at the specific 768-881px range.

Fixes: [#29514](https://github.com/zulip/zulip/issues/29514).

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
