### PR TITLE
kandra: Log and timestamp autossh output.

### DIFF
--- a/puppet/kandra/templates/supervisor/conf.d/autossh_tunnels.conf.erb
+++ b/puppet/kandra/templates/supervisor/conf.d/autossh_tunnels.conf.erb
@@ -5,12 +5,14 @@ i = 0
 @hosts.each do |host|
 -%>
 [program:autossh-tunnel-<%= host %>]
-command=autossh -N -M <%= 20000 + 2 * i %> -o ControlMaster=yes nagios@<%= host %><% unless host.include?(".") %>.<%= @default_host_domain %><% end %>
+environment=AUTOSSH_DEBUG=1
+command=bash -c 'exec autossh -N -M <%= 20000 + 2 * i %> -o ControlMaster=yes nagios@<%= host %><% unless host.include?(".") %>.<%= @default_host_domain %><% end %> 2>&1 | ts "%%b %%d %%H:%%M:%%.S"'
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)
 autorestart=true               ; whether/when to restart (default: unexpected)
 stopsignal=TERM                 ; signal used to kill process (default TERM)
 stopwaitsecs=30                ; max num secs to wait b4 SIGKILL (default 10)
+stopasgroup=true
 user=nagios                    ; setuid to this UNIX account to run the program
 redirect_stderr=true           ; redirect proc stderr to stdout (default false)
 stdout_logfile=/var/log/zulip/autossh.<%= host %>.log         ; stdout log path, NONE for none; default AUTO


### PR DESCRIPTION
By default, autossh writes to syslog; setting AUTOSSH_DEBUG is the only way to produce output to STDERR.  Timestamp that and log that to the logfile, making the logs perhaps useful.

<!-- Describe your pull request here.-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
