### PR TITLE
timeout: Remove inappropriate uses and rename to unsafe_timeout

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -68,7 +68,7 @@ from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.subdomains import is_static_or_current_realm_url
 from zerver.lib.tex import render_tex
 from zerver.lib.thumbnail import user_uploads_or_external
-from zerver.lib.timeout import timeout
+from zerver.lib.timeout import unsafe_timeout
 from zerver.lib.timezone import common_timezones
 from zerver.lib.types import LinkifierDict
 from zerver.lib.url_encoding import encode_stream, hash_util_encode
@@ -2667,7 +2667,7 @@ def do_convert(
         # extremely inefficient in corner cases) as well as user
         # errors (e.g. a linkifier that makes some syntax
         # infinite-loop).
-        rendering_result.rendered_content = timeout(5, lambda: _md_engine.convert(content))
+        rendering_result.rendered_content = unsafe_timeout(5, lambda: _md_engine.convert(content))
 
         # Throw an exception if the content is huge; this protects the
         # rest of the codebase from any bugs where we end up rendering

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1560,7 +1560,7 @@ Output:
         markdown.__init__.do_convert.
         """
         with mock.patch(
-            "zerver.lib.markdown.timeout", side_effect=subprocess.CalledProcessError(1, [])
+            "zerver.lib.markdown.unsafe_timeout", side_effect=subprocess.CalledProcessError(1, [])
         ), self.assertLogs(level="ERROR"):  # For markdown_logger.exception
             yield
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -737,18 +737,6 @@ def mock_queue_publish(
 
 
 @contextmanager
-def timeout_mock(mock_path: str) -> Iterator[None]:
-    # timeout() doesn't work in test environment with database operations
-    # and they don't get committed - so we need to replace it with a mock
-    # that just calls the function.
-    def mock_timeout(seconds: int, func: Callable[[], object]) -> object:
-        return func()
-
-    with mock.patch(f"{mock_path}.timeout", new=mock_timeout):
-        yield
-
-
-@contextmanager
 def ratelimit_rule(
     range_seconds: int,
     num_requests: int,

--- a/zerver/lib/timeout.py
+++ b/zerver/lib/timeout.py
@@ -22,7 +22,7 @@ class TimeoutExpiredError(Exception):
 ResultT = TypeVar("ResultT")
 
 
-def timeout(timeout: float, func: Callable[[], ResultT]) -> ResultT:
+def unsafe_timeout(timeout: float, func: Callable[[], ResultT]) -> ResultT:
     """Call the function in a separate thread.
     Return its return value, or raise an exception,
     within approximately 'timeout' seconds.

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3305,7 +3305,7 @@ class MarkdownErrorTests(ZulipTestCase):
         throws an exception"""
         msg = "mock rendered message\n" * 10 * settings.MAX_MESSAGE_LENGTH
 
-        with mock.patch("zerver.lib.markdown.timeout", return_value=msg), mock.patch(
+        with mock.patch("zerver.lib.markdown.unsafe_timeout", return_value=msg), mock.patch(
             "zerver.lib.markdown.markdown_logger"
         ):
             with self.assertRaises(MarkdownRenderingError):

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -24,8 +24,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import get_subscription, timeout_mock
-from zerver.lib.timeout import TimeoutExpiredError
+from zerver.lib.test_helpers import get_subscription
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import (
     Message,
@@ -67,8 +66,7 @@ class FirstUnreadAnchorTests(ZulipTestCase):
         self.login("hamlet")
 
         # Mark all existing messages as read
-        with timeout_mock("zerver.views.message_flags"):
-            result = self.client_post("/json/mark_all_as_read")
+        result = self.client_post("/json/mark_all_as_read")
         result_dict = self.assert_json_success(result)
         self.assertTrue(result_dict["complete"])
 
@@ -128,8 +126,7 @@ class FirstUnreadAnchorTests(ZulipTestCase):
     def test_visible_messages_use_first_unread_anchor(self) -> None:
         self.login("hamlet")
 
-        with timeout_mock("zerver.views.message_flags"):
-            result = self.client_post("/json/mark_all_as_read")
+        result = self.client_post("/json/mark_all_as_read")
         result_dict = self.assert_json_success(result)
         self.assertTrue(result_dict["complete"])
 
@@ -756,8 +753,7 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
             [third_message_id, fourth_message_id],
         )
 
-        with timeout_mock("zerver.views.message_flags"):
-            result = self.client_post("/json/mark_all_as_read", {})
+        result = self.client_post("/json/mark_all_as_read", {})
         self.assertEqual(self.get_mobile_push_notification_ids(user_profile), [])
         mock_push_notifications.assert_called()
 
@@ -779,8 +775,7 @@ class MarkAllAsReadEndpointTest(ZulipTestCase):
             .count()
         )
         self.assertNotEqual(unread_count, 0)
-        with timeout_mock("zerver.views.message_flags"):
-            result = self.client_post("/json/mark_all_as_read", {})
+        result = self.client_post("/json/mark_all_as_read", {})
         result_dict = self.assert_json_success(result)
         self.assertTrue(result_dict["complete"])
 
@@ -793,7 +788,7 @@ class MarkAllAsReadEndpointTest(ZulipTestCase):
 
     def test_mark_all_as_read_timeout_response(self) -> None:
         self.login("hamlet")
-        with mock.patch("zerver.views.message_flags.timeout", side_effect=TimeoutExpiredError):
+        with mock.patch("time.monotonic", side_effect=[10000, 10051]):
             result = self.client_post("/json/mark_all_as_read", {})
             result_dict = self.assert_json_success(result)
             self.assertFalse(result_dict["complete"])

--- a/zerver/tests/test_timeout.py
+++ b/zerver/tests/test_timeout.py
@@ -4,7 +4,7 @@ import traceback
 from unittest import skipIf
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.timeout import TimeoutExpiredError, timeout
+from zerver.lib.timeout import TimeoutExpiredError, unsafe_timeout
 
 
 class TimeoutTestCase(ZulipTestCase):
@@ -20,12 +20,12 @@ class TimeoutTestCase(ZulipTestCase):
         return 42  # nocoverage
 
     def test_timeout_returns(self) -> None:
-        ret = timeout(1, lambda: 42)
+        ret = unsafe_timeout(1, lambda: 42)
         self.assertEqual(ret, 42)
 
     def test_timeout_exceeded(self) -> None:
         try:
-            timeout(1, lambda: self.sleep_x_seconds_y_times(0.1, 50))
+            unsafe_timeout(1, lambda: self.sleep_x_seconds_y_times(0.1, 50))
             raise AssertionError("Failed to raise a timeout")
         except TimeoutExpiredError as exc:
             tb = traceback.format_tb(exc.__traceback__)
@@ -34,7 +34,7 @@ class TimeoutTestCase(ZulipTestCase):
 
     def test_timeout_raises(self) -> None:
         try:
-            timeout(1, self.something_exceptional)
+            unsafe_timeout(1, self.something_exceptional)
             raise AssertionError("Failed to raise an exception")
         except ValueError as exc:
             tb = traceback.format_tb(exc.__traceback__)
@@ -47,7 +47,7 @@ class TimeoutTestCase(ZulipTestCase):
         # kill it
         with self.assertLogs(level="WARNING") as m:
             try:
-                timeout(1, lambda: self.sleep_x_seconds_y_times(5, 1))
+                unsafe_timeout(1, lambda: self.sleep_x_seconds_y_times(5, 1))
                 raise AssertionError("Failed to raise a timeout")
             except TimeoutExpiredError as exc:
                 tb = traceback.format_tb(exc.__traceback__)


### PR DESCRIPTION
The `zerver.lib.timeout` strategy using asynchronous exceptions has a number of safety caveats (read the docstring!!) and should only be used in very specific circumstances.