### PR TITLE
Automate the second stage of bootstrapping Kandra database replicas.

### DIFF
--- a/puppet/kandra/files/postgresql/setup_data.sh
+++ b/puppet/kandra/files/postgresql/setup_data.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -eux
+
+service postgresql stop
+
+cert_file="$(crudini --get /etc/zulip/zulip.conf postgresql ssl_cert_file)"
+if [ -z "$cert_file" ] || [ ! -f "$cert_file" ]; then
+    echo "Certificate file is not set or does not exist!"
+    exit 1
+fi
+
+key_file="$(crudini --get /etc/zulip/zulip.conf postgresql ssl_key_file)"
+if [ -z "$key_file" ] || [ ! -f "$key_file" ]; then
+    echo "Key file is not set or does not exist!"
+    exit 1
+fi
+
+cert_cn="$(openssl x509 -noout -subject -in "$cert_file" | sed -n '/^subject/s/^.*CN\s*=\s*//p')"
+
+if [ "$cert_cn" != "$(hostname)" ]; then
+    echo "Configured certificate does not match host!"
+    exit 1
+fi
+
+echo "Checking for S3 secrets..."
+crudini --get /etc/zulip/zulip-secrets.conf secrets s3_region >/dev/null
+crudini --get /etc/zulip/zulip-secrets.conf secrets s3_backups_bucket >/dev/null
+crudini --get /etc/zulip/zulip-secrets.conf secrets s3_backups_key >/dev/null
+crudini --get /etc/zulip/zulip-secrets.conf secrets s3_backups_secret_key >/dev/null
+
+if [ ! -f "/var/lib/postgresql/.postgresql/postgresql.crt" ]; then
+    echo "Replication certificate file is not set or does not exist!"
+    exit 1
+fi
+if [ ! -f "/var/lib/postgresql/.postgresql/postgresql.key" ]; then
+    echo "Replication key file is not set or does not exist!"
+    exit 1
+fi
+
+version="$(crudini --get /etc/zulip/zulip.conf postgresql version)"
+mkdir -p "/srv/data/postgresql/$version"
+chown postgres.postgres "/srv/data/postgresql/$version"
+chmod 700 "/srv/data/postgresql/$version"
+
+/usr/local/bin/env-wal-g backup-fetch "/var/lib/postgresql/$version/main" LATEST
+chown -R postgres.postgres "/var/lib/postgresql/$version/main"

--- a/puppet/kandra/manifests/profile/postgresql.pp
+++ b/puppet/kandra/manifests/profile/postgresql.pp
@@ -34,6 +34,25 @@ class kandra::profile::postgresql inherits kandra::profile::base {
     unless  => 'test /var/lib/postgresql/ -ef /srv/data/postgresql/',
   }
 
+  # This is the second stage, after secrets are configured
+  $replication_primary = zulipconf('postgresql', 'replication_primary', undef)
+  if $replication_primary != undef {
+      file { '/root/setup_data.sh':
+        ensure => file,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0744',
+        source => 'puppet:///modules/kandra/postgresql/setup_data.sh',
+      }
+      exec { 'setup_data':
+        command => '/root/setup_data.sh',
+        require => [File['/usr/local/bin/env-wal-g'], Exec['setup_disks']],
+        unless  => "test -d /srv/data/postgresql/${zulip::postgresql_common::version}/main",
+        timeout => 0,
+        notify  => Exec[$zulip::postgresql_base::postgresql_restart],
+      }
+  }
+
   file { "${zulip::postgresql_base::postgresql_confdir}/pg_hba.conf":
     ensure  => file,
     require => Package["postgresql-${zulip::postgresql_common::version}"],

--- a/puppet/kandra/manifests/profile/postgresql.pp
+++ b/puppet/kandra/manifests/profile/postgresql.pp
@@ -37,6 +37,7 @@ class kandra::profile::postgresql inherits kandra::profile::base {
   file { "${zulip::postgresql_base::postgresql_confdir}/pg_hba.conf":
     ensure  => file,
     require => Package["postgresql-${zulip::postgresql_common::version}"],
+    notify  => Exec[$zulip::postgresql_base::postgresql_restart],
     owner   => 'postgres',
     group   => 'postgres',
     mode    => '0640',

--- a/puppet/zulip/manifests/profile/postgresql.pp
+++ b/puppet/zulip/manifests/profile/postgresql.pp
@@ -77,5 +77,6 @@ class zulip::profile::postgresql {
     require     => $require,
     refreshonly => true,
     subscribe   => [ File[$postgresql_conf_file] ],
+    onlyif      => "test -d ${zulip::postgresql_base::postgresql_datadir}",
   }
 }

--- a/puppet/zulip/manifests/profile/postgresql.pp
+++ b/puppet/zulip/manifests/profile/postgresql.pp
@@ -66,8 +66,15 @@ class zulip::profile::postgresql {
     }
   }
 
+  $backups_s3_bucket = zulipsecret('secrets', 's3_backups_bucket', '')
+  $backups_directory = zulipconf('postgresql', 'backups_directory', '')
+  if $backups_s3_bucket != '' or $backups_directory != '' {
+    $require = [File['/usr/local/bin/env-wal-g'], Package[$zulip::postgresql_base::postgresql]]
+  } else {
+    $require = [Package[$zulip::postgresql_base::postgresql]]
+  }
   exec { $zulip::postgresql_base::postgresql_restart:
-    require     => Package[$zulip::postgresql_base::postgresql],
+    require     => $require,
     refreshonly => true,
     subscribe   => [ File[$postgresql_conf_file] ],
   }

--- a/tools/setup/bootstrap-aws-installer
+++ b/tools/setup/bootstrap-aws-installer
@@ -72,7 +72,7 @@ git -C zulip checkout "$BRANCH"
 
 (
     export APT_OPTIONS="-o Dpkg::Options::=--force-confnew"
-    /root/zulip/scripts/setup/install --puppet-classes "$FULL_ROLES"
+    /root/zulip/scripts/setup/install --puppet-classes "$FULL_ROLES" --postgresql-version=14
 )
 
 # Delete the ubuntu user


### PR DESCRIPTION
If there is a replication primary configured, and no current database, then we check all of the required secrets are in place, then pull down the latest backup and trigger a PostgreSQL restart, which will pick up downloading the remaining WAL logs to catch up, then start streaming from the configured primary.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
