### PR TITLE
popover_menus: Fix reactions popover going off screen on small height.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -302,7 +302,7 @@ function get_props_for_popover_centering(
     return {
         arrow: false,
         getReferenceClientRect: () => new DOMRect(0, 0, 0, 0),
-        placement: "top",
+        placement: "bottom",
         popperOptions: {
             modifiers: [
                 {
@@ -312,6 +312,9 @@ function get_props_for_popover_centering(
                             // Calculate the offset needed to place the reference in the center
                             const x_offset_to_center = window.innerWidth / 2;
                             let y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
+                            if (y_offset_to_center < 0) {
+                                y_offset_to_center = 0;
+                            }
 
                             // Move popover to the top of the screen if user is focused on an element which can
                             // open keyboard on a mobile device causing the screen to resize.


### PR DESCRIPTION
The function get_props_for_popover_centering calculates the Y offset for popovers in a way that makes it go into the negatives if the screen height is less than the popover height. This causes the reactions popover to go off screen on a small landscape screen. Adding a check for Y offset being less than zero does not solve the issue, but doing both that along with setting the placement property to "bottom" fixes it.

I'm not fully aware of how tippyjs works, and if there is a problem with making the placement "bottom" instead of "top". So if this is not the correct solution we at least know where in the code the issue originates from. 

Fixes #29472

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Before](https://github.com/zulip/zulip/assets/107076289/44b75983-6034-48de-b1bc-04b8a82a2705)
![After](https://github.com/zulip/zulip/assets/107076289/47084273-d1be-4ade-a0bc-7a8354f13810)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

Also this is my first pull request, let me know if I've done anything wrong.
