### PR TITLE
rename: Replace huddle with direct_message_group in locale.

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -2268,7 +2268,7 @@ msgstr "\n    لا تقم بالرد على هذا البريد. خادم \"زو
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/be/LC_MESSAGES/django.po
+++ b/locale/be/LC_MESSAGES/django.po
@@ -2264,7 +2264,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -2265,7 +2265,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/bqi/LC_MESSAGES/django.po
+++ b/locale/bqi/LC_MESSAGES/django.po
@@ -2264,7 +2264,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -2266,7 +2266,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -2270,8 +2270,8 @@ msgstr "\n    Neodpovídejte na tento elektronický dopis. Tento server Zulipu n
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Seskupit PM s %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Seskupit PM s %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -2265,7 +2265,7 @@ msgstr "\nPeidiwch ag ymateb i'r e-bost hwn. Nid yw'r gweinydd Zulip hwn wedi'i 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -2265,7 +2265,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -2297,8 +2297,8 @@ msgstr "\n    Antworte nicht auf diese E-Mail. Dieser Zulip-Server ist nicht daf
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Gruppen-DMs mit %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Gruppen-DMs mit %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -2267,8 +2267,8 @@ msgstr "\n    Do not reply to this email. This Zulip server is not configured to
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Group DMs with %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -2297,7 +2297,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2281,7 +2281,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -2270,8 +2270,8 @@ msgstr "\n    به این ایمیل پاسخ ندهید. این سرور زول
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "پیام مستقیم گروهی با %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "پیام مستقیم گروهی با %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2272,7 +2272,7 @@ msgstr "\nÄlä vastaa tähän sähköpostiin. Tätä Zulip-palvelinta ei ole m�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2289,8 +2289,8 @@ msgstr "\n    Ne répondez pas à ce courriel. Le serveur Zulip n'est pas config
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Regrouper les messages directs avec %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Regrouper les messages directs avec %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/gl/LC_MESSAGES/django.po
+++ b/locale/gl/LC_MESSAGES/django.po
@@ -2297,7 +2297,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/gu/LC_MESSAGES/django.po
+++ b/locale/gu/LC_MESSAGES/django.po
@@ -2265,8 +2265,8 @@ msgstr "\nઆ ઇમેઇલને જવાબ આપતા ન રહેવ�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "સાથે %(huddle_display_name)s સાથે સમૂહ DMs"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "સાથે %(direct_message_group_display_name)s સાથે સમૂહ DMs"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -2270,7 +2270,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -2272,7 +2272,7 @@ msgstr "\n    Ne válaszolj erre az e-mailre. Ezen a Zulip szerveren a bejövő 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -2267,7 +2267,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -2274,8 +2274,8 @@ msgstr "\n    Non rispondere a questa email. Questo server Zulip non è configur
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Messaggi privati di gruppo con %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Messaggi privati di gruppo con %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -2275,7 +2275,7 @@ msgstr "\n    このメールに返信しないでください。このZulipサ�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -2276,7 +2276,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -2264,7 +2264,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -2298,7 +2298,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ml/LC_MESSAGES/django.po
+++ b/locale/ml/LC_MESSAGES/django.po
@@ -2364,7 +2364,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -2274,8 +2274,8 @@ msgstr "\nЭнэ имэйлд хариу бичих хэрэггүй. Энэ Zul
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групп DM-үүд %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групп DM-үүд %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -2268,7 +2268,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -2296,7 +2296,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -2274,7 +2274,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -2271,7 +2271,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -2379,7 +2379,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -2265,7 +2265,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -2271,8 +2271,8 @@ msgstr "\n    Nu răspunde acestui email. Acest server Zulip nu este configurat 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Grupați DM cu %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Grupați DM cu %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -2282,8 +2282,8 @@ msgstr "\n    Не отвечайте на это письмо. Этот сер�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групповые личные сообщения я %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групповые личные сообщения я %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/si/LC_MESSAGES/django.po
+++ b/locale/si/LC_MESSAGES/django.po
@@ -2266,7 +2266,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -2266,8 +2266,8 @@ msgstr "\n    Не одговарајте на ову е-поруку. Овај 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групне ДП са %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групне ДП са %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2264,7 +2264,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -2347,7 +2347,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/tl/LC_MESSAGES/django.po
+++ b/locale/tl/LC_MESSAGES/django.po
@@ -2264,7 +2264,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -2274,8 +2274,8 @@ msgstr "\nBu e-postaya cevap vermeyin. Bu Zulip sunucusu gelen e-postaları alma
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "%(huddle_display_name)s ile olan Grup DM'leri"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "%(direct_message_group_display_name)s ile olan Grup DM'leri"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -2267,7 +2267,7 @@ msgstr "\n    Не відповідайте на цей електронний �
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2267,7 +2267,7 @@ msgstr "\n    Do not reply to this email. This Zulip server is not configured to
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2274,7 +2274,7 @@ msgstr "\n    请勿回复此电子邮件。 (<a href=\"%(url)s\">help</a>).\n  
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/locale/zh_Hant/LC_MESSAGES/django.po
@@ -2266,7 +2266,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -2270,7 +2270,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,5 +1,5 @@
 {% if show_message_content %}
-    {% if group_pm %} {% trans %}Group DMs with {{ huddle_display_name }}{% endtrans %}
+    {% if group_pm %} {% trans %}Group DMs with {{ direct_message_group_display_name }}{% endtrans %}
     {% elif private_message %} {% trans %}DMs with {{ sender_str }}{% endtrans %}
     {% elif stream_email_notify or mention or followed_topic_email_notify %}
         {#

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -480,18 +480,18 @@ def do_send_missedmessage_events_reply_in_zulip(
         other_recipients = [r["full_name"] for r in display_recipient if r["id"] != user_profile.id]
         context.update(group_pm=True)
         if len(other_recipients) == 2:
-            huddle_display_name = " and ".join(other_recipients)
-            context.update(huddle_display_name=huddle_display_name)
+            direct_message_group_display_name = " and ".join(other_recipients)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
         elif len(other_recipients) == 3:
-            huddle_display_name = (
+            direct_message_group_display_name = (
                 f"{other_recipients[0]}, {other_recipients[1]}, and {other_recipients[2]}"
             )
-            context.update(huddle_display_name=huddle_display_name)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
         else:
-            huddle_display_name = "{}, and {} others".format(
+            direct_message_group_display_name = "{}, and {} others".format(
                 ", ".join(other_recipients[:2]), len(other_recipients) - 2
             )
-            context.update(huddle_display_name=huddle_display_name)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
     elif missed_messages[0]["message"].recipient.type == Recipient.PERSONAL:
         narrow_url = personal_narrow_url(
             realm=user_profile.realm,
@@ -546,7 +546,7 @@ def do_send_missedmessage_events_reply_in_zulip(
             messages=[],
             sender_str="",
             realm_str=realm.name,
-            huddle_display_name="",
+            direct_message_group_display_name="",
             show_message_content=False,
             message_content_disabled_by_user=not user_profile.message_content_in_email_notifications,
             message_content_disabled_by_realm=not realm.message_content_allowed_in_email_notifications,


### PR DESCRIPTION
Across 46 portable object files, replace huddle_display_name with direct_message_group_display name. To pass tests, huddle_display_name in ``missed_message.subject.txt`` and ``email_notifications.py`` were renamed as well.

Fixes part of #28640.