### PR TITLE
stream-settings: Remove unused tooltip for announcement stream.

### DIFF
--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -1,7 +1,5 @@
 import $ from "jquery";
-import tippy from "tippy.js";
 
-import render_announce_stream_docs from "../templates/announce_stream_docs.hbs";
 import render_subscription_invites_warning_modal from "../templates/confirm_dialog/confirm_subscription_invites_warning.hbs";
 
 import * as channel from "./channel";
@@ -18,7 +16,6 @@ import * as stream_data from "./stream_data";
 import * as stream_settings_components from "./stream_settings_components";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as ui_report from "./ui_report";
-import {parse_html} from "./ui_util";
 
 let created_stream;
 
@@ -452,16 +449,6 @@ export function set_up_handlers() {
 
         // This is an inexpensive check.
         stream_name_error.pre_validate(stream_name);
-    });
-
-    tippy("#announce-stream-docs", {
-        content: () =>
-            parse_html(
-                render_announce_stream_docs({
-                    new_stream_announcements_stream:
-                        stream_data.get_new_stream_announcements_stream(),
-                }),
-            ),
     });
 
     // Do not allow the user to enter newline characters while typing out the

--- a/web/templates/announce_stream_docs.hbs
+++ b/web/templates/announce_stream_docs.hbs
@@ -1,9 +1,0 @@
-{{! Explanation of what "announce stream" does when creating a stream }}
-<div>
-
-    {{#tr}}
-    <p>Stream will be announced in <b>#{new_stream_announcements_stream}</b>.</p>
-    {{/tr}}
-    <p>{{t 'Organization administrators can change the announcement stream in the organization settings.' }}</p>
-
-</div>


### PR DESCRIPTION
In commit 449febf036, the tooltip that provided information about the announcement stream was replace with inline text on the stream creation form.

Removes the now unused template and code in stream_create for this tooltip.

See #24816, #23327 and https://chat.zulip.org/#narrow/stream/9-issues/topic/private.20announcement.20streams/near/1465348 for more context on the changes that removed this tooltip.

This removes two translated strings from the web app code, and is a prep commit for the stream to channel rename.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
