### PR TITLE
all-wildcards: Update for "channel" wildcard as preferred to "stream".

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -399,6 +399,8 @@ export function broadcast_mentions() {
     if (compose_state.get_message_type() === "private") {
         wildcard_mention_array = ["all", "everyone"];
     } else if (compose_validate.stream_wildcard_mention_allowed()) {
+        // TODO: Eventually remove "stream" wildcard from typeahead suggestions
+        // once the rename of stream to channel has settled for users.
         wildcard_mention_array = ["all", "everyone", "stream", "channel", "topic"];
     } else if (compose_validate.topic_wildcard_mention_allowed()) {
         wildcard_mention_array = ["topic"];

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1357,8 +1357,11 @@ export function get_mention_syntax(full_name: string, user_id?: number, silent =
         mention += "@**";
     }
     const wildcard_match = full_name_matches_wildcard_mention(full_name);
-    if (wildcard_match && user_id === undefined) {
-        mention += util.canonicalize_stream_synonyms(full_name);
+    // TODO: Eventually remove "stream" wildcard from typeahead suggestions
+    // once the rename of stream to channel has settled for users.
+    // Until then, when selected, replace with "channel" wildcard.
+    if (wildcard_match && user_id === undefined && full_name === "stream") {
+        mention += "channel";
     } else {
         mention += full_name;
     }

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -1150,8 +1150,8 @@ test_people("get_mention_syntax", () => {
     // blueslip warning is not raised for wildcard mentions without a user_id
     assert.equal(people.get_mention_syntax("all"), "@**all**");
     assert.equal(people.get_mention_syntax("everyone", undefined, true), "@_**everyone**");
-    assert.equal(people.get_mention_syntax("stream"), "@**stream**");
-    assert.equal(people.get_mention_syntax("channel"), "@**stream**");
+    assert.equal(people.get_mention_syntax("stream"), "@**channel**");
+    assert.equal(people.get_mention_syntax("channel"), "@**channel**");
     assert.equal(people.get_mention_syntax("topic"), "@**topic**");
 
     people.add_active_user(stephen1);


### PR DESCRIPTION
Updates the logic for adding a wildcard mention syntax in a message to use the "channel" wildcard instead of the "stream" wildcard.

Adds some TODO notes for eventually removing the "stream" wildcard from the typeahead suggestions in the web app.

Part of stream to channel rename project.

**Notes**:
- Translated string in typeahead is updated in #29765
- Help center documentation will be updated separately from these changes.

**Screenshots and screen captures:**

<details>
<summary>typeahead suggestions when composing a message</summary>

![Screenshot from 2024-04-24 21-40-39](https://github.com/zulip/zulip/assets/63245456/2767d442-c2a5-44f3-b618-91b7c06ac3e9)
![Screenshot from 2024-04-24 21-40-44](https://github.com/zulip/zulip/assets/63245456/6fbb4968-9188-42d3-9d9f-3a1f2b4897d4)
![Screenshot from 2024-04-24 21-40-57](https://github.com/zulip/zulip/assets/63245456/31f1fec7-c272-4889-aa85-c5df48068d95)
![Screenshot from 2024-04-24 21-41-02](https://github.com/zulip/zulip/assets/63245456/22c223d8-8854-4867-a17a-425993b1e27f)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
