### PR TITLE
narrow: Do not create huddles when fetching messages.

### DIFF
--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -61,6 +61,7 @@ from zerver.models import (
     UserTopic,
 )
 from zerver.models.realms import get_realm
+from zerver.models.recipients import get_or_create_huddle
 from zerver.models.streams import get_stream
 from zerver.views.message_fetch import get_messages_backend
 
@@ -362,7 +363,21 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE (flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)",
         )
 
+    def test_add_term_using_dm_operator_more_than_one_user_as_operand_no_huddle(self) -> None:
+        # If the group doesn't exist, it's a flat false
+        two_others = f"{self.example_user('cordelia').email},{self.example_user('othello').email}"
+        term = dict(operator="dm", operand=two_others)
+        self._do_add_term_test(term, "WHERE false")
+
     def test_add_term_using_dm_operator_more_than_one_user_as_operand(self) -> None:
+        # Make the huddle first
+        get_or_create_huddle(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("cordelia").id,
+                self.example_user("othello").id,
+            ]
+        )
         two_others = f"{self.example_user('cordelia').email},{self.example_user('othello').email}"
         term = dict(operator="dm", operand=two_others)
         self._do_add_term_test(term, "WHERE recipient_id = %(recipient_id_1)s")
@@ -379,9 +394,25 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT ((flags & %(flags_1)s) != %(param_1)s AND realm_id = %(realm_id_1)s AND (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s))",
         )
 
+    def test_add_term_using_dm_operator_more_than_one_user_as_operand_no_huddle_and_negated(
+        self,
+    ) -> None:  # NEGATED
+        # If the group doesn't exist, it's a flat true
+        two_others = f"{self.example_user('cordelia').email},{self.example_user('othello').email}"
+        term = dict(operator="dm", operand=two_others, negated=True)
+        self._do_add_term_test(term, "WHERE true")
+
     def test_add_term_using_dm_operator_more_than_one_user_as_operand_and_negated(
         self,
     ) -> None:  # NEGATED
+        # Make the huddle first
+        get_or_create_huddle(
+            [
+                self.example_user("hamlet").id,
+                self.example_user("cordelia").id,
+                self.example_user("othello").id,
+            ]
+        )
         two_others = f"{self.example_user('cordelia').email},{self.example_user('othello').email}"
         term = dict(operator="dm", operand=two_others, negated=True)
         self._do_add_term_test(term, "WHERE recipient_id != %(recipient_id_1)s")
@@ -2170,6 +2201,23 @@ class GetOldMessagesTest(ZulipTestCase):
 
             for message in result["messages"]:
                 self.assertEqual(dr_emails(message["display_recipient"]), emails)
+
+    def test_get_messages_with_nonexistant_group_dm(self) -> None:
+        me = self.example_user("hamlet")
+        # Huddle which doesn't match anything gets no results
+        non_existant_huddle = [
+            me.id,
+            self.example_user("iago").id,
+            self.example_user("othello").id,
+        ]
+        self.login_user(me)
+        narrow: List[Dict[str, Any]] = [dict(operator="dm", operand=non_existant_huddle)]
+        result = self.get_and_check_messages(dict(narrow=orjson.dumps(narrow).decode()))
+        self.assertEqual(result["messages"], [])
+
+        narrow = [dict(operator="dm", operand=non_existant_huddle, negated=True)]
+        result = self.get_and_check_messages(dict(narrow=orjson.dumps(narrow).decode()))
+        self.assertEqual([m["id"] for m in result["messages"]], [1, 3])
 
     def test_get_visible_messages_with_narrow_dm(self) -> None:
         me = self.example_user("hamlet")


### PR DESCRIPTION
9a682fb20a40 started performing message fetching in a read-only transaction.  However, our use of `get_or_create_huddle` can violate the read-only promise, and result in a user-facing 500.

In the cases where we're attempting to narrow to a huddle that does not exist, this is equivalent to a false condition; catch those, without making the huddle row, and insert a false.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
