### PR TITLE
search-suggestions: Update for "channel" and "channels" to be defaults.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -220,7 +220,7 @@ async function search_tests(page: Page): Promise<void> {
     await search_and_check(
         page,
         "Verona",
-        "Stream",
+        "Channel",
         expect_verona_stream,
         "#Verona - Zulip Dev - Zulip",
     );

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -27,7 +27,7 @@ function restore_draft(draft_id) {
             narrow.activate(
                 [
                     {
-                        operator: "stream",
+                        operator: "channel",
                         operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
                     },
                     {operator: "topic", operand: compose_args.topic},

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -37,8 +37,8 @@ type Part =
           content: string;
       }
     | {
-          type: "stream_topic";
-          stream: string;
+          type: "channel_topic";
+          channel: string;
           topic: string;
       }
     | {
@@ -108,9 +108,9 @@ function zephyr_topic_name_match(message: Message & {type: "stream"}, operand: s
 }
 
 function message_in_home(message: Message): boolean {
-    // The home view contains messages not sent to muted streams, with
-    // additional logic for unmuted topics, mentions, and
-    // single-stream windows.
+    // The home view contains messages not sent to muted channels,
+    // with additional logic for unmuted topics, mentions, and
+    // single-channel windows.
     if (message.type === "private") {
         return true;
     }
@@ -411,9 +411,6 @@ export class Filter {
                     negated = true;
                     operator = operator.slice(1);
                 }
-                if (operator === CHANNEL_SYNONYM) {
-                    operator = "channel";
-                }
                 operand = Filter.decodeOperand(parts.join(":"), operator);
 
                 // We use Filter.operator_to_prefix() to check if the
@@ -459,7 +456,7 @@ export class Filter {
             if (term.operator === "") {
                 return term.operand;
             }
-            const operator = util.canonicalize_stream_synonyms(term.operator);
+            const operator = Filter.canonicalize_operator(term.operator);
             return sign + operator + ":" + Filter.encodeOperand(term.operand.toString());
         });
         return term_strings.join(" ");
@@ -534,9 +531,9 @@ export class Filter {
 
         switch (operator) {
             case "channel":
-                return verb + CHANNEL_SYNONYM;
+                return verb + "channel";
             case "channels":
-                return verb + CHANNELS_SYNONYM;
+                return verb + "channels";
             case "near":
                 return verb + "messages around";
 
@@ -583,11 +580,11 @@ export class Filter {
                 Filter.canonicalize_operator(term.operator) === expected && !term.negated;
 
             if (is(terms[0], "channel") && is(terms[1], "topic")) {
-                const stream = terms[0].operand;
+                const channel = terms[0].operand;
                 const topic = terms[1].operand;
                 parts.push({
-                    type: "stream_topic",
-                    stream,
+                    type: "channel_topic",
+                    channel,
                     topic,
                 });
                 terms = terms.slice(2);
@@ -732,7 +729,7 @@ export class Filter {
 
         // All search/narrow term types, including negations, with the
         // property that if a message is in the view, then any other
-        // message sharing its recipient (stream/topic or direct
+        // message sharing its recipient (channel/topic or direct
         // message recipient) must also be present in the view.
         const valid_term_types = new Set([
             "channel",
@@ -850,8 +847,8 @@ export class Filter {
     }
 
     // This is used to control the behaviour for "exiting search"
-    // within a narrow (E.g. a stream/topic + search) to bring you to
-    // the containing common narrow (stream/topic, in the example)
+    // within a narrow (E.g. a channel/topic + search) to bring you to
+    // the containing common narrow (channel/topic, in the example)
     // rather than the "Combined feed" view.
     //
     // Note from tabbott: The slug-based approach may not be ideal; we
@@ -861,7 +858,7 @@ export class Filter {
 
         // this comes first because it has 3 term_types but is not a "complex filter"
         if (_.isEqual(term_types, ["channel", "topic", "search"])) {
-            // if stream does not exist, redirect to All
+            // if channel does not exist, redirect to home view
             if (!this._sub) {
                 return "#";
             }
@@ -883,7 +880,7 @@ export class Filter {
         if (term_types[1] === "search") {
             switch (term_types[0]) {
                 case "channel":
-                    // if stream does not exist, redirect to All
+                    // if channel does not exist, redirect to home view
                     if (!this._sub) {
                         return "#";
                     }

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -156,7 +156,7 @@ export function group_edit_url(group: UserGroup, right_side_tab: string): string
 }
 
 export function search_public_streams_notice_url(terms: NarrowTerm[]): string {
-    const public_operator = {operator: "streams", operand: "public"};
+    const public_operator = {operator: "channels", operand: "public"};
     return search_terms_to_hash([public_operator, ...terms]);
 }
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1209,7 +1209,7 @@ export function process_hotkey(e, hotkey) {
                     narrow.activate(
                         [
                             {
-                                operator: "stream",
+                                operator: "channel",
                                 operand: stream_data.get_stream_name_from_id(msg.stream_id),
                             },
                             {operator: "topic", operand: msg.topic},

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1393,7 +1393,7 @@ export function with_first_message_id(stream_id, topic_name, success_cb, error_c
         num_before: 1,
         num_after: 0,
         narrow: JSON.stringify([
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic_name},
         ]),
     };
@@ -1421,7 +1421,7 @@ export function is_message_oldest_or_newest(
         num_before: 1,
         num_after: 1,
         narrow: JSON.stringify([
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic_name},
         ]),
     };

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -406,7 +406,7 @@ export function update_messages(events) {
                     // The fix is likely somewhat involved, so punting for now.
                     const new_stream_name = sub_store.get(new_stream_id).name;
                     new_filter = new_filter.filter_with_new_params({
-                        operator: "stream",
+                        operator: "channel",
                         operand: new_stream_name,
                     });
                     changed_narrow = true;

--- a/web/src/message_flags.ts
+++ b/web/src/message_flags.ts
@@ -102,7 +102,7 @@ export function unstar_all_messages_in_topic(stream_id: number, topic: string): 
         num_before: 1000,
         num_after: 0,
         narrow: JSON.stringify([
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic},
             {operator: "is", operand: "starred"},
         ]),

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -843,7 +843,7 @@ export function render_message_list_with_selected_message(opts) {
 
 export function activate_stream_for_cycle_hotkey(stream_name) {
     // This is the common code for A/D hotkeys.
-    const filter_expr = [{operator: "stream", operand: stream_name}];
+    const filter_expr = [{operator: "channel", operand: stream_name}];
     activate(filter_expr, {});
 }
 
@@ -914,7 +914,7 @@ export function narrow_to_next_topic(opts = {}) {
     }
 
     const filter_expr = [
-        {operator: "stream", operand: next_narrow.stream},
+        {operator: "channel", operand: next_narrow.stream},
         {operator: "topic", operand: next_narrow.topic},
     ];
 
@@ -980,7 +980,7 @@ export function by_topic(target_id, opts) {
 
     const stream_name = stream_data.get_stream_name_from_id(original.stream_id);
     const search_terms = [
-        {operator: "stream", operand: stream_name},
+        {operator: "channel", operand: stream_name},
         {operator: "topic", operand: original.topic},
     ];
     opts = {then_select_id: target_id, ...opts};
@@ -1042,7 +1042,7 @@ export function to_compose_target() {
         const stream_name = stream_data.get_sub_by_id(stream_id).name;
         // If we are composing to a new topic, we narrow to the stream but
         // grey-out the message view instead of narrowing to an empty view.
-        const terms = [{operator: "stream", operand: stream_name}];
+        const terms = [{operator: "channel", operand: stream_name}];
         const topic = compose_state.topic();
         if (topic !== "") {
             terms.push({operator: "topic", operand: topic});

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -22,7 +22,7 @@ function narrow_via_edit_scheduled_message(compose_args) {
         narrow.activate(
             [
                 {
-                    operator: "stream",
+                    operator: "channel",
                     operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
                 },
                 {operator: "topic", operand: compose_args.topic},

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -33,8 +33,8 @@ type Suggestion = {
 
 export const max_num_of_search_results = 12;
 
-function stream_matches_query(stream_name: string, q: string): boolean {
-    return common.phrase_match(q, stream_name);
+function channel_matches_query(channel_name: string, q: string): boolean {
+    return common.phrase_match(q, channel_name);
 }
 
 function make_person_highlighter(query: string): (person: User) => string {
@@ -119,8 +119,10 @@ function compare_by_huddle(huddle_emails: string[]): (person1: User, person2: Us
     };
 }
 
-function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
-    const valid = ["channel", "search", ""];
+function get_channel_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
+    // For users with "stream" in their muscle memory, still
+    // have suggestions with "channel:" operator.
+    const valid = ["stream", "channel", "search", ""];
     const incompatible_patterns = [
         {operator: "channel"},
         {operator: "channels"},
@@ -133,23 +135,23 @@ function get_stream_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggesti
     }
 
     const query = last.operand;
-    let streams = stream_data.subscribed_streams();
+    let channels = stream_data.subscribed_streams();
 
-    streams = streams.filter((stream) => stream_matches_query(stream, query));
+    channels = channels.filter((channel) => channel_matches_query(channel, query));
 
-    streams = typeahead_helper.sorter(query, streams, (x) => x);
+    channels = typeahead_helper.sorter(query, channels, (x) => x);
 
     const regex = typeahead_helper.build_highlight_regex(query);
     const highlight_query = typeahead_helper.highlight_with_escaping_and_regex;
 
-    const objs = streams.map((stream) => {
-        const prefix = "stream";
-        const highlighted_stream = highlight_query(regex, stream);
+    const objs = channels.map((channel) => {
+        const prefix = "channel";
+        const highlighted_channel = highlight_query(regex, channel);
         const verb = last.negated ? "exclude " : "";
-        const description_html = verb + prefix + " " + highlighted_stream;
+        const description_html = verb + prefix + " " + highlighted_channel;
         const term = {
             operator: "channel",
-            operand: stream,
+            operand: channel,
             negated: last.negated,
         };
         const search_string = Filter.unparse([term]);
@@ -363,7 +365,7 @@ export function get_topic_suggestions_from_candidates({
     const max_num_topics = 10;
 
     if (guess === "") {
-        // In the search UI, once you autocomplete the stream,
+        // In the search UI, once you autocomplete the channel,
         // we just show you the most recent topics before you even
         // need to start typing any characters.
         return candidate_topics.slice(0, max_num_topics);
@@ -375,7 +377,7 @@ export function get_topic_suggestions_from_candidates({
     // so we do an aggressive search here.
     //
     // The following loop can be expensive if you have lots
-    // of topics in a stream, so we try to exit the loop as
+    // of topics in a channel, so we try to exit the loop as
     // soon as we find enough matches.
     const topics: string[] = [];
     for (const topic of candidate_topics) {
@@ -404,20 +406,20 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     const operator = Filter.canonicalize_operator(last.operator);
     const operand = last.operand;
     const negated = operator === "topic" && last.negated;
-    let stream: string | undefined;
+    let channel: string | undefined;
     let guess: string | undefined;
     const filter = new Filter(terms);
     const suggest_terms: NarrowTerm[] = [];
 
-    // stream:Rome -> show all Rome topics
-    // stream:Rome topic: -> show all Rome topics
-    // stream:Rome f -> show all Rome topics with a word starting in f
-    // stream:Rome topic:f -> show all Rome topics with a word starting in f
-    // stream:Rome topic:f -> show all Rome topics with a word starting in f
+    // channel:Rome -> show all Rome topics
+    // channel:Rome topic: -> show all Rome topics
+    // channel:Rome f -> show all Rome topics with a word starting in f
+    // channel:Rome topic:f -> show all Rome topics with a word starting in f
+    // channel:Rome topic:f -> show all Rome topics with a word starting in f
 
-    // When narrowed to a stream:
-    //   topic: -> show all topics in current stream
-    //   foo -> show all topics in current stream with words starting with foo
+    // When narrowed to a channel:
+    //   topic: -> show all topics in current channel
+    //   foo -> show all topics in current channel with words starting with foo
 
     // If somebody explicitly types search:, then we might
     // not want to suggest topics, but I feel this is a very
@@ -427,34 +429,34 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
     switch (operator) {
         case "channel":
             guess = "";
-            stream = operand;
+            channel = operand;
             suggest_terms.push(last);
             break;
         case "topic":
         case "search":
             guess = operand;
             if (filter.has_operator("channel")) {
-                stream = filter.operands("channel")[0];
+                channel = filter.operands("channel")[0];
             } else {
-                stream = narrow_state.stream_name();
-                if (stream) {
-                    suggest_terms.push({operator: "channel", operand: stream});
+                channel = narrow_state.stream_name();
+                if (channel) {
+                    suggest_terms.push({operator: "channel", operand: channel});
                 }
             }
             break;
     }
 
-    if (!stream) {
+    if (!channel) {
         return [];
     }
 
-    const stream_sub = stream_data.get_sub(stream);
-    if (!stream_sub) {
+    const subscription = stream_data.get_sub(channel);
+    if (!subscription) {
         return [];
     }
 
-    if (stream_data.can_access_topic_history(stream_sub)) {
-        stream_topic_history_util.get_server_history(stream_sub.stream_id, () => {
+    if (stream_data.can_access_topic_history(subscription)) {
+        stream_topic_history_util.get_server_history(subscription.stream_id, () => {
             // Fetch topic history from the server, in case we will need it.
             // Note that we won't actually use the results from the server here
             // for this particular keystroke from the user, because we want to
@@ -465,7 +467,7 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         });
     }
 
-    const candidate_topics = stream_topic_history.get_recent_topic_names(stream_sub.stream_id);
+    const candidate_topics = stream_topic_history.get_recent_topic_names(subscription.stream_id);
 
     if (!candidate_topics?.length) {
         return [];
@@ -488,9 +490,9 @@ function get_topic_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
 }
 
 function get_term_subset_suggestions(terms: NarrowTerm[]): Suggestion[] {
-    // For stream:a topic:b search:c, suggest:
-    //  stream:a topic:b
-    //  stream:a
+    // For channel:a topic:b search:c, suggest:
+    //  channel:a topic:b
+    //  channel:a
     if (terms.length < 1) {
         return [];
     }
@@ -546,11 +548,17 @@ function get_special_filter_suggestions(
     return filtered_suggestions;
 }
 
-function get_streams_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
+function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
+    let search_string = "channels:public";
+    // show "channels:public" option for users who
+    // have "streams" in their muscle memory
+    if (last.operator === "search" && common.phrase_match(last.operand, "streams")) {
+        search_string = "streams:public";
+    }
     const suggestions = [
         {
-            search_string: "streams:public",
-            description_html: "All public streams in organization",
+            search_string,
+            description_html: "All public channels in organization",
             incompatible_patterns: [
                 {operator: "is", operand: "dm"},
                 {operator: "channel"},
@@ -639,9 +647,8 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
     const verb = negated ? "exclude " : "";
 
     const sender_query = negated_symbol + "sender:" + people.my_current_email();
-    const from_query = negated_symbol + "from:" + people.my_current_email();
     const sender_me_query = negated_symbol + "sender:me";
-    const from_me_query = negated_symbol + "from:me";
+    const from_string = negated_symbol + "from";
     const sent_string = negated_symbol + "sent";
     const description_html = verb + "sent by me";
 
@@ -655,18 +662,12 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
         last.operator === "" ||
         sender_query.startsWith(last_string) ||
         sender_me_query.startsWith(last_string) ||
+        from_string.startsWith(last_string) ||
         last_string === sent_string
     ) {
         return [
             {
                 search_string: sender_query,
-                description_html,
-            },
-        ];
-    } else if (from_query.startsWith(last_string) || from_me_query.startsWith(last_string)) {
-        return [
-            {
-                search_string: from_query,
                 description_html,
             },
         ];
@@ -694,7 +695,17 @@ function get_operator_suggestions(last: NarrowTerm): Suggestion[] {
         last_operand = last_operand.slice(1);
     }
 
-    let choices = ["stream", "topic", "dm", "dm-including", "sender", "near", "from", "pm-with"];
+    let choices = [
+        "channel",
+        "topic",
+        "dm",
+        "dm-including",
+        "sender",
+        "near",
+        "from",
+        "pm-with",
+        "stream",
+    ];
     choices = choices.filter((choice) => common.phrase_match(last_operand, choice));
 
     return choices.map((choice) => {
@@ -702,6 +713,11 @@ function get_operator_suggestions(last: NarrowTerm): Suggestion[] {
         // who have "pm-with" in their muscle memory.
         if (choice === "pm-with") {
             choice = "dm";
+        }
+        // Map results for "channel:" operator for users
+        // who have "stream" in their muscle memory.
+        if (choice === "stream") {
+            choice = "channel";
         }
         const op = [{operator: choice, operand: "", negated}];
         return format_as_suggestion(op);
@@ -818,10 +834,10 @@ export function get_search_result(query: string): Suggestion[] {
 
     // Remember to update the spectator list when changing this.
     let filterers = [
-        get_streams_filter_suggestions,
+        get_channels_filter_suggestions,
         get_is_filter_suggestions,
         get_sent_by_me_suggestions,
-        get_stream_suggestions,
+        get_channel_suggestions,
         get_people("sender"),
         get_people("dm"),
         get_people("dm-including"),
@@ -834,7 +850,7 @@ export function get_search_result(query: string): Suggestion[] {
 
     if (page_params.is_spectator) {
         filterers = [
-            get_stream_suggestions,
+            get_channel_suggestions,
             get_people("sender"),
             get_people("from"),
             get_topic_suggestions,

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -863,7 +863,7 @@ export function initialize_everything(state_data) {
             const sub = sub_store.get(stream_id);
             narrow.activate(
                 [
-                    {operator: "stream", operand: sub.name},
+                    {operator: "channel", operand: sub.name},
                     {operator: "topic", operand: topic},
                 ],
                 {trigger: "sidebar"},

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -479,7 +479,7 @@ export function mark_stream_as_read(stream_id) {
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
         ],
         "add",
         {
@@ -492,7 +492,7 @@ export function mark_topic_as_read(stream_id, topic) {
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic},
         ],
         "add",
@@ -506,7 +506,7 @@ export function mark_topic_as_read(stream_id, topic) {
 export function mark_topic_as_unread(stream_id, topic) {
     bulk_update_read_flags_for_narrow(
         [
-            {operator: "stream", operand: stream_id},
+            {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic},
         ],
         "remove",

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -2,9 +2,9 @@
 
     {{#if (eq this.type "plain_text")~}}
         {{~this.content~}}
-    {{else if (eq this.type "stream_topic")}}
+    {{else if (eq this.type "channel_topic")}}
         {{~!-- squash whitespace --~}}
-        stream {{this.stream}} > {{this.topic}}
+        channel {{this.channel}} > {{this.topic}}
         {{~!-- squash whitespace --~}}
     {{else if (eq this.type "invalid_has")}}
         {{~!-- squash whitespace --~}}

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -19,11 +19,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">stream:<span class="operator_value">stream</span></td>
+                        <td class="operator">channel:<span class="operator_value">channel</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to messages on stream <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">stream</span>{{/inline}}
+                                Narrow to messages on channel <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">channel</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>
@@ -61,9 +61,9 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">streams:public</td>
+                        <td class="operator">channels:public</td>
                         <td class="definition">
-                            {{t 'Search all public streams in the organization.'}}
+                            {{t 'Search all public channels in the organization.'}}
                         </td>
                     </tr>
                     <tr>

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -84,7 +84,7 @@ function test(label, f) {
 test("basics", () => {
     let terms = [
         {operator: "channel", operand: "foo"},
-        {operator: "channel", operand: "exclude_stream", negated: true},
+        {operator: "channel", operand: "exclude_me", negated: true},
         {operator: "topic", operand: "bar"},
     ];
     let filter = new Filter(terms);
@@ -96,7 +96,7 @@ test("basics", () => {
     assert.ok(!filter.has_operator("search"));
 
     assert.ok(filter.has_operand("channel", "foo"));
-    assert.ok(!filter.has_operand("channel", "exclude_stream"));
+    assert.ok(!filter.has_operand("channel", "exclude_me"));
     assert.ok(!filter.has_operand("channel", "nada"));
 
     assert.ok(!filter.is_keyword_search());
@@ -112,9 +112,16 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel"));
     assert.ok(filter.can_bucket_by("channel", "topic"));
 
+    // "stream" was renamed to "channel"
+    terms = [{operator: "stream", operand: "foo"}];
+    assert.ok(filter.has_operator("channel"));
+    assert.deepEqual(filter.operands("channel"), ["foo"]);
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(filter.can_apply_locally());
+
     terms = [
-        {operator: "stream", operand: "foo"},
-        {operator: "stream", operand: "exclude_stream", negated: true},
+        {operator: "channel", operand: "foo"},
+        {operator: "channel", operand: "exclude_me", negated: true},
         {operator: "topic", operand: "bar"},
     ];
     filter = new Filter(terms);
@@ -125,7 +132,7 @@ test("basics", () => {
     assert.ok(!filter.has_operator("search"));
 
     assert.ok(filter.has_operand("channel", "foo"));
-    assert.ok(!filter.has_operand("channel", "exclude_stream"));
+    assert.ok(!filter.has_operand("channel", "exclude_me"));
     assert.ok(!filter.has_operand("channel", "nada"));
 
     assert.ok(!filter.is_keyword_search());
@@ -139,7 +146,7 @@ test("basics", () => {
     assert.ok(!filter.is_conversation_view());
 
     terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
         {operator: "search", operand: "pizza"},
     ];
@@ -157,7 +164,7 @@ test("basics", () => {
     assert.ok(!filter.is_conversation_view());
 
     terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
         {operator: "near", operand: 17},
     ];
@@ -174,10 +181,10 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
 
-    // If our only stream operator is negated, then for all intents and purposes,
-    // we don't consider ourselves to have a stream operator, because we don't
-    // want to have the stream in the tab bar or unsubscribe messaging, etc.
-    terms = [{operator: "stream", operand: "exclude", negated: true}];
+    // If our only channel operator is negated, then for all intents and purposes,
+    // we don't consider ourselves to have a channel operator, because we don't
+    // want to have the channel in the tab bar or unsubscribe messaging, etc.
+    terms = [{operator: "channel", operand: "exclude", negated: true}];
     filter = new Filter(terms);
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("channel"));
@@ -211,7 +218,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
 
-    terms = [{operator: "streams", operand: "public", negated: true}];
+    terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
     assert.ok(!filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("channels"));
@@ -219,18 +226,6 @@ test("basics", () => {
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(filter.has_negated_operand("channels", "public"));
     assert.ok(!filter.can_apply_locally());
-    assert.ok(!filter.is_personal_filter());
-    assert.ok(!filter.is_conversation_view());
-
-    terms = [{operator: "streams", operand: "public"}];
-    filter = new Filter(terms);
-    assert.ok(!filter.contains_only_private_messages());
-    assert.ok(filter.has_operator("channels"));
-    assert.ok(!filter.can_mark_messages_read());
-    assert.ok(filter.supports_collapsing_recipients());
-    assert.ok(!filter.has_negated_operand("channels", "public"));
-    assert.ok(!filter.can_apply_locally());
-    assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
 
@@ -245,6 +240,13 @@ test("basics", () => {
     assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+
+    // "streams" was renamed to "channels"
+    terms = [{operator: "streams", operand: "public"}];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("channels"));
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.includes_full_stream_history());
 
     terms = [{operator: "is", operand: "dm"}];
     filter = new Filter(terms);
@@ -341,9 +343,9 @@ test("basics", () => {
     terms = [
         {operator: "is", operand: "resolved", negated: true},
         {operator: "is", operand: "dm", negated: true},
-        {operator: "stream", operand: "stream_name", negated: true},
-        {operator: "streams", operand: "web-public", negated: true},
-        {operator: "streams", operand: "public"},
+        {operator: "channel", operand: "channel_name", negated: true},
+        {operator: "channels", operand: "web-public", negated: true},
+        {operator: "channels", operand: "public"},
         {operator: "topic", operand: "patience", negated: true},
         {operator: "in", operand: "all"},
     ];
@@ -359,7 +361,7 @@ test("basics", () => {
     assert.ok(!filter.is_conversation_view());
 
     terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
     ];
     filter = new Filter(terms);
@@ -374,8 +376,9 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
 
+    // "stream" was renamed to "channel"
     terms = [
-        {operator: "channel", operand: "foo"},
+        {operator: "stream", operand: "foo"},
         {operator: "topic", operand: "bar"},
     ];
     filter = new Filter(terms);
@@ -480,32 +483,32 @@ test("can_mark_messages_read", () => {
     assert_not_mark_read_with_is_operands();
     assert_not_mark_read_when_searching();
 
-    const stream_term = [{operator: "stream", operand: "foo"}];
-    let filter = new Filter(stream_term);
+    const channel_term = [{operator: "channel", operand: "foo"}];
+    let filter = new Filter(channel_term);
     assert.ok(filter.can_mark_messages_read());
-    assert_not_mark_read_with_has_operands(stream_term);
-    assert_not_mark_read_with_is_operands(stream_term);
-    assert_not_mark_read_when_searching(stream_term);
+    assert_not_mark_read_with_has_operands(channel_term);
+    assert_not_mark_read_with_is_operands(channel_term);
+    assert_not_mark_read_when_searching(channel_term);
 
-    const stream_negated_operator = [{operator: "stream", operand: "foo", negated: true}];
-    filter = new Filter(stream_negated_operator);
+    const channel_negated_operator = [{operator: "channel", operand: "foo", negated: true}];
+    filter = new Filter(channel_negated_operator);
     assert.ok(!filter.can_mark_messages_read());
 
-    const stream_topic_terms = [
-        {operator: "stream", operand: "foo"},
+    const channel_topic_terms = [
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
     ];
-    filter = new Filter(stream_topic_terms);
+    filter = new Filter(channel_topic_terms);
     assert.ok(filter.can_mark_messages_read());
-    assert_not_mark_read_with_has_operands(stream_topic_terms);
-    assert_not_mark_read_with_is_operands(stream_topic_terms);
-    assert_not_mark_read_when_searching(stream_topic_terms);
+    assert_not_mark_read_with_has_operands(channel_topic_terms);
+    assert_not_mark_read_with_is_operands(channel_topic_terms);
+    assert_not_mark_read_when_searching(channel_topic_terms);
 
-    const stream_negated_topic_terms = [
-        {operator: "stream", operand: "foo"},
+    const channel_negated_topic_terms = [
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar", negated: true},
     ];
-    filter = new Filter(stream_negated_topic_terms);
+    filter = new Filter(channel_negated_topic_terms);
     assert.ok(!filter.can_mark_messages_read());
 
     const dm = [{operator: "dm", operand: "joe@example.com,"}];
@@ -600,7 +603,7 @@ test("show_first_unread", () => {
 
 test("filter_with_new_params_topic", () => {
     const terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "old topic"},
     ];
     const filter = new Filter(terms);
@@ -618,9 +621,9 @@ test("filter_with_new_params_topic", () => {
     assert.deepEqual(new_filter.operands("topic"), ["new topic"]);
 });
 
-test("filter_with_new_params_stream", () => {
+test("filter_with_new_params_channel", () => {
     const terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "old topic"},
     ];
     const filter = new Filter(terms);
@@ -630,17 +633,17 @@ test("filter_with_new_params_stream", () => {
     assert.ok(!filter.has_topic("foo", "wrong"));
 
     const new_filter = filter.filter_with_new_params({
-        operator: "stream",
-        operand: "new stream",
+        operator: "channel",
+        operand: "new channel",
     });
 
-    assert.deepEqual(new_filter.operands("channel"), ["new stream"]);
+    assert.deepEqual(new_filter.operands("channel"), ["new channel"]);
     assert.deepEqual(new_filter.operands("topic"), ["old topic"]);
 });
 
 test("new_style_terms", () => {
     const term = {
-        operator: "stream",
+        operator: "channel",
         operand: "foo",
     };
     const terms = [term];
@@ -653,13 +656,13 @@ test("new_style_terms", () => {
 test("public_terms", ({override}) => {
     stream_data.clear_subscriptions();
     let terms = [
-        {operator: "stream", operand: "some_stream"},
+        {operator: "channel", operand: "some_channel"},
         {operator: "in", operand: "all"},
         {operator: "topic", operand: "bar"},
     ];
     let filter = new Filter(terms);
     const expected_terms = [
-        {operator: "channel", operand: "some_stream"},
+        {operator: "channel", operand: "some_channel"},
         {operator: "in", operand: "all"},
         {operator: "topic", operand: "bar"},
     ];
@@ -762,7 +765,7 @@ test("predicate_basics", () => {
     const stream_id = 42;
     make_sub("Foo", stream_id);
     let predicate = get_predicate([
-        ["stream", "Foo"],
+        ["channel", "Foo"],
         ["topic", "Bar"],
     ]);
 
@@ -772,16 +775,16 @@ test("predicate_basics", () => {
     assert.ok(!predicate({type: stream_message, stream_id: 9999999}));
     assert.ok(!predicate({type: direct_message}));
 
-    // For old streams that we are no longer subscribed to, we may not have
-    // a sub, but these should still match by stream name.
+    // For old channels that we are no longer subscribed to, we may not have
+    // a subscription, but these should still match by channel name.
     const old_sub = {
-        name: "old-Stream",
+        name: "old-subscription",
         stream_id: 5,
         subscribed: false,
     };
     stream_data.add_sub(old_sub);
     predicate = get_predicate([
-        ["stream", "old-Stream"],
+        ["channel", "old-subscription"],
         ["topic", "Bar"],
     ]);
     assert.ok(predicate({type: stream_message, stream_id: 5, topic: "bar"}));
@@ -798,7 +801,7 @@ test("predicate_basics", () => {
     assert.ok(predicate({type: direct_message}));
     assert.ok(!predicate({type: stream_message}));
 
-    predicate = get_predicate([["streams", "public"]]);
+    predicate = get_predicate([["channels", "public"]]);
     assert.ok(predicate({}));
 
     predicate = get_predicate([["is", "starred"]]);
@@ -999,12 +1002,12 @@ test("negated_predicates", () => {
     const social_stream_id = 555;
     make_sub("social", social_stream_id);
 
-    narrow = [{operator: "stream", operand: "social", negated: true}];
+    narrow = [{operator: "channel", operand: "social", negated: true}];
     predicate = new Filter(narrow).predicate();
     assert.ok(predicate({type: stream_message, stream_id: 999999}));
     assert.ok(!predicate({type: stream_message, stream_id: social_stream_id}));
 
-    narrow = [{operator: "streams", operand: "public", negated: true}];
+    narrow = [{operator: "channels", operand: "public", negated: true}];
     predicate = new Filter(narrow).predicate();
     assert.ok(predicate({}));
 });
@@ -1013,25 +1016,25 @@ function test_mit_exceptions() {
     const foo_stream_id = 555;
     make_sub("Foo", foo_stream_id);
     let predicate = get_predicate([
-        ["stream", "Foo"],
+        ["channel", "Foo"],
         ["topic", "personal"],
     ]);
     assert.ok(predicate({type: stream_message, stream_id: foo_stream_id, topic: "personal"}));
     assert.ok(predicate({type: stream_message, stream_id: foo_stream_id, topic: ""}));
-    // 9999 doesn't correspond to any stream
+    // 9999 doesn't correspond to any channel
     assert.ok(!predicate({type: stream_message, stream_id: 9999}));
     assert.ok(!predicate({type: stream_message, stream_id: foo_stream_id, topic: "whatever"}));
     assert.ok(!predicate({type: direct_message}));
 
     predicate = get_predicate([
-        ["stream", "Foo"],
+        ["channel", "Foo"],
         ["topic", "bar"],
     ]);
     assert.ok(predicate({type: stream_message, stream_id: foo_stream_id, topic: "bar.d"}));
 
-    // Try to get the MIT regex to explode for an empty stream.
+    // Try to get the MIT regex to explode for an empty channel.
     let terms = [
-        {operator: "stream", operand: ""},
+        {operator: "channel", operand: ""},
         {operator: "topic", operand: "bar"},
     ];
     predicate = new Filter(terms).predicate();
@@ -1039,7 +1042,7 @@ function test_mit_exceptions() {
 
     // Try to get the MIT regex to explode for an empty topic.
     terms = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: ""},
     ];
     predicate = new Filter(terms).predicate();
@@ -1074,7 +1077,7 @@ test("predicate_edge_cases", () => {
     const stream_id = 101;
     make_sub("Off topic", stream_id);
     const terms = [
-        {operator: "stream", operand: "Off topic"},
+        {operator: "channel", operand: "Off topic"},
         {operator: "topic", operand: "Mars"},
     ];
     const filter = new Filter(terms);
@@ -1100,9 +1103,10 @@ test("parse", () => {
     ];
     _test();
 
+    // "stream" was renamed to "channel"
     string = "stream:Foo topic:Bar yo";
     terms = [
-        {operator: "channel", operand: "Foo"},
+        {operator: "stream", operand: "Foo"},
         {operator: "topic", operand: "Bar"},
         {operator: "search", operand: "yo"},
     ];
@@ -1116,11 +1120,11 @@ test("parse", () => {
     terms = [{operator: "sender", operand: "leo+test@zulip.com"}];
     _test();
 
-    string = "stream:With+Space";
+    string = "channel:With+Space";
     terms = [{operator: "channel", operand: "With Space"}];
     _test();
 
-    string = 'stream:"with quoted space" topic:and separate';
+    string = 'channel:"with quoted space" topic:and separate';
     terms = [
         {operator: "channel", operand: "with quoted space"},
         {operator: "topic", operand: "and"},
@@ -1128,11 +1132,11 @@ test("parse", () => {
     ];
     _test();
 
-    string = 'stream:"unclosed quote';
+    string = 'channel:"unclosed quote';
     terms = [{operator: "channel", operand: "unclosed quote"}];
     _test();
 
-    string = 'stream:""';
+    string = 'channel:""';
     terms = [{operator: "channel", operand: ""}];
     _test();
 
@@ -1140,14 +1144,14 @@ test("parse", () => {
     terms = [{operator: "search", operand: "https://www.google.com"}];
     _test();
 
-    string = "stream:foo -stream:exclude";
+    string = "channel:foo -channel:exclude";
     terms = [
         {operator: "channel", operand: "foo"},
         {operator: "channel", operand: "exclude", negated: true},
     ];
     _test();
 
-    string = "text stream:foo more text";
+    string = "text channel:foo more text";
     terms = [
         {operator: "search", operand: "text"},
         {operator: "channel", operand: "foo"},
@@ -1155,40 +1159,45 @@ test("parse", () => {
     ];
     _test();
 
-    string = "text streams:public more text";
+    string = "text channels:public more text";
     terms = [
         {operator: "search", operand: "text"},
-        {operator: "streams", operand: "public"},
+        {operator: "channels", operand: "public"},
         {operator: "search", operand: "more text"},
     ];
     _test();
 
+    string = "channels:public";
+    terms = [{operator: "channels", operand: "public"}];
+    _test();
+
+    string = "-channels:public";
+    terms = [{operator: "channels", operand: "public", negated: true}];
+    _test();
+
+    // "streams" was renamed to "channels"
     string = "streams:public";
     terms = [{operator: "streams", operand: "public"}];
     _test();
 
-    string = "-streams:public";
-    terms = [{operator: "streams", operand: "public", negated: true}];
-    _test();
-
-    string = "stream:foo :emoji: are cool";
+    string = "channel:foo :emoji: are cool";
     terms = [
         {operator: "channel", operand: "foo"},
         {operator: "search", operand: ":emoji: are cool"},
     ];
     _test();
 
-    string = ":stream: stream:foo :emoji: are cool";
+    string = ":channel: channel:foo :emoji: are cool";
     terms = [
-        {operator: "search", operand: ":stream:"},
+        {operator: "search", operand: ":channel:"},
         {operator: "channel", operand: "foo"},
         {operator: "search", operand: ":emoji: are cool"},
     ];
     _test();
 
-    string = ":stream: stream:foo -:emoji: are cool";
+    string = ":channel: channel:foo -:emoji: are cool";
     terms = [
-        {operator: "search", operand: ":stream:"},
+        {operator: "search", operand: ":channel:"},
         {operator: "channel", operand: "foo"},
         {operator: "search", operand: "-:emoji: are cool"},
     ];
@@ -1198,7 +1207,7 @@ test("parse", () => {
     terms = [];
     _test();
 
-    string = 'stream: separated topic: "with space"';
+    string = 'channel: separated topic: "with space"';
     terms = [
         {operator: "channel", operand: "separated"},
         {operator: "topic", operand: "with space"},
@@ -1215,23 +1224,23 @@ test("unparse", () => {
         {operator: "topic", operand: "Bar", negated: true},
         {operator: "search", operand: "yo"},
     ];
-    string = "stream:Foo -topic:Bar yo";
+    string = "channel:Foo -topic:Bar yo";
     assert.deepEqual(Filter.unparse(terms), string);
 
     terms = [
-        {operator: "streams", operand: "public"},
+        {operator: "channels", operand: "public"},
         {operator: "search", operand: "text"},
     ];
 
-    string = "streams:public text";
+    string = "channels:public text";
     assert.deepEqual(Filter.unparse(terms), string);
 
-    terms = [{operator: "streams", operand: "public"}];
-    string = "streams:public";
+    terms = [{operator: "channels", operand: "public"}];
+    string = "channels:public";
     assert.deepEqual(Filter.unparse(terms), string);
 
-    terms = [{operator: "streams", operand: "public", negated: true}];
-    string = "-streams:public";
+    terms = [{operator: "channels", operand: "public", negated: true}];
+    string = "-channels:public";
     assert.deepEqual(Filter.unparse(terms), string);
 
     terms = [{operator: "id", operand: 50}];
@@ -1245,6 +1254,15 @@ test("unparse", () => {
     terms = [{operator: "", operand: ""}];
     string = "";
     assert.deepEqual(Filter.unparse(terms), string);
+
+    // canonical version of the operator is
+    // used in the unparsed search string
+    terms = [
+        {operator: "stream", operand: "Foo"},
+        {operator: "subject", operand: "Bar"},
+    ];
+    string = "channel:Foo topic:Bar";
+    assert.deepEqual(Filter.unparse(terms), string);
 });
 
 test("describe", ({mock_template}) => {
@@ -1252,33 +1270,33 @@ test("describe", ({mock_template}) => {
     let string;
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    narrow = [{operator: "streams", operand: "public"}];
-    string = "streams public";
+    narrow = [{operator: "channels", operand: "public"}];
+    string = "channels public";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
-    narrow = [{operator: "streams", operand: "public", negated: true}];
-    string = "exclude streams public";
+    narrow = [{operator: "channels", operand: "public", negated: true}];
+    string = "exclude channels public";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
         {operator: "is", operand: "starred"},
     ];
-    string = "stream devel, starred messages";
+    string = "channel devel, starred messages";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "river"},
+        {operator: "channel", operand: "river"},
         {operator: "is", operand: "unread"},
     ];
-    string = "stream river, unread messages";
+    string = "channel river, unread messages";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
         {operator: "topic", operand: "JS"},
     ];
-    string = "stream devel > JS";
+    string = "channel devel > JS";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
@@ -1318,10 +1336,10 @@ test("describe", ({mock_template}) => {
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
         {operator: "topic", operand: "JS", negated: true},
     ];
-    string = "stream devel, exclude topic JS";
+    string = "channel devel, exclude topic JS";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
@@ -1332,40 +1350,48 @@ test("describe", ({mock_template}) => {
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
         {operator: "is", operand: "starred", negated: true},
     ];
-    string = "stream devel, exclude starred messages";
+    string = "channel devel, exclude starred messages";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
         {operator: "has", operand: "image", negated: true},
     ];
-    string = "stream devel, exclude messages with one or more image";
+    string = "channel devel, exclude messages with one or more image";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
         {operator: "has", operand: "abc", negated: true},
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
     ];
-    string = "invalid abc operand for has operator, stream devel";
+    string = "invalid abc operand for has operator, channel devel";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
         {operator: "has", operand: "image", negated: true},
-        {operator: "stream", operand: "devel"},
+        {operator: "channel", operand: "devel"},
     ];
-    string = "exclude messages with one or more image, stream devel";
+    string = "exclude messages with one or more image, channel devel";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [];
     string = "combined feed";
     assert.equal(Filter.search_description_as_html(narrow), string);
+
+    // canonical version of the operator is used in description
+    narrow = [
+        {operator: "stream", operand: "devel"},
+        {operator: "subject", operand: "JS", negated: true},
+    ];
+    string = "channel devel, exclude topic JS";
+    assert.equal(Filter.search_description_as_html(narrow), string);
 });
 
 test("can_bucket_by", () => {
-    let terms = [{operator: "stream", operand: "My stream"}];
+    let terms = [{operator: "channel", operand: "My channel"}];
     let filter = new Filter(terms);
     assert.equal(filter.can_bucket_by("channel"), true);
     assert.equal(filter.can_bucket_by("channel", "topic"), false);
@@ -1374,7 +1400,7 @@ test("can_bucket_by", () => {
     terms = [
         // try a non-orthodox ordering
         {operator: "topic", operand: "My topic"},
-        {operator: "stream", operand: "My stream"},
+        {operator: "channel", operand: "My channel"},
     ];
     filter = new Filter(terms);
     assert.equal(filter.can_bucket_by("channel"), true);
@@ -1382,7 +1408,7 @@ test("can_bucket_by", () => {
     assert.equal(filter.can_bucket_by("dm"), false);
 
     terms = [
-        {operator: "stream", operand: "My stream", negated: true},
+        {operator: "channel", operand: "My channel", negated: true},
         {operator: "topic", operand: "My topic"},
     ];
     filter = new Filter(terms);
@@ -1538,7 +1564,7 @@ test("update_email", () => {
     const terms = [
         {operator: "dm", operand: "steve@foo.com"},
         {operator: "sender", operand: "steve@foo.com"},
-        {operator: "stream", operand: "steve@foo.com"}, // try to be tricky
+        {operator: "channel", operand: "steve@foo.com"}, // try to be tricky
     ];
     const filter = new Filter(terms);
     filter.update_email(steve.user_id, "showell@foo.com");
@@ -1618,20 +1644,20 @@ test("navbar_helpers", () => {
     const is_dm = [{operator: "is", operand: "dm"}];
     const is_mentioned = [{operator: "is", operand: "mentioned"}];
     const is_resolved = [{operator: "is", operand: "resolved"}];
-    const streams_public = [{operator: "streams", operand: "public"}];
-    const stream_topic_terms = [
-        {operator: "stream", operand: "foo"},
+    const channels_public = [{operator: "channels", operand: "public"}];
+    const channel_topic_terms = [
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
     ];
-    // foo stream exists
-    const stream_term = [{operator: "stream", operand: "foo"}];
+    // foo channel exists
+    const channel_term = [{operator: "channel", operand: "foo"}];
     make_private_sub("psub", "22");
-    const private_stream_term = [{operator: "stream", operand: "psub"}];
+    const private_channel_term = [{operator: "channel", operand: "psub"}];
     make_web_public_sub("webPublicSub", "12"); // capitalized just to try be tricky and robust.
-    const web_public_stream = [{operator: "stream", operand: "webPublicSub"}];
-    const non_existent_stream = [{operator: "stream", operand: "Elephant"}];
-    const non_existent_stream_topic = [
-        {operator: "stream", operand: "Elephant"},
+    const web_public_channel = [{operator: "channel", operand: "webPublicSub"}];
+    const non_existent_channel = [{operator: "channel", operand: "Elephant"}];
+    const non_existent_channel_topic = [
+        {operator: "channel", operand: "Elephant"},
         {operator: "topic", operand: "pink"},
     ];
     const dm = [{operator: "dm", operand: "joe@example.com"}];
@@ -1646,8 +1672,8 @@ test("navbar_helpers", () => {
     // not common narrows, but used for browser title updates
     const is_alerted = [{operator: "is", operand: "alerted"}];
     const is_unread = [{operator: "is", operand: "unread"}];
-    const stream_topic_near = [
-        {operator: "stream", operand: "foo"},
+    const channel_topic_near = [
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
         {operator: "near", operand: "12"},
     ];
@@ -1714,49 +1740,49 @@ test("navbar_helpers", () => {
             redirect_url_with_search: "/#narrow/topics/is/resolved",
         },
         {
-            terms: stream_topic_terms,
+            terms: channel_topic_terms,
             is_common_narrow: true,
             zulip_icon: "hashtag",
             title: "Foo",
             redirect_url_with_search: "/#narrow/stream/43-Foo/topic/bar",
         },
         {
-            terms: streams_public,
+            terms: channels_public,
             is_common_narrow: true,
             icon: undefined,
             title: "translated: Messages in all public streams",
             redirect_url_with_search: "/#narrow/streams/public",
         },
         {
-            terms: stream_term,
+            terms: channel_term,
             is_common_narrow: true,
             zulip_icon: "hashtag",
             title: "Foo",
             redirect_url_with_search: "/#narrow/stream/43-Foo",
         },
         {
-            terms: non_existent_stream,
+            terms: non_existent_channel,
             is_common_narrow: true,
             icon: "question-circle-o",
             title: "translated: Unknown stream #Elephant",
             redirect_url_with_search: "#",
         },
         {
-            terms: non_existent_stream_topic,
+            terms: non_existent_channel_topic,
             is_common_narrow: true,
             icon: "question-circle-o",
             title: "translated: Unknown stream #Elephant",
             redirect_url_with_search: "#",
         },
         {
-            terms: private_stream_term,
+            terms: private_channel_term,
             is_common_narrow: true,
             zulip_icon: "lock",
             title: "psub",
             redirect_url_with_search: "/#narrow/stream/22-psub",
         },
         {
-            terms: web_public_stream,
+            terms: web_public_channel,
             is_common_narrow: true,
             zulip_icon: "globe",
             title: "webPublicSub",
@@ -1818,7 +1844,7 @@ test("navbar_helpers", () => {
             redirect_url_with_search: "#",
         },
         {
-            terms: stream_topic_near,
+            terms: channel_topic_near,
             is_common_narrow: false,
             zulip_icon: "hashtag",
             title: "Foo",
@@ -1864,7 +1890,7 @@ test("navbar_helpers", () => {
 
     // incomplete and weak test cases just to restore coverage of filter.ts
     const complex_term = [
-        {operator: "stream", operand: "foo"},
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
         {operator: "sender", operand: "me"},
     ];
@@ -1875,18 +1901,18 @@ test("navbar_helpers", () => {
     assert.equal(filter.generate_redirect_url(), redirect_url);
     assert.equal(filter.is_common_narrow(), false);
 
-    const stream_topic_search_term = [
-        {operator: "stream", operand: "foo"},
+    const channel_topic_search_term = [
+        {operator: "channel", operand: "foo"},
         {operator: "topic", operand: "bar"},
         {operator: "search", operand: "potato"},
     ];
 
-    const stream_topic_search_term_test_case = {
-        terms: stream_topic_search_term,
+    const channel_topic_search_term_test_case = {
+        terms: channel_topic_search_term,
         title: undefined,
     };
 
-    test_get_title(stream_topic_search_term_test_case);
+    test_get_title(channel_topic_search_term_test_case);
 
     realm.realm_enable_guest_user_indicator = false;
     const guest_user_test_cases_without_indicator = [
@@ -1921,7 +1947,7 @@ test("navbar_helpers", () => {
     // this is actually wrong, but the code is currently not robust enough to throw an error here
     // also, used as an example of triggering last return statement.
     const default_redirect = {
-        terms: [{operator: "stream", operand: "foo"}],
+        terms: [{operator: "channel", operand: "foo"}],
         redirect_url: "#",
     };
 
@@ -1956,16 +1982,16 @@ run_test("is_spectator_compatible", () => {
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "dm-including", operand: "hamlet@zulip.com"}]),
     );
-    assert.ok(Filter.is_spectator_compatible([{operator: "stream", operand: "Denmark"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channel", operand: "Denmark"}]));
     assert.ok(
         Filter.is_spectator_compatible([
-            {operator: "stream", operand: "Denmark"},
+            {operator: "channel", operand: "Denmark"},
             {operator: "topic", operand: "logic"},
         ]),
     );
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "starred"}]));
     assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "dm"}]));
-    assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "public"}]));
+    assert.ok(Filter.is_spectator_compatible([{operator: "channels", operand: "public"}]));
 
     // Malformed input not allowed
     assert.ok(!Filter.is_spectator_compatible([{operator: "has"}]));
@@ -1976,6 +2002,10 @@ run_test("is_spectator_compatible", () => {
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "pm-with", operand: "hamlet@zulip.com"}]),
     );
+    // "stream" was renamted to "channel"
+    assert.ok(Filter.is_spectator_compatible([{operator: "stream", operand: "Denmark"}]));
+    // "streams" was renamed to "channels"
+    assert.ok(Filter.is_spectator_compatible([{operator: "streams", operand: "public"}]));
     // "group-pm-with:" was replaced with "dm-including:"
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "group-pm-with", operand: "hamlet@zulip.com"}]),

--- a/web/tests/message_flags.test.js
+++ b/web/tests/message_flags.test.js
@@ -136,7 +136,7 @@ run_test("unstar_all_in_topic", ({override}) => {
         num_before: 1000,
         num_after: 0,
         narrow: JSON.stringify([
-            {operator: "stream", operand: 20},
+            {operator: "channel", operand: 20},
             {operator: "topic", operand: "topic"},
             {operator: "is", operand: "starred"},
         ]),

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -692,7 +692,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     assert.equal(args.called, true);
     assert.equal(args.opts.trigger, "narrow_to_compose_target");
     assert.deepEqual(args.terms, [
-        {operator: "stream", operand: "ROME"},
+        {operator: "channel", operand: "ROME"},
         {operator: "topic", operand: "one"},
     ]);
 
@@ -702,7 +702,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     narrow.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [
-        {operator: "stream", operand: "ROME"},
+        {operator: "channel", operand: "ROME"},
         {operator: "topic", operand: "four"},
     ]);
 
@@ -711,14 +711,14 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.terms, [{operator: "stream", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "channel", operand: "ROME"}]);
 
     // Test with no topic
     compose_state.topic(undefined);
     args.called = false;
     narrow.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.terms, [{operator: "stream", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "channel", operand: "ROME"}]);
 });
 
 run_test("narrow_to_compose_target direct messages", ({override, override_rewire}) => {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -66,7 +66,7 @@ test("stream", () => {
 
     const public_terms = narrow_state.public_search_terms();
     assert.deepEqual(public_terms, expected_terms);
-    assert.equal(narrow_state.search_string(), "stream:Test topic:Bar yo");
+    assert.equal(narrow_state.search_string(), "channel:Test topic:Bar yo");
 });
 
 test("narrowed", () => {

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -102,14 +102,14 @@ test("basic_get_suggestions_for_spectator", () => {
 test("subset_suggestions", ({mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    const query = "stream:Denmark topic:Hamlet shakespeare";
+    const query = "channel:Denmark topic:Hamlet shakespeare";
 
     const suggestions = get_suggestions(query);
 
     const expected = [
-        "stream:Denmark topic:Hamlet shakespeare",
-        "stream:Denmark topic:Hamlet",
-        "stream:Denmark",
+        "channel:Denmark topic:Hamlet shakespeare",
+        "channel:Denmark topic:Hamlet",
+        "channel:Denmark",
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -192,7 +192,7 @@ test("dm_suggestions", ({override, mock_template}) => {
 
     query = "is:unread from:ted";
     suggestions = get_suggestions(query);
-    expected = ["is:unread from:ted", "is:unread from:ted@zulip.com", "is:unread"];
+    expected = ["is:unread sender:ted", "is:unread sender:ted@zulip.com", "is:unread"];
     assert.deepEqual(suggestions.strings, expected);
 
     // Users can enter bizarre queries, and if they do, we want to
@@ -230,10 +230,10 @@ test("dm_suggestions", ({override, mock_template}) => {
     // Make sure it handles past context correctly
     query = "stream:Denmark dm:";
     suggestions = get_suggestions(query);
-    expected = ["stream:Denmark dm:", "stream:Denmark"];
+    expected = ["channel:Denmark dm:", "channel:Denmark"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "sender:ted@zulip.com sender:";
+    query = "from:ted@zulip.com from:";
     suggestions = get_suggestions(query);
     expected = ["sender:ted@zulip.com sender:", "sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
@@ -248,7 +248,7 @@ test("dm_suggestions", ({override, mock_template}) => {
 
     query = "pm-with:t";
     suggestions = get_suggestions(query);
-    expected = ["pm-with:t", "dm:ted@zulip.com"];
+    expected = ["dm:t", "dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -326,7 +326,7 @@ test("group_suggestions", ({mock_template}) => {
     query = "pm-with:bob@zulip.com,";
     suggestions = get_suggestions(query);
     expected = [
-        "pm-with:bob@zulip.com,",
+        "dm:bob@zulip.com,",
         "dm:bob@zulip.com,alice@zulip.com",
         "dm:bob@zulip.com,jeff@zulip.com",
         "dm:bob@zulip.com,ted@zulip.com",
@@ -344,12 +344,12 @@ test("group_suggestions", ({mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "stream:Denmark has:link dm:bob@zulip.com,Smit";
+    query = "channel:Denmark has:link dm:bob@zulip.com,Smit";
     suggestions = get_suggestions(query);
     expected = [
-        "stream:Denmark has:link dm:bob@zulip.com,Smit",
-        "stream:Denmark has:link",
-        "stream:Denmark",
+        "channel:Denmark has:link dm:bob@zulip.com,Smit",
+        "channel:Denmark has:link",
+        "channel:Denmark",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -419,7 +419,7 @@ test("empty_query_suggestions", () => {
     const suggestions = get_suggestions(query);
 
     const expected = [
-        "streams:public",
+        "channels:public",
         "is:dm",
         "is:starred",
         "is:mentioned",
@@ -427,8 +427,8 @@ test("empty_query_suggestions", () => {
         "is:unread",
         "is:resolved",
         "sender:myself@zulip.com",
-        "stream:devel",
-        "stream:office",
+        "channel:devel",
+        "channel:office",
         "has:link",
         "has:image",
         "has:attachment",
@@ -503,12 +503,12 @@ test("has_suggestions", ({override, mock_template}) => {
     expected = ["att", "has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "stream:Denmark is:alerted has:lin";
+    query = "channel:Denmark is:alerted has:lin";
     suggestions = get_suggestions(query);
     expected = [
-        "stream:Denmark is:alerted has:link",
-        "stream:Denmark is:alerted",
-        "stream:Denmark",
+        "channel:Denmark is:alerted has:link",
+        "channel:Denmark is:alerted",
+        "channel:Denmark",
     ];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -585,14 +585,20 @@ test("check_is_suggestions", ({override, mock_template}) => {
     expected = ["-is:starred"];
     assert.deepEqual(suggestions.strings, expected);
 
+    // Still returns suggestions for "streams:public",
+    // but shows html description used for "channels:public"
     query = "st";
     suggestions = get_suggestions(query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["st", "streams:public", "is:starred", "channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "stream:Denmark has:link is:sta";
+    query = "channel:Denmark has:link is:sta";
     suggestions = get_suggestions(query);
-    expected = ["stream:Denmark has:link is:starred", "stream:Denmark has:link", "stream:Denmark"];
+    expected = [
+        "channel:Denmark has:link is:starred",
+        "channel:Denmark has:link",
+        "channel:Denmark",
+    ];
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -621,12 +627,12 @@ test("sent_by_me_suggestions", ({override, mock_template}) => {
 
     query = "from";
     suggestions = get_suggestions(query);
-    expected = ["from", "from:myself@zulip.com", "from:"];
+    expected = ["from", "sender:myself@zulip.com", "sender:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-from";
     suggestions = get_suggestions(query);
-    expected = ["-from", "-from:myself@zulip.com", "-from:"];
+    expected = ["-from", "-sender:myself@zulip.com", "-sender:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:bob@zulip.com";
@@ -636,7 +642,7 @@ test("sent_by_me_suggestions", ({override, mock_template}) => {
 
     query = "from:bob@zulip.com";
     suggestions = get_suggestions(query);
-    expected = ["from:bob@zulip.com"];
+    expected = ["sender:bob@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sent";
@@ -649,13 +655,13 @@ test("sent_by_me_suggestions", ({override, mock_template}) => {
     expected = ["-sent", "-sender:myself@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "stream:Denmark topic:Denmark1 sent";
+    query = "channel:Denmark topic:Denmark1 sent";
     suggestions = get_suggestions(query);
     expected = [
-        "stream:Denmark topic:Denmark1 sent",
-        "stream:Denmark topic:Denmark1 sender:myself@zulip.com",
-        "stream:Denmark topic:Denmark1",
-        "stream:Denmark",
+        "channel:Denmark topic:Denmark1 sent",
+        "channel:Denmark topic:Denmark1 sender:myself@zulip.com",
+        "channel:Denmark topic:Denmark1",
+        "channel:Denmark",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -706,8 +712,8 @@ test("topic_suggestions", ({override, mock_template}) => {
         "sender:ted@zulip.com",
         "dm:ted@zulip.com",
         "dm-including:ted@zulip.com",
-        "stream:office topic:team",
-        "stream:office topic:test",
+        "channel:office topic:team",
+        "channel:office topic:test",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -715,40 +721,40 @@ test("topic_suggestions", ({override, mock_template}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for <strong>te</strong>");
-    assert.equal(describe("stream:office topic:team"), "Stream office > team");
+    assert.equal(describe("channel:office topic:team"), "Channel office > team");
 
-    suggestions = get_suggestions("topic:staplers stream:office");
-    expected = ["topic:staplers stream:office", "topic:staplers"];
+    suggestions = get_suggestions("topic:staplers channel:office");
+    expected = ["topic:staplers channel:office", "topic:staplers"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("stream:devel topic:");
-    expected = ["stream:devel topic:", "stream:devel topic:REXX", "stream:devel"];
+    suggestions = get_suggestions("channel:devel topic:");
+    expected = ["channel:devel topic:", "channel:devel topic:REXX", "channel:devel"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("stream:devel -topic:");
-    expected = ["stream:devel -topic:", "stream:devel -topic:REXX", "stream:devel"];
+    suggestions = get_suggestions("channel:devel -topic:");
+    expected = ["channel:devel -topic:", "channel:devel -topic:REXX", "channel:devel"];
     assert.deepEqual(suggestions.strings, expected);
 
     suggestions = get_suggestions("-topic:te");
-    expected = ["-topic:te", "stream:office -topic:team", "stream:office -topic:test"];
+    expected = ["-topic:te", "channel:office -topic:team", "channel:office -topic:test"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("is:alerted stream:devel is:starred topic:");
+    suggestions = get_suggestions("is:alerted channel:devel is:starred topic:");
     expected = [
-        "is:alerted stream:devel is:starred topic:",
-        "is:alerted stream:devel is:starred topic:REXX",
-        "is:alerted stream:devel is:starred",
-        "is:alerted stream:devel",
+        "is:alerted channel:devel is:starred topic:",
+        "is:alerted channel:devel is:starred topic:REXX",
+        "is:alerted channel:devel is:starred",
+        "is:alerted channel:devel",
         "is:alerted",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("is:dm stream:devel topic:");
-    expected = ["is:dm stream:devel topic:", "is:dm stream:devel", "is:dm"];
+    suggestions = get_suggestions("is:dm channel:devel topic:");
+    expected = ["is:dm channel:devel topic:", "is:dm channel:devel", "is:dm"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("topic:REXX stream:devel topic:");
-    expected = ["topic:REXX stream:devel topic:", "topic:REXX stream:devel", "topic:REXX"];
+    suggestions = get_suggestions("topic:REXX channel:devel topic:");
+    expected = ["topic:REXX channel:devel topic:", "topic:REXX channel:devel", "topic:REXX"];
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -798,19 +804,19 @@ test("topic_suggestions (limits)", () => {
 test("whitespace_glitch", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    const query = "stream:office "; // note trailing space
+    const query = "channel:office "; // note trailing space
 
     override(stream_topic_history_util, "get_server_history", noop);
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
     const suggestions = get_suggestions(query);
 
-    const expected = ["stream:office"];
+    const expected = ["channel:office"];
 
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("stream_completion", ({override, mock_template}) => {
+test("channel_completion", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
@@ -818,19 +824,19 @@ test("stream_completion", ({override, mock_template}) => {
 
     override(narrow_state, "stream_name", noop);
 
-    let query = "stream:of";
+    let query = "channel:of";
     let suggestions = get_suggestions(query);
-    let expected = ["stream:of", "stream:office"];
+    let expected = ["channel:of", "channel:office"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "-stream:of";
+    query = "-channel:of";
     suggestions = get_suggestions(query);
-    expected = ["-stream:of", "-stream:office"];
+    expected = ["-channel:of", "-channel:office"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "hel";
     suggestions = get_suggestions(query);
-    expected = ["hel", "stream:dev+help"];
+    expected = ["hel", "channel:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -1004,29 +1010,29 @@ test("operator_suggestions", ({override, mock_template}) => {
     override(narrow_state, "stream_name", () => undefined);
 
     // Completed operator should return nothing
-    let query = "stream:";
+    let query = "channel:";
     let suggestions = get_suggestions(query);
-    let expected = ["stream:"];
+    let expected = ["channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "st";
+    query = "ch";
     suggestions = get_suggestions(query);
-    expected = ["st", "streams:public", "is:starred", "stream:"];
+    expected = ["ch", "channels:public", "channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-s";
     suggestions = get_suggestions(query);
-    expected = ["-s", "-streams:public", "-sender:myself@zulip.com", "-stream:", "-sender:"];
+    expected = ["-s", "-sender:myself@zulip.com", "-sender:", "-channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
-    query = "stream:Denmark is:alerted -f";
+    query = "channel:Denmark is:alerted -f";
     suggestions = get_suggestions(query);
     expected = [
-        "stream:Denmark is:alerted -f",
-        "stream:Denmark is:alerted -from:myself@zulip.com",
-        "stream:Denmark is:alerted -from:",
-        "stream:Denmark is:alerted",
-        "stream:Denmark",
+        "channel:Denmark is:alerted -f",
+        "channel:Denmark is:alerted -sender:myself@zulip.com",
+        "channel:Denmark is:alerted -sender:",
+        "channel:Denmark is:alerted",
+        "channel:Denmark",
     ];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -1038,20 +1044,20 @@ test("queries_with_spaces", ({mock_template}) => {
     stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
     // test allowing spaces with quotes surrounding operand
-    let query = 'stream:"dev he"';
+    let query = 'channel:"dev he"';
     let suggestions = get_suggestions(query);
-    let expected = ["stream:dev+he", "stream:dev+help"];
+    let expected = ["channel:dev+he", "channel:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 
     // test mismatched quote
-    query = 'stream:"dev h';
+    query = 'channel:"dev h';
     suggestions = get_suggestions(query);
-    expected = ["stream:dev+h", "stream:dev+help"];
+    expected = ["channel:dev+h", "channel:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 
     // test extra space after operator still works
-    query = "stream: offi";
+    query = "channel: offi";
     suggestions = get_suggestions(query);
-    expected = ["stream:offi", "stream:office"];
+    expected = ["channel:offi", "channel:office"];
     assert.deepEqual(suggestions.strings, expected);
 });


### PR DESCRIPTION
Updates implementation of the new "channel" and "channels" search operators in the web app to be the defaults.
- "stream" and "streams" still display suggestions, for folks who have those in their muscle memory.
- Changes `Filter.unparse` to use `Filter.canonicalize_operator` when setting the operator value in the string.
  - This impacts the search suggestion behavior for the `from` operator, as the canonicalized version of that is `sender`.
  - But it doesn't change what suggestions are shown to the user (see screenshots below).
  - It changes what string is shown in the search bar if a user selects one of the shown suggestions.
- Updates filters and narrows set in the web app to use "channel" and "channels", instead of "stream" and "streams".
- Updates info overlay for search operators, but does not update the help center documentation as of yet.

**Note**: These changes do not update any of the URLs for these narrows, so these will still be shown as `/#narrow/stream/...` and `/#narrow/streams/public` 

---

**Screenshots and screen captures:**

<details>
<summary>Search - no input</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-04-24 19-16-46](https://github.com/zulip/zulip/assets/63245456/a96943f6-35b8-47bd-b2d9-d66361283493) | ![Screenshot from 2024-04-24 19-17-58](https://github.com/zulip/zulip/assets/63245456/ece6be49-20fb-4fad-9095-de3431f53621)

</details>
<details>
<summary>Search - channel operator</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-04-24 19-23-05](https://github.com/zulip/zulip/assets/63245456/7b4ab2a0-fafc-447b-af6d-ba9d1444caf1) | ![Screenshot from 2024-04-24 19-19-46](https://github.com/zulip/zulip/assets/63245456/9ed9f90b-bf15-4095-9e9a-28b11244b2ab)
| ![Screenshot from 2024-04-24 19-23-15](https://github.com/zulip/zulip/assets/63245456/7295668c-0408-4aed-b6a6-c019743813c0) | ![Screenshot from 2024-04-24 19-19-54](https://github.com/zulip/zulip/assets/63245456/774a5c2e-a20e-4479-ad60-05ba46c39941)
|![Screenshot from 2024-04-24 19-23-28](https://github.com/zulip/zulip/assets/63245456/e71a7c73-4a60-453a-8460-ca35eb87041d) | ![Screenshot from 2024-04-24 19-20-07](https://github.com/zulip/zulip/assets/63245456/4eac2aea-6701-4c45-8f15-0b6c71f35d29)
| ![Screenshot from 2024-04-24 19-23-37](https://github.com/zulip/zulip/assets/63245456/88cbfda8-4a70-4a87-a14b-99122c182a47) | ![Screenshot from 2024-04-24 19-20-19](https://github.com/zulip/zulip/assets/63245456/c564763d-ecbb-483f-8edf-3e30dbaf2d7f)
| ![Screenshot from 2024-04-24 19-23-55](https://github.com/zulip/zulip/assets/63245456/b7ce7442-4e6e-4ba3-946c-b7b6aeed9914) | ![Screenshot from 2024-04-24 19-20-28](https://github.com/zulip/zulip/assets/63245456/9a2a900f-1a33-4235-abb0-54eb73aed64a)
</details>
<details>
<summary>Search - stream operator</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-04-24 19-26-10](https://github.com/zulip/zulip/assets/63245456/52f23ee3-7226-41d1-8ce5-7cc92b251868) | ![Screenshot from 2024-04-24 19-28-27](https://github.com/zulip/zulip/assets/63245456/d7e91ebd-8634-4b73-aac4-2fcd8f6af5b6)
| ![Screenshot from 2024-04-24 19-26-19](https://github.com/zulip/zulip/assets/63245456/3de80910-4194-4b5e-bada-9ae3f7d295e7) | ![Screenshot from 2024-04-24 19-28-34](https://github.com/zulip/zulip/assets/63245456/62ac0656-9979-4eb4-8532-f348159923f1)
| ![Screenshot from 2024-04-24 19-26-33](https://github.com/zulip/zulip/assets/63245456/505d02ab-ab1e-4805-8ebf-5e8c445430c2) | ![Screenshot from 2024-04-24 19-28-42](https://github.com/zulip/zulip/assets/63245456/fe99a4a0-b048-4e39-bfe3-d1b9149f818a)
| ![Screenshot from 2024-04-24 19-26-42](https://github.com/zulip/zulip/assets/63245456/ff8df87e-8912-47c7-b974-39066e8d935f) | ![Screenshot from 2024-04-24 19-28-50](https://github.com/zulip/zulip/assets/63245456/01bfba45-c198-4325-876d-e95f21b8d285)
| ![Screenshot from 2024-04-24 19-26-50](https://github.com/zulip/zulip/assets/63245456/5fee6a35-09d1-4269-b2d1-05019cf22087) | ![Screenshot from 2024-04-24 19-28-58](https://github.com/zulip/zulip/assets/63245456/34b9e3ee-5ae8-4874-94c1-2877f729057d)
</details>
<details>
<summary>Search - channels and streams</summary>

| Before | After |
| --- | --- |
![Screenshot from 2024-04-24 19-42-50](https://github.com/zulip/zulip/assets/63245456/af76c61f-9cd7-4272-b61b-70446d71b3db) | ![Screenshot from 2024-04-24 19-35-46](https://github.com/zulip/zulip/assets/63245456/172ff5e4-4815-4124-a89b-c95ff697e3a6)
![Screenshot from 2024-04-24 19-42-55](https://github.com/zulip/zulip/assets/63245456/2e22ab30-1bfe-489e-943c-f30638a3b371) | ![Screenshot from 2024-04-24 19-31-20](https://github.com/zulip/zulip/assets/63245456/89f892fd-7ec1-40d8-9be0-302dbefb0e46)
![Screenshot from 2024-04-24 19-43-03](https://github.com/zulip/zulip/assets/63245456/74f69151-b218-4757-8ef8-52aee2ef5d31) | ![Screenshot from 2024-04-24 19-36-21](https://github.com/zulip/zulip/assets/63245456/dc1a4b17-527a-4705-ba65-ee2d328c1324)
![Screenshot from 2024-04-24 19-43-34](https://github.com/zulip/zulip/assets/63245456/baf06736-3f34-4e54-9758-9adb4505504a) | ![Screenshot from 2024-04-24 19-36-39](https://github.com/zulip/zulip/assets/63245456/5c9ed515-9ede-40aa-b81a-afc3748d4b95)
![Screenshot from 2024-04-24 19-43-41](https://github.com/zulip/zulip/assets/63245456/6a83d2ed-db8d-49ec-96b8-39dfc9fea20e) | ![Screenshot from 2024-04-24 19-36-47](https://github.com/zulip/zulip/assets/63245456/f42a3538-734a-4911-a170-83f0ce329a6c)
![Screenshot from 2024-04-24 19-43-50](https://github.com/zulip/zulip/assets/63245456/66173985-4f0d-4706-8525-15b7354b871c) | ![Screenshot from 2024-04-24 19-37-10](https://github.com/zulip/zulip/assets/63245456/587f6ed2-fa30-41b9-a21c-16eb31bff219)
</details>
<details>
<summary>Search - from search</summary>

| Before | After |
| --- | --- |
![Screenshot from 2024-04-24 19-52-41](https://github.com/zulip/zulip/assets/63245456/399d0563-4537-43f0-accf-74e6f2d23ea5) | ![Screenshot from 2024-04-24 19-54-46](https://github.com/zulip/zulip/assets/63245456/6c313ac2-7c61-4289-8e8a-5d29c0d0d3b2)
![Screenshot from 2024-04-24 19-52-51](https://github.com/zulip/zulip/assets/63245456/9eac7cac-d863-4fa5-8bbb-c93faf7651d2) | ![Screenshot from 2024-04-24 19-54-55](https://github.com/zulip/zulip/assets/63245456/41580f4d-8af5-4d02-a881-70dd00697900)
![Screenshot from 2024-04-24 19-53-08](https://github.com/zulip/zulip/assets/63245456/dd84054b-6f79-4c44-a7b3-dbcc15373f3b) | ![Screenshot from 2024-04-24 19-55-05](https://github.com/zulip/zulip/assets/63245456/60953021-8c97-436e-a241-f2c6eda4826e)
</details>
<details>
<summary>Search operators info overlay</summary>

| Before | After |
| --- | --- |
![Screenshot from 2024-04-24 20-00-55](https://github.com/zulip/zulip/assets/63245456/e658afd0-354f-486e-bbf1-63bf00d8f56f) | ![Screenshot from 2024-04-24 20-00-29](https://github.com/zulip/zulip/assets/63245456/526409d9-8510-4df5-b183-c3129352d62a)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
