### PR TITLE
narrow-filters: Add support for "channel" and "channels" operators.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,17 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 250**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added support for two [search/narrow filters](/api/construct-narrow)
+  related to stream messages: `channel` and `channels`. The `channel`
+  operator is an alias for the `stream` operator. The `channels`
+  operator is an alias for the `streams` operator.
+
 **Feature level 249**
 
 * [`GET /messages`](/api/get-messages), [`GET

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -51,6 +51,13 @@ important optimization when fetching messages in certain cases (e.g.
 when [adding the `read` flag to a user's personal
 messages](/api/update-message-flags-for-narrow)).
 
+**Changes**: In Zulip 9.0 (feature level 250), support was added for
+two filters related to stream messages: `channel` and `channels`. The
+`channel` operator is an alias for the `stream` operator. The `channels`
+operator is an alias for the `streams` operator. Both `channel` and
+`channels` return the same exact results as `stream` and `streams`
+respectively.
+
 **Changes**: In Zulip 9.0 (feature level 249), narrows gained support
 for a new filter `has:reaction`. This allows clients to retrieve only
 messages that have at least one reaction.

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -164,9 +164,9 @@ export function initialize(): void {
                 if (narrow_filter === undefined) {
                     display_current_view = $t({defaultMessage: "Currently viewing all messages."});
                 } else if (
-                    _.isEqual(narrow_filter.sorted_term_types(), ["stream"]) &&
+                    _.isEqual(narrow_filter.sorted_term_types(), ["channel"]) &&
                     compose_state.get_message_type() === "stream" &&
-                    narrow_filter.operands("stream")[0] === compose_state.stream_name()
+                    narrow_filter.operands("channel")[0] === compose_state.stream_name()
                 ) {
                     display_current_view = $t({
                         defaultMessage: "Currently viewing the entire stream.",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1100,10 +1100,11 @@ export class Filter {
     }
 
     filter_with_new_params(params: NarrowTerm): Filter {
+        const new_params = this.fix_terms([params])[0];
         const terms = this._terms.map((term) => {
             const new_term = {...term};
-            if (new_term.operator === params.operator && !new_term.negated) {
-                new_term.operand = params.operand;
+            if (new_term.operator === new_params.operator && !new_term.negated) {
+                new_term.operand = new_params.operand;
             }
             return new_term;
         });

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -92,6 +92,7 @@ export function is_create_new_stream_narrow(): boolean {
 }
 
 export const allowed_web_public_narrows = [
+    "channel",
     "streams",
     "stream",
     "topic",

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -92,6 +92,7 @@ export function is_create_new_stream_narrow(): boolean {
 }
 
 export const allowed_web_public_narrows = [
+    "channels",
     "channel",
     "streams",
     "stream",

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -11,6 +11,7 @@ import * as sub_store from "./sub_store";
 import type {StreamSubscription} from "./sub_store";
 import * as user_groups from "./user_groups";
 import type {UserGroup} from "./user_groups";
+import * as util from "./util";
 
 export function build_reload_url(): string {
     let hash = window.location.hash;
@@ -93,7 +94,7 @@ export function search_terms_to_hash(terms?: NarrowTerm[]): string {
 
         for (const term of terms) {
             // Support legacy tuples.
-            const operator = term.operator;
+            const operator = util.canonicalize_stream_synonym(term.operator);
             const operand = term.operand;
 
             const sign = term.negated ? "-" : "";

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -94,7 +94,7 @@ export function search_terms_to_hash(terms?: NarrowTerm[]): string {
 
         for (const term of terms) {
             // Support legacy tuples.
-            const operator = util.canonicalize_stream_synonym(term.operator);
+            const operator = util.canonicalize_stream_synonyms(term.operator);
             const operand = term.operand;
 
             const sign = term.negated ? "-" : "";

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -301,7 +301,7 @@ export function load_messages(opts, attempt = 1) {
         // This is a bit of a hack; ideally we'd unify this logic in
         // some way with the above logic, and not need to do JSON
         // parsing/stringifying here.
-        const web_public_narrow = {negated: false, operator: "streams", operand: "web-public"};
+        const web_public_narrow = {negated: false, operator: "channels", operand: "web-public"};
 
         if (!data.narrow) {
             /* For the "All messages" feed, this will be the only operator. */

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -472,7 +472,7 @@ export class MessageListView {
         // we can infer that whenever the historical flag flips
         // between adjacent messages, the current user must have
         // (un)subscribed in between those messages.
-        if (!this.list.data.filter.has_operator("stream")) {
+        if (!this.list.data.filter.has_operator("channel")) {
             return;
         }
         if (last_msg_container === undefined) {

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -59,7 +59,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
         title,
         is_spectator: page_params.is_spectator,
     });
-    if (filter.has_operator("stream") && !filter._sub) {
+    if (filter.has_operator("channel") && !filter._sub) {
         return {
             ...icon_data,
             sub_count: "0",

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -220,7 +220,7 @@ export function activate(raw_terms, opts) {
         // message in case the message was moved after the link was
         // created. This ensures near / id links work and will redirect
         // correctly if the topic was moved (including being resolved).
-        if (id_info.target_id && filter.has_operator("stream") && filter.has_operator("topic")) {
+        if (id_info.target_id && filter.has_operator("channel") && filter.has_operator("topic")) {
             const target_message = message_store.get(id_info.target_id);
 
             function adjusted_terms_if_moved(terms, message) {
@@ -230,7 +230,7 @@ export function activate(raw_terms, opts) {
                 for (const term of terms) {
                     const adjusted_term = {...term};
                     if (
-                        term.operator === "stream" &&
+                        term.operator === "channel" &&
                         !util.lower_same(term.operand, message.display_recipient)
                     ) {
                         adjusted_term.operand = message.display_recipient;
@@ -262,7 +262,7 @@ export function activate(raw_terms, opts) {
                 // location, then we should retarget this narrow operation
                 // to where the message is located now.
                 const narrow_topic = filter.operands("topic")[0];
-                const narrow_stream_name = filter.operands("stream")[0];
+                const narrow_stream_name = filter.operands("channel")[0];
                 const narrow_stream_data = stream_data.get_sub(narrow_stream_name);
                 if (!narrow_stream_data) {
                     // The id of the target message is correct but the stream name is

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -40,8 +40,8 @@ function retrieve_search_query_data(): SearchData {
     };
 
     // Add in stream:foo and topic:bar if present
-    if (current_filter.has_operator("stream") || current_filter.has_operator("topic")) {
-        const stream = current_filter.operands("stream")[0];
+    if (current_filter.has_operator("channel") || current_filter.has_operator("topic")) {
+        const stream = current_filter.operands("channel")[0];
         const topic = current_filter.operands("topic")[0];
         if (stream) {
             search_string_result.stream_query = stream;
@@ -103,7 +103,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
 
     if (num_terms !== 1) {
         // For invalid-multi-operator narrows, we display an invalid narrow message
-        const streams = current_filter.operands("stream");
+        const streams = current_filter.operands("channel");
         const topics = current_filter.operands("topic");
 
         // No message can have multiple streams
@@ -147,7 +147,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
 
         if (
             page_params.is_spectator &&
-            first_operator === "stream" &&
+            first_operator === "channel" &&
             !stream_data.is_web_public_by_stream_name(first_operand)
         ) {
             // For non web-public streams, show `login_to_access` modal.
@@ -242,7 +242,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
             }
             // fallthrough to default case if no match is found
             break;
-        case "stream":
+        case "channel":
             if (!stream_data.is_subscribed_by_name(first_operand)) {
                 // You are narrowed to a stream which does not exist or is a private stream
                 // in which you were never subscribed.

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -97,7 +97,7 @@ export function set_compose_defaults(): {
     // Set the stream, topic, and/or direct message recipient
     // if they are uniquely specified in the narrow view.
 
-    if (single.has("stream")) {
+    if (single.has("channel")) {
         // The raw stream name from collect_single may be an arbitrary
         // unvalidated string from the URL fragment and thus not be valid.
         // So we look up the resolved stream and return that if appropriate.
@@ -125,7 +125,7 @@ export function stream_name(current_filter: Filter | undefined = filter()): stri
     if (current_filter === undefined) {
         return undefined;
     }
-    const stream_operands = current_filter.operands("stream");
+    const stream_operands = current_filter.operands("channel");
     if (stream_operands.length === 1) {
         const name = stream_operands[0];
 
@@ -142,7 +142,7 @@ export function stream_sub(
     if (current_filter === undefined) {
         return undefined;
     }
-    const stream_operands = current_filter.operands("stream");
+    const stream_operands = current_filter.operands("channel");
     if (stream_operands.length !== 1) {
         return undefined;
     }
@@ -269,7 +269,7 @@ export function _possible_unread_message_ids(
     let topic_name;
     let current_filter_pm_string;
 
-    if (current_filter.can_bucket_by("stream", "topic")) {
+    if (current_filter.can_bucket_by("channel", "topic")) {
         sub = stream_sub(current_filter);
         topic_name = topic(current_filter);
         if (sub === undefined || topic_name === undefined) {
@@ -278,7 +278,7 @@ export function _possible_unread_message_ids(
         return unread.get_msg_ids_for_topic(sub.stream_id, topic_name);
     }
 
-    if (current_filter.can_bucket_by("stream")) {
+    if (current_filter.can_bucket_by("channel")) {
         sub = stream_sub(current_filter);
         if (sub === undefined) {
             return [];
@@ -342,7 +342,7 @@ export function narrowed_by_topic_reply(current_filter: Filter | undefined = fil
     const terms = current_filter.terms();
     return (
         terms.length === 2 &&
-        current_filter.operands("stream").length === 1 &&
+        current_filter.operands("channel").length === 1 &&
         current_filter.operands("topic").length === 1
     );
 }
@@ -359,14 +359,14 @@ export function narrowed_by_stream_reply(current_filter: Filter | undefined = fi
         return false;
     }
     const terms = current_filter.terms();
-    return terms.length === 1 && current_filter.operands("stream").length === 1;
+    return terms.length === 1 && current_filter.operands("channel").length === 1;
 }
 
 export function narrowed_to_topic(current_filter: Filter | undefined = filter()): boolean {
     if (current_filter === undefined) {
         return false;
     }
-    return current_filter.has_operator("stream") && current_filter.has_operator("topic");
+    return current_filter.has_operator("channel") && current_filter.has_operator("topic");
 }
 
 export function is_for_stream_id(stream_id: number, filter?: Filter): boolean {

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -33,7 +33,7 @@ export function compute_narrow_title(filter?: Filter): string {
         return $t({defaultMessage: "Search results"});
     }
 
-    if (filter.has_operator("stream")) {
+    if (filter.has_operator("channel")) {
         if (!filter._sub) {
             // The stream is not set because it does not currently
             // exist (possibly due to a stream name change), or it

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1362,7 +1362,7 @@ export function get_mention_syntax(full_name: string, user_id?: number, silent =
     }
     const wildcard_match = full_name_matches_wildcard_mention(full_name);
     if (wildcard_match && user_id === undefined) {
-        mention += util.canonicalize_stream_synonym(full_name);
+        mention += util.canonicalize_stream_synonyms(full_name);
     } else {
         mention += full_name;
     }

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -123,7 +123,7 @@ function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggesti
     const valid = ["channel", "search", ""];
     const incompatible_patterns = [
         {operator: "channel"},
-        {operator: "streams"},
+        {operator: "channels"},
         {operator: "is", operand: "dm"},
         {operator: "dm"},
         {operator: "dm-including"},
@@ -557,7 +557,7 @@ function get_streams_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): 
                 {operator: "dm-including"},
                 {operator: "dm"},
                 {operator: "in"},
-                {operator: "streams"},
+                {operator: "channels"},
             ],
         },
     ];

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -120,9 +120,9 @@ function compare_by_huddle(huddle_emails: string[]): (person1: User, person2: Us
 }
 
 function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
-    const valid = ["stream", "search", ""];
+    const valid = ["channel", "search", ""];
     const incompatible_patterns = [
-        {operator: "stream"},
+        {operator: "channel"},
         {operator: "streams"},
         {operator: "is", operand: "dm"},
         {operator: "dm"},
@@ -148,7 +148,7 @@ function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggesti
         const verb = last.negated ? "exclude " : "";
         const description_html = verb + prefix + " " + highlighted_stream;
         const term = {
-            operator: "stream",
+            operator: "channel",
             operand: stream,
             negated: last.negated,
         };
@@ -162,7 +162,7 @@ function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggesti
 function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
     // For users with "pm-with" in their muscle memory, still
     // have group direct message suggestions with "dm:" operator.
-    if (!check_validity(last, terms, ["dm", "pm-with"], [{operator: "stream"}])) {
+    if (!check_validity(last, terms, ["dm", "pm-with"], [{operator: "channel"}])) {
         return [];
     }
 
@@ -286,14 +286,14 @@ function get_person_suggestions(
 
     switch (autocomplete_operator) {
         case "dm-including":
-            incompatible_patterns = [{operator: "stream"}, {operator: "is", operand: "resolved"}];
+            incompatible_patterns = [{operator: "channel"}, {operator: "is", operand: "resolved"}];
             break;
         case "dm":
         case "pm-with":
             incompatible_patterns = [
                 {operator: "dm"},
                 {operator: "pm-with"},
-                {operator: "stream"},
+                {operator: "channel"},
                 {operator: "is", operand: "resolved"},
             ];
             break;
@@ -397,7 +397,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         {operator: "dm-including"},
         {operator: "topic"},
     ];
-    if (!check_validity(last, terms, ["stream", "topic", "search"], incompatible_patterns)) {
+    if (!check_validity(last, terms, ["channel", "topic", "search"], incompatible_patterns)) {
         return [];
     }
 
@@ -425,7 +425,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     // in terms of telling us whether they provided the operator,
     // i.e. "foo" and "search:foo" both become [{operator: 'search', operand: 'foo'}].
     switch (operator) {
-        case "stream":
+        case "channel":
             guess = "";
             stream = operand;
             suggest_terms.push(last);
@@ -433,12 +433,12 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         case "topic":
         case "search":
             guess = operand;
-            if (filter.has_operator("stream")) {
-                stream = filter.operands("stream")[0];
+            if (filter.has_operator("channel")) {
+                stream = filter.operands("channel")[0];
             } else {
                 stream = narrow_state.stream_name();
                 if (stream) {
-                    suggest_terms.push({operator: "stream", operand: stream});
+                    suggest_terms.push({operator: "channel", operand: stream});
                 }
             }
             break;
@@ -553,7 +553,7 @@ function get_streams_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): 
             description_html: "All public streams in organization",
             incompatible_patterns: [
                 {operator: "is", operand: "dm"},
-                {operator: "stream"},
+                {operator: "channel"},
                 {operator: "dm-including"},
                 {operator: "dm"},
                 {operator: "in"},
@@ -571,7 +571,7 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             incompatible_patterns: [
                 {operator: "is", operand: "dm"},
                 {operator: "is", operand: "resolved"},
-                {operator: "stream"},
+                {operator: "channel"},
                 {operator: "dm"},
                 {operator: "in"},
             ],

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -674,7 +674,7 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
         topic_selected: false,
     };
 
-    const op_stream = filter.operands("stream");
+    const op_stream = filter.operands("channel");
     if (op_stream.length === 0) {
         return result;
     }

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -281,9 +281,19 @@ export function is_stream_synonym(text: string): boolean {
     return text === "channel";
 }
 
-export function canonicalize_stream_synonym(text: string): string {
+export function is_streams_synonym(text: string): boolean {
+    return text === "channels";
+}
+
+// For parts of the codebase that have been converted to use
+// channel/channels internally, this is used to convert those
+// back into stream/streams for external presentation.
+export function canonicalize_stream_synonyms(text: string): string {
     if (is_stream_synonym(text.toLowerCase())) {
         return "stream";
+    }
+    if (is_streams_synonym(text.toLowerCase())) {
+        return "streams";
     }
     return text;
 }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -214,10 +214,10 @@ test("basics", () => {
     terms = [{operator: "streams", operand: "public", negated: true}];
     filter = new Filter(terms);
     assert.ok(!filter.contains_only_private_messages());
-    assert.ok(!filter.has_operator("streams"));
+    assert.ok(!filter.has_operator("channels"));
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
-    assert.ok(filter.has_negated_operand("streams", "public"));
+    assert.ok(filter.has_negated_operand("channels", "public"));
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
@@ -225,10 +225,22 @@ test("basics", () => {
     terms = [{operator: "streams", operand: "public"}];
     filter = new Filter(terms);
     assert.ok(!filter.contains_only_private_messages());
-    assert.ok(filter.has_operator("streams"));
+    assert.ok(filter.has_operator("channels"));
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
-    assert.ok(!filter.has_negated_operand("streams", "public"));
+    assert.ok(!filter.has_negated_operand("channels", "public"));
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+
+    terms = [{operator: "channels", operand: "public"}];
+    filter = new Filter(terms);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(!filter.has_negated_operand("channels", "public"));
     assert.ok(!filter.can_apply_locally());
     assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
@@ -1442,7 +1454,7 @@ test("term_type", () => {
         };
     }
 
-    assert_term_type(term("streams", "public"), "streams-public");
+    assert_term_type(term("channels", "public"), "channels-public");
     assert_term_type(term("channel", "whatever"), "channel");
     assert_term_type(term("dm", "whomever"), "dm");
     assert_term_type(term("dm", "whomever", true), "not-dm");
@@ -1466,7 +1478,7 @@ test("term_type", () => {
     assert_term_sort(["bogus", "channel", "topic"], ["channel", "topic", "bogus"]);
     assert_term_sort(["channel", "topic", "channel"], ["channel", "channel", "topic"]);
 
-    assert_term_sort(["search", "streams-public"], ["streams-public", "search"]);
+    assert_term_sort(["search", "channels-public"], ["channels-public", "search"]);
 
     const terms = [
         {operator: "topic", operand: "lunch"},

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -33,6 +33,7 @@ const hash_util = zrequire("hash_util");
 const hashchange = zrequire("hashchange");
 const narrow = zrequire("../src/narrow");
 const stream_data = zrequire("stream_data");
+const {Filter} = zrequire("../src/filter");
 
 run_test("terms_round_trip", () => {
     let terms;
@@ -76,6 +77,29 @@ run_test("terms_round_trip", () => {
     assert.equal(hash, "#narrow/stream/987-Florida.2C-USA");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [{operator: "stream", operand: "Florida, USA", negated: false}]);
+});
+
+run_test("stream_to_channel_rename", () => {
+    let terms;
+    let hash;
+    let narrow;
+    let filter;
+
+    terms = [{operator: "channel", operand: "devel"}];
+    hash = hash_util.search_terms_to_hash(terms);
+    assert.equal(hash, "#narrow/stream/devel");
+    narrow = hash_util.parse_narrow(hash.split("/"));
+    assert.deepEqual(narrow, [{operator: "stream", operand: "devel", negated: false}]);
+    filter = new Filter(narrow);
+    assert.deepEqual(filter.terms(), [{operator: "channel", operand: "devel", negated: false}]);
+
+    terms = [{operator: "channels", operand: "public"}];
+    hash = hash_util.search_terms_to_hash(terms);
+    assert.equal(hash, "#narrow/streams/public");
+    narrow = hash_util.parse_narrow(hash.split("/"));
+    assert.deepEqual(narrow, [{operator: "streams", operand: "public", negated: false}]);
+    filter = new Filter(narrow);
+    assert.deepEqual(filter.terms(), [{operator: "channels", operand: "public", negated: false}]);
 });
 
 run_test("terms_trailing_slash", () => {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -59,7 +59,7 @@ test("stream", () => {
     assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));
 
     const expected_terms = [
-        {negated: false, operator: "stream", operand: "Test"},
+        {negated: false, operator: "channel", operand: "Test"},
         {negated: false, operator: "topic", operand: "Bar"},
         {negated: false, operator: "search", operand: "yo"},
     ];
@@ -130,7 +130,7 @@ test("terms", () => {
     ]);
     let result = narrow_state.search_terms();
     assert.equal(result.length, 3);
-    assert.equal(result[0].operator, "stream");
+    assert.equal(result[0].operator, "channel");
     assert.equal(result[0].operand, "Foo");
 
     assert.equal(result[1].operator, "topic");
@@ -146,7 +146,7 @@ test("terms", () => {
     page_params.narrow = [{operator: "stream", operand: "Foo"}];
     result = narrow_state.search_terms();
     assert.equal(result.length, 1);
-    assert.equal(result[0].operator, "stream");
+    assert.equal(result[0].operator, "channel");
     assert.equal(result[0].operand, "Foo");
 });
 
@@ -243,7 +243,7 @@ test("update_email", () => {
     const filter = narrow_state.filter();
     assert.deepEqual(filter.operands("dm"), ["showell@foo.com"]);
     assert.deepEqual(filter.operands("sender"), ["showell@foo.com"]);
-    assert.deepEqual(filter.operands("stream"), ["steve@foo.com"]);
+    assert.deepEqual(filter.operands("channel"), ["steve@foo.com"]);
 });
 
 test("topic", () => {

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -97,20 +97,35 @@ def read_stop_words() -> List[str]:
     return stop_words_list
 
 
+# "stream" is a legacy alias for "channel"
+channel_operators: List[str] = ["channel", "stream"]
+
+
 def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
+    supported_operators = [*channel_operators, "topic", "sender", "is"]
     for narrow_term in narrow:
         operator = narrow_term.operator
-        if operator not in ["stream", "topic", "sender", "is"]:
+        if operator not in supported_operators:
             raise JsonableError(_("Operator {operator} not supported.").format(operator=operator))
 
 
 def is_spectator_compatible(narrow: Iterable[Dict[str, Any]]) -> bool:
     # This implementation should agree with is_spectator_compatible in hash_parser.ts.
+    supported_operators = [
+        *channel_operators,
+        "streams",
+        "topic",
+        "sender",
+        "has",
+        "search",
+        "near",
+        "id",
+    ]
     for element in narrow:
         operator = element["operator"]
         if "operand" not in element:
             return False
-        if operator not in ["streams", "stream", "topic", "sender", "has", "search", "near", "id"]:
+        if operator not in supported_operators:
             return False
     return True
 
@@ -142,7 +157,7 @@ def build_narrow_predicate(
 
     def narrow_predicate(*, message: Dict[str, Any], flags: List[str]) -> bool:
         def satisfies_operator(*, operator: str, operand: str) -> bool:
-            if operator == "stream":
+            if operator in channel_operators:
                 if message["type"] != "stream":
                     return False
                 if operand.lower() != message["display_recipient"].lower():
@@ -268,7 +283,9 @@ class NarrowBuilder:
             "has": self.by_has,
             "in": self.by_in,
             "is": self.by_is,
-            "stream": self.by_stream,
+            "channel": self.by_channel,
+            # "stream" is a legacy alias for "channel"
+            "stream": self.by_channel,
             "streams": self.by_streams,
             "topic": self.by_topic,
             "sender": self.by_sender,
@@ -424,47 +441,49 @@ class NarrowBuilder:
                     s[i] = "\\" + c
         return "".join(s)
 
-    def by_stream(
+    def by_channel(
         self, query: Select, operand: Union[str, int], maybe_negate: ConditionTransform
     ) -> Select:
         self.check_not_both_channel_and_dm_narrow(is_channel_narrow=True)
 
         try:
             # Because you can see your own message history for
-            # private streams you are no longer subscribed to, we
+            # private channels you are no longer subscribed to, we
             # need get_stream_by_narrow_operand_access_unchecked here.
-            stream = get_stream_by_narrow_operand_access_unchecked(operand, self.realm)
+            channel = get_stream_by_narrow_operand_access_unchecked(operand, self.realm)
 
-            if self.is_web_public_query and not stream.is_web_public:
-                raise BadNarrowOperatorError("unknown web-public stream " + str(operand))
+            if self.is_web_public_query and not channel.is_web_public:
+                raise BadNarrowOperatorError("unknown web-public channel " + str(operand))
         except Stream.DoesNotExist:
-            raise BadNarrowOperatorError("unknown stream " + str(operand))
+            raise BadNarrowOperatorError("unknown channel " + str(operand))
 
         if self.realm.is_zephyr_mirror_realm:
             # MIT users expect narrowing to "social" to also show messages to
             # /^(un)*social(.d)*$/ (unsocial, ununsocial, social.d, ...).
 
             # In `ok_to_include_history`, we assume that a non-negated
-            # `stream` term for a public stream will limit the query to
-            # that specific stream.  So it would be a bug to hit this
-            # codepath after relying on this term there.  But all streams in
+            # `channel` term for a public channel will limit the query to
+            # that specific channel. So it would be a bug to hit this
+            # codepath after relying on this term there. But all channels in
             # a Zephyr realm are private, so that doesn't happen.
-            assert not stream.is_public()
+            assert not channel.is_public()
 
-            m = re.search(r"^(?:un)*(.+?)(?:\.d)*$", stream.name, re.IGNORECASE)
+            m = re.search(r"^(?:un)*(.+?)(?:\.d)*$", channel.name, re.IGNORECASE)
             # Since the regex has a `.+` in it and "" is invalid as a
-            # stream name, this will always match
+            # channel name, this will always match
             assert m is not None
-            base_stream_name = m.group(1)
+            base_channel_name = m.group(1)
 
-            matching_streams = get_active_streams(self.realm).filter(
-                name__iregex=rf"^(un)*{self._pg_re_escape(base_stream_name)}(\.d)*$"
+            matching_channels = get_active_streams(self.realm).filter(
+                name__iregex=rf"^(un)*{self._pg_re_escape(base_channel_name)}(\.d)*$"
             )
-            recipient_ids = [matching_stream.recipient_id for matching_stream in matching_streams]
+            recipient_ids = [
+                matching_channel.recipient_id for matching_channel in matching_channels
+            ]
             cond = column("recipient_id", Integer).in_(recipient_ids)
             return query.where(maybe_negate(cond))
 
-        recipient_id = stream.recipient_id
+        recipient_id = channel.recipient_id
         assert recipient_id is not None
         cond = column("recipient_id", Integer) == recipient_id
         return query.where(maybe_negate(cond))
@@ -812,8 +831,8 @@ def narrow_parameter(var_name: str, json: str) -> OptionalNarrowListT:
             # in handle_operators_supporting_id_based_api function where you will need to
             # update operators_supporting_id, or operators_supporting_ids array.
             operators_supporting_id = [
+                *channel_operators,
                 "id",
-                "stream",
                 "sender",
                 "group-pm-with",
                 "dm-including",
@@ -863,17 +882,17 @@ def ok_to_include_history(
 ) -> bool:
     # There are occasions where we need to find Message rows that
     # have no corresponding UserMessage row, because the user is
-    # reading a public stream that might include messages that
+    # reading a public channel that might include messages that
     # were sent while the user was not subscribed, but which they are
     # allowed to see.  We have to be very careful about constructing
     # queries in those situations, so this function should return True
     # only if we are 100% sure that we're gonna add a clause to the
-    # query that narrows to a particular public stream on the user's realm.
+    # query that narrows to a particular public channel on the user's realm.
     # If we screw this up, then we can get into a nasty situation of
     # polluting our narrow results with messages from other realms.
 
     # For web-public queries, we are always returning history.  The
-    # analogues of the below stream access checks for whether streams
+    # analogues of the below channel access checks for whether channels
     # have is_web_public set and banning is operators in this code
     # path are done directly in NarrowBuilder.
     if is_web_public_query:
@@ -885,7 +904,7 @@ def ok_to_include_history(
     include_history = False
     if narrow is not None:
         for term in narrow:
-            if term["operator"] == "stream" and not term.get("negated", False):
+            if term["operator"] in channel_operators and not term.get("negated", False):
                 operand: Union[str, int] = term["operand"]
                 if isinstance(operand, str):
                     include_history = can_access_stream_history_by_name(user_profile, operand)
@@ -908,12 +927,12 @@ def ok_to_include_history(
     return include_history
 
 
-def get_stream_from_narrow_access_unchecked(
+def get_channel_from_narrow_access_unchecked(
     narrow: OptionalNarrowListT, realm: Realm
 ) -> Optional[Stream]:
     if narrow is not None:
         for term in narrow:
-            if term["operator"] == "stream":
+            if term["operator"] in channel_operators:
                 return get_stream_by_narrow_operand_access_unchecked(term["operand"], realm)
     return None
 
@@ -922,21 +941,21 @@ def exclude_muting_conditions(
     user_profile: UserProfile, narrow: OptionalNarrowListT
 ) -> List[ClauseElement]:
     conditions: List[ClauseElement] = []
-    stream_id = None
+    channel_id = None
     try:
-        # Note: It is okay here to not check access to stream
-        # because we are only using the stream id to exclude data,
+        # Note: It is okay here to not check access to channel
+        # because we are only using the channel ID to exclude data,
         # not to include results.
-        stream = get_stream_from_narrow_access_unchecked(narrow, user_profile.realm)
-        if stream is not None:
-            stream_id = stream.id
+        channel = get_channel_from_narrow_access_unchecked(narrow, user_profile.realm)
+        if channel is not None:
+            channel_id = channel.id
     except Stream.DoesNotExist:
         pass
 
-    # Stream-level muting only applies when looking at views that
-    # include multiple streams, since we do want users to be able to
-    # browser messages within a muted stream.
-    if stream_id is None:
+    # Channel-level muting only applies when looking at views that
+    # include multiple channels, since we do want users to be able to
+    # browser messages within a muted channel.
+    if channel_id is None:
         rows = Subscription.objects.filter(
             user_profile=user_profile,
             active=True,
@@ -945,11 +964,11 @@ def exclude_muting_conditions(
         ).values("recipient_id")
         muted_recipient_ids = [row["recipient_id"] for row in rows]
         if len(muted_recipient_ids) > 0:
-            # Only add the condition if we have muted streams to simplify/avoid warnings.
+            # Only add the condition if we have muted channels to simplify/avoid warnings.
             condition = not_(column("recipient_id", Integer).in_(muted_recipient_ids))
             conditions.append(condition)
 
-    conditions = exclude_topic_mutes(conditions, user_profile, stream_id)
+    conditions = exclude_topic_mutes(conditions, user_profile, channel_id)
 
     # Muted user logic for hiding messages is implemented entirely
     # client-side. This is by design, as it allows UI to hint that

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6189,7 +6189,12 @@ paths:
             subscribed to appropriate streams or use a shared history
             search narrow with this endpoint.
 
-            **Changes**: In Zulip 9.0 (feature level 249), added new `has:reaction`
+            **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
+            for two new filters related to stream messages: `channel` and `channels`;
+            which are aliases for (and return the same results as) the `stream` and
+            `streams` filters respectively.
+
+            In Zulip 9.0 (feature level 249), added new `has:reaction`
             filter, matching messages with at least one emoji reaction.
 
             In Zulip 7.0 (feature level 177), narrows gained support
@@ -7062,7 +7067,12 @@ paths:
                     optimization. Including that filter takes advantage of the fact that
                     the server has a database index for unread messages.
 
-                    **Changes**: In Zulip 9.0 (feature level 249), added new `has:reaction`
+                    **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
+                    for two new filters related to stream messages: `channel` and `channels`;
+                    which are aliases for (and return the same results as) the `stream` and
+                    `streams` filters respectively.
+
+                    In Zulip 9.0 (feature level 249), added new `has:reaction`
                     filter, matching messages with at least one emoji reaction.
 
                     In Zulip 7.0 (feature level 177), narrows gained support
@@ -7489,7 +7499,12 @@ paths:
             A structure defining the narrow to check against. See how to
             [construct a narrow](/api/construct-narrow).
 
-            **Changes**: In Zulip 9.0 (feature level 249), added new `has:reaction`
+            **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
+            for two new filters related to stream messages: `channel` and `channels`;
+            which are aliases for (and return the same results as) the `stream` and
+            `streams` filters respectively.
+
+            In Zulip 9.0 (feature level 249), added new `has:reaction`
             filter, matching messages with at least one emoji reaction.
 
             In Zulip 7.0 (feature level 177), narrows gained support
@@ -21368,9 +21383,12 @@ components:
         See the `all_public_streams` parameter for how to process all
         public stream messages in an organization.
 
-        Defaults to `[]`.
+        **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
+        for two new filters related to stream messages: `channel` and `channels`;
+        which are aliases for (and return the same results as) the `stream` and
+        `streams` filters respectively.
 
-        **Changes**: In Zulip 9.0 (feature level 249), added new `has:reaction`
+        In Zulip 9.0 (feature level 249), added new `has:reaction`
         filter, matching messages with at least one emoji reaction.
 
         In Zulip 7.0 (feature level 177), narrows gained support

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -82,14 +82,14 @@ def get_sqlalchemy_query_params(query: ClauseElement) -> Dict[str, object]:
     return comp.params
 
 
-def get_recipient_id_for_stream_name(realm: Realm, stream_name: str) -> Optional[int]:
-    stream = get_stream(stream_name, realm)
-    return stream.recipient.id if stream.recipient is not None else None
+def get_recipient_id_for_channel_name(realm: Realm, channel_name: str) -> Optional[int]:
+    channel = get_stream(channel_name, realm)
+    return channel.recipient.id if channel.recipient is not None else None
 
 
-def mute_stream(realm: Realm, user_profile: UserProfile, stream_name: str) -> None:
-    stream = get_stream(stream_name, realm)
-    recipient = stream.recipient
+def mute_channel(realm: Realm, user_profile: UserProfile, channel_name: str) -> None:
+    channel = get_stream(channel_name, realm)
+    recipient = channel.recipient
     subscription = Subscription.objects.get(recipient=recipient, user_profile=user_profile)
     subscription.is_muted = True
     subscription.save()
@@ -137,33 +137,33 @@ class NarrowBuilderTest(ZulipTestCase):
         term = dict(operator="streams", operand="invalid_operands")
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
 
-    def test_add_term_using_streams_operator_and_public_stream_operand(self) -> None:
+    def test_add_term_using_streams_operator_and_public_operand(self) -> None:
         term = dict(operator="streams", operand="public")
         self._do_add_term_test(
             term,
             "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
         )
 
-        # Add new streams
-        stream_dicts: List[StreamDict] = [
+        # Add new channels
+        channel_dicts: List[StreamDict] = [
             {
-                "name": "publicstream",
-                "description": "Public stream with public history",
+                "name": "public-channel",
+                "description": "Public channel with public history",
             },
             {
-                "name": "privatestream",
-                "description": "Private stream with non-public history",
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
                 "invite_only": True,
             },
             {
-                "name": "privatewithhistory",
-                "description": "Private stream with public history",
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
                 "invite_only": True,
                 "history_public_to_subscribers": True,
             },
         ]
         realm = get_realm("zulip")
-        created, existing = create_streams_if_needed(realm, stream_dicts)
+        created, existing = create_streams_if_needed(realm, channel_dicts)
         self.assert_length(created, 3)
         self.assert_length(existing, 0)
 
@@ -173,33 +173,33 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])",
         )
 
-    def test_add_term_using_streams_operator_and_public_stream_operand_negated(self) -> None:
+    def test_add_term_using_streams_operator_and_public_operand_negated(self) -> None:
         term = dict(operator="streams", operand="public", negated=True)
         self._do_add_term_test(
             term,
             "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))",
         )
 
-        # Add new streams
-        stream_dicts: List[StreamDict] = [
+        # Add new channels
+        channel_dicts: List[StreamDict] = [
             {
-                "name": "publicstream",
-                "description": "Public stream with public history",
+                "name": "public-channel",
+                "description": "Public channel with public history",
             },
             {
-                "name": "privatestream",
-                "description": "Private stream with non-public history",
+                "name": "private-channel",
+                "description": "Private channel with non-public history",
                 "invite_only": True,
             },
             {
-                "name": "privatewithhistory",
-                "description": "Private stream with public history",
+                "name": "private-channel-with-history",
+                "description": "Private channel with public history",
                 "invite_only": True,
                 "history_public_to_subscribers": True,
             },
         ]
         realm = get_realm("zulip")
-        created, existing = create_streams_if_needed(realm, stream_dicts)
+        created, existing = create_streams_if_needed(realm, channel_dicts)
         self.assert_length(created, 3)
         self.assert_length(existing, 0)
 
@@ -310,15 +310,15 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)",
         )
 
-    def test_combined_stream_dm(self) -> None:
+    def test_combined_channel_dm(self) -> None:
         term1 = dict(operator="dm", operand=self.othello_email)
         self._build_query(term1)
 
         topic_term = dict(operator="topic", operand="bogus")
         self.assertRaises(BadNarrowOperatorError, self._build_query, topic_term)
 
-        stream_term = dict(operator="streams", operand="public")
-        self.assertRaises(BadNarrowOperatorError, self._build_query, stream_term)
+        channel_term = dict(operator="streams", operand="public")
+        self.assertRaises(BadNarrowOperatorError, self._build_query, channel_term)
 
     def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
         self,
@@ -511,25 +511,25 @@ class NarrowBuilderTest(ZulipTestCase):
         self.assertRaises(BadNarrowOperatorError, self._build_query, term)
 
     def test_add_term_using_in_operator(self) -> None:
-        mute_stream(self.realm, self.user_profile, "Verona")
+        mute_channel(self.realm, self.user_profile, "Verona")
         term = dict(operator="in", operand="home")
         self._do_add_term_test(term, "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))")
 
     def test_add_term_using_in_operator_and_negated(self) -> None:
         # negated = True should not change anything
-        mute_stream(self.realm, self.user_profile, "Verona")
+        mute_channel(self.realm, self.user_profile, "Verona")
         term = dict(operator="in", operand="home", negated=True)
         self._do_add_term_test(term, "WHERE (recipient_id NOT IN (__[POSTCOMPILE_recipient_id_1]))")
 
     def test_add_term_using_in_operator_and_all_operand(self) -> None:
-        mute_stream(self.realm, self.user_profile, "Verona")
+        mute_channel(self.realm, self.user_profile, "Verona")
         term = dict(operator="in", operand="all")
         query = self._build_query(term)
         self.assertEqual(get_sqlalchemy_sql(query), "SELECT id \nFROM zerver_message")
 
     def test_add_term_using_in_operator_all_operand_and_negated(self) -> None:
         # negated = True should not change anything
-        mute_stream(self.realm, self.user_profile, "Verona")
+        mute_channel(self.realm, self.user_profile, "Verona")
         term = dict(operator="in", operand="all", negated=True)
         query = self._build_query(term)
         self.assertEqual(get_sqlalchemy_sql(query), "SELECT id \nFROM zerver_message")
@@ -543,9 +543,9 @@ class NarrowBuilderTest(ZulipTestCase):
         query = self._build_query(term)
         self.assertEqual(get_sqlalchemy_sql(query), "SELECT id \nFROM zerver_message")
 
-    def test_add_term_non_web_public_stream_in_web_public_query(self) -> None:
-        self.make_stream("non-web-public-stream", realm=self.realm)
-        term = dict(operator="stream", operand="non-web-public-stream")
+    def test_add_term_non_web_public_channel_in_web_public_query(self) -> None:
+        self.make_stream("non-web-public-channel", realm=self.realm)
+        term = dict(operator="stream", operand="non-web-public-channel")
         builder = NarrowBuilder(self.user_profile, column("id", Integer), self.realm, True)
 
         def _build_query(term: Dict[str, Any]) -> Select:
@@ -926,11 +926,11 @@ class NarrowLibraryTest(ZulipTestCase):
 class IncludeHistoryTest(ZulipTestCase):
     def test_ok_to_include_history(self) -> None:
         user_profile = self.example_user("hamlet")
-        self.make_stream("public_stream", realm=user_profile.realm)
+        self.make_stream("public_channel", realm=user_profile.realm)
 
-        # Negated stream searches should not include history.
+        # Negated channel searches should not include history.
         narrow = [
-            dict(operator="stream", operand="public_stream", negated=True),
+            dict(operator="stream", operand="public_channel", negated=True),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -946,27 +946,27 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
-        # Definitely forbid seeing history on private streams.
-        self.make_stream("private_stream", realm=user_profile.realm, invite_only=True)
+        # Definitely forbid seeing history on private channels.
+        self.make_stream("private_channel", realm=user_profile.realm, invite_only=True)
         subscribed_user_profile = self.example_user("cordelia")
-        self.subscribe(subscribed_user_profile, "private_stream")
+        self.subscribe(subscribed_user_profile, "private_channel")
         narrow = [
-            dict(operator="stream", operand="private_stream"),
+            dict(operator="stream", operand="private_channel"),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
-        # Verify that with stream.history_public_to_subscribers, subscribed
+        # Verify that with history_public_to_subscribers, subscribed
         # users can access history.
         self.make_stream(
-            "private_stream_2",
+            "private_channel_2",
             realm=user_profile.realm,
             invite_only=True,
             history_public_to_subscribers=True,
         )
         subscribed_user_profile = self.example_user("cordelia")
-        self.subscribe(subscribed_user_profile, "private_stream_2")
+        self.subscribe(subscribed_user_profile, "private_channel_2")
         narrow = [
-            dict(operator="stream", operand="private_stream_2"),
+            dict(operator="stream", operand="private_channel_2"),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
         self.assertTrue(ok_to_include_history(narrow, subscribed_user_profile, False))
@@ -991,7 +991,7 @@ class IncludeHistoryTest(ZulipTestCase):
         # If we are looking for something like starred messages, there is
         # no point in searching historical messages.
         narrow = [
-            dict(operator="stream", operand="public_stream"),
+            dict(operator="stream", operand="public_channel"),
             dict(operator="is", operand="starred"),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
@@ -1021,12 +1021,12 @@ class IncludeHistoryTest(ZulipTestCase):
 
         # simple True case
         narrow = [
-            dict(operator="stream", operand="public_stream"),
+            dict(operator="stream", operand="public_channel"),
         ]
         self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
         narrow = [
-            dict(operator="stream", operand="public_stream"),
+            dict(operator="stream", operand="public_channel"),
             dict(operator="topic", operand="whatever"),
             dict(operator="search", operand="needle in haystack"),
         ]
@@ -1043,27 +1043,27 @@ class IncludeHistoryTest(ZulipTestCase):
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
 
-        # Guest user can't access public stream
-        self.subscribe(subscribed_user_profile, "public_stream_2")
+        # Guest user can't access public channel
+        self.subscribe(subscribed_user_profile, "public_channel_2")
         narrow = [
-            dict(operator="stream", operand="public_stream_2"),
+            dict(operator="stream", operand="public_channel_2"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
         self.assertTrue(ok_to_include_history(narrow, subscribed_user_profile, False))
 
-        # Definitely, a guest user can't access the unsubscribed private stream
-        self.subscribe(subscribed_user_profile, "private_stream_3")
+        # Definitely, a guest user can't access the unsubscribed private channel
+        self.subscribe(subscribed_user_profile, "private_channel_3")
         narrow = [
-            dict(operator="stream", operand="private_stream_3"),
+            dict(operator="stream", operand="private_channel_3"),
         ]
         self.assertFalse(ok_to_include_history(narrow, guest_user_profile, False))
         self.assertTrue(ok_to_include_history(narrow, subscribed_user_profile, False))
 
-        # Guest user can access (history of) subscribed private streams
-        self.subscribe(guest_user_profile, "private_stream_4")
-        self.subscribe(subscribed_user_profile, "private_stream_4")
+        # Guest user can access (history of) subscribed private channels
+        self.subscribe(guest_user_profile, "private_channel_4")
+        self.subscribe(subscribed_user_profile, "private_channel_4")
         narrow = [
-            dict(operator="stream", operand="private_stream_4"),
+            dict(operator="stream", operand="private_channel_4"),
         ]
         self.assertTrue(ok_to_include_history(narrow, guest_user_profile, False))
         self.assertTrue(ok_to_include_history(narrow, subscribed_user_profile, False))
@@ -1719,12 +1719,12 @@ class GetOldMessagesTest(ZulipTestCase):
 
         query_ids: Dict[str, Union[int, str]] = {}
 
-        scotland_stream = get_stream("Scotland", hamlet_user.realm)
-        assert scotland_stream.recipient_id is not None
+        scotland_channel = get_stream("Scotland", hamlet_user.realm)
+        assert scotland_channel.recipient_id is not None
         assert hamlet_user.recipient_id is not None
         assert othello_user.recipient_id is not None
         query_ids["realm_id"] = hamlet_user.realm_id
-        query_ids["scotland_recipient"] = scotland_stream.recipient_id
+        query_ids["scotland_recipient"] = scotland_channel.recipient_id
         query_ids["hamlet_id"] = hamlet_user.id
         query_ids["othello_id"] = othello_user.id
         query_ids["hamlet_recipient"] = hamlet_user.recipient_id
@@ -1734,7 +1734,7 @@ class GetOldMessagesTest(ZulipTestCase):
             .values_list("recipient_id", flat=True)
             .order_by("id")
         )
-        query_ids["public_streams_recipients"] = ", ".join(str(r) for r in recipients)
+        query_ids["public_channels_recipients"] = ", ".join(str(r) for r in recipients)
         return query_ids
 
     def check_unauthenticated_response(
@@ -1851,18 +1851,18 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.client_get("/api/v1/messages", dict(get_params))
         self.check_unauthenticated_response(result, www_authenticate='Basic realm="zulip"')
 
-        # Successful access to web-public stream messages.
-        web_public_stream_get_params: Dict[str, Union[int, str, bool]] = {
+        # Successful access to web-public channel messages.
+        web_public_channel_get_params: Dict[str, Union[int, str, bool]] = {
             **get_params,
             "narrow": orjson.dumps([dict(operator="streams", operand="web-public")]).decode(),
         }
-        result = self.client_get("/json/messages", dict(web_public_stream_get_params))
+        result = self.client_get("/json/messages", dict(web_public_channel_get_params))
         # More detailed check of message parameters is done in `test_get_messages_with_web_public`.
         self.assert_json_success(result)
 
         # Realm doesn't exist in our database.
         with mock.patch("zerver.context_processors.get_realm", side_effect=Realm.DoesNotExist):
-            result = self.client_get("/json/messages", dict(web_public_stream_get_params))
+            result = self.client_get("/json/messages", dict(web_public_channel_get_params))
             self.assert_json_error(result, "Invalid subdomain", status_code=404)
 
         # Cannot access direct messages without login.
@@ -1898,19 +1898,19 @@ class GetOldMessagesTest(ZulipTestCase):
         do_set_realm_property(
             get_realm("zulip"), "enable_spectator_access", False, acting_user=None
         )
-        result = self.client_get("/json/messages", dict(web_public_stream_get_params))
+        result = self.client_get("/json/messages", dict(web_public_channel_get_params))
         self.check_unauthenticated_response(result)
         do_set_realm_property(get_realm("zulip"), "enable_spectator_access", True, acting_user=None)
         # Verify works after enabling `realm.enable_spectator_access` again.
-        result = self.client_get("/json/messages", dict(web_public_stream_get_params))
+        result = self.client_get("/json/messages", dict(web_public_channel_get_params))
         self.assert_json_success(result)
 
-        # Cannot access even web-public streams without `streams:web-public` narrow.
-        non_web_public_stream_get_params: Dict[str, Union[int, str, bool]] = {
+        # Cannot access even web-public channels without `streams:web-public` narrow.
+        non_web_public_channel_get_params: Dict[str, Union[int, str, bool]] = {
             **get_params,
             "narrow": orjson.dumps([dict(operator="stream", operand="Rome")]).decode(),
         }
-        result = self.client_get("/json/messages", dict(non_web_public_stream_get_params))
+        result = self.client_get("/json/messages", dict(non_web_public_channel_get_params))
         self.check_unauthenticated_response(result)
 
         # Verify that same request would work with `streams:web-public` added.
@@ -1919,7 +1919,7 @@ class GetOldMessagesTest(ZulipTestCase):
             "narrow": orjson.dumps(
                 [
                     dict(operator="streams", operand="web-public"),
-                    # Rome is a web-public stream.
+                    # Rome is a web-public channel.
                     dict(operator="stream", operand="Rome"),
                 ]
             ).decode(),
@@ -1927,13 +1927,13 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.client_get("/json/messages", dict(rome_web_public_get_params))
         self.assert_json_success(result)
 
-        # Cannot access non-web-public stream even with `streams:web-public` narrow.
+        # Cannot access non-web-public channel even with `streams:web-public` narrow.
         scotland_web_public_get_params: Dict[str, Union[int, str, bool]] = {
             **get_params,
             "narrow": orjson.dumps(
                 [
                     dict(operator="streams", operand="web-public"),
-                    # Scotland is not a web-public stream.
+                    # Scotland is not a web-public channel.
                     dict(operator="stream", operand="Scotland"),
                 ]
             ).decode(),
@@ -1945,7 +1945,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def setup_web_public_test(self, num_web_public_message: int = 1) -> None:
         """
-        Send N+2 messages, N in a web-public stream, then one in a non-web-public stream
+        Send N+2 messages, N in a web-public channel, then one in a non-web-public channel
         and then a direct message.
         """
         user_profile = self.example_user("iago")
@@ -1953,17 +1953,17 @@ class GetOldMessagesTest(ZulipTestCase):
             user_profile.realm, "enable_spectator_access", True, acting_user=user_profile
         )
         self.login("iago")
-        web_public_stream = self.make_stream("web-public-stream", is_web_public=True)
-        non_web_public_stream = self.make_stream("non-web-public-stream")
-        self.subscribe(user_profile, web_public_stream.name)
-        self.subscribe(user_profile, non_web_public_stream.name)
+        web_public_channel = self.make_stream("web-public-channel", is_web_public=True)
+        non_web_public_channel = self.make_stream("non-web-public-channel")
+        self.subscribe(user_profile, web_public_channel.name)
+        self.subscribe(user_profile, non_web_public_channel.name)
 
         for _ in range(num_web_public_message):
             self.send_stream_message(
-                user_profile, web_public_stream.name, content="web-public message"
+                user_profile, web_public_channel.name, content="web-public message"
             )
         self.send_stream_message(
-            user_profile, non_web_public_stream.name, content="non-web-public message"
+            user_profile, non_web_public_channel.name, content="non-web-public message"
         )
         self.send_personal_message(
             user_profile, self.example_user("hamlet"), content="direct message"
@@ -1983,7 +1983,7 @@ class GetOldMessagesTest(ZulipTestCase):
             self.assertEqual(msg["sender_email"], sender.email)
             self.assertEqual(msg["avatar_url"], avatar_url(sender))
 
-    def test_unauthenticated_narrow_to_web_public_streams(self) -> None:
+    def test_unauthenticated_narrow_to_web_public_channels(self) -> None:
         self.setup_web_public_test()
 
         post_params: Dict[str, Union[int, str, bool]] = {
@@ -1993,7 +1993,7 @@ class GetOldMessagesTest(ZulipTestCase):
             "narrow": orjson.dumps(
                 [
                     dict(operator="streams", operand="web-public"),
-                    dict(operator="stream", operand="web-public-stream"),
+                    dict(operator="stream", operand="web-public-channel"),
                 ]
             ).decode(),
         }
@@ -2004,7 +2004,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         An unauthenticated call to GET /json/messages with valid parameters
         including `streams:web-public` narrow returns list of messages in the
-        `web-public` streams.
+        web-public channels.
         """
         self.setup_web_public_test(num_web_public_message=8)
 
@@ -2288,19 +2288,19 @@ class GetOldMessagesTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        stream_name = "test stream"
-        self.subscribe(cordelia, stream_name)
+        channel_name = "test channel"
+        self.subscribe(cordelia, channel_name)
 
-        old_message_id = self.send_stream_message(cordelia, stream_name, content="foo")
+        old_message_id = self.send_stream_message(cordelia, channel_name, content="foo")
 
-        self.subscribe(hamlet, stream_name)
+        self.subscribe(hamlet, channel_name)
 
         content = "hello @**King Hamlet**"
-        new_message_id = self.send_stream_message(cordelia, stream_name, content=content)
+        new_message_id = self.send_stream_message(cordelia, channel_name, content=content)
 
         self.login_user(hamlet)
         narrow = [
-            dict(operator="stream", operand=stream_name),
+            dict(operator="stream", operand=channel_name),
         ]
 
         req = dict(
@@ -2325,48 +2325,48 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assertEqual(old_message["flags"], ["read", "historical"])
         self.assertEqual(new_message["flags"], ["mentioned"])
 
-    def test_get_messages_with_narrow_stream(self) -> None:
+    def test_get_messages_with_narrow_channel(self) -> None:
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
         realm = hamlet.realm
 
-        num_messages_per_stream = 5
-        stream_names = ["Scotland", "Verona", "Venice"]
+        num_messages_per_channel = 5
+        channel_names = ["Scotland", "Verona", "Venice"]
 
-        def send_messages_to_all_streams() -> None:
+        def send_messages_to_all_channels() -> None:
             Message.objects.filter(realm_id=realm.id, recipient__type=Recipient.STREAM).delete()
-            for stream_name in stream_names:
-                self.subscribe(hamlet, stream_name)
-                for i in range(num_messages_per_stream):
-                    message_id = self.send_stream_message(hamlet, stream_name, content=f"test {i}")
+            for channel_name in channel_names:
+                self.subscribe(hamlet, channel_name)
+                for i in range(num_messages_per_channel):
+                    message_id = self.send_stream_message(hamlet, channel_name, content=f"test {i}")
                     message = Message.objects.get(id=message_id)
-                    self.assert_message_stream_name(message, stream_name)
+                    self.assert_message_stream_name(message, channel_name)
 
-        send_messages_to_all_streams()
+        send_messages_to_all_channels()
 
         self.send_personal_message(hamlet, hamlet)
 
         messages = get_user_messages(hamlet)
-        stream_messages = [msg for msg in messages if msg.is_stream_message()]
-        self.assertGreater(len(messages), len(stream_messages))
-        self.assert_length(stream_messages, num_messages_per_stream * len(stream_names))
+        channel_messages = [msg for msg in messages if msg.is_stream_message()]
+        self.assertGreater(len(messages), len(channel_messages))
+        self.assert_length(channel_messages, num_messages_per_channel * len(channel_names))
 
-        for stream_name in stream_names:
-            stream = get_stream(stream_name, realm)
-            for operand in [stream.name, stream.id]:
+        for channel_name in channel_names:
+            channel = get_stream(channel_name, realm)
+            for operand in [channel.name, channel.id]:
                 narrow = [dict(operator="stream", operand=operand)]
                 result = self.get_and_check_messages(
                     dict(narrow=orjson.dumps(narrow).decode(), num_after=100)
                 )
                 fetched_messages: List[Dict[str, object]] = result["messages"]
-                self.assert_length(fetched_messages, num_messages_per_stream)
+                self.assert_length(fetched_messages, num_messages_per_channel)
 
                 for message_dict in fetched_messages:
                     self.assertEqual(message_dict["type"], "stream")
-                    self.assertEqual(message_dict["display_recipient"], stream_name)
-                    self.assertEqual(message_dict["recipient_id"], stream.recipient_id)
+                    self.assertEqual(message_dict["display_recipient"], channel_name)
+                    self.assertEqual(message_dict["recipient_id"], channel.recipient_id)
 
-    def test_get_visible_messages_with_narrow_stream(self) -> None:
+    def test_get_visible_messages_with_narrow_channel(self) -> None:
         self.login("hamlet")
         self.subscribe(self.example_user("hamlet"), "Scotland")
 
@@ -2377,39 +2377,39 @@ class GetOldMessagesTest(ZulipTestCase):
         narrow = [dict(operator="stream", operand="Scotland")]
         self.message_visibility_test(narrow, message_ids, 2)
 
-    def test_get_messages_with_narrow_stream_mit_unicode_regex(self) -> None:
+    def test_get_messages_with_narrow_channel_mit_unicode_regex(self) -> None:
         """
         A request for old messages for a user in the mit.edu relam with Unicode
-        stream name should be correctly escaped in the database query.
+        channel name should be correctly escaped in the database query.
         """
         user = self.mit_user("starnine")
         self.login_user(user)
-        # We need to subscribe to a stream and then send a message to
-        # it to ensure that we actually have a stream message in this
+        # We need to subscribe to a channel and then send a message to
+        # it to ensure that we actually have a channel message in this
         # narrow view.
-        lambda_stream_name = "\u03bb-stream"
-        stream = self.subscribe(user, lambda_stream_name)
-        self.assertTrue(stream.is_in_zephyr_realm)
+        lambda_channel_name = "\u03bb-channel"
+        channel = self.subscribe(user, lambda_channel_name)
+        self.assertTrue(channel.is_in_zephyr_realm)
 
-        lambda_stream_d_name = "\u03bb-stream.d"
-        self.subscribe(user, lambda_stream_d_name)
+        lambda_channel_d_name = "\u03bb-channel.d"
+        self.subscribe(user, lambda_channel_d_name)
 
-        self.send_stream_message(user, "\u03bb-stream")
-        self.send_stream_message(user, "\u03bb-stream.d")
+        self.send_stream_message(user, "\u03bb-channel")
+        self.send_stream_message(user, "\u03bb-channel.d")
 
-        narrow = [dict(operator="stream", operand="\u03bb-stream")]
+        narrow = [dict(operator="stream", operand="\u03bb-channel")]
         result = self.get_and_check_messages(
             dict(num_after=2, narrow=orjson.dumps(narrow).decode()), subdomain="zephyr"
         )
 
         messages = get_user_messages(self.mit_user("starnine"))
-        stream_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_stream_message()]
 
         self.assert_length(result["messages"], 2)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")
-            stream_id = stream_messages[i].recipient.id
-            self.assertEqual(message["recipient_id"], stream_id)
+            channel_id = channel_messages[i].recipient.id
+            self.assertEqual(message["recipient_id"], channel_id)
 
     def test_get_messages_with_narrow_topic_mit_unicode_regex(self) -> None:
         """
@@ -2418,8 +2418,8 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         mit_user_profile = self.mit_user("starnine")
         self.login_user(mit_user_profile)
-        # We need to subscribe to a stream and then send a message to
-        # it to ensure that we actually have a stream message in this
+        # We need to subscribe to a channel and then send a message to
+        # it to ensure that we actually have a channel message in this
         # narrow view.
         self.subscribe(mit_user_profile, "Scotland")
         self.send_stream_message(mit_user_profile, "Scotland", topic_name="\u03bb-topic")
@@ -2434,12 +2434,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = get_user_messages(mit_user_profile)
-        stream_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_stream_message()]
         self.assert_length(result["messages"], 5)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")
-            stream_id = stream_messages[i].recipient.id
-            self.assertEqual(message["recipient_id"], stream_id)
+            channel_id = channel_messages[i].recipient.id
+            self.assertEqual(message["recipient_id"], channel_id)
 
     def test_get_messages_with_narrow_topic_mit_personal(self) -> None:
         """
@@ -2447,8 +2447,8 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         mit_user_profile = self.mit_user("starnine")
 
-        # We need to subscribe to a stream and then send a message to
-        # it to ensure that we actually have a stream message in this
+        # We need to subscribe to a channel and then send a message to
+        # it to ensure that we actually have a channel message in this
         # narrow view.
         self.login_user(mit_user_profile)
         self.subscribe(mit_user_profile, "Scotland")
@@ -2468,12 +2468,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = get_user_messages(mit_user_profile)
-        stream_messages = [msg for msg in messages if msg.is_stream_message()]
+        channel_messages = [msg for msg in messages if msg.is_stream_message()]
         self.assert_length(result["messages"], 7)
         for i, message in enumerate(result["messages"]):
             self.assertEqual(message["type"], "stream")
-            stream_id = stream_messages[i].recipient.id
-            self.assertEqual(message["recipient_id"], stream_id)
+            channel_id = channel_messages[i].recipient.id
+            self.assertEqual(message["recipient_id"], channel_id)
 
     def test_get_messages_with_narrow_sender(self) -> None:
         """
@@ -2487,7 +2487,7 @@ class GetOldMessagesTest(ZulipTestCase):
         iago = self.example_user("iago")
 
         # We need to send a message here to ensure that we actually
-        # have a stream message in this narrow view.
+        # have a channel message in this narrow view.
         self.send_stream_message(hamlet, "Denmark")
         self.send_stream_message(othello, "Denmark")
         self.send_personal_message(othello, hamlet)
@@ -2522,8 +2522,8 @@ class GetOldMessagesTest(ZulipTestCase):
 
         def send(content: str) -> int:
             msg_id = self.send_stream_message(
-                sender=user,
-                stream_name="Verona",
+                user,
+                "Verona",
                 content=content,
             )
             return msg_id
@@ -2589,8 +2589,8 @@ class GetOldMessagesTest(ZulipTestCase):
 
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=cordelia,
-                stream_name="Verona",
+                cordelia,
+                "Verona",
                 content=content,
                 topic_name=topic,
             )
@@ -2741,11 +2741,11 @@ class GetOldMessagesTest(ZulipTestCase):
 
     @override_settings(USING_PGROONGA=False)
     def test_get_messages_with_search_not_subscribed(self) -> None:
-        """Verify support for searching a stream you're not subscribed to"""
-        self.subscribe(self.example_user("hamlet"), "newstream")
+        """Verify support for searching a channel you're not subscribed to"""
+        self.subscribe(self.example_user("hamlet"), "new-channel")
         self.send_stream_message(
-            sender=self.example_user("hamlet"),
-            stream_name="newstream",
+            self.example_user("hamlet"),
+            "new-channel",
             content="Public special content!",
             topic_name="new",
         )
@@ -2753,21 +2753,21 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.login("cordelia")
 
-        stream_search_narrow = [
+        channel_search_narrow = [
             dict(operator="search", operand="special"),
-            dict(operator="stream", operand="newstream"),
+            dict(operator="stream", operand="new-channel"),
         ]
-        stream_search_result: Dict[str, Any] = self.get_and_check_messages(
+        channel_search_result: Dict[str, Any] = self.get_and_check_messages(
             dict(
-                narrow=orjson.dumps(stream_search_narrow).decode(),
+                narrow=orjson.dumps(channel_search_narrow).decode(),
                 anchor=0,
                 num_after=10,
                 num_before=10,
             )
         )
-        self.assert_length(stream_search_result["messages"], 1)
+        self.assert_length(channel_search_result["messages"], 1)
         self.assertEqual(
-            stream_search_result["messages"][0]["match_content"],
+            channel_search_result["messages"][0]["match_content"],
             '<p>Public <span class="highlight">special</span> content!</p>',
         )
 
@@ -2790,8 +2790,8 @@ class GetOldMessagesTest(ZulipTestCase):
 
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=self.example_user("cordelia"),
-                stream_name="Verona",
+                self.example_user("cordelia"),
+                "Verona",
                 content=content,
                 topic_name=topic,
             )
@@ -2998,8 +2998,8 @@ class GetOldMessagesTest(ZulipTestCase):
 
         def send(content: str) -> int:
             msg_id = self.send_stream_message(
-                sender=user,
-                stream_name="Verona",
+                user,
+                "Verona",
                 topic_name="test_topic",
                 content=content,
             )
@@ -3481,14 +3481,14 @@ class GetOldMessagesTest(ZulipTestCase):
             result = self.client_get("/json/messages", post_params)
             self.assert_json_error_contains(result, error_msg)
 
-    def test_bad_narrow_stream_content(self) -> None:
+    def test_bad_narrow_channel_content(self) -> None:
         """
-        If an invalid stream name is requested in get_messages, an error is
+        If an invalid channel name is requested in get_messages, an error is
         returned.
         """
         self.login("hamlet")
-        bad_stream_content: Tuple[int, List[None], List[str]] = (0, [], ["x", "y"])
-        self.exercise_bad_narrow_operand("stream", bad_stream_content, "Bad value for 'narrow'")
+        bad_channel_content: Tuple[int, List[None], List[str]] = (0, [], ["x", "y"])
+        self.exercise_bad_narrow_operand("stream", bad_channel_content, "Bad value for 'narrow'")
 
     def test_bad_narrow_one_on_one_email_content(self) -> None:
         """
@@ -3496,18 +3496,18 @@ class GetOldMessagesTest(ZulipTestCase):
         an error is returned.
         """
         self.login("hamlet")
-        bad_stream_content: Tuple[int, List[None], List[str]] = (0, [], ["x", "y"])
-        self.exercise_bad_narrow_operand("dm", bad_stream_content, "Bad value for 'narrow'")
+        bad_channel_content: Tuple[int, List[None], List[str]] = (0, [], ["x", "y"])
+        self.exercise_bad_narrow_operand("dm", bad_channel_content, "Bad value for 'narrow'")
 
-    def test_bad_narrow_nonexistent_stream(self) -> None:
+    def test_bad_narrow_nonexistent_channel(self) -> None:
         self.login("hamlet")
         self.exercise_bad_narrow_operand(
-            "stream", ["non-existent stream"], "Invalid narrow operator: unknown stream"
+            "stream", ["non-existent channel"], "Invalid narrow operator: unknown stream"
         )
 
-        non_existing_stream_id = 1232891381239
+        non_existing_channel_id = 1232891381239
         self.exercise_bad_narrow_operand_using_dict_api(
-            "stream", [non_existing_stream_id], "Invalid narrow operator: unknown stream"
+            "stream", [non_existing_channel_id], "Invalid narrow operator: unknown stream"
         )
 
     def test_bad_narrow_nonexistent_email(self) -> None:
@@ -3590,7 +3590,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
         # With the same data setup, we now want to test that a reasonable
         # search still gets the first message sent to Hamlet (before he
-        # subscribed) and other recent messages to the stream.
+        # subscribed) and other recent messages to the channel.
         query_params = dict(
             anchor="first_unread",
             num_before=10,
@@ -3699,7 +3699,7 @@ class GetOldMessagesTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
 
         # Have Othello send messages to Hamlet that he hasn't read.
-        # Here, Hamlet isn't subscribed to the stream Scotland
+        # Here, Hamlet isn't subscribed to the channel Scotland
         self.send_stream_message(self.example_user("othello"), "Scotland")
         first_unread_message_id = self.send_personal_message(
             self.example_user("othello"),
@@ -3851,9 +3851,9 @@ class GetOldMessagesTest(ZulipTestCase):
         queries = [q for q in all_queries if q.sql.startswith("SELECT message_id, flags")]
         self.assert_length(queries, 1)
 
-        stream = get_stream("Scotland", realm)
-        assert stream.recipient is not None
-        recipient_id = stream.recipient.id
+        channel = get_stream("Scotland", realm)
+        assert channel.recipient is not None
+        recipient_id = channel.recipient.id
         cond = f"AND NOT (recipient_id = {recipient_id} AND upper(subject) = upper('golf'))"
         self.assertIn(cond, queries[0].sql)
 
@@ -3868,11 +3868,11 @@ class GetOldMessagesTest(ZulipTestCase):
         self.make_stream("web stuff")
         user_profile = self.example_user("hamlet")
 
-        self.make_stream("irrelevant_stream")
+        self.make_stream("irrelevant_channel")
 
         # Test the do-nothing case first.
         muted_topics = [
-            ["irrelevant_stream", "irrelevant_topic"],
+            ["irrelevant_channel", "irrelevant_topic"],
         ]
         set_topic_visibility_policy(user_profile, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
@@ -3884,9 +3884,10 @@ class GetOldMessagesTest(ZulipTestCase):
         muting_conditions = exclude_muting_conditions(user_profile, narrow)
         self.assertEqual(muting_conditions, [])
 
-        # Also test that passing stream ID works
+        # Also test that passing channel ID works
+        channel_id = get_stream("Scotland", realm).id
         narrow = [
-            dict(operator="stream", operand=get_stream("Scotland", realm).id),
+            dict(operator="stream", operand=channel_id),
         ]
         muting_conditions = exclude_muting_conditions(user_profile, narrow)
         self.assertEqual(muting_conditions, [])
@@ -3918,16 +3919,16 @@ WHERE NOT (recipient_id = %(recipient_id_1)s AND upper(subject) = upper(%(param_
         params = get_sqlalchemy_query_params(query)
 
         self.assertEqual(
-            params["recipient_id_1"], get_recipient_id_for_stream_name(realm, "Scotland")
+            params["recipient_id_1"], get_recipient_id_for_channel_name(realm, "Scotland")
         )
         self.assertEqual(params["param_1"], "golf")
 
-        mute_stream(realm, user_profile, "Verona")
+        mute_channel(realm, user_profile, "Verona")
 
-        # Using a bogus stream name should be similar to using no narrow at
+        # Using a bogus channel name should be similar to using no narrow at
         # all, and we'll exclude all mutes.
         narrow = [
-            dict(operator="stream", operand="bogus-stream-name"),
+            dict(operator="stream", operand="bogus-channel-name"),
         ]
 
         muting_conditions = exclude_muting_conditions(user_profile, narrow)
@@ -3945,14 +3946,14 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
         self.assertEqual(get_sqlalchemy_sql(query), expected_query)
         params = get_sqlalchemy_query_params(query)
         self.assertEqual(
-            params["recipient_id_1"], [get_recipient_id_for_stream_name(realm, "Verona")]
+            params["recipient_id_1"], [get_recipient_id_for_channel_name(realm, "Verona")]
         )
         self.assertEqual(
-            params["recipient_id_2"], get_recipient_id_for_stream_name(realm, "Scotland")
+            params["recipient_id_2"], get_recipient_id_for_channel_name(realm, "Scotland")
         )
         self.assertEqual(params["param_1"], "golf")
         self.assertEqual(
-            params["recipient_id_3"], get_recipient_id_for_stream_name(realm, "web stuff")
+            params["recipient_id_3"], get_recipient_id_for_channel_name(realm, "web stuff")
         )
         self.assertEqual(params["param_2"], "css")
 
@@ -4051,13 +4052,13 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
             sql,
         )
 
-        sql_template = "SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE realm_id = 2 AND recipient_id IN ({public_streams_recipients}) ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
+        sql_template = "SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE realm_id = 2 AND recipient_id IN ({public_channels_recipients}) ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
             {"anchor": 0, "num_before": 0, "num_after": 9, "narrow": '[["streams", "public"]]'}, sql
         )
 
-        sql_template = "SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (recipient_id NOT IN ({public_streams_recipients})) ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
+        sql_template = "SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (recipient_id NOT IN ({public_channels_recipients})) ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC"
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
             {
@@ -4191,8 +4192,8 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
 
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=cordelia,
-                stream_name="Verona",
+                cordelia,
+                "Verona",
                 content=content,
                 topic_name=topic,
             )

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -311,14 +311,21 @@ class NarrowBuilderTest(ZulipTestCase):
         )
 
     def test_combined_channel_dm(self) -> None:
+        expected_error_message = (
+            "Invalid narrow operator: No message can be both a channel message and direct message"
+        )
         term1 = dict(operator="dm", operand=self.othello_email)
         self._build_query(term1)
 
         topic_term = dict(operator="topic", operand="bogus")
-        self.assertRaises(BadNarrowOperatorError, self._build_query, topic_term)
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(topic_term)
+        self.assertEqual(expected_error_message, str(error.exception))
 
-        channel_term = dict(operator="streams", operand="public")
-        self.assertRaises(BadNarrowOperatorError, self._build_query, channel_term)
+        channels_term = dict(operator="streams", operand="public")
+        with self.assertRaises(BadNarrowOperatorError) as error:
+            self._build_query(channels_term)
+        self.assertEqual(expected_error_message, str(error.exception))
 
     def test_add_term_using_dm_operator_not_the_same_user_as_operand_and_negated(
         self,


### PR DESCRIPTION
Adds backend support for `channel` and `channels` as search/narrow operators and updates the web-app to start using these operators in the `Filter` class, without making user-facing changes to search suggestion strings and URLs.

In the backend changes:
- There's a prep commit to make the test changes easier to read.
- Implements each operator in a separate commit.
- Since the backend/server code isn't user-facing, I went ahead and updated `zerver/lib/narrow.py` and `zerver/tests/test_message_fetch.py` for the stream to channel rename.

In the frontend changes:
- There's a prep commit to make the test changes easier to read.
- Implements each operator in a separate commit.
- The search suggestions still use the "stream" and "stream" strings and neither of the new operators will offer suggestions until a colon is added, e.g. `channel:` is input into the search field.
- URLs still all use "stream" and "streams" with these changes even though the `Filter` class has been updated.

The final commit is the API documentation update and version bump. There are no help center or general API documentation updates in these changes, as those will be done when the user-facing strings are updated.

Part of the stream to channel rename project. See [relevant CZO](https://chat.zulip.org/#narrow/stream/438-release-management/topic/rename.20.22stream.22.20to.20.22channel.22.20project.2C.20.2328468/near/1758864) discussion.

---

**Screenshots and screen captures:**

<details>
<summary>API changelog entry</summary>

![Screenshot from 2024-04-09 20-40-09](https://github.com/zulip/zulip/assets/63245456/7498426b-0d6c-438e-b545-6f8463fc97e1)
</details>
<details>
<summary>Construct a narrow updated "Changes" note</summary>

[Current documentation](https://zulip.com/api/construct-narrow)
![Screenshot from 2024-04-09 20-41-36](https://github.com/zulip/zulip/assets/63245456/a3388ca2-380c-48b7-accb-8d1d9a3771aa)
</details>
<details>
<summary>Get messages endpoint - narrow parameter</summary>

[Current documentation](https://zulip.com/api/get-messages#parameter-narrow)
![Screenshot from 2024-04-09 20-40-28](https://github.com/zulip/zulip/assets/63245456/baffc12c-ef48-4759-8555-3e71ae3f0779)
</details>
<details>
<summary>Update message flags endpoint - narrow parameter</summary>

[Current documentation](https://zulip.com/api/update-message-flags-for-narrow#parameter-narrow)
![Screenshot from 2024-04-09 20-40-56](https://github.com/zulip/zulip/assets/63245456/bdd4305b-c603-4214-b7d9-afdfd876e0f2)
</details>
<details>
<summary>Check messages match narrow endpoint - narrow parameter</summary>

[Current documentation](https://zulip.com/api/check-messages-match-narrow#parameter-narrow)
![Screenshot from 2024-04-09 20-41-08](https://github.com/zulip/zulip/assets/63245456/00d985be-ff8b-4458-91e9-2b110ce589db)
</details>
<details>
<summary>Register queue endpoint - narrow parameter</summary>

[Current documentation](https://zulip.com/api/register-queue#parameter-narrow)
![Screenshot from 2024-04-09 20-41-18](https://github.com/zulip/zulip/assets/63245456/33d2cb5f-f2e5-46e5-b1e9-d2cd35cee7c8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
