### PR TITLE
add-reaction: Update reaction data in cache.

### DIFF
--- a/web/src/message_helper.js
+++ b/web/src/message_helper.js
@@ -3,6 +3,7 @@ import * as message_store from "./message_store";
 import * as message_user_ids from "./message_user_ids";
 import * as people from "./people";
 import * as pm_conversations from "./pm_conversations";
+import * as reactions from "./reactions";
 import * as recent_senders from "./recent_senders";
 import * as stream_topic_history from "./stream_topic_history";
 import * as user_status from "./user_status";
@@ -23,8 +24,16 @@ export function process_new_message(message) {
         return cached_msg;
     }
 
+    if (!message.reactions) {
+        message.reactions = [];
+    }
+
     message_store.set_message_booleans(message);
     message.sent_by_me = people.is_current_user(message.sender_email);
+
+    // Cleaning message_reactions during initial message processing
+    // to avoid message_reactions being undefined during rendering
+    message.message_reactions = reactions.get_message_reactions(message);
 
     people.extract_people_from_message(message);
     people.maybe_incr_recipient_count(message);
@@ -74,9 +83,7 @@ export function process_new_message(message) {
     }
 
     alert_words.process_message(message);
-    if (!message.reactions) {
-        message.reactions = [];
-    }
+
     message_store.update_message_cache(message);
     return message;
 }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -26,7 +26,6 @@ import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as popovers from "./popovers";
-import * as reactions from "./reactions";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
 import * as sidebar_ui from "./sidebar_ui";
@@ -525,8 +524,6 @@ export class MessageListView {
         };
 
         for (const message_container of message_containers) {
-            const message_reactions = reactions.get_message_reactions(message_container.msg);
-            message_container.msg.message_reactions = message_reactions;
             message_container.include_recipient = false;
 
             if (
@@ -778,8 +775,6 @@ export class MessageListView {
     }
 
     _get_message_template(message_container) {
-        const msg_reactions = reactions.get_message_reactions(message_container.msg);
-        message_container.msg.message_reactions = msg_reactions;
         const msg_to_render = {
             ...message_container,
             message_list_id: this.list.id,

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -678,7 +678,7 @@ export function update_vote_text_on_message(message: Message): void {
     // users depends on total reactions on the message, we need to
     // recalculate this whenever adjusting reaction rendering on a
     // message.
-    set_clean_reactions(message);
+    message.message_reactions = get_message_reactions(message);
     const reaction_counts_and_user_ids = get_reaction_counts_and_user_ids(message);
     const should_display_reactors = check_should_display_reactors(reaction_counts_and_user_ids);
     for (const [reaction, clean_reaction] of message.clean_reactions.entries()) {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -147,6 +147,8 @@ people.add_active_user(me);
 people.add_active_user(test_user);
 people.initialize_current_user(me.user_id);
 
+// process_new_messages calls get_message_reactions, so we need to stub it.
+reactions.get_message_reactions = (message) => message.reactions;
 message_helper.process_new_message(test_message);
 
 const realm_emoji = {};

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -124,6 +124,7 @@ run_test("update_messages", () => {
         {
             alerted: false,
             collapsed: false,
+            clean_reactions: new Map(),
             content: "<b>new content</b>",
             display_recipient: denmark.name,
             historical: false,
@@ -134,8 +135,8 @@ run_test("update_messages", () => {
             stream_wildcard_mentioned: false,
             topic_wildcard_mentioned: false,
             mentioned_me_directly: false,
+            message_reactions: [],
             raw_content: "**new content**",
-            reactions: [],
             reply_to: alice.email,
             sender_email: alice.email,
             sender_full_name: alice.full_name,

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -528,6 +528,36 @@ test("update_vote_text_on_message", ({override_rewire}) => {
             }),
         ),
         id: 1001,
+        message_reactions: [
+            {
+                class: "message_reaction reacted",
+                count: 2,
+                emoji_alt_code: false,
+                emoji_code: "1f44b",
+                emoji_name: "wave",
+                is_realm_emoji: false,
+                label: "translated: You (click to remove) and Bob van Roberts reacted with :wave:",
+                local_id: "unicode_emoji,1f44b",
+                reaction_type: "unicode_emoji",
+                user_ids: [5, 6],
+                vote_text: "translated: You, Bob van Roberts",
+            },
+            {
+                class: "message_reaction reacted",
+                count: 1,
+                emoji_alt_code: false,
+                emoji_code: "992",
+                emoji_name: "inactive_realm_emoji",
+                is_realm_emoji: true,
+                label: "translated: You (click to remove) reacted with :inactive_realm_emoji:",
+                local_id: "realm_emoji,992",
+                reaction_type: "realm_emoji",
+                still_url: "/still/url/for/992",
+                url: "/url/for/992",
+                user_ids: [5],
+                vote_text: "translated: You",
+            },
+        ],
     };
     // message.reactions is deleted too.
     assert.deepEqual(message, updated_message);


### PR DESCRIPTION
Updates the reaction data in the cache after a new reaction
has been added or existing reaction has been modified.
Earlier only clean_reactions was being updated, as a result we were left
with a stale message_reactions in the cache.

This does not seem intentional.
Earlier this wasn't noticed as `message_reactions` was being set each time the `message_list_view` was being rendered.

This was changed in [clean reaction during initial processing](https://github.com/zulip/zulip/commit/c22a94dc89e6db3662ec7f2d2a00d35406144cbd).

[CZO Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/emoji.20reaction.20vanishes)
