### PR TITLE
Document new roles filer for Users table

### DIFF
--- a/help/change-a-users-role.md
+++ b/help/change-a-users-role.md
@@ -21,6 +21,7 @@ organization](/help/deactivate-your-organization) instead).
 
 ## Related articles
 
+* [Roles and permissions](/help/roles-and-permissions)
 * [Change a user's name](/help/change-a-users-name)
 * [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
 * [Manage a user](/help/manage-a-user)

--- a/help/find-administrators.md
+++ b/help/find-administrators.md
@@ -1,0 +1,15 @@
+# Find administrators
+
+[Administrators](/help/roles-and-permissions) can take actions other users are
+not permitted to, such as managing your organization's permissions settings.
+
+!!! tip ""
+
+    Organization owners can do anything that an organization administrator can do.
+
+{!view-users-by-role.md!}
+
+## Related articles
+
+* [Roles and permissions](/help/roles-and-permissions)
+* [Customize organization settings](/help/customize-organization-settings)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -122,6 +122,7 @@
 * [View someone's profile](/help/view-someones-profile)
 * [Direct messages](/help/direct-messages)
 * [User groups](/help/user-groups)
+* [Find administrators](/help/find-administrators)
 
 ## Streams & topics
 * [Streams and topics](/help/streams-and-topics)

--- a/help/include/view-users-by-role.md
+++ b/help/include/view-users-by-role.md
@@ -1,0 +1,7 @@
+{start_tabs}
+
+{settings_tab|user-list-admin}
+
+1. Select the desired role from the dropdown above the **Users** table.
+
+{end_tabs}

--- a/help/roles-and-permissions.md
+++ b/help/roles-and-permissions.md
@@ -42,6 +42,10 @@ role](/help/roles-and-permissions#change-a-users-role) if needed.
   For example, someone from your billing department can be a **billing
   administrator**, but not an **administrator** for the organization.
 
+## View users by role
+
+{!view-users-by-role.md!}
+
 ## Change a user's role
 
 {!change-a-users-role.md!}

--- a/help/user-list.md
+++ b/help/user-list.md
@@ -57,3 +57,4 @@ show it.
 - [View someone's profile](/help/view-someones-profile)
 - [Status and availability](/help/status-and-availability)
 - [Searching for messages](/help/search-for-messages)
+- [Find administrators](/help/find-administrators)


### PR DESCRIPTION
Follow-up to https://github.com/zulip/zulip/pull/29597.

<details>
<summary>
Roles and permissions
</summary>

Current: https://zulip.com/help/roles-and-permissions

![CleanShot 2024-04-10 at 17 15 09@2x](https://github.com/zulip/zulip/assets/2090066/d9ca8969-7c9e-44e2-8bbc-ff43592529f6)

</details>


<details>
<summary>
New page: Find administrators
</summary>

![CleanShot 2024-04-10 at 17 18 50@2x](https://github.com/zulip/zulip/assets/2090066/c3e7a4b0-667b-412d-8fa4-03159fcec9fc)

</details>



Notes:
- I didn't document the Deactivated users filter. It seems fine to me to leave that undocumented, and let users discover it when viewing that panel.