### PR TITLE
stream_settings: Fix error on stream setting update when compose closed.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -226,7 +226,6 @@ export function on_compose_select_recipient_update(): void {
     if (curr_message_type === "stream") {
         // Update stream name in the recipient box.
         const stream_id = compose_state.stream_id();
-        assert(stream_id !== undefined);
         update_recipient_label(stream_id);
     }
 


### PR DESCRIPTION
Previously, when stream settings were updated, without opening the compose box, assertion error were thrown.

This error was a result of a regression in compose_recipient, due to an extra assert statement added during its typescript migration in 25ff0d441858aa5c8f0bf51b47ad2a872141c262.

This is fixed by removing the statement.

<!-- Describe your pull request here.-->

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/updating.20stream.20settings.2E/near/1776498)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
