### PR TITLE
stripe: Remove invalid comment.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -419,7 +419,6 @@ class BillingError(JsonableError):
     CONTACT_SUPPORT = gettext_lazy("Something went wrong. Please contact {email}.")
     TRY_RELOADING = gettext_lazy("Something went wrong. Please reload the page.")
 
-    # description is used only for tests
     def __init__(self, description: str, message: Optional[str] = None) -> None:
         self.error_description = description
         if message is None:

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1265,12 +1265,11 @@ export class MessageListView {
     }
 
     _find_message_group(message_group_id) {
-        // Ideally, we'd maintain this data structure with a hash
-        // table or at least a pointer from the message containers (in
-        // either case, updating the data structure when message
-        // groups are merged etc.), but we only call this from flows
-        // like message editing, so it's not a big performance
-        // problem.
+        // Finds the message group with a given message group ID.
+        //
+        // This function does a linear search, so be careful to avoid
+        // calling it in a loop. If you need that, we'll need to add a
+        // hash table to make this O(1) runtime.
         return this._message_groups.find(
             // Since we don't have a way to get a message group from
             // the containing message container, we just do a search


### PR DESCRIPTION
We use `error_description` in upgrade.ts to determine if the error was related to customer's card. Doesn't seem like there is any harm in doing so since we are explicitly handling "stripe.CardError" and raising these errors with "card error" description.
