### PR TITLE
katex: Properly align timestamps with KaTeX-only messages.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -407,8 +407,9 @@
        `.rendered_markdown` out of the baseline group
        formed with EDITED/MOVED markers and the
        timestamp when the first child of the rendered
-       markdown is a media element. */
-    &:has(> .message_inline_image:first-child) {
+       markdown is a media element or KaTeX. */
+    &:has(> .message_inline_image:first-child),
+    &:has(> p:first-child > .katex-display) {
         align-self: center;
     }
 
@@ -416,6 +417,13 @@
        we provide a small layout hack using an
        inline grid. */
     @supports not selector(:has(*)) {
+        p:first-child > .katex-display {
+            /* KaTeX should take up 100% of the message box,
+               so that KaTeX's own CSS for centering still works. */
+            width: 100%;
+        }
+
+        p:first-child > .katex-display,
         .message_inline_image {
             /* We'll display this bit of media as
                an inline grid. That will allow us
@@ -437,6 +445,7 @@
             grid-template: "media" minmax(0, auto) / minmax(0, auto);
         }
 
+        p:first-child > .katex-display > .katex,
         .message_inline_image a,
         .message_inline_image video {
             /* We explicitly place the containing
@@ -444,6 +453,7 @@
             grid-area: media;
         }
 
+        p:first-child > .katex-display::before,
         .message_inline_image::before {
             /* We generate a single . here to create
                text content enough for a baseline.


### PR DESCRIPTION
This PR extends to KaTeX-only messages the CSS in place to properly align timestamps and EDITED/MOVED markers on image-only messages.

**Screenshots and screen captures:**

| Before | After (`:has()`) | After (inline-grid fallback) |
| --- | --- | --- |
| ![katex-before](https://github.com/zulip/zulip/assets/170719/2af016eb-de42-407c-9c65-b20af610f33e) | ![katex-after](https://github.com/zulip/zulip/assets/170719/e8d1b2a4-67b3-4df3-bc87-508061f9280b) | ![katex-fallback](https://github.com/zulip/zulip/assets/170719/c7e3ffd7-7c8b-4d6d-b6b6-f4e0c7a42cb6) |
