### PR TITLE
Message Feed: Improve placeholder text for empty unsubscribed stream.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -266,19 +266,23 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                 if (can_toggle_narrowed_stream()) {
                     return {
                         title: $t({
-                            defaultMessage:
-                                "You aren't subscribed to this stream and nobody has talked about that yet!",
+                            defaultMessage: "There are no messages here.",
                         }),
                         // TODO: Consider moving the button to be its own option in the template.
                         html: $t_html(
                             {
-                                defaultMessage: "<z-button>Subscribe</z-button>",
+                                defaultMessage:
+                                    "Why not <z-link>start the conversation</z-link>? <z-button>Subscribe</z-button>",
                             },
                             {
-                                "z-button": (content_html) =>
-                                    `<button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">${content_html.join(
+                                "z-link": (content_html) =>
+                                    `<a href="#" class="empty_feed_compose_stream">${content_html.join(
                                         "",
-                                    )}</button>`,
+                                    )}</a>`,
+                                "z-button": (content_html) =>
+                                    `<div class="sub_button_row new-style"><button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">${content_html.join(
+                                        "",
+                                    )}</button></div>`,
                             },
                         ),
                     };

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1946,6 +1946,7 @@ nav {
 
 .sub_button_row {
     text-align: center;
+    margin-top: 15px;
 }
 
 .small_square_button {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -232,8 +232,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You aren't subscribed to this stream and nobody has talked about that yet!",
-            'translated HTML: <button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">Subscribe</button>',
+            "translated: There are no messages here.",
+            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>? <div class="sub_button_row new-style"><button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">Subscribe</button></div>',
         ),
     );
 


### PR DESCRIPTION
This pr changes the placeholder text along with fixing the style issue of subscribe button in empty unsubscribed streams.

Fixes: #29692.

**Screenshots and screen captures:**
| Before | After | 
| ----- | ----- | 
| ![image](https://github.com/zulip/zulip/assets/91622060/252b4b18-b7fa-4da0-9b9a-eed8f7b14877) | ![image](https://github.com/zulip/zulip/assets/91622060/782f99ef-95c2-483e-ad88-7b7bd1300293) |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
