### PR TITLE
Revert "apt-repos: Disallow libmagic1 1:5.45-2 (Ubuntu 24.04) again."

### DIFF
--- a/scripts/setup/apt-repos/zulip/zulip.pref
+++ b/scripts/setup/apt-repos/zulip/zulip.pref
@@ -1,4 +1,0 @@
-# https://bugs.launchpad.net/ubuntu/+source/file/+bug/2059723
-Package: libmagic1
-Pin: version 1:5.45-2
-Pin-Priority: -1


### PR DESCRIPTION
This reverts commit 13e28fc3aceccfd43595ed246291ce30a10d8a8a.