### PR TITLE
list_widget: Fix recent view "load more" fails to render.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -326,6 +326,9 @@ export function create<Key, Item = Key>(
             // Stop once the offset reaches the length of the original list.
             if (this.all_rendered()) {
                 render_empty_list_message_if_needed($container, meta.filter_value);
+                if (opts.callback_after_render) {
+                    opts.callback_after_render();
+                }
                 return;
             }
 


### PR DESCRIPTION
`callback_after_render` was not being called when `render` did an early return which caused "load more" to not be updated.

This is noticeable now since we are doing fewer calls to `process_messages` which also updates the `load more` banner.
