### PR TITLE
message feed: Provide more info in empty views.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -1,6 +1,8 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import render_empty_view_messages from "../templates/empty_view_messages.hbs";
+
 import {$t, $t_html} from "./i18n";
 import type {NarrowBannerData, SearchData} from "./narrow_error";
 import {narrow_error} from "./narrow_error";
@@ -173,33 +175,14 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                     // You currently have no starred messages.
                     return {
                         title: $t({defaultMessage: "You have no starred messages."}),
-                        html: $t_html(
-                            {
-                                defaultMessage:
-                                    "Learn more about starring messages <z-link>here</z-link>.",
-                            },
-                            {
-                                "z-link": (content_html) =>
-                                    `<a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">${content_html.join(
-                                        "",
-                                    )}</a>`,
-                            },
-                        ),
+                        html: render_empty_view_messages({is_empty_starred: true}),
                     };
                 case "mentioned":
                     return {
-                        title: $t({defaultMessage: "You haven't been mentioned yet!"}),
-                        html: $t_html(
-                            {
-                                defaultMessage: "Learn more about mentions <z-link>here</z-link>.",
-                            },
-                            {
-                                "z-link": (content_html) =>
-                                    `<a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">${content_html.join(
-                                        "",
-                                    )}</a>`,
-                            },
-                        ),
+                        title: $t({
+                            defaultMessage: "This view will show messages where you are mentioned.",
+                        }),
+                        html: render_empty_view_messages({is_empty_mentioned: true}),
                     };
                 case "dm":
                     // You have no direct messages.

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1972,6 +1972,13 @@ $option_title_width: 180px;
     }
 }
 
+.empty-view-message {
+    width: 100%; /* Ensures it takes the full width up to 800px */
+    .left {
+        text-align: left;
+    }
+}
+
 #generate-integration-url-modal {
     .inline {
         display: inline;

--- a/web/templates/empty_view_messages.hbs
+++ b/web/templates/empty_view_messages.hbs
@@ -1,0 +1,22 @@
+<div class="empty-view-message">
+    <p class="left">
+        {{#if is_empty_starred}}
+            {{#tr}} Starring messages is a good way to keep track of important messages,
+                such as tasks you need to go back to, or useful references.
+                To star a message, click the <star-icon-link></star-icon-link> in its upper right.
+                <z-link>Learn more. </z-link>
+                {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "star-icon-link"}}<i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>{{/inline}}
+            {{/tr}}
+        {{else if is_empty_mentioned}}
+            {{#tr}}To call attention to a message, you can mention a user, a group, topic participants,
+            or all subscribers to a stream. Type <mention-icon-link></mention-icon-link> in the compose box,
+            and choose who you'd like to mention from the list of suggestions.
+                <z-link>Learn more. </z-link>
+                {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "mention-icon-link"}}<i class="fa fa-at"></i>{{/inline}}
+            {{/tr}}
+        {{/if}}
+    </p>
+</div>
+

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -38,6 +38,15 @@ function empty_narrow_html(title, html, search_data) {
     return require("../templates/empty_feed_notice.hbs")(opts);
 }
 
+function empty_view_messages_html(title, is_empty_starred, is_empty_mentioned) {
+    const opts = {
+        is_empty_starred,
+        is_empty_mentioned,
+    };
+    const html_body = require("../templates/empty_view_messages.hbs")(opts);
+    return empty_narrow_html(title, html_body);
+}
+
 function set_filter(terms) {
     terms = terms.map((op) => ({
         operator: op[0],
@@ -206,6 +215,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     realm.stop_words = [];
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
+    mock_template("empty_view_messages.hbs", true, (_data, html) => html);
 
     message_lists.set_current(undefined);
     narrow_banner.show_empty_narrow_message();
@@ -279,19 +289,17 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: You have no starred messages.",
-            'translated HTML: Learn more about starring messages <a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">here</a>.',
-        ),
+        empty_view_messages_html("translated: You have no starred messages.", true, false),
     );
 
     set_filter([["is", "mentioned"]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: You haven't been mentioned yet!",
-            'translated HTML: Learn more about mentions <a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">here</a>.',
+        empty_view_messages_html(
+            "translated: This view will show messages where you are mentioned.",
+            false,
+            true,
         ),
     );
 


### PR DESCRIPTION
Change messages in narrow_banner.ts to provide more description for empty starred and mentions views.
Limit message max width to 800px and use icon class for the star and @ symbols.




<!-- Describe your pull request here.-->

Fixes: #29378 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2024-04-24 15-46-48](https://github.com/zulip/zulip/assets/73965466/ea50e318-d933-41c0-a2a5-43827e48e1a4)
![Screenshot from 2024-04-24 15-47-04](https://github.com/zulip/zulip/assets/73965466/122727aa-5d4b-44fe-85aa-ab7f29bb73b0)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
