### PR TITLE
markdown: Refactor Markdown element spacing.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -201,12 +201,10 @@ $message_box_margin: 3px;
         .message_content {
             grid-area: message;
             /*
-            Space between two single line messages in a paragraph is 10px.
-            There is 3px margin above and below a message. So, having a 2px
-            padding above and below the message will make the space between
-            all single paragraphs the same.
+            Space between two single line messages is 10px, which is maintained
+            by setting 5px of padding above messages without a sender.
             */
-            padding: 2px 0;
+            padding: 5px 0 0;
             color: var(--color-text-message-default);
             line-height: var(--message-box-line-height);
             min-height: 17px;
@@ -378,7 +376,8 @@ $message_box_margin: 3px;
             }
 
             .message_content {
-                padding-top: 0;
+                /* Top padding is reduced when there is a sender line. */
+                padding-top: 3px;
                 grid-area: message;
             }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -94,11 +94,6 @@
         padding-left: 5px;
         margin: 5px 0 6px 10px;
         border-left: 5px solid hsl(0deg 0% 87%);
-
-        & p {
-            line-height: inherit;
-            font-size: inherit;
-        }
     }
 
     &.rtl blockquote {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -34,12 +34,6 @@
         margin-left: 0;
     }
 
-    /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */
-    & p + ul,
-    p + ol {
-        margin-top: 0;
-    }
-
     & hr {
         border-bottom: 1px solid hsl(0deg 0% 87%);
         border-top: 1px solid hsl(0deg 0% 87%);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1,6 +1,6 @@
 .rendered_markdown {
     & p {
-        margin: 3px 0 5px;
+        margin: 0 0 5px;
     }
 
     /* The spacing between two paragraphs is significantly larger.  We
@@ -10,9 +10,8 @@
         margin-top: 10px;
     }
 
-    /* Ensure bulleted lists are nicely centered in 1-line messages */
     & ul {
-        margin: 2px 0 5px 20px;
+        margin: 0 0 5px 20px;
     }
 
     /* Swap the left and right margins of bullets for Right-To-Left languages */
@@ -21,9 +20,8 @@
         margin-left: 0;
     }
 
-    /* Ensure ordered lists are nicely centered in 1-line messages */
     & ol {
-        margin: 2px 0 5px 20px;
+        margin: 0 0 5px 20px;
     }
 
     /* Swap the left and right margins of ordered list for Right-To-Left languages */
@@ -46,6 +44,9 @@
     h6 {
         font-weight: 600;
         line-height: 1.4;
+        /* Headings take a margin-top because of the pronounced extra
+           space they require, but are zeroed out below when they open
+           a message. */
         margin-top: 15px;
         margin-bottom: 5px;
     }
@@ -90,7 +91,7 @@
     /* Formatting for blockquotes */
     & blockquote {
         padding-left: 5px;
-        margin: 5px 0 5px 10px;
+        margin: 0 0 5px 10px;
         border-left: 5px solid hsl(0deg 0% 87%);
     }
 
@@ -106,7 +107,7 @@
     /* Formatting for Markdown tables */
     & table {
         padding-right: 10px;
-        margin: 5px;
+        margin: 0 5px 5px;
         width: 99%;
         display: block;
         max-width: fit-content;
@@ -577,7 +578,7 @@
     .message_embed {
         display: block;
         position: relative;
-        margin: 5px 0;
+        margin: 0 0 5px;
         border: none;
         border-left: 3px solid hsl(0deg 0% 93%);
         height: 80px;
@@ -680,7 +681,7 @@
         overflow-x: auto;
         word-break: break-all;
         word-wrap: normal;
-        margin: 5px 0;
+        margin: 0 0 5px;
         padding: 5px 7px 3px;
         display: block;
         border-radius: 4px;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -219,10 +219,11 @@
     /* LaTeX styling */
     .katex-display {
         /* KaTeX sometimes overdraws its bounding box by a little, so we
-           enlarge its scrolling area by stealing 3px from the margin
-           of the enclosing <p>. */
-        margin: -3px 0;
+           enlarge its scrolling area by adding 3px of padding to its top
+           and bottom. To prevent what will appear as extra whitespace,
+           we reduce surrounding margins by the same 3px. */
         padding: 3px 0;
+        margin: -3px 0;
         overflow: auto hidden;
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -235,10 +235,9 @@
         border: hsl(0deg 0% 50%) 1px solid;
         padding: 2px 8px 2px 10px;
         border-radius: 10px;
-        position: relative;
-        top: 1px;
-        display: block;
-        margin: 5px 0 15px;
+        /* Space any subsequent Markdown content the same
+           distance as adjacent paragraphs are spaced. */
+        margin: 0 0 10px;
 
         .spoiler-header {
             /* We use flexbox to display the spoiler message
@@ -330,6 +329,13 @@
                 }
             }
         }
+    }
+
+    & > .spoiler-block:last-child {
+        /* A spoiler block at the end of a message, or as
+           a message's only content, gets the same bottom
+           margin as other elements. */
+        margin-bottom: 5px;
     }
 
     /* embedded link previews */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1,8 +1,6 @@
 .rendered_markdown {
-    /* The default top/bottom margins for paragraphs are small, to make sure
-       they look nice next to blockquotes, lists, etc. */
     & p {
-        margin: 3px 0;
+        margin: 3px 0 5px;
     }
 
     /* The spacing between two paragraphs is significantly larger.  We
@@ -92,7 +90,7 @@
     /* Formatting for blockquotes */
     & blockquote {
         padding-left: 5px;
-        margin: 5px 0 6px 10px;
+        margin: 5px 0 5px 10px;
         border-left: 5px solid hsl(0deg 0% 87%);
     }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -1,3 +1,9 @@
+.widget-content {
+    /* TODO: Coordinate this value with other Markdown
+       element spacing, as a variable. */
+    margin-bottom: 5px;
+}
+
 .widget-choices {
     & ul {
         padding: 3px;
@@ -66,10 +72,6 @@
                 outline-color: hsl(0deg 0% 100% / 0%);
             }
         }
-    }
-
-    .add-task-bar {
-        margin-bottom: 5px;
     }
 }
 

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -18,5 +18,4 @@
         <input type="text" class="poll-option" placeholder="{{t 'New option'}}" />
         <button class="poll-option">{{t "Add option" }}</button>
     </div>
-    <br />
 </div>


### PR DESCRIPTION
This PR adjusts the inter-element spacing for all rendered-Markdown elements. The purpose of these adjustments is to make it easier to create a reasonable set of variables for declaring space between Markdown elements as part of the user-adjustable information density project, #12611.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/rendered.20Markdown.20CSS.20adjustments/near/1783569)

The PR shifts all spacing to `margin-bottom`, rather than a combination of top and bottom margin, except for specific sibling combinators (e.g., `p + p`), where `margin-top` is necessary to increase the desired spacing when one element follows a specific other.

Additionally, space above the rendered-Markdown area that was previously set by margins bleeding out from Markdown elements is now more reliably set by top padding on the Markdown area itself. **The bottom of the rendered-Markdown area continues to be spaced by Markdown elements**, and will be adjusted and addressed in some future PR.

There are subtle improvements here, including especially that all messages begin on the same vertical line, with or without a sender. Previously, for example, single-line list item messages were taller than single-line paragraph messages. Those are now uniform. Relatedly, a message opening with a list sat a pixel higher in the message area than those messages that opened with a paragraph.

Spacing around all Markdown elements and widgets is now also uniform, and in the case of poll widgets, achieved purely through CSS (previously, the poll widget depended on a break tag to maintain its bottom spacing (!).

Finally, `5px` is now the shared `margin-bottom` value for all Markdown elements and widgets, including spoiler blocks. Previously, paragraphs had a value of 3px, blockquotes a value of 6px, and spoilers a value of 15px. But 5px was otherwise the value on all other elements.

**Screenshots and screen captures:**

_Note that comparing before & after images is in certain cases less useful than comparing after images against other after images, e.g., for seeing how message text all begins on the same horizontal line with this refactoring._

| One-liners, Before | One-liners, After |
| --- | --- |
| ![one-liners-main](https://github.com/zulip/zulip/assets/170719/d1dba062-9ec8-4e09-b342-51d3e85cabf2) | ![one-liners-proposed](https://github.com/zulip/zulip/assets/170719/b1d5ffad-a0ee-4281-a061-8226ddcd3771) |
| ![decorated-one-liners-main](https://github.com/zulip/zulip/assets/170719/464095ac-c734-4e01-a96f-ef39ba298720) | ![decorated-one-liners-proposed](https://github.com/zulip/zulip/assets/170719/f2310127-24e0-494c-9cc6-0198abc9b498) |

| Previews, Before | Previews, After |
| --- | --- |
| ![ext-image-previews-main](https://github.com/zulip/zulip/assets/170719/65be9ff5-fcd3-47ac-946f-04397a62063c) | ![ext-image-previews-proposed](https://github.com/zulip/zulip/assets/170719/abbc2538-d154-43be-891c-d977355ab190) |
| ![link-preview-main](https://github.com/zulip/zulip/assets/170719/58a71e0e-4166-4e18-a071-5488b17670ab) | ![link-preview-proposed](https://github.com/zulip/zulip/assets/170719/4df6bf42-c5d2-4444-bffa-2d11f3642a64) |
| ![inline-images-main](https://github.com/zulip/zulip/assets/170719/c067a301-ab4b-4895-b7d2-0053ce580f21) | ![inline-images-proposed](https://github.com/zulip/zulip/assets/170719/5cd5f3b8-5bcf-4a6d-9776-5de98023c9e4) |

| Widgets, Before | Widgets, After |
| --- | --- |
| ![polls-main](https://github.com/zulip/zulip/assets/170719/64a6f05f-93cf-45b6-9bfc-cec0583c75d5) | ![polls-proposed](https://github.com/zulip/zulip/assets/170719/581fd577-c3b3-4969-a094-feab8295b6be) |
| ![todo-widget-main](https://github.com/zulip/zulip/assets/170719/442c67e3-2101-48a5-be48-b0cce98efad2) | ![todo-widget-proposed](https://github.com/zulip/zulip/assets/170719/e125e79d-dcda-45a5-bda3-8f4566552887) |
| ![spoilers-main](https://github.com/zulip/zulip/assets/170719/4b07fff0-9367-4121-a7af-b8d33b38c723) | ![spoilers-proposed](https://github.com/zulip/zulip/assets/170719/0fd728c0-02f6-4807-92e6-ccd6f014cfb3) |
