### PR TITLE
message_edit: Correct unpleasant content shifts between edit and preview.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -534,7 +534,7 @@
     vertical-align: middle;
     border: 1px solid hsl(0deg 0% 80%);
     padding: 4px 6px;
-    margin-bottom: 10px;
+    margin: 0 0 10px;
 
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
     transition:

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -520,7 +520,6 @@
 /* Additional message-editing UI styles. */
 
 .message_edit_content {
-    line-height: 18px;
     max-height: 24em;
     width: 100%;
     min-width: 206px;
@@ -533,7 +532,9 @@
     border-radius: 4px;
     vertical-align: middle;
     border: 1px solid hsl(0deg 0% 80%);
-    padding: 4px 6px;
+    /* Match textarea padding to compose box and
+       message-edit preview area. */
+    padding: 5px;
     margin: 0 0 10px;
 
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -521,8 +521,40 @@
 
 .message_edit_content {
     line-height: 18px;
-    resize: vertical !important;
     max-height: 24em;
+    width: 100%;
+    min-width: 206px;
+    box-sizing: border-box;
+    /* Setting resize as none hides the bottom right diagonal box
+       (which even has a background color of its own!). */
+    resize: none !important;
+    color: hsl(0deg 0% 33%);
+    background-color: hsl(0deg 0% 100%);
+    border-radius: 4px;
+    vertical-align: middle;
+    border: 1px solid hsl(0deg 0% 80%);
+    padding: 4px 6px;
+    margin-bottom: 10px;
+
+    box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+    transition:
+        border linear 0.2s,
+        box-shadow linear 0.2s;
+
+    &:focus {
+        border-color: hsl(206.5deg 80% 62% / 80%);
+        outline: 0;
+
+        box-shadow:
+            inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+            0 0 8px hsl(206.5deg 80% 62% / 60%);
+    }
+
+    &:read-only,
+    &:disabled {
+        cursor: not-allowed;
+        background-color: hsl(0deg 0% 93%);
+    }
 }
 
 .message_edit_countdown_timer {
@@ -589,42 +621,6 @@
     .edit-controls {
         margin-left: 0;
         margin-top: 0;
-    }
-
-    & textarea {
-        width: 100%;
-        min-width: 206px;
-        box-sizing: border-box;
-        /* Setting resize as none hides the bottom right diagonal box
-           (which even has a background color of its own!). */
-        resize: none !important;
-        color: hsl(0deg 0% 33%);
-        background-color: hsl(0deg 0% 100%);
-        border-radius: 4px;
-        vertical-align: middle;
-        border: 1px solid hsl(0deg 0% 80%);
-        padding: 4px 6px;
-        margin-bottom: 10px;
-
-        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
-        transition:
-            border linear 0.2s,
-            box-shadow linear 0.2s;
-
-        &:focus {
-            border-color: hsl(206.5deg 80% 62% / 80%);
-            outline: 0;
-
-            box-shadow:
-                inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                0 0 8px hsl(206.5deg 80% 62% / 60%);
-        }
-
-        &:read-only,
-        &:disabled {
-            cursor: not-allowed;
-            background-color: hsl(0deg 0% 93%);
-        }
     }
 }
 


### PR DESCRIPTION
This PR offers some cleanup on the `message_row.css` file by putting all textarea-related styles behind the `.message_content_edit` class.

It removes any browser-default top margin from the textarea. Additionally, the PR makes minor adjustments to the padding and line-height of the `.message_content_edit` class to bring it in line both with the main compose box as well as the message-area edit preview.

Note that there are still discrepancies between the height of the textarea and preview area, as well as differences in bottom-margin with where the formatting buttons sit. Those will presumably be addressed and cleaned up as part of #28702.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/shifts.20on.20message-edit.20preview/near/1781484)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![edit-and-preview-before](https://github.com/zulip/zulip/assets/170719/61d58770-8006-4ce4-9bd3-ad74efcd7278) | ![edit-and-preview-after](https://github.com/zulip/zulip/assets/170719/28628de8-f14b-49b3-a9e3-52a4234c7362) |
|![message-edit-before](https://github.com/zulip/zulip/assets/170719/6c9b89f1-53d5-487d-8dce-2aadab271ab2) | ![message-edit-after](https://github.com/zulip/zulip/assets/170719/dff63b8c-ef3a-4e1c-828c-e8cee52a6ba6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>