### PR TITLE
uploads: Ask user about deleting uploaded files when removed from edited message

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 257**
+* [`PATCH /messages/{message_id}`](/api/update-message),
+  [`PATCH /scheduled_messages/<int:scheduled_message_id>`](/api/update-scheduled-message):
+  These endpoints now return the detached_files within the response after editing the message.
+
 **Feature level 256**
 
 * [`GET /events`](/api/get-events): Stream update events with a new

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import {z} from "zod";
 
 import render_confirm_delete_attachment from "../templates/confirm_dialog/confirm_delete_attachment.hbs";
+import render_confirm_delete_detached_attachments_modal from "../templates/confirm_dialog/confirm_delete_detached_attachments.hbs";
 import render_settings_upload_space_stats from "../templates/settings/upload_space_stats.hbs";
 import render_uploaded_files_list from "../templates/settings/uploaded_files_list.hbs";
 
@@ -107,6 +108,48 @@ function delete_attachments(attachment: string, file_name: string): void {
             dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment, {});
         },
         loading_spinner: true,
+    });
+}
+
+export function suggest_delete_detached_attachments(attachments_list: []): void {
+    const html_body = render_confirm_delete_detached_attachments_modal({
+        attachments_list,
+        realm_allow_edit_history: realm.realm_allow_edit_history,
+    });
+    dialog_widget.launch({
+        id: "confirm_delete_attachments_modal",
+        html_heading: $t_html({defaultMessage: "Delete uploaded files?"}),
+        html_body,
+        html_submit_button: $t_html({defaultMessage: "Delete"}),
+        html_exit_button: $t_html({defaultMessage: "Don't delete"}),
+        loading_spinner: true,
+        on_click() {
+            const delete_attachment = async ({id}: {id: number}): Promise<unknown> =>
+                channel.async_request(channel.del, "/json/attachments/" + id);
+            const requests = attachments_list.map(async (attachment) =>
+                delete_attachment(attachment),
+            );
+
+            dialog_widget.show_dialog_spinner();
+            Promise.all(requests)
+                .then(() => {
+                    dialog_widget.close();
+                })
+                .catch(() => {
+                    dialog_widget.hide_dialog_spinner();
+                    ui_report.error(
+                        $t_html({defaultMessage: "One or more files could not be deleted."}),
+                        undefined,
+                        $("#dialog_error"),
+                    );
+                });
+        },
+    });
+
+    // This is to open "Manage uploaded files" link.
+    $("#confirm_delete_attachments_modal .uploaded_files_settings_link").on("click", (e) => {
+        e.stopPropagation();
+        dialog_widget.close();
     });
 }
 

--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -223,3 +223,23 @@ export function xhr_error_message(message: string, xhr: JQuery.jqXHR<unknown>): 
 
     return message;
 }
+
+export async function async_request(
+    request_method: typeof call,
+    url: string,
+    data: Parameters<AjaxRequestHandler>[0]["data"] = {},
+): Promise<{data: unknown; textStatus: string; jqXHR: JQuery.jqXHR<unknown>}> {
+    return await new Promise((resolve, reject) => {
+        void request_method({
+            url,
+            data,
+            success(data, textStatus, jqXHR) {
+                resolve({data, textStatus, jqXHR});
+            },
+            error(xhr, error_type, xhn) {
+                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                reject({xhr, error_type, xhn});
+            },
+        });
+    });
+}

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -12,6 +12,7 @@ import render_message_moved_widget_body from "../templates/message_moved_widget_
 import render_resolve_topic_time_limit_error_modal from "../templates/resolve_topic_time_limit_error_modal.hbs";
 import render_topic_edit_form from "../templates/topic_edit_form.hbs";
 
+import * as attachments_ui from "./attachments_ui";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_actions from "./compose_actions";
@@ -1054,7 +1055,7 @@ export function save_message_row_edit($row) {
     channel.patch({
         url: "/json/messages/" + message.id,
         data: request,
-        success() {
+        success(res) {
             if (edit_locally_echoed) {
                 delete message.local_edit_timestamp;
                 currently_echoing_messages.delete(message_id);
@@ -1066,6 +1067,9 @@ export function save_message_row_edit($row) {
             // re-renders. Note that any subsequent editing will
             // create a fresh Save button, without the spinner
             // class attached.
+            if (res.detached_files.length) {
+                attachments_ui.suggest_delete_detached_attachments(res.detached_files);
+            }
         },
         error(xhr) {
             if (msg_list === message_lists.current) {

--- a/web/templates/confirm_dialog/confirm_delete_detached_attachments.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_detached_attachments.hbs
@@ -1,0 +1,23 @@
+<div>
+    {{#if realm_allow_edit_history}}
+        {{#tr}}
+            The following <z-link>uploaded files</z-link> are now only accessible via this message's edit history. Would you like to delete them?
+            {{#*inline "z-link"}}<a class="uploaded_files_settings_link" href="/#settings/uploaded-files">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{#tr}}
+            The following <z-link>uploaded files</z-link> are now only accessible via this message's edit history, which is currently disabled in this organization. Would you like to delete them?
+            {{#*inline "z-link"}}<a class="uploaded_files_settings_link" href="/#settings/uploaded-files">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{/if}}
+</div>
+<p>
+    <ul>
+        {{#each attachments_list}}
+            <li>
+                <a href="/user_uploads/{{this.path_id}}" rel="noopener noreferrer" target="_blank">{{this.name}}</a>
+            </li>
+        {{/each}}
+    </ul>
+
+</p>

--- a/web/tests/channel.test.js
+++ b/web/tests/channel.test.js
@@ -430,3 +430,40 @@ test("error in callback", () => {
         },
     });
 });
+
+test("async_request", () => {
+    let response_promise;
+    test_with_mock_ajax({
+        xhr: {
+            data: "hello",
+            status: 200,
+            responseJSON: undefined,
+            responseText: "success",
+        },
+        run_code() {
+            response_promise = channel.async_request(channel.get, "/json/endpoint");
+        },
+
+        check_ajax_options(options) {
+            assert.equal(options.type, "GET");
+            assert.equal(options.dataType, "json");
+            options.simulate_success();
+            response_promise.then((data) => {
+                assert.equal(data.jqXHR.data, "hello");
+                assert.equal(data.jqXHR.responseText, "success");
+            });
+        },
+    });
+    test_with_mock_ajax({
+        xhr: xhr_401,
+        run_code() {
+            response_promise = channel.async_request(channel.get, "/json/endpoint");
+        },
+        check_ajax_options(options) {
+            options.simulate_error();
+            response_promise.catch((error) => {
+                assert.equal(error.xhr.status, 401);
+            });
+        },
+    });
+});

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -402,7 +402,7 @@ def do_update_message(
     rendering_result: Optional[MessageRenderingResult],
     prior_mention_user_ids: Set[int],
     mention_data: Optional[MentionData] = None,
-) -> int:
+) -> Tuple[int, List[Dict[str, Any]]]:
     """
     The main function for message editing.  A message edit event can
     modify:
@@ -442,7 +442,7 @@ def do_update_message(
         event["stream_id"] = stream_being_edited.id
 
     ums = UserMessage.objects.filter(message=target_message.id)
-
+    detached_files: List[Dict[str, Any]] = []
     if content is not None:
         assert rendering_result is not None
 
@@ -481,7 +481,7 @@ def do_update_message(
 
         # target_message.has_image and target_message.has_link will have been
         # already updated by Markdown rendering in the caller.
-        target_message.has_attachment = check_attachment_reference_change(
+        target_message.has_attachment, detached_files = check_attachment_reference_change(
             target_message, rendering_result
         )
 
@@ -1106,7 +1106,7 @@ def do_update_message(
             changed_messages_count,
         )
 
-    return changed_messages_count
+    return changed_messages_count, detached_files
 
 
 def check_time_limit_for_change_all_propagate_mode(
@@ -1211,7 +1211,7 @@ def check_update_message(
     send_notification_to_old_thread: bool = True,
     send_notification_to_new_thread: bool = True,
     content: Optional[str] = None,
-) -> int:
+) -> Tuple[int, List[Dict[str, Any]]]:
     """This will update a message given the message id and user profile.
     It checks whether the user profile has the permission to edit the message
     and raises a JsonableError if otherwise.
@@ -1336,7 +1336,7 @@ def check_update_message(
     ):
         check_time_limit_for_change_all_propagate_mode(message, user_profile, topic_name, stream_id)
 
-    number_changed = do_update_message(
+    number_changed, detached_files = do_update_message(
         user_profile,
         message,
         new_stream,
@@ -1362,4 +1362,4 @@ def check_update_message(
         }
         queue_json_publish("embed_links", event_data)
 
-    return number_changed
+    return number_changed, detached_files

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5916,7 +5916,39 @@ paths:
                 contentType: application/json
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      detached_files:
+                        type: array
+                        description: |
+                          Returns details on all uploaded files whose only references were removed when editing this message. Users should be presented with this list of messages and asked if they want to delete the uploaded files, which would otherwise remain visible only in message edit history.
+                        items:
+                          $ref: "#/components/schemas/Attachments"
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "detached_files":
+                          [
+                            {
+                              "id": 3,
+                              "name": "1253601-1.jpg",
+                              "path_id": "2/5d/BD5NRptFxPDKY3RUKwhhup8r/1253601-1.jpg",
+                              "size": 1339060,
+                              "create_time": 1687984706000,
+                              "messages": [],
+                            },
+                          ],
+                      }
         "400":
           description: Bad request.
           content:
@@ -7920,7 +7952,39 @@ paths:
                 contentType: application/json
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      detached_files:
+                        type: array
+                        description: |
+                          Returns details on all uploaded files whose only references were removed when editing this message. Users should be presented with this list of messages and asked if they want to delete the uploaded files, which would otherwise remain visible only in message edit history.
+                        items:
+                          $ref: "#/components/schemas/Attachments"
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "detached_files":
+                          [
+                            {
+                              "id": 3,
+                              "name": "1253601-1.jpg",
+                              "path_id": "2/5d/BD5NRptFxPDKY3RUKwhhup8r/1253601-1.jpg",
+                              "size": 1339060,
+                              "create_time": 1687984706000,
+                              "messages": [],
+                            },
+                          ],
+                      }
         "400":
           description: Bad request.
           content:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -128,7 +128,7 @@ def update_message_backend(
     send_notification_to_new_thread: Json[bool] = True,
     content: Optional[str] = None,
 ) -> HttpResponse:
-    number_changed = check_update_message(
+    number_changed, detached_files = check_update_message(
         user_profile,
         message_id,
         stream_id,
@@ -143,8 +143,7 @@ def update_message_backend(
     log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
     log_data["extra"] = f"[{number_changed}]"
-
-    return json_success(request)
+    return json_success(request, data={"detached_files": detached_files})
 
 
 def validate_can_delete_message(user_profile: UserProfile, message: Message) -> None:

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -97,7 +97,7 @@ def update_scheduled_message_backend(
     client = RequestNotes.get_notes(request).client
     assert client is not None
 
-    edit_scheduled_message(
+    detached_files = edit_scheduled_message(
         sender,
         client,
         scheduled_message_id,
@@ -108,8 +108,7 @@ def update_scheduled_message_backend(
         deliver_at,
         realm=user_profile.realm,
     )
-
-    return json_success(request)
+    return json_success(request, data={"detached_files": detached_files})
 
 
 @has_request_variables


### PR DESCRIPTION
Complete the unfinished work from https://github.com/zulip/zulip/pull/25764 in May 2023. When a user edits a message, attachments can be removed or changed. When the user hits 'save', if any attachments are removed, a modal will pop up asking the user to delete them.

   -  merge #25764, resolve conflict, fix bugs.
   -  add test cases.

Fixes: https://github.com/zulip/zulip/issues/25525

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


![Screenshot from 2024-05-03 09-38-15](https://github.com/zulip/zulip/assets/73965466/d6b6b7d3-4781-4892-9e04-44bc6e1f335e)
![Screenshot from 2024-05-03 09-38-34](https://github.com/zulip/zulip/assets/73965466/a6d3559f-e60c-4912-8f92-265ba758eb54)

<details>



<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x] Visual appearance of the changes.
- [x ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
