### PR TITLE
message-editing: include stream icon in message sent  and visibility notification banners

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 import render_automatic_new_visibility_policy_banner from "../templates/compose_banner/automatic_new_visibility_policy_banner.hbs";
 import render_message_sent_banner from "../templates/compose_banner/message_sent_banner.hbs";
 import render_unmute_topic_banner from "../templates/compose_banner/unmute_topic_banner.hbs";
+import render_inline_decorated_stream_topic from "../templates/inline_decorated_stream_topic.hbs";
 
 import * as blueslip from "./blueslip";
 import * as compose_banner from "./compose_banner";
@@ -82,8 +83,16 @@ export function notify_automatic_new_visibility_policy(
 // Handlebars templates that will do further escaping.
 function get_message_header(message: Message): string {
     if (message.type === "stream") {
-        const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
-        return `#${stream_name} > ${message.topic}`;
+        const stream = stream_data.get_sub_by_id(message.stream_id);
+        const stream_topic = $t(
+            {defaultMessage: "{stream} > {topic}"},
+            {stream: stream?.name.trimEnd(), topic: message.topic},
+        );
+        const stream_name_with_topic_html = render_inline_decorated_stream_topic({
+            stream,
+            stream_topic,
+        });
+        return stream_name_with_topic_html;
     }
     if (message.display_recipient.length > 2) {
         return $t(

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -7,6 +7,7 @@ import render_private_stream_warning from "../templates/compose_banner/private_s
 import render_stream_wildcard_warning from "../templates/compose_banner/stream_wildcard_warning.hbs";
 import render_wildcard_mention_not_allowed_error from "../templates/compose_banner/wildcard_mention_not_allowed_error.hbs";
 import render_compose_limit_indicator from "../templates/compose_limit_indicator.hbs";
+import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 
 import * as compose_banner from "./compose_banner";
 import * as compose_pm_pill from "./compose_pm_pill";
@@ -184,10 +185,14 @@ export function warn_if_private_stream_is_linked(
     );
 
     if (!existing_stream_warnings.includes(linked_stream.stream_id)) {
+        const channel_name_html = render_inline_decorated_stream_name({
+            stream: linked_stream,
+            in_message: true,
+        });
         const new_row_html = render_private_stream_warning({
             stream_id: linked_stream.stream_id,
             banner_type: compose_banner.WARNING,
-            channel_name: linked_stream.name,
+            channel_name: channel_name_html,
             classname: compose_banner.CLASSNAMES.private_stream_warning,
         });
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
@@ -328,9 +333,9 @@ export function warn_if_in_search_view(): void {
 
 function show_stream_wildcard_warnings(opts: StreamWildcardOptions): void {
     const subscriber_count = peer_data.get_subscriber_count(opts.stream_id) || 0;
-    const stream_name = sub_store.maybe_get_stream_name(opts.stream_id);
     const is_edit_container = opts.$banner_container.closest(".edit_form_banners").length > 0;
     const classname = compose_banner.CLASSNAMES.wildcard_warning;
+    const stream = sub_store.get(opts.stream_id);
 
     let button_text = opts.scheduling_message
         ? $t({defaultMessage: "Yes, schedule"})
@@ -340,10 +345,14 @@ function show_stream_wildcard_warnings(opts: StreamWildcardOptions): void {
         button_text = $t({defaultMessage: "Yes, save"});
     }
 
+    const stream_name_with_icon_html = render_inline_decorated_stream_name({
+        stream,
+        in_message: true,
+    });
     const stream_wildcard_html = render_stream_wildcard_warning({
         banner_type: compose_banner.WARNING,
         subscriber_count,
-        channel_name: stream_name,
+        channel_name: stream_name_with_icon_html,
         wildcard_mention: opts.stream_wildcard_mention,
         button_text,
         hide_close_button: true,

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -914,7 +914,6 @@ div.overlay {
 
 .stream-privacy-type-icon {
     position: relative;
-    top: 0.06rem;
     padding-right: 1px;
     width: 12px;
 
@@ -926,6 +925,10 @@ div.overlay {
     &.zulip-icon-lock,
     &.zulip-icon-users {
         font-size: 0.8em;
+    }
+
+    &.zulip-icon-in-message {
+        left: 3px;
     }
 }
 

--- a/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
+++ b/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
@@ -2,13 +2,13 @@
     <p class="banner_message">
         {{#if followed}}
             {{#tr}}
-                Now following <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                Now following <z-link></z-link>.
+                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{{channel_topic}}}</a>{{/inline}}
             {{/tr}}
         {{else}}
             {{#tr}}
-                Unmuted <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                Unmuted <z-link></z-link>.
+                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{{channel_topic}}}</a>{{/inline}}
             {{/tr}}
         {{/if}}
     </p>

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -1,7 +1,15 @@
 <div class="above_compose_banner main-view-banner success {{classname}}">
     <p class="banner_content">
         {{banner_text}}
-        {{#if link_text}} <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
+        {{#if link_text}}
+            <a class="above_compose_banner_action_link"
+              {{#if above_composebox_narrow_url}}
+              href="{{above_composebox_narrow_url}}"
+              {{/if}}
+              data-message-id="{{link_msg_id}}">
+                {{{link_text}}}
+            </a>
+        {{/if}}
     </p>
     <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
 </div>

--- a/web/templates/compose_banner/private_stream_warning.hbs
+++ b/web/templates/compose_banner/private_stream_warning.hbs
@@ -1,5 +1,7 @@
 {{#> compose_banner }}
     <p class="banner_message">
-        {{#tr}}Warning: <strong>#{channel_name}</strong> is a private channel.{{/tr}}
+        {{#tr}}Warning: <z-link></z-link> is a private channel.
+        {{#*inline "z-link"}}{{{channel_name}}}{{/inline}}
+        {{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/templates/compose_banner/stream_wildcard_warning.hbs
+++ b/web/templates/compose_banner/stream_wildcard_warning.hbs
@@ -1,7 +1,11 @@
 {{#> compose_banner }}
     <p class="banner_message">
         {{#tr}}
-        Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{channel_name}? If not, please edit your message to remove the <strong>@{wildcard_mention}</strong> mention.
+            Are you sure you want to send @-mention notifications to the
+            <strong>{subscriber_count}</strong> users subscribed to <z-link></z-link>?
+            If not, please edit your message to remove the <strong>@{wildcard_mention}</strong>
+            mention.
+            {{#*inline "z-link"}}{{{channel_name}}}{{/inline}}
         {{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/templates/inline_decorated_stream_name.hbs
+++ b/web/templates/inline_decorated_stream_name.hbs
@@ -1,8 +1,11 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
 {{#if stream.invite_only }}
-<i class="zulip-icon zulip-icon-lock stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
+<i class="zulip-icon zulip-icon-lock stream-privacy-type-icon {{#if in_message}}zulip-icon-in-message{{/if}}"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
 {{ else if stream.is_web_public }}
-<i class="zulip-icon zulip-icon-globe stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
+<i class="zulip-icon zulip-icon-globe stream-privacy-type-icon {{#if in_message}}zulip-icon-in-message{{/if}}"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
 {{ else }}
-<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
+<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon {{#if in_message}}zulip-icon-in-message{{/if}}"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
 {{/if}}

--- a/web/templates/inline_decorated_stream_topic.hbs
+++ b/web/templates/inline_decorated_stream_topic.hbs
@@ -1,0 +1,11 @@
+{{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
+{{#if stream.invite_only }}
+<i class="zulip-icon zulip-icon-lock stream-privacy-type-icon zulip-icon-in-message"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream_topic}}
+{{ else if stream.is_web_public }}
+<i class="zulip-icon zulip-icon-globe stream-privacy-type-icon zulip-icon-in-message"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream_topic}}
+{{ else }}
+<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon zulip-icon-in-message"
+  {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream_topic}}
+{{/if}}

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -178,6 +178,7 @@ test_ui("validate", ({mock_template}) => {
         deactivated_user_error_rendered = true;
         return "<banner-stub>";
     });
+
     assert.ok(!compose_validate.validate());
     assert.ok(deactivated_user_error_rendered);
 
@@ -385,6 +386,11 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
         assert.equal(data.subscriber_count, 16);
         return "<banner-stub>";
     });
+    mock_template(
+        "inline_decorated_stream_name.hbs",
+        true,
+        (_args, rendered_html) => rendered_html,
+    );
 
     override_rewire(compose_validate, "wildcard_mention_policy_authorizes_user", () => true);
     compose_state.message_content("Hey @**all**");
@@ -627,9 +633,13 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     let banner_rendered = false;
     mock_template("compose_banner/private_stream_warning.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.private_stream_warning);
-        assert.equal(data.channel_name, "Denmark");
+        assert.match(data.channel_name, new RegExp("Denmark"));
         banner_rendered = true;
         return "<banner-stub>";
+    });
+    mock_template("inline_decorated_stream_name.hbs", true, (data, html) => {
+        assert.strictEqual(data.in_message, true);
+        return html;
     });
 
     function test_noop_case(invite_only) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fix the "Compose banners" item in #25257. Compose banners include message validation and message notification banners, created in compose_validate.ts and compose_notification.ts. This PR puts a stream icon in these banners.
    

Fixes: #25257 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**_message notifications and links_**
![Screenshot from 2024-04-28 14-08-53](https://github.com/zulip/zulip/assets/73965466/5112b687-0970-4b71-bb71-4f10b1cded62)
![Screenshot from 2024-04-28 14-09-57](https://github.com/zulip/zulip/assets/73965466/4fe6439e-dfd4-49bb-ae94-843b72d739f5)
![Screenshot from 2024-04-28 14-13-06](https://github.com/zulip/zulip/assets/73965466/69c47144-0d8d-4933-b005-fab60f27af21)
![Screenshot from 2024-04-28 14-13-21](https://github.com/zulip/zulip/assets/73965466/c0829dfd-0f56-42d0-9473-8a0d4465ecac)
![Screenshot from 2024-04-28 14-14-14](https://github.com/zulip/zulip/assets/73965466/d485f362-3235-4867-87e4-63a02feb7853)
![Screenshot from 2024-04-28 14-14-32](https://github.com/zulip/zulip/assets/73965466/853c0ad4-b362-4236-8e08-82d874f8b2db)

**_message validation warnings_**

![Screenshot from 2024-04-28 14-51-22](https://github.com/zulip/zulip/assets/73965466/ac304231-9dba-4e0f-bc2e-1c4b85ab18a3)
![Screenshot from 2024-04-28 14-24-19](https://github.com/zulip/zulip/assets/73965466/8476e699-b998-430a-8ddd-2f5539cb9d79)
![Screenshot from 2024-04-28 14-58-01](https://github.com/zulip/zulip/assets/73965466/f340284e-2422-4b54-8473-76b217106e22)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
