### PR TITLE
Update translated strings for stream to channel rename.

### DIFF
--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -306,7 +306,7 @@ class TestGetChartData(ZulipTestCase):
             },
             subdomain="zephyr",
         )
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_include_empty_subgroups(self) -> None:
         FillState.objects.create(

--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -192,21 +192,21 @@ class TestGetChartData(ZulipTestCase):
                 "end_times": [datetime_to_timestamp(dt) for dt in self.end_times_day],
                 "frequency": CountStat.DAY,
                 "everyone": {
-                    "Public streams": self.data(100),
-                    "Private streams": self.data(0),
+                    "Public channels": self.data(100),
+                    "Private channels": self.data(0),
                     "Direct messages": self.data(101),
                     "Group direct messages": self.data(0),
                 },
                 "user": {
-                    "Public streams": self.data(200),
-                    "Private streams": self.data(201),
+                    "Public channels": self.data(200),
+                    "Private channels": self.data(201),
                     "Direct messages": self.data(0),
                     "Group direct messages": self.data(0),
                 },
                 "display_order": [
                     "Direct messages",
-                    "Public streams",
-                    "Private streams",
+                    "Public channels",
+                    "Private channels",
                     "Group direct messages",
                 ],
                 "result": "success",
@@ -343,8 +343,8 @@ class TestGetChartData(ZulipTestCase):
         self.assertEqual(
             data["everyone"],
             {
-                "Public streams": [0],
-                "Private streams": [0],
+                "Public channels": [0],
+                "Private channels": [0],
                 "Direct messages": [0],
                 "Group direct messages": [0],
             },
@@ -352,8 +352,8 @@ class TestGetChartData(ZulipTestCase):
         self.assertEqual(
             data["user"],
             {
-                "Public streams": [0],
-                "Private streams": [0],
+                "Public channels": [0],
+                "Private channels": [0],
                 "Direct messages": [0],
                 "Group direct messages": [0],
             },

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -310,8 +310,8 @@ def get_chart_data(
         tables = (aggregate_table, UserCount)
         subgroup_to_label = {
             stats[0]: {
-                "public_stream": _("Public streams"),
-                "private_stream": _("Private streams"),
+                "public_stream": _("Public channels"),
+                "private_stream": _("Private channels"),
                 "private_message": _("Direct messages"),
                 "huddle_message": _("Group direct messages"),
             }
@@ -336,7 +336,7 @@ def get_chart_data(
     elif chart_name == "messages_sent_by_stream":
         if stream is None:
             raise JsonableError(
-                _("Missing stream for chart: {chart_name}").format(chart_name=chart_name)
+                _("Missing channel for chart: {chart_name}").format(chart_name=chart_name)
             )
         stats = [COUNT_STATS["messages_in_stream:is_bot:day"]]
         tables = (aggregate_table, StreamCount)

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 255**
+
+* "Stream" was renamed to "Channel" across strings in the Zulip API
+  and UI. Clients supporting a range of server versions are encouraged
+  to use different strings based on the server's API feature level for
+  consistency. Note that feature level marks the strings transition
+  only: Actual API changes related to this transition have their own
+  API changelog entries.
+
 **Feature level 254**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -23,10 +23,10 @@
         {% endfor %}
     {% endif %}
 
-    {% if new_streams.html %}
-    <p class="digest_paragraph"><b>{% trans %}New streams{% endtrans %}</b></p>
+    {% if new_channels.html %}
+    <p class="digest_paragraph"><b>{% trans %}New channels{% endtrans %}</b></p>
 
-    <p class="digest_paragraph">{{ new_streams.html|display_list(1000)|safe }}.</p>
+    <p class="digest_paragraph">{{ new_channels.html|display_list(1000)|safe }}.</p>
     {% endif %}
 
     <br />

--- a/templates/zerver/emails/digest.txt
+++ b/templates/zerver/emails/digest.txt
@@ -5,8 +5,8 @@
 {% endfor %}{% endfor %}
 {% if convo.count > 0 %}+ {{ convo.count }} more message{{ convo.count|pluralize }} by {{ convo.participants|display_list(4) }}.{% endif %}{% endfor %}{% endfor %}{% endif %}
 
-{% if new_streams.plain %}** New streams **
-    {{ new_streams.plain|display_list(1000) }}.
+{% if new_channels.plain %}** {% trans %}New channels{% endtrans %} **
+    {{ new_channels.plain|display_list(1000) }}.
 {% endif %}
 
 {% trans organization_url=realm_uri %}Click here to log in to Zulip and catch up: {{ organization_url }}.{% endtrans %}

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -30,17 +30,17 @@
     {% elif mentioned_user_group_name %}
     {% trans %}You are receiving this because @{{ mentioned_user_group_name }} was mentioned.{% endtrans %}<br />
     {% elif topic_wildcard_mentioned_in_followed_topic %}
-    {% trans %}You are receiving this because all topic participants were mentioned in #{{ stream_name }} > {{ topic_name }}.{% endtrans %}<br />
+    {% trans %}You are receiving this because all topic participants were mentioned in #{{ channel_name }} > {{ topic_name }}.{% endtrans %}<br />
     {% elif stream_wildcard_mentioned_in_followed_topic %}
     {% trans %}You are receiving this because you have wildcard mention notifications enabled for topics you follow.{% endtrans %}<br />
     {% elif topic_wildcard_mentioned %}
-    {% trans %}You are receiving this because all topic participants were mentioned in #{{ stream_name }} > {{ topic_name }}.{% endtrans %}<br />
+    {% trans %}You are receiving this because all topic participants were mentioned in #{{ channel_name }} > {{ topic_name }}.{% endtrans %}<br />
     {% elif stream_wildcard_mentioned %}
-    {% trans %}You are receiving this because everyone was mentioned in #{{ stream_name }}.{% endtrans %}<br />
+    {% trans %}You are receiving this because everyone was mentioned in #{{ channel_name }}.{% endtrans %}<br />
     {% elif followed_topic_email_notify %}
     {% trans %}You are receiving this because you have email notifications enabled for topics you follow.{% endtrans %}<br />
     {% elif stream_email_notify %}
-    {% trans %}You are receiving this because you have email notifications enabled for #{{ stream_name }}.{% endtrans %}<br />
+    {% trans %}You are receiving this because you have email notifications enabled for #{{ channel_name }}.{% endtrans %}<br />
     {% endif %}
     {% if reply_to_zulip %}
     {% trans notif_url=realm_uri + "/#settings/notifications" %}Reply to this email directly, <a href="{{ narrow_url }}">view it in {{ realm_name }} Zulip</a>, or <a href="{{ notif_url }}">manage email preferences</a>.{% endtrans %}

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -9,8 +9,8 @@
         advantage of this to retain thread continuity in email notifications
         even after a topic is resolved.
         #}
-        {% if topic_resolved %}{% trans %}[resolved] #{{ stream_name }} > {{ topic_name }}{% endtrans %}
-        {% else %}#{{ stream_name }} > {{ topic_name }}
+        {% if topic_resolved %}{% trans %}[resolved] #{{ channel_name }} > {{ topic_name }}{% endtrans %}
+        {% else %}#{{ channel_name }} > {{ topic_name }}
         {% endif %}
     {% endif %}
 {% else %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -26,17 +26,17 @@ See {{ alert_notif_url }} for more details.
 {% elif mentioned_user_group_name %}
 {% trans %}You are receiving this because @{{ mentioned_user_group_name }} was mentioned.{% endtrans %}
 {% elif topic_wildcard_mentioned_in_followed_topic %}
-{% trans %}You are receiving this because all topic participants were mentioned in #{{ stream_name }} > {{ topic_name }}.{% endtrans %}
+{% trans %}You are receiving this because all topic participants were mentioned in #{{ channel_name }} > {{ topic_name }}.{% endtrans %}
 {% elif stream_wildcard_mentioned_in_followed_topic %}
 {% trans %}You are receiving this because you have wildcard mention notifications enabled for topics you follow.{% endtrans %}
 {% elif topic_wildcard_mentioned %}
-{% trans %}You are receiving this because all topic participants were mentioned in #{{ stream_name }} > {{ topic_name }}.{% endtrans %}
+{% trans %}You are receiving this because all topic participants were mentioned in #{{ channel_name }} > {{ topic_name }}.{% endtrans %}
 {% elif stream_wildcard_mentioned %}
-{% trans %}You are receiving this because everyone was mentioned in #{{ stream_name }}.{% endtrans %}
+{% trans %}You are receiving this because everyone was mentioned in #{{ channel_name }}.{% endtrans %}
 {% elif followed_topic_email_notify %}
 {% trans %}You are receiving this because you have email notifications enabled for topics you follow.{% endtrans %}
 {% elif stream_email_notify %}
-{% trans %}You are receiving this because you have email notifications enabled for #{{ stream_name }}.{% endtrans %}
+{% trans %}You are receiving this because you have email notifications enabled for #{{ channel_name }}.{% endtrans %}
 {% endif %}
 
 {% if reply_to_zulip  %}

--- a/templates/zerver/emails/onboarding_zulip_topics.html
+++ b/templates/zerver/emails/onboarding_zulip_topics.html
@@ -10,19 +10,19 @@
 </p>
 
 <p>
-    {{ _("In Zulip, <b>streams</b> determine who gets a message. <b>Topics</b> tell you what the message is about.")}} {{ _("Using topics, you can read Zulip one conversation at a time. You'll see each message in context, no matter how many different discussions are going on.") }}
+    {{ _("In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell you what the message is about.")}} {{ _("Using topics, you can read Zulip one conversation at a time. You'll see each message in context, no matter how many different discussions are going on.") }}
 </p>
 
-<img class="responsive-width" src="{{ email_images_base_url }}/streams-and-topics.png" alt="{{ _('Streams and topics in the Zulip app') }}"/>
+<img class="responsive-width" src="{{ email_images_base_url }}/streams-and-topics.png" alt="{{ _('Channels and topics in the Zulip app') }}"/>
 
 <p>
-    {{ _("To kick off a new conversation, just pick a stream and start a new topic. This way, the new conversation thread won't interrupt ongoing discussions. For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”") }}
+    {{ _("To kick off a new conversation, just pick a channel and start a new topic. This way, the new conversation thread won't interrupt ongoing discussions. For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”") }}
 </p>
 
 <img class="responsive-width" src="{{ email_images_base_url }}/day2_2.png" alt="{{ _('Examples of short topics') }}"/>
 
 <p>
-    {% trans %}Don't stress about picking the perfect name for your topic. If anything is out of place, it's easy to <a href="{{ move_messages_link }}">move messages</a>, <a href="{{ rename_topics_link }}">rename topics</a>, or even <a href="{{ move_topic_to_different_stream_link }}">move a topic to a different stream</a>.{% endtrans %}
+    {% trans %}Don't stress about picking the perfect name for your topic. If anything is out of place, it's easy to <a href="{{ move_messages_link }}">move messages</a>, <a href="{{ rename_topics_link }}">rename topics</a>, or even <a href="{{ move_channels_link }}">move a topic to a different channel</a>.{% endtrans %}
 </p>
 
 <a class="button" href="{{ realm_uri }}">{{ _("Go to Zulip") }}</a>

--- a/templates/zerver/emails/onboarding_zulip_topics.txt
+++ b/templates/zerver/emails/onboarding_zulip_topics.txt
@@ -1,10 +1,10 @@
 {{ _("Here are some tips for keeping your Zulip conversations organized with topics.") }}
 
-{{ _("In Zulip, streams determine who gets a message. Topics tell you what the message is about.") }} {{ _("Using topics, you can read Zulip one conversation at a time. You'll see each message in context, no matter how many different discussions are going on.") }}
+{{ _("In Zulip, channels determine who gets a message. Topics tell you what the message is about.") }} {{ _("Using topics, you can read Zulip one conversation at a time. You'll see each message in context, no matter how many different discussions are going on.") }}
 
-{{ _("To kick off a new conversation, just pick a stream and start a new topic. This way, the new conversation thread won't interrupt ongoing discussions. For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”") }}
+{{ _("To kick off a new conversation, just pick a channel and start a new topic. This way, the new conversation thread won't interrupt ongoing discussions. For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”") }}
 
-{% trans %}Don't stress about picking the perfect name for your topic. If anything is out of place, it's easy to move messages ({{ move_messages_link }}), rename topics ({{ rename_topics_link }}), or even move a topic to a different stream ({{ move_topic_to_different_stream_link }}).{% endtrans %}
+{% trans %}Don't stress about picking the perfect name for your topic. If anything is out of place, it's easy to move messages ({{ move_messages_link }}), rename topics ({{ rename_topics_link }}), or even move a topic to a different channel ({{ move_channels_link }}).{% endtrans %}
 
 
 {{ _("Go to Zulip") }}:

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -102,7 +102,7 @@ IGNORED_PHRASES = [
     r"in 20 minutes",
     r"in 3 hours",
     # these are used as topics
-    r"^new streams$",
+    r"^new channels$",
     r"^stream events$",
     # These are used as example short names (e.g. an uncapitalized context):
     r"^marketing$",

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -103,7 +103,7 @@ IGNORED_PHRASES = [
     r"in 3 hours",
     # these are used as topics
     r"^new channels$",
-    r"^stream events$",
+    r"^channel events$",
     # These are used as example short names (e.g. an uncapitalized context):
     r"^marketing$",
     r"^cookie$",

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -83,7 +83,7 @@ IGNORED_PHRASES = [
     r"acme",
     # Fragments of larger strings
     r"is …",
-    r"your subscriptions on your Streams page",
+    r"your subscriptions on your Channels page",
     r"Add global time<br />Everyone sees global times in their own time zone\.",
     r"user",
     r"an unknown operating system",

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -96,7 +96,7 @@ IGNORED_PHRASES = [
     r"^deprecated$",
     # We want the similar text in the Private Messages section to have the same capitalization.
     r"more conversations",
-    r"back to streams",
+    r"back to channels",
     # Capital 'i' looks weird in reminders popover
     r"in 1 hour",
     r"in 20 minutes",

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 254
+API_FEATURE_LEVEL = 255
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -115,13 +115,13 @@ async function test_streams_with_empty_names_cannot_be_created(page: Page): Prom
     await page.waitForSelector("form#stream_creation_form", {visible: true});
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "  "});
     await page.click("form#stream_creation_form button.finalize_create_stream");
-    assert.strictEqual(await stream_name_error(page), "Choose a name for the new stream.");
+    assert.strictEqual(await stream_name_error(page), "Choose a name for the new channel.");
 }
 
 async function test_streams_with_duplicate_names_cannot_be_created(page: Page): Promise<void> {
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "Puppeteer"});
     await page.click("form#stream_creation_form button.finalize_create_stream");
-    assert.strictEqual(await stream_name_error(page), "A stream with this name already exists.");
+    assert.strictEqual(await stream_name_error(page), "A channel with this name already exists.");
 
     const cancel_button_selector = "form#stream_creation_form button.button.white";
     await page.click(cancel_button_selector);

--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -75,7 +75,7 @@ async function test_user_filter_ui(page: Page): Promise<void> {
 }
 
 async function create_stream(page: Page): Promise<void> {
-    await page.waitForSelector('xpath///*[text()="Create stream"]', {visible: true});
+    await page.waitForSelector('xpath///*[text()="Create channel"]', {visible: true});
     await common.fill_form(page, "form#stream_creation_form", {
         stream_name: "Puppeteer",
         stream_description: "Everything Puppeteer",

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -31,8 +31,8 @@ export function initialize(): void {
             popover_menus.on_show_prep(instance);
 
             //  When showing the popover menu, we want the
-            // "Add streams" and the "Filter streams" tooltip
-            //  to appear below the "Add streams" icon.
+            // "Add channels" and the "Filter channels" tooltip
+            //  to appear below the "Add channels" icon.
             const add_streams_tooltip: ReferenceElement | undefined =
                 $("#add_streams_tooltip").get(0);
             assert(add_streams_tooltip !== undefined);
@@ -55,9 +55,9 @@ export function initialize(): void {
             instance.destroy();
             popover_menus.popover_instances.stream_settings = null;
             //  After the popover menu is closed, we want the
-            //  "Add streams" and the "Filter streams" tooltip
+            //  "Add channels" and the "Filter channels" tooltip
             //  to appear at it's original position that is
-            //  above the "Add streams" icon.
+            //  above the "Add channels" icon.
             const add_streams_tooltip: ReferenceElement | undefined =
                 $("#add_streams_tooltip").get(0);
             assert(add_streams_tooltip !== undefined);

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -29,8 +29,8 @@ const admin_settings_label = {
     }),
     // Organization settings
     realm_allow_edit_history: $t({defaultMessage: "Enable message edit history"}),
-    realm_mandatory_topics: $t({defaultMessage: "Require topics in stream messages"}),
-    realm_new_stream_announcements_stream: $t({defaultMessage: "New stream announcements"}),
+    realm_mandatory_topics: $t({defaultMessage: "Require topics in channel messages"}),
+    realm_new_stream_announcements_stream: $t({defaultMessage: "New channel announcements"}),
     realm_signup_announcements_stream: $t({defaultMessage: "New user announcements"}),
     realm_zulip_update_announcements_stream: $t({defaultMessage: "Zulip update announcements"}),
     realm_inline_image_preview: $t({
@@ -42,7 +42,7 @@ const admin_settings_label = {
         defaultMessage: "Allow message content in message notification emails",
     }),
     realm_enable_spectator_access: $t({
-        defaultMessage: "Allow creating web-public streams (visible to anyone on the Internet)",
+        defaultMessage: "Allow creating web-public channels (visible to anyone on the Internet)",
     }),
     realm_digest_emails_enabled: $t({
         defaultMessage: "Send weekly digest emails to inactive users",

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -328,7 +328,7 @@ export class BuddyList extends BuddyListConf {
 
         let header_text;
         if (current_sub) {
-            header_text = $t({defaultMessage: "In this stream"});
+            header_text = $t({defaultMessage: "In this channel"});
         } else {
             header_text = $t({defaultMessage: "In this conversation"});
         }

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -173,7 +173,7 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
 
     const new_row_html = render_stream_does_not_exist_error({
         banner_type: ERROR,
-        stream_name,
+        channel_name: stream_name,
         classname: CLASSNAMES.stream_does_not_exist,
     });
     append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
@@ -192,7 +192,7 @@ export function show_stream_not_subscribed_error(sub: StreamSubscription): void 
         banner_type: ERROR,
         banner_text: $t({
             defaultMessage:
-                "You're not subscribed to this stream. You will not be notified if other users reply to your message.",
+                "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
         }),
         button_text: stream_data.can_toggle_subscription(sub)
             ? $t({defaultMessage: "Subscribe"})

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -69,7 +69,7 @@ export function notify_automatic_new_visibility_policy(
             banner_type: compose_banner.SUCCESS,
             classname: compose_banner.CLASSNAMES.automatic_new_visibility_policy,
             link_msg_id: data.id,
-            stream_topic,
+            channel_topic: stream_topic,
             narrow_url,
             followed,
             button_text: $t({defaultMessage: "Change setting"}),

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -131,7 +131,7 @@ export function get_posting_policy_error_message(): string {
     const stream = sub_store.get(compose_state.selected_recipient_id);
     if (stream && !stream_data.can_post_messages_in_stream(stream)) {
         return $t({
-            defaultMessage: "You do not have permission to post in this stream.",
+            defaultMessage: "You do not have permission to post in this channel.",
         });
     }
     return "";
@@ -174,7 +174,7 @@ function update_recipient_label(stream_id?: number): void {
     const stream = stream_id !== undefined ? stream_data.get_sub_by_id(stream_id) : undefined;
     if (stream === undefined) {
         $("#compose_select_recipient_widget .dropdown_widget_value").text(
-            $t({defaultMessage: "Select a stream"}),
+            $t({defaultMessage: "Select a channel"}),
         );
     } else {
         $("#compose_select_recipient_widget .dropdown_widget_value").html(

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -171,7 +171,7 @@ export function initialize(): void {
                     narrow_filter.operands("channel")[0] === compose_state.stream_name()
                 ) {
                     display_current_view = $t({
-                        defaultMessage: "Currently viewing the entire stream.",
+                        defaultMessage: "Currently viewing the entire channel.",
                     });
                 } else if (
                     _.isEqual(narrow_filter.sorted_term_types(), ["is-dm"]) &&

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -304,11 +304,11 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
 
         if (stream_name && opts.topic) {
             return $t(
-                {defaultMessage: "Message #{stream_name} > {topic_name}"},
-                {stream_name, topic_name: opts.topic},
+                {defaultMessage: "Message #{channel_name} > {topic_name}"},
+                {channel_name: stream_name, topic_name: opts.topic},
             );
         } else if (stream_name) {
-            return $t({defaultMessage: "Message #{stream_name}"}, {stream_name});
+            return $t({defaultMessage: "Message #{channel_name}"}, {channel_name: stream_name});
         }
     } else if (opts.direct_message_user_ids.length > 0) {
         const users = people.get_users_from_ids(opts.direct_message_user_ids);

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -187,7 +187,7 @@ export function warn_if_private_stream_is_linked(
         const new_row_html = render_private_stream_warning({
             stream_id: linked_stream.stream_id,
             banner_type: compose_banner.WARNING,
-            stream_name: linked_stream.name,
+            channel_name: linked_stream.name,
             classname: compose_banner.CLASSNAMES.private_stream_warning,
         });
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
@@ -514,7 +514,7 @@ export function validate_stream_message_mentions(opts: StreamWildcardOptions): b
             const new_row_html = render_wildcard_mention_not_allowed_error({
                 banner_type: compose_banner.ERROR,
                 classname: compose_banner.CLASSNAMES.wildcards_not_allowed,
-                stream_wildcard_mention: opts.stream_wildcard_mention,
+                wildcard_mention_string: opts.stream_wildcard_mention,
             });
             compose_banner.append_compose_banner_to_banner_list(
                 $(new_row_html),

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -343,8 +343,8 @@ function show_stream_wildcard_warnings(opts: StreamWildcardOptions): void {
     const stream_wildcard_html = render_stream_wildcard_warning({
         banner_type: compose_banner.WARNING,
         subscriber_count,
-        stream_name,
-        stream_wildcard_mention: opts.stream_wildcard_mention,
+        channel_name: stream_name,
+        wildcard_mention: opts.stream_wildcard_mention,
         button_text,
         hide_close_button: true,
         classname,
@@ -553,7 +553,7 @@ function validate_stream_message(scheduling_message: boolean): boolean {
     const $banner_container = $("#compose_banners");
     if (stream_id === undefined) {
         compose_banner.show_error_message(
-            $t({defaultMessage: "Please specify a stream."}),
+            $t({defaultMessage: "Please specify a channel."}),
             compose_banner.CLASSNAMES.missing_stream,
             $banner_container,
             $("#compose_select_recipient_widget_wrapper"),
@@ -585,7 +585,7 @@ function validate_stream_message(scheduling_message: boolean): boolean {
     if (!stream_data.can_post_messages_in_stream(sub)) {
         compose_banner.show_error_message(
             $t({
-                defaultMessage: "You do not have permission to post in this stream.",
+                defaultMessage: "You do not have permission to post in this channel.",
             }),
             compose_banner.CLASSNAMES.no_post_permissions,
             $banner_container,

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -391,7 +391,7 @@ function get_wildcard_string(mention) {
     if (mention === "topic") {
         return $t({defaultMessage: "Notify topic"});
     }
-    return $t({defaultMessage: "Notify stream"});
+    return $t({defaultMessage: "Notify channel"});
 }
 
 export function broadcast_mentions() {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -975,7 +975,7 @@ export class Filter {
         ) {
             if (!this._sub) {
                 const search_text = this.operands("channel")[0];
-                return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});
+                return $t({defaultMessage: "Unknown channel #{search_text}"}, {search_text});
             }
             return this._sub.name;
         }
@@ -1025,9 +1025,9 @@ export class Filter {
                 case "in-home":
                     return $t({defaultMessage: "Combined feed"});
                 case "in-all":
-                    return $t({defaultMessage: "All messages including muted streams"});
+                    return $t({defaultMessage: "All messages including muted channels"});
                 case "channels-public":
-                    return $t({defaultMessage: "Messages in all public streams"});
+                    return $t({defaultMessage: "Messages in all public channels"});
                 case "is-starred":
                     return $t({defaultMessage: "Starred messages"});
                 case "is-mentioned":

--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -25,7 +25,7 @@ actually do much of the work.
 Our gear menu has these choices:
 
 =================
-hash:  Stream settings
+hash:  Channel settings
 hash:  Settings
 hash:  Organization settings
 link:  Usage statistics

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -53,13 +53,13 @@ const markdown_help_rows = [
         usage_html: format_usage_html("Ctrl", "Shift", "L"),
     },
     {
-        markdown: "#**stream name**",
-        output_html: "<p><a>#stream name</a></p>",
-        effect_html: "(links to a stream)",
+        markdown: "#**channel name**",
+        output_html: "<p><a>#channel name</a></p>",
+        effect_html: "(links to a channel)",
     },
     {
-        markdown: "#**stream name>topic name**",
-        output_html: "<p><a>#stream name > topic name</a></p>",
+        markdown: "#**channel name>topic name**",
+        output_html: "<p><a>#channel name > topic name</a></p>",
         effect_html: "(links to topic)",
     },
     {

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -89,7 +89,7 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
 function get_display_stream_name(stream_id: number): string {
     const stream_name = sub_store.maybe_get_stream_name(stream_id);
     if (stream_name === undefined) {
-        return $t({defaultMessage: "Unknown stream"});
+        return $t({defaultMessage: "Unknown channel"});
     }
     return stream_name;
 }

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -65,7 +65,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
             sub_count: "0",
             formatted_sub_count: "0",
             rendered_narrow_description: $t({
-                defaultMessage: "This stream does not exist or is private.",
+                defaultMessage: "This channel does not exist or is private.",
             }),
         };
     }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -112,7 +112,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                 title: default_banner_for_multiple_filters,
                 html: $t_html({
                     defaultMessage:
-                        "<p>You are searching for messages that belong to more than one stream, which is not possible.</p>",
+                        "<p>You are searching for messages that belong to more than one channel, which is not possible.</p>",
                 }),
             };
         }
@@ -264,28 +264,11 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                 }
 
                 if (can_toggle_narrowed_stream()) {
-                    return {
-                        title: $t({
-                            defaultMessage:
-                                "You aren't subscribed to this stream and nobody has talked about that yet!",
-                        }),
-                        // TODO: Consider moving the button to be its own option in the template.
-                        html: $t_html(
-                            {
-                                defaultMessage: "<z-button>Subscribe</z-button>",
-                            },
-                            {
-                                "z-button": (content_html) =>
-                                    `<button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">${content_html.join(
-                                        "",
-                                    )}</button>`,
-                            },
-                        ),
-                    };
+                    return default_banner;
                 }
 
                 return {
-                    title: $t({defaultMessage: "This stream does not exist or is private."}),
+                    title: $t({defaultMessage: "This channel does not exist or is private."}),
                 };
             }
             // else fallthrough to default case

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -33,7 +33,7 @@ function setup_settings_label() {
         }),
         presence_enabled_parens_text: $t({defaultMessage: "invisible mode off"}),
         send_stream_typing_notifications: $t({
-            defaultMessage: "Let recipients see when I'm typing messages in streams",
+            defaultMessage: "Let recipients see when I'm typing messages in channels",
         }),
         send_private_typing_notifications: $t({
             defaultMessage: "Let recipients see when I'm typing direct messages",

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -821,7 +821,7 @@ export function save_discard_widget_status_handler(
             banner_type: compose_banner.WARNING,
             banner_text: $t({
                 defaultMessage:
-                    "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+                    "Only subscribers can access or join private channels, so you will lose access to this channel if you convert it to a private channel while not subscribed to it.",
             }),
             button_text: $t({defaultMessage: "Subscribe"}),
             classname: "stream_privacy_warning",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -76,15 +76,15 @@ export const user_list_style_values = {
 export const web_stream_unreads_count_display_policy_values = {
     all_streams: {
         code: 1,
-        description: $t({defaultMessage: "All streams"}),
+        description: $t({defaultMessage: "All channels"}),
     },
     unmuted_streams: {
         code: 2,
-        description: $t({defaultMessage: "Unmuted streams and topics"}),
+        description: $t({defaultMessage: "Unmuted channels and topics"}),
     },
     no_streams: {
         code: 3,
-        description: $t({defaultMessage: "No streams"}),
+        description: $t({defaultMessage: "No channels"}),
     },
 };
 
@@ -585,7 +585,7 @@ export const notification_settings_labels = {
         defaultMessage: "Automatically follow topics where I'm mentioned",
     }),
     automatically_unmute_topics_in_muted_streams_policy: $t({
-        defaultMessage: "Automatically unmute topics in muted streams",
+        defaultMessage: "Automatically unmute topics in muted channels",
     }),
     desktop_icon_count_display: $t({
         defaultMessage: "Unread count badge (appears in desktop sidebar and browser tab)",
@@ -631,7 +631,7 @@ export const realm_user_settings_defaults_labels = {
         defaultMessage: "Let recipients see when a user is typing direct messages",
     }),
     realm_send_stream_typing_notifications: $t({
-        defaultMessage: "Let recipients see when a user is typing stream messages",
+        defaultMessage: "Let recipients see when a user is typing channel messages",
     }),
 };
 
@@ -650,12 +650,12 @@ export const general_notifications_table_labels = {
         "all_mentions",
     ],
     stream: {
-        is_muted: $t({defaultMessage: "Mute stream"}),
+        is_muted: $t({defaultMessage: "Mute channel"}),
         desktop_notifications: $t({defaultMessage: "Visual desktop notifications"}),
         audible_notifications: $t({defaultMessage: "Audible desktop notifications"}),
         push_notifications: $t({defaultMessage: "Mobile notifications"}),
         email_notifications: $t({defaultMessage: "Email notifications"}),
-        pin_to_top: $t({defaultMessage: "Pin stream to top of left sidebar"}),
+        pin_to_top: $t({defaultMessage: "Pin channel to top of left sidebar"}),
         wildcard_mentions_notify: $t({defaultMessage: "Notifications for @all/@everyone mentions"}),
     },
 };
@@ -849,7 +849,7 @@ export type AllNotifications = {
 export const all_notifications = (settings_object: Settings): AllNotifications => ({
     general_settings: [
         {
-            label: $t({defaultMessage: "Streams"}),
+            label: $t({defaultMessage: "Channels"}),
             notification_settings: get_notifications_table_row_data(
                 stream_notification_settings,
                 settings_object,
@@ -966,7 +966,7 @@ export const user_topic_visibility_policy_values = {
     },
     inherit: {
         code: 0,
-        description: $t({defaultMessage: "Default for stream"}),
+        description: $t({defaultMessage: "Default for channel"}),
     },
 };
 

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -673,7 +673,7 @@ export function init_dropdown_widgets() {
         },
         default_id: realm.realm_new_stream_announcements_stream_id,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view stream"}),
+        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view channel"}),
     });
     settings_components.set_new_stream_announcements_stream_widget(
         new_stream_announcements_stream_widget,
@@ -696,7 +696,7 @@ export function init_dropdown_widgets() {
         },
         default_id: realm.realm_signup_announcements_stream_id,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view stream"}),
+        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view channel"}),
     });
     settings_components.set_signup_announcements_stream_widget(signup_announcements_stream_widget);
     signup_announcements_stream_widget.setup();
@@ -717,7 +717,7 @@ export function init_dropdown_widgets() {
         },
         default_id: realm.realm_zulip_update_announcements_stream_id,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view stream"}),
+        text_if_current_value_not_in_options: $t({defaultMessage: "Cannot view channel"}),
     });
     settings_components.set_zulip_update_announcements_stream_widget(
         zulip_update_announcements_stream_widget,

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -187,7 +187,7 @@ function show_add_default_streams_modal() {
                 },
                 error(xhr) {
                     ui_report.error(
-                        $t_html({defaultMessage: "Failed adding one or more streams."}),
+                        $t_html({defaultMessage: "Failed adding one or more channels."}),
                         xhr,
                         $("#dialog_error"),
                     );
@@ -209,7 +209,7 @@ function show_add_default_streams_modal() {
     }
 
     dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Add default streams"}),
+        html_heading: $t_html({defaultMessage: "Add default channels"}),
         html_body,
         html_submit_button: $t_html({defaultMessage: "Add"}),
         help_link: "/help/set-default-streams-for-new-users",

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -42,7 +42,7 @@ export function should_show_first_stream_created_modal() {
 class StreamSubscriptionError {
     report_no_subs_to_stream() {
         $("#stream_subscription_error").text(
-            $t({defaultMessage: "You cannot create a stream with no subscribers."}),
+            $t({defaultMessage: "You cannot create a channel with no subscribers."}),
         );
         $("#stream_subscription_error").show();
     }
@@ -51,7 +51,7 @@ class StreamSubscriptionError {
         $("#stream_subscription_error").text(
             $t({
                 defaultMessage:
-                    "You must be an organization administrator to create a stream without subscribing.",
+                    "You must be an organization administrator to create a channel without subscribing.",
             }),
         );
         $("#stream_subscription_error").show();
@@ -66,7 +66,7 @@ const stream_subscription_error = new StreamSubscriptionError();
 class StreamNameError {
     report_already_exists() {
         $("#stream_name_error").text(
-            $t({defaultMessage: "A stream with this name already exists."}),
+            $t({defaultMessage: "A channel with this name already exists."}),
         );
         $("#stream_name_error").show();
     }
@@ -76,7 +76,7 @@ class StreamNameError {
     }
 
     report_empty_stream() {
-        $("#stream_name_error").text($t({defaultMessage: "Choose a name for the new stream."}));
+        $("#stream_name_error").text($t({defaultMessage: "Choose a name for the new channel."}));
         $("#stream_name_error").show();
     }
 
@@ -176,7 +176,7 @@ function create_stream() {
     // and paste over a description with newline characters in it. Prevent that.
     if (description.includes("\n")) {
         ui_report.client_error(
-            $t_html({defaultMessage: "The stream description cannot contain newline characters."}),
+            $t_html({defaultMessage: "The channel description cannot contain newline characters."}),
             $(".stream_create_info"),
         );
         return undefined;
@@ -269,7 +269,7 @@ function create_stream() {
     data.can_remove_subscribers_group = can_remove_subscribers_group_id;
 
     loading.make_indicator($("#stream_creating_indicator"), {
-        text: $t({defaultMessage: "Creating stream..."}),
+        text: $t({defaultMessage: "Creating channel..."}),
     });
 
     // Subscribe yourself and possible other people to a new stream.
@@ -280,7 +280,7 @@ function create_stream() {
             $("#create_stream_name").val("");
             $("#create_stream_description").val("");
             ui_report.success(
-                $t_html({defaultMessage: "Stream successfully created!"}),
+                $t_html({defaultMessage: "Channel successfully created!"}),
                 $(".stream_create_info"),
             );
             loading.destroy_indicator($("#stream_creating_indicator"));
@@ -295,13 +295,13 @@ function create_stream() {
                 // parsing the error string, so it works correctly
                 // with i18n.  And likely we should be reporting the
                 // error text directly rather than turning it into
-                // "Error creating stream"?
+                // "Error creating channel"?
                 stream_name_error.report_already_exists();
                 stream_name_error.select();
             }
 
             ui_report.error(
-                $t_html({defaultMessage: "Error creating stream"}),
+                $t_html({defaultMessage: "Error creating channel"}),
                 xhr,
                 $(".stream_create_info"),
             );
@@ -428,7 +428,7 @@ export function set_up_handlers() {
 
         if (principals.length >= 50) {
             const html_body = render_subscription_invites_warning_modal({
-                stream_name,
+                channel_name: stream_name,
                 count: principals.length,
             });
 

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -388,7 +388,7 @@ function show_stream_email_address_modal(address) {
     });
 
     dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Generate stream email address"}),
+        html_heading: $t_html({defaultMessage: "Generate channel email address"}),
         html_body: copy_email_address_modal_html,
         id: "copy_email_address_modal",
         html_submit_button: $t_html({defaultMessage: "Copy address"}),
@@ -452,8 +452,8 @@ export function initialize() {
         const change_stream_info_modal = render_change_stream_info_modal(template_data);
         dialog_widget.launch({
             html_heading: $t_html(
-                {defaultMessage: "Edit #{stream_name}"},
-                {stream_name: stream.name},
+                {defaultMessage: "Edit #{channel_name}"},
+                {channel_name: stream.name},
             ),
             html_body: change_stream_info_modal,
             id: "change_stream_info_modal",
@@ -592,7 +592,7 @@ export function initialize() {
         const stream_id = get_stream_id(e.target);
         if (!stream_id) {
             ui_report.client_error(
-                $t_html({defaultMessage: "Invalid stream ID"}),
+                $t_html({defaultMessage: "Invalid channel ID"}),
                 $(".stream_change_property_info"),
             );
             return;
@@ -602,7 +602,7 @@ export function initialize() {
             const stream_id = $(".dialog_submit_button").data("stream-id");
             if (!stream_id) {
                 ui_report.client_error(
-                    $t_html({defaultMessage: "Invalid stream ID"}),
+                    $t_html({defaultMessage: "Invalid channel ID"}),
                     $(".stream_change_property_info"),
                 );
                 return;

--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -247,7 +247,7 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
 
     function removal_failure() {
         show_stream_subscription_request_result({
-            message: $t({defaultMessage: "Error removing user from this stream."}),
+            message: $t({defaultMessage: "Error removing user from this channel."}),
             add_class: "text-error",
             remove_class: "text-success",
         });

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -497,7 +497,7 @@ export async function build_move_topic_to_stream_popover(
         const stream = stream_data.get_sub_by_id(stream_id);
         if (stream === undefined) {
             $("#move_topic_to_stream_widget .dropdown_widget_value").text(
-                $t({defaultMessage: "Select a stream"}),
+                $t({defaultMessage: "Select a channel"}),
             );
         } else {
             $("#move_topic_to_stream_widget .dropdown_widget_value").html(

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -36,7 +36,9 @@ export const show_subs_pane = {
     nothing_selected() {
         $(".settings, #stream-creation").hide();
         $(".nothing-selected").show();
-        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Stream settings"}));
+        $("#subscription_overlay .stream-info-title").text(
+            $t({defaultMessage: "Channel settings"}),
+        );
     },
     settings(sub) {
         $(".settings, #stream-creation").hide();
@@ -46,7 +48,7 @@ export const show_subs_pane = {
     create_stream() {
         $(".nothing-selected, .settings, #stream-creation").hide();
         $("#stream-creation").show();
-        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create stream"}));
+        $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create channel"}));
     },
 };
 
@@ -140,8 +142,8 @@ export function ajaxSubscribe(stream, color, $stream_row) {
                 true_stream_name = res.already_subscribed[people.my_current_email()][0];
                 ui_report.success(
                     $t_html(
-                        {defaultMessage: "Already subscribed to {stream}"},
-                        {stream: true_stream_name},
+                        {defaultMessage: "Already subscribed to {channel}"},
+                        {channel: true_stream_name},
                     ),
                     $(".stream_change_property_info"),
                 );

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -261,7 +261,7 @@ export function add_sub_to_table(sub) {
 function show_first_stream_created_modal(stream) {
     dialog_widget.launch({
         html_heading: $t_html(
-            {defaultMessage: "Stream <b><z-stream></z-stream></b> created!"},
+            {defaultMessage: "Channel <b><z-stream></z-stream></b> created!"},
             {
                 "z-stream": () => render_inline_decorated_stream_name({stream}),
             },
@@ -604,7 +604,7 @@ export function setup_page(callback) {
             child_wants_focus: true,
             values: [
                 {label: $t({defaultMessage: "Subscribed"}), key: "subscribed"},
-                {label: $t({defaultMessage: "All streams"}), key: "all-streams"},
+                {label: $t({defaultMessage: "All channels"}), key: "all-streams"},
             ],
             callback(_value, key) {
                 switch_stream_tab(key);
@@ -842,7 +842,7 @@ export function toggle_view(event) {
 
     if (event === "right_arrow" && stream_filter_tab === "Subscribed") {
         toggler.goto("all-streams");
-    } else if (event === "left_arrow" && stream_filter_tab === "All streams") {
+    } else if (event === "left_arrow" && stream_filter_tab === "All channels") {
         toggler.goto("subscribed");
     }
 }

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -362,11 +362,11 @@ export function update_add_subscriptions_elements(sub) {
         if (!settings_data.user_can_subscribe_other_users()) {
             tooltip_message = $t({
                 defaultMessage:
-                    "You do not have permission to add other users to streams in this organization.",
+                    "You do not have permission to add other users to channels in this organization.",
             });
         } else {
             tooltip_message = $t({
-                defaultMessage: "Only stream members can add users to a private stream.",
+                defaultMessage: "Only channel members can add users to a private channel.",
             });
         }
         settings_components.initialize_disable_btn_hint_popover(

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -380,7 +380,7 @@ export function initialize(): void {
     delegate("body", {
         target: ".settings-radio-input-parent.default_stream_private_tooltip",
         content: $t({
-            defaultMessage: "Default streams for new users cannot be made private.",
+            defaultMessage: "Default channels for new users cannot be made private.",
         }),
         appendTo: () => document.body,
         onHidden(instance) {
@@ -391,7 +391,7 @@ export function initialize(): void {
     delegate("body", {
         target: ".default-stream.default_stream_private_tooltip",
         content: $t({
-            defaultMessage: "Private streams cannot be default streams for new users.",
+            defaultMessage: "Private channels cannot be default channels for new users.",
         }),
         appendTo: () => document.body,
         onHidden(instance) {
@@ -480,7 +480,7 @@ export function initialize(): void {
         target: "#stream_creation_form .add_subscribers_disabled",
         content: $t({
             defaultMessage:
-                "You do not have permission to add other users to streams in this organization.",
+                "You do not have permission to add other users to channels in this organization.",
         }),
         appendTo: () => document.body,
         onHidden(instance) {
@@ -555,7 +555,7 @@ export function initialize(): void {
                 instance.setContent(
                     $t({
                         defaultMessage:
-                            "You do not have permission to move messages to another stream in this organization.",
+                            "You do not have permission to move messages to another channel in this organization.",
                     }),
                 );
                 return undefined;

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -144,10 +144,10 @@ function reset_subscribe_widget() {
     $("#user-profile-modal .add-subscription-button").prop("disabled", true);
     settings_components.initialize_disable_btn_hint_popover(
         $("#user-profile-modal .add-subscription-button-wrapper"),
-        $t({defaultMessage: "Select a stream to subscribe"}),
+        $t({defaultMessage: "Select a channel to subscribe"}),
     );
     $("#user_profile_subscribe_widget .dropdown_widget_value").text(
-        $t({defaultMessage: "Select a stream"}),
+        $t({defaultMessage: "Select a channel"}),
     );
     //  There are two cases when the subscribe widget is reset: when the user_profile
     //  is setup (the object is null), or after subscribing of a user in the dropdown.
@@ -435,7 +435,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},
-            {label: $t({defaultMessage: "Streams"}), key: "user-profile-streams-tab"},
+            {label: $t({defaultMessage: "Channels"}), key: "user-profile-streams-tab"},
             {label: $t({defaultMessage: "User groups"}), key: "user-profile-groups-tab"},
         ],
         callback(_name, key) {
@@ -909,13 +909,13 @@ export function initialize() {
             let error_message;
             if (people.is_my_user_id(target_user_id)) {
                 error_message = $t(
-                    {defaultMessage: "Error in unsubscribing from #{stream_name}"},
-                    {stream_name: sub.name},
+                    {defaultMessage: "Error in unsubscribing from #{channel_name}"},
+                    {channel_name: sub.name},
                 );
             } else {
                 error_message = $t(
-                    {defaultMessage: "Error removing user from #{stream_name}"},
-                    {stream_name: sub.name},
+                    {defaultMessage: "Error removing user from #{channel_name}"},
+                    {channel_name: sub.name},
                 );
             }
 

--- a/web/src/user_topics_ui.js
+++ b/web/src/user_topics_ui.js
@@ -34,7 +34,7 @@ export function handle_topic_updates(user_topic_event) {
         if ($row.length) {
             // If the row exists, update the status only.
             // We don't call 'populate_list' in this case as it re-creates the panel (re-sorts by date updated +
-            // removes topics with status set to 'Default for stream'), making it hard to review the changes
+            // removes topics with status set to 'Default for channel'), making it hard to review the changes
             // and undo if needed.
             const $status = $row.find("select.settings_user_topic_visibility_policy");
             $status.val(visibility_policy);

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -56,7 +56,7 @@ export function filters_dropdown_options(current_value: string | number | undefi
             unique_id: FILTERS.ALL_TOPICS,
             name: $t({defaultMessage: "All topics"}),
             description: $t({
-                defaultMessage: "Includes muted streams and topics",
+                defaultMessage: "Includes muted channels and topics",
             }),
             bold_current_selection: current_value === FILTERS.ALL_TOPICS,
         },

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1177,7 +1177,7 @@ textarea.new_message_textarea,
         font-weight: lighter;
     }
 
-    /* This is the "Select a stream" default message */
+    /* This is the "Select a channel" default message */
     .text-warning {
         color: inherit;
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1425,7 +1425,7 @@ li.topic-list-item {
             /* TODO: Rewrite the show-more and show-less
                buttons as grids alongside the left sidebar
                header rewrites. The 12px left padding here
-               aligns the "back to streams" text with the
+               aligns the "back to channels" text with the
                DIRECT MESSAGES heading above, which itself
                is offset -3 px to the left, but reserves
                15px for the arrow marker. 15px - 3px = 12px. */

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -7,20 +7,20 @@
     {{else}}
         <span class="stream-status">
             {{#if deactivated}}
-                {{t "This stream has been archived." }}
+                {{t "This channel has been archived." }}
             {{else if subscribed }}
                 {{#tr}}
-                    You subscribed to stream <z-stream-name></z-stream-name>.
+                    You subscribed to channel <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{else if just_unsubscribed }}
                 {{#tr}}
-                    You unsubscribed from stream <z-stream-name></z-stream-name>.
+                    You unsubscribed from channel <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{else}}
                 {{#tr}}
-                    You are not subscribed to stream <z-stream-name></z-stream-name>.
+                    You are not subscribed to channel <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{/if}}

--- a/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
+++ b/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
@@ -2,12 +2,12 @@
     <p class="banner_message">
         {{#if followed}}
             {{#tr}}
-                Now following <z-link>{stream_topic}</z-link>.
+                Now following <z-link>{channel_topic}</z-link>.
                 {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{else}}
             {{#tr}}
-                Unmuted <z-link>{stream_topic}</z-link>.
+                Unmuted <z-link>{channel_topic}</z-link>.
                 {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{/if}}

--- a/web/templates/compose_banner/not_subscribed_warning.hbs
+++ b/web/templates/compose_banner/not_subscribed_warning.hbs
@@ -2,15 +2,15 @@
     <p class="banner_message">
         {{#if can_subscribe_other_users}}
             {{#if should_add_guest_user_indicator}}
-            {{#tr}}<strong>{name}</strong> <i>(guest)</i> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}
+            {{#tr}}<strong>{name}</strong> <i>(guest)</i> is not subscribed to this channel. They will not be notified unless you subscribe them.{{/tr}}
             {{else}}
-            {{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}
+            {{#tr}}<strong>{name}</strong> is not subscribed to this channel. They will not be notified unless you subscribe them.{{/tr}}
             {{/if}}
         {{else}}
             {{#if should_add_guest_user_indicator}}
-            {{#tr}}<strong>{name}</strong> <i>(guest)</i> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}
+            {{#tr}}<strong>{name}</strong> <i>(guest)</i> is not subscribed to this channel. They will not be notified if you mention them.{{/tr}}
             {{else}}
-            {{#tr}}<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.{{/tr}}
+            {{#tr}}<strong>{name}</strong> is not subscribed to this channel. They will not be notified if you mention them.{{/tr}}
             {{/if}}
         {{/if}}
     </p>

--- a/web/templates/compose_banner/private_stream_warning.hbs
+++ b/web/templates/compose_banner/private_stream_warning.hbs
@@ -1,5 +1,5 @@
 {{#> compose_banner }}
     <p class="banner_message">
-        {{#tr}}Warning: <strong>#{stream_name}</strong> is a private stream.{{/tr}}
+        {{#tr}}Warning: <strong>#{channel_name}</strong> is a private channel.{{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/templates/compose_banner/stream_does_not_exist_error.hbs
+++ b/web/templates/compose_banner/stream_does_not_exist_error.hbs
@@ -1,8 +1,8 @@
 {{#> compose_banner }}
     <p class="banner_message">
         {{#tr}}
-        The stream <b>#{stream_name}</b> does not exist. Manage your subscriptions
-        <z-link>on your Streams page</z-link>.
+        The channel <b>#{channel_name}</b> does not exist. Manage your subscriptions
+        <z-link>on your Channels page</z-link>.
         {{#*inline "z-link"}}<a href='#streams/all'>{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </p>

--- a/web/templates/compose_banner/stream_wildcard_warning.hbs
+++ b/web/templates/compose_banner/stream_wildcard_warning.hbs
@@ -1,7 +1,7 @@
 {{#> compose_banner }}
     <p class="banner_message">
         {{#tr}}
-        Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{stream_name}? If not, please edit your message to remove the <strong>@{stream_wildcard_mention}</strong> mention.
+        Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{channel_name}? If not, please edit your message to remove the <strong>@{wildcard_mention}</strong> mention.
         {{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/templates/compose_banner/unmute_topic_banner.hbs
+++ b/web/templates/compose_banner/unmute_topic_banner.hbs
@@ -1,7 +1,7 @@
 {{#> compose_banner }}
     <p class="banner_message">
         {{#if (eq muted_narrow "stream")}}
-            {{#tr}}Your message was sent to a stream you have muted.{{/tr}}
+            {{#tr}}Your message was sent to a channel you have muted.{{/tr}}
         {{else if (eq muted_narrow "topic")}}
             {{#tr}}Your message was sent to a topic you have muted.{{/tr}}
         {{/if}}

--- a/web/templates/compose_banner/wildcard_mention_not_allowed_error.hbs
+++ b/web/templates/compose_banner/wildcard_mention_not_allowed_error.hbs
@@ -1,7 +1,7 @@
 {{#> compose_banner }}
     <p class="banner_message">
-        {{#if stream_wildcard_mention}}
-            {{#tr}}You do not have permission to use <b>@{stream_wildcard_mention}</b> mentions in this stream.{{/tr}}
+        {{#if wildcard_mention_string}}
+            {{#tr}}You do not have permission to use <b>@{wildcard_mention_string}</b> mentions in this channel.{{/tr}}
         {{else}}
             {{#tr}}You do not have permission to use <b>@topic</b> mentions in this topic.{{/tr}}
         {{/if}}

--- a/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -1,14 +1,14 @@
 <p>
     {{#tr}}
-        Archiving stream <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
+        Archiving channel <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
         {{#*inline "z-stream"}}<strong>{{{stream_name_with_privacy_symbol_html}}}</strong>{{/inline}}
     {{/tr}}
 </p>
 {{#if is_announcement_stream}}
-<p class="notification_stream_archive_warning">{{#tr}}Archiving this stream will also disable settings that were configured to use this stream:{{/tr}}</p>
+<p class="notification_stream_archive_warning">{{#tr}}Archiving this channel will also disable settings that were configured to use this channel:{{/tr}}</p>
 <ul>
     {{#if is_new_stream_announcements_stream}}
-        <li>{{#tr}}New stream notifications{{/tr}}</li>
+        <li>{{#tr}}New channel notifications{{/tr}}</li>
     {{/if}}
     {{#if is_signup_announcements_stream}}
         <li>{{#tr}}New user notifications{{/tr}}</li>

--- a/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
+++ b/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
@@ -1,6 +1,6 @@
 <p>
     {{#tr}}
-    The topic <strong>{topic_name}</strong> already exists in this stream.
+    The topic <strong>{topic_name}</strong> already exists in this channel.
     Are you sure you want to combine messages from these topics? This cannot be undone.
     {{/tr}}
 </p>

--- a/web/templates/confirm_dialog/confirm_reactivate_bot.hbs
+++ b/web/templates/confirm_dialog/confirm_reactivate_bot.hbs
@@ -1,7 +1,7 @@
 <p>
     {{#tr}}
     <z-user></z-user> will have the same properties as it did prior to deactivation,
-    including role, owner and stream subscriptions.
+    including role, owner and channel subscriptions.
     {{#*inline "z-user"}}<strong>{{username}}</strong>{{/inline}}
     {{/tr}}
 </p>
@@ -11,6 +11,6 @@
         Because the original owner of this bot <z-bot-owner></z-bot-owner> is deactivated, you will become the owner for this bot.
         {{#*inline "z-bot-owner"}}<strong>{{owner_name}}</strong>{{/inline}}
         {{/tr}}
-        {{t "However, it will no longer be subscribed to the private streams that you are not subscribed to." }}
+        {{t "However, it will no longer be subscribed to the private channels that you are not subscribed to." }}
     </p>
 {{/if}}

--- a/web/templates/confirm_dialog/confirm_reactivate_user.hbs
+++ b/web/templates/confirm_dialog/confirm_reactivate_user.hbs
@@ -1,6 +1,6 @@
 <p>
     {{#tr}}
-    <z-user></z-user> will have the same role, stream subscriptions,
+    <z-user></z-user> will have the same role, channel subscriptions,
     user group memberships, and other settings and permissions as they did
     prior to deactivation.
     {{#*inline "z-user"}}<strong>{{username}}</strong>{{/inline}}

--- a/web/templates/confirm_dialog/confirm_subscription_invites_warning.hbs
+++ b/web/templates/confirm_dialog/confirm_subscription_invites_warning.hbs
@@ -1,3 +1,3 @@
 <p>
-    {{t "Are you sure you want to create stream ''''{stream_name}'''' and subscribe {count} users to it?" }}
+    {{t "Are you sure you want to create channel ''''{channel_name}'''' and subscribe {count} users to it?" }}
 </p>

--- a/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -1,16 +1,16 @@
 {{#unless unsubscribing_other_user}}
-    <p>{{t "Once you leave this stream, you will not be able to rejoin."}}</p>
+    <p>{{t "Once you leave this channel, you will not be able to rejoin."}}</p>
 {{/unless}}
 {{#if display_stream_archive_warning}}
     <p>
         {{#if unsubscribing_other_user}}
             {{#tr}}
-            Because you are removing the last subscriber from a private stream, it will be automatically <z-link>archived</z-link>.
+            Because you are removing the last subscriber from a private channel, it will be automatically <z-link>archived</z-link>.
             {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{else}}
             {{#tr}}
-            Because you are the only subscriber, this stream will be automatically <z-link>archived</z-link>.
+            Because you are the only subscriber, this channel will be automatically <z-link>archived</z-link>.
             {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{/if}}

--- a/web/templates/gear_menu_popover.hbs
+++ b/web/templates/gear_menu_popover.hbs
@@ -57,7 +57,7 @@
                 <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
                     <a href="#streams/subscribed" class="navigate-link-on-enter popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Stream settings' }}</span>
+                        <span class="popover-menu-label">{{t 'Channel settings' }}</span>
                     </a>
                 </li>
                 <li class="link-item popover-menu-inner-list-item admin-menu-item hidden-for-spectators">

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -56,14 +56,14 @@
         </select>
     </div>
     <div>
-        <label>{{t "Streams they should join" }}</label>
+        <label>{{t "Channels they should join" }}</label>
         <div id="streams_to_add">
             {{#if show_select_default_streams_option}}
             <div class="select_default_streams new-style">
                 <label class="checkbox display-block">
                     <input type="checkbox" id="invite_select_default_streams" checked="checked" />
                     <span></span>
-                    {{t 'Default streams for this organization'}}
+                    {{t 'Default channels for this organization'}}
                 </label>
             </div>
             {{/if}}
@@ -83,7 +83,7 @@
                         #{{name}}
                         {{/if}}
                         {{#if (eq name ../new_stream_announcements_stream)}}
-                        <i>({{t 'Receives new stream announcements' }})</i>
+                        <i>({{t 'Receives new channel announcements' }})</i>
                         {{/if}}
                     </label>
                 {{/each}}

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -13,7 +13,7 @@
                     <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New stream message' }}</td>
+                    <td class="definition">{{t 'New channel message' }}</td>
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
@@ -82,7 +82,7 @@
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Filter streams' }}</td>
+                    <td class="definition">{{t 'Filter channels' }}</td>
                     <td><span class="hotkey"><kbd>Q</kbd></span></td>
                 </tr>
                 <tr>
@@ -144,7 +144,7 @@
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to stream from topic view' }}</td>
+                    <td class="definition">{{t 'Go to channel from topic view' }}</td>
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
@@ -164,7 +164,7 @@
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cycle between stream views' }}</td>
+                    <td class="definition">{{t 'Cycle between channel views' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
@@ -185,7 +185,7 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'New stream message' }}</td>
+                    <td class="definition">{{t 'New channel message' }}</td>
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
@@ -368,11 +368,11 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Stream settings' }}</th>
+                        <th colspan="2">{{t 'Channel settings' }}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Scroll through streams' }}</td>
+                    <td class="definition">{{t 'Scroll through channels' }}</td>
                     <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></span></td>
                 </tr>
                 <tr>
@@ -380,15 +380,15 @@
                     <td><span class="hotkey"><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View stream messages' }}</td>
+                    <td class="definition">{{t 'View channel messages' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Subscribe to/unsubscribe from selected stream' }}</td>
+                    <td class="definition">{{t 'Subscribe to/unsubscribe from selected channel' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Create new stream' }}</td>
+                    <td class="definition">{{t 'Create new channel' }}</td>
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
             </table>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -147,7 +147,7 @@
             </div>
         </div>
         <a class="zoom-out-hide" id="hide-more-direct-messages">
-            <span> {{t 'back to streams' }}</span>
+            <span> {{t 'back to channels' }}</span>
         </a>
     </div>
     {{~!-- squash whitespace --~}}
@@ -158,10 +158,10 @@
 
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide {{#if hide_unread_counts}}hide_unread_counts{{/if}}">
-                <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</span></h4>
+                <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
-                    <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+                    <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
                         <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                     </span>
                     <span class="unread_count"></span>
@@ -169,14 +169,14 @@
                 </div>
 
                 <div class="input-append notdisplayed stream_search_section">
-                    <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
+                    <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>
             <div id="topics_header">
-                <a class="show-all-streams" tabindex="0">{{t 'Back to streams' }}</a> <span class="unread_count"></span>
+                <a class="show-all-streams" tabindex="0">{{t 'Back to channels' }}</a> <span class="unread_count"></span>
             </div>
             <div id="stream-filters-container">
                 <ul id="stream_filters" class="filters"></ul>
@@ -187,7 +187,7 @@
                     <a class="login_button">
                         <i class="zulip-icon zulip-icon-log-in" aria-hidden="true"></i>
                         {{~!-- squash whitespace --~}}
-                        {{t 'Log in to browse more streams'}}
+                        {{t 'Log in to browse more channels'}}
                     </a>
                 </div>
             </div>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -21,7 +21,7 @@
         &nbsp;
         <span>
             {{#tr}}
-            Consider <z-link>searching all public streams</z-link>.
+            Consider <z-link>searching all public channels</z-link>.
             {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </span>

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -4,10 +4,10 @@
 </a>
 <template id="stream-details-tooltip-template">
     <div>
-        <div>{{t "Go to stream settings" }}</div>
+        <div>{{t "Go to channel settings" }}</div>
         {{#unless is_spectator}}
         <div class="tooltip-inner-content italic">
-            {{t "This stream has {sub_count, plural, =0 {no subscribers} one {# subscriber} other {# subscribers}}." }}
+            {{t "This channel has {sub_count, plural, =0 {no subscribers} one {# subscriber} other {# subscribers}}." }}
         </div>
         {{/unless}}
     </div>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -5,7 +5,7 @@
     {{#if only_topic_edit }}
     <p>{{t "Rename topic to:" }}</p>
     {{else}}
-    <p>{{t "Select a stream below or change topic name." }}</p>
+    <p>{{t "Select a channel below or change topic name." }}</p>
     {{/if}}
     <div class="topic_stream_edit_header">
         {{#unless only_topic_edit}}

--- a/web/templates/popovers/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar_stream_setting_popover.hbs
@@ -1,12 +1,12 @@
 <ul class="nav nav-list">
     <li>
         <a href="#streams/all" class="navigate_and_close_popover">
-            {{t "Browse streams" }}
+            {{t "Browse channels" }}
         </a>
     </li>
     <li>
         <a href="#streams/new" class="navigate_and_close_popover">
-            {{t "Create a stream" }}
+            {{t "Create a channel" }}
         </a>
     </li>
 </ul>

--- a/web/templates/popovers/mobile_message_buttons_popover.hbs
+++ b/web/templates/popovers/mobile_message_buttons_popover.hbs
@@ -3,7 +3,7 @@
         <a class="compose_mobile_stream_button">
             <i class="fa fa-bullhorn" aria-hidden="true"></i>
             {{#if is_in_private_narrow }}
-            {{t "New stream message" }}
+            {{t "New channel message" }}
             {{else}}
             {{t "New topic" }}
             {{/if}}

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -15,7 +15,7 @@
             <tbody data-empty="{{t 'No conversations match your filters.' }}" class="required-text"></tbody>
             <thead>
                 <tr>
-                    <th data-sort="stream_sort">{{t 'Stream' }}</th>
+                    <th data-sort="stream_sort">{{t 'Channel' }}</th>
                     <th data-sort="topic_sort">{{t 'Topic' }}</th>
                     <th data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="unread_sort tippy-zulip-delayed-tooltip hidden-for-spectators">
                         <i class="zulip-icon zulip-icon-unread"></i>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -19,11 +19,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">stream:<span class="operator_value">stream</span></td>
+                        <td class="operator">channel:<span class="operator_value">channel</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to messages on stream <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">stream</span>{{/inline}}
+                                Narrow to messages on channel <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">channel</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>
@@ -61,9 +61,9 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">streams:public</td>
+                        <td class="operator">channels:public</td>
                         <td class="definition">
-                            {{t 'Search all public streams in the organization.'}}
+                            {{t 'Search all public channels in the organization.'}}
                         </td>
                     </tr>
                     <tr>

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -17,7 +17,7 @@
                 <button type="submit" class="btn deactivate_bot danger-red tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Deactivate bot' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-user-times" aria-hidden="true"></i>
                 </button>
-                <button type="submit" class="btn open_bots_subscribed_streams tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Subscribed streams' }}" data-user-id="{{user_id}}">
+                <button type="submit" class="btn open_bots_subscribed_streams tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Subscribed channels' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-hashtag purple" aria-hidden="true"></i>
                 </button>
                 {{#if is_incoming_webhook_bot}}

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -3,13 +3,13 @@
         {{> ../help_link_widget link="/help/export-your-organization" }}
     </h3>
     <p>
-        {{t 'Exports all users, settings, and all data visible in public streams.' }}
+        {{t 'Exports all users, settings, and all data visible in public channels.' }}
         {{t 'Any organization administrator can conduct an export.'}}
         {{t 'Depending on the size of your organization, an export can take anywhere from seconds to an hour.' }}
     </p>
     <p>
         {{#tr}}
-            <z-link>Click here</z-link> to learn about exporting private streams and direct messages.
+            <z-link>Click here</z-link> to learn about exporting private channels and direct messages.
             {{#*inline "z-link"}}<a href="/help/export-your-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
         {{t 'Note that organizations are limited to five exports per week.' }}

--- a/web/templates/settings/default_stream_choice.hbs
+++ b/web/templates/settings/default_stream_choice.hbs
@@ -1,5 +1,5 @@
 <div class="choice-row" data-value="{{value}}">
-    {{> ../dropdown_widget widget_name=stream_dropdown_widget_name default_text=(t 'Select stream')}}
+    {{> ../dropdown_widget widget_name=stream_dropdown_widget_name default_text=(t 'Select channel')}}
     <button type="button" class="button rounded small delete-choice" title="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -1,13 +1,13 @@
 <div id="admin-default-streams-list" class="settings-section" data-name="default-streams-list">
-    <p>{{t "Configure the default streams new users are subscribed to when joining your organization." }}</p>
+    <p>{{t "Configure the default channels new users are subscribed to when joining your organization." }}</p>
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Default streams"}}</h3>
+        <h3>{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
             {{#if is_admin}}
-                <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add stream" }}</button>
+                <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
             {{/if}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default streams' }}" aria-label="{{t 'Filter streams' }}"/>
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default channels' }}" aria-label="{{t 'Filter channels' }}"/>
         </div>
     </div>
 
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody data-empty="{{t 'There are no default streams.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
+            <tbody data-empty="{{t 'There are no default channels.' }}" data-search-results-empty="{{t 'No default channels match your current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -140,7 +140,7 @@
           prefix=prefix}}
 
         <div class="input-group">
-            <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}
+            <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive channels" }}
                 {{> ../help_link_widget link="/help/manage-inactive-streams" }}
             </label>
             <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element settings_select bootstrap-focus-style" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -4,7 +4,7 @@
             <h3>{{t "Notification triggers" }}</h3>
             {{> settings_save_discard_widget section_name="general-notify-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
-        <p>{{t "Configure how Zulip notifies you about new messages. In muted streams, stream notification settings apply only to unmuted topics." }}</p>
+        <p>{{t "Configure how Zulip notifies you about new messages. In muted channels, channel notification settings apply only to unmuted topics." }}</p>
         <table class="notification-table table table-bordered wrapped-table">
             <thead>
                 <tr>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -64,12 +64,12 @@
 
         <div id="org-stream-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Stream permissions" }}</h3>
+                <h3>{{t "Channel permissions" }}</h3>
                 {{> settings_save_discard_widget section_name="stream-permissions" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_create_public_stream_policy" class="dropdown-title">{{t "Who can create public streams" }}</label>
+                    <label for="realm_create_public_stream_policy" class="dropdown-title">{{t "Who can create public channels" }}</label>
                     <select name="realm_create_public_stream_policy" id="id_realm_create_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
@@ -83,19 +83,19 @@
                   is_disabled=disable_enable_spectator_access_setting
                   help_link="/help/public-access-option"}}
                 <div class="input-group realm_create_web_public_stream_policy">
-                    <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
+                    <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public channels" }}</label>
                     <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=create_web_public_stream_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private streams" }}</label>
+                    <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private channels" }}</label>
                     <select name="realm_create_private_stream_policy" id="id_realm_create_private_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
+                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to channels" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
@@ -186,7 +186,7 @@
             </div>
 
             <div class="input-group">
-                <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
+                <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another channel" }}
                 </label>
                 <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element bootstrap-focus-style move-message-policy-setting settings_select" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
@@ -194,7 +194,7 @@
             </div>
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="dropdown-title">{{t "Time limit for moving messages between streams" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="realm_move_messages_between_streams_limit_seconds" class="dropdown-title">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_between_streams_limit_seconds" id="id_realm_move_messages_between_streams_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -17,7 +17,7 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th data-sort="alphabetic" data-sort-prop="stream">{{t "Stream" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="stream">{{t "Channel" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="topic">{{t "Topic" }}</th>
                 <th data-sort="numeric" data-sort-prop="visibility_policy">{{t "Status" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_updated" class="active topic_date_updated">{{t "Date updated" }}</th>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -126,7 +126,7 @@
                     {{#unless is_guest}}
                     <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-streams-list">
                         <i class="icon fa fa-exchange" aria-hidden="true"></i>
-                        <div class="text">{{t "Default streams" }}</div>
+                        <div class="text">{{t "Default channels" }}</div>
                         {{#unless is_admin}}
                         <i class="locked fa fa-lock tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                         {{/unless}}

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -1,7 +1,7 @@
 <div class="add_subscribers_container">
     <div class="pill-container person_picker">
         <div class="input" contenteditable="true"
-          data-placeholder="{{t 'Add subscribers. Use usergroup or #streamname to bulk add subscribers.' }}">
+          data-placeholder="{{t 'Add subscribers. Use usergroup or #channelname to bulk add subscribers.' }}">
             {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
         </div>
     </div>

--- a/web/templates/stream_settings/announce_stream_checkbox.hbs
+++ b/web/templates/stream_settings/announce_stream_checkbox.hbs
@@ -1,7 +1,7 @@
 <label class="checkbox">
     <input type="checkbox" name="announce" value="announce" checked />
     <span></span>
-    {{t "Announce new stream in"}}
+    {{t "Announce new channel in"}}
     {{#if new_stream_announcements_stream_sub}}
         <strong>
             {{> ../inline_decorated_stream_name

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -63,7 +63,7 @@
                 <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
             </div>
             {{else}}
-            <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Stream created recently' }}">
+            <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Channel created recently' }}">
                 <span class="stream-message-count-text">{{t "New" }}</span>
             </div>
             {{/if}}

--- a/web/templates/stream_settings/change_stream_info_modal.hbs
+++ b/web/templates/stream_settings/change_stream_info_modal.hbs
@@ -1,6 +1,6 @@
 <div>
     <label for="change_stream_name">
-        {{t 'Stream name' }}
+        {{t 'Channel name' }}
     </label>
     <input type="text" id="change_stream_name" class="modal_text_input" name="stream_name" value="{{ stream_name }}" maxlength="{{ max_stream_name_length }}" />
 </div>

--- a/web/templates/stream_settings/confirm_stream_privacy_change_modal.hbs
+++ b/web/templates/stream_settings/confirm_stream_privacy_change_modal.hbs
@@ -1,7 +1,7 @@
 <div class="confirm-stream-privacy-modal">
     <div class="new-style">
         <p class="confirm-stream-privacy-info">
-            {{t "This change will make this stream's entire message history accessible according to the new configuration."}}
+            {{t "This change will make this channel's entire message history accessible according to the new configuration."}}
         </p>
     </div>
 </div>

--- a/web/templates/stream_settings/copy_email_address_modal.hbs
+++ b/web/templates/stream_settings/copy_email_address_modal.hbs
@@ -1,7 +1,7 @@
 <div class="copy-email-modal">
     <div class="new-style">
         <p class="question-which-parts">
-            {{t "Which parts of the email should be included in the Zulip message sent to this stream?"}}
+            {{t "Which parts of the email should be included in the Zulip message sent to this channel?"}}
         </p>
         {{#each tags}}
             {{#if (eq this.name "prefer-html") }}
@@ -17,7 +17,7 @@
         {{/each}}
         <hr />
         <p class="stream-email-header">
-            {{t "Stream email address:"}}
+            {{t "Channel email address:"}}
         </p>
         <div class="stream-email">
             <div class="email-address">{{email_address}}</div>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -25,7 +25,7 @@
                 <th data-sort="email">{{t "Email" }}</th>
                 <th>{{t "Action" }}</th>
             </thead>
-            <tbody id="create_stream_subscribers" class="subscriber_table" data-empty="{{t 'This stream has no subscribers.' }}" data-search-results-empty="{{t 'No stream subscribers match your current filter.'}}"></tbody>
+            <tbody id="create_stream_subscribers" class="subscriber_table" data-empty="{{t 'This channel has no subscribers.' }}" data-search-results-empty="{{t 'No channel subscribers match your current filter.'}}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -1,5 +1,5 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
-  aria-label="{{t 'Stream creation' }}">
+  aria-label="{{t 'Channel creation' }}">
     <form id="stream_creation_form">
         <div class="stream-creation-simplebar-container" data-simplebar>
             <div class="alert stream_create_info"></div>
@@ -7,19 +7,19 @@
             <div class="stream-creation-body">
                 <section class="block">
                     <label for="create_stream_name">
-                        {{t "Stream name" }}
+                        {{t "Channel name" }}
                     </label>
                     <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
-                      placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
+                      placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
                     <div id="stream_name_error" class="stream_creation_error"></div>
                 </section>
                 <section class="block">
                     <label for="create_stream_description">
-                        {{t "Stream description" }}
+                        {{t "Channel description" }}
                         {{> ../help_link_widget link="/help/change-the-stream-description" }}
                     </label>
                     <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
-                      placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
+                      placeholder="{{t 'Channel description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
                 </section>
                 {{#if ask_to_announce_stream}}
                     <div id="announce-new-stream">
@@ -28,7 +28,7 @@
                 {{/if}}
                 <section class="block" id="make-invite-only">
                     <div class="stream-types">
-                        <h3 class="stream_setting_subsection_title">{{t "Stream permissions" }}</h3>
+                        <h3 class="stream_setting_subsection_title">{{t "Channel permissions" }}</h3>
                         {{> stream_types
                           stream_post_policy=stream_post_policy_values.everyone.code
                           is_stream_edit=false

--- a/web/templates/stream_settings/stream_description.hbs
+++ b/web/templates/stream_settings/stream_description.hbs
@@ -4,6 +4,6 @@
 </span>
 {{else}}
 <span class="sub-stream-description no-description">
-    {{t "This stream does not yet have a description." }}
+    {{t "This channel does not yet have a description." }}
 </span>
 {{/if}}

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -27,7 +27,7 @@
                     <th>{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody class="subscriber_table" data-empty="{{t 'This stream has no subscribers.' }}" data-search-results-empty="{{t 'No stream subscribers match your current filter.'}}"></tbody>
+                <tbody class="subscriber_table" data-empty="{{t 'This channel has no subscribers.' }}" data-search-results-empty="{{t 'No channel subscribers match your current filter.'}}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -6,7 +6,7 @@
             <template id="cannot-subscribe-tooltip-template">
                 <span>
                     {{#tr}}
-                        Cannot subscribe to private stream <z-stream></z-stream>
+                        Cannot subscribe to private channel <z-stream></z-stream>
                         {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=../sub}}{{/inline}}
                     {{/tr}}
                 </span>
@@ -21,7 +21,7 @@
         </div>
         <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="bottom" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
         {{#if is_realm_admin}}
-        <button class="button small rounded btn-danger deactivate tippy-zulip-delayed-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+        <button class="button small rounded btn-danger deactivate tippy-zulip-delayed-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive channel'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}
     </div>
     {{/with}}
@@ -43,7 +43,7 @@
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
                 <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
-                    <button id="open_stream_info_modal" class="button rounded small btn-warning tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edit stream name and description' }}">
+                    <button id="open_stream_info_modal" class="button rounded small btn-warning tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edit channel name and description' }}">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </button>
                 </div>
@@ -55,7 +55,7 @@
             </div>
             <div class="stream-permissions settings-subsection-parent" id="stream_permission_settings">
                 <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title">{{t "Stream permissions" }}
+                    <h3 class="stream_setting_subsection_title">{{t "Channel permissions" }}
                     </h3>
                     {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
                 </div>
@@ -78,7 +78,7 @@
             <div class="stream_details_box">
                 <div class="stream_details_box_header">
                     <h3 class="stream_setting_subsection_title">
-                        {{t "Stream details" }}
+                        {{t "Channel details" }}
                     </h3>
                     <div class="stream_email_address_error alert-notification"></div>
                 </div>
@@ -105,7 +105,7 @@
                     {{/if}}
                 </div>
                 <div class="stream_details_subsection">
-                    {{t "Stream ID"}}<br/>
+                    {{t "Channel ID"}}<br/>
                     {{stream_id}}
                 </div>
                 {{/with}}
@@ -113,7 +113,7 @@
                 <div class="input-group stream-email-box">
                     <label for="copy_stream_email_button" class="title inline-block">Email address</label>
                     <p class="field-hint">
-                        {{t "You can use email to send messages to Zulip streams."}}
+                        {{t "You can use email to send messages to Zulip channels."}}
                         {{> ../help_link_widget link="/help/message-a-stream-by-email" }}
                     </p>
                     <button class="button small rounded copy_email_button" id="copy_stream_email_button" type="button">
@@ -144,7 +144,7 @@
                     </div>
                 {{/each}}
                 <div class="input-group">
-                    <label for="streamcolor">{{t "Stream color" }}</label>
+                    <label for="streamcolor">{{t "Channel color" }}</label>
                     <span class="sub_setting_control">
                         <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
                     </span>
@@ -154,7 +154,7 @@
                 <div class="subsection-header">
                     <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
                     <div class="stream_change_property_status alert-notification"></div>
-                    <p>{{t "In muted streams, stream notification settings apply only to unmuted topics." }}</p>
+                    <p>{{t "In muted channels, channel notification settings apply only to unmuted topics." }}</p>
                 </div>
                 <div class="input-group">
                     <button class="button small rounded reset-stream-notifications-button" type="button">{{t "Reset to default notifications" }}</button>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -3,7 +3,7 @@
         <div class="subscriptions-container overlay-container">
             <div class="subscriptions-header">
                 <div class="fa fa-chevron-left"></div>
-                <span class="subscriptions-title">{{t 'Streams' }}</span>
+                <span class="subscriptions-title">{{t 'Channels' }}</span>
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
@@ -21,7 +21,7 @@
                 </div>
                 <div class="input-append stream_name_search_section" id="stream_filter">
                     <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
-                      placeholder="{{t 'Filter streams' }}" value=""/>
+                      placeholder="{{t 'Filter channels' }}" value=""/>
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
@@ -29,17 +29,17 @@
                 <div class="no-streams-to-show">
                     <div class="subscribed_streams_tab_empty_text">
                         <span>
-                            {{t 'You are not subscribed to any streams.'}}
+                            {{t 'You are not subscribed to any channels.'}}
                             {{#if can_view_all_streams}}
-                            <a href="#streams/all">{{t 'View all streams'}}</a>
+                            <a href="#streams/all">{{t 'View all channels'}}</a>
                             {{/if}}
                         </span>
                     </div>
                     <div class="all_streams_tab_empty_text">
                         <span>
-                            {{t 'There are no streams you can view in this organization.'}}
+                            {{t 'There are no channels you can view in this organization.'}}
                             {{#if can_create_streams}}
-                                <a href="#streams/new">{{t 'Create a stream'}}</a>
+                                <a href="#streams/new">{{t 'Create a channel'}}</a>
                             {{/if}}
                         </span>
                     </div>
@@ -49,14 +49,14 @@
             </div>
             <div class="right">
                 <div class="display-type">
-                    <div id="stream_settings_title" class="stream-info-title">{{t 'Stream settings' }}</div>
+                    <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
                 </div>
                 <div class="nothing-selected">
                     {{#if can_create_streams}}
-                    <button type="button" class="create_stream_button animated-purple-button">{{t 'Create stream' }}</button>
+                    <button type="button" class="create_stream_button animated-purple-button">{{t 'Create channel' }}</button>
                     <span>
                         {{#tr}}
-                            First time? Read our <z-link>guidelines</z-link> for creating and naming streams.
+                            First time? Read our <z-link>guidelines</z-link> for creating and naming channels.
                             {{#*inline "z-link"}}<a href="/help/getting-your-organization-started-with-zulip#create-streams" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                         {{/tr}}
                     </span>

--- a/web/templates/stream_settings/stream_settings_tip.hbs
+++ b/web/templates/stream_settings/stream_settings_tip.hbs
@@ -1,6 +1,6 @@
 {{#unless can_change_stream_permissions}}
     {{#if can_change_name_description}}
-        <div class="tip">{{t "Only subscribers to this stream can edit stream permissions."}}</div>
+        <div class="tip">{{t "Only subscribers to this channel can edit channel permissions."}}</div>
     {{else}}
         <div class="tip">{{t "Only organization administrators can edit these settings."}}</div>
     {{/if}}

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -1,6 +1,6 @@
 <div class="input-group stream-privacy-values">
     <div class="alert stream-privacy-status"></div>
-    <label>{{t 'Who can access the stream?'}}
+    <label>{{t 'Who can access the channel?'}}
         {{> ../help_link_widget link="/help/stream-permissions" }}
     </label>
 
@@ -21,13 +21,13 @@
       prefix="id_"
       setting_name="is_default_stream"
       is_checked=check_default_stream
-      label="Default stream for new users"
+      label=(t "Default channel for new users")
       help_link="/help/set-default-streams-for-new-users"
       }}
 </div>
 
 <div class="input-group">
-    <label class="dropdown-title">{{t 'Who can post to the stream?'}}
+    <label class="dropdown-title">{{t 'Who can post to the channel?'}}
         {{> ../help_link_widget link="/help/stream-sending-policy" }}
     </label>
     <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
@@ -41,7 +41,7 @@
 
 {{> ../dropdown_widget_with_label
   widget_name=can_remove_subscribers_setting_widget_name
-  label=(t 'Who can unsubscribe others from this stream?')
+  label=(t 'Who can unsubscribe others from this channel?')
   value_type="number"}}
 
 {{#if (or is_owner is_stream_edit)}}

--- a/web/templates/stream_sidebar_actions.hbs
+++ b/web/templates/stream_sidebar_actions.hbs
@@ -17,16 +17,16 @@
     <li class="stream-menu-item">
         <a tabindex="0" class="open_stream_settings">
             <i class="fa fa-cog" aria-hidden="true"></i>
-            {{t "Stream settings" }}
+            {{t "Channel settings" }}
         </a>
     </li>
     <li class="stream-menu-item hidden-for-spectators">
         <a tabindex="0" class="pin_to_top">
             <i class="fa fa-thumb-tack stream-pin-icon" aria-hidden="true"></i>
             {{#if stream.pin_to_top}}
-            {{t "Unpin stream from top"}}
+            {{t "Unpin channel from top"}}
             {{else}}
-            {{t "Pin stream to top"}}
+            {{t "Pin channel to top"}}
             {{/if}}
         </a>
     </li>
@@ -40,10 +40,10 @@
         <a tabindex="0" class="toggle_stream_muted">
             {{#if stream.is_muted}}
             <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
-            {{t "Unmute stream"}}
+            {{t "Unmute channel"}}
             {{else}}
             <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
-            {{t "Mute stream"}}
+            {{t "Mute channel"}}
             {{/if}}
         </a>
     </li>

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,16 +1,16 @@
 {{#if exactly_one_unsubscribed_stream}}
     <a href="#streams/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~t "Browse 1 more stream" ~}}
+        {{~t "Browse 1 more channel" ~}}
     </a>
 {{else if can_subscribe_stream_count}}
     <a href="#streams/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~t "Browse {can_subscribe_stream_count} more streams" ~}}
+        {{~t "Browse {can_subscribe_stream_count} more channels" ~}}
     </a>
 {{else if can_create_streams}}
     <a href="#streams/new">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~t "Create a stream" ~}}
+        {{~t "Create a channel" ~}}
     </a>
 {{/if}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -30,7 +30,7 @@
     {{tooltip_hotkey_hints "C"}}
 </template>
 <template id="new_stream_message_button_tooltip_template">
-    {{t 'New stream message' }}
+    {{t 'New channel message' }}
     {{tooltip_hotkey_hints "C"}}
 </template>
 <template id="new_direct_message_button_tooltip_template">
@@ -127,7 +127,7 @@
     {{t 'Starred messages' }}
 </template>
 <template id="filter-streams-tooltip-template">
-    {{t 'Filter streams' }}
+    {{t 'Filter channels' }}
     {{tooltip_hotkey_hints "Q"}}
 </template>
 <template id="message-expander-tooltip-template">
@@ -183,7 +183,7 @@
     {{tooltip_hotkey_hints "/"}}
 </template>
 <template id="streamlist-toggle-tooltip-template" >
-    {{t 'View streams' }}
+    {{t 'View channels' }}
     {{tooltip_hotkey_hints "Q"}}
 </template>
 <template id="show-userlist-tooltip-template">
@@ -210,7 +210,7 @@
     {{tooltip_hotkey_hints "Backspace"}}
 </template>
 <template id="create-new-stream-tooltip-template">
-    {{t 'Create new stream' }}
+    {{t 'Create new channel' }}
     {{tooltip_hotkey_hints "N"}}
 </template>
 <template id="toggle-subscription-tooltip-template">
@@ -218,7 +218,7 @@
     {{tooltip_hotkey_hints "Shift" "S"}}
 </template>
 <template id="view-stream-tooltip-template">
-    {{t 'View stream' }}
+    {{t 'View channel' }}
     {{tooltip_hotkey_hints "Shift" "V"}}
 </template>
 <template id="mobile-push-notification-tooltip-template">

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -41,6 +41,6 @@
 {{#if is_unsubscribed}}
 &nbsp;
 <span class="fa fa-exclamation-triangle unsubscribed_icon"
-  title="{{t 'You are not currently subscribed to this stream.' }}"></span>
+  title="{{t 'You are not currently subscribed to this channel.' }}"></span>
 {{/if}}
 {{~/if}}

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -1,7 +1,7 @@
 <div class="add_members_container">
     <div class="pill-container person_picker">
         <div class="input" contenteditable="true"
-          data-placeholder="{{t 'Add members. Use usergroup or #streamname to bulk add members.' }}">
+          data-placeholder="{{t 'Add members. Use usergroup or #channelname to bulk add members.' }}">
             {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
         </div>
     </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -105,21 +105,21 @@
                         <div class="alert stream_list_info"></div>
                         {{#if show_user_subscribe_widget}}
                             <div class="header-section">
-                                <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to streams'}}</h3>
+                                <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to channels'}}</h3>
                             </div>
                             {{> user_profile_subscribe_widget}}
                         {{/if}}
                         <div class="stream-list-top-section">
                             <div class="header-section">
-                                <h3 class="stream-tab-element-header">{{t 'Subscribed streams' }}</h3>
+                                <h3 class="stream-tab-element-header">{{t 'Subscribed channels' }}</h3>
                             </div>
-                            <input type="text" class="stream-search modal_text_input" placeholder="{{t 'Filter streams' }}" />
+                            <input type="text" class="stream-search modal_text_input" placeholder="{{t 'Filter channels' }}" />
                             <button type="button" class="clear_search_button" id="clear_stream_search">
                                 <i class="fa fa-remove" aria-hidden="true"></i>
                             </button>
                         </div>
                         <div class="subscription-stream-list empty-list">
-                            <table class="user-stream-list" data-empty="{{t 'No stream subscriptions.'}}" data-search-results-empty="{{t 'No matching streams' }}"></table>
+                            <table class="user-stream-list" data-empty="{{t 'No channel subscriptions.'}}" data-search-results-empty="{{t 'No matching channels' }}"></table>
                         </div>
                     </div>
 

--- a/web/templates/user_stream_list_item.hbs
+++ b/web/templates/user_stream_list_item.hbs
@@ -8,7 +8,7 @@
     {{#if show_unsubscribe_button}}
     <td class="remove_subscription">
         <div class="subscription_list_remove">
-            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded btn-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use stream settings to unsubscribe from private streams."}}{{else}}{{t "Use stream settings to unsubscribe the last user from a private stream."}}{{/if}}'>
+            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded btn-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use channel settings to unsubscribe from private channels."}}{{else}}{{t "Use channel settings to unsubscribe the last user from a private channel."}}{{/if}}'>
                 {{t 'Unsubscribe' }}
             </button>
         </div>

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -395,7 +395,7 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
     let wildcards_not_allowed_rendered = false;
     mock_template("compose_banner/wildcard_mention_not_allowed_error.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.wildcards_not_allowed);
-        assert.equal(data.stream_wildcard_mention, "all");
+        assert.equal(data.wildcard_mention_string, "all");
         wildcards_not_allowed_rendered = true;
         return "<banner-stub>";
     });
@@ -627,7 +627,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     let banner_rendered = false;
     mock_template("compose_banner/private_stream_warning.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.private_stream_warning);
-        assert.equal(data.stream_name, "Denmark");
+        assert.equal(data.channel_name, "Denmark");
         banner_rendered = true;
         return "<banner-stub>";
     });

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -235,7 +235,7 @@ test_ui("validate", ({mock_template}) => {
     let empty_stream_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.missing_stream);
-        assert.equal(data.banner_text, $t({defaultMessage: "Please specify a stream."}));
+        assert.equal(data.banner_text, $t({defaultMessage: "Please specify a channel."}));
         empty_stream_error_rendered = true;
         return "<banner-stub>";
     });
@@ -428,7 +428,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", ({mock_template})
         assert.equal(
             data.banner_text,
             $t({
-                defaultMessage: "You do not have permission to post in this stream.",
+                defaultMessage: "You do not have permission to post in this channel.",
             }),
         );
         banner_rendered = true;
@@ -473,7 +473,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", ({mock_templ
         assert.equal(
             data.banner_text,
             $t({
-                defaultMessage: "You do not have permission to post in this stream.",
+                defaultMessage: "You do not have permission to post in this channel.",
             }),
         );
         banner_rendered = true;
@@ -509,7 +509,7 @@ test_ui("test_validate_stream_message_post_policy_full_members_only", ({mock_tem
         assert.equal(
             data.banner_text,
             $t({
-                defaultMessage: "You do not have permission to post in this stream.",
+                defaultMessage: "You do not have permission to post in this channel.",
             }),
         );
         banner_rendered = true;

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -86,10 +86,10 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     assert.equal(mention_topic.email, "topic");
     assert.equal(mention_topic.full_name, "topic");
 
-    assert.equal(mention_all.special_item_text, "all (translated: Notify stream)");
-    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify stream)");
-    assert.equal(mention_stream.special_item_text, "stream (translated: Notify stream)");
-    assert.equal(mention_channel.special_item_text, "channel (translated: Notify stream)");
+    assert.equal(mention_all.special_item_text, "all (translated: Notify channel)");
+    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify channel)");
+    assert.equal(mention_stream.special_item_text, "stream (translated: Notify channel)");
+    assert.equal(mention_channel.special_item_text, "channel (translated: Notify channel)");
     assert.equal(mention_topic.special_item_text, "topic (translated: Notify topic)");
 
     compose_validate.stream_wildcard_mention_allowed = () => false;

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1689,7 +1689,7 @@ test("navbar_helpers", () => {
             terms: in_all,
             is_common_narrow: true,
             icon: "home",
-            title: "translated: All messages including muted streams",
+            title: "translated: All messages including muted channels",
             redirect_url_with_search: "#",
         },
         {
@@ -1724,7 +1724,7 @@ test("navbar_helpers", () => {
             terms: streams_public,
             is_common_narrow: true,
             icon: undefined,
-            title: "translated: Messages in all public streams",
+            title: "translated: Messages in all public channels",
             redirect_url_with_search: "/#narrow/streams/public",
         },
         {
@@ -1738,14 +1738,14 @@ test("navbar_helpers", () => {
             terms: non_existent_stream,
             is_common_narrow: true,
             icon: "question-circle-o",
-            title: "translated: Unknown stream #Elephant",
+            title: "translated: Unknown channel #Elephant",
             redirect_url_with_search: "#",
         },
         {
             terms: non_existent_stream_topic,
             is_common_narrow: true,
             icon: "question-circle-o",
-            title: "translated: Unknown stream #Elephant",
+            title: "translated: Unknown channel #Elephant",
             redirect_url_with_search: "#",
         },
         {

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -15,9 +15,9 @@ page_params.request_language = "en";
 page_params.translation_data = {
     "Quote and reply": "Citer et répondre",
     "Notification triggers": "Déclencheurs de notification",
-    "You subscribed to stream {stream}": "Vous n'êtes pas abonnés au canal {stream}",
-    "<p>The stream <b>{stream_name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Streams page</z-link>.</p>":
-        "<p>Le canal <b>{stream_name}</b> n'existe pas.</p><p>Gérez vos abonnements <z-link>sur votre page canaux</z-link>.</p>",
+    "You subscribed to channel {name}": "Vous n'êtes pas abonnés au canal {name}",
+    "<p>The channel <b>{name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Channels page</z-link>.</p>":
+        "<p>Le canal <b>{name}</b> n'existe pas.</p><p>Gérez vos abonnements <z-link>sur votre page canaux</z-link>.</p>",
 };
 
 // Re-register Zulip extensions so extensions registered previously with
@@ -41,10 +41,10 @@ run_test("$t", () => {
     assert.equal(
         $t(
             {
-                id: "You subscribed to stream {stream}",
-                defaultMessage: "You subscribed to stream {stream}",
+                id: "You subscribed to channel {name}",
+                defaultMessage: "You subscribed to channel {name}",
             },
-            {stream: "l'abonnement"},
+            {name: "l'abonnement"},
         ),
         "Vous n'êtes pas abonnés au canal l'abonnement",
     );
@@ -54,16 +54,16 @@ run_test("$tr", () => {
     assert.equal(
         $t_html(
             {
-                id: "<p>The stream <b>{stream_name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Streams page</z-link>.</p>",
+                id: "<p>The channel <b>{name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Channels page</z-link>.</p>",
                 defaultMessage:
-                    "<p>The stream <b>{stream_name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Streams page</z-link>.</p>",
+                    "<p>The channel <b>{name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Channels page</z-link>.</p>",
             },
             {
-                stream_name: "l'abonnement",
-                "z-link": (content_html) => `<a href='#streams/all'>${content_html.join("")}</a>`,
+                name: "l'abonnement",
+                "z-link": (content_html) => `<a href='#channels/all'>${content_html.join("")}</a>`,
             },
         ),
-        "<p>Le canal <b>l&#39;abonnement</b> n'existe pas.</p><p>Gérez vos abonnements <a href='#streams/all'>sur votre page canaux</a>.</p>",
+        "<p>Le canal <b>l&#39;abonnement</b> n'existe pas.</p><p>Gérez vos abonnements <a href='#channels/all'>sur votre page canaux</a>.</p>",
     );
 });
 

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -111,7 +111,7 @@ run_test("tr_tag", ({mock_template}) => {
             twenty_four_hour_time: "Time format",
             automatically_follow_topics_policy: "Automatically follow topics",
             automatically_unmute_topics_in_muted_streams_policy:
-                "Automatically unmute topics in muted streams",
+                "Automatically unmute topics in muted channels",
             automatically_follow_topics_where_mentioned:
                 "Automatically follow topics where I'm mentioned",
         },

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -222,7 +222,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This stream does not exist or is private."),
+        empty_narrow_html("translated: This channel does not exist or is private."),
     );
 
     // for non-subbed public stream
@@ -232,8 +232,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You aren't subscribed to this stream and nobody has talked about that yet!",
-            'translated HTML: <button class="button white rounded stream_sub_unsub_button sea-green" type="button" name="subscription">Subscribe</button>',
+            "translated: There are no messages here.",
+            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
 
@@ -524,7 +524,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This stream does not exist or is private."),
+        empty_narrow_html("translated: This channel does not exist or is private."),
     );
 });
 
@@ -626,7 +626,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: No search results.",
-            "translated HTML: <p>You are searching for messages that belong to more than one stream, which is not possible.</p>",
+            "translated HTML: <p>You are searching for messages that belong to more than one channel, which is not possible.</p>",
         ),
     );
 

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -815,7 +815,10 @@ run_test("narrow_compute_title", () => {
     assert.equal(narrow_title.compute_narrow_title(filter), "#Foo");
 
     filter = new Filter([{operator: "stream", operand: "Elephant"}]);
-    assert.equal(narrow_title.compute_narrow_title(filter), "translated: Unknown stream #Elephant");
+    assert.equal(
+        narrow_title.compute_narrow_title(filter),
+        "translated: Unknown channel #Elephant",
+    );
 
     // Direct messages with narrows
     const joe = {

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -43,7 +43,7 @@ run_test("all_notifications", () => {
 
     assert.deepEqual(notifications.general_settings, [
         {
-            label: "translated: Streams",
+            label: "translated: Channels",
             notification_settings: [
                 {
                     is_checked: false,

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -93,8 +93,8 @@ def do_create_default_stream_group(
         if stream.id in default_stream_ids:
             raise JsonableError(
                 _(
-                    "'{stream_name}' is a default stream and cannot be added to '{group_name}'",
-                ).format(stream_name=stream.name, group_name=group_name)
+                    "'{channel_name}' is a default stream and cannot be added to '{group_name}'",
+                ).format(channel_name=stream.name, group_name=group_name)
             )
 
     check_default_stream_group_name(group_name)
@@ -120,14 +120,14 @@ def do_add_streams_to_default_stream_group(
         if stream.id in default_stream_ids:
             raise JsonableError(
                 _(
-                    "'{stream_name}' is a default stream and cannot be added to '{group_name}'",
-                ).format(stream_name=stream.name, group_name=group.name)
+                    "'{channel_name}' is a default stream and cannot be added to '{group_name}'",
+                ).format(channel_name=stream.name, group_name=group.name)
             )
         if stream in group.streams.all():
             raise JsonableError(
                 _(
-                    "Stream '{stream_name}' is already present in default stream group '{group_name}'",
-                ).format(stream_name=stream.name, group_name=group.name)
+                    "Stream '{channel_name}' is already present in default stream group '{group_name}'",
+                ).format(channel_name=stream.name, group_name=group.name)
             )
         group.streams.add(stream)
 
@@ -143,8 +143,8 @@ def do_remove_streams_from_default_stream_group(
         if stream.id not in group_stream_ids:
             raise JsonableError(
                 _(
-                    "Stream '{stream_name}' is not present in default stream group '{group_name}'",
-                ).format(stream_name=stream.name, group_name=group.name)
+                    "Stream '{channel_name}' is not present in default stream group '{group_name}'",
+                ).format(channel_name=stream.name, group_name=group.name)
             )
 
     delete_stream_ids = {stream.id for stream in streams}

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -17,11 +17,11 @@ from zerver.tornado.django_api import send_event_on_commit
 def check_default_stream_group_name(group_name: str) -> None:
     if group_name.strip() == "":
         raise JsonableError(
-            _("Invalid default stream group name '{group_name}'").format(group_name=group_name)
+            _("Invalid default channel group name '{group_name}'").format(group_name=group_name)
         )
     if len(group_name) > DefaultStreamGroup.MAX_NAME_LENGTH:
         raise JsonableError(
-            _("Default stream group name too long (limit: {max_length} characters)").format(
+            _("Default channel group name too long (limit: {max_length} characters)").format(
                 max_length=DefaultStreamGroup.MAX_NAME_LENGTH,
             )
         )
@@ -29,7 +29,7 @@ def check_default_stream_group_name(group_name: str) -> None:
         if ord(i) == 0:
             raise JsonableError(
                 _(
-                    "Default stream group name '{group_name}' contains NULL (0x00) characters."
+                    "Default channel group name '{group_name}' contains NULL (0x00) characters."
                 ).format(
                     group_name=group_name,
                 )
@@ -45,7 +45,7 @@ def lookup_default_stream_groups(
             default_stream_group = DefaultStreamGroup.objects.get(name=group_name, realm=realm)
         except DefaultStreamGroup.DoesNotExist:
             raise JsonableError(
-                _("Invalid default stream group {group_name}").format(group_name=group_name)
+                _("Invalid default channel group {group_name}").format(group_name=group_name)
             )
         default_stream_groups.append(default_stream_group)
     return default_stream_groups
@@ -93,7 +93,7 @@ def do_create_default_stream_group(
         if stream.id in default_stream_ids:
             raise JsonableError(
                 _(
-                    "'{channel_name}' is a default stream and cannot be added to '{group_name}'",
+                    "'{channel_name}' is a default channel and cannot be added to '{group_name}'",
                 ).format(channel_name=stream.name, group_name=group_name)
             )
 
@@ -104,7 +104,7 @@ def do_create_default_stream_group(
     if not created:
         raise JsonableError(
             _(
-                "Default stream group '{group_name}' already exists",
+                "Default channel group '{group_name}' already exists",
             ).format(group_name=group_name)
         )
 
@@ -120,13 +120,13 @@ def do_add_streams_to_default_stream_group(
         if stream.id in default_stream_ids:
             raise JsonableError(
                 _(
-                    "'{channel_name}' is a default stream and cannot be added to '{group_name}'",
+                    "'{channel_name}' is a default channel and cannot be added to '{group_name}'",
                 ).format(channel_name=stream.name, group_name=group.name)
             )
         if stream in group.streams.all():
             raise JsonableError(
                 _(
-                    "Stream '{channel_name}' is already present in default stream group '{group_name}'",
+                    "Channel '{channel_name}' is already present in default channel group '{group_name}'",
                 ).format(channel_name=stream.name, group_name=group.name)
             )
         group.streams.add(stream)
@@ -143,7 +143,7 @@ def do_remove_streams_from_default_stream_group(
         if stream.id not in group_stream_ids:
             raise JsonableError(
                 _(
-                    "Stream '{channel_name}' is not present in default stream group '{group_name}'",
+                    "Channel '{channel_name}' is not present in default channel group '{group_name}'",
                 ).format(channel_name=stream.name, group_name=group.name)
             )
 
@@ -158,14 +158,14 @@ def do_change_default_stream_group_name(
 ) -> None:
     if group.name == new_group_name:
         raise JsonableError(
-            _("This default stream group is already named '{group_name}'").format(
+            _("This default channel group is already named '{group_name}'").format(
                 group_name=new_group_name
             )
         )
 
     if DefaultStreamGroup.objects.filter(name=new_group_name, realm=realm).exists():
         raise JsonableError(
-            _("Default stream group '{group_name}' already exists").format(
+            _("Default channel group '{group_name}' already exists").format(
                 group_name=new_group_name
             )
         )

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -103,7 +103,7 @@ def validate_message_edit_payload(
 
     if not message.is_stream_message():
         if stream_id is not None:
-            raise JsonableError(_("Direct messages cannot be moved to streams."))
+            raise JsonableError(_("Direct messages cannot be moved to channels."))
         if topic_name is not None:
             raise JsonableError(_("Direct messages cannot have topics."))
 
@@ -114,7 +114,7 @@ def validate_message_edit_payload(
         check_stream_topic(topic_name)
 
     if stream_id is not None and content is not None:
-        raise JsonableError(_("Cannot change message content while changing stream"))
+        raise JsonableError(_("Cannot change message content while changing channel"))
 
     # Right now, we prevent users from editing widgets.
     if content is not None and is_widget_message(message):
@@ -1325,7 +1325,7 @@ def check_update_message(
             )
             if (timezone_now() - message.date_sent) > timedelta(seconds=deadline_seconds):
                 raise JsonableError(
-                    _("The time limit for editing this message's stream has passed")
+                    _("The time limit for editing this message's channel has passed")
                 )
 
     if (

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1460,34 +1460,34 @@ def send_pm_if_empty_stream(
                 if stream_id is not None:
                     arg_dict = {
                         **arg_dict,
-                        "stream_id": stream_id,
+                        "channel_id": stream_id,
                     }
                     content = _(
                         "Your bot {bot_identity} tried to send a message to stream ID "
-                        "{stream_id}, but there is no stream with that ID."
+                        "{channel_id}, but there is no stream with that ID."
                     ).format(**arg_dict)
                 else:
                     assert stream_name is not None
                     arg_dict = {
                         **arg_dict,
-                        "stream_name": f"#**{stream_name}**",
-                        "new_stream_link": "#streams/new",
+                        "channel_name": f"#**{stream_name}**",
+                        "new_channel_link": "#streams/new",
                     }
                     content = _(
                         "Your bot {bot_identity} tried to send a message to stream "
-                        "{stream_name}, but that stream does not exist. "
-                        "Click [here]({new_stream_link}) to create it."
+                        "{channel_name}, but that stream does not exist. "
+                        "Click [here]({new_channel_link}) to create it."
                     ).format(**arg_dict)
             else:
                 if num_subscribers_for_stream_id(stream.id) > 0:
                     return
                 arg_dict = {
                     **arg_dict,
-                    "stream_name": f"#**{stream.name}**",
+                    "channel_name": f"#**{stream.name}**",
                 }
                 content = _(
                     "Your bot {bot_identity} tried to send a message to "
-                    "stream {stream_name}. The stream exists but "
+                    "stream {channel_name}. The stream exists but "
                     "does not have any subscribers."
                 ).format(**arg_dict)
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1260,7 +1260,7 @@ def extract_stream_indicator(s: str) -> Union[str, int]:
     # once we improve our documentation.
     if isinstance(data, list):
         if len(data) != 1:  # nocoverage
-            raise JsonableError(_("Expected exactly one stream"))
+            raise JsonableError(_("Expected exactly one channel"))
         data = data[0]
 
     if isinstance(data, str):
@@ -1271,7 +1271,7 @@ def extract_stream_indicator(s: str) -> Union[str, int]:
         # We had a stream id.
         return data
 
-    raise JsonableError(_("Invalid data type for stream"))
+    raise JsonableError(_("Invalid data type for channel"))
 
 
 def extract_private_recipients(s: str) -> Union[List[str], List[int]]:
@@ -1463,8 +1463,8 @@ def send_pm_if_empty_stream(
                         "channel_id": stream_id,
                     }
                     content = _(
-                        "Your bot {bot_identity} tried to send a message to stream ID "
-                        "{channel_id}, but there is no stream with that ID."
+                        "Your bot {bot_identity} tried to send a message to channel ID "
+                        "{channel_id}, but there is no channel with that ID."
                     ).format(**arg_dict)
                 else:
                     assert stream_name is not None
@@ -1474,8 +1474,8 @@ def send_pm_if_empty_stream(
                         "new_channel_link": "#streams/new",
                     }
                     content = _(
-                        "Your bot {bot_identity} tried to send a message to stream "
-                        "{channel_name}, but that stream does not exist. "
+                        "Your bot {bot_identity} tried to send a message to channel "
+                        "{channel_name}, but that channel does not exist. "
                         "Click [here]({new_channel_link}) to create it."
                     ).format(**arg_dict)
             else:
@@ -1487,7 +1487,7 @@ def send_pm_if_empty_stream(
                 }
                 content = _(
                     "Your bot {bot_identity} tried to send a message to "
-                    "stream {channel_name}. The stream exists but "
+                    "channel {channel_name}. The channel exists but "
                     "does not have any subscribers."
                 ).format(**arg_dict)
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -241,7 +241,7 @@ def do_unarchive_stream(
         raise JsonableError(_("Stream is not currently deactivated"))
     if Stream.objects.filter(realm=realm, name=new_name).exists():
         raise JsonableError(
-            _("Stream named {stream_name} already exists").format(stream_name=new_name)
+            _("Stream named {channel_name} already exists").format(channel_name=new_name)
         )
     assert stream.recipient_id is not None
 
@@ -312,7 +312,7 @@ def do_unarchive_stream(
             sender,
             stream,
             str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
-            _("Stream {stream_name} un-archived.").format(stream_name=new_name),
+            _("Stream {channel_name} un-archived.").format(channel_name=new_name),
         )
 
 
@@ -1467,10 +1467,10 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
             sender,
             stream,
             str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
-            _("{user_name} renamed stream {old_stream_name} to {new_stream_name}.").format(
+            _("{user_name} renamed stream {old_channel_name} to {new_channel_name}.").format(
                 user_name=silent_mention_syntax_for_user(user_profile),
-                old_stream_name=f"**{old_name}**",
-                new_stream_name=f"**{new_name}**",
+                old_channel_name=f"**{old_name}**",
+                new_channel_name=f"**{new_name}**",
             ),
         )
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -114,7 +114,7 @@ def send_user_remove_events_on_stream_deactivation(
 def do_deactivate_stream(stream: Stream, *, acting_user: Optional[UserProfile]) -> None:
     # If the stream is already deactivated, this is a no-op
     if stream.deactivated is True:
-        raise JsonableError(_("Stream is already deactivated"))
+        raise JsonableError(_("Channel is already deactivated"))
 
     # We want to mark all messages in the to-be-deactivated stream as
     # read for all users; otherwise they will pollute queries like
@@ -238,10 +238,10 @@ def do_unarchive_stream(
 ) -> None:
     realm = stream.realm
     if not stream.deactivated:
-        raise JsonableError(_("Stream is not currently deactivated"))
+        raise JsonableError(_("Channel is not currently deactivated"))
     if Stream.objects.filter(realm=realm, name=new_name).exists():
         raise JsonableError(
-            _("Stream named {channel_name} already exists").format(channel_name=new_name)
+            _("Channel named {channel_name} already exists").format(channel_name=new_name)
         )
     assert stream.recipient_id is not None
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -312,7 +312,7 @@ def do_unarchive_stream(
             sender,
             stream,
             str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
-            _("Stream {channel_name} un-archived.").format(channel_name=new_name),
+            _("Channel {channel_name} un-archived.").format(channel_name=new_name),
         )
 
 
@@ -1176,11 +1176,12 @@ def send_change_stream_permission_notification(
 
     with override_language(stream.realm.default_language):
         notification_string = _(
-            "{user} changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **{old_policy}** to **{new_policy}**."
+            "{user} changed the [access permissions]({help_link}) "
+            "for this channel from **{old_policy}** to **{new_policy}**."
         )
         notification_string = notification_string.format(
             user=user_mention,
+            help_link="/help/stream-permissions",
             old_policy=old_policy_name,
             new_policy=new_policy_name,
         )
@@ -1351,13 +1352,14 @@ def send_change_stream_post_policy_notification(
 
     with override_language(stream.realm.default_language):
         notification_string = _(
-            "{user} changed the [posting permissions](/help/stream-sending-policy) "
-            "for this stream:\n\n"
+            "{user} changed the [posting permissions]({help_link}) "
+            "for this channel:\n\n"
             "* **Old permissions**: {old_policy}.\n"
             "* **New permissions**: {new_policy}.\n"
         )
         notification_string = notification_string.format(
             user=user_mention,
+            help_link="/help/stream-sending-policy",
             old_policy=Stream.POST_POLICIES[old_post_policy],
             new_policy=Stream.POST_POLICIES[new_post_policy],
         )
@@ -1467,7 +1469,7 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
             sender,
             stream,
             str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
-            _("{user_name} renamed stream {old_channel_name} to {new_channel_name}.").format(
+            _("{user_name} renamed channel {old_channel_name} to {new_channel_name}.").format(
                 user_name=silent_mention_syntax_for_user(user_profile),
                 old_channel_name=f"**{old_name}**",
                 new_channel_name=f"**{new_name}**",
@@ -1488,7 +1490,7 @@ def send_change_stream_description_notification(
             old_description = "*" + _("No description.") + "*"
 
         notification_string = (
-            _("{user} changed the description for this stream.").format(user=user_mention)
+            _("{user} changed the description for this channel.").format(user=user_mention)
             + "\n\n* **"
             + _("Old description")
             + ":**"
@@ -1561,24 +1563,29 @@ def send_change_stream_message_retention_days_notification(
     with override_language(stream.realm.default_language):
         if old_value == Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP["unlimited"]:
             old_retention_period = _("Forever")
-            new_retention_period = f"{new_value} days"
-            summary_line = f"Messages in this stream will now be automatically deleted {new_value} days after they are sent."
+            new_retention_period = _("{number_of_days} days").format(number_of_days=new_value)
+            summary_line = _(
+                "Messages in this channel will now be automatically deleted {number_of_days} days after they are sent."
+            ).format(number_of_days=new_value)
         elif new_value == Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP["unlimited"]:
-            old_retention_period = f"{old_value} days"
+            old_retention_period = _("{number_of_days} days").format(number_of_days=old_value)
             new_retention_period = _("Forever")
-            summary_line = _("Messages in this stream will now be retained forever.")
+            summary_line = _("Messages in this channel will now be retained forever.")
         else:
-            old_retention_period = f"{old_value} days"
-            new_retention_period = f"{new_value} days"
-            summary_line = f"Messages in this stream will now be automatically deleted {new_value} days after they are sent."
+            old_retention_period = _("{number_of_days} days").format(number_of_days=old_value)
+            new_retention_period = _("{number_of_days} days").format(number_of_days=new_value)
+            summary_line = _(
+                "Messages in this channel will now be automatically deleted {number_of_days} days after they are sent."
+            ).format(number_of_days=new_value)
         notification_string = _(
-            "{user} has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            "{user} has changed the [message retention period]({help_link}) for this channel:\n"
             "* **Old retention period**: {old_retention_period}\n"
             "* **New retention period**: {new_retention_period}\n\n"
             "{summary_line}"
         )
         notification_string = notification_string.format(
             user=user_mention,
+            help_link="/help/message-retention-policy",
             old_retention_period=old_retention_period,
             new_retention_period=new_retention_period,
             summary_line=summary_line,

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -108,7 +108,7 @@ class Addressee:
 
         if recipient_type_name == "stream":
             if len(message_to) > 1:
-                raise JsonableError(_("Cannot send to multiple streams"))
+                raise JsonableError(_("Cannot send to multiple channels"))
 
             if message_to:
                 stream_name_or_id = message_to[0]
@@ -120,7 +120,7 @@ class Addressee:
                     # Use the user's default stream
                     stream_name_or_id = sender.default_sending_stream_id
                 else:
-                    raise JsonableError(_("Missing stream"))
+                    raise JsonableError(_("Missing channel"))
 
             if topic_name is None:
                 raise JsonableError(_("Missing topic"))

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -19,7 +19,7 @@ from zerver.lib.logging_util import log_to_file
 from zerver.lib.message import get_last_message_id
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress, send_future_email
-from zerver.lib.url_encoding import encode_stream
+from zerver.lib.url_encoding import stream_narrow_url
 from zerver.models import (
     Message,
     Realm,
@@ -255,18 +255,16 @@ def gather_new_streams(
     else:
         new_streams = [stream for stream in recently_created_streams if stream.is_web_public]
 
-    base_url = f"{realm.uri}/#narrow/stream/"
-
-    streams_html = []
-    streams_plain = []
+    channels_html = []
+    channels_plain = []
 
     for stream in new_streams:
-        narrow_url = base_url + encode_stream(stream.id, stream.name)
-        stream_link = f"<a href='{narrow_url}'>{stream.name}</a>"
-        streams_html.append(stream_link)
-        streams_plain.append(stream.name)
+        narrow_url = stream_narrow_url(realm, stream)
+        channel_link = f"<a href='{narrow_url}'>{stream.name}</a>"
+        channels_html.append(channel_link)
+        channels_plain.append(stream.name)
 
-    return len(new_streams), {"html": streams_html, "plain": streams_plain}
+    return len(new_streams), {"html": channels_html, "plain": channels_plain}
 
 
 def enough_traffic(hot_conversations: str, new_streams: int) -> bool:
@@ -376,7 +374,7 @@ def bulk_get_digest_context(
             recently_created_streams=recently_created_streams,
             can_access_public=user.can_access_public_streams(),
         )
-        context["new_streams"] = new_streams
+        context["new_channels"] = new_streams
         context["new_streams_count"] = new_streams_count
 
         yield user, context

--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -60,7 +60,7 @@ def further_validated_draft_dict(
         if "\0" in topic_name:
             raise JsonableError(_("Topic must not contain null bytes"))
         if len(to) != 1:
-            raise JsonableError(_("Must specify exactly 1 stream ID for stream messages"))
+            raise JsonableError(_("Must specify exactly 1 channel ID for channel messages"))
         stream, sub = access_stream_by_id(user_profile, to[0])
         recipient_id = stream.recipient_id
     elif draft_dict.type == "private" and len(to) != 0:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -6,6 +6,7 @@ from email.message import EmailMessage
 from typing import Dict, List, Match, Optional, Tuple
 
 from django.conf import settings
+from django.utils.translation import gettext as _
 from typing_extensions import override
 
 from zerver.actions.message_send import (
@@ -205,7 +206,9 @@ def send_mm_reply_to_stream(
             message_content=body,
         )
     except JsonableError as error:
-        error_message = f"Error sending message to stream {stream.name} via message notification email reply:\n{error.msg}"
+        error_message = _(
+            "Error sending message to channel {channel_name} via message notification email reply:\n{error_message}"
+        ).format(channel_name=stream.name, error_message=error.msg)
         internal_send_private_message(
             get_system_bot(settings.NOTIFICATION_BOT, user_profile.realm_id),
             user_profile,

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -527,7 +527,7 @@ def do_send_missedmessage_events_reply_in_zulip(
         context.update(narrow_url=narrow_url)
         topic_resolved, topic_name = get_topic_resolution_and_bare_name(message.topic_name())
         context.update(
-            stream_name=stream.name,
+            channel_name=stream.name,
             topic_name=topic_name,
             topic_resolved=topic_resolved,
         )
@@ -852,7 +852,7 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
             unsubscribe_link=unsubscribe_link,
             move_messages_link=realm_url + "/help/move-content-to-another-topic",
             rename_topics_link=realm_url + "/help/rename-a-topic",
-            move_topic_to_different_stream_link=realm_url + "/help/move-content-to-another-stream",
+            move_channels_link=realm_url + "/help/move-content-to-another-stream",
         )
 
         send_future_email(

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -174,7 +174,7 @@ class StreamDoesNotExistError(JsonableError):
     @staticmethod
     @override
     def msg_format() -> str:
-        return _("Stream '{stream}' does not exist")
+        return _("Channel '{stream}' does not exist")
 
 
 class StreamWithIDDoesNotExistError(JsonableError):
@@ -187,7 +187,7 @@ class StreamWithIDDoesNotExistError(JsonableError):
     @staticmethod
     @override
     def msg_format() -> str:
-        return _("Stream with ID '{stream_id}' does not exist")
+        return _("Channel with ID '{stream_id}' does not exist")
 
 
 class CannotDeactivateLastUserError(JsonableError):
@@ -631,7 +631,7 @@ class StreamWildcardMentionNotAllowedError(JsonableError):
     @staticmethod
     @override
     def msg_format() -> str:
-        return _("You do not have permission to use stream wildcard mentions in this stream.")
+        return _("You do not have permission to use channel wildcard mentions in this channel.")
 
 
 class TopicWildcardMentionNotAllowedError(JsonableError):

--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -31,10 +31,10 @@ class Hotspot:
 INTRO_HOTSPOTS: List[Hotspot] = [
     Hotspot(
         name="intro_streams",
-        title=gettext_lazy("Catch up on a stream"),
+        title=gettext_lazy("Catch up on a channel"),
         description=gettext_lazy(
-            "Messages sent to a stream are seen by everyone subscribed "
-            "to that stream. Try clicking on one of the stream links below."
+            "Messages sent to a channel are seen by everyone subscribed "
+            "to that channel. Try clicking on one of the channel links below."
         ),
     ),
     Hotspot(

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -137,7 +137,7 @@ def bot_commands(no_help_command: bool = False) -> str:
         "apps",
         "profile",
         "theme",
-        "streams",
+        "channels",
         "topics",
         "message formatting",
         "keyboard shortcuts",
@@ -172,12 +172,13 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
     elif human_response_lower in ["stream", "streams", "channel", "channels"]:
         return "".join(
             [
-                _(
-                    "In Zulip, streams [determine who gets a message](/help/streams-and-topics). "
-                    "They are similar to channels in other chat apps."
+                _("In Zulip, channels [determine who gets a message]({help_link}).").format(
+                    help_link="/help/streams-and-topics"
                 )
                 + "\n\n",
-                _("[Browse and subscribe to streams](#streams/all)."),
+                _("[Browse and subscribe to channels]({settings_link}).").format(
+                    settings_link="#streams/all"
+                ),
             ]
         )
     elif human_response_lower in ["topic", "topics"]:
@@ -268,36 +269,38 @@ def send_initial_realm_messages(realm: Realm) -> None:
     # view slightly less overwhelming
     with override_language(realm.default_language):
         content_of_private_streams_topic_name = (
-            _("This is a private stream, as indicated by the lock icon next to the stream name.")
+            _("This is a private channel, as indicated by the lock icon next to the channel name.")
             + " "
-            + _("Private streams are only visible to stream members.")
+            + _("Private channels are only visible to channel members.")
             + "\n"
             "\n"
             + _(
-                "To manage this stream, go to [Stream settings]({stream_settings_url}) "
-                "and click on `{initial_private_stream_name}`."
+                "To manage this channel, go to [Channel settings]({channel_settings_url}) "
+                "and click on `{initial_private_channel_name}`."
             )
         ).format(
-            stream_settings_url="#streams/subscribed",
-            initial_private_stream_name=Realm.INITIAL_PRIVATE_STREAM_NAME,
+            channel_settings_url="#streams/subscribed",
+            initial_private_channel_name=Realm.INITIAL_PRIVATE_STREAM_NAME,
         )
 
         content1_of_topic_demonstration_topic_name = (
             _(
-                "This is a message on stream #**{default_notification_stream_name}** with the "
+                "This is a message on channel #**{default_notification_channel_name}** with the "
                 "topic `topic demonstration`."
             )
-        ).format(default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
+        ).format(default_notification_channel_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME)
 
         content2_of_topic_demonstration_topic_name = (
             _("Topics are a lightweight tool to keep conversations organized.")
             + " "
-            + _("You can learn more about topics at [Streams and topics]({about_topics_help_url}).")
+            + _(
+                "You can learn more about topics at [Channels and topics]({about_topics_help_url})."
+            )
         ).format(about_topics_help_url="/help/streams-and-topics")
 
         content_of_swimming_turtles_topic_name = (
             _(
-                "This is a message on stream #**{default_notification_stream_name}** with the "
+                "This is a message on channel #**{default_notification_channel_name}** with the "
                 "topic `swimming turtles`."
             )
             + "\n"
@@ -310,7 +313,7 @@ def send_initial_realm_messages(realm: Realm) -> None:
             previous message."
             )
         ).format(
-            default_notification_stream_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME,
+            default_notification_channel_name=Realm.DEFAULT_NOTIFICATION_STREAM_NAME,
             start_topic_help_url="/help/starting-a-new-topic",
         )
 
@@ -334,7 +337,7 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
     welcome_messages: List[Dict[str, str]] = [
         {
             "stream": Realm.INITIAL_PRIVATE_STREAM_NAME,
-            "topic_name": "private streams",
+            "topic_name": "private channels",
             "content": content_of_private_streams_topic_name,
         },
         {

--- a/zerver/lib/recipient_parsing.py
+++ b/zerver/lib/recipient_parsing.py
@@ -11,7 +11,7 @@ def extract_stream_id(req_to: str) -> int:
     try:
         stream_id = int(req_to)
     except ValueError:
-        raise JsonableError(_("Invalid data type for stream ID"))
+        raise JsonableError(_("Invalid data type for channel ID"))
     return stream_id
 
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -239,21 +239,21 @@ def check_stream_access_based_on_stream_post_policy(sender: UserProfile, stream:
     if sender.is_realm_admin or is_cross_realm_bot_email(sender.delivery_email):
         pass
     elif stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS:
-        raise JsonableError(_("Only organization administrators can send to this stream."))
+        raise JsonableError(_("Only organization administrators can send to this channel."))
     elif (
         stream.stream_post_policy == Stream.STREAM_POST_POLICY_MODERATORS
         and not sender.is_moderator
     ):
         raise JsonableError(
-            _("Only organization administrators and moderators can send to this stream.")
+            _("Only organization administrators and moderators can send to this channel.")
         )
     elif stream.stream_post_policy != Stream.STREAM_POST_POLICY_EVERYONE and sender.is_guest:
-        raise JsonableError(_("Guests cannot send to this stream."))
+        raise JsonableError(_("Guests cannot send to this channel."))
     elif (
         stream.stream_post_policy == Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS
         and sender.is_provisional_member
     ):
-        raise JsonableError(_("New members cannot send to this stream."))
+        raise JsonableError(_("New members cannot send to this channel."))
 
 
 def access_stream_for_send_message(
@@ -313,22 +313,25 @@ def access_stream_for_send_message(
 
     # All other cases are an error.
     raise JsonableError(
-        _("Not authorized to send to stream '{channel_name}'").format(channel_name=stream.name)
+        _("Not authorized to send to channel '{channel_name}'").format(channel_name=stream.name)
     )
 
 
 def check_for_exactly_one_stream_arg(stream_id: Optional[int], stream: Optional[str]) -> None:
     if stream_id is None and stream is None:
-        raise JsonableError(_("Please supply 'stream'."))
+        # Uses the same translated string as RequestVariableMissingError
+        # with the stream_id parameter, which is the more common use case.
+        error = _("Missing '{var_name}' argument").format(var_name="stream_id")
+        raise JsonableError(error)
 
     if stream_id is not None and stream is not None:
-        raise JsonableError(_("Please choose one: 'stream' or 'stream_id'."))
+        raise JsonableError(_("Please supply only one channel parameter: name or ID."))
 
 
 def check_stream_access_for_delete_or_update(
     user_profile: UserProfile, stream: Stream, sub: Optional[Subscription] = None
 ) -> None:
-    error = _("Invalid stream ID")
+    error = _("Invalid channel ID")
     if stream.realm_id != user_profile.realm_id:
         raise JsonableError(error)
 
@@ -347,7 +350,7 @@ def access_stream_for_delete_or_update(
     try:
         stream = Stream.objects.get(id=stream_id)
     except Stream.DoesNotExist:
-        raise JsonableError(_("Invalid stream ID"))
+        raise JsonableError(_("Invalid channel ID"))
 
     try:
         sub = Subscription.objects.get(
@@ -430,7 +433,7 @@ def access_stream_by_id(
     require_active: bool = True,
     allow_realm_admin: bool = False,
 ) -> Tuple[Stream, Optional[Subscription]]:
-    error = _("Invalid stream ID")
+    error = _("Invalid channel ID")
     try:
         stream = get_stream_by_id_in_realm(stream_id, user_profile.realm)
     except Stream.DoesNotExist:
@@ -472,9 +475,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
     check_stream_name(name)
     try:
         get_stream(name, realm)
-        raise JsonableError(
-            _("Stream name '{channel_name}' is already taken.").format(channel_name=name)
-        )
+        raise JsonableError(_("Channel name already in use."))
     except Stream.DoesNotExist:
         pass
 
@@ -482,7 +483,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
 def access_stream_by_name(
     user_profile: UserProfile, stream_name: str, allow_realm_admin: bool = False
 ) -> Tuple[Stream, Optional[Subscription]]:
-    error = _("Invalid stream name '{channel_name}'").format(channel_name=stream_name)
+    error = _("Invalid channel name '{channel_name}'").format(channel_name=stream_name)
     try:
         stream = get_realm_stream(stream_name, user_profile.realm_id)
     except Stream.DoesNotExist:
@@ -498,7 +499,7 @@ def access_stream_by_name(
 
 
 def access_web_public_stream(stream_id: int, realm: Realm) -> Stream:
-    error = _("Invalid stream ID")
+    error = _("Invalid channel ID")
     try:
         stream = get_stream_by_id_in_realm(stream_id, realm)
     except Stream.DoesNotExist:
@@ -602,7 +603,7 @@ def can_access_stream_history(user_profile: UserProfile, stream: Stream) -> bool
 
     if stream.is_history_public_to_subscribers():
         # In this case, we check if the user is subscribed.
-        error = _("Invalid stream name '{channel_name}'").format(channel_name=stream.name)
+        error = _("Invalid channel name '{channel_name}'").format(channel_name=stream.name)
         try:
             access_stream_common(user_profile, stream, error)
         except JsonableError:
@@ -747,11 +748,11 @@ def list_to_streams(
             if is_default_stream and not user_profile.is_realm_admin:
                 raise JsonableError(_("Insufficient permission"))
             if invite_only and is_default_stream:
-                raise JsonableError(_("A default stream cannot be private."))
+                raise JsonableError(_("A default channel cannot be private."))
 
         if not autocreate:
             raise JsonableError(
-                _("Stream(s) ({channel_names}) do not exist").format(
+                _("Channel(s) ({channel_names}) do not exist").format(
                     channel_names=", ".join(
                         stream_dict["name"] for stream_dict in missing_stream_dicts
                     ),
@@ -760,7 +761,7 @@ def list_to_streams(
 
         if web_public_stream_requested:
             if not user_profile.realm.web_public_streams_enabled():
-                raise JsonableError(_("Web-public streams are not enabled."))
+                raise JsonableError(_("Web-public channels are not enabled."))
             if not user_profile.can_create_web_public_streams():
                 # We set create_web_public_stream_policy to allow only organization owners
                 # to create web-public streams, because of their sensitive nature.
@@ -790,7 +791,9 @@ def access_default_stream_group_by_id(realm: Realm, group_id: int) -> DefaultStr
         return DefaultStreamGroup.objects.get(realm=realm, id=group_id)
     except DefaultStreamGroup.DoesNotExist:
         raise JsonableError(
-            _("Default stream group with id '{group_id}' does not exist.").format(group_id=group_id)
+            _("Default channel group with id '{group_id}' does not exist.").format(
+                group_id=group_id
+            )
         )
 
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -313,7 +313,7 @@ def access_stream_for_send_message(
 
     # All other cases are an error.
     raise JsonableError(
-        _("Not authorized to send to stream '{stream_name}'").format(stream_name=stream.name)
+        _("Not authorized to send to stream '{channel_name}'").format(channel_name=stream.name)
     )
 
 
@@ -473,7 +473,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
     try:
         get_stream(name, realm)
         raise JsonableError(
-            _("Stream name '{stream_name}' is already taken.").format(stream_name=name)
+            _("Stream name '{channel_name}' is already taken.").format(channel_name=name)
         )
     except Stream.DoesNotExist:
         pass
@@ -482,7 +482,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
 def access_stream_by_name(
     user_profile: UserProfile, stream_name: str, allow_realm_admin: bool = False
 ) -> Tuple[Stream, Optional[Subscription]]:
-    error = _("Invalid stream name '{stream_name}'").format(stream_name=stream_name)
+    error = _("Invalid stream name '{channel_name}'").format(channel_name=stream_name)
     try:
         stream = get_realm_stream(stream_name, user_profile.realm_id)
     except Stream.DoesNotExist:
@@ -602,7 +602,7 @@ def can_access_stream_history(user_profile: UserProfile, stream: Stream) -> bool
 
     if stream.is_history_public_to_subscribers():
         # In this case, we check if the user is subscribed.
-        error = _("Invalid stream name '{stream_name}'").format(stream_name=stream.name)
+        error = _("Invalid stream name '{channel_name}'").format(channel_name=stream.name)
         try:
             access_stream_common(user_profile, stream, error)
         except JsonableError:
@@ -751,8 +751,8 @@ def list_to_streams(
 
         if not autocreate:
             raise JsonableError(
-                _("Stream(s) ({stream_names}) do not exist").format(
-                    stream_names=", ".join(
+                _("Stream(s) ({channel_names}) do not exist").format(
+                    channel_names=", ".join(
                         stream_dict["name"] for stream_dict in missing_stream_dicts
                     ),
                 )

--- a/zerver/lib/string_validation.py
+++ b/zerver/lib/string_validation.py
@@ -38,11 +38,11 @@ def check_string_is_printable(var: str) -> Optional[int]:
 
 def check_stream_name(stream_name: str) -> None:
     if stream_name.strip() == "":
-        raise JsonableError(_("Stream name can't be empty!"))
+        raise JsonableError(_("Channel name can't be empty."))
 
     if len(stream_name) > Stream.MAX_NAME_LENGTH:
         raise JsonableError(
-            _("Stream name too long (limit: {max_length} characters).").format(
+            _("Channel name too long (limit: {max_length} characters).").format(
                 max_length=Stream.MAX_NAME_LENGTH
             )
         )
@@ -50,7 +50,7 @@ def check_stream_name(stream_name: str) -> None:
     invalid_character_pos = check_string_is_printable(stream_name)
     if invalid_character_pos is not None:
         raise JsonableError(
-            _("Invalid character in stream name, at position {position}!").format(
+            _("Invalid character in channel name, at position {position}.").format(
                 position=invalid_character_pos
             )
         )

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -329,14 +329,14 @@ def validate_user_access_to_subscribers_helper(
         # Adding an `else` would ensure better code coverage.
 
     if not user_profile.can_access_public_streams() and not stream_dict["invite_only"]:
-        raise JsonableError(_("Subscriber data is not available for this stream"))
+        raise JsonableError(_("Subscriber data is not available for this channel"))
 
     # Organization administrators can view subscribers for all streams.
     if user_profile.is_realm_admin:
         return
 
     if stream_dict["invite_only"] and not check_user_subscribed(user_profile):
-        raise JsonableError(_("Unable to retrieve subscribers for private stream"))
+        raise JsonableError(_("Unable to retrieve subscribers for private channel"))
 
 
 def bulk_get_subscriber_user_ids(

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -335,7 +335,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
 
     DEFAULT_NOTIFICATION_STREAM_NAME = "general"
     INITIAL_PRIVATE_STREAM_NAME = "core team"
-    STREAM_EVENTS_NOTIFICATION_TOPIC_NAME = gettext_lazy("stream events")
+    STREAM_EVENTS_NOTIFICATION_TOPIC_NAME = gettext_lazy("channel events")
     new_stream_announcements_stream = models.ForeignKey(
         "Stream",
         related_name="+",

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -90,7 +90,7 @@ class Stream(models.Model):
     POST_POLICIES: Dict[int, StrPromise] = {
         # These strings should match the strings in the
         # stream_post_policy_values object in stream_data.js.
-        STREAM_POST_POLICY_EVERYONE: gettext_lazy("All stream members can post"),
+        STREAM_POST_POLICY_EVERYONE: gettext_lazy("All channel members can post"),
         STREAM_POST_POLICY_ADMINS: gettext_lazy("Only organization administrators can post"),
         STREAM_POST_POLICY_MODERATORS: gettext_lazy(
             "Only organization administrators and moderators can post"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6653,7 +6653,7 @@ paths:
                       - example:
                           {
                             "result": "error",
-                            "msg": "You do not have permission to use stream wildcard mentions in this stream.",
+                            "msg": "You do not have permission to use channel wildcard mentions in this channel.",
                             "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
                           }
                         description: |
@@ -8010,7 +8010,7 @@ paths:
                       - example:
                           {
                             "result": "error",
-                            "msg": "You do not have permission to use stream wildcard mentions in this stream.",
+                            "msg": "You do not have permission to use channel wildcard mentions in this channel.",
                             "code": "STREAM_WILDCARD_MENTION_NOT_ALLOWED",
                           }
                         description: |
@@ -21300,9 +21300,9 @@ components:
           example:
             {
               "code": "STREAM_DOES_NOT_EXIST",
-              "msg": "Stream 'nonexistent_stream' does not exist",
+              "msg": "Channel 'nonexistent' does not exist",
               "result": "error",
-              "stream": "nonexistent_stream",
+              "stream": "nonexistent",
             }
     NonExistingStreamIdError:
       allOf:
@@ -21319,7 +21319,7 @@ components:
           example:
             {
               "code": "STREAM_DOES_NOT_EXIST",
-              "msg": "Stream with ID '9' does not exist",
+              "msg": "Channel with ID '9' does not exist",
               "result": "error",
               "stream_id": 9,
             }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5139,7 +5139,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Invalid stream name 'nonexistent'",
+                        "msg": "Invalid channel name 'nonexistent'",
                         "result": "error",
                       }
                     description: |
@@ -6041,7 +6041,7 @@ paths:
                       - example:
                           {
                             "code": "BAD_REQUEST",
-                            "msg": "Private streams cannot be made default.",
+                            "msg": "Private channels cannot be made default.",
                             "result": "error",
                           }
                         description: |
@@ -9469,7 +9469,7 @@ paths:
                   - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
-                        "msg": "Unable to access stream (private_stream).",
+                        "msg": "Unable to access channel (private).",
                         "result": "error",
                         "code": "BAD_REQUEST",
                       }
@@ -21281,7 +21281,7 @@ components:
             code: {}
           example:
             {
-              "msg": "Invalid stream ID",
+              "msg": "Invalid channel ID",
               "code": "BAD_REQUEST",
               "result": "error",
             }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12049,7 +12049,7 @@ paths:
                       - example:
                           {
                             "code": "BAD_REQUEST",
-                            "msg": "Stream does not exist with id: 11. No invites were sent.",
+                            "msg": "Invalid channel ID 11. No invites were sent.",
                             "result": "error",
                           }
                         description: |
@@ -12061,7 +12061,7 @@ paths:
                       - example:
                           {
                             "code": "BAD_REQUEST",
-                            "msg": "You do not have permission to subscribe other users to streams.",
+                            "msg": "You do not have permission to subscribe other users to channels.",
                             "result": "error",
                           }
                         description: |
@@ -12162,7 +12162,7 @@ paths:
                       - example:
                           {
                             "code": "BAD_REQUEST",
-                            "msg": "Invalid stream ID 11. No invites were sent.",
+                            "msg": "Invalid channel ID 11. No invites were sent.",
                             "result": "error",
                           }
                         description: |
@@ -12174,7 +12174,7 @@ paths:
                       - example:
                           {
                             "code": "BAD_REQUEST",
-                            "msg": "You do not have permission to subscribe other users to streams.",
+                            "msg": "You do not have permission to subscribe other users to channels.",
                             "result": "error",
                           }
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5517,7 +5517,7 @@ paths:
                     example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Must specify exactly 1 stream ID for stream messages",
+                        "msg": "Must specify exactly 1 channel ID for channel messages",
                         "result": "error",
                       }
   /drafts/{draft_id}:
@@ -18321,7 +18321,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Missing stream_id",
+                        "msg": "Missing channel ID",
                         "result": "error",
                       }
                     description: |

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -472,7 +472,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "default_sending_stream": "Denmark",
         }
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'Denmark'")
+        self.assert_json_error(result, "Invalid channel name 'Denmark'")
 
     def test_add_bot_with_default_events_register_stream(self) -> None:
         bot_email = "hambot-bot@zulip.testserver"
@@ -556,7 +556,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "default_events_register_stream": "Denmark",
         }
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'Denmark'")
+        self.assert_json_error(result, "Invalid channel name 'Denmark'")
 
     def test_add_bot_with_default_all_public_streams(self) -> None:
         self.login("hamlet")
@@ -1403,7 +1403,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'Denmark'")
+        self.assert_json_error(result, "Invalid channel name 'Denmark'")
 
     def test_patch_bot_to_stream_not_found(self) -> None:
         self.login("hamlet")
@@ -1418,7 +1418,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'missing'")
+        self.assert_json_error(result, "Invalid channel name 'missing'")
 
     def test_patch_bot_events_register_stream(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -1453,7 +1453,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.subscribe(bot_user, stream_name)
         bot_info = dict(default_events_register_stream=stream_name)
         result = self.client_patch(url, bot_info)
-        self.assert_json_error_contains(result, "Invalid stream name")
+        self.assert_json_error_contains(result, "Invalid channel name")
 
         # Subscribing the owner allows us to patch the stream.
         self.subscribe(hamlet, stream_name)
@@ -1520,7 +1520,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'Denmark'")
+        self.assert_json_error(result, "Invalid channel name 'Denmark'")
 
     def test_patch_bot_events_register_stream_none(self) -> None:
         self.login("hamlet")
@@ -1560,7 +1560,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_error(result, "Invalid stream name 'missing'")
+        self.assert_json_error(result, "Invalid channel name 'missing'")
 
     def test_patch_bot_default_all_public_streams_true(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -186,7 +186,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         kwargs = mock_send_future_email.call_args[1]
         self.assertEqual(kwargs["to_user_ids"], [polonius.id])
 
-        new_stream_names = kwargs["context"]["new_streams"]["plain"]
+        new_stream_names = kwargs["context"]["new_channels"]["plain"]
         self.assertTrue("web_public_stream" in new_stream_names)
 
     def test_no_logging(self) -> None:

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -240,7 +240,7 @@ class DraftCreationTests(ZulipTestCase):
             }
         ]
         self.create_and_check_drafts_for_error(
-            draft_dicts, "Must specify exactly 1 stream ID for stream messages"
+            draft_dicts, "Must specify exactly 1 channel ID for channel messages"
         )
 
     def test_create_stream_draft_for_inaccessible_stream(self) -> None:

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -255,7 +255,7 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
-        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream ID")
+        self.create_and_check_drafts_for_error(draft_dicts, "Invalid channel ID")
 
         # When the stream itself does not exist:
         draft_dicts = [
@@ -267,7 +267,7 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
-        self.create_and_check_drafts_for_error(draft_dicts, "Invalid stream ID")
+        self.create_and_check_drafts_for_error(draft_dicts, "Invalid channel ID")
 
     def test_create_personal_message_draft_for_non_existing_user(self) -> None:
         draft_dicts = [

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1174,7 +1174,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         self.assertEqual(
             message.content,
-            "Error sending message to stream announce via message notification email reply:\nOnly organization administrators can send to this stream.",
+            "Error sending message to channel announce via message notification email reply:\nOnly organization administrators can send to this channel.",
         )
         self.assertEqual(
             message.sender,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3171,7 +3171,7 @@ class NormalActionsTest(BaseAction):
                 client="Internal",
             )
 
-            fields[TOPIC_NAME] = "stream events"
+            fields[TOPIC_NAME] = "channel events"
 
             msg = events[1]["message"]
             for k, v in fields.items():

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -292,7 +292,7 @@ class TestStreamHelpers(ZulipTestCase):
         access_stream_for_send_message(cordelia, stream, forwarder_user_profile=None)
 
         # ...but Othello can't.
-        with self.assertRaisesRegex(JsonableError, "Not authorized to send to stream"):
+        with self.assertRaisesRegex(JsonableError, "Not authorized to send to channel"):
             access_stream_for_send_message(othello, stream, forwarder_user_profile=None)
 
 

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1044,7 +1044,7 @@ earl-test@zulip.com""",
         self.login("hamlet")
         self.assert_json_error(
             self.invite("iago-test@zulip.com", ["NotARealStream"]),
-            f"Stream does not exist with id: {self.INVALID_STREAM_ID}. No invites were sent.",
+            f"Invalid channel ID {self.INVALID_STREAM_ID}. No invites were sent.",
         )
         self.check_sent_emails([])
 
@@ -1293,7 +1293,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         self.login("hamlet")
         result = self.invite(invitee, ["Denmark", "Scotland"])
         self.assert_json_error(
-            result, "You do not have permission to subscribe other users to streams."
+            result, "You do not have permission to subscribe other users to channels."
         )
 
         result = self.invite(invitee, [])
@@ -2487,7 +2487,7 @@ class MultiuseInviteTest(ZulipTestCase):
             },
         )
         self.assert_json_error(
-            result, "You do not have permission to subscribe other users to streams."
+            result, "You do not have permission to subscribe other users to channels."
         )
 
         result = self.client_post(
@@ -2682,7 +2682,7 @@ class MultiuseInviteTest(ZulipTestCase):
                 "invite_expires_in_minutes": 2 * 24 * 60,
             },
         )
-        self.assert_json_error(result, "Invalid stream ID 54321. No invites were sent.")
+        self.assert_json_error(result, "Invalid channel ID 54321. No invites were sent.")
 
     def test_create_multiuse_link_invalid_invite_as_api_call(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1423,7 +1423,7 @@ class EditMessageTest(ZulipTestCase):
                 },
             )
         self.assert_json_error(
-            result, "You do not have permission to use stream wildcard mentions in this stream."
+            result, "You do not have permission to use channel wildcard mentions in this channel."
         )
 
         with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=14):

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -590,7 +590,7 @@ class UnreadCountTests(ZulipTestCase):
                 "stream_id": invalid_stream_id,
             },
         )
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_mark_all_topics_unread_with_invalid_stream_name(self) -> None:
         self.login("hamlet")
@@ -602,7 +602,7 @@ class UnreadCountTests(ZulipTestCase):
                 "topic_name": "whatever",
             },
         )
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_mark_all_in_stream_topic_read(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -76,7 +76,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             },
         )
 
-        self.assert_json_error(result, "Direct messages cannot be moved to streams.")
+        self.assert_json_error(result, "Direct messages cannot be moved to channels.")
 
     def test_move_message_to_stream_with_content(self) -> None:
         (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
@@ -91,7 +91,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 "content": "Not allowed",
             },
         )
-        self.assert_json_error(result, "Cannot change message content while changing stream")
+        self.assert_json_error(result, "Cannot change message content while changing channel")
 
         messages = get_topic_messages(user_profile, old_stream, "test")
         self.assert_length(messages, 3)
@@ -943,7 +943,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             cordelia,
             test_stream_1,
             test_stream_2,
-            expect_error_message="The time limit for editing this message's stream has passed",
+            expect_error_message="The time limit for editing this message's channel has passed",
         )
 
         # admins and moderators can move messages irrespective of time limit.

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -394,7 +394,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             },
         )
 
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_move_message_realm_admin_cant_move_to_private_stream_without_subscription(
         self,
@@ -414,7 +414,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             },
         )
 
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_move_message_realm_admin_cant_move_from_private_stream_without_subscription(
         self,
@@ -1000,7 +1000,7 @@ class MessageMoveStreamTest(ZulipTestCase):
         do_change_stream_post_policy(
             new_stream, Stream.STREAM_POST_POLICY_ADMINS, acting_user=user_profile
         )
-        error_msg = "Only organization administrators can send to this stream."
+        error_msg = "Only organization administrators can send to this channel."
         check_move_message_to_stream(UserProfile.ROLE_MODERATOR, error_msg)
         check_move_message_to_stream(UserProfile.ROLE_REALM_ADMINISTRATOR)
 
@@ -1012,7 +1012,7 @@ class MessageMoveStreamTest(ZulipTestCase):
         do_change_stream_post_policy(
             new_stream, Stream.STREAM_POST_POLICY_MODERATORS, acting_user=user_profile
         )
-        error_msg = "Only organization administrators and moderators can send to this stream."
+        error_msg = "Only organization administrators and moderators can send to this channel."
         check_move_message_to_stream(UserProfile.ROLE_MEMBER, error_msg)
         check_move_message_to_stream(UserProfile.ROLE_MODERATOR)
 
@@ -1024,7 +1024,7 @@ class MessageMoveStreamTest(ZulipTestCase):
         do_change_stream_post_policy(
             new_stream, Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS, acting_user=user_profile
         )
-        error_msg = "New members cannot send to this stream."
+        error_msg = "New members cannot send to this channel."
 
         do_set_realm_property(
             user_profile.realm, "waiting_period_threshold", 100000, acting_user=None

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -268,7 +268,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             non_admin_profile,
             stream_name,
-            "Only organization administrators can send to this stream.",
+            "Only organization administrators can send to this channel.",
         )
         non_admin_owned_bot = self.create_test_bot(
             short_name="whatever2",
@@ -278,7 +278,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             non_admin_owned_bot,
             stream_name,
-            "Only organization administrators can send to this stream.",
+            "Only organization administrators can send to this channel.",
         )
 
         moderator_profile = self.example_user("shiva")
@@ -288,7 +288,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             moderator_profile,
             stream_name,
-            "Only organization administrators can send to this stream.",
+            "Only organization administrators can send to this channel.",
         )
         moderator_owned_bot = self.create_test_bot(
             short_name="whatever3",
@@ -298,7 +298,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             moderator_owned_bot,
             stream_name,
-            "Only organization administrators can send to this stream.",
+            "Only organization administrators can send to this channel.",
         )
 
         # Bots without owner (except cross realm bot) cannot send to announcement only streams
@@ -313,7 +313,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             bot_without_owner,
             stream_name,
-            "Only organization administrators can send to this stream.",
+            "Only organization administrators can send to this channel.",
         )
 
         # Cross realm bots should be allowed
@@ -326,7 +326,7 @@ class MessagePOSTTest(ZulipTestCase):
         guest_profile = self.example_user("polonius")
         # Guests cannot send to non-STREAM_POST_POLICY_EVERYONE streams
         self._send_and_verify_message(
-            guest_profile, stream_name, "Only organization administrators can send to this stream."
+            guest_profile, stream_name, "Only organization administrators can send to this channel."
         )
 
     def test_sending_message_as_stream_post_policy_moderators(self) -> None:
@@ -370,7 +370,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             non_admin_profile,
             stream_name,
-            "Only organization administrators and moderators can send to this stream.",
+            "Only organization administrators and moderators can send to this channel.",
         )
         non_admin_owned_bot = self.create_test_bot(
             short_name="whatever3",
@@ -380,7 +380,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             non_admin_owned_bot,
             stream_name,
-            "Only organization administrators and moderators can send to this stream.",
+            "Only organization administrators and moderators can send to this channel.",
         )
 
         # Bots without owner (except cross realm bot) cannot send to STREAM_POST_POLICY_MODERATORS streams.
@@ -395,7 +395,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             bot_without_owner,
             stream_name,
-            "Only organization administrators and moderators can send to this stream.",
+            "Only organization administrators and moderators can send to this channel.",
         )
 
         # System bots should be allowed
@@ -410,7 +410,7 @@ class MessagePOSTTest(ZulipTestCase):
         self._send_and_verify_message(
             guest_profile,
             stream_name,
-            "Only organization administrators and moderators can send to this stream.",
+            "Only organization administrators and moderators can send to this channel.",
         )
 
     def test_sending_message_as_stream_post_policy_restrict_new_members(self) -> None:
@@ -453,7 +453,7 @@ class MessagePOSTTest(ZulipTestCase):
         # Non admins and their owned bots can send to STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS streams,
         # if the user is not a new member
         self._send_and_verify_message(
-            non_admin_profile, stream_name, "New members cannot send to this stream."
+            non_admin_profile, stream_name, "New members cannot send to this channel."
         )
         non_admin_owned_bot = self.create_test_bot(
             short_name="whatever2",
@@ -461,7 +461,7 @@ class MessagePOSTTest(ZulipTestCase):
             user_profile=non_admin_profile,
         )
         self._send_and_verify_message(
-            non_admin_owned_bot, stream_name, "New members cannot send to this stream."
+            non_admin_owned_bot, stream_name, "New members cannot send to this channel."
         )
 
         non_admin_profile.date_joined = timezone_now() - timedelta(days=11)
@@ -485,7 +485,7 @@ class MessagePOSTTest(ZulipTestCase):
             acting_user=None,
         )
         self._send_and_verify_message(
-            bot_without_owner, stream_name, "New members cannot send to this stream."
+            bot_without_owner, stream_name, "New members cannot send to this channel."
         )
 
         moderator_profile = self.example_user("shiva")
@@ -516,7 +516,7 @@ class MessagePOSTTest(ZulipTestCase):
         guest_profile = self.example_user("polonius")
         # Guests cannot send to non-STREAM_POST_POLICY_EVERYONE streams
         self._send_and_verify_message(
-            guest_profile, stream_name, "Guests cannot send to this stream."
+            guest_profile, stream_name, "Guests cannot send to this channel."
         )
 
     def test_api_message_with_default_to(self) -> None:
@@ -1447,7 +1447,7 @@ class MessagePOSTTest(ZulipTestCase):
 
         # Guest user can't send message to unsubscribed public streams
         result = self.api_post(sender, "/api/v1/messages", payload)
-        self.assert_json_error(result, "Not authorized to send to stream 'public stream'")
+        self.assert_json_error(result, "Not authorized to send to channel 'public stream'")
 
         self.subscribe(sender, stream_name)
         # Guest user can send message to subscribed public streams

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -135,7 +135,7 @@ class MessagePOSTTest(ZulipTestCase):
                 "topic": "Test topic for stream ID message",
             },
         )
-        self.assert_json_error(result, "Stream with ID '99999' does not exist")
+        self.assert_json_error(result, "Channel with ID '99999' does not exist")
 
         msg = self.get_last_message()
         expected = (
@@ -558,7 +558,7 @@ class MessagePOSTTest(ZulipTestCase):
                 "topic": "Test topic",
             },
         )
-        self.assert_json_error(result, "Stream 'nonexistent_stream' does not exist")
+        self.assert_json_error(result, "Channel 'nonexistent_stream' does not exist")
 
     def test_message_to_nonexistent_stream_with_bad_characters(self) -> None:
         """
@@ -576,7 +576,7 @@ class MessagePOSTTest(ZulipTestCase):
             },
         )
         self.assert_json_error(
-            result, "Stream '&amp;&lt;&quot;&#x27;&gt;&lt;non-existent&gt;' does not exist"
+            result, "Channel '&amp;&lt;&quot;&#x27;&gt;&lt;non-existent&gt;' does not exist"
         )
 
     def test_message_to_stream_with_automatically_change_visibility_policy(self) -> None:
@@ -1961,7 +1961,7 @@ class StreamMessagesTest(ZulipTestCase):
             else:
                 with self.assertRaisesRegex(
                     JsonableError,
-                    "You do not have permission to use stream wildcard mentions in this stream.",
+                    "You do not have permission to use channel wildcard mentions in this channel.",
                 ):
                     self.send_stream_message(sender, "test_stream", content)
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -140,7 +140,7 @@ class MessagePOSTTest(ZulipTestCase):
         msg = self.get_last_message()
         expected = (
             "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "stream ID 99999, but there is no stream with that ID."
+            "channel ID 99999, but there is no channel with that ID."
         )
         self.assertEqual(msg.content, expected)
 
@@ -175,7 +175,7 @@ class MessagePOSTTest(ZulipTestCase):
         msg = self.get_second_to_last_message()
         expected = (
             "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "stream #**Acropolis**. The stream exists but does not have any subscribers."
+            "channel #**Acropolis**. The channel exists but does not have any subscribers."
         )
         self.assertEqual(msg.content, expected)
 
@@ -210,7 +210,7 @@ class MessagePOSTTest(ZulipTestCase):
         msg = self.get_second_to_last_message()
         expected = (
             "Your bot `whatever-bot@zulip.testserver` tried to send a message to "
-            "stream #**Acropolis**. The stream exists but does not have any subscribers."
+            "channel #**Acropolis**. The channel exists but does not have any subscribers."
         )
         self.assertEqual(msg.content, expected)
 
@@ -2428,13 +2428,13 @@ class ExtractTest(ZulipTestCase):
             123,
         )
 
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream"):
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel"):
             extract_stream_indicator("{}")
 
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream"):
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel"):
             extract_stream_indicator("[{}]")
 
-        with self.assertRaisesRegex(JsonableError, "Expected exactly one stream"):
+        with self.assertRaisesRegex(JsonableError, "Expected exactly one channel"):
             extract_stream_indicator('[1,2,"general"]')
 
     def test_extract_private_recipients_emails(self) -> None:
@@ -3053,7 +3053,7 @@ class CheckMessageTest(ZulipTestCase):
 
         new_count = message_stream_count(parent)
         self.assertEqual(new_count, old_count + 1)
-        self.assertIn("that stream does not exist.", most_recent_message(parent).content)
+        self.assertIn("that channel does not exist.", most_recent_message(parent).content)
 
         # Try sending to stream that exists with no subscribers soon
         # after; due to rate-limiting, this should send nothing.

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -160,7 +160,7 @@ class TopicHistoryTest(ZulipTestCase):
         # non-sensible stream id
         endpoint = "/json/users/me/9999999999/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         # out of realm
         bad_stream = self.make_stream(
@@ -169,7 +169,7 @@ class TopicHistoryTest(ZulipTestCase):
         )
         endpoint = f"/json/users/me/{bad_stream.id}/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         # private stream to which I am not subscribed
         private_stream = self.make_stream(
@@ -178,7 +178,7 @@ class TopicHistoryTest(ZulipTestCase):
         )
         endpoint = f"/json/users/me/{private_stream.id}/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_get_topics_web_public_stream_web_public_request(self) -> None:
         iago = self.example_user("iago")
@@ -204,13 +204,13 @@ class TopicHistoryTest(ZulipTestCase):
         stream = get_stream("Verona", self.example_user("iago").realm)
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint)
-        self.assert_json_error(result, "Invalid stream ID", 400)
+        self.assert_json_error(result, "Invalid channel ID", 400)
 
     def test_get_topics_non_existent_stream_web_public_request(self) -> None:
         non_existent_stream_id = 10000000000000000000000
         endpoint = f"/json/users/me/{non_existent_stream_id}/topics"
         result = self.client_get(endpoint)
-        self.assert_json_error(result, "Invalid stream ID", 400)
+        self.assert_json_error(result, "Invalid channel ID", 400)
 
 
 class TopicDeleteTest(ZulipTestCase):

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -635,7 +635,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
         prev_message = self.get_second_to_last_message()
         self.assertIn(
-            "tried to send a message to stream #**Denmark**, but that stream does not exist",
+            "tried to send a message to channel #**Denmark**, but that channel does not exist",
             prev_message.content,
         )
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -520,7 +520,7 @@ class RealmTest(ZulipTestCase):
             new_stream_announcements_stream_id=orjson.dumps(invalid_notif_stream_id).decode()
         )
         result = self.client_patch("/json/realm", req)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
         realm = get_realm("zulip")
         assert realm.new_stream_announcements_stream is not None
         self.assertNotEqual(realm.new_stream_announcements_stream.id, invalid_notif_stream_id)
@@ -605,7 +605,7 @@ class RealmTest(ZulipTestCase):
             ).decode()
         )
         result = self.client_patch("/json/realm", req)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
         realm = get_realm("zulip")
         assert realm.signup_announcements_stream is not None
         self.assertNotEqual(
@@ -679,7 +679,7 @@ class RealmTest(ZulipTestCase):
             ).decode()
         )
         result = self.client_patch("/json/realm", req)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
         realm = get_realm("zulip")
         assert realm.zulip_update_announcements_stream is not None
         self.assertNotEqual(

--- a/zerver/tests/test_recipient_parsing.py
+++ b/zerver/tests/test_recipient_parsing.py
@@ -11,13 +11,13 @@ class TestRecipientParsing(ZulipTestCase):
         stream_id = extract_stream_id("1")
         self.assertEqual(stream_id, 1)
 
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
             extract_stream_id("1,2")
 
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
             extract_stream_id("[1]")
 
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
             extract_stream_id("general")
 
     def test_extract_recipient_ids(self) -> None:

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -505,7 +505,7 @@ class ScheduledMessageTest(ZulipTestCase):
         }
         result = self.client_patch(f"/json/scheduled_messages/{scheduled_message_id}", payload)
         self.assert_json_error(
-            result, "Topic required when updating scheduled message type to stream."
+            result, "Topic required when updating scheduled message type to channel."
         )
 
         # Edit message `type` to stream with valid `to` and `topic` succeeds

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1304,7 +1304,7 @@ class RealmCreationTest(ZulipTestCase):
         # Check welcome messages
         for stream_name, text, message_count in [
             (Realm.DEFAULT_NOTIFICATION_STREAM_NAME, "with the topic", 4),
-            (Realm.INITIAL_PRIVATE_STREAM_NAME, "private stream", 1),
+            (Realm.INITIAL_PRIVATE_STREAM_NAME, "private channel", 1),
         ]:
             stream = get_stream(stream_name, realm)
             recipient = stream.recipient
@@ -1737,21 +1737,23 @@ class RealmCreationTest(ZulipTestCase):
         self.assertEqual(realm.string_id, string_id)
         self.assertEqual(realm.default_language, realm_language)
 
-        # Check welcome messages
-        with_the_topic_in_italian = "con l'argomento"
-        private_stream_in_italian = "canale privato"
+        # TODO: When Italian translated strings are updated for changes
+        # that are part of the stream -> channel rename, uncomment below.
+        # # Check welcome messages
+        # with_the_topic_in_italian = "con l'argomento"
+        # private_stream_in_italian = "canale privato"
 
-        for stream_name, text, message_count in [
-            (Realm.DEFAULT_NOTIFICATION_STREAM_NAME, with_the_topic_in_italian, 4),
-            (Realm.INITIAL_PRIVATE_STREAM_NAME, private_stream_in_italian, 1),
-        ]:
-            stream = get_stream(stream_name, realm)
-            recipient = stream.recipient
-            messages = Message.objects.filter(realm_id=realm.id, recipient=recipient).order_by(
-                "date_sent"
-            )
-            self.assert_length(messages, message_count)
-            self.assertIn(text, messages[0].content)
+        # for stream_name, text, message_count in [
+        #     (Realm.DEFAULT_NOTIFICATION_STREAM_NAME, with_the_topic_in_italian, 4),
+        #     (Realm.INITIAL_PRIVATE_STREAM_NAME, private_stream_in_italian, 1),
+        # ]:
+        #     stream = get_stream(stream_name, realm)
+        #     recipient = stream.recipient
+        #     messages = Message.objects.filter(realm_id=realm.id, recipient=recipient).order_by(
+        #         "date_sent"
+        #     )
+        #     self.assert_length(messages, message_count)
+        #     self.assertIn(text, messages[0].content)
 
     @override_settings(OPEN_REALM_CREATION=True, CLOUD_FREE_TRIAL_DAYS=30)
     def test_create_realm_during_free_trial(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -675,7 +675,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Private, protected history** to **Public**."
+            "for this channel from **Private, protected history** to **Public**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -736,7 +736,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Public** to **Private, protected history**."
+            "for this channel from **Public** to **Private, protected history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -853,7 +853,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Private, protected history** to **Public, protected history**."
+            "for this channel from **Private, protected history** to **Public, protected history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -892,7 +892,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Public** to **Private, shared history**."
+            "for this channel from **Public** to **Private, shared history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -931,7 +931,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Private, protected history** to **Private, shared history**."
+            "for this channel from **Private, protected history** to **Private, shared history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -1014,7 +1014,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Public** to **Web-public**."
+            "for this channel from **Public** to **Web-public**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -1051,7 +1051,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**Iago|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Private, protected history** to **Private, shared history**."
+            "for this channel from **Private, protected history** to **Private, shared history**."
         )
         self.assertEqual(messages[0].content, expected_notification)
 
@@ -1081,7 +1081,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assert_length(messages, 2)
         expected_notification = (
             f"@_**Iago|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
-            "for this stream from **Private, shared history** to **Private, protected history**."
+            "for this channel from **Private, shared history** to **Private, protected history**."
         )
         self.assertEqual(messages[1].content, expected_notification)
 
@@ -1746,7 +1746,7 @@ class StreamAdminTest(ZulipTestCase):
         # Inspect the notification message sent
         message = self.get_last_message()
         actual_stream = Stream.objects.get(id=message.recipient.type_id)
-        message_content = f"@_**King Hamlet|{user_profile.id}** renamed stream **stream_name1** to **stream_name2**."
+        message_content = f"@_**King Hamlet|{user_profile.id}** renamed channel **stream_name1** to **stream_name2**."
         self.assertEqual(actual_stream.name, "stream_name2")
         self.assertEqual(actual_stream.realm_id, user_profile.realm_id)
         self.assertEqual(message.recipient.type, Recipient.STREAM)
@@ -1873,7 +1873,7 @@ class StreamAdminTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
-            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
+            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
             "```` quote\n"
             "Test description\n"
@@ -1895,7 +1895,7 @@ class StreamAdminTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
-            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
+            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
             "```` quote\n"
             "*No description.*\n"
@@ -1917,7 +1917,7 @@ class StreamAdminTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
-            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this stream.\n\n"
+            f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
             "```` quote\n"
             "Test description\n"
@@ -1985,7 +1985,7 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the "
-            "[posting permissions](/help/stream-sending-policy) for this stream:\n\n"
+            "[posting permissions](/help/stream-sending-policy) for this channel:\n\n"
             "* **Old permissions**: All stream members can post.\n"
             "* **New permissions**: Only organization administrators can post."
         )
@@ -2048,7 +2048,7 @@ class StreamAdminTest(ZulipTestCase):
             messages = get_topic_messages(user_profile, stream, "stream events")
             expected_notification = (
                 f"@_**{user_profile.full_name}|{user_profile.id}** changed the "
-                "[posting permissions](/help/stream-sending-policy) for this stream:\n\n"
+                "[posting permissions](/help/stream-sending-policy) for this channel:\n\n"
                 f"* **Old permissions**: {Stream.POST_POLICIES[old_post_policy]}.\n"
                 f"* **New permissions**: {Stream.POST_POLICIES[policy]}."
             )
@@ -2082,10 +2082,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 1)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
             "* **Old retention period**: Forever\n"
             "* **New retention period**: 2 days\n\n"
-            "Messages in this stream will now be automatically deleted 2 days after they are sent."
+            "Messages in this channel will now be automatically deleted 2 days after they are sent."
         )
         self.assertEqual(messages[0].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(
@@ -2103,10 +2103,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 2)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
             "* **Old retention period**: 2 days\n"
             "* **New retention period**: 8 days\n\n"
-            "Messages in this stream will now be automatically deleted 8 days after they are sent."
+            "Messages in this channel will now be automatically deleted 8 days after they are sent."
         )
         self.assertEqual(messages[1].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(
@@ -2125,10 +2125,10 @@ class StreamAdminTest(ZulipTestCase):
         messages = get_topic_messages(user_profile, stream, "stream events")
         self.assert_length(messages, 3)
         expected_notification = (
-            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
+            f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
             "* **Old retention period**: 8 days\n"
             "* **New retention period**: Forever\n\n"
-            "Messages in this stream will now be retained forever."
+            "Messages in this channel will now be retained forever."
         )
         self.assertEqual(messages[2].content, expected_notification)
         realm_audit_log = RealmAuditLog.objects.filter(
@@ -4229,9 +4229,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
         self.assertEqual(msg.recipient.type_id, new_stream_announcements_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(self.test_realm).id)
-        expected_msg = (
-            f"@_**{invitee_full_name}|{invitee.id}** created a new stream #**{invite_streams[0]}**."
-        )
+        expected_msg = f"@_**{invitee_full_name}|{invitee.id}** created a new channel #**{invite_streams[0]}**."
         self.assertEqual(msg.content, expected_msg)
 
         msg = self.get_last_message()
@@ -4239,7 +4237,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type_id, target_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(self.test_realm).id)
         expected_msg = (
-            f"**Public** stream created by @_**{invitee_full_name}|{invitee.id}**. **Description:**\n"
+            f"**Public** channel created by @_**{invitee_full_name}|{invitee.id}**. **Description:**\n"
             "```` quote\n*No description.*\n````"
         )
         self.assertEqual(msg.content, expected_msg)
@@ -4275,7 +4273,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type_id, new_stream_announcements_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(realm).id)
         stream_id = Stream.objects.latest("id").id
-        expected_rendered_msg = f'<p><span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span> created a new stream <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>'
+        expected_rendered_msg = f'<p><span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span> created a new channel <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>'
         self.assertEqual(msg.rendered_content, expected_rendered_msg)
 
     def test_successful_subscriptions_notifies_with_escaping(self) -> None:
@@ -4304,9 +4302,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(
             msg.sender_id, self.notification_bot(new_stream_announcements_stream.realm).id
         )
-        expected_msg = (
-            f"@_**{invitee_full_name}|{invitee.id}** created a new stream #**{invite_streams[0]}**."
-        )
+        expected_msg = f"@_**{invitee_full_name}|{invitee.id}** created a new channel #**{invite_streams[0]}**."
         self.assertEqual(msg.content, expected_msg)
 
     def test_non_ascii_stream_subscription(self) -> None:
@@ -4641,7 +4637,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.topic_name(), "stream events")
         self.assertEqual(msg.sender.email, settings.NOTIFICATION_BOT)
         self.assertIn(
-            f"**{policy_name}** stream created by @_**{self.test_user.full_name}|{self.test_user.id}**. **Description:**\n"
+            f"**{policy_name}** channel created by @_**{self.test_user.full_name}|{self.test_user.id}**. **Description:**\n"
             "```` quote",
             msg.content,
         )
@@ -5973,7 +5969,7 @@ class GetSubscribersTest(ZulipTestCase):
             )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the following streams:
+            @**King Hamlet|{hamlet.id}** subscribed you to the following channels:
 
             * #**stream_0**
             * #**stream_1**
@@ -6008,7 +6004,7 @@ class GetSubscribersTest(ZulipTestCase):
         )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the stream #**stream_invite_only_1**.
+            @**King Hamlet|{hamlet.id}** subscribed you to the channel #**stream_invite_only_1**.
             """
         for user in [cordelia, othello, polonius]:
             self.assert_user_got_subscription_notification(user, msg)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -671,7 +671,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -732,7 +732,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream.invite_only)
         self.assertFalse(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -849,7 +849,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(stream.invite_only)
         self.assertFalse(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -888,7 +888,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -927,7 +927,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -1010,7 +1010,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertFalse(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**King Hamlet|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -1047,7 +1047,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream.invite_only)
         self.assertTrue(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**Iago|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -1077,7 +1077,7 @@ class StreamAdminTest(ZulipTestCase):
         self.assertTrue(stream.invite_only)
         self.assertFalse(stream.history_public_to_subscribers)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 2)
         expected_notification = (
             f"@_**Iago|{user_profile.id}** changed the [access permissions](/help/stream-permissions) "
@@ -1871,7 +1871,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = get_stream("stream_name1", realm)
         self.assertEqual(stream.description, "")
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
@@ -1893,7 +1893,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = get_stream("stream_name1", realm)
         self.assertEqual(stream.description, "Test description")
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
@@ -1915,7 +1915,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = get_stream("stream_name1", realm)
         self.assertEqual(stream.description, "a multi line description")
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the description for this channel.\n\n"
             "* **Old description:**\n"
@@ -1982,7 +1982,7 @@ class StreamAdminTest(ZulipTestCase):
         stream = get_stream("stream_name1", user_profile.realm)
         self.assertEqual(stream.stream_post_policy, Stream.STREAM_POST_POLICY_ADMINS)
 
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the "
             "[posting permissions](/help/stream-sending-policy) for this channel:\n\n"
@@ -2045,7 +2045,7 @@ class StreamAdminTest(ZulipTestCase):
             stream = get_stream("stream_name1", user_profile.realm)
             self.assertEqual(stream.stream_post_policy, policy)
 
-            messages = get_topic_messages(user_profile, stream, "stream events")
+            messages = get_topic_messages(user_profile, stream, "channel events")
             expected_notification = (
                 f"@_**{user_profile.full_name}|{user_profile.id}** changed the "
                 "[posting permissions](/help/stream-sending-policy) for this channel:\n\n"
@@ -2079,7 +2079,7 @@ class StreamAdminTest(ZulipTestCase):
             f"/json/streams/{stream.id}", {"message_retention_days": orjson.dumps(2).decode()}
         )
         self.assert_json_success(result)
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 1)
         expected_notification = (
             f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
@@ -2100,7 +2100,7 @@ class StreamAdminTest(ZulipTestCase):
             f"/json/streams/{stream.id}", {"message_retention_days": orjson.dumps(8).decode()}
         )
         self.assert_json_success(result)
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 2)
         expected_notification = (
             f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
@@ -2122,7 +2122,7 @@ class StreamAdminTest(ZulipTestCase):
             {"message_retention_days": orjson.dumps("realm_default").decode()},
         )
         self.assert_json_success(result)
-        messages = get_topic_messages(user_profile, stream, "stream events")
+        messages = get_topic_messages(user_profile, stream, "channel events")
         self.assert_length(messages, 3)
         expected_notification = (
             f"@_**Desdemona|{user_profile.id}** has changed the [message retention period](/help/message-retention-policy) for this channel:\n"
@@ -4634,7 +4634,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # verify that a welcome message was sent to the stream
         msg = self.get_last_message()
         self.assertEqual(msg.recipient.type, msg.recipient.STREAM)
-        self.assertEqual(msg.topic_name(), "stream events")
+        self.assertEqual(msg.topic_name(), "channel events")
         self.assertEqual(msg.sender.email, settings.NOTIFICATION_BOT)
         self.assertIn(
             f"**{policy_name}** channel created by @_**{self.test_user.full_name}|{self.test_user.id}**. **Description:**\n"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3071,7 +3071,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         # Test creating a default stream group which contains a default stream
         do_add_default_stream(remaining_streams[0])
         with self.assertRaisesRegex(
-            JsonableError, "'stream1' is a default stream and cannot be added to 'new group1'"
+            JsonableError, "'stream1' is a default channel and cannot be added to 'new group1'"
         ):
             do_create_default_stream_group(
                 realm, new_group_name, "This is group1", remaining_streams
@@ -3118,7 +3118,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
                 "stream_names": orjson.dumps(stream_names).decode(),
             },
         )
-        self.assert_json_error(result, "Default stream group 'group1' already exists")
+        self.assert_json_error(result, "Default channel group 'group1' already exists")
 
         # Test adding streams to existing default stream group
         group_id = default_stream_groups[0].id
@@ -3156,7 +3156,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             {"op": "add", "stream_names": orjson.dumps(new_stream_names).decode()},
         )
         self.assert_json_error(
-            result, "'stream4' is a default stream and cannot be added to 'group1'"
+            result, "'stream4' is a default channel and cannot be added to 'group1'"
         )
 
         do_remove_default_stream(new_streams[0])
@@ -3175,7 +3175,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             {"op": "add", "stream_names": orjson.dumps(new_stream_names).decode()},
         )
         self.assert_json_error(
-            result, "Stream 'stream4' is already present in default stream group 'group1'"
+            result, "Channel 'stream4' is already present in default channel group 'group1'"
         )
 
         # Test removing streams from default stream group
@@ -3207,7 +3207,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             {"op": "remove", "stream_names": orjson.dumps(new_stream_names).decode()},
         )
         self.assert_json_error(
-            result, "Stream 'stream4' is not present in default stream group 'group1'"
+            result, "Channel 'stream4' is not present in default channel group 'group1'"
         )
 
         # Test changing description of default stream group
@@ -3239,7 +3239,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             f"/json/default_stream_groups/{group_id}",
             {"new_group_name": "group2"},
         )
-        self.assert_json_error(result, "Default stream group 'group2' already exists")
+        self.assert_json_error(result, "Default channel group 'group2' already exists")
         new_group = lookup_default_stream_groups(["group2"], realm)[0]
         do_remove_default_stream_group(realm, new_group)
 
@@ -3247,7 +3247,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             f"/json/default_stream_groups/{group_id}",
             {"new_group_name": group_name},
         )
-        self.assert_json_error(result, "This default stream group is already named 'group1'")
+        self.assert_json_error(result, "This default channel group is already named 'group1'")
 
         result = self.client_patch(
             f"/json/default_stream_groups/{group_id}",
@@ -3288,7 +3288,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
                 "stream_names": orjson.dumps(stream_names).decode(),
             },
         )
-        self.assert_json_error(result, "Invalid default stream group name ''")
+        self.assert_json_error(result, "Invalid default channel group name ''")
 
         result = self.client_post(
             "/json/default_stream_groups/create",
@@ -3300,7 +3300,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         )
         self.assert_json_error(
             result,
-            f"Default stream group name too long (limit: {DefaultStreamGroup.MAX_NAME_LENGTH} characters)",
+            f"Default channel group name too long (limit: {DefaultStreamGroup.MAX_NAME_LENGTH} characters)",
         )
 
         result = self.client_post(
@@ -3312,14 +3312,14 @@ class DefaultStreamGroupTest(ZulipTestCase):
             },
         )
         self.assert_json_error(
-            result, "Default stream group name 'abc\000' contains NULL (0x00) characters."
+            result, "Default channel group name 'abc\000' contains NULL (0x00) characters."
         )
 
         # Also test that lookup_default_stream_groups raises an
         # error if we pass it a bad name.  This function is used
         # during registration, but it's a bit heavy to do a full
         # test of that.
-        with self.assertRaisesRegex(JsonableError, "Invalid default stream group invalid-name"):
+        with self.assertRaisesRegex(JsonableError, "Invalid default channel group invalid-name"):
             lookup_default_stream_groups(["invalid-name"], realm)
 
 
@@ -3917,7 +3917,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "delete": orjson.dumps([invalid_stream_name]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
-        self.assert_json_error(result, "Stream name can't be empty!")
+        self.assert_json_error(result, "Channel name can't be empty.")
 
     def test_stream_name_too_long(self) -> None:
         user = self.example_user("hamlet")
@@ -3928,7 +3928,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "delete": orjson.dumps([long_stream_name]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
-        self.assert_json_error(result, "Stream name too long (limit: 60 characters).")
+        self.assert_json_error(result, "Channel name too long (limit: 60 characters).")
 
     def test_stream_name_contains_null(self) -> None:
         user = self.example_user("hamlet")
@@ -3939,7 +3939,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "delete": orjson.dumps([stream_name]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
-        self.assert_json_error(result, "Invalid character in stream name, at position 4!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 4.")
 
     def test_compose_views_rollback(self) -> None:
         """
@@ -4015,7 +4015,7 @@ class SubscriptionAPITest(ZulipTestCase):
         result = self.api_post(
             user, "/api/v1/users/me/subscriptions", post_data_cc, subdomain="zulip"
         )
-        self.assert_json_error(result, "Invalid character in stream name, at position 4!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 4.")
 
         # For Cn category
         post_data_cn = {
@@ -4027,7 +4027,7 @@ class SubscriptionAPITest(ZulipTestCase):
         result = self.api_post(
             user, "/api/v1/users/me/subscriptions", post_data_cn, subdomain="zulip"
         )
-        self.assert_json_error(result, "Invalid character in stream name, at position 4!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 4.")
 
     def test_invalid_stream_rename(self) -> None:
         """
@@ -4039,16 +4039,16 @@ class SubscriptionAPITest(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
         # Check for empty name
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": ""})
-        self.assert_json_error(result, "Stream name can't be empty!")
+        self.assert_json_error(result, "Channel name can't be empty.")
         # Check for long name
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "a" * 61})
-        self.assert_json_error(result, "Stream name too long (limit: 60 characters).")
+        self.assert_json_error(result, "Channel name too long (limit: 60 characters).")
         # Check for Cc characters
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "test\n\rname"})
-        self.assert_json_error(result, "Invalid character in stream name, at position 5!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 5.")
         # Check for Cn characters
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "test\ufffeame"})
-        self.assert_json_error(result, "Invalid character in stream name, at position 5!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 5.")
 
     def test_successful_subscriptions_list(self) -> None:
         """
@@ -4329,7 +4329,7 @@ class SubscriptionAPITest(ZulipTestCase):
         result = self.common_subscribe_to_streams(
             self.test_user, [long_stream_name], allow_fail=True
         )
-        self.assert_json_error(result, "Stream name too long (limit: 60 characters).")
+        self.assert_json_error(result, "Channel name too long (limit: 60 characters).")
 
     def test_subscriptions_add_stream_with_null(self) -> None:
         """
@@ -4338,7 +4338,7 @@ class SubscriptionAPITest(ZulipTestCase):
         """
         stream_name = "abc\000"
         result = self.common_subscribe_to_streams(self.test_user, [stream_name], allow_fail=True)
-        self.assert_json_error(result, "Invalid character in stream name, at position 4!")
+        self.assert_json_error(result, "Invalid character in channel name, at position 4.")
 
     def _test_user_settings_for_creating_streams(
         self,
@@ -4594,7 +4594,7 @@ class SubscriptionAPITest(ZulipTestCase):
         result = self.common_subscribe_to_streams(
             self.test_user, [invalid_stream_name], allow_fail=True
         )
-        self.assert_json_error(result, "Stream name can't be empty!")
+        self.assert_json_error(result, "Channel name can't be empty.")
 
     def assert_adding_subscriptions_for_principal(
         self,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1986,7 +1986,7 @@ class StreamAdminTest(ZulipTestCase):
         expected_notification = (
             f"@_**{user_profile.full_name}|{user_profile.id}** changed the "
             "[posting permissions](/help/stream-sending-policy) for this channel:\n\n"
-            "* **Old permissions**: All stream members can post.\n"
+            "* **Old permissions**: All channel members can post.\n"
             "* **New permissions**: Only organization administrators can post."
         )
         self.assertEqual(messages[-1].content, expected_notification)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -93,9 +93,8 @@ class TutorialTests(ZulipTestCase):
         for content in messages:
             self.send_personal_message(user, bot, content)
             expected_response = (
-                "In Zulip, streams [determine who gets a message](/help/streams-and-topics). "
-                "They are similar to channels in other chat apps.\n\n"
-                "[Browse and subscribe to streams](#streams/all)."
+                "In Zulip, channels [determine who gets a message](/help/streams-and-topics).\n\n"
+                "[Browse and subscribe to channels](#streams/all)."
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 
@@ -154,7 +153,7 @@ class TutorialTests(ZulipTestCase):
             expected_response = (
                 "Here are a few messages I understand: "
                 "`apps`, `profile`, `theme`, "
-                "`streams`, `topics`, `message formatting`, `keyboard shortcuts`.\n\n"
+                "`channels`, `topics`, `message formatting`, `keyboard shortcuts`.\n\n"
                 "Check out our [Getting started guide](/help/getting-started-with-zulip), "
                 "or browse the [Help center](/help/) to learn more!"
             )
@@ -169,7 +168,7 @@ class TutorialTests(ZulipTestCase):
             self.send_personal_message(user, bot, content)
             expected_response = (
                 "I’m sorry, I did not understand your message. Please try one of the following commands: "
-                "`apps`, `profile`, `theme`, `streams`, "
+                "`apps`, `profile`, `theme`, `channels`, "
                 "`topics`, `message formatting`, `keyboard shortcuts`, `help`."
             )
             self.assertEqual(most_recent_message(user).content, expected_response)

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -105,7 +105,7 @@ class TypingValidateStreamIdTopicArgumentsTest(ZulipTestCase):
             "/api/v1/typing",
             {"type": "stream", "op": "start", "topic": "test"},
         )
-        self.assert_json_error(result, "Missing stream_id")
+        self.assert_json_error(result, "Missing 'stream_id' argument")
 
     def test_invalid_stream_id(self) -> None:
         """
@@ -583,7 +583,9 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         # No events should be sent now
         with self.capture_send_event_calls(expected_num_events=0) as events:
             result = self.api_post(sender, "/api/v1/typing", params)
-        self.assert_json_error(result, "User has disabled typing notifications for stream messages")
+        self.assert_json_error(
+            result, "User has disabled typing notifications for channel messages"
+        )
         self.assertEqual(events, [])
 
     def test_typing_notifications_disabled(self) -> None:

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -145,7 +145,7 @@ class TypingValidateStreamIdTopicArgumentsTest(ZulipTestCase):
                 "topic": topic_name,
             },
         )
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
 
 class TypingHappyPathTestDirectMessages(ZulipTestCase):

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -190,15 +190,15 @@ class MutedTopicsTestsDeprecated(ZulipTestCase):
 
         data = {"stream_id": 999999999, "topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         data = {"topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please supply 'stream'.")
+        self.assert_json_error(result, "Missing 'stream_id' argument")
 
         data = {"stream": stream.name, "stream_id": stream.id, "topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please choose one: 'stream' or 'stream_id'.")
+        self.assert_json_error(result, "Please supply only one channel parameter: name or ID.")
 
         data = {"stream_id": stream.id, "topic": "a" * (MAX_TOPIC_NAME_LENGTH + 1), "op": "add"}
         result = self.api_patch(user, url, data)
@@ -234,11 +234,11 @@ class MutedTopicsTestsDeprecated(ZulipTestCase):
 
         data = {"topic": "Verona3", "op": "remove"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please supply 'stream'.")
+        self.assert_json_error(result, "Missing 'stream_id' argument")
 
         data = {"stream": stream.name, "stream_id": stream.id, "topic": "Verona3", "op": "remove"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please choose one: 'stream' or 'stream_id'.")
+        self.assert_json_error(result, "Please supply only one channel parameter: name or ID.")
 
         data = {"stream_id": stream.id, "topic": "a" * (MAX_TOPIC_NAME_LENGTH + 1), "op": "remove"}
         result = self.api_patch(user, url, data)
@@ -447,7 +447,7 @@ class MutedTopicsTests(ZulipTestCase):
             "visibility_policy": UserTopic.VisibilityPolicy.MUTED,
         }
         result = self.api_post(user, url, data)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         stream = get_stream("Verona", user.realm)
         data = {
@@ -472,7 +472,7 @@ class MutedTopicsTests(ZulipTestCase):
         }
 
         result = self.api_post(user, url, data)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         stream = get_stream("Verona", user.realm)
         data = {
@@ -663,7 +663,7 @@ class UnmutedTopicsTests(ZulipTestCase):
         }
 
         result = self.api_post(user, url, data)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
     def test_unmuted_topic_remove_invalid(self) -> None:
         user = self.example_user("hamlet")
@@ -677,7 +677,7 @@ class UnmutedTopicsTests(ZulipTestCase):
         }
 
         result = self.api_post(user, url, data)
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
 
 class AutomaticallyFollowTopicsTests(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1492,7 +1492,7 @@ class UserProfileTest(ZulipTestCase):
 
         # Invalid stream ID.
         result = self.client_get(f"/json/users/{iago.id}/subscriptions/25")
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         result = orjson.loads(
             self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}").content
@@ -1541,7 +1541,7 @@ class UserProfileTest(ZulipTestCase):
         # Unsubscribed non-admins cannot check subscription status in a private stream.
         self.login("shiva")
         result = self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}")
-        self.assert_json_error(result, "Invalid stream ID")
+        self.assert_json_error(result, "Invalid channel ID")
 
         # Subscribed non-admins can check subscription status in a private stream
         self.subscribe(self.example_user("shiva"), stream.name)

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -84,8 +84,8 @@ def invite_users_backend(
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
             raise JsonableError(
-                _("Stream does not exist with id: {stream_id}. No invites were sent.").format(
-                    stream_id=stream_id
+                _("Stream does not exist with id: {channel_id}. No invites were sent.").format(
+                    channel_id=stream_id
                 )
             )
         streams.append(stream)
@@ -221,8 +221,8 @@ def generate_multiuse_invite_backend(
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
             raise JsonableError(
-                _("Invalid stream ID {stream_id}. No invites were sent.").format(
-                    stream_id=stream_id
+                _("Invalid stream ID {channel_id}. No invites were sent.").format(
+                    channel_id=stream_id
                 )
             )
         streams.append(stream)

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -84,14 +84,14 @@ def invite_users_backend(
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
             raise JsonableError(
-                _("Stream does not exist with id: {channel_id}. No invites were sent.").format(
+                _("Invalid channel ID {channel_id}. No invites were sent.").format(
                     channel_id=stream_id
                 )
             )
         streams.append(stream)
 
     if len(streams) and not user_profile.can_subscribe_other_users():
-        raise JsonableError(_("You do not have permission to subscribe other users to streams."))
+        raise JsonableError(_("You do not have permission to subscribe other users to channels."))
 
     do_invite_users(
         user_profile,
@@ -221,14 +221,14 @@ def generate_multiuse_invite_backend(
             (stream, sub) = access_stream_by_id(user_profile, stream_id)
         except JsonableError:
             raise JsonableError(
-                _("Invalid stream ID {channel_id}. No invites were sent.").format(
+                _("Invalid channel ID {channel_id}. No invites were sent.").format(
                     channel_id=stream_id
                 )
             )
         streams.append(stream)
 
     if len(streams) and not user_profile.can_subscribe_other_users():
-        raise JsonableError(_("You do not have permission to subscribe other users to streams."))
+        raise JsonableError(_("You do not have permission to subscribe other users to channels."))
 
     invite_link = do_create_multiuse_invite_link(
         user_profile, invite_as, invite_expires_in_minutes, streams

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -73,7 +73,7 @@ def update_scheduled_message_backend(
         recipient_type_name = "stream"
 
     if recipient_type_name is not None and recipient_type_name == "stream" and topic_name is None:
-        raise JsonableError(_("Topic required when updating scheduled message type to stream."))
+        raise JsonableError(_("Topic required when updating scheduled message type to channel."))
 
     if recipient_type_name is not None and recipient_type_name == "direct":
         # For now, use "private" from Message.API_RECIPIENT_TYPES.

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -130,7 +130,7 @@ def add_default_stream(
 ) -> HttpResponse:
     (stream, sub) = access_stream_by_id(user_profile, stream_id)
     if stream.invite_only:
-        raise JsonableError(_("Private streams cannot be made default."))
+        raise JsonableError(_("Private channels cannot be made default."))
     do_add_default_stream(stream)
     return json_success(request)
 
@@ -296,7 +296,7 @@ def update_stream_backend(
 
     # Ensure that a stream cannot be both a default stream for new users and private
     if proposed_is_private and proposed_is_default_stream:
-        raise JsonableError(_("A default stream cannot be private."))
+        raise JsonableError(_("A default channel cannot be private."))
 
     if is_private is not None:
         # We require even realm administrators to be actually
@@ -309,7 +309,7 @@ def update_stream_backend(
     # web-public, we don't use an "is not None" check.
     if is_web_public:
         if not user_profile.realm.web_public_streams_enabled():
-            raise JsonableError(_("Web-public streams are not enabled."))
+            raise JsonableError(_("Web-public channels are not enabled."))
         if not user_profile.can_create_web_public_streams():
             raise JsonableError(_("Insufficient permission"))
 
@@ -351,7 +351,7 @@ def update_stream_backend(
     if new_name is not None:
         new_name = new_name.strip()
         if stream.name == new_name:
-            raise JsonableError(_("Stream already has that name!"))
+            raise JsonableError(_("Channel already has that name."))
         if stream.name.lower() != new_name.lower():
             # Check that the stream name is available (unless we are
             # are only changing the casing of the stream name).
@@ -380,7 +380,7 @@ def update_stream_backend(
         ] != getattr(stream, setting_group_id_name):
             if sub is None and stream.invite_only:
                 # Admins cannot change this setting for unsubscribed private streams.
-                raise JsonableError(_("Invalid stream ID"))
+                raise JsonableError(_("Invalid channel ID"))
 
             user_group_id = request_settings_dict[setting_group_id_name]
             user_group = access_user_group_for_setting(
@@ -636,7 +636,7 @@ def add_subscriptions_backend(
     )
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
         raise JsonableError(
-            _("Unable to access stream ({channel_name}).").format(
+            _("Unable to access channel ({channel_name}).").format(
                 channel_name=unauthorized_streams[0].name,
             )
         )
@@ -649,7 +649,7 @@ def add_subscriptions_backend(
         and not all(stream.invite_only for stream in streams)
     ):
         raise JsonableError(
-            _("You can only invite other Zephyr mirroring users to private streams.")
+            _("You can only invite other Zephyr mirroring users to private channels.")
         )
 
     if is_default_stream:
@@ -1016,7 +1016,7 @@ def update_subscription_properties_backend(
         (stream, sub) = access_stream_by_id(user_profile, stream_id)
         if sub is None:
             raise JsonableError(
-                _("Not subscribed to stream id {channel_id}").format(channel_id=stream_id)
+                _("Not subscribed to channel ID {channel_id}").format(channel_id=stream_id)
             )
 
         try:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -514,9 +514,9 @@ def you_were_just_subscribed_message(
     subscriptions = sorted(stream_names)
     if len(subscriptions) == 1:
         with override_language(recipient_user.default_language):
-            return _("{user_full_name} subscribed you to the stream {stream_name}.").format(
+            return _("{user_full_name} subscribed you to the stream {channel_name}.").format(
                 user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
-                stream_name=f"#**{subscriptions[0]}**",
+                channel_name=f"#**{subscriptions[0]}**",
             )
 
     with override_language(recipient_user.default_language):
@@ -524,8 +524,8 @@ def you_were_just_subscribed_message(
             user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
         )
     message += "\n\n"
-    for stream_name in subscriptions:
-        message += f"* #**{stream_name}**\n"
+    for channel_name in subscriptions:
+        message += f"* #**{channel_name}**\n"
     return message
 
 
@@ -636,8 +636,8 @@ def add_subscriptions_backend(
     )
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
         raise JsonableError(
-            _("Unable to access stream ({stream_name}).").format(
-                stream_name=unauthorized_streams[0].name,
+            _("Unable to access stream ({channel_name}).").format(
+                channel_name=unauthorized_streams[0].name,
             )
         )
     # Newly created streams are also authorized for the creator
@@ -761,14 +761,14 @@ def send_messages_for_new_subscribers(
         if new_stream_announcements_stream is not None:
             with override_language(new_stream_announcements_stream.realm.default_language):
                 if len(created_streams) > 1:
-                    content = _("{user_name} created the following streams: {stream_str}.")
+                    content = _("{user_name} created the following streams: {new_channels}.")
                 else:
-                    content = _("{user_name} created a new stream {stream_str}.")
+                    content = _("{user_name} created a new stream {new_channels}.")
                 topic_name = _("new streams")
 
             content = content.format(
                 user_name=silent_mention_syntax_for_user(user_profile),
-                stream_str=", ".join(f"#**{s.name}**" for s in created_streams),
+                new_channels=", ".join(f"#**{s.name}**" for s in created_streams),
             )
 
             sender = get_system_bot(
@@ -1016,7 +1016,7 @@ def update_subscription_properties_backend(
         (stream, sub) = access_stream_by_id(user_profile, stream_id)
         if sub is None:
             raise JsonableError(
-                _("Not subscribed to stream id {stream_id}").format(stream_id=stream_id)
+                _("Not subscribed to stream id {channel_id}").format(channel_id=stream_id)
             )
 
         try:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -514,13 +514,13 @@ def you_were_just_subscribed_message(
     subscriptions = sorted(stream_names)
     if len(subscriptions) == 1:
         with override_language(recipient_user.default_language):
-            return _("{user_full_name} subscribed you to the stream {channel_name}.").format(
+            return _("{user_full_name} subscribed you to the channel {channel_name}.").format(
                 user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
                 channel_name=f"#**{subscriptions[0]}**",
             )
 
     with override_language(recipient_user.default_language):
-        message = _("{user_full_name} subscribed you to the following streams:").format(
+        message = _("{user_full_name} subscribed you to the following channels:").format(
             user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
         )
     message += "\n\n"
@@ -761,10 +761,10 @@ def send_messages_for_new_subscribers(
         if new_stream_announcements_stream is not None:
             with override_language(new_stream_announcements_stream.realm.default_language):
                 if len(created_streams) > 1:
-                    content = _("{user_name} created the following streams: {new_channels}.")
+                    content = _("{user_name} created the following channels: {new_channels}.")
                 else:
-                    content = _("{user_name} created a new stream {new_channels}.")
-                topic_name = _("new streams")
+                    content = _("{user_name} created a new channel {new_channels}.")
+                topic_name = _("new channels")
 
             content = content.format(
                 user_name=silent_mention_syntax_for_user(user_profile),
@@ -798,7 +798,7 @@ def send_messages_for_new_subscribers(
                         stream=stream,
                         topic_name=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
                         content=_(
-                            "**{policy}** stream created by {user_name}. **Description:**"
+                            "**{policy}** channel created by {user_name}. **Description:**"
                         ).format(
                             user_name=silent_mention_syntax_for_user(user_profile),
                             policy=get_stream_permission_policy_name(

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -38,13 +38,13 @@ def send_notification_backend(
 
     if recipient_type_name == "stream":
         if stream_id is None:
-            raise JsonableError(_("Missing stream_id"))
+            raise JsonableError(_("Missing '{var_name}' argument").format(var_name="stream_id"))
 
         if topic is None:
             raise JsonableError(_("Missing topic"))
 
         if not user_profile.send_stream_typing_notifications:
-            raise JsonableError(_("User has disabled typing notifications for stream messages"))
+            raise JsonableError(_("User has disabled typing notifications for channel messages"))
 
         # Verify that the user has access to the stream and has
         # permission to send messages to it.

--- a/zerver/views/user_topics.py
+++ b/zerver/views/user_topics.py
@@ -99,7 +99,7 @@ def update_user_topic(
     visibility_policy: int = REQ(json_validator=check_int_in(UserTopic.VisibilityPolicy.values)),
 ) -> HttpResponse:
     if visibility_policy == UserTopic.VisibilityPolicy.INHERIT:
-        error = _("Invalid stream ID")
+        error = _("Invalid channel ID")
         stream = access_stream_to_remove_visibility_policy_by_id(user_profile, stream_id, error)
     else:
         (stream, sub) = access_stream_by_id(user_profile, stream_id)

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -54,7 +54,7 @@ class HelloWorldHookTests(WebhookTestCase):
         self.url = self.build_webhook_url()
         realm = get_realm("zulip")
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
-        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to stream #**nonexistent**, but that stream does not exist. Click [here](#streams/new) to create it."
+        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to channel #**nonexistent**, but that channel does not exist. Click [here](#streams/new) to create it."
         self.send_and_test_private_message(
             "goodbye",
             expected_message=expected_message,


### PR DESCRIPTION
Updates user-facing, translated strings for the stream to channel rename (#28468) project.

Currently every separate commit should pass relevant test suites for the changes. I tried to structure them for ease of review. I imagine that some of them could be squashed after being reviewed and before being committed if we think that would be better.

---

**Backend changes**

Strings that needed to be updated were identified with:
```
git grep -i -e '".*stream' --and --not -e msgstr locale/ru/LC_MESSAGES/
```

<details>
<summary>git grep results</summary>

```console
$ git grep -i -e '".*stream' --and --not -e msgstr locale/ru/LC_MESSAGES/
locale/ru/LC_MESSAGES/django.po:msgid "Public streams"
locale/ru/LC_MESSAGES/django.po:msgid "Private streams"
locale/ru/LC_MESSAGES/django.po:msgid "Missing stream for chart: {chart_name}"
locale/ru/LC_MESSAGES/django.po:msgid "New streams"
locale/ru/LC_MESSAGES/django.po:"#%(stream_name)s > %(topic_name)s."
locale/ru/LC_MESSAGES/django.po:"You are receiving this because everyone was mentioned in #%(stream_name)s."
locale/ru/LC_MESSAGES/django.po:"#%(stream_name)s."
locale/ru/LC_MESSAGES/django.po:msgid "[resolved] #%(stream_name)s > %(topic_name)s"
locale/ru/LC_MESSAGES/django.po:"In Zulip, <b>streams</b> determine who gets a message. <b>Topics</b> tell "
locale/ru/LC_MESSAGES/django.po:msgid "Streams and topics in the Zulip app"
locale/ru/LC_MESSAGES/django.po:"To kick off a new conversation, just pick a stream and start a new topic. "
locale/ru/LC_MESSAGES/django.po:"<a href=\"%(move_topic_to_different_stream_link)s\">move a topic to a "
locale/ru/LC_MESSAGES/django.po:"different stream</a>."
locale/ru/LC_MESSAGES/django.po:"In Zulip, streams determine who gets a message. Topics tell you what the "
locale/ru/LC_MESSAGES/django.po:"topics (%(rename_topics_link)s), or even move a topic to a different stream "
locale/ru/LC_MESSAGES/django.po:"(%(move_topic_to_different_stream_link)s)."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid default stream group name '{group_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "Default stream group name too long (limit: {max_length} characters)"
locale/ru/LC_MESSAGES/django.po:"Default stream group name '{group_name}' contains NULL (0x00) characters."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid default stream group {group_name}"
locale/ru/LC_MESSAGES/django.po:"'{stream_name}' is a default stream and cannot be added to '{group_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "Default stream group '{group_name}' already exists"
locale/ru/LC_MESSAGES/django.po:"Stream '{stream_name}' is already present in default stream group "
locale/ru/LC_MESSAGES/django.po:"Stream '{stream_name}' is not present in default stream group '{group_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "This default stream group is already named '{group_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "Direct messages cannot be moved to streams."
locale/ru/LC_MESSAGES/django.po:msgid "Cannot change message content while changing stream"
locale/ru/LC_MESSAGES/django.po:msgid "The time limit for editing this message's stream has passed"
locale/ru/LC_MESSAGES/django.po:msgid "Expected exactly one stream"
locale/ru/LC_MESSAGES/django.po:msgid "Invalid data type for stream"
locale/ru/LC_MESSAGES/django.po:"Your bot {bot_identity} tried to send a message to stream ID {stream_id}, "
locale/ru/LC_MESSAGES/django.po:"but there is no stream with that ID."
locale/ru/LC_MESSAGES/django.po:"Your bot {bot_identity} tried to send a message to stream {stream_name}, but"
locale/ru/LC_MESSAGES/django.po:" that stream does not exist. Click [here]({new_stream_link}) to create it."
locale/ru/LC_MESSAGES/django.po:"Your bot {bot_identity} tried to send a message to stream {stream_name}. The"
locale/ru/LC_MESSAGES/django.po:" stream exists but does not have any subscribers."
locale/ru/LC_MESSAGES/django.po:msgid "Stream is already deactivated"
locale/ru/LC_MESSAGES/django.po:msgid "Stream is not currently deactivated"
locale/ru/LC_MESSAGES/django.po:msgid "Stream named {stream_name} already exists"
locale/ru/LC_MESSAGES/django.po:msgid "Stream {stream_name} un-archived."
locale/ru/LC_MESSAGES/django.po:"{user} changed the [access permissions](/help/stream-permissions) for this "
locale/ru/LC_MESSAGES/django.po:"stream from **{old_policy}** to **{new_policy}**."
locale/ru/LC_MESSAGES/django.po:"{user} changed the [posting permissions](/help/stream-sending-policy) for this stream:\n"
locale/ru/LC_MESSAGES/django.po:msgid "{user_name} renamed stream {old_stream_name} to {new_stream_name}."
locale/ru/LC_MESSAGES/django.po:msgid "{user} changed the description for this stream."
locale/ru/LC_MESSAGES/django.po:msgid "Messages in this stream will now be retained forever."
locale/ru/LC_MESSAGES/django.po:"{user} has changed the [message retention period](/help/message-retention-policy) for this stream:\n"
locale/ru/LC_MESSAGES/django.po:msgid "Cannot send to multiple streams"
locale/ru/LC_MESSAGES/django.po:msgid "Missing stream"
locale/ru/LC_MESSAGES/django.po:msgid "Must specify exactly 1 stream ID for stream messages"
locale/ru/LC_MESSAGES/django.po:msgid "Stream '{stream}' does not exist"
locale/ru/LC_MESSAGES/django.po:msgid "Stream with ID '{stream_id}' does not exist"
locale/ru/LC_MESSAGES/django.po:"You do not have permission to use stream wildcard mentions in this stream."
locale/ru/LC_MESSAGES/django.po:msgid "Catch up on a stream"
locale/ru/LC_MESSAGES/django.po:"Messages sent to a stream are seen by everyone subscribed to that stream. "
locale/ru/LC_MESSAGES/django.po:"Try clicking on one of the stream links below."
locale/ru/LC_MESSAGES/django.po:"In Zulip, streams [determine who gets a message](/help/streams-and-topics). "
locale/ru/LC_MESSAGES/django.po:msgid "[Browse and subscribe to streams](#streams/all)."
locale/ru/LC_MESSAGES/django.po:"In Zulip, topics [tell you what a message is about](/help/streams-and-"
locale/ru/LC_MESSAGES/django.po:"This is a private stream, as indicated by the lock icon next to the stream "
locale/ru/LC_MESSAGES/django.po:msgid "Private streams are only visible to stream members."
locale/ru/LC_MESSAGES/django.po:"To manage this stream, go to [Stream settings]({stream_settings_url}) and "
locale/ru/LC_MESSAGES/django.po:"click on `{initial_private_stream_name}`."
locale/ru/LC_MESSAGES/django.po:"This is a message on stream #**{default_notification_stream_name}** with the"
locale/ru/LC_MESSAGES/django.po:"You can learn more about topics at [Streams and "
locale/ru/LC_MESSAGES/django.po:"This is a message on stream #**{default_notification_stream_name}** with the"
locale/ru/LC_MESSAGES/django.po:msgid "Invalid data type for stream ID"
locale/ru/LC_MESSAGES/django.po:msgid "Only organization administrators can send to this stream."
locale/ru/LC_MESSAGES/django.po:"Only organization administrators and moderators can send to this stream."
locale/ru/LC_MESSAGES/django.po:msgid "Guests cannot send to this stream."
locale/ru/LC_MESSAGES/django.po:msgid "New members cannot send to this stream."
locale/ru/LC_MESSAGES/django.po:msgid "Not authorized to send to stream '{stream_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "Please supply 'stream'."
locale/ru/LC_MESSAGES/django.po:msgid "Please choose one: 'stream' or 'stream_id'."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid stream ID"
locale/ru/LC_MESSAGES/django.po:msgid "Stream name '{stream_name}' is already taken."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid stream name '{stream_name}'"
locale/ru/LC_MESSAGES/django.po:msgid "A default stream cannot be private."
locale/ru/LC_MESSAGES/django.po:msgid "Stream(s) ({stream_names}) do not exist"
locale/ru/LC_MESSAGES/django.po:msgid "Web-public streams are not enabled."
locale/ru/LC_MESSAGES/django.po:msgid "Default stream group with id '{group_id}' does not exist."
locale/ru/LC_MESSAGES/django.po:msgid "Stream name can't be empty!"
locale/ru/LC_MESSAGES/django.po:msgid "Stream name too long (limit: {max_length} characters)."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid character in stream name, at position {position}!"
locale/ru/LC_MESSAGES/django.po:msgid "Subscriber data is not available for this stream"
locale/ru/LC_MESSAGES/django.po:msgid "Unable to retrieve subscribers for private stream"
locale/ru/LC_MESSAGES/django.po:msgid "stream events"
locale/ru/LC_MESSAGES/django.po:msgid "All stream members can post"
locale/ru/LC_MESSAGES/django.po:msgid "Stream does not exist with id: {stream_id}. No invites were sent."
locale/ru/LC_MESSAGES/django.po:msgid "You do not have permission to subscribe other users to streams."
locale/ru/LC_MESSAGES/django.po:msgid "Invalid stream ID {stream_id}. No invites were sent."
locale/ru/LC_MESSAGES/django.po:msgid "Topic required when updating scheduled message type to stream."
locale/ru/LC_MESSAGES/django.po:msgid "Private streams cannot be made default."
locale/ru/LC_MESSAGES/django.po:msgid "Stream already has that name!"
locale/ru/LC_MESSAGES/django.po:msgid "{user_full_name} subscribed you to the stream {stream_name}."
locale/ru/LC_MESSAGES/django.po:msgid "{user_full_name} subscribed you to the following streams:"
locale/ru/LC_MESSAGES/django.po:msgid "Unable to access stream ({stream_name})."
locale/ru/LC_MESSAGES/django.po:msgid "You can only invite other Zephyr mirroring users to private streams."
locale/ru/LC_MESSAGES/django.po:msgid "{user_name} created the following streams: {stream_str}."
locale/ru/LC_MESSAGES/django.po:msgid "{user_name} created a new stream {stream_str}."
locale/ru/LC_MESSAGES/django.po:msgid "new streams"
locale/ru/LC_MESSAGES/django.po:msgid "**{policy}** stream created by {user_name}. **Description:**"
locale/ru/LC_MESSAGES/django.po:msgid "Not subscribed to stream id {stream_id}"
locale/ru/LC_MESSAGES/django.po:msgid "Missing stream_id"
locale/ru/LC_MESSAGES/django.po:msgid "User has disabled typing notifications for stream messages"
```
</details>

---

**Frontend changes**:

Currently only updates the translated strings on the frontend / web app code. 

```
git grep -i 'stream' locale/ru/translations.json
```

<details>
<summary>git grep results</summary>

```console
locale/ru/translations.json:  "<p>Stream will be announced in <b>#{new_stream_announcements_stream}</b>.</p>": "",
locale/ru/translations.json:  "<p>You are searching for messages that belong to more than one stream, which is not possible.</p>": "<p>Вы ищете сообщения, которые относятся более чем к одному каналу, а это невозможно.</p>",
locale/ru/translations.json:  "<strong>{name}</strong> <i>(guest)</i> is not subscribed to this stream. They will not be notified if you mention them.": "<strong>{name}</strong> <i>(гость)</i> не подписан/а на этот канал. Он/а не получит оповещение при упоминании.",
locale/ru/translations.json:  "<strong>{name}</strong> <i>(guest)</i> is not subscribed to this stream. They will not be notified unless you subscribe them.": "<strong>{name}</strong> <i>(гость)</i> не подписан/а на этот канал. Он/а не будет получать оповещения, пока вы его/ее не подпишете.",
locale/ru/translations.json:  "<strong>{name}</strong> is not subscribed to this stream. They will not be notified if you mention them.": "<strong>{name}</strong> не подписан/а на этот канал. Он/а не получит оповещение при упоминании.",
locale/ru/translations.json:  "<strong>{name}</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.": "<strong>{name}</strong> не подписан/а на этот канал. Он/а не будет получать оповещения, пока вы его/ее не подпишете.",
locale/ru/translations.json:  "<z-link>Click here</z-link> to learn about exporting private streams and direct messages.": "<z-link>Нажмите здесь</z-link>, чтобы узнать больше об экспорте закрытых каналов и личных сообщений.",
locale/ru/translations.json:  "<z-user></z-user> will have the same properties as it did prior to deactivation, including role, owner and stream subscriptions.": "<z-user></z-user> будет иметь те же свойства, что и до отключения, в том числе роль, владельца и подписки на каналы.",
locale/ru/translations.json:  "<z-user></z-user> will have the same role, stream subscriptions, user group memberships, and other settings and permissions as they did prior to deactivation.": "<z-user></z-user> будут иметь ту же роль, подписки на каналы, членство в группах пользователей и другие настройки и разрешения, что и до отключения.",
locale/ru/translations.json:  "A stream needs to have a name": "Канал должен иметь название",
locale/ru/translations.json:  "A stream with this name already exists": "Канал с таким названием уже существует",
locale/ru/translations.json:  "Add default streams": "Добавить каналы по умолчанию",
locale/ru/translations.json:  "Add members. Use usergroup or #streamname to bulk add members.": "Добавить участников. Используйте название группы пользователей или #название_канала для массового добавления подписчиков.",
locale/ru/translations.json:  "Add stream": "Добавить канал",
locale/ru/translations.json:  "Add streams": "Добавить каналы",
locale/ru/translations.json:  "Add subscribers. Use usergroup or #streamname to bulk add subscribers.": "Добавить подписчиков. Используйте название группы пользователей или #название_канала для массового добавления подписчиков.",
locale/ru/translations.json:  "All messages including muted streams": "Все сообщения, включая заглушенные каналы",
locale/ru/translations.json:  "All streams": "Все каналы",
locale/ru/translations.json:  "Allow creating web-public streams (visible to anyone on the Internet)": "Разрешить создание открытых веб-каналов (видны любому в Интернет)",
locale/ru/translations.json:  "Already subscribed to {stream}": "Уже подписан на {stream}",
locale/ru/translations.json:  "Announce new stream in": "Анонсировать новый канал в",
locale/ru/translations.json:  "Archive stream": "Архивировать канал",
locale/ru/translations.json:  "Archiving stream <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.": "Архивация канала <z-stream></z-stream> мгновенно отпишет всех его подписчиков. Это действие нельзя будет отменить.",
locale/ru/translations.json:  "Archiving this stream will also disable settings that were configured to use this stream:": "Архивация этого канала отключит настройки, сделанные для его использования:",
locale/ru/translations.json:  "Are you sure you want to create stream ''''{stream_name}'''' and subscribe {count} users to it?": "Вы уверены что хотите создать канал ''''{stream_name}'''' и подписать {count} пользователей на него?",
locale/ru/translations.json:  "Are you sure you want to send @-mention notifications to the <strong>{subscriber_count}</strong> users subscribed to #{stream_name}? If not, please edit your message to remove the <strong>@{stream_wildcard_mention}</strong> mention.": "Вы уверены, что хотите отправить @-упоминания для <strong>{subscriber_count}</strong> подписчиков канала #{stream_name}? Если нет, отредактируйте сообщение, убрав <strong>@{stream_wildcard_mention}</strong> упоминание.",
locale/ru/translations.json:  "Are you sure you want to unstar all messages in <stream-topic></stream-topic>?  This action cannot be undone.": "Вы уверены в том, что хотите снять отметку со всех сообщений в <stream-topic></stream-topic>?   Это действие нельзя будет отменить.",
locale/ru/translations.json:  "Automatically unmute topics in muted streams": "Автоматически включать темы в заглушенных каналах",
locale/ru/translations.json:  "Back to streams": "Назад к каналам",
locale/ru/translations.json:  "Because you are removing the last subscriber from a private stream, it will be automatically <z-link>archived</z-link>.": "Вы убираете последнего подписчика из закрытого канала, поэтому он будет автоматически <z-link>заархивирован</z-link>.",
locale/ru/translations.json:  "Because you are the only subscriber, this stream will be automatically <z-link>archived</z-link>.": "Поскольку вы единственный подписчик, этот канал будет автоматически <z-link>заархивирован</z-link>.",
locale/ru/translations.json:  "Browse 1 more stream": "Просмотреть еще 1 канал",
locale/ru/translations.json:  "Browse streams": "Просмотреть каналы",
locale/ru/translations.json:  "Browse {can_subscribe_stream_count} more streams": "Просмотр каналов - еще {can_subscribe_stream_count} шт.",
locale/ru/translations.json:  "Cannot subscribe to <z-stream></z-stream>": "Не удалось подписаться на <z-stream></z-stream>",
locale/ru/translations.json:  "Cannot subscribe to private stream <z-stream></z-stream>": "Не удалось подписаться на закрытый канал <z-stream></z-stream>",
locale/ru/translations.json:  "Cannot view stream": "Не удается просмотреть канал",
locale/ru/translations.json:  "Configure how Zulip notifies you about new messages. In muted streams, stream notification settings apply only to unmuted topics.": "Настройте оповещения Zulip о новых сообщениях. Для заглушенных каналов настройки оповещения относятся только к включенным темам.",
locale/ru/translations.json:  "Configure the default streams new users are subscribed to when joining your organization.": "Укажите каналы по умолчанию, на которые автоматически будут подписаны новые пользователи вашей организации.",
locale/ru/translations.json:  "Consider <z-link>searching all public streams</z-link>.": "Попробуйте <z-link>искать во всех открытых каналах</z-link>.",
locale/ru/translations.json:  "Create a stream": "Создать канал",
locale/ru/translations.json:  "Create new stream": "Создать новый канал",
locale/ru/translations.json:  "Create stream": "Создать канал",
locale/ru/translations.json:  "Creating stream...": "Создаю канал...",
locale/ru/translations.json:  "Currently viewing the entire stream.": "В данный момент отображается весь канал.",
locale/ru/translations.json:  "Cycle between stream narrows": "Переключаться между каналами",
locale/ru/translations.json:  "Default for stream": "По умолчанию для канала",
locale/ru/translations.json:  "Default streams": "Каналы по умолчанию",
locale/ru/translations.json:  "Default streams for new users cannot be made private.": "Каналы по умолчанию для новых пользователей нельзя делать закрытыми.",
locale/ru/translations.json:  "Default streams for this organization": "Канал по умолчанию для этой организации.",
locale/ru/translations.json:  "Demote inactive streams": "Убирать неактивные каналы",
locale/ru/translations.json:  "Edit #{stream_name}": "Редактировать #{stream_name}",
locale/ru/translations.json:  "Edit stream name and description": "Редактировать название и описание канала",
locale/ru/translations.json:  "Error creating stream": "Ошибка создания канала",
locale/ru/translations.json:  "Error in unsubscribing from #{stream_name}": "Ошибка при отписке от #{stream_name}",
locale/ru/translations.json:  "Error removing user from #{stream_name}": "Ошибка при удалении пользователя из #{stream_name}",
locale/ru/translations.json:  "Error removing user from this stream.": "Ошибка удаления пользователя с канала.",
locale/ru/translations.json:  "Exports all users, settings, and all data visible in public streams.": "Выгрузка всех пользователей, настроек, и всех данных, доступных в публичных каналах.",
locale/ru/translations.json:  "Failed adding one or more streams.": "Не удалось добавить одну или несколько тем.",
locale/ru/translations.json:  "Filter default streams": "Фильтр каналов",
locale/ru/translations.json:  "Filter streams": "Фильтр каналов",
locale/ru/translations.json:  "First time? Read our <z-link>guidelines</z-link> for creating and naming streams.": "В первый раз? Прочтите наши <z-link>рекомендации</z-link> по созданию и именованию каналов.",
locale/ru/translations.json:  "Forked from upstream at {zulip_merge_base}": "Форк апстрима с {zulip_merge_base}",
locale/ru/translations.json:  "Generate stream email address": "Создать адрес электронной почты канала",
locale/ru/translations.json:  "Go to stream settings": "К настройкам канала",
locale/ru/translations.json:  "However, it will no longer be subscribed to the private streams that you are not subscribed to.": "Тем не менее, будет прекращена подписка на закрытые каналы, на которые вы не подписаны.",
locale/ru/translations.json:  "In muted streams, stream notification settings apply only to unmuted topics.": "Для заглушенных каналов настройки оповещения относятся только к включенным темам.",
locale/ru/translations.json:  "In this stream": "",
locale/ru/translations.json:  "Includes muted streams and topics": "Включает заглушенные каналы и темы",
locale/ru/translations.json:  "Invalid stream ID": "Неверный код канала",
locale/ru/translations.json:  "Let recipients see when I'm typing messages in streams": "Показывать получателям, что я печатаю сообщение для канала",
locale/ru/translations.json:  "Let recipients see when a user is typing stream messages": "Показывать получателям, что пользователь печатает сообщение для канала",
locale/ru/translations.json:  "Log in to browse more streams": "Войдите, чтобы видеть больше каналов",
locale/ru/translations.json:  "Message #{stream_name}": "Написать в #{stream_name}",
locale/ru/translations.json:  "Message #{stream_name} > {topic_name}": "Написать в #{stream_name} > {topic_name}",
locale/ru/translations.json:  "Messages in all public streams": "Сообщения во всех открытых каналах",
locale/ru/translations.json:  "Mute stream": "Заглушить канал",
locale/ru/translations.json:  "Narrow to messages on stream <z-value></z-value>.": "Показать только сообщения канала <z-value></z-value>.",
locale/ru/translations.json:  "Narrow to stream from topic view": "Показать канал из просмотра темы",
locale/ru/translations.json:  "New stream announcements": "Объявления о новых каналах",
locale/ru/translations.json:  "New stream message": "Новое сообщение",
locale/ru/translations.json:  "New stream notifications": "Оповещения о новых каналах",
locale/ru/translations.json:  "No default streams match your current filter.": "Нет каналов по умолчанию, соответствующих текущему фильтру.",
locale/ru/translations.json:  "No matching streams": "Нет подходящих каналов",
locale/ru/translations.json:  "No stream subscribers match your current filter.": "Нет подписчиков канала, соответствующих текущему фильтру.",
locale/ru/translations.json:  "No stream subscriptions.": "Нет подписок на каналы.",
locale/ru/translations.json:  "No streams": "Никакие каналы",
locale/ru/translations.json:  "Notify stream": "Оповестить канал",
locale/ru/translations.json:  "Now following <z-link>{stream_topic}</z-link>.": "Тема <z-link>{stream_topic}</z-link> будет отслеживаться.",
locale/ru/translations.json:  "Once you leave this stream, you will not be able to rejoin.": "Если вы покините этот канала, вы не сможете вновь к нему присоединиться.",
locale/ru/translations.json:  "Only stream members can add users to a private stream.": "Только участники канала могут добавлять пользователей к закрытому каналу.",
locale/ru/translations.json:  "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.": "Только подписчики могут иметь доступ или присоединяться к закрытым каналам, поэтому вы потеряете доступ к этому каналу, если преобразуете его в закрытый не будучи подписанными на него.",
locale/ru/translations.json:  "Only subscribers to this stream can edit stream permissions.": "Только подписчики данного канала могут изменять его разрешения.",
locale/ru/translations.json:  "Organization administrators can change the announcement stream in the organization settings.": "Администраторы организации могут изменить канал для объявлений в настройках организации.",
locale/ru/translations.json:  "Pin stream to top": "Закрепить канал сверху",
locale/ru/translations.json:  "Pin stream to top of left sidebar": "Закрепить наверху в списке каналов",
locale/ru/translations.json:  "Please specify a stream.": "Пожалуйста, укажите канал.",
locale/ru/translations.json:  "Private streams cannot be default streams for new users.": "Закрытые каналы не могут быть каналами по умолчанию для новых пользователей. ",
locale/ru/translations.json:  "Receives new stream announcements": "Получает объявления о новых каналах",
locale/ru/translations.json:  "Require topics in stream messages": "Требовать тему в сообщениях канала",
locale/ru/translations.json:  "STREAMS": "КАНАЛЫ",
locale/ru/translations.json:  "Scroll through streams": "Прокрутка каналов",
locale/ru/translations.json:  "Search all public streams in the organization.": "Искать во всех публичных каналах организации.",
locale/ru/translations.json:  "Select a stream": "Выберите канал",
locale/ru/translations.json:  "Select a stream below or change topic name.": "Выберите ниже канал или измените название темы.",
locale/ru/translations.json:  "Select a stream to subscribe": "Выберите канал для подписки",
locale/ru/translations.json:  "Select stream": "Выберите канал",
locale/ru/translations.json:  "Stream": "Канал",
locale/ru/translations.json:  "Stream color": "Цвет канала",
locale/ru/translations.json:  "Stream created recently": "Недавно созданные каналы",
locale/ru/translations.json:  "Stream creation": "Создание канала",
locale/ru/translations.json:  "Stream description": "Описание канала",
locale/ru/translations.json:  "Stream email address:": "Адрес электронной почты канала:",
locale/ru/translations.json:  "Stream name": "Имя канала",
locale/ru/translations.json:  "Stream permissions": "Разрешения канала",
locale/ru/translations.json:  "Stream settings": "Настройки канала",
locale/ru/translations.json:  "Stream successfully created!": "Канал успешно создан!",
locale/ru/translations.json:  "Streams": "Каналы",
locale/ru/translations.json:  "Streams they should join": "Каналы, к которым они должны присоединиться",
locale/ru/translations.json:  "Subscribe to <z-stream></z-stream>": "Подписаться на <z-stream></z-stream>",
locale/ru/translations.json:  "Subscribe to/unsubscribe from selected stream": "Подписаться/отписаться от выбранного канала",
locale/ru/translations.json:  "Subscribe {full_name} to streams": "Подписка {full_name} на каналы",
locale/ru/translations.json:  "Subscribed streams": "Подписка на каналы",
locale/ru/translations.json:  "The stream <b>#{stream_name}</b> does not exist. Manage your subscriptions <z-link>on your Streams page</z-link>.": "Канал <b>#{stream_name}</b> отсутствует. Управляйте подписками <z-link>на странице ваших каналов</z-link>.",
locale/ru/translations.json:  "The stream description cannot contain newline characters.": "Описание канала не должна содержать перенос строки.",
locale/ru/translations.json:  "The topic <strong>{topic_name}</strong> already exists in this stream. Are you sure you want to combine messages from these topics? This cannot be undone.": "",
locale/ru/translations.json:  "There are no default streams.": "",
locale/ru/translations.json:  "There are no streams you can view in this organization.": "В этой организации нет каналов, которые вы можете просматривать.",
locale/ru/translations.json:  "This change will make this stream's entire message history accessible according to the new configuration.": "",
locale/ru/translations.json:  "This stream does not exist or is private.": "Этот канал не существует или является закрытым.",
locale/ru/translations.json:  "This stream does not yet have a description.": "У этого канала еще нет описания.",
locale/ru/translations.json:  "This stream has been deactivated": "Этот канал был отключен",
locale/ru/translations.json:  "This stream has no subscribers.": "У этого канала нет подписчиков.",
locale/ru/translations.json:  "This stream has {sub_count, plural, =0 {no subscribers} one {# subscriber} other {# subscribers}}.": "У этого канала {sub_count, plural, =0 {нет подписчиков} one {# подписчик} other {# подписчиков}}.",
locale/ru/translations.json:  "Time limit for moving messages between streams": "Ограничение времени для перемещения сообщений в другой канал",
locale/ru/translations.json:  "Unknown stream": "Неизвестный канал",
locale/ru/translations.json:  "Unknown stream #{search_text}": "Неизвестный канал #{search_text}",
locale/ru/translations.json:  "Unmute stream": "Включить канал",
locale/ru/translations.json:  "Unmuted <z-link>{stream_topic}</z-link>.": "Включена тема <z-link>{stream_topic}</z-link>.",
locale/ru/translations.json:  "Unmuted streams and topics": "Включенные каналы и темы",
locale/ru/translations.json:  "Unpin stream from top": "Открепить канал сверху",
locale/ru/translations.json:  "Unsubscribe from <z-stream></z-stream>": "Отписаться от <z-stream></z-stream>",
locale/ru/translations.json:  "Use stream settings to unsubscribe from private streams.": "Используйте настройки канала, чтобы отписаться от закрытых каналов.",
locale/ru/translations.json:  "Use stream settings to unsubscribe the last user from a private stream.": "Используйте настройки канала, чтобы отписать последнего пользователя от закрытого канала.",
locale/ru/translations.json:  "View all streams": "Просмотреть все каналы",
locale/ru/translations.json:  "View stream": "Просмотр канала",
locale/ru/translations.json:  "View stream messages": "Показать сообщения канала",
locale/ru/translations.json:  "View streams": "Просмотр каналов",
locale/ru/translations.json:  "Warning: <strong>#{stream_name}</strong> is a private stream.": "Внимание: <strong>#{stream_name}</strong> — это закрытый канал.",
locale/ru/translations.json:  "Which parts of the email should be included in the Zulip message sent to this stream?": "Какие части электронной почты следует включать в сообщения Zulip, отправляемые в канал?",
locale/ru/translations.json:  "Who can access the stream?": "Кто имеет доступ к каналу?",
locale/ru/translations.json:  "Who can add users to streams": "Кто имеет право добавлять пользователей к каналам",
locale/ru/translations.json:  "Who can create private streams": "Кто может создавать закрытые каналы",
locale/ru/translations.json:  "Who can create public streams": "Кто может создавать открытые каналы",
locale/ru/translations.json:  "Who can create web-public streams": "Кто может создавать открытые веб-каналы",
locale/ru/translations.json:  "Who can move messages to another stream": "Кто может перемещать сообщения в другой канал",
locale/ru/translations.json:  "Who can post to the stream?": "Кто может писать сообщения в канале?",
locale/ru/translations.json:  "Who can unsubscribe others from this stream?": "Кто может отписать других от данного канала?",
locale/ru/translations.json:  "You are not currently subscribed to this stream.": "Вы не подписаны на этот канал.",
locale/ru/translations.json:  "You are not subscribed to any streams.": "Вы не подписаны ни на один канал.",
locale/ru/translations.json:  "You are not subscribed to stream <z-stream-name></z-stream-name>": "Вы не подписаны на канал <z-stream-name></z-stream-name>",
locale/ru/translations.json:  "You aren't subscribed to this stream and nobody has talked about that yet!": "Вы не подписаны на этот канал и никто об этом ещё не упоминал!",
locale/ru/translations.json:  "You can use email to send messages to Zulip streams.": "Вы можете писать в каналы Zulip по электронной почте.",
locale/ru/translations.json:  "You cannot create a stream with no subscribers!": "Вы не можете создать канал без подписчиков!",
locale/ru/translations.json:  "You do not have permission to add other users to streams in this organization.": "У вас нет права добавлять других пользователей в каналы в этой организации.",
locale/ru/translations.json:  "You do not have permission to move messages to another stream in this organization.": "",
locale/ru/translations.json:  "You do not have permission to post in this stream.": "У вас нет права писать в данном канале.",
locale/ru/translations.json:  "You do not have permission to use <b>@{stream_wildcard_mention}</b> mentions in this stream.": "Вам не разрешено использовать <b>@{stream_wildcard_mention}</b> упоминания в этом канале.",
locale/ru/translations.json:  "You have muted <z-stream-topic></z-stream-topic>.": "Вы заглушили <z-stream-topic></z-stream-topic>.",
locale/ru/translations.json:  "You must be an organization administrator to create a stream without subscribing.": "Вы должны быть администратором, чтобы создавать каналы не подписываясь.",
locale/ru/translations.json:  "You subscribed to stream <z-stream-name></z-stream-name>": "Вы подписались на канал <z-stream-name></z-stream-name>",
locale/ru/translations.json:  "You unsubscribed from stream <z-stream-name></z-stream-name>": "Вы отменили подписку на канал <z-stream-name></z-stream-name>",
locale/ru/translations.json:  "You're not subscribed to this stream. You will not be notified if other users reply to your message.": "Вы не подписаны на этот канал. Вы не получите уведомление, если кто-то ответит на ваше сообщение.",
locale/ru/translations.json:  "Your message was sent to a stream you have muted.": "Ваше сообщение отправлено в канал, который вы заглушили.",
locale/ru/translations.json:  "back to streams": "назад к каналам",
```
</details>

- Results where the only instance of "stream" in the string was "<z-stream>" were not updated.
- Results where the string is no longer in the code base either led to identifying the recently updated version of the string or identified as having been removed from the codebase.

---

**To be added to these changes:**

- frontend filter/search/wildcard adjustments for channel to stream
- URL updates (frontend and backend)
- API changelog entry

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
