### PR TITLE
stream_settings: Fix stream row switching behavior when adding subscribers.

### DIFF
--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -91,6 +91,20 @@ export function is_create_new_stream_narrow(): boolean {
     return window.location.hash === "#streams/new";
 }
 
+// This checks whether the user is in the stream settings menu
+// and is opening the 'Subscribers' tab on the right panel.
+export function is_subscribers_section_opened_for_stream(): boolean {
+    const hash_components = window.location.hash.slice(1).split(/\//);
+
+    if (hash_components[0] !== "streams") {
+        return false;
+    }
+    if (!hash_components[3]) {
+        return false;
+    }
+    return hash_components[3] === "subscribers";
+}
+
 export const allowed_web_public_narrows = [
     "channels",
     "channel",

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -794,9 +794,16 @@ export function launch(section, left_side_tab, right_side_tab) {
 
 export function switch_rows(event) {
     const active_data = stream_settings_components.get_active_data();
+    const $add_subscriber_pill_input = $(".add_subscribers_container .input");
     let $switch_row;
     if (hash_parser.is_create_new_stream_narrow()) {
         // Prevent switching stream rows when creating a new stream
+        return false;
+    } else if (
+        hash_parser.is_subscribers_section_opened_for_stream() &&
+        $add_subscriber_pill_input.is(":focus")
+    ) {
+        // Prevent switching stream rows when adding a subscriber
         return false;
     } else if (!active_data.id || active_data.$row.hasClass("notdisplayed")) {
         $switch_row = $("div.stream-row:not(.notdisplayed)").first();

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -161,6 +161,23 @@ run_test("test_is_create_new_stream_narrow", () => {
     assert.equal(hash_parser.is_create_new_stream_narrow(), false);
 });
 
+run_test("test_is_subscribers_section_opened_for_stream", () => {
+    window.location.hash = "#streams/1/Design/subscribers";
+    assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), true);
+
+    window.location.hash = "#streams/99/.EC.A1.B0.EB.A6.AC.EB.B2.95.20.F0.9F.98.8E/subscribers";
+    assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), true);
+
+    window.location.hash = "#streams/random/subscribers";
+    assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), false);
+
+    window.location.hash = "#some/random/place/subscribers";
+    assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), false);
+
+    window.location.hash = "#";
+    assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), false);
+});
+
 run_test("test_parse_narrow", () => {
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "99-frontend"]), [
         {negated: false, operator: "stream", operand: "frontend"},


### PR DESCRIPTION
## :bookmark_tabs:  Overview
The root cause of the bug is that the `switch_rows(event)` function in `stream_settings_ui.js` does not consider whether the user is currently editing the `add_subscriber_pill` input in the right panel of the stream settings menu for the key up/down event to trigger the stream row switching process.

Adjusted the `switch_rows(event)` behavior by adding a condition to prevent switching stream row when the user in the subscriber tab on stream settings menu (`hash_parser.is_on_stream_subscribers()`) and is focused on the `add_subscribers_pill` input

Fixes zulip#29690
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Up.2Fdown.20in.20stream.20add.20users/near/1772561)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 25-04-24 17:46:54.webm](https://github.com/zulip/zulip/assets/108744694/24f535c0-4a0f-44a6-bc48-32802b7d32a3)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
