### PR TITLE
compose_tooltips: Improve tooltip logic for compose_reply_button.

### DIFF
--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -67,20 +67,20 @@ function update_reply_button_state(disable = false) {
     $(".compose_reply_button").attr("disabled", disable);
     if (disable) {
         $("#compose_buttons .compose-reply-button-wrapper").attr(
-            "data-tooltip-template-id",
-            "compose_reply_direct_disabled_button_tooltip_template",
+            "data-reply-button-type",
+            "direct_disabled",
         );
         return;
     }
     if (narrow_state.is_message_feed_visible()) {
         $("#compose_buttons .compose-reply-button-wrapper").attr(
-            "data-tooltip-template-id",
-            "compose_reply_message_button_tooltip_template",
+            "data-reply-button-type",
+            "selected_message",
         );
     } else {
         $("#compose_buttons .compose-reply-button-wrapper").attr(
-            "data-tooltip-template-id",
-            "compose_reply_selected_topic_button_tooltip_template",
+            "data-reply-button-type",
+            "selected_conversation",
         );
     }
 }

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -68,7 +68,7 @@ function update_reply_button_state(disable = false) {
     if (disable) {
         $("#compose_buttons .compose-reply-button-wrapper").attr(
             "data-tooltip-template-id",
-            "compose_reply_button_disabled_tooltip_template",
+            "compose_reply_direct_disabled_button_tooltip_template",
         );
         return;
     }

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -21,7 +21,6 @@ export function initialize(): void {
         target: [
             // Ideally this would be `#compose_buttons .button`, but the
             // reply button's actual area is its containing span.
-            "#compose_buttons .compose-reply-button-wrapper",
             "#left_bar_compose_mobile_button_big",
             "#new_direct_message_button",
         ].join(","),
@@ -31,6 +30,52 @@ export function initialize(): void {
         // trigger after it closes, which results in tooltip being displayed.
         trigger: "mouseenter",
         appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+    delegate("body", {
+        target: "#compose_buttons .compose-reply-button-wrapper",
+        delay: EXTRA_LONG_HOVER_DELAY,
+        // Only show on mouseenter since for spectators, clicking on these
+        // buttons opens login modal, and Micromodal returns focus to the
+        // trigger after it closes, which results in tooltip being displayed.
+        trigger: "mouseenter",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const button_type = $elem.attr("data-reply-button-type");
+            switch (button_type) {
+                case "direct_disabled": {
+                    instance.setContent(
+                        parse_html(
+                            $("#compose_reply_direct_disabled_button_tooltip_template").html(),
+                        ),
+                    );
+                    return;
+                }
+                case "selected_message": {
+                    instance.setContent(
+                        parse_html($("#compose_reply_message_button_tooltip_template").html()),
+                    );
+                    return;
+                }
+                case "selected_conversation": {
+                    instance.setContent(
+                        parse_html(
+                            $("#compose_reply_selected_topic_button_tooltip_template").html(),
+                        ),
+                    );
+                    return;
+                }
+                default: {
+                    instance.setContent(
+                        parse_html($("#compose_reply_message_button_tooltip_template").html()),
+                    );
+                    return;
+                }
+            }
+        },
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -13,7 +13,7 @@
     <div id="compose_controls" class="new-style">
         <div id="compose_buttons">
             <div class="new_message_button reply_button_container">
-                <div class="compose-reply-button-wrapper" data-tooltip-template-id="compose_reply_message_button_tooltip_template">
+                <div class="compose-reply-button-wrapper" data-reply-button-type="selected_message">
                     <button type="button" class="button small compose_reply_button"
                       id="left_bar_compose_reply_button_big">
                         {{t 'Compose message' }}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -18,7 +18,7 @@
     {{t 'Reply to selected conversation' }}
     {{tooltip_hotkey_hints "R"}}
 </template>
-<template id="compose_reply_button_disabled_tooltip_template">
+<template id="compose_reply_direct_disabled_button_tooltip_template">
     {{t 'You are not allowed to send direct messages in this organization.' }}
 </template>
 <template id="left_bar_compose_mobile_button_tooltip_template">


### PR DESCRIPTION
Change compose_reply_button tooltip logic to show the correct tooltip. Earlier in organizations where DMs were disabled, a stale tooltip was being displayed.

Similar to [#28523](https://github.com/zulip/zulip/pull/28523), When the user hovers over the `compose_reply_button` sometimes had stale tooltip content rendered on it. In this PR, we change the logic used to render this tooltip, to now render the tooltip content on the fly via `instance.setContent()` which should eliminate any such bug.

Earlier if the user hovered over the `compose_reply_button` when it was disabled and switched to a stream in which it was enabled before waiting for the tooltip delay, the next time the user hovers over the `compose_reply_button` the stale disabled tooltip is displayed instead of the enabled one.

This is fixed by checking if the `compose_reply_button` is enabled on the fly while rendering the tooltip.

Fixes [#29238](https://github.com/zulip/zulip/issues/29238).]
**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/29176437/e090c324-95ca-4a58-be44-4f16e5fb47ec)
![image](https://github.com/zulip/zulip/assets/29176437/e833ea63-7fae-428c-be87-6b82b8a15012)


<details>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
