### PR TITLE
pg_backup_and_purge: Properly preserve needed base backups.

### DIFF
--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -73,7 +73,14 @@ for line in lines[1:]:
 one_month_ago = now - timedelta(days=30)
 for date in sorted(backups.keys(), reverse=True):
     if date < one_month_ago:
-        subprocess.check_call(["env-wal-g", "delete", "--confirm", "before", backups[date]])
+        # We pass `FIND_FULL` such that if delta backups are being
+        # used, we keep the prior FULL backup and all of the deltas
+        # that we need.  In practice, this means that if we're doing
+        # weekly full backups (`backups_incremental = 6`), we only
+        # delete any data once a week.
+        subprocess.check_call(
+            ["env-wal-g", "delete", "--confirm", "before", "FIND_FULL", backups[date]]
+        )
         # Because we're going from most recent to least recent, we
         # only have to do one delete operation
         break


### PR DESCRIPTION
Without `FIND_FULL`, `wal_g delete before ...` will fail, rather than delete a base backup which is needed by the delta backups after it. By passing `FIND_FULL`[^1], we tell it explicitly that we're OK preserving files before the specified one, as long as they are necessary for the delta chain.

[^1]: https://github.com/wal-g/wal-g/blob/master/docs/README.md#delete

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
