### PR TITLE
message_list_view: Restore date on previous sticky header.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1594,8 +1594,22 @@ export class MessageListView {
             /* No headers are present */
             return;
         }
-        /* Intentionally remove sticky headers class here to make calculations simpler. */
-        $(".sticky_header").removeClass("sticky_header");
+
+        const $current_sticky_header = $(".sticky_header");
+        if ($current_sticky_header.length === 1) {
+            // Reset the date on the header in case we changed it.
+            const message_group_id = rows
+                .get_message_recipient_row($current_sticky_header)
+                .attr("id");
+            const group = this._find_message_group(message_group_id);
+            if (group !== undefined) {
+                const rendered_date = group.date;
+                $current_sticky_header.find(".recipient_row_date").html(rendered_date);
+                /* Intentionally remove sticky headers class here to make calculations simpler. */
+            }
+            $current_sticky_header.removeClass("sticky_header");
+        }
+
         /* visible_top is navbar top position + height for us. */
         const visible_top = message_viewport.message_viewport_info().visible_top;
         /* We need date to be properly visible on the header, so partially visible headers


### PR DESCRIPTION
We forgot to restore the date on sticky header if the header is no longer sticky.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/incorrect.20message.20timestamp

Reproducer:
* Have two messages with same sender on different dates next to each other in a stream narrow.
* Scroll so that sticky header is on the 2nd message.
* Scroll down fast so that to avoid us capturing the sticky header over the first message.
* Scroll up slowly so to see the group header of the messages have the date of the second message.

Super easy to reproduce here - https://chat.zulip.org/#narrow/stream/1-announce/topic/server.20releases/near/1592347