### PR TITLE
typing: Move the typing notifications to below the mark as read banner.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -272,9 +272,11 @@
                         <div id="message-lists-container"></div>
                         <div id="scheduled_message_indicator">
                         </div>
+                        <div id="mark_read_on_scroll_state_banner">
+                        </div>
                         <div id="typing_notifications">
                         </div>
-                        <div id="mark_read_on_scroll_state_banner">
+                        <div id="mark_read_on_scroll_state_banner_place_holder">
                         </div>
                         <div id="bottom_whitespace">
                         </div>

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -23,6 +23,10 @@ export function register_update_unread_counts_hook(f: UpdateUnreadCountsHook): v
     update_unread_counts_hooks.push(f);
 }
 
+function set_mark_read_on_scroll_state_banner(template: string): void {
+    $("#mark_read_on_scroll_state_banner").html(template);
+}
+
 export function update_unread_banner(): void {
     if (message_lists.current === undefined) {
         return;
@@ -34,17 +38,15 @@ export function update_unread_banner(): void {
         user_settings.web_mark_read_on_scroll_policy ===
         web_mark_read_on_scroll_policy_values.never.code
     ) {
-        $("#mark_read_on_scroll_state_banner").html(render_mark_as_read_disabled_banner());
+        set_mark_read_on_scroll_state_banner(render_mark_as_read_disabled_banner());
     } else if (
         user_settings.web_mark_read_on_scroll_policy ===
             web_mark_read_on_scroll_policy_values.conversation_only.code &&
         !is_conversation_view
     ) {
-        $("#mark_read_on_scroll_state_banner").html(
-            render_mark_as_read_only_in_conversation_view(),
-        );
+        set_mark_read_on_scroll_state_banner(render_mark_as_read_only_in_conversation_view());
     } else {
-        $("#mark_read_on_scroll_state_banner").html(render_mark_as_read_turned_off_banner());
+        set_mark_read_on_scroll_state_banner(render_mark_as_read_turned_off_banner());
         if (message_lists.current.can_mark_messages_read_without_setting()) {
             hide_unread_banner();
         }

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -23,8 +23,12 @@ export function register_update_unread_counts_hook(f: UpdateUnreadCountsHook): v
     update_unread_counts_hooks.push(f);
 }
 
-function set_mark_read_on_scroll_state_banner(template: string): void {
-    $("#mark_read_on_scroll_state_banner").html(template);
+function set_mark_read_on_scroll_state_banner(banner_html: string): void {
+    $("#mark_read_on_scroll_state_banner").html(banner_html);
+    // This place holder is essential since hiding the unread banner would reduce
+    // scrollable place, shifting the message list downward if the scrollbar is
+    // at bottom.
+    $("#mark_read_on_scroll_state_banner_place_holder").html(banner_html);
 }
 
 export function update_unread_banner(): void {
@@ -34,6 +38,8 @@ export function update_unread_banner(): void {
 
     const filter = narrow_state.filter();
     const is_conversation_view = filter === undefined ? false : filter.is_conversation_view();
+    toggle_dummy_banner(false);
+
     if (
         user_settings.web_mark_read_on_scroll_policy ===
         web_mark_read_on_scroll_policy_values.never.code
@@ -53,10 +59,14 @@ export function update_unread_banner(): void {
     }
 }
 
+function toggle_dummy_banner(state: boolean): void {
+    $("#mark_read_on_scroll_state_banner_place_holder").toggleClass("hide", !state);
+    $("#mark_read_on_scroll_state_banner_place_holder").toggleClass("invisible", state);
+}
+
 export function hide_unread_banner(): void {
-    // Use visibility instead of hide() to prevent messages on the screen from
-    // shifting vertically.
-    $("#mark_read_on_scroll_state_banner").toggleClass("invisible", true);
+    $("#mark_read_on_scroll_state_banner").toggleClass("hide", true);
+    toggle_dummy_banner(true);
 }
 
 export function reset_unread_banner(): void {
@@ -66,7 +76,8 @@ export function reset_unread_banner(): void {
 
 export function notify_messages_remain_unread(): void {
     if (!user_closed_unread_banner) {
-        $("#mark_read_on_scroll_state_banner").toggleClass("invisible", false);
+        $("#mark_read_on_scroll_state_banner").toggleClass("hide", false);
+        toggle_dummy_banner(false);
     }
 }
 

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -13,6 +13,7 @@
     #message_feed_errors_container,
     #bottom_whitespace,
     #mark_read_on_scroll_state_banner,
+    #mark_read_on_scroll_state_banner_place_holder,
     .trailing_bookend,
     #compose {
         display: none;

--- a/web/styles/typing_notifications.css
+++ b/web/styles/typing_notifications.css
@@ -9,3 +9,10 @@
     list-style: none;
     margin: 0;
 }
+
+#mark_as_read_turned_off_banner {
+    /* override the margin of main-view-banner since it causes
+       more gap than we want between mark as read banner and typing
+       notification.  */
+    margin: 5px 0;
+}


### PR DESCRIPTION
Previously, the typing notifications used to appear between the message list and the mark as read banner in a thread. This would cause the banner to shift down whenever someone starts typing, and shift back up if everyone stops typing.

This frequent bouncing of the banner could be distracting, and hence, is fixed by moving the typing notifications to below the mark as read banner.

<!-- Describe your pull request here.-->

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Typing.20notifications.20cause.20bouncing.20banner/near/1778791)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/97049524/d3784ff5-bd20-41fb-b9fe-512a41e79f8b)<br>
![image](https://github.com/zulip/zulip/assets/97049524/1460a077-dac2-49d3-a8c9-e2636f8e29c6)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
