### PR TITLE
kandra: Add teleport services to "needsrestart" skip list.

### DIFF
--- a/puppet/kandra/files/needrestart/zulip.conf
+++ b/puppet/kandra/files/needrestart/zulip.conf
@@ -7,6 +7,7 @@ my @ignore = (
     qr/^rabbitmq-server\.service$/,
     qr/^redis-server\.service$/,
     qr/^supervisor\.service$/,
+    qr/^teleport(\w*)\.service$/,
 );
 
 $nrconf{override_rc}{$_} = 0 for @ignore;


### PR DESCRIPTION
These are often how one is connected to the node, and restarting them would drop the connection one us actively using.
