### PR TITLE
push_notifications: Use ignore_conflicts, over catching IntegrityError.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -26,7 +26,7 @@ import gcm
 import lxml.html
 import orjson
 from django.conf import settings
-from django.db import IntegrityError, transaction
+from django.db import transaction
 from django.db.models import F, Q
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
@@ -687,7 +687,7 @@ def send_notifications_to_bouncer(
 
 def add_push_device_token(
     user_profile: UserProfile, token_str: str, kind: int, ios_app_id: Optional[str] = None
-) -> PushDeviceToken:
+) -> None:
     logger.info(
         "Registering push device: %d %r %d %r", user_profile.id, token_str, kind, ios_app_id
     )
@@ -697,45 +697,42 @@ def add_push_device_token(
     # These can be used to discern whether the user has any mobile
     # devices configured, and is also where we will store encryption
     # keys for mobile push notifications.
-    try:
-        with transaction.atomic():
-            token = PushDeviceToken.objects.create(
+    PushDeviceToken.objects.bulk_create(
+        [
+            PushDeviceToken(
                 user_id=user_profile.id,
-                kind=kind,
                 token=token_str,
+                kind=kind,
                 ios_app_id=ios_app_id,
                 # last_updated is to be renamed to date_created.
                 last_updated=timezone_now(),
-            )
-    except IntegrityError:
-        token = PushDeviceToken.objects.get(
-            user_id=user_profile.id,
-            kind=kind,
-            token=token_str,
-        )
+            ),
+        ],
+        ignore_conflicts=True,
+    )
+
+    if not uses_notification_bouncer():
+        return
 
     # If we're sending things to the push notification bouncer
     # register this user with them here
-    if uses_notification_bouncer():
-        post_data = {
-            "server_uuid": settings.ZULIP_ORG_ID,
-            "user_uuid": str(user_profile.uuid),
-            "realm_uuid": str(user_profile.realm.uuid),
-            # user_id is sent so that the bouncer can delete any pre-existing registrations
-            # for this user+device to avoid duplication upon adding the uuid registration.
-            "user_id": str(user_profile.id),
-            "token": token_str,
-            "token_kind": kind,
-        }
+    post_data = {
+        "server_uuid": settings.ZULIP_ORG_ID,
+        "user_uuid": str(user_profile.uuid),
+        "realm_uuid": str(user_profile.realm.uuid),
+        # user_id is sent so that the bouncer can delete any pre-existing registrations
+        # for this user+device to avoid duplication upon adding the uuid registration.
+        "user_id": str(user_profile.id),
+        "token": token_str,
+        "token_kind": kind,
+    }
 
-        if kind == PushDeviceToken.APNS:
-            post_data["ios_app_id"] = ios_app_id
+    if kind == PushDeviceToken.APNS:
+        post_data["ios_app_id"] = ios_app_id
 
-        logger.info("Sending new push device to bouncer: %r", post_data)
-        # Calls zilencer.views.register_remote_push_device
-        send_to_push_bouncer("POST", "push/register", post_data)
-
-    return token
+    logger.info("Sending new push device to bouncer: %r", post_data)
+    # Calls zilencer.views.register_remote_push_device
+    send_to_push_bouncer("POST", "push/register", post_data)
 
 
 def remove_push_device_token(user_profile: UserProfile, token_str: str, kind: int) -> None:

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -260,9 +260,9 @@ def register_remote_push_device(
             remote_realm.last_request_datetime = timezone_now()
             remote_realm.save(update_fields=["last_request_datetime"])
 
-    try:
-        with transaction.atomic():
-            RemotePushDeviceToken.objects.create(
+    RemotePushDeviceToken.objects.bulk_create(
+        [
+            RemotePushDeviceToken(
                 server=server,
                 kind=token_kind,
                 token=token,
@@ -270,9 +270,10 @@ def register_remote_push_device(
                 # last_updated is to be renamed to date_created.
                 last_updated=timezone_now(),
                 **kwargs,
-            )
-    except IntegrityError:
-        pass
+            ),
+        ],
+        ignore_conflicts=True,
+    )
 
     return json_success(request)
 

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -745,7 +745,7 @@ def batch_create_table_data(
     row_objects: List[ModelT],
 ) -> None:
     # We ignore previously-existing data, in case it was truncated and
-    # re-created on the remote server.  `ignore_concflicts=True`
+    # re-created on the remote server.  `ignore_conflicts=True`
     # cannot return the ids, or count thereof, of the new inserts,
     # (see https://code.djangoproject.com/ticket/0138) so we rely on
     # having a lock to accurately count them before and after.  This


### PR DESCRIPTION
The IntegrityError shows up in the database logs, which looks unnecessarily concerning.  Use `ON CONFLICT IGNORE` to mark this as expected, especially since the return value is never used.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
