### PR TITLE
export: Create REALM_EXPORTED audit log for exports via shell.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -2418,9 +2418,15 @@ def export_realm_wrapper(
 
 
 def get_realm_exports_serialized(user: UserProfile) -> List[Dict[str, Any]]:
+    # Exclude exports made via shell. 'acting_user=None', since they
+    # aren't supported in the current API format.
+    #
+    # TODO: We should return those via the API as well, with an
+    # appropriate way to express for who issued them; this requires an
+    # API change.
     all_exports = RealmAuditLog.objects.filter(
         realm=user.realm, event_type=RealmAuditLog.REALM_EXPORTED
-    )
+    ).exclude(acting_user=None)
     exports_dict = {}
     for export in all_exports:
         export_url = None

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -5,12 +5,13 @@ from typing import Any
 
 from django.conf import settings
 from django.core.management.base import CommandError
+from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.lib.export import export_realm_wrapper
 from zerver.lib.management import ZulipBaseCommand
-from zerver.models import Message, Reaction, UserProfile
+from zerver.models import Message, Reaction, RealmAuditLog, UserProfile
 
 
 class Command(ZulipBaseCommand):
@@ -205,6 +206,13 @@ class Command(ZulipBaseCommand):
 
         def percent_callback(bytes_transferred: Any) -> None:
             print(end=".", flush=True)
+
+        RealmAuditLog.objects.create(
+            acting_user=None,
+            realm=realm,
+            event_type=RealmAuditLog.REALM_EXPORTED,
+            event_time=timezone_now(),
+        )
 
         # Allows us to trigger exports separately from command line argument parsing
         export_realm_wrapper(


### PR DESCRIPTION
This PR creates `REALM_EXPORTED` audit log to help during import to distinguish readily between imports from another Zulip server vs imports from another product.

Prep PR for #29762

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
