### PR TITLE
unarchive_stream: Prevent unarchiving a stream in the wrong realm.

### DIFF
--- a/zerver/management/commands/unarchive_stream.py
+++ b/zerver/management/commands/unarchive_stream.py
@@ -43,6 +43,10 @@ class Command(ZulipBaseCommand):
 
         if options["stream_id"] is not None:
             stream = Stream.objects.get(id=options["stream_id"])
+            if stream.realm_id != realm.id:
+                raise CommandError(
+                    f"Stream id {stream.id}, named '{stream.name}', is in realm '{stream.realm.string_id}', not '{realm.string_id}'"
+                )
             if not stream.deactivated:
                 raise CommandError(
                     f"Stream id {stream.id}, named '{stream.name}', is not deactivated"


### PR DESCRIPTION


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
