### PR TITLE
tooling: Make populate_db generate more production like data.

### DIFF
--- a/tools/rebuild-test-database
+++ b/tools/rebuild-test-database
@@ -33,7 +33,7 @@ create_zulip_test
 # This next line can be simplified to "-n0" once we fix our app (and tests) with 0 messages.
 ./manage.py populate_db --test-suite -n30 --threads=1 \
     --max-topics=3 \
-    --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0
+    --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0 --percent-attachments=0
 
 ./manage.py dumpdata \
     zerver.UserProfile zerver.Stream zerver.Recipient \


### PR DESCRIPTION
Fix remaining items in 
Add attachments in messages.



<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
