### PR TITLE
message_row: Clean up Sass variables, correct line-heights.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -71,6 +71,7 @@
     */
     --message-box-avatar-width: 35px;
     --message-box-avatar-height: var(--message-box-avatar-width);
+    --message-box-avatar-column-width: 46px;
     --message-box-line-height: 1.214;
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -78,6 +78,10 @@
     --message-box-line-height: 1.214;
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;
+    /* The line-height on the sender line should coordinate with the
+       height of the hover icons. The sender line never wraps, so this
+       just keeps the two in line with the grid definition. */
+    --message-box-sender-line-height: var(--message-box-icon-height);
     /* This width is updated with an exact pixel
        width upon UI initialization. */
     --message-box-timestamp-column-width: 0;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -72,6 +72,9 @@
     --message-box-avatar-width: 35px;
     --message-box-avatar-height: var(--message-box-avatar-width);
     --message-box-avatar-column-width: 46px;
+    /* 6px appears to provide 5px of space between the avatar
+       and the selected-message outline, which is offset by -1px. */
+    --message-box-vertical-margin: 6px;
     --message-box-line-height: 1.214;
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,5 +1,3 @@
-$message_box_margin: 3px;
-
 .message_row {
     display: grid;
     /* Prevent the messagebox column from overflowing the 1fr
@@ -318,17 +316,6 @@ $message_box_margin: 3px;
                 .message_sender {
                     /* Don't display message sender as flexbox for me-messages. */
                     display: block;
-                    /* This preserves a consistent bottom spacing on the me-message
-                       grid, which ordinarily benefits from the margin of <p>
-                       elements in the markdown--which single-line me-messages do
-                       not receive.
-
-                       It also ensures a uniform space-relationship between the top: of the avatar and the top of the sender_name line.
-
-                       However, this should all arguably be handled from the grid
-                       container or the grid definition itself. */
-                    margin: $message_box_margin 0;
-
                     /* Set the same line-height as on message content for
                        me-messages. */
                     line-height: var(--message-box-line-height);
@@ -380,13 +367,6 @@ $message_box_margin: 3px;
                 grid-area: message;
             }
 
-            .message-time {
-                /* Don't adjust the line-height for collapsed or
-                   edited/source messages when there's a sender,
-                   as the sender text is always visible. */
-                line-height: inherit;
-            }
-
             .slow-send-spinner {
                 align-self: center;
                 position: unset;
@@ -413,8 +393,6 @@ $message_box_margin: 3px;
                    message-box grid's baseline group, too. */
                 align-items: baseline;
 
-                margin-top: $message_box_margin;
-
                 .zulip-icon.zulip-icon-bot {
                     align-self: center;
                     padding: 0 0 0 5px;
@@ -424,10 +402,10 @@ $message_box_margin: 3px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
-                    /* It is important to use line-height `normal` here since user's name can
-                       be in any language and `line-height: 1` doesn't work to accommodate text
-                       from start and end vertically in all languages. */
-                    line-height: normal;
+                    /* A generous line-height on the sender name is necessary
+                       for internationalization and non-Western Latin character
+                       sets. */
+                    line-height: var(--message-box-sender-line-height);
                     outline: none;
                     align-self: baseline;
                 }
@@ -515,20 +493,8 @@ $message_box_margin: 3px;
        collapsed message, or source/edit view). This
        line-height also keeps EDITED/MOVED messages
        in place, care of their baseline-group participation
-       within the grid.
-
-       That said, 28px is a bit of a magical number.
-       In theory, this should be 27px. That's the height
-       of a single-message row without a sender. (See the
-       calculations for the height of a single-line,
-       sender-less message row in the message box grid.)
-       But when shifting into collapsed or source views,
-       28px is necessary to maintain the vertical alignment
-       of the EDITED messages, hover controls, and
-       timestamp. It's possible that this is also due to a
-       a rounding error, given how --message-box-line-height
-       is expressed as a unitless decimal. */
-    line-height: 28px;
+       within the grid. */
+    line-height: var(--message-box-sender-line-height);
     grid-area: time;
     display: block;
     font-size: 13px;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,4 +1,3 @@
-$distance_of_non_text_elements_from_message_box: 6px;
 $message_box_margin: 3px;
 
 .message_row {
@@ -255,7 +254,7 @@ $message_box_margin: 3px;
               is preserved from the message itself--keeping the time,
               edit message, and controls at the same vertical alignment. */
             align-self: start;
-            margin-top: $distance_of_non_text_elements_from_message_box;
+            margin-top: var(--message-box-vertical-margin);
         }
 
         .message_length_controller {
@@ -356,7 +355,7 @@ $message_box_margin: 3px;
                     .message_edit {
                         /* Use the sender grid area for the me-message edit/view-source box */
                         grid-area: sender;
-                        margin-top: $distance_of_non_text_elements_from_message_box;
+                        margin-top: var(--message-box-vertical-margin);
                     }
                 }
             }
@@ -368,7 +367,7 @@ $message_box_margin: 3px;
                 /* Because the avatar may be the tallest element in a
                   single-line me message, this margin preserves the
                   overall height of the message box. */
-                margin: $distance_of_non_text_elements_from_message_box 0;
+                margin: var(--message-box-vertical-margin) 0;
             }
 
             .status-message {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,5 +1,4 @@
 $avatar_column_width: 46px;
-$distance_of_text_elements_from_message_box_top: 8.5px;
 $distance_of_non_text_elements_from_message_box: 6px;
 $message_box_margin: 3px;
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,4 +1,3 @@
-$avatar_column_width: 46px;
 $distance_of_non_text_elements_from_message_box: 6px;
 $message_box_margin: 3px;
 
@@ -139,7 +138,7 @@ $message_box_margin: 3px;
             in the column. */
         grid-template:
             var(--message-box-icon-height) repeat(3, auto) /
-            $avatar_column_width minmax(0, 1fr) calc(
+            var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
                 3 * var(--message-box-icon-width)
             )
             8px minmax(var(--message-box-timestamp-column-width), max-content);
@@ -155,7 +154,9 @@ $message_box_margin: 3px;
             cursor: default;
             /* Set the controls area to 0 to give more space
                to the edit/source view area. */
-            grid-template-columns: $avatar_column_width minmax(0, 1fr) 0 8px minmax(
+            grid-template-columns:
+                var(--message-box-avatar-column-width) minmax(0, 1fr)
+                0 8px minmax(
                     var(--message-box-timestamp-column-width),
                     max-content
                 );
@@ -163,7 +164,7 @@ $message_box_margin: 3px;
 
         @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
             grid-template-columns:
-                $avatar_column_width minmax(0, 1fr) calc(
+                var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
                     2 * var(--message-box-icon-width)
                 )
                 8px minmax(


### PR DESCRIPTION
This PR achieves two primary goals:

1) It cleans up all of the legacy Sass-style variables in `message_row.css`
2) It aligns the `line-height` values on the sender line, including the sender name and timestamp, with the height value set on the hover icons.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/fixes.20to.20the.20sender.20line/near/1785636)

The second change in particular means no more reliance on a magical `margin-top: 3px` value set against the old 20.5px sender-line line-height established by `line-height: normal`. The MDN docs indicate that `normal` equates to a line-height of approximately `1.2`, though that value was closer to `1.464` in situ on the message box previously (14px font-size × 1.464 = ~20.5).

This change also now means that single-line messages are their correct height; the previous eyeballed `28px` line-height on timestamps meant that the single-line message height was 27.25px, not the correct 27px height arrived at from 5px of top padding on the message-content area, a 17px line height, and another 5px of (currently) margin-bottom on paragraphs (5 + 17 + 5 = 27px). This is keeping in league with the overall goal of these preparatory PRs to make message boxes and their content easier to reason about.

The changes here also begin to make variables out of values that might well need adjusting as the information-density project moves forward.

**Screenshots and screen captures:**

There is a subtle sub-pixel upward shift with this change; however, note that the status emoji are now more squarely centered with the sender name text.

Additionally, the apparent upward shift should probably be contrasted against the 6px `margin-top` value on the sender avatar. It's unclear to me where that value came from, though it does remain in place here. One theory is that it preserves an apparent 5px space around the avatar when the selected-message outline in place, as that is much more obvious than the reduced space around, say, the top of a message or sender line, or even the hover icons themselves.

| Sender line showing grid, before | Sender line showing grid, after |
| --- | --- |
| ![showing-grid-main](https://github.com/zulip/zulip/assets/170719/df47c1bf-8a4e-4623-b2c2-e742650099c0) | ![showing-grid-proposed](https://github.com/zulip/zulip/assets/170719/0824d4df-e40f-4e45-9914-9e06cb210ef7) |

| Sender lines, before | Sender lines, after |
| --- | --- |
| ![sender-lines-main](https://github.com/zulip/zulip/assets/170719/5433e551-2729-4e28-b25b-0094a2cd529c) | ![sender-lines-proposed](https://github.com/zulip/zulip/assets/170719/9ce761b7-f341-42d1-ad46-ce02981458f3) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
