### PR TITLE
Enable reaction button to be visible upon clicking a message box in mobile devices.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -289,6 +289,11 @@ export function initialize() {
         navigate.to_end();
     });
 
+    $("body").on("click", ".message_row", function () {
+        $(".selected_msg_for_touchscreen").removeClass("selected_msg_for_touchscreen");
+        $(this).addClass("selected_msg_for_touchscreen");
+    });
+
     // MESSAGE EDITING
 
     $("body").on("click", ".edit_content_button, .view_source_button", function (e) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1369,6 +1369,19 @@ td.pointer {
     }
 }
 
+.selected_msg_for_touchscreen {
+    @media (hover: none) {
+        .message_reactions {
+            .message_reaction {
+                + .reaction_button {
+                    visibility: visible;
+                    pointer-events: all;
+                }
+            }
+        }
+    }
+}
+
 .message_sender {
     & i.zulip-icon.zulip-icon-bot {
         font-size: 12px;


### PR DESCRIPTION
This PR makes the reaction button visible when clicking on a message box in a mobile view, enhancing the user experience.

Fixes #29529 

**Note:**  This PR is built upon the work done in the [Closed PR#29533](https://github.com/zulip/zulip/pull/29533), which provided a valuable contribution in making this current PR.

**Screenshots and screen captures:**

[reaction.webm](https://github.com/zulip/zulip/assets/128511266/1e2c2954-b450-4529-91d2-798ca3832438)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
