### PR TITLE
topic: Move sqlalchemy methods into their own file.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -13,6 +13,7 @@ from zulint.custom_rules import Rule, RuleList
 FILES_WITH_LEGACY_SUBJECT = {
     # This basically requires a big DB migration:
     "zerver/lib/topic.py",
+    "zerver/lib/topic_sqlalchemy.py",
     # This is for backward compatibility.
     "zerver/tests/test_legacy_subject.py",
     # Other migration-related changes require extreme care.

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -38,8 +38,8 @@ from zerver.lib.message import (
     remove_message_id_from_unread_mgs,
 )
 from zerver.lib.muted_users import get_user_mutes
-from zerver.lib.narrow import check_narrow_for_events, read_stop_words
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NarrowTerm, read_stop_words
+from zerver.lib.narrow_predicate import check_narrow_for_events
 from zerver.lib.presence import get_presence_for_user, get_presences_for_realm
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.realm_logo import get_realm_logo_source, get_realm_logo_url

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1,16 +1,13 @@
-import os
 import re
 from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
-    Collection,
     Dict,
     Generic,
     Iterable,
     List,
     Optional,
-    Protocol,
     Sequence,
     Set,
     Tuple,
@@ -48,7 +45,7 @@ from typing_extensions import TypeAlias, override
 from zerver.lib.addressee import get_user_profiles, get_user_profiles_by_ids
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.message import get_first_visible_message_id
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_predicate import channel_operators, channels_operators
 from zerver.lib.recipient_users import recipient_for_user_profiles
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
@@ -58,7 +55,6 @@ from zerver.lib.streams import (
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
 )
-from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
 from zerver.lib.topic_sqlalchemy import (
     get_resolved_topic_condition_sa,
     topic_column_sa,
@@ -80,34 +76,6 @@ from zerver.models.users import (
     get_user_by_id_in_realm_including_cross_realm,
     get_user_including_cross_realm,
 )
-
-stop_words_list: Optional[List[str]] = None
-
-
-def read_stop_words() -> List[str]:
-    global stop_words_list
-    if stop_words_list is None:
-        file_path = os.path.join(
-            settings.DEPLOY_ROOT, "puppet/zulip/files/postgresql/zulip_english.stop"
-        )
-        with open(file_path) as f:
-            stop_words_list = f.read().splitlines()
-
-    return stop_words_list
-
-
-# "stream" is a legacy alias for "channel"
-channel_operators: List[str] = ["channel", "stream"]
-# "streams" is a legacy alias for "channels"
-channels_operators: List[str] = ["channels", "streams"]
-
-
-def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
-    supported_operators = [*channel_operators, "topic", "sender", "is"]
-    for narrow_term in narrow:
-        operator = narrow_term.operator
-        if operator not in supported_operators:
-            raise JsonableError(_("Operator {operator} not supported.").format(operator=operator))
 
 
 def is_spectator_compatible(narrow: Iterable[Dict[str, Any]]) -> bool:
@@ -144,64 +112,6 @@ def is_web_public_narrow(narrow: Optional[Iterable[Dict[str, Any]]]) -> bool:
         and term["negated"] is False
         for term in narrow
     )
-
-
-class NarrowPredicate(Protocol):
-    def __call__(self, *, message: Dict[str, Any], flags: List[str]) -> bool: ...
-
-
-def build_narrow_predicate(
-    narrow: Collection[NarrowTerm],
-) -> NarrowPredicate:
-    """Changes to this function should come with corresponding changes to
-    NarrowLibraryTest."""
-    check_narrow_for_events(narrow)
-
-    def narrow_predicate(*, message: Dict[str, Any], flags: List[str]) -> bool:
-        def satisfies_operator(*, operator: str, operand: str) -> bool:
-            if operator in channel_operators:
-                if message["type"] != "stream":
-                    return False
-                if operand.lower() != message["display_recipient"].lower():
-                    return False
-            elif operator == "topic":
-                if message["type"] != "stream":
-                    return False
-                topic_name = get_topic_from_message_info(message)
-                if operand.lower() != topic_name.lower():
-                    return False
-            elif operator == "sender":
-                if operand.lower() != message["sender_email"].lower():
-                    return False
-            elif operator == "is" and operand in ["dm", "private"]:
-                # "is:private" is a legacy alias for "is:dm"
-                if message["type"] != "private":
-                    return False
-            elif operator == "is" and operand in ["starred"]:
-                if operand not in flags:
-                    return False
-            elif operator == "is" and operand == "unread":
-                if "read" in flags:
-                    return False
-            elif operator == "is" and operand in ["alerted", "mentioned"]:
-                if "mentioned" not in flags:
-                    return False
-            elif operator == "is" and operand == "resolved":
-                if message["type"] != "stream":
-                    return False
-                topic_name = get_topic_from_message_info(message)
-                if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
-                    return False
-            return True
-
-        for narrow_term in narrow:
-            # TODO: Eventually handle negated narrow terms.
-            if not satisfies_operator(operator=narrow_term.operator, operand=narrow_term.operand):
-                return False
-
-        return True
-
-    return narrow_predicate
 
 
 LARGER_THAN_MAX_MESSAGE_ID = 10000000000000000

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -58,10 +58,9 @@ from zerver.lib.streams import (
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
 )
-from zerver.lib.topic import (
-    RESOLVED_TOPIC_PREFIX,
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+from zerver.lib.topic_sqlalchemy import (
     get_resolved_topic_condition_sa,
-    get_topic_from_message_info,
     topic_column_sa,
     topic_match_sa,
 )

--- a/zerver/lib/narrow_helpers.py
+++ b/zerver/lib/narrow_helpers.py
@@ -18,8 +18,11 @@ from users:
     specification internally as dataclasses.
 """
 
+import os
 from dataclasses import dataclass
-from typing import Collection, Sequence
+from typing import Collection, List, Optional, Sequence
+
+from django.conf import settings
 
 
 @dataclass
@@ -35,3 +38,18 @@ def narrow_dataclasses_from_tuples(tups: Collection[Sequence[str]]) -> Collectio
     therefore as of summer 2023, they do not yet support the "negated" flag.
     """
     return [NarrowTerm(operator=tup[0], operand=tup[1]) for tup in tups]
+
+
+stop_words_list: Optional[List[str]] = None
+
+
+def read_stop_words() -> List[str]:
+    global stop_words_list
+    if stop_words_list is None:
+        file_path = os.path.join(
+            settings.DEPLOY_ROOT, "puppet/zulip/files/postgresql/zulip_english.stop"
+        )
+        with open(file_path) as f:
+            stop_words_list = f.read().splitlines()
+
+    return stop_words_list

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -1,0 +1,78 @@
+from typing import Any, Collection, Dict, List, Protocol
+
+from django.utils.translation import gettext as _
+
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+
+# "stream" is a legacy alias for "channel"
+channel_operators: List[str] = ["channel", "stream"]
+# "streams" is a legacy alias for "channels"
+channels_operators: List[str] = ["channels", "streams"]
+
+
+def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
+    supported_operators = [*channel_operators, "topic", "sender", "is"]
+    for narrow_term in narrow:
+        operator = narrow_term.operator
+        if operator not in supported_operators:
+            raise JsonableError(_("Operator {operator} not supported.").format(operator=operator))
+
+
+class NarrowPredicate(Protocol):
+    def __call__(self, *, message: Dict[str, Any], flags: List[str]) -> bool: ...
+
+
+def build_narrow_predicate(
+    narrow: Collection[NarrowTerm],
+) -> NarrowPredicate:
+    """Changes to this function should come with corresponding changes to
+    NarrowLibraryTest."""
+    check_narrow_for_events(narrow)
+
+    def narrow_predicate(*, message: Dict[str, Any], flags: List[str]) -> bool:
+        def satisfies_operator(*, operator: str, operand: str) -> bool:
+            if operator in channel_operators:
+                if message["type"] != "stream":
+                    return False
+                if operand.lower() != message["display_recipient"].lower():
+                    return False
+            elif operator == "topic":
+                if message["type"] != "stream":
+                    return False
+                topic_name = get_topic_from_message_info(message)
+                if operand.lower() != topic_name.lower():
+                    return False
+            elif operator == "sender":
+                if operand.lower() != message["sender_email"].lower():
+                    return False
+            elif operator == "is" and operand in ["dm", "private"]:
+                # "is:private" is a legacy alias for "is:dm"
+                if message["type"] != "private":
+                    return False
+            elif operator == "is" and operand in ["starred"]:
+                if operand not in flags:
+                    return False
+            elif operator == "is" and operand == "unread":
+                if "read" in flags:
+                    return False
+            elif operator == "is" and operand in ["alerted", "mentioned"]:
+                if "mentioned" not in flags:
+                    return False
+            elif operator == "is" and operand == "resolved":
+                if message["type"] != "stream":
+                    return False
+                topic_name = get_topic_from_message_info(message)
+                if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+                    return False
+            return True
+
+        for narrow_term in narrow:
+            # TODO: Eventually handle negated narrow terms.
+            if not satisfies_operator(operator=narrow_term.operator, operand=narrow_term.operand):
+                return False
+
+        return True
+
+    return narrow_predicate

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -5,8 +5,6 @@ import orjson
 from django.db import connection
 from django.db.models import F, Func, JSONField, Q, QuerySet, Subquery, TextField, Value
 from django.db.models.functions import Cast
-from sqlalchemy.sql import ColumnElement, column, func, literal
-from sqlalchemy.types import Boolean, Text
 
 from zerver.lib.request import REQ
 from zerver.lib.types import EditHistoryEvent
@@ -70,22 +68,6 @@ using "subject" in the DB sense, and nothing customer facing.
 # zerver/lib/message.py, and it's not user facing.
 DB_TOPIC_NAME = "subject"
 MESSAGE__TOPIC = "message__subject"
-
-
-def topic_match_sa(topic_name: str) -> ColumnElement[Boolean]:
-    # _sa is short for SQLAlchemy, which we use mostly for
-    # queries that search messages
-    topic_cond = func.upper(column("subject", Text)) == func.upper(literal(topic_name))
-    return topic_cond
-
-
-def get_resolved_topic_condition_sa() -> ColumnElement[Boolean]:
-    resolved_topic_cond = column("subject", Text).startswith(RESOLVED_TOPIC_PREFIX)
-    return resolved_topic_cond
-
-
-def topic_column_sa() -> ColumnElement[Text]:
-    return column("subject", Text)
 
 
 def filter_by_topic_name_via_message(

--- a/zerver/lib/topic_sqlalchemy.py
+++ b/zerver/lib/topic_sqlalchemy.py
@@ -1,0 +1,20 @@
+from sqlalchemy.sql import ColumnElement, column, func, literal
+from sqlalchemy.types import Boolean, Text
+
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX
+
+
+def topic_match_sa(topic_name: str) -> ColumnElement[Boolean]:
+    # _sa is short for SQLAlchemy, which we use mostly for
+    # queries that search messages
+    topic_cond = func.upper(column("subject", Text)) == func.upper(literal(topic_name))
+    return topic_cond
+
+
+def get_resolved_topic_condition_sa() -> ColumnElement[Boolean]:
+    resolved_topic_cond = column("subject", Text).startswith(RESOLVED_TOPIC_PREFIX)
+    return resolved_topic_cond
+
+
+def topic_column_sa() -> ColumnElement[Text]:
+    return column("subject", Text)

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import ClauseElement, and_, column, not_, or_
 from sqlalchemy.types import Integer
 
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.topic import topic_match_sa
+from zerver.lib.topic_sqlalchemy import topic_match_sa
 from zerver.lib.types import UserTopicDict
 from zerver.models import UserProfile, UserTopic
 from zerver.models.streams import get_stream

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -33,7 +33,6 @@ from zerver.lib.narrow import (
     LARGER_THAN_MAX_MESSAGE_ID,
     BadNarrowOperatorError,
     NarrowBuilder,
-    build_narrow_predicate,
     exclude_muting_conditions,
     find_first_unread_anchor,
     is_spectator_compatible,
@@ -41,6 +40,7 @@ from zerver.lib.narrow import (
     post_process_limited_query,
 )
 from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_predicate import build_narrow_predicate
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import StreamDict, create_streams_if_needed, get_public_streams_queryset
 from zerver.lib.test_classes import ZulipTestCase

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -41,8 +41,8 @@ from typing_extensions import override
 from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message_cache import MessageDict
-from zerver.lib.narrow import build_narrow_predicate
 from zerver.lib.narrow_helpers import narrow_dataclasses_from_tuples
+from zerver.lib.narrow_predicate import build_narrow_predicate
 from zerver.lib.notification_data import UserMessageNotificationsData
 from zerver.lib.queue import queue_json_publish, retry_event
 from zerver.middleware import async_request_timer_restart

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -24,7 +24,8 @@ from zerver.lib.narrow import (
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
-from zerver.lib.topic import DB_TOPIC_NAME, MATCH_TOPIC, topic_column_sa
+from zerver.lib.topic import DB_TOPIC_NAME, MATCH_TOPIC
+from zerver.lib.topic_sqlalchemy import topic_column_sa
 from zerver.lib.validator import check_bool, check_int, check_list, to_non_negative_int
 from zerver.models import UserMessage, UserProfile
 


### PR DESCRIPTION
Loading sqlalchemy can take a significant amount of time, so splitting these into these own file can be a significant startup-time savings.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
