### PR TITLE
navbar: Fix left/right arrow key navigation between menus.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -825,7 +825,7 @@ export function process_hotkey(e, hotkey) {
 
     // Handle hotkeys for active popovers here which can handle keys other than `menu_dropdown_hotkeys`.
     if (
-        navbar_menus.is_navbar_menus_displayed() &&
+        (navbar_menus.is_navbar_menus_displayed() || navbar_menus.can_handle_navigation_hotkey()) &&
         navbar_menus.handle_keyboard_events(event_name)
     ) {
         return true;

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -3,6 +3,11 @@ import * as navbar_help_menu from "./navbar_help_menu";
 import {page_params} from "./page_params";
 import * as personal_menu_popover from "./personal_menu_popover";
 import * as popover_menus from "./popover_menus";
+import {
+    hide_userlist_sidebar,
+    right_sidebar_expanded_as_overlay,
+    show_userlist_sidebar,
+} from "./sidebar_ui";
 
 export function is_navbar_menus_displayed() {
     return (
@@ -23,6 +28,18 @@ export function handle_keyboard_events(event_name) {
         // Open gear menu popover on left arrow.
         personal_menu_popover.toggle();
         gear_menu.toggle();
+        return true;
+    }
+
+    if (popover_menus.is_help_menu_popover_displayed() && event_name === "left_arrow") {
+        navbar_help_menu.toggle();
+        if (!right_sidebar_expanded_as_overlay) {
+            show_userlist_sidebar();
+        }
+        return true;
+    } else if (right_sidebar_expanded_as_overlay) {
+        hide_userlist_sidebar();
+        navbar_help_menu.toggle();
         return true;
     }
 

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -1,3 +1,4 @@
+import {media_breakpoints_num} from "./css_variables";
 import * as gear_menu from "./gear_menu";
 import * as navbar_help_menu from "./navbar_help_menu";
 import {page_params} from "./page_params";
@@ -10,9 +11,16 @@ import {
 } from "./sidebar_ui";
 
 // Available menu options based on user type
-const popover_menus_options = page_params.is_spectator
-    ? ["signup_button", "login_button", "navbar_help_menu", "gear_menu"]
-    : ["user_list_toggle", "navbar_help_menu", "gear_menu", "personal_menu"];
+function getPopoverMenusOptions() {
+    if (page_params.is_spectator) {
+        return window.innerWidth < media_breakpoints_num.xl
+            ? ["navbar_help_menu", "gear_menu", "login_button"]
+            : ["signup_button", "login_button", "navbar_help_menu", "gear_menu"];
+    }
+    return ["navbar_help_menu", "gear_menu", "personal_menu"];
+}
+
+const popover_menus_options = getPopoverMenusOptions();
 
 export function is_navbar_menus_displayed() {
     return (
@@ -56,17 +64,12 @@ function is_menu_displayed(selected_popover_menu) {
     return false;
 }
 
-// if (popover_menus.is_gear_menu_popover_displayed()) {
-//     if (event_name === "gear_menu") {
-//         gear_menu.toggle();
 // Handle navigation events for specific menus
 function handle_menu_event(selected_popover_menu, event_name, index) {
     switch (event_name) {
         case "gear_menu":
             toggle_menu(selected_popover_menu);
             return true;
-        // } else if (event_name === "right_arrow" && !page_params.is_spectator) {
-        //     // Open personal menu popover on g + right arrow.
         case "left_arrow":
             if (index > 0) {
                 toggle_menu(selected_popover_menu);
@@ -113,11 +116,24 @@ function toggle_menu(selected_popover_menu) {
 
     // Toggle the focus state of a button
     function toggle_button_focus(selected_popover_menu) {
-        const selected_element = document.querySelector("." + selected_popover_menu);
-        if (document.activeElement.classList.contains(selected_popover_menu)) {
-            selected_element.blur();
+        if (window.innerWidth < media_breakpoints_num.xl) {
+            const selected_element = document.querySelector(
+                ".spectator_narrow_login_button ." + selected_popover_menu,
+            );
+            if (selected_element) {
+                if (selected_element === document.activeElement) {
+                    selected_element.blur();
+                } else {
+                    selected_element.focus();
+                }
+            }
         } else {
-            selected_element.focus();
+            const selected_element = document.querySelector("." + selected_popover_menu);
+            if (document.activeElement.classList.contains(selected_popover_menu)) {
+                selected_element.blur();
+            } else {
+                selected_element.focus();
+            }
         }
     }
 }

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -9,6 +9,11 @@ import {
     show_userlist_sidebar,
 } from "./sidebar_ui";
 
+// Available menu options based on user type
+const popover_menus_options = page_params.is_spectator
+    ? ["signup_button", "login_button", "navbar_help_menu", "gear_menu"]
+    : ["user_list_toggle", "navbar_help_menu", "gear_menu", "personal_menu"];
+
 export function is_navbar_menus_displayed() {
     return (
         popover_menus.is_personal_menu_popover_displayed() ||
@@ -17,58 +22,102 @@ export function is_navbar_menus_displayed() {
     );
 }
 
+export function can_handle_navigation_hotkey() {
+    return (
+        document.activeElement &&
+        (document.activeElement.classList.contains("signup_button") ||
+            document.activeElement.classList.contains("login_button"))
+    );
+}
+
+// Handle keyboard events for navigation
 export function handle_keyboard_events(event_name) {
-    // We don't need to process arrow keys in navbar menus for spectators
-    // since they only have gear menu present.
-    if (
-        popover_menus.is_personal_menu_popover_displayed() &&
-        (event_name === "left_arrow" || event_name === "gear_menu") &&
-        !page_params.is_spectator
-    ) {
-        // Open gear menu popover on left arrow.
-        personal_menu_popover.toggle();
-        gear_menu.toggle();
-        return true;
-    }
+    const index = popover_menus_options.findIndex((menu) => is_menu_displayed(menu));
 
-    if (popover_menus.is_help_menu_popover_displayed() && event_name === "left_arrow") {
-        navbar_help_menu.toggle();
-        if (!right_sidebar_expanded_as_overlay) {
-            show_userlist_sidebar();
-        }
-        return true;
-    } else if (right_sidebar_expanded_as_overlay) {
-        hide_userlist_sidebar();
-        navbar_help_menu.toggle();
-        return true;
+    if (index !== -1) {
+        return handle_menu_event(popover_menus_options[index], event_name, index);
     }
-
-    if (
-        popover_menus.is_help_menu_popover_displayed() &&
-        (event_name === "right_arrow" || event_name === "gear_menu")
-    ) {
-        // Open gear menu popover on right arrow.
-        navbar_help_menu.toggle();
-        gear_menu.toggle();
-        return true;
-    }
-
-    if (popover_menus.is_gear_menu_popover_displayed()) {
-        if (event_name === "gear_menu") {
-            gear_menu.toggle();
-            return true;
-        } else if (event_name === "right_arrow" && !page_params.is_spectator) {
-            // Open personal menu popover on g + right arrow.
-            gear_menu.toggle();
-            personal_menu_popover.toggle();
-            return true;
-        } else if (event_name === "left_arrow") {
-            // Open help menu popover on g + left arrow.
-            gear_menu.toggle();
-            navbar_help_menu.toggle();
-            return true;
-        }
-    }
-
     return false;
+}
+// Check if a specific menu is displayed
+function is_menu_displayed(selected_popover_menu) {
+    switch (selected_popover_menu) {
+        case "signup_button":
+            return document.activeElement.classList.contains("signup_button");
+        case "login_button":
+            return document.activeElement.classList.contains("login_button");
+        case "navbar_help_menu":
+            return popover_menus.is_help_menu_popover_displayed();
+        case "gear_menu":
+            return popover_menus.is_gear_menu_popover_displayed();
+        case "personal_menu":
+            return popover_menus.is_personal_menu_popover_displayed();
+    }
+    return false;
+}
+
+// if (popover_menus.is_gear_menu_popover_displayed()) {
+//     if (event_name === "gear_menu") {
+//         gear_menu.toggle();
+// Handle navigation events for specific menus
+function handle_menu_event(selected_popover_menu, event_name, index) {
+    switch (event_name) {
+        case "gear_menu":
+            toggle_menu(selected_popover_menu);
+            return true;
+        // } else if (event_name === "right_arrow" && !page_params.is_spectator) {
+        //     // Open personal menu popover on g + right arrow.
+        case "left_arrow":
+            if (index > 0) {
+                toggle_menu(selected_popover_menu);
+                toggle_menu(popover_menus_options[index - 1]);
+                return true;
+            }
+            break;
+        case "right_arrow":
+            if (index < popover_menus_options.length - 1) {
+                toggle_menu(selected_popover_menu);
+                toggle_menu(popover_menus_options[index + 1]);
+                return true;
+            }
+            break;
+    }
+    return false;
+}
+
+// Toggle the display state of a specific menu
+function toggle_menu(selected_popover_menu) {
+    switch (selected_popover_menu) {
+        case "signup_button":
+        case "login_button":
+            toggle_button_focus(selected_popover_menu);
+            break;
+        case "user_list_toggle":
+            if (!right_sidebar_expanded_as_overlay) {
+                show_userlist_sidebar();
+            } else if (right_sidebar_expanded_as_overlay) {
+                hide_userlist_sidebar();
+                navbar_help_menu.toggle();
+            }
+            break;
+        case "navbar_help_menu":
+            navbar_help_menu.toggle();
+            break;
+        case "gear_menu":
+            gear_menu.toggle();
+            break;
+        case "personal_menu":
+            personal_menu_popover.toggle();
+            break;
+    }
+
+    // Toggle the focus state of a button
+    function toggle_button_focus(selected_popover_menu) {
+        const selected_element = document.querySelector("." + selected_popover_menu);
+        if (document.activeElement.classList.contains(selected_popover_menu)) {
+            selected_element.blur();
+        } else {
+            selected_element.focus();
+        }
+    }
 }

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -117,7 +117,9 @@ export function is_in_focus() {
         !sidebar_ui.any_sidebar_expanded_as_overlay() &&
         !overlays.any_active() &&
         !modals.any_active() &&
-        !$(".home-page-input").is(":focus")
+        !document.activeElement.classList.contains("signup_button") &&
+        !document.activeElement.classList.contains("login_button") &&
+        !document.activeElement.classList.contains(".home-page-input")
     );
 }
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -5,6 +5,7 @@ import render_right_sidebar from "../templates/right_sidebar.hbs";
 
 import {buddy_list} from "./buddy_list";
 import {media_breakpoints_num} from "./css_variables";
+import * as navbar_help_menu from "./navbar_help_menu";
 import {page_params} from "./page_params";
 import * as rendered_markdown from "./rendered_markdown";
 import * as resize from "./resize";
@@ -20,12 +21,16 @@ export let right_sidebar_expanded_as_overlay = false;
 export function hide_userlist_sidebar(): void {
     $(".app-main .column-right").removeClass("expanded");
     right_sidebar_expanded_as_overlay = false;
+    // Remove focus from the user list toggle button
+    $("#userlist-toggle-button").trigger("blur");
 }
 
 export function show_userlist_sidebar(): void {
     $(".app-main .column-right").addClass("expanded");
     resize.resize_page_components();
     right_sidebar_expanded_as_overlay = true;
+    // Set focus on the user list toggle button
+    $("#userlist-toggle-button").trigger("focus");
 }
 
 export function show_streamlist_sidebar(): void {
@@ -80,6 +85,19 @@ export function initialize(): void {
             return;
         }
         show_userlist_sidebar();
+    });
+
+    $("#userlist-toggle-button").on("keydown", (e) => {
+        if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (e.key === "ArrowRight") {
+                // Handle right arrow key press
+                hide_userlist_sidebar();
+                navbar_help_menu.toggle();
+            }
+        }
     });
 
     $("#streamlist-toggle-button").on("click", (e) => {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -65,10 +65,12 @@ export function hide_all(): void {
 }
 
 export function initialize(): void {
-    $("body").on("click", ".login_button", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        window.location.href = spectators.build_login_link();
+    $("body").on("click keydown", ".login_button", (e) => {
+        if (e.type === "click" || (e.type === "keydown" && e.key === "Enter")) {
+            e.preventDefault();
+            e.stopPropagation();
+            window.location.href = spectators.build_login_link();
+        }
     });
 
     $("#userlist-toggle-button").on("click", (e) => {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -440,12 +440,13 @@ body.has-overlay-scrollbar {
                 --color-navbar-spectator-low-attention-brand-button-background
             );
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: var(
                     --color-navbar-spectator-low-attention-brand-button-text
                 );
                 background-color: var(
-                    --color-navbar-spectator-low-attention-brand-button-background-hover
+                    --color-navbar-spectator-medium-attention-brand-button-background-hover
                 );
             }
 
@@ -467,7 +468,8 @@ body.has-overlay-scrollbar {
                 --color-navbar-spectator-medium-attention-brand-button-background
             );
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: var(
                     --color-navbar-spectator-medium-attention-brand-button-text
                 );

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -506,19 +506,32 @@ body.has-overlay-scrollbar {
             display: none;
         }
 
-        .login_button {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100%;
+        & .login_button {
+            color: var(
+                --color-navbar-spectator-low-attention-brand-button-text
+            );
+            background-color: var(
+                --color-navbar-spectator-low-attention-brand-button-background
+            );
 
-            &:hover {
-                text-decoration: none;
+            &:hover,
+            &:focus {
+                color: var(
+                    --color-navbar-spectator-low-attention-brand-button-text
+                );
+                background-color: var(
+                    --color-navbar-spectator-medium-attention-brand-button-background-hover
+                );
             }
 
-            & i {
-                color: var(--color-navbar-icon);
-                font-size: 1.6em;
+            &:active {
+                transform: scale(0.98);
+                color: var(
+                    --color-navbar-spectator-low-attention-brand-button-text
+                );
+                background-color: var(
+                    --color-navbar-spectator-low-attention-brand-button-background-active
+                );
             }
         }
     }

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -58,7 +58,7 @@
                 </a>
             </div>
             <div class="spectator_narrow_login_button only-visible-for-spectators" data-tippy-content="{{t 'Log in' }}" data-tippy-placement="bottom">
-                <a class="header-button login_button">
+                <a tabindex="0" class="header-button login_button">
                     <i class="zulip-icon zulip-icon-log-in"></i>
                 </a>
             </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -33,7 +33,7 @@
                 <a href="/register/"  class="signup_button">
                     {{t 'Sign up' }}
                 </a>
-                <a class="login_button">
+                <a tabindex="0" class="login_button">
                     {{t 'Log in' }}
                 </a>
             </div>


### PR DESCRIPTION
I am also an applicant of GSOC this year.

This PR is built above and is a continuation of #29167. 
The left and right arrow keys now allow navigating between the userlist sidebar, help menu popover, and gear menu popover. Pressing the right arrow key from the userlist sidebar toggle button will open the help menu popover. Pressing the left arrow key from the help menu will hide it and re-focus the userlist sidebar toggle button.

I faced issues with the right arrow keypress while the user list was focused. I initially tried using event_name == "right_arrow" to detect the right arrow key press, but it wasn't being recognized when the userlist toggle button was focused.

To overcome these issues, I decided to directly handle the keydown event on the userlist toggle button using the $("#userlist-toggle-button").on("keydown", ...) event listener. By attaching the event listener directly to the toggle button, I ensured that the right arrow key press would be captured when the button was focused.

Inside the keydown event handler, I used e.key === "ArrowRight" to check if the pressed key was the right arrow key. This approach relies on the key property of the event object, which provides a string representation of the pressed key. Using "ArrowRight" as the comparison value ensures that the right arrow key is correctly detected.

Fixes: #29465.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
