### PR TITLE
messages: Remove use of @overload in access_message.

### DIFF
--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -4,7 +4,7 @@ from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
 from zerver.lib.exceptions import ReactionExistsError
 from zerver.lib.message import (
-    access_message,
+    access_message_and_usermessage,
     set_visibility_policy_possible,
     should_change_visibility_policy,
     visibility_policy_for_participation,
@@ -126,8 +126,8 @@ def check_add_reaction(
     emoji_code: Optional[str],
     reaction_type: Optional[str],
 ) -> None:
-    message, has_user_message = access_message(
-        user_profile, message_id, lock_message=True, get_user_message="exists"
+    message, user_message = access_message_and_usermessage(
+        user_profile, message_id, lock_message=True
     )
 
     if emoji_code is None or reaction_type is None:
@@ -181,7 +181,7 @@ def check_add_reaction(
         # realm emoji).
         check_emoji_request(user_profile.realm, emoji_name, emoji_code, reaction_type)
 
-    if not has_user_message:
+    if user_message is None:
         # See called function for more context.
         create_historical_user_messages(user_id=user_profile.id, message_ids=[message.id])
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -42,7 +42,7 @@ from zerver.lib.avatar import absolute_avatar_url, get_avatar_for_inaccessible_u
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.emoji_utils import hex_codepoint_to_emoji
 from zerver.lib.exceptions import ErrorCode, JsonableError
-from zerver.lib.message import access_message, huddle_users
+from zerver.lib.message import access_message_and_usermessage, huddle_users
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.remote_server import (
     send_json_to_push_bouncer,
@@ -1292,11 +1292,8 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
 
     with transaction.atomic(savepoint=False):
         try:
-            (message, user_message) = access_message(
-                user_profile,
-                missed_message["message_id"],
-                lock_message=True,
-                get_user_message="object",
+            (message, user_message) = access_message_and_usermessage(
+                user_profile, missed_message["message_id"], lock_message=True
             )
         except JsonableError:
             if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -14,7 +14,12 @@ from zerver.actions.message_edit import check_update_message
 from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
-from zerver.lib.message import access_message, access_web_public_message, messages_for_ids
+from zerver.lib.message import (
+    access_message,
+    access_message_and_usermessage,
+    access_web_public_message,
+    messages_for_ids,
+)
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -197,9 +202,7 @@ def json_fetch_raw_message(
         message = access_web_public_message(realm, message_id)
         user_profile = None
     else:
-        (message, user_message) = access_message(
-            maybe_user_profile, message_id, get_user_message="object"
-        )
+        (message, user_message) = access_message_and_usermessage(maybe_user_profile, message_id)
         user_profile = maybe_user_profile
 
     flags = ["read"]


### PR DESCRIPTION
f92d43c6908e added uses of `@overload` to probide multiple type signatures for `access_message`, based on the `get_user_message` parameter.  Unfortunately, mypy does not check the function body against overload signatures, so it allows type errors to go undetected.

Replace the overloads with two functions, for one of which also returns the usermessage.  The third form, of only returning if the usermessage exists, is not in a high-enough performance endpoint that a third form is worth maintaining; it uses the usermessage form.

Fixes: https://github.com/zulip/zulip/pull/29409#discussion_r1536029108

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
