### PR TITLE
Drafts

### DIFF
--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -1,8 +1,9 @@
 # Draft messages
 
-Zulip automatically saves the content of your message as a draft when you
-close the compose box, ensuring that you never lose your work. Drafts are
-saved for 30 days.
+Zulip automatically saves the content of your message as a draft when you close
+the compose box, ensuring that you never lose your work. When you start
+composing, the most recently edited draft for the conversation you are composing
+to automatically appears in the compose box. Drafts are saved for 30 days.
 
 !!! warn ""
 
@@ -10,6 +11,8 @@ saved for 30 days.
     other devices and browsers.
 
 ## Save a draft
+
+### Save a draft and stop composing
 
 {start_tabs}
 
@@ -31,23 +34,56 @@ saved for 30 days.
 
 {end_tabs}
 
-## Edit a draft
+### Save a draft and start a new message
 
 {start_tabs}
 
 {tab|desktop-web}
 
+{!start-composing.md!}
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
+   in the bottom right corner of the compose box, next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
+
+1. Select **Save draft and start a new message**.
+
+{end_tabs}
+
+## Restore a draft
+
+To make it easier to find the draft you are looking for, drafts for the
+conversation you are composing to are shown at the top of the drafts list in the
+web and desktop apps. If you have saved drafts for the current conversation, the
+counter next to the **Drafts** button in the compose box shows how many there are.
+
+{start_tabs}
+
+{tab|via-left-sidebar}
+
 {!go-to-draft-messages.md!}
 
 1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the draft you
-   want to edit.
-
-1. Edit the message.
+   want to restore.
 
 !!! keyboard_tip ""
 
-    You can also use <kbd>Enter</kbd> within the drafts view to restore the
-    selected draft.
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts, and
+    <kbd>Enter</kbd> within the drafts view to restore the selected draft.
+
+{tab|via-compose-box-buttons}
+
+{!start-composing.md!}
+
+1. Click the **Drafts** button on the right side of the compose box.
+
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the draft you
+   want to restore.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts, and
+    <kbd>Enter</kbd> within the drafts view to restore the selected draft.
 
 {end_tabs}
 
@@ -57,7 +93,7 @@ saved for 30 days.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 {!go-to-draft-messages.md!}
 
@@ -66,8 +102,22 @@ saved for 30 days.
 
 !!! keyboard_tip ""
 
-    You can also use <kbd>Backspace</kbd> within the drafts view to delete the
-    selected draft.
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts, and
+    <kbd>Backspace</kbd> within the drafts view to delete the selected draft.
+
+{tab|via-compose-box-buttons}
+
+{!start-composing.md!}
+
+1. Click the **Drafts** button on the right side of the compose box.
+
+1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the draft you
+   want to delete.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts, and
+    <kbd>Backspace</kbd> within the drafts view to delete the selected draft.
 
 {end_tabs}
 
@@ -75,7 +125,7 @@ saved for 30 days.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 {!go-to-draft-messages.md!}
 
@@ -86,19 +136,26 @@ saved for 30 days.
 1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon in the
    upper right corner of the drafts view to delete all selected drafts.
 
-{end_tabs}
+!!! keyboard_tip ""
 
-## View your drafts
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts.
 
-{start_tabs}
+{tab|via-compose-box-buttons}
 
-{tab|desktop-web}
+{!start-composing.md!}
 
-{!go-to-draft-messages.md!}
+1. Click the **Drafts** button on the right side of the compose box.
+
+1. Click **Select all drafts** in the upper right corner of
+   the drafts view, or select the drafts you want to delete
+   by toggling the checkboxes on the right.
+
+1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon in the
+   upper right corner of the drafts view to delete all selected drafts.
 
 !!! keyboard_tip ""
 
-    Use <kbd>D</kbd> to bring up your list of saved drafts.
+    You can also use <kbd>D</kbd> to bring up your list of saved drafts.
 
 {end_tabs}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -108,7 +108,7 @@ TAB_SECTION_LABELS = {
     "via-paste": "Via paste",
     "via-drag-and-drop": "Via drag-and-drop",
     "via-markdown": "Via Markdown",
-    "via-compose-box-buttons": "Via compose box buttons",
+    "via-compose-box-buttons": "Via compose box button",
     "stream-compose": "Compose to a stream",
     "dm-compose": "Compose a DM",
     "v8": "Zulip Server 8.0+",


### PR DESCRIPTION
Notes:
- I changed the tab label, but was too lazy to change the name of the tab to match. We could do this as a follow-up if we want, or someone else could take over this PR if we think it's worth doing upfront.
- The new "Restore draft" framing is consistent with what we already do in the tooltip:
![CleanShot 2024-04-22 at 14 28 54](https://github.com/zulip/zulip/assets/2090066/464752ce-264e-4ef4-b48d-78b31e8ff715)


Current: https://zulip.com/help/view-and-edit-your-message-drafts
<details>
<summary>
Via left sidebar
</summary>

![CleanShot 2024-04-22 at 14 32 27](https://github.com/zulip/zulip/assets/2090066/917b2cf5-5e6a-4a9e-9569-99ba2ae93f68)
![CleanShot 2024-04-22 at 14 32 34](https://github.com/zulip/zulip/assets/2090066/603d7d4e-15b3-4bc9-a742-1cfdc4db3d59)


</details>

<details>
<summary>
Via compose box button
</summary>

![CleanShot 2024-04-22 at 14 32 56](https://github.com/zulip/zulip/assets/2090066/db4c6af2-34f7-4567-b4bb-a4e92d14c462)
![CleanShot 2024-04-22 at 14 33 05](https://github.com/zulip/zulip/assets/2090066/1afc4e36-0a9c-4143-b424-e7db05f2641d)

</details>

Example of impact of renaming the tab (https://zulip.com/help/text-emphasis)
<details>
<summary>
Screenshot
</summary>

![CleanShot 2024-04-22 at 14 14 54](https://github.com/zulip/zulip/assets/2090066/63c435e6-0b5c-49af-917c-3806789556b9)


</details>
