### PR TITLE
invoice_paid_event: Verify invoice before activating fixed-price plan.

### DIFF
--- a/corporate/lib/stripe_event_handler.py
+++ b/corporate/lib/stripe_event_handler.py
@@ -133,7 +133,11 @@ def handle_invoice_paid_event(stripe_invoice: stripe.Invoice, invoice: Invoice) 
             customer, customer.required_plan_tier
         )
 
-    if stripe_invoice.collection_method == "send_invoice" and configured_fixed_price_plan:
+    if (
+        stripe_invoice.collection_method == "send_invoice"
+        and configured_fixed_price_plan
+        and configured_fixed_price_plan.sent_invoice_id == invoice.stripe_invoice_id
+    ):
         billing_session = get_billing_session_for_stripe_webhook(customer, user_id=None)
         remote_server_legacy_plan = billing_session.get_remote_server_legacy_plan(customer)
         assert customer.required_plan_tier is not None


### PR DESCRIPTION
Earlier, we were not verifying that the invoice which got paid is for the fixed-price plan.

That could result in a bug where another support invoice with collection_method = "send_invoice" got paid while a fixed-price plam is already configured. The fixed-price plan would be falsely activated.

This PR is to verifiy the invoice before activating the fixed-price plan.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
