### PR TITLE
Navbar: Describe views in top navbar.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -912,7 +912,12 @@ export class Filter {
         return "#"; // redirect to All
     }
 
-    add_icon_data(context: {title: string; is_spectator: boolean}): IconData {
+    add_icon_data(context: {
+        title: string;
+        description?: string;
+        link?: string;
+        is_spectator: boolean;
+    }): IconData {
         // We have special icons for the simple narrows available for the via sidebars.
         const term_types = this.sorted_term_types();
         let icon;
@@ -1043,6 +1048,25 @@ export class Filter {
             }
         }
         /* istanbul ignore next */
+        return undefined;
+    }
+
+    get_description(): {description: string; link: string} | undefined {
+        const term_types = this.sorted_term_types();
+        switch (term_types[0]) {
+            case "is-mentioned":
+                return {
+                    description: $t({defaultMessage: "Messages where you are mentioned."}),
+                    link: "/help/view-your-mentions",
+                };
+            case "is-starred":
+                return {
+                    description: $t({
+                        defaultMessage: "Important messages, tasks, and other useful references.",
+                    }),
+                    link: "/help/star-a-message#view-your-starred-messages",
+                };
+        }
         return undefined;
     }
 

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -84,7 +84,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     const description = filter.get_description()?.description;
     const link = filter.get_description()?.link;
     assert(title !== undefined);
-    const icon_data = filter.add_icon_data({
+    const context = filter.add_icon_data({
         title,
         description,
         link,
@@ -93,7 +93,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
 
     if (filter.has_operator("channel") && !filter._sub) {
         return {
-            ...icon_data,
+            ...context,
             sub_count: "0",
             formatted_sub_count: "0",
             rendered_narrow_description: $t({
@@ -109,7 +109,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
         const current_stream = filter._sub;
         const sub_count = peer_data.get_subscriber_count(current_stream.stream_id);
         return {
-            ...icon_data,
+            ...context,
             is_admin: current_user.is_admin,
             rendered_narrow_description: current_stream.rendered_description,
             sub_count,
@@ -118,7 +118,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
         };
     }
 
-    return icon_data;
+    return context;
 }
 
 export function colorize_message_view_header(): void {

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -94,6 +94,11 @@
         padding-left: 10px;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        .help_link_widget,
+        .fa {
+            margin: 0;
+        }
     }
 
     /* The very last element in the navbar is the search icon, the second

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -4,3 +4,12 @@
 <i class="fa fa-{{icon}}" aria-hidden="true"></i>
 {{/if}}
 <span class="message-header-navbar-title">{{title}}</span>
+{{#if description}}
+    <span class="narrow_description rendered_markdown">{{description}}
+        {{#if link}}
+        <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+        </a>
+        {{/if}}
+    </span>
+{{/if}}

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1628,11 +1628,26 @@ test("navbar_helpers", () => {
         assert.deepEqual(filter.get_title(), test_case.title);
     }
 
+    function test_get_description(test_case) {
+        const filter = new Filter(test_case.terms);
+        const description = filter.get_description();
+
+        if (test_case.description !== undefined && test_case.link !== undefined) {
+            assert.deepEqual(description, {
+                description: test_case.description,
+                link: test_case.link,
+            });
+        } else {
+            assert.strictEqual(description, undefined);
+        }
+    }
+
     function test_helpers(test_case) {
         // debugging tip: add a `console.log(test_case)` here
         test_common_narrow(test_case);
         test_add_icon_data(test_case);
         test_get_title(test_case);
+        test_get_description(test_case);
         test_redirect_url_with_search(test_case);
     }
 
@@ -1703,6 +1718,8 @@ test("navbar_helpers", () => {
             zulip_icon: "star-filled",
             title: "translated: Starred messages",
             redirect_url_with_search: "/#narrow/is/starred",
+            description: "translated: Important messages, tasks, and other useful references.",
+            link: "/help/star-a-message#view-your-starred-messages",
         },
         {
             terms: in_home,
@@ -1731,6 +1748,8 @@ test("navbar_helpers", () => {
             zulip_icon: "at-sign",
             title: "translated: Mentions",
             redirect_url_with_search: "/#narrow/is/mentioned",
+            description: "translated: Messages where you are mentioned.",
+            link: "/help/view-your-mentions",
         },
         {
             terms: is_resolved,


### PR DESCRIPTION
Adds description in views styled like stream descriptions along with adding a help center link to the appropriate page at the end of each description.

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Describe.20views.20in.20top.20navbar.20.2329769/near/1782549)

Fixes: #29769

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/91622060/090db422-55b9-4b47-844d-26d15317fe00)
![image](https://github.com/zulip/zulip/assets/91622060/8d051ac4-f130-4593-a903-6a1affc7f039)
![image](https://github.com/zulip/zulip/assets/91622060/f1de6f90-fcc2-4809-a837-04ce2bd67168)
![image](https://github.com/zulip/zulip/assets/91622060/5d1fc548-e666-41f4-904c-a6d47754f637)
![image](https://github.com/zulip/zulip/assets/91622060/d555f806-147b-4bbd-936d-81dcc0838a57)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
