### PR TITLE
message_row: Fix me messages, consolidate sender-line selectors.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -267,6 +267,9 @@
     --color-text-message-default: hsl(0deg 0% 15%);
     --color-text-message-view-header: hsl(0deg 0% 20% / 100%);
     --color-text-message-header: hsl(0deg 0% 15%);
+    /* Light and dark mode both use the same hover color on
+       sender names. */
+    --color-text-sender-name-hover: hsl(200deg 100% 40%);
     --color-text-dropdown-input: hsl(0deg 0% 13.33%);
     --color-text-self-direct-mention: hsl(240deg 52% 45% / 100%);
     --color-text-self-group-mention: hsl(183deg 52% 26% / 100%);

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -438,7 +438,7 @@
             cursor: pointer;
             /* TODO: Refactor the teetering nested classes
                above so that !important can be removed. */
-            color: hsl(200deg 100% 40%) !important;
+            color: var(--color-text-sender-name-hover) !important;
         }
 
         .message-avatar {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -319,6 +319,10 @@
                     /* Set the same line-height as on message content for
                        me-messages. */
                     line-height: var(--message-box-line-height);
+                    /* Ensure the same spacing below messages as for any other
+                       paragraph.
+                       TODO: Coordinate this with other info-density variables. */
+                    padding-bottom: 5px;
 
                     /* Display message components inline, with wrapping white-space,
                        so the sender name and message display as a continuous line
@@ -388,6 +392,10 @@
                 text-overflow: ellipsis;
                 grid-area: sender;
                 display: flex;
+                /* A generous line-height on the sender name is necessary
+                   for internationalization and non-Western Latin character
+                   sets. */
+                line-height: var(--message-box-sender-line-height);
                 /* Ensure flexed sender info (name, status emoji, inline EDITED)
                    forms a baseline group, which will participate with the
                    message-box grid's baseline group, too. */
@@ -402,10 +410,6 @@
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
-                    /* A generous line-height on the sender name is necessary
-                       for internationalization and non-Western Latin character
-                       sets. */
-                    line-height: var(--message-box-sender-line-height);
                     outline: none;
                     align-self: baseline;
                 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -402,18 +402,47 @@
                 align-items: baseline;
 
                 .zulip-icon.zulip-icon-bot {
+                    font-size: 12px;
                     align-self: center;
                     padding: 0 0 0 5px;
                 }
 
                 .sender_name {
+                    display: inline-flex;
+                    font-weight: 700;
+                    color: var(--color-text-sender-name);
+                    column-gap: 3px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                     outline: none;
                     align-self: baseline;
+
+                    .sender_name_text {
+                        overflow: hidden;
+                        white-space: nowrap;
+                        display: inline-flex;
+
+                        .user-name {
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    &.sender_info_hovered {
+        .sender_name {
+            cursor: pointer;
+            /* TODO: Refactor the teetering nested classes
+               above so that !important can be removed. */
+            color: hsl(200deg 100% 40%) !important;
+        }
+
+        .message-avatar {
+            cursor: pointer;
         }
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1390,41 +1390,6 @@ td.pointer {
     }
 }
 
-.message_sender {
-    & i.zulip-icon.zulip-icon-bot {
-        font-size: 12px;
-    }
-}
-
-.sender_name {
-    display: inline-flex;
-    font-weight: 700;
-    color: var(--color-text-sender-name);
-    column-gap: 3px;
-
-    .sender_name_text {
-        overflow: hidden;
-        white-space: nowrap;
-        display: inline-flex;
-
-        .user-name {
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-}
-
-.sender_info_hovered {
-    .sender_name {
-        cursor: pointer;
-        color: hsl(200deg 100% 40%);
-    }
-
-    .message-avatar {
-        cursor: pointer;
-    }
-}
-
 .always_visible_topic_edit,
 .on_hover_topic_read,
 .stream_unmuted.on_hover_topic_unmute,


### PR DESCRIPTION
This PR chiefly fixes a regression introduced in #29819 that caused broken and unnecessarily complicated dueling line-height values between sender rows on ordinary messages vs. me-messages.

Additionally, this PR adds the 5px of space below a me-message, so that long me-messages that wrap onto multiple lines will have the same apparent space beneath them as ordinary paragraph messages.

Finally, because the work was sitting there for the doing, this moves all of the sender-related selectors out of `zulip.css` and puts them into `message_row.css`, where they belong.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/fixes.20to.20the.20sender.20line/near/1785636)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![me-messages-before](https://github.com/zulip/zulip/assets/170719/42c61b0f-d163-49a6-84bb-1b410d35fce2) | ![me-messages-after](https://github.com/zulip/zulip/assets/170719/182f5cc7-638f-41e4-88c5-3dac8639cd2e) |
