### PR TITLE
info_density: Apply database values outside of dense mode (dev only).

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -769,8 +769,8 @@ export function dispatch_normal_event(event) {
                 activity_ui.build_user_sidebar();
             }
             if (event.property === "dense_mode") {
-                $("body").toggleClass("less_dense_mode");
-                $("body").toggleClass("more_dense_mode");
+                $("body").toggleClass("less-dense-mode");
+                $("body").toggleClass("more-dense-mode");
             }
             if (
                 event.property === "web_font_size_px" ||

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -278,9 +278,9 @@ export function initialize_kitchen_sink_stuff() {
     }
 
     if (!user_settings.dense_mode) {
-        $("body").addClass("less_dense_mode");
+        $("body").addClass("less-dense-mode");
     } else {
-        $("body").addClass("more_dense_mode");
+        $("body").addClass("more-dense-mode");
     }
 
     // To keep the specificity same for the CSS related to hiding the

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -66,6 +66,12 @@
     --base-font-size-px: 14px;
     --base-line-height-unitless: 1.214;
 
+    .more-dense-mode {
+        /* The legacy values here are not altered by JavaScript */
+        --base-font-size-px: 14px;
+        --base-line-height-unitless: 1.214;
+    }
+
     /*
     Message box elements and values.
     */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -64,7 +64,7 @@
     /* Information density and typography values */
     /* The legacy values here are updated via JavaScript */
     --base-font-size-px: 14px;
-    --base-line-height-unitless: calc(20 / 14);
+    --base-line-height-unitless: 1.214;
 
     /*
     Message box elements and values.
@@ -75,7 +75,6 @@
     /* 6px appears to provide 5px of space between the avatar
        and the selected-message outline, which is offset by -1px. */
     --message-box-vertical-margin: 6px;
-    --message-box-line-height: 1.214;
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;
     /* The line-height on the sender line should coordinate with the

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -203,7 +203,7 @@
             */
             padding: 5px 0 0;
             color: var(--color-text-message-default);
-            line-height: var(--message-box-line-height);
+            line-height: var(--base-line-height-unitless);
             min-height: 17px;
             display: block;
             position: relative;
@@ -318,7 +318,7 @@
                     display: block;
                     /* Set the same line-height as on message content for
                        me-messages. */
-                    line-height: var(--message-box-line-height);
+                    line-height: var(--base-line-height-unitless);
                     /* Ensure the same spacing below messages as for any other
                        paragraph.
                        TODO: Coordinate this with other info-density variables. */

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -203,6 +203,7 @@
             */
             padding: 5px 0 0;
             color: var(--color-text-message-default);
+            font-size: var(--base-font-size-px);
             line-height: var(--base-line-height-unitless);
             min-height: 17px;
             display: block;

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -930,7 +930,7 @@ run_test("user_settings", ({override}) => {
     toggled = [];
     dispatch(event);
     assert_same(user_settings.dense_mode, true);
-    assert_same(toggled, ["less_dense_mode", "more_dense_mode"]);
+    assert_same(toggled, ["less-dense-mode", "more-dense-mode"]);
 
     event = event_fixtures.user_settings__web_font_size_px;
     user_settings.web_font_size_px = 14;


### PR DESCRIPTION
Here we go. This PR applies database-stored information density values to the message-content area when "Dense mode" is unselected in user preferences. This is what's necessary to begin building out the information density project, and getting more Zulip developers in on experimenting with values as that project progresses.

**Screenshots and screen captures:**

Small but compounding sub-pixel rounding causes shifts to certain elements. But overall, things look as they should in the subtle shift from 1.214 to 1.22 for a `line-height` value.

| Before (legacy values) | After (legacy-equivalent db values)
| --- | --- |
| ![legacy-info-density](https://github.com/zulip/zulip/assets/170719/65acbd48-0dd2-4f6b-b029-aac35d5b460b) | ![legacy-info-density-db-values](https://github.com/zulip/zulip/assets/170719/2e8ade32-97a1-45c9-8f20-ba2651e40fe4) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
