### PR TITLE
Add early-exit to click handlers when shift is pressed

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -464,7 +464,7 @@ export function initialize() {
     }
 
     $("#message_feed_container").on("click", ".narrows_by_recipient", function (e) {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
         e.preventDefault();
@@ -473,7 +473,7 @@ export function initialize() {
     });
 
     $("#message_feed_container").on("click", ".narrows_by_topic", function (e) {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
         e.preventDefault();
@@ -483,7 +483,7 @@ export function initialize() {
 
     // SIDEBARS
     $(".buddy-list-section").on("click", ".selectable_sidebar_block", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
 
@@ -845,7 +845,7 @@ export function initialize() {
     });
 
     $("body").on("click", "#header-container .brand", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
 

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -1307,7 +1307,7 @@ export function initialize() {
     });
 
     $("body").on("click", "#inbox-list .inbox-left-part-wrapper", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -1548,7 +1548,7 @@ export function initialize({
     });
 
     $("body").on("click", "td.recent_topic_stream", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
 
@@ -1559,7 +1559,7 @@ export function initialize({
     });
 
     $("body").on("click", "td.recent_topic_name", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -823,7 +823,7 @@ export function set_event_handlers({
     on_stream_click: (stream_id: number, trigger: string) => void;
 }): void {
     $("#stream_filters").on("click", "li .subscription_block", (e) => {
-        if (e.metaKey || e.ctrlKey) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
         }
         const stream_id = stream_id_for_elt($(e.target).parents("li"));

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -339,7 +339,7 @@ export function initialize({
         "click",
         ".sidebar-topic-check, .topic-name, .topic-markers-and-controls",
         (e) => {
-            if (e.metaKey || e.ctrlKey) {
+            if (e.metaKey || e.ctrlKey || e.shiftKey) {
                 return;
             }
             if ($(e.target).closest(".show-more-topics").length > 0) {


### PR DESCRIPTION
See #17935.

This is because shift-clicking a link on most browsers should open the link in a new window, not navigate inside the current tab. Right now Zulip early-exits in various click handlers when ctrl is pressed to support "ctrl-click opens new tab". This simply adds shift to the same code.

I checked every element whose handler I was modifying to check that they did have link semantics and shift-clicking them made sense.

## Further work

Looking at the `initialize` function in `topic_list.ts`:

https://github.com/zulip/zulip/blob/e7a19aca757820fe53f896ab15ad4128bf94838a/web/src/topic_list.ts#L333-L344

I'm not sure the early-exit is enough. I suspect `.sidebar-topic-check` and `.topic-markers-and-controls` should be turned into `<a>` links inside the template code. I might open an issue or a follow-up PR.