### PR TITLE
api-docs: Tweak newly documented invites endpoints documentation.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -92,7 +92,7 @@
 
 * [Get all invitations](/api/get-invites)
 * [Send invitations](/api/send-invites)
-* [Create reusable invitation link](/api/create-invite-link)
+* [Create a reusable invitation link](/api/create-invite-link)
 * [Revoke an email invitation](/api/revoke-email-invite)
 
 #### Server & organizations

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12060,7 +12060,7 @@ paths:
   /invites/multiuse:
     post:
       operationId: create-invite-link
-      summary: Create reusable invitation link
+      summary: Create a reusable invitation link
       tags: ["invites"]
       description: |
         Create a [reusable invitation link](/help/invite-new-users#create-a-reusable-invitation-link)
@@ -12207,7 +12207,7 @@ paths:
                             "code": "BAD_REQUEST",
                           }
                         description: |
-                          A typical failed JSON response for an invalid `invite_id`:
+                          A typical failed JSON response for an invalid email invitation ID:
   /register:
     post:
       operationId: register-queue
@@ -19836,7 +19836,13 @@ components:
         id:
           type: integer
           description: |
-            The unique ID of the invitation.
+            The ID of the invitation.
+
+            Note that email invitations and reusable invitation links are stored
+            in different database tables on the server, so each ID is guaranteed
+            to be unique in combination with the boolean value of `is_multiuse`,
+            e.g. there can only be one invitation with `id: 1` and `is_multiuse:
+            true`.
         invited_by_user_id:
           type: integer
           description: |


### PR DESCRIPTION
Makes a few small tweaks on the newly documented invites endpoints for current API documentation conventions that were missed in the review process.

- Adds indefinite article to title for creating a reusable invitation link.
- Updates the error response for the delete an email invitation endpoint.
- Updates the ID field description for the invitation object to clarify when in the get invitations endpoint there might be more than one invitation with the same ID integer, which is true for the success example on the page.

**Screenshots and screen captures:**

<details>
<summary>Updated title for creating a reusable invitation link</summary>

[Current documentation](https://zulip.com/api/create-invite-link)
![Screenshot from 2024-04-21 18-58-27](https://github.com/zulip/zulip/assets/63245456/850193ae-61cf-4deb-816e-256f52a351fc)
</details>
<details>
<summary>Updated error response for delete email invitation endpoint</summary>

See main for current documentation
![Screenshot from 2024-04-21 18-58-40](https://github.com/zulip/zulip/assets/63245456/f5dc71a3-0c5c-4989-bad3-241f7744453a)
</details>
<details>
<summary>Updated id field in get invitations response</summary>

[Current documentation](https://zulip.com/api/get-invites)
![Screenshot from 2024-04-21 19-14-20](https://github.com/zulip/zulip/assets/63245456/1bf5ac81-ea73-43f6-9b66-22db93f7af2c)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
