### PR TITLE
help and portico: Document custom domain request process on Cloud.

### DIFF
--- a/help/change-organization-url.md
+++ b/help/change-organization-url.md
@@ -1,5 +1,7 @@
 # Change organization URL
 
+{!owner-only.md!}
+
 Zulip supports changing the URL for an organization.  Changing the
 organization URL is a disruptive operation for users:
 
@@ -13,13 +15,43 @@ mention](/help/mention-a-user-or-group#mention-everyone-on-a-stream)
 in an announcement stream to notify users that they need to update
 their clients.
 
-If you're using Zulip Cloud (E.g. `https://example.zulipchat.com`),
-you can request a change by emailing support@zulip.com. Custom domains
-(i.e. those that do not have the form `example.zulipchat.com`) have a
-maintenance cost for our operational team and thus are only available
-for paid plans.
+## Change your Zulip Cloud subdomain
 
-## Self-hosting
+Zulip Cloud organizations are generally hosted at `<subdomain>.zulipchat.com`,
+with the subdomain chosen when the organization was created. Organization
+[owners](/help/roles-and-permissions) can request to change the subdomain.
+
+{start_tabs}
+
+Please e-mail [support@zulip.com](mailto:support@zulip.com) with the following
+information:
+
+1. Your organization's current subdomain.
+
+1. The subdomain you would like to move your organization to.
+
+{end_tabs}
+
+## Move to a custom URL on Zulip Cloud
+
+{!cloud-plus-only.md!}
+
+Because maintaining custom URLs requires effort from our operational team,
+this feature is available only for organizations with 25+ [Zulip Cloud
+Plus](https://zulip.com/plans/#cloud) licenses.
+
+{start_tabs}
+
+Please e-mail [support@zulip.com](mailto:support@zulip.com) with the following
+information:
+
+1. Your organization's current URL.
+
+1. The URL you would like to move your organization to.
+
+{end_tabs}
+
+## Change the URL for your self-hosted server
 
 If you're self-hosting, you can change the root domain of your Zulip
 server by changing the `EXTERNAL_HOST` [setting][zulip-settings].  If

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -995,11 +995,11 @@
             </tr>
             <tr>
                 <td class="comparison-table-feature">
-                    Custom domain
+                    <a href="/help/change-organization-url">Custom domain</a>
                 </td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
-                <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>
+                <td class="comparison-value-positive cloud-cell" data-title="{{ _('25 users minimum') }}"><i class="icon icon-check"></i></td>
 
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -126,7 +126,7 @@
                                 <li><span>All Standard plan features</span></li>
                                 <li><span><a href="/help/saml-authentication">SSO with SAML</a> (Okta, OneLogIn, etc.)</span></li>
                                 <li><span><a href="/help/scim">SCIM user sync</a></span></li>
-                                <li><span>Custom domain</span></li>
+                                <li><span><a href="/help/change-organization-url">Custom domain</a></span></li>
                                 <li><span>Limit user list access for <a href="/help/guest-users">guests</a></span></li>
                                 <li><span>Priority commercial support</span></li>
                             </ul>


### PR DESCRIPTION
Notes/questions:

- Is there any additional information that folks should provide when contacting support about changing the subdomain or full URL, or any additional steps they should take? @alexmv @mateuszmandera for your thoughts. In any case, this could potentially be expanded upon as a follow-up; these changes don't remove any information.
- I didn't audit the help article intro, or the contents of the self-hosted section.
- I played with including the license minimum in the Plus plan overview box at the top of /plans, but it didn't look good. I think it's OK to relegate the info to the help page + tooltip.

Current help page: https://zulip.com/help/change-organization-url
<details>
<summary>
Updated
</summary>

![Screenshot 2024-04-25 at 14 40 47](https://github.com/zulip/zulip/assets/2090066/957dfc67-7bc0-451d-9838-3ac821ecb566)

</details>


Current: https://zulip.com/plans/#cloud
<details>
<summary>
Updated parts
</summary>

![Screenshot 2024-04-25 at 14 18 08](https://github.com/zulip/zulip/assets/2090066/fae2037a-bbed-4b54-bb19-0e7d1523f143)


![Screenshot 2024-04-25 at 14 18 22](https://github.com/zulip/zulip/assets/2090066/003140ed-38b4-41e5-85dd-69a93149b831)

</details>