### PR TITLE
Migrate to typed endpoint

### DIFF
--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -108,6 +108,7 @@ OptionalTopic: TypeAlias = Annotated[
     StringConstraints(strip_whitespace=True),
     ApiParamConfig(whence="topic", aliases=("subject",)),
 ]
+ApnsAppId: TypeAlias = Annotated[str, StringConstraints(pattern="^[.a-zA-Z0-9-]+$")]
 
 # Reusable annotation metadata for Annotated types
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1180,7 +1180,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
                 result = self.client_post(
                     endpoint, {"token": token, "appid": "'; tables --"}, subdomain="zulip"
                 )
-                self.assert_json_error(result, "Invalid app ID")
+                self.assert_json_error(result, "appid has invalid format")
 
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"}, subdomain="zulip")
@@ -4618,7 +4618,7 @@ class TestPushApi(BouncerTestCase):
                 self.assert_json_error(result, "Missing 'appid' argument")
 
                 result = self.client_post(endpoint, {"token": label, "appid": "'; tables --"})
-                self.assert_json_error(result, "Invalid app ID")
+                self.assert_json_error(result, "appid has invalid format")
 
             # Try to remove a non-existent token...
             result = self.client_delete(endpoint, {"token": "abcd1234"})

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -8,21 +8,22 @@ from zerver.actions.reactions import check_add_reaction, do_remove_reaction
 from zerver.lib.emoji import get_emoji_data
 from zerver.lib.exceptions import JsonableError, ReactionDoesNotExistError
 from zerver.lib.message import access_message
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import Reaction, UserProfile
 
 
 # transaction.atomic is required since we use FOR UPDATE queries in access_message
 @transaction.atomic
-@has_request_variables
+@typed_endpoint
 def add_reaction(
     request: HttpRequest,
     user_profile: UserProfile,
     message_id: int,
-    emoji_name: str = REQ(),
-    emoji_code: Optional[str] = REQ(default=None),
-    reaction_type: Optional[str] = REQ(default=None),
+    *,
+    emoji_name: str,
+    emoji_code: Optional[str] = None,
+    reaction_type: Optional[str] = None,
 ) -> HttpResponse:
     check_add_reaction(user_profile, message_id, emoji_name, emoji_code, reaction_type)
 
@@ -31,14 +32,15 @@ def add_reaction(
 
 # transaction.atomic is required since we use FOR UPDATE queries in access_message
 @transaction.atomic
-@has_request_variables
+@typed_endpoint
 def remove_reaction(
     request: HttpRequest,
     user_profile: UserProfile,
     message_id: int,
-    emoji_name: Optional[str] = REQ(default=None),
-    emoji_code: Optional[str] = REQ(default=None),
-    reaction_type: str = REQ(default="unicode_emoji"),
+    *,
+    emoji_name: Optional[str] = None,
+    emoji_code: Optional[str] = None,
+    reaction_type: str = "unicode_emoji",
 ) -> HttpResponse:
     message = access_message(user_profile, message_id, lock_message=True)
 

--- a/zerver/views/read_receipts.py
+++ b/zerver/views/read_receipts.py
@@ -1,20 +1,21 @@
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.utils.translation import gettext as _
+from pydantic import NonNegativeInt
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import to_non_negative_int
+from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.models import UserMessage, UserProfile
 
 
-@has_request_variables
+@typed_endpoint
 def read_receipts(
     request: HttpRequest,
     user_profile: UserProfile,
-    message_id: int = REQ(converter=to_non_negative_int, path_only=True),
+    *,
+    message_id: PathOnly[NonNegativeInt],
 ) -> HttpResponse:
     message = access_message(user_profile, message_id)
 

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -66,7 +66,12 @@ from zerver.lib.request import RequestNotes, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.timestamp import timestamp_to_datetime
-from zerver.lib.typed_endpoint import JsonBodyPayload, RequiredStringConstraint, typed_endpoint
+from zerver.lib.typed_endpoint import (
+    ApnsAppId,
+    JsonBodyPayload,
+    RequiredStringConstraint,
+    typed_endpoint,
+)
 from zerver.lib.typed_endpoint_validators import check_string_fixed_length
 from zerver.lib.types import RemoteRealmDictValue
 from zerver.models.realms import DisposableEmailError
@@ -239,7 +244,7 @@ def register_remote_push_device(
     realm_uuid: Optional[str] = None,
     token: Annotated[str, RequiredStringConstraint],
     token_kind: Json[int],
-    ios_app_id: Annotated[Optional[str], StringConstraints(pattern="^[.a-zA-Z0-9-]+$")] = None,
+    ios_app_id: Optional[ApnsAppId] = None,
 ) -> HttpResponse:
     validate_bouncer_token_request(token, token_kind)
     if token_kind == RemotePushDeviceToken.APNS and ios_app_id is None:


### PR DESCRIPTION
Migrates `reactions.py`, `push_notifications.py`, `read_receipts.py` to use `typed endpoint` instead of `has_request_variables`.