### PR TITLE
settings: Do not scroll to save button when typing in textarea / input.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -531,12 +531,20 @@ export function change_save_button_state($element: JQuery, state: string): void 
     assert(data_status !== undefined);
     $saveBtn.attr("data-status", data_status);
     if (state === "unsaved") {
-        // Ensure the save button is visible when the state is "unsaved",
-        // so the user does not miss saving their changes.
-        scroll_util.scroll_element_into_container(
-            $element.parent(".subsection-header"),
-            $("#settings_content"),
-        );
+        // Do not scroll if the currently focused element is a textarea or an input
+        // of type text, to not interrupt the user's typing flow. Scrolling will happen
+        // anyway when the field loses focus (via the change event) if necessary.
+        if (
+            !document.activeElement ||
+            !$(document.activeElement).is('textarea, input[type="text"]')
+        ) {
+            // Ensure the save button is visible when the state is "unsaved",
+            // so the user does not miss saving their changes.
+            scroll_util.scroll_element_into_container(
+                $element.parent(".subsection-header"),
+                $("#settings_content"),
+            );
+        }
         enable_or_disable_save_button($element.closest(".settings-subsection-parent"));
     }
     assert(is_show !== undefined);

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {$t} = require("./lib/i18n");
-const {mock_esm, zrequire} = require("./lib/namespace");
+const {mock_esm, zrequire, set_global} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
@@ -19,6 +19,7 @@ mock_esm("../src/loading", {
     destroy_indicator: noop,
 });
 mock_esm("../src/scroll_util", {scroll_element_into_container: noop});
+set_global("document", "document-stub");
 
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");


### PR DESCRIPTION
In an unsaved state, when focus is in a textarea or an input of type text, we don't yet scroll the save button into view to not interrupt the user's typing. When the input / textarea loses focus, we scroll then if needed, triggered via the `change` event.

Fixes: [issue reported on CZO here](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22Save.20changes.22.20in.20settings.20often.20missed.20when.20out.20of.20view/near/1768180)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
