### PR TITLE
help: Document option to disable seeing typing notifications.

### DIFF
--- a/help/typing-notifications.md
+++ b/help/typing-notifications.md
@@ -13,17 +13,33 @@ if all the content of the message is erased, or if the message is
 [saved as a draft](/help/view-and-edit-your-message-drafts#save-a-draft).
 Just having the compose box open will not send a typing notification.
 
-### Disable typing notifications
+## Disable sending typing notifications
 
 If you'd prefer that others not know whether you're typing, you can
 configure Zulip to not send typing notifications.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {settings_tab|account-and-privacy}
 
 1. Under **Privacy**, toggle **Let recipients see when I'm typing direct
    messages** and **Let recipients see when I'm typing messages in streams**.
+
+{end_tabs}
+
+## Disable seeing typing notifications
+
+If you'd prefer not to see notifications when others type, you can disable them.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|preferences}
+
+1. Under **Advanced**, toggle **Show when other users are typing**.
 
 {end_tabs}
 


### PR DESCRIPTION
Follow-up to #29642 / PR #29719. @roanster007 FYI

Current: https://zulip.com/help/typing-notifications
<details>
<summary>
Updated
</summary>

![CleanShot 2024-04-16 at 16 21 53@2x](https://github.com/zulip/zulip/assets/2090066/333f4041-d6dd-4da5-9fa5-02dd221ff078)

</details>