### PR TITLE
message-flags: Migrate message flag endpoints to typed_endpoint.

### DIFF
--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -398,9 +398,128 @@ class UnreadCountTests(ZulipTestCase):
             .values_list("message_id", flat=True),
             message_ids[5::2],
         )
+        response = self.assert_json_success(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": message_ids[3],
+                    "include_anchor": "false",
+                    "num_before": 0,
+                    "num_after": 5,
+                    "narrow": orjson.dumps([["stream", "Verona"], ["topic", "topic 1"]]).decode(),
+                    "op": "add",
+                    "flag": "starred",
+                },
+            )
+        )
+        cordelia = self.example_user("cordelia")
+        response = self.assert_json_success(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": message_ids[3],
+                    "include_anchor": "false",
+                    "num_before": 0,
+                    "num_after": 5,
+                    "narrow": orjson.dumps([{"operator": "dm", "operand": [cordelia.id]}]).decode(),
+                    "op": "add",
+                    "flag": "starred",
+                },
+            )
+        )
 
     def test_update_flags_for_narrow_misuse(self) -> None:
         self.login("hamlet")
+
+        self.assert_json_error(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": "1",
+                    "include_anchor": "false",
+                    "num_before": "1",
+                    "num_after": "1",
+                    "narrow": "[[],[]]",
+                    "op": "add",
+                    "flag": "read",
+                },
+            ),
+            "Invalid narrow[0]: Value error, element is not a string pair",
+        )
+
+        self.assert_json_error(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": "1",
+                    "include_anchor": "false",
+                    "num_before": "1",
+                    "num_after": "1",
+                    "narrow": orjson.dumps(
+                        [
+                            {"operator": None, "operand": "Verona"},
+                            {"operator": "topic", "operand": "topic 1"},
+                        ]
+                    ).decode(),
+                    "op": "add",
+                    "flag": "read",
+                },
+            ),
+            "Invalid narrow[0]: Value error, operator is missing",
+        )
+
+        self.assert_json_error(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": "1",
+                    "include_anchor": "false",
+                    "num_before": "1",
+                    "num_after": "1",
+                    "narrow": orjson.dumps(
+                        [
+                            {"operator": "stream", "operand": None},
+                            {"operator": "topic", "operand": "topic 1"},
+                        ]
+                    ).decode(),
+                    "op": "add",
+                    "flag": "read",
+                },
+            ),
+            "Invalid narrow[0]: Value error, operand is missing",
+        )
+
+        self.assert_json_error(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": "1",
+                    "include_anchor": "false",
+                    "num_before": "1",
+                    "num_after": "1",
+                    "narrow": orjson.dumps(["asadasd"]).decode(),
+                    "op": "add",
+                    "flag": "read",
+                },
+            ),
+            "Invalid narrow[0]: Value error, dict or list required",
+        )
+
+        self.assert_json_error(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": "1",
+                    "include_anchor": "false",
+                    "num_before": "1",
+                    "num_after": "1",
+                    "narrow": orjson.dumps([{"operator": "search", "operand": ""}]).decode(),
+                    "op": "add",
+                    "flag": "read",
+                },
+            ),
+            "operand cannot be blank.",
+        )
 
         response = self.client_post(
             "/json/messages/flags/narrow",

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -2,6 +2,8 @@ from typing import List, Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
+from pydantic import Json, NonNegativeInt
+from typing_extensions import Annotated
 
 from zerver.actions.message_flags import (
     do_mark_all_as_read,
@@ -9,18 +11,17 @@ from zerver.actions.message_flags import (
     do_update_message_flags,
 )
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.narrow import (
-    OptionalNarrowListT,
-    fetch_messages,
-    narrow_parameter,
-    parse_anchor_value,
-)
-from zerver.lib.request import REQ, RequestNotes, has_request_variables
+from zerver.lib.narrow import OptionalNarrowListT, fetch_messages, parse_anchor_value
+from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.timeout import TimeoutExpiredError, timeout
 from zerver.lib.topic import user_message_exists_for_topic
-from zerver.lib.validator import check_bool, check_int, check_list, to_non_negative_int
+from zerver.lib.typed_endpoint import (
+    ApiParamConfig,
+    typed_endpoint,
+    typed_endpoint_without_parameters,
+)
 from zerver.models import UserActivity, UserProfile
 
 
@@ -37,13 +38,14 @@ def get_latest_update_message_flag_activity(user_profile: UserProfile) -> Option
 
 # NOTE: If this function name is changed, add the new name to the
 # query in get_latest_update_message_flag_activity
-@has_request_variables
+@typed_endpoint
 def update_message_flags(
     request: HttpRequest,
     user_profile: UserProfile,
-    messages: List[int] = REQ(json_validator=check_list(check_int)),
-    operation: str = REQ("op"),
-    flag: str = REQ(),
+    *,
+    messages: Json[List[int]],
+    operation: Annotated[str, ApiParamConfig("op")],
+    flag: str,
 ) -> HttpResponse:
     request_notes = RequestNotes.get_notes(request)
     assert request_notes.log_data is not None
@@ -67,17 +69,18 @@ MAX_MESSAGES_PER_UPDATE = 5000
 
 # NOTE: If this function name is changed, add the new name to the
 # query in get_latest_update_message_flag_activity
-@has_request_variables
+@typed_endpoint
 def update_message_flags_for_narrow(
     request: HttpRequest,
     user_profile: UserProfile,
-    anchor_val: str = REQ("anchor"),
-    include_anchor: bool = REQ(json_validator=check_bool, default=True),
-    num_before: int = REQ(converter=to_non_negative_int),
-    num_after: int = REQ(converter=to_non_negative_int),
-    narrow: OptionalNarrowListT = REQ("narrow", converter=narrow_parameter),
-    operation: str = REQ("op"),
-    flag: str = REQ(),
+    *,
+    anchor_val: Annotated[str, ApiParamConfig("anchor")],
+    include_anchor: Json[bool] = True,
+    num_before: Json[NonNegativeInt],
+    num_after: Json[NonNegativeInt],
+    narrow: Json[OptionalNarrowListT],
+    operation: Annotated[str, ApiParamConfig("op")],
+    flag: str,
 ) -> HttpResponse:
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor=False)
 
@@ -117,7 +120,7 @@ def update_message_flags_for_narrow(
     )
 
 
-@has_request_variables
+@typed_endpoint_without_parameters
 def mark_all_as_read(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     request_notes = RequestNotes.get_notes(request)
     try:
@@ -132,9 +135,9 @@ def mark_all_as_read(request: HttpRequest, user_profile: UserProfile) -> HttpRes
     return json_success(request, data={"complete": True})
 
 
-@has_request_variables
+@typed_endpoint
 def mark_stream_as_read(
-    request: HttpRequest, user_profile: UserProfile, stream_id: int = REQ(json_validator=check_int)
+    request: HttpRequest, user_profile: UserProfile, *, stream_id: Json[int]
 ) -> HttpResponse:
     stream, sub = access_stream_by_id(user_profile, stream_id)
     assert stream.recipient_id is not None
@@ -148,12 +151,13 @@ def mark_stream_as_read(
     return json_success(request)
 
 
-@has_request_variables
+@typed_endpoint
 def mark_topic_as_read(
     request: HttpRequest,
     user_profile: UserProfile,
-    stream_id: int = REQ(json_validator=check_int),
-    topic_name: str = REQ(),
+    *,
+    stream_id: Json[int],
+    topic_name: str,
 ) -> HttpResponse:
     stream, sub = access_stream_by_id(user_profile, stream_id)
     assert stream.recipient_id is not None


### PR DESCRIPTION
Migrate `message_flags.py` to `typed_endpoint` as part of the project to migrate the server’s Python codebase from the legacy `@has_request_variables` decorator to the new `@typed_endpoint`