### PR TITLE
Break `zproject.settings` import cycles at type-checking time

### DIFF
--- a/zerver/lib/db.py
+++ b/zerver/lib/db.py
@@ -51,11 +51,3 @@ class TimeTrackingConnection(connection):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.queries: List[Dict[str, str]] = []
         super().__init__(*args, **kwargs)
-
-
-def reset_queries() -> None:
-    from django.db import connections
-
-    for conn in connections.all():
-        if conn.connection is not None:
-            conn.connection.queries = []

--- a/zerver/lib/db_connections.py
+++ b/zerver/lib/db_connections.py
@@ -1,0 +1,7 @@
+from django.db import connections
+
+
+def reset_queries() -> None:
+    for conn in connections.all():
+        if conn.connection is not None:
+            conn.connection.queries = []

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -25,7 +25,7 @@ from sentry_sdk import set_tag
 from typing_extensions import Annotated, Concatenate, ParamSpec, override
 
 from zerver.lib.cache import get_remote_cache_requests, get_remote_cache_time
-from zerver.lib.db import reset_queries
+from zerver.lib.db_connections import reset_queries
 from zerver.lib.debug import maybe_tracemalloc_listen
 from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticationError, WebhookError
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time

--- a/zerver/worker/base.py
+++ b/zerver/worker/base.py
@@ -16,7 +16,7 @@ from returns.curry import partial
 from typing_extensions import override
 
 from zerver.lib.context_managers import lockfile
-from zerver.lib.db import reset_queries
+from zerver.lib.db_connections import reset_queries
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.queue import SimpleQueueClient

--- a/zerver/worker/missedmessage_emails.py
+++ b/zerver/worker/missedmessage_emails.py
@@ -11,7 +11,7 @@ from django.db.utils import IntegrityError
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
-from zerver.lib.db import reset_queries
+from zerver.lib.db_connections import reset_queries
 from zerver.lib.email_notifications import MissedMessageData, handle_missedmessage_emails
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.models import ScheduledMessageNotificationEmail

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -12,8 +12,6 @@ from .config import DEVELOPMENT, PRODUCTION, get_secret
 if TYPE_CHECKING:
     from django_auth_ldap.config import LDAPSearch
 
-    from zerver.models.users import UserProfile
-
 if PRODUCTION:  # nocoverage
     from .prod_settings import EXTERNAL_HOST, ZULIP_ADMINISTRATOR
 else:
@@ -634,4 +632,4 @@ CAN_ACCESS_ALL_USERS_GROUP_LIMITS_PRESENCE = False
 # in some places through the codebase.
 SIGNED_ACCESS_TOKEN_VALIDITY_IN_SECONDS = 60
 
-CUSTOM_AUTHENTICATION_WRAPPER_FUNCTION: Optional[Callable[..., Optional["UserProfile"]]] = None
+CUSTOM_AUTHENTICATION_WRAPPER_FUNCTION: Optional[Callable[..., Any]] = None

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -15,13 +15,21 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/settings.html for more information
 #
 ########################################################################
-import django_stubs_ext
+from typing import TYPE_CHECKING
 
 # Monkey-patch certain types that are declared as generic types
 # generic in django-stubs, but not (yet) as generic types in Django
 # itself. This is necessary to ensure type references like
 # django.db.models.Lookup[int] work correctly at runtime.
-django_stubs_ext.monkeypatch()
+#
+# Hide this from mypy to avoid creating stupid cycles like
+# zproject.settings → django_stubs_ext → django_stubs_ext.patch →
+# django.contrib.admin.options → django.contrib.contenttypes.models →
+# confirmation.models → django.conf → zproject.settings.
+if not TYPE_CHECKING:
+    import django_stubs_ext
+
+    django_stubs_ext.monkeypatch()
 
 from .configured_settings import *  # noqa: F403 isort: skip
 from .computed_settings import *  # noqa: F403 isort: skip


### PR DESCRIPTION
Import cycles aren’t ordinarily a problem for mypy, but cycles involving the Django settings module are a problem for django-stubs, and becoming more of a problem for django-stubs 5.

- Preparation for #29721.