### PR TITLE
search: Add is:followed filter.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 265**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `is:followed`, matching messages in topics that the current user is
+  [following](/help/follow-a-topic).
+
 **Feature level 264**
 
 * `PATCH /realm`, [`POST /register`](/api/register-queue),

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -51,8 +51,12 @@ important optimization when fetching messages in certain cases (e.g.
 when [adding the `read` flag to a user's personal
 messages](/api/update-message-flags-for-narrow)).
 
-**Changes**: In Zulip 9.0 (feature level 250), support was added for
-two filters related to channel messages: `channel` and `channels`. The
+**Changes**: In Zulip 9.0 (feature level 265), support was added for a
+new `is:followed` filter, matching messages in topics that the current
+user is [following](/help/follow-a-topic).
+
+In Zulip 9.0 (feature level 250), support was added for
+two filters related to stream messages: `channel` and `channels`. The
 `channel` operator is an alias for the `stream` operator. The `channels`
 operator is an alias for the `streams` operator. Both `channel` and
 `channels` return the same exact results as `stream` and `streams`

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -116,6 +116,7 @@ Zulip offers the following filters based on the location of the message.
 
 ### Search by message status
 
+* `is:followed`: Search messages in [followed topics](/help/follow-a-topic).
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
 * `is:unread`: Search your unread messages.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 264
+API_FEATURE_LEVEL = 265
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -261,6 +261,10 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                     return {
                         title: $t({defaultMessage: "No topics are marked as resolved."}),
                     };
+                case "followed":
+                    return {
+                        title: $t({defaultMessage: "You aren't following any topics."}),
+                    };
             }
             // fallthrough to default case if no match is found
             break;

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -602,6 +602,16 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             incompatible_patterns: [{operator: "is", operand: "mentioned"}],
         },
         {
+            search_string: "is:followed",
+            description_html: "followed topics",
+            incompatible_patterns: [
+                {operator: "is", operand: "followed"},
+                {operator: "is", operand: "dm"},
+                {operator: "dm"},
+                {operator: "dm-including"},
+            ],
+        },
+        {
             search_string: "is:alerted",
             description_html: "alerted messages",
             incompatible_patterns: [{operator: "is", operand: "alerted"}],

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -31,6 +31,10 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}topics marked as resolved
             {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "followed")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}followed topics
+            {{~!-- squash whitespace --~}}
         {{else}}
             {{~!-- squash whitespace --~}}
             invalid {{this.operand}} operand for is operator

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -130,6 +130,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">is:followed</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in followed topics.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">is:unread</td>
                         <td class="definition">
                             {{t 'Narrow to unread messages.'}}

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -337,6 +337,13 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         empty_narrow_html("translated: No topics are marked as resolved."),
     );
 
+    set_filter([["is", "followed"]]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: You aren't following any topics."),
+    );
+
     // organization has disabled sending direct messages
     realm.realm_private_message_policy =
         settings_config.private_message_policy_values.disabled.code;

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -438,6 +438,7 @@ test("empty_query_suggestions", () => {
         "is:dm",
         "is:starred",
         "is:mentioned",
+        "is:followed",
         "is:alerted",
         "is:unread",
         "is:resolved",
@@ -461,6 +462,7 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:followed"), "Followed topics");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
     assert.equal(describe("has:link"), "Messages that contain links");
     assert.equal(describe("has:image"), "Messages that contain images");
@@ -543,6 +545,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:dm",
         "is:starred",
         "is:mentioned",
+        "is:followed",
         "is:alerted",
         "is:unread",
         "is:resolved",
@@ -563,6 +566,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:followed"), "Followed topics");
 
     query = "-i";
     suggestions = get_suggestions(query);
@@ -571,6 +575,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "-is:dm",
         "-is:starred",
         "-is:mentioned",
+        "-is:followed",
         "-is:alerted",
         "-is:unread",
         "-is:resolved",
@@ -583,12 +588,21 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Exclude topics marked as resolved");
+    assert.equal(describe("-is:followed"), "Exclude followed topics");
 
     // operand suggestions follow.
 
     query = "is:";
     suggestions = get_suggestions(query);
-    expected = ["is:dm", "is:starred", "is:mentioned", "is:alerted", "is:unread", "is:resolved"];
+    expected = [
+        "is:dm",
+        "is:starred",
+        "is:mentioned",
+        "is:followed",
+        "is:alerted",
+        "is:unread",
+        "is:resolved",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:st";

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -58,6 +58,7 @@ from zerver.lib.streams import (
     get_web_public_streams_queryset,
 )
 from zerver.lib.topic_sqlalchemy import (
+    get_followed_topic_condition_sa,
     get_resolved_topic_condition_sa,
     topic_column_sa,
     topic_match_sa,
@@ -404,6 +405,9 @@ class NarrowBuilder:
             return query.where(maybe_negate(cond))
         elif operand == "resolved":
             cond = get_resolved_topic_condition_sa()
+            return query.where(maybe_negate(cond))
+        elif operand == "followed":
+            cond = get_followed_topic_condition_sa(self.user_profile.id)
             return query.where(maybe_negate(cond))
         raise BadNarrowOperatorError("unknown 'is' operand " + operand)
 
@@ -912,7 +916,7 @@ def ok_to_include_history(
         # that's a property on the UserMessage table.  There cannot be
         # historical messages in these cases anyway.
         for term in narrow:
-            if term["operator"] == "is" and term["operand"] not in {"resolved"}:
+            if term["operator"] == "is" and term["operand"] not in {"resolved", "followed"}:
                 include_history = False
 
     return include_history

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -14,10 +14,15 @@ channels_operators: List[str] = ["channels", "streams"]
 
 def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
     supported_operators = [*channel_operators, "topic", "sender", "is"]
+    unsupported_is_operands = ["followed"]
     for narrow_term in narrow:
         operator = narrow_term.operator
         if operator not in supported_operators:
             raise JsonableError(_("Operator {operator} not supported.").format(operator=operator))
+        if operator == "is" and narrow_term.operand in unsupported_is_operands:
+            raise JsonableError(
+                _("Operand {operand} not supported.").format(operand=narrow_term.operand)
+            )
 
 
 class NarrowPredicate(Protocol):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10182,6 +10182,7 @@ paths:
                     - 0
                     - 1
                     - 2
+                    - 3
                   example: 1
               required:
                 - stream_id


### PR DESCRIPTION
Create the is:followed search operator.
Fetch all messages that are from followed topics
using exists.
Update API documentation and changelog.

Co-authored-by: Nimish <medatwalnimish@gmail.com>

Fixes #27309.

Added `Followed` enum `3` to `visibility_policy` of `user_topics` endpoint in `zulip.yaml` .

Screenshots.

Top of view
![image](https://github.com/zulip/zulip/assets/2746074/04bdeda3-c240-454b-afe9-22afcb69a9b3)


Search suggestions
![image](https://github.com/zulip/zulip/assets/29176437/3299f29a-22ed-4e2a-9d39-7d142a5974e4)

Help menu.
![image](https://github.com/zulip/zulip/assets/29176437/31a72257-df0f-4c31-bbb6-1055a4f0e7ca)
![image](https://github.com/zulip/zulip/assets/29176437/9a1de00a-8072-4d38-9dad-4bb029997e93)

Api Change log
![image](https://github.com/zulip/zulip/assets/29176437/933785a3-de3f-47c2-832b-6c91ea798a46)
construct-narrow documentation
![image](https://github.com/zulip/zulip/assets/29176437/b5e680f3-5a69-4b90-a7e0-74ea3d5c0074)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
