### PR TITLE
settings_users: Reverse order of roles in role filters.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -138,10 +138,12 @@ function role_selected_handler(event, dropdown, widget) {
 function get_roles() {
     return [
         {unique_id: "0", name: $t({defaultMessage: "All roles"})},
-        ...Object.values(settings_config.user_role_values).map((user_role_value) => ({
-            unique_id: user_role_value.code.toString(),
-            name: user_role_value.description,
-        })),
+        ...Object.values(settings_config.user_role_values)
+            .map((user_role_value) => ({
+                unique_id: user_role_value.code.toString(),
+                name: user_role_value.description,
+            }))
+            .reverse(),
     ];
 }
 


### PR DESCRIPTION
Fixes #29687.
We could have used Array.reverse() before running Array.map() in the previous code, but that would loop through the array twice. That's why switched to a for loop here.

**Screenshots and screen captures:**

<details>
<summary>Role filter dropdown</summary>

![Screenshot 2024-04-11 at 3 28 19 PM](https://github.com/zulip/zulip/assets/13910561/15ade992-9dfd-4b70-a24d-3a59480ea803)

</details>

<details>
<summary> Role filter dropdown on users list page along with active filters and their results</summary>

![Screenshot 2024-04-11 at 3 28 34 PM](https://github.com/zulip/zulip/assets/13910561/71f88106-855b-4cf7-b042-ec9a444a2ec2)


</details>

<details>
<summary>Role filter dropdown on deactivated users list page along with active filters and their results </summary>

![Screenshot 2024-04-11 at 3 29 09 PM](https://github.com/zulip/zulip/assets/13910561/a366981b-f038-4973-b325-d2d51a92e493)

</details>

**Self-review checklist:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
