### PR TITLE
portico: Update text on home page.

### DIFF
--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -85,9 +85,14 @@
         <div class="screen-2">
             <div class="screen-2__container">
                 <div class="screen-2__content">
-                    <h2 class="screen-2__header">Efficient communication.</h2>
+                    <h2 class="screen-2__header">What makes Zulip different</h2>
                     <div class="screen-2__desc">
-                        Unlike other chat apps, Zulip lets you read and respond to&nbsp;every message <em>in&nbsp;context</em>, no&nbsp;matter when it&nbsp;was sent. Maintain your <em>focus</em> and catch up&nbsp;on&nbsp;your own time <em>without stress</em>, reading just the&nbsp;topics <em>you care about</em>.
+                        <p>
+                            People often tell us that traditional team chat tools (Slack, Microsoft Teams, etc.) feel chaotic and stressful.
+                        </p>
+                        <p>
+                            Zulip is designed around <strong>conversations</strong> that are labeled with topics, to make communication feel <a href="/why-zulip/">organized and efficient</a>. It’s easy to get an overview of what conversations are happening, and to read one conversation at a time.
+                        </p>
                     </div>
                     <div class="quote">
                         <div class="quote__text">
@@ -145,7 +150,7 @@
         <div class="screen-3">
             <div class="screen-3__container">
                 <div class="screen-3__content">
-                    <h2 class="screen-3__header">Collaboration at scale.</h2>
+                    <h2 class="screen-3__header">Collaboration at scale</h2>
                     <div class="screen-3__desc">
                         Zulip helps teams of&nbsp;all sizes be <em>more productive</em> together, from a&nbsp;few friends hacking on&nbsp;a&nbsp;new idea, to&nbsp;<em>globally distributed</em> organizations with hundreds of&nbsp;people tackling the world&rsquo;s hardest problems.
                     </div>
@@ -207,7 +212,7 @@
         <div class="screen-4">
             <div class="screen-4__container">
                 <div class="screen-4__content">
-                    <h2 class="screen-4__header">Enterprise ready.</h2>
+                    <h2 class="screen-4__header">Enterprise ready</h2>
                     <div class="screen-4__desc">
                         <p>
                             Take charge of&nbsp;your mission-critical communications with Zulip&rsquo;s reliable <a href="/for/open-source/">100% free and open-source software</a>, with no&nbsp;vendor lock-in. You can count on&nbsp;our industry-leading <a href="/security/">security practices</a> to&nbsp;keep your data safe.


### PR DESCRIPTION
Notes:
- I tried different widths, and didn't feel the need to use `&nbsp;` anywhere.
- We should make the link to /why-zulip show up with the same formatting as links in the Enterprise section, as a blocker to deploying this. @amanagr it would be great to get a follow-up PR for that.
- Other formatting improvements can happen as part of a broader redesign for this page.

![CleanShot 2024-04-12 at 13 11 03](https://github.com/zulip/zulip/assets/2090066/fad999a4-414c-4d9f-8d4c-6a75c360bbf4)


