### PR TITLE
setting_ui: Fix sorting by "Invited by" column.

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -124,7 +124,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
         init_sort: sort_invitee,
         sort_fields: {
             invitee: sort_invitee,
-            ...ListWidget.generic_sort_functions("alphabetic", ["ref"]),
+            ...ListWidget.generic_sort_functions("alphabetic", ["referrer_name"]),
             ...ListWidget.generic_sort_functions("numeric", [
                 "invited",
                 "expiry_date",

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -16,7 +16,7 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="invitee">{{t "Invitee" }}</th>
                 {{#if is_admin }}
-                <th data-sort="alphabetic" data-sort-prop="ref">{{t "Invited by" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="referrer_name">{{t "Invited by" }}</th>
                 {{/if}}
                 <th data-sort="numeric" data-sort-prop="invited">{{t "Invited at" }}</th>
                 <th data-sort="numeric" data-sort-prop="expiry_date">{{t "Expires at" }}</th>


### PR DESCRIPTION
>GSoC'2024 Participant

Previously, the sorting was broken due to
incorrect referencing of the property.
The code has been updated to use the "referrer_name" property instead of "ref".

![image](https://github.com/zulip/zulip/assets/73663475/7688484e-4ad0-4e33-8114-218eb1522898)
![image](https://github.com/zulip/zulip/assets/73663475/0592dc09-5768-4f0f-81b3-1409d89a072e)

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/.60Invited.20by.60.20field.20sorting.20is.20broke/near/1784697)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
