### PR TITLE
markdown: Modernize presentation of spoiler headers.

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -270,7 +270,7 @@ export const update_elements = ($content: JQuery): void => {
         // Add the expand/collapse button to spoiler blocks
         const toggle_button_html =
             '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
-        $(this).prepend($(toggle_button_html));
+        $(this).append($(toggle_button_html));
     });
 
     // Display the view-code-in-playground and the copy-to-clipboard button inside the div.codehilite element,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -252,8 +252,23 @@
         margin: 5px 0 15px;
 
         .spoiler-header {
-            padding: 5px;
+            /* We use flexbox to display the spoiler message
+               and button. */
+            display: flex;
+            align-items: center;
+            padding: 8px 5px;
             font-weight: bold;
+
+            > p {
+                /* Disallow margin from ordinary rendered-markdown
+                   paragraphs. The header's vertical space is handled
+                   independently by padding on .spoiler-header. */
+                margin: 0;
+                /* Message grows to push the arrow to the right,
+                   but shrinks so as to allow long multi-line
+                   spoiler messages to wrap. */
+                flex: 1 1 auto;
+            }
         }
 
         .spoiler-content {
@@ -278,9 +293,8 @@
         }
 
         .spoiler-button {
-            float: right;
-            width: 25px;
-            height: 25px;
+            /* Keep the button to a consistent right-hand edge. */
+            padding-right: 3px;
 
             &:hover .spoiler-arrow {
                 &::before,
@@ -292,15 +306,9 @@
 
         .spoiler-arrow {
             float: right;
-            width: 13px;
-            height: 13px;
-            position: relative;
-            bottom: -5px;
-            left: -10px;
+            width: 15px;
             cursor: pointer;
             transition: 0.4s ease;
-            margin-top: 2px;
-            text-align: left;
             transform: rotate(45deg);
 
             &::before,

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -490,9 +490,9 @@ run_test("spoiler-header", () => {
     const $content = get_content_element();
     const $header = $.create("div.spoiler-header");
     $content.set_find_results("div.spoiler-header", $array([$header]));
-    let $prepended;
-    $header.prepend = ($element) => {
-        $prepended = $element;
+    let $appended;
+    $header.append = ($element) => {
+        $appended = $element;
     };
 
     // Test that the show/hide button gets added to a spoiler header.
@@ -502,7 +502,7 @@ run_test("spoiler-header", () => {
     $header.html(label);
     rm.update_elements($content);
     assert.equal(label, $header.html());
-    assert.equal($prepended.selector, toggle_button_html);
+    assert.equal($appended.selector, toggle_button_html);
 });
 
 run_test("spoiler-header-empty-fill", () => {
@@ -510,13 +510,9 @@ run_test("spoiler-header-empty-fill", () => {
     const $content = get_content_element();
     const $header = $.create("div.spoiler-header");
     $content.set_find_results("div.spoiler-header", $array([$header]));
-    let $appended;
+    const $appended = [];
     $header.append = ($element) => {
-        $appended = $element;
-    };
-    let $prepended;
-    $header.prepend = ($element) => {
-        $prepended = $element;
+        $appended.push($element);
     };
 
     // Test that an empty header gets the default text applied (through i18n filter).
@@ -524,9 +520,9 @@ run_test("spoiler-header-empty-fill", () => {
         '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
     $header.empty();
     rm.update_elements($content);
-    assert.equal($appended.selector, "<p>");
-    assert.equal($appended.text(), $t({defaultMessage: "Spoiler"}));
-    assert.equal($prepended.selector, toggle_button_html);
+    assert.equal($appended[0].selector, "<p>");
+    assert.equal($appended[0].text(), $t({defaultMessage: "Spoiler"}));
+    assert.equal($appended[1].selector, toggle_button_html);
 });
 
 function assert_clipboard_setup() {


### PR DESCRIPTION
This PR decouples the spoiler header from rendered-markdown styles, and modernizes the structure and layout of the arrow in spoiler headers.

The only visual changes are to better and more robustly lay out and vertically center the spoiler-header arrows, with a design change on multi-line rows to center the vertically center the arrow within the box.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/arrows.20on.20spoiler.20headers/near/1779476)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![spoilers-before](https://github.com/zulip/zulip/assets/170719/147519ce-7023-47b3-8d7f-d10da557586c) | ![spoilers-after](https://github.com/zulip/zulip/assets/170719/5b634fd3-3589-4f24-9ede-6bcdee56d3cb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>