### PR TITLE
upload: Only load S3 backend (and thus boto3) if necessary.

### DIFF
--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -12,8 +12,6 @@ from django.utils.translation import gettext as _
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.upload.base import ZulipUploadBackend
-from zerver.lib.upload.local import LocalUploadBackend
-from zerver.lib.upload.s3 import S3UploadBackend
 from zerver.models import Attachment, Message, Realm, RealmEmoji, ScheduledMessage, UserProfile
 
 
@@ -53,9 +51,13 @@ def get_file_info(user_file: UploadedFile) -> Tuple[str, str]:
 
 # Common and wrappers
 if settings.LOCAL_UPLOADS_DIR is not None:
+    from zerver.lib.upload.local import LocalUploadBackend
+
     upload_backend: ZulipUploadBackend = LocalUploadBackend()
-else:
-    upload_backend = S3UploadBackend()  # nocoverage
+else:  # nocoverage
+    from zerver.lib.upload.s3 import S3UploadBackend
+
+    upload_backend = S3UploadBackend()
 
 # Message attachment uploads
 


### PR DESCRIPTION
Because loading boto3 is so slow, this saves a significant amount of time (0.3s or so) in process startup on servers which are not using the S3 file storage backend.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
