### PR TITLE
left_sidebar: Fix topic resolve/rename options in three dot menu.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -11,6 +11,7 @@ import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_lists from "./message_lists";
+import {get_messages_in_topic} from "./message_util";
 import * as muted_users from "./muted_users";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -121,11 +122,12 @@ export function get_actions_popover_content_context(message_id) {
 
 export function get_topic_popover_content_context({stream_id, topic_name, url}) {
     const sub = sub_store.get(stream_id);
+    const message = get_messages_in_topic(stream_id, topic_name)[0];
     const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const has_unread_messages = num_unread_for_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = settings_data.user_can_move_messages_between_streams();
-    const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
+    const can_rename_topic = message_edit.is_topic_editable(message);
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;
     return {


### PR DESCRIPTION
Previously, even when a user doesn't have permissions to resolve or rename a topic, the options to do so were still visible in the three dot menu of the topic in left sidebar.

This is because, previously it was only checked if user can move messages to another topic to decide the display of options in the menu. However, it is also possible that the user has permission to rename/resolve the topic, but just that the user isn't an admin, and the deadline to edit topic has expired.

This is fixed by rather using the message_edit.is_topic_editable() method to decide whether to show these options.

<!-- Describe your pull request here.-->

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20edit.20options.20in.20three.20dot.20menu/near/1777796)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
