### PR TITLE
Add button to toggle left sidebar.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -114,6 +114,11 @@ export function initialize(): void {
         e.preventDefault();
         e.stopPropagation();
 
+        if (window.innerWidth >= media_breakpoints_num.md) {
+            $("body").toggleClass("hide-left-sidebar");
+            return;
+        }
+
         if (left_sidebar_expanded_as_overlay) {
             hide_streamlist_sidebar();
             return;

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -110,7 +110,7 @@ export function initialize(): void {
         show_userlist_sidebar();
     });
 
-    $("#streamlist-toggle-button").on("click", (e) => {
+    $(".left-sidebar-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -136,7 +136,7 @@ export function initialize(): void {
             const $elt = $(e.target);
             // Since sidebar toggle buttons have their own click handlers, don't handle them here.
             if (
-                $elt.closest("#streamlist-toggle-button").length ||
+                $elt.closest(".left-sidebar-toggle-button").length ||
                 $elt.closest("#userlist-toggle-button").length
             ) {
                 return;

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -5,6 +5,8 @@ import render_right_sidebar from "../templates/right_sidebar.hbs";
 
 import {buddy_list} from "./buddy_list";
 import {media_breakpoints_num} from "./css_variables";
+import * as message_lists from "./message_lists";
+import * as message_viewport from "./message_viewport";
 import {page_params} from "./page_params";
 import * as rendered_markdown from "./rendered_markdown";
 import * as resize from "./resize";
@@ -116,6 +118,14 @@ export function initialize(): void {
 
         if (window.innerWidth >= media_breakpoints_num.md) {
             $("body").toggleClass("hide-left-sidebar");
+            if (
+                message_lists.current !== undefined &&
+                window.innerWidth <= media_breakpoints_num.xl
+            ) {
+                // We expand the middle column width between md and xl breakpoints when the
+                // left sidebar is hidden. This can cause the pointer to move out of view.
+                message_viewport.scroll_to_selected();
+            }
             return;
         }
 

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -5,6 +5,7 @@ import render_right_sidebar from "../templates/right_sidebar.hbs";
 
 import {buddy_list} from "./buddy_list";
 import {media_breakpoints_num} from "./css_variables";
+import {localstorage} from "./localstorage";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import {page_params} from "./page_params";
@@ -15,6 +16,22 @@ import * as settings_data from "./settings_data";
 import * as spectators from "./spectators";
 import {current_user} from "./state_data";
 import {user_settings} from "./user_settings";
+
+function save_sidebar_toggle_status(): void {
+    const ls = localstorage();
+    ls.set("left-sidebar", $("body").hasClass("hide-left-sidebar"));
+    ls.set("right-sidebar", $("body").hasClass("hide-right-sidebar"));
+}
+
+export function restore_sidebar_toggle_status(): void {
+    const ls = localstorage();
+    if (ls.get("left-sidebar")) {
+        $("body").addClass("hide-left-sidebar");
+    }
+    if (ls.get("right-sidebar")) {
+        $("body").addClass("hide-right-sidebar");
+    }
+}
 
 export let left_sidebar_expanded_as_overlay = false;
 export let right_sidebar_expanded_as_overlay = false;
@@ -102,6 +119,7 @@ export function initialize(): void {
             if (!$("body").hasClass("hide-right-sidebar")) {
                 fix_invite_user_button_flicker();
             }
+            save_sidebar_toggle_status();
             return;
         }
 
@@ -126,6 +144,7 @@ export function initialize(): void {
                 // left sidebar is hidden. This can cause the pointer to move out of view.
                 message_viewport.scroll_to_selected();
             }
+            save_sidebar_toggle_status();
             return;
         }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -968,6 +968,8 @@ export function initiate_search(): void {
     ) {
         popovers.hide_all();
         sidebar_ui.show_streamlist_sidebar();
+    } else if (!sidebar_ui.left_sidebar_expanded_as_overlay) {
+        $("body").removeClass("hide-left-sidebar");
     }
     $filter.trigger("focus");
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -592,6 +592,24 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".header-main .column-left .left-sidebar-toggle-button",
+        delay: LONG_HOVER_DELAY,
+        placement: "bottom",
+        appendTo: () => document.body,
+        onShow(instance) {
+            let template = "show-left-sidebar-tooltip-template";
+            if ($("#left-sidebar-container").is(":visible")) {
+                template = "hide-left-sidebar-tooltip-template";
+            }
+            $(instance.reference).attr("data-tooltip-template-id", template);
+            instance.setContent(get_tooltip_content(instance.reference));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: "#userlist-toggle",
         delay: LONG_HOVER_DELAY,
         placement: "bottom",

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -658,6 +658,7 @@ export function initialize_everything(state_data) {
        user_settings before setting the theme. Because information
        density is so fundamental, we initialize that first, however. */
     initialize_user_settings(user_settings_params);
+    sidebar_ui.restore_sidebar_toggle_status();
     information_density.initialize();
     if (page_params.is_spectator) {
         const ls = localstorage();

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -88,7 +88,7 @@ export function update_unread_counts(skip_animations = false): void {
     }
 
     // Set the unread indicator on the toggle for the left sidebar
-    set_count_toggle_button($("#streamlist-toggle-unreadcount"), res.home_unread_messages);
+    set_count_toggle_button($(".left-sidebar-toggle-unreadcount"), res.home_unread_messages);
 }
 
 export function should_display_bankruptcy_banner(): boolean {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -361,19 +361,6 @@ $user_status_emoji_width: 24px;
     }
 }
 
-@media (width < $sm_min) {
-    #userlist-toggle {
-        height: 30px;
-        line-height: 30px;
-    }
-
-    #userlist-toggle-button {
-        height: 30px;
-        padding-top: 0;
-        padding-bottom: 0;
-    }
-}
-
 .right-sidebar-shortcuts .realm-description {
     display: flex;
     flex-direction: column;

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -233,7 +233,7 @@
             width: 100%;
             border-radius: 0;
             box-shadow: none;
-            /* To be visible over `#streamlist-toggle-unreadcount` */
+            /* To be visible over `.left-sidebar-toggle-unreadcount` */
             z-index: 20;
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1417,6 +1417,9 @@ nav {
     .column-left {
         text-align: left;
         margin-left: 15px;
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
 
         .nav-logo {
             display: inline-block;
@@ -1427,6 +1430,15 @@ nav {
 
             @media (height < $short_navbar_cutoff_height) {
                 height: 15px;
+            }
+        }
+
+        .left-sidebar-toggle-button {
+            margin-right: 5px;
+
+            .left-sidebar-toggle-unreadcount {
+                top: 10px;
+                right: 14px;
             }
         }
     }
@@ -1946,6 +1958,41 @@ select.invite-as {
     visibility: hidden;
 }
 
+%hide-left-sidebar {
+    .app-main .column-left {
+        display: none;
+
+        &.expanded {
+            display: block;
+            position: absolute;
+            float: none;
+            left: 0;
+            top: 0;
+
+            .left-sidebar {
+                background-color: var(--color-background);
+                box-shadow: 0 2px 3px 0 hsl(0deg 0% 0% / 10%);
+                border-right: 1px solid var(--color-border-sidebar);
+                height: 100%;
+                padding-left: 10px;
+                width: var(--left-sidebar-width);
+            }
+        }
+    }
+}
+
+.hide-left-sidebar {
+    @extend %hide-left-sidebar;
+}
+
+body:not(.hide-left-sidebar) {
+    /* User can clearly see the unread count in the left sidebar. So,
+       we don't need an indicator here as it will only serve as a disctraction. */
+    #header-container .column-left .left-sidebar-toggle-unreadcount {
+        display: none !important;
+    }
+}
+
 @media (width < $xl_min) {
     .default-sidebar-behaviour {
         @extend %hide-right-sidebar;
@@ -1969,26 +2016,10 @@ select.invite-as {
 
 @media (width < $md_min) {
     .default-sidebar-behaviour {
-        .app-main .column-left,
+        @extend %hide-left-sidebar;
+
         .header-main .column-left {
             display: none;
-        }
-
-        .app-main .column-left.expanded {
-            display: block;
-            position: absolute;
-            float: none;
-            left: 0;
-            top: 0;
-
-            .left-sidebar {
-                background-color: var(--color-background);
-                box-shadow: 0 2px 3px 0 hsl(0deg 0% 0% / 10%);
-                border-right: 1px solid var(--color-border-sidebar);
-                height: 100%;
-                padding-left: 10px;
-                width: var(--left-sidebar-width);
-            }
         }
 
         .app-main .column-middle {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1310,7 +1310,7 @@ div.focused-message-list {
     visibility: hidden;
 }
 
-#streamlist-toggle-button {
+#header-container .left-sidebar-toggle-button {
     text-decoration: none;
     color: var(--color-navbar-icon);
     display: flex;
@@ -2072,7 +2072,7 @@ select.invite-as {
         height: var(--header-height) !important;
     }
 
-    #streamlist-toggle-button {
+    .left-sidebar-toggle-button {
         height: var(--header-height);
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1316,8 +1316,8 @@ div.focused-message-list {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: var(--header-height);
+    height: var(--header-height);
 
     &:hover {
         background-color: var(--color-header-button-hover);
@@ -2107,9 +2107,18 @@ body:not(.hide-left-sidebar) {
         height: var(--header-height);
     }
 
+    nav
+        .column-left
+        .left-sidebar-toggle-button
+        .left-sidebar-toggle-unreadcount {
+        top: 5px;
+        right: 9px;
+    }
+
     .left-sidebar-toggle-unreadcount {
         /* Adjust in response to shorter navbar. */
         top: 5px;
+        right: 4px;
     }
 
     #top_navbar .column-right #personal-menu .header-button-avatar {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2026,6 +2026,13 @@ body:not(.hide-left-sidebar) {
             margin-right: 7px;
         }
     }
+
+    .hide-left-sidebar {
+        #compose-content,
+        .app-main .column-middle {
+            margin-left: 7px;
+        }
+    }
 }
 
 @media (width < $md_min) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1418,14 +1418,14 @@ nav {
         text-align: left;
         margin-left: 15px;
         display: flex;
-        justify-content: space-between;
-        gap: 10px;
+        justify-content: left;
+        gap: 4px;
 
         .nav-logo {
             display: inline-block;
             vertical-align: top;
-            margin-top: 8px;
-            height: 25px;
+            margin-top: 10px;
+            height: 20px;
             max-width: 200px;
 
             @media (height < $short_navbar_cutoff_height) {
@@ -1438,7 +1438,7 @@ nav {
 
             .left-sidebar-toggle-unreadcount {
                 top: 10px;
-                right: 14px;
+                left: 21px;
             }
         }
     }
@@ -2133,7 +2133,7 @@ body:not(.hide-left-sidebar) {
         .left-sidebar-toggle-button
         .left-sidebar-toggle-unreadcount {
         top: 5px;
-        right: 9px;
+        left: 16px;
     }
 
     .left-sidebar-toggle-unreadcount {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1322,7 +1322,7 @@ div.focused-message-list {
     &:hover {
         background-color: var(--color-header-button-hover);
 
-        #streamlist-toggle-unreadcount {
+        .left-sidebar-toggle-unreadcount {
             border-color: var(--color-header-button-hover-no-alpha);
         }
     }
@@ -1342,13 +1342,13 @@ div.focused-message-list {
 
     &:active,
     &:focus-visible {
-        #streamlist-toggle-unreadcount {
+        .left-sidebar-toggle-unreadcount {
             border-color: var(--color-header-button-focus-no-alpha);
         }
     }
 }
 
-#streamlist-toggle-unreadcount {
+.left-sidebar-toggle-unreadcount {
     position: absolute;
     display: none;
     height: 6px;
@@ -2076,7 +2076,7 @@ select.invite-as {
         height: var(--header-height);
     }
 
-    #streamlist-toggle-unreadcount {
+    .left-sidebar-toggle-unreadcount {
         /* Adjust in response to shorter navbar. */
         top: 5px;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1952,6 +1952,13 @@ select.invite-as {
 
 .hide-right-sidebar {
     @extend %hide-right-sidebar;
+
+    &.fluid_layout_width {
+        #compose-content,
+        .app-main .column-middle {
+            margin-right: 7px;
+        }
+    }
 }
 
 .hide-right-sidebar-by-visibility .app-main .column-right {
@@ -1983,6 +1990,13 @@ select.invite-as {
 
 .hide-left-sidebar {
     @extend %hide-left-sidebar;
+
+    &.fluid_layout_width {
+        #compose-content,
+        .app-main .column-middle {
+            margin-left: 7px;
+        }
+    }
 }
 
 body:not(.hide-left-sidebar) {

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -8,7 +8,7 @@
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
                 <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="streamlist-toggle-tooltip-template">
-                    <a id="streamlist-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>
+                    <a class="left-sidebar-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>
                         <span id="streamlist-toggle-unreadcount">0</span>
                     </a>
                 </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -4,12 +4,16 @@
             <a href="" class="brand no-style">
                 <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
             </a>
+            <a class="left-sidebar-toggle-button {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" tabindex="0" role="button">
+                <i class="fa fa-reorder" aria-hidden="true"></i>
+                <span class="left-sidebar-toggle-unreadcount">0</span>
+            </a>
         </div>
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
-                <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="streamlist-toggle-tooltip-template">
+                <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="show-left-sidebar-tooltip-template">
                     <a class="left-sidebar-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>
-                        <span id="streamlist-toggle-unreadcount">0</span>
+                        <span class="left-sidebar-toggle-unreadcount">0</span>
                     </a>
                 </div>
                 <div class="top-navbar-container">

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -1,12 +1,12 @@
 <div class="header">
     <nav class="header-main" id="top_navbar">
         <div class="column-left">
-            <a href="" class="brand no-style">
-                <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
-            </a>
             <a class="left-sidebar-toggle-button {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" tabindex="0" role="button">
                 <i class="fa fa-reorder" aria-hidden="true"></i>
                 <span class="left-sidebar-toggle-unreadcount">0</span>
+            </a>
+            <a href="" class="brand no-style">
+                <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
             </a>
         </div>
         <div class="column-middle" id="navbar-middle">

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -203,9 +203,12 @@
     {{t 'Search' }}
     {{tooltip_hotkey_hints "/"}}
 </template>
-<template id="streamlist-toggle-tooltip-template" >
-    {{t 'View channels' }}
+<template id="show-left-sidebar-tooltip-template" >
+    {{t 'Show left sidebar' }}
     {{tooltip_hotkey_hints "Q"}}
+</template>
+<template id="hide-left-sidebar-tooltip-template" >
+    {{t 'Hide left sidebar' }}
 </template>
 <template id="show-userlist-tooltip-template">
     {{t 'Show user list' }}


### PR DESCRIPTION
Unread indicator is not visible on the toggle button in 1st screenshot since it seems like that is more distracting that helpful when left sidebar is visible.

<img width="1152" alt="Screenshot 2024-04-22 at 2 03 21 PM" src="https://github.com/zulip/zulip/assets/25124304/9a5a0fb3-d089-4978-a203-0e4dafed7cd4">
<img width="1152" alt="Screenshot 2024-04-22 at 2 03 16 PM" src="https://github.com/zulip/zulip/assets/25124304/ad3ee54d-e339-4eff-954c-1ecee8a87510">
<img width="1785" alt="Screenshot 2024-04-22 at 2 05 14 PM" src="https://github.com/zulip/zulip/assets/25124304/29e61c8b-6902-46c0-bc4b-2a0732715f80">
