### PR TITLE
api-docs: Bump API version for addition of channel/channels operators.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,7 +58,7 @@ operator is an alias for the `streams` operator. Both `channel` and
 `channels` return the same exact results as `stream` and `streams`
 respectively.
 
-**Changes**: In Zulip 9.0 (feature level 249), narrows gained support
+In Zulip 9.0 (feature level 249), narrows gained support
 for a new filter `has:reaction`. This allows clients to retrieve only
 messages that have at least one reaction.
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 249
+API_FEATURE_LEVEL = 250
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump


### PR DESCRIPTION
In commit 32d5b4fe3ea, the channel and channels operators were documented in the API docs. This bumps the API version to match those changes.

Also, cleans up one **Changes** note from the same commit noted above in the documentation for constructing narrows.

Follow-up to #29663.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
