### PR TITLE
audit_log: Update audit log entries created while creating a group.

### DIFF
--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -67,18 +67,6 @@ def create_user_group_in_database(
             event_time=creation_time,
             modified_user_group=user_group,
         ),
-        RealmAuditLog(
-            realm=realm,
-            acting_user=acting_user,
-            event_type=RealmAuditLog.USER_GROUP_GROUP_BASED_SETTING_CHANGED,
-            event_time=creation_time,
-            modified_user_group=user_group,
-            extra_data={
-                RealmAuditLog.OLD_VALUE: None,
-                RealmAuditLog.NEW_VALUE: user_group.can_mention_group.id,
-                "property": "can_mention_group",
-            },
-        ),
     ] + [
         RealmAuditLog(
             realm=realm,

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -493,21 +493,7 @@ def create_system_user_groups_for_realm(realm: Realm) -> Dict[int, UserGroup]:
     system_groups_name_dict = get_role_based_system_groups_dict(realm)
     for group in system_user_groups_list:
         user_group = set_defaults_for_group_settings(group, {}, system_groups_name_dict)
-        groups_with_updated_settings.append(group)
-        realmauditlog_objects.append(
-            RealmAuditLog(
-                realm=realm,
-                acting_user=None,
-                event_type=RealmAuditLog.USER_GROUP_GROUP_BASED_SETTING_CHANGED,
-                event_time=creation_time,
-                modified_user_group=user_group,
-                extra_data={
-                    RealmAuditLog.OLD_VALUE: None,
-                    RealmAuditLog.NEW_VALUE: user_group.can_mention_group.id,
-                    "property": "can_mention_group",
-                },
-            )
-        )
+        groups_with_updated_settings.append(user_group)
     UserGroup.objects.bulk_update(groups_with_updated_settings, ["can_mention_group"])
 
     subgroup_objects: List[GroupGroupMembership] = []

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1360,7 +1360,6 @@ class SlackImporter(ZulipTestCase):
                 RealmAuditLog.USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED,
                 RealmAuditLog.USER_GROUP_DIRECT_SUBGROUP_MEMBERSHIP_ADDED,
                 RealmAuditLog.USER_GROUP_DIRECT_SUPERGROUP_MEMBERSHIP_ADDED,
-                RealmAuditLog.USER_GROUP_GROUP_BASED_SETTING_CHANGED,
             },
         )
 


### PR DESCRIPTION
Earlier a extra audit log entry of type `USER_GROUP_GROUP_BASED_SETTING_CHANGED` was
made when a new user group is created. This commit updates the code to not create that audit log entry.

There is no need to create these entry as we would still have the required data from the "OLD_VALUE" field in the audit log entry created when changing the setting and this also makes it consistent with the entries created for other operations like stream creation.

Taken from #26355, since this was pending from a long time.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/stream/101-design/topic/New.20permissions.20model/near/1612949

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
