### PR TITLE
invite_user_modal: Always show scrollbar.

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -63,6 +63,7 @@ export type DialogWidgetConfig = {
     post_render?: () => void;
     loading_spinner?: boolean;
     update_submit_disabled_state_on_change?: boolean;
+    always_visible_scrollbar?: boolean;
 };
 
 type RequestOpts = {
@@ -130,6 +131,9 @@ export function launch(conf: DialogWidgetConfig): void {
     //   submit button when clicked.
     // * update_submit_disabled_state_on_change: If true, updates state of submit button
     //   on valid input change in modal.
+    // * always_visible_scrollbar: Whether the scrollbar is always visible if modal body
+    //   has scrollable content. Default behaviour is to hide the scrollbar when it is
+    //   not in use.
 
     const html_submit_button = conf.html_submit_button ?? $t_html({defaultMessage: "Save changes"});
     const html_exit_button = conf.html_exit_button ?? $t_html({defaultMessage: "Cancel"});
@@ -141,6 +145,7 @@ export function launch(conf: DialogWidgetConfig): void {
         html_body: conf.html_body,
         id: conf.id,
         single_footer_button: conf.single_footer_button,
+        always_visible_scrollbar: conf.always_visible_scrollbar,
     });
     const $dialog = $(html);
     $("body").append($dialog);

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -494,6 +494,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         loading_spinner: true,
         on_click: invite_users,
         post_render: invite_user_modal_post_render,
+        always_visible_scrollbar: true,
     });
 }
 

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -10,7 +10,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content" data-simplebar>
+            <main class="modal__content" data-simplebar {{#if always_visible_scrollbar}}data-simplebar-auto-hide="false"{{/if}}>
                 <div class="alert" id="dialog_error"></div>
                 {{{ html_body }}}
             </main>


### PR DESCRIPTION
We now always show the scrollbar in invite modal body if it is scrollable. This avoids confusion and makes it clear that some options are out of view.

Fixes: #29393.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/6f074c1d-6fca-4fe4-be0f-5bf42283187e) | ![image](https://github.com/zulip/zulip/assets/133781250/944c023d-04a0-46e7-a466-6d8ffacb499c) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
