### PR TITLE
reactions: Message-reaction refactors.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -86,12 +86,6 @@
         color: var(--color-message-reaction-button-text-hover);
     }
 
-    & i {
-        font-size: 1.3em;
-        float: left;
-        color: var(--color-message-reaction-button-text);
-    }
-
     &:hover .reaction_button {
         visibility: visible;
         pointer-events: all;
@@ -120,6 +114,7 @@
 
         & i {
             font-size: 1em;
+            color: var(--color-message-reaction-button-text);
         }
 
         &:hover i {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -2,6 +2,10 @@
     overflow: hidden;
     user-select: none;
 
+    &:has(.message_reaction) {
+        padding-bottom: 5px;
+    }
+
     .message_reaction {
         display: flex;
         /* Set a pixel and half padding to maintain
@@ -106,10 +110,6 @@
         color: var(--color-message-reaction-button-text);
         background-color: var(--color-message-reaction-button-background);
         border: 1px solid var(--color-message-reaction-button-border);
-        /* TODO: Eventually this space will be set on the message
-           box, at least in part, but for now this preserves the
-           space beneath the reactions area. */
-        margin-bottom: 4px;
 
         & i {
             font-size: 1em;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -101,8 +101,7 @@
         pointer-events: none;
         /* Set top/bottom padding to accommodate borders
            and padding around reaction pills. */
-        padding: 4.5px 6px;
-        height: 13px;
+        padding: 4px 6px;
         border-radius: 21px;
         color: var(--color-message-reaction-button-text);
         background-color: var(--color-message-reaction-button-background);
@@ -147,6 +146,7 @@
             font-weight: 700;
             color: var(--color-message-reaction-button-text);
             margin-right: 0;
+            line-height: 14px;
         }
 
         &:hover .message_reaction_count {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -97,7 +97,6 @@
         pointer-events: all;
     }
 
-    .reaction_button,
     .emoji-message-control-button-container {
         display: flex;
         align-items: center;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -43,33 +43,6 @@
             transform: scale(var(--scale-message-reaction-active));
         }
 
-        + .reaction_button {
-            visibility: hidden;
-            pointer-events: none;
-            /* Set top/bottom padding to accommodate borders
-               and padding around reaction pills. */
-            padding: 4.5px 6px;
-            height: 13px;
-            border-radius: 21px;
-            color: var(--color-message-reaction-button-text);
-            background-color: var(--color-message-reaction-button-background);
-            border: 1px solid var(--color-message-reaction-button-border);
-            /* TODO: Eventually this space will be set on the message
-               box, at least in part, but for now this preserves the
-               space beneath the reactions area. */
-            margin-bottom: 4px;
-
-            &:hover {
-                color: var(--color-message-reaction-button-text-hover);
-                background-color: var(
-                    --color-message-reaction-button-background-hover
-                );
-                border-color: var(--color-message-reaction-button-border-hover);
-                box-shadow: inset 0 0 5px 0
-                    var(--color-message-reaction-shadow-inner);
-            }
-        }
-
         .emoji {
             margin: 1px 3px;
             height: 17px;
@@ -119,7 +92,7 @@
         color: var(--color-message-reaction-button-text);
     }
 
-    &:hover .message_reaction + .reaction_button {
+    &:hover .reaction_button {
         visibility: visible;
         pointer-events: all;
     }
@@ -131,6 +104,21 @@
     }
 
     .reaction_button {
+        visibility: hidden;
+        pointer-events: none;
+        /* Set top/bottom padding to accommodate borders
+           and padding around reaction pills. */
+        padding: 4.5px 6px;
+        height: 13px;
+        border-radius: 21px;
+        color: var(--color-message-reaction-button-text);
+        background-color: var(--color-message-reaction-button-background);
+        border: 1px solid var(--color-message-reaction-button-border);
+        /* TODO: Eventually this space will be set on the message
+           box, at least in part, but for now this preserves the
+           space beneath the reactions area. */
+        margin-bottom: 4px;
+
         & i {
             font-size: 1em;
         }
@@ -149,13 +137,16 @@
         }
 
         &:hover {
-            border: 1px solid var(--color-message-reaction-button-border-hover);
+            color: var(--color-message-reaction-button-text-hover);
             background-color: var(
                 --color-message-reaction-button-background-hover
             );
+            border: 1px solid var(--color-message-reaction-button-border-hover);
+            border-color: var(--color-message-reaction-button-border-hover);
+            box-shadow: inset 0 0 5px 0
+                var(--color-message-reaction-shadow-inner);
             cursor: pointer;
             opacity: 1;
-            color: var(--color-message-reaction-button-text-hover);
         }
 
         .message_reaction_count {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1379,13 +1379,9 @@ td.pointer {
 
 .selected_msg_for_touchscreen {
     @media (hover: none) {
-        .message_reactions {
-            .message_reaction {
-                + .reaction_button {
-                    visibility: visible;
-                    pointer-events: all;
-                }
-            }
+        .message_reactions .reaction_button {
+            visibility: visible;
+            pointer-events: all;
         }
     }
 }


### PR DESCRIPTION
This PR introduces some aggressive cleanup and rethought approaches to spacing in preparing emoji reactions to play nicely with user-selectable font-size and line-height.

The changes here do not affect the appearance of the reactions emoji. Instead, the changes in how space within and around them is declared should head off little shifts in alignment as work progresses on adjusting the font-size and line-height in the message area. 

As discussed on CZO, this does increase the space below reactions from 4px to 5px, in keeping with a recurring 5px spacing-value found elsewhere in the message area.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/space.20beneath.20reactions/near/1786348)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![reactions-before](https://github.com/zulip/zulip/assets/170719/73426361-125d-40f8-84f8-bbaab7bc362f) | ![reactions-after](https://github.com/zulip/zulip/assets/170719/6383d6c4-13c3-419d-9ea8-cce0141d4da2) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>