### PR TITLE
pronoun-settings: Use tippy instead of bootstrap for typeaheads.

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -57,6 +57,7 @@ import "../../styles/user_status.css";
 import "../../styles/widgets.css";
 import "../../styles/print.css";
 import "../../styles/inbox.css";
+import "../../styles/tippy_typeahead.css";
 
 // This should be last.
 import "../ui_init";

--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -2,12 +2,11 @@ import $ from "jquery";
 
 import render_settings_custom_user_profile_field from "../templates/settings/custom_user_profile_field.hbs";
 
-import * as bootstrap_typeahead from "./bootstrap_typeahead";
 import {$t} from "./i18n";
 import * as people from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import {realm} from "./state_data";
-import * as typeahead_helper from "./typeahead_helper";
+import * as tippy_typeahead from "./tippy_typeahead";
 import * as user_pill from "./user_pill";
 
 export function append_custom_profile_fields(element_id, user_id) {
@@ -165,22 +164,7 @@ export function initialize_custom_pronouns_type_fields(element_id) {
         $t({defaultMessage: "she/her"}),
         $t({defaultMessage: "they/them"}),
     ];
-    const bootstrap_typeahead_input = {
-        $element: $(element_id).find(".pronouns_type_field"),
-        type: "input",
-    };
-    bootstrap_typeahead.create(bootstrap_typeahead_input, {
-        items: 3,
-        fixed: true,
-        helpOnEmptyStrings: true,
-        source() {
-            return commonly_used_pronouns;
-        },
-        sorter(items, query) {
-            return bootstrap_typeahead.defaultSorter(items, query);
-        },
-        highlighter_html(item) {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
-    });
+
+    const $pronouns_type_field = $(element_id).find(".pronouns_type_field");
+    tippy_typeahead.initTippyTypeahead($pronouns_type_field, commonly_used_pronouns, "bottom-end");
 }

--- a/web/src/tippy_typeahead.ts
+++ b/web/src/tippy_typeahead.ts
@@ -1,0 +1,60 @@
+import $ from "jquery";
+import tippy from "tippy.js";
+
+import {parse_html} from "./ui_util";
+
+export function initTippyTypeahead(
+    $element: JQuery<HTMLInputElement>,
+    suggestions: string[],
+    placement:
+        | "top"
+        | "bottom"
+        | "left"
+        | "right"
+        | "top-start"
+        | "bottom-start"
+        | "top-end"
+        | "bottom-end" = "bottom-start",
+): void {
+    // Initialize tippy for typeahead
+    const matches = suggestions.filter((item) =>
+        item.toLowerCase().includes($element.val()!.toLowerCase()),
+    );
+    const tooltip = tippy($element.get(0)!, {
+        content: parse_html(
+            "<div>" +
+                matches
+                    .map((match) => `<div class="tippy-typeahead-suggestion">${match}</div>`)
+                    .join("") +
+                "</div>",
+        ),
+        trigger: "focus",
+        placement,
+        arrow: false,
+        interactive: true,
+    });
+
+    $element.on("focus", () => {
+        tooltip.show();
+    });
+
+    $element.on("input", function () {
+        const query = $(this).val()!.toLowerCase();
+        const matches = suggestions.filter((item) => item.toLowerCase().includes(query));
+        if (matches.length > 0) {
+            const tooltipContent = matches
+                .map((match) => `<div class="tippy-typeahead-suggestion">${match}</div>`)
+                .join("");
+            tooltip.setContent(parse_html("<div>" + tooltipContent + "</div>"));
+            tooltip.show();
+        } else {
+            tooltip.hide();
+        }
+    });
+
+    $element.parent().on("click", ".tippy-typeahead-suggestion", function () {
+        const suggestion = $(this).text();
+        $element.val(suggestion);
+        tooltip.hide();
+    });
+}

--- a/web/styles/tippy_typeahead.css
+++ b/web/styles/tippy_typeahead.css
@@ -1,0 +1,9 @@
+.tippy-typeahead-suggestion:hover {
+    background-color: hsl(200deg 100% 50%);
+    color: hsl(0deg 0% 100%);
+    cursor: pointer;
+}
+
+.tippy-typeahead-suggestion {
+    padding: 0.15rem;
+}

--- a/web/tests/tippy_typeahead.test.js
+++ b/web/tests/tippy_typeahead.test.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const tippy = require("tippy.js");
+
+const {mock_esm, zrequire} = require("./lib/namespace");
+const {make_stub} = require("./lib/stub");
+const {run_test} = require("./lib/test");
+const $ = require("./lib/zjquery");
+
+const tippy_typeahead = zrequire("tippy_typeahead");
+
+run_test("initialize_tippy_typehead_test", ({override}) => {
+    const commonly_used_pronouns = ["he/him", "she/her", "they/them"];
+    let tippy_show_called;
+    let tippy_hide_called;
+
+    let my_content;
+    override(tippy, "default", (element, options) => {
+        assert.ok(element);
+        assert.equal(options.content, my_content);
+        return {
+            setContent(c) {
+                assert.equal(c, my_content);
+            },
+            show() {
+                tippy_show_called = true;
+            },
+            hide() {
+                tippy_hide_called = true;
+            },
+        };
+    });
+    const ui_util = mock_esm("../src/ui_util");
+    ui_util.parse_html = (html) => html;
+
+    const $pronouns_type_field = $.create(".pronouns_type_field");
+    const $pronouns_type_field_parent = $.create(".pronouns_type_field_parent");
+    const $tippy_typeahead_suggestion = $.create(".tippy-typeahead-suggestion");
+    $tippy_typeahead_suggestion.text = () => "he/him";
+
+    const stub = make_stub();
+    $pronouns_type_field.get = stub.f;
+
+    $pronouns_type_field_parent.on = (action, selector, defined_fn) => {
+        if (action === "click" && selector === ".tippy-typeahead-suggestion") {
+            $tippy_typeahead_suggestion.on("click", defined_fn);
+        }
+    };
+
+    $pronouns_type_field.parent = () => $pronouns_type_field_parent;
+
+    my_content =
+        "<div>" +
+        commonly_used_pronouns
+            .map((match) => `<div class="tippy-typeahead-suggestion">${match}</div>`)
+            .join("") +
+        "</div>";
+    tippy_typeahead.initTippyTypeahead($pronouns_type_field, commonly_used_pronouns);
+    $pronouns_type_field.trigger("focus");
+    assert.ok(tippy_show_called);
+
+    $pronouns_type_field.val("unknown pronoun");
+    $pronouns_type_field.trigger("input");
+    assert.ok(tippy_hide_called);
+
+    tippy_show_called = false;
+    my_content = `<div><div class="tippy-typeahead-suggestion">he/him</div></div>`;
+    $pronouns_type_field.val("he/him");
+    $pronouns_type_field.trigger("input");
+    assert.ok(tippy_show_called);
+
+    tippy_hide_called = false;
+    $tippy_typeahead_suggestion.trigger("click");
+    assert.equal($pronouns_type_field.val(), "he/him");
+    assert.ok(tippy_hide_called);
+});


### PR DESCRIPTION
Create tippy_typeahead module.
Use tippy_typeahead instead of bootstrap_typeahead for the pronouns input field in user settings.

Fixes #29303.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/29176437/fa06649c-7bd5-4ab4-87f7-eab48de3ec69)

https://github.com/zulip/zulip/assets/29176437/26c7231d-f193-4e20-8eee-74723f968fda




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
