### PR TITLE
narrow: Adjust for moved message with canonical terms.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -226,14 +226,14 @@ export function activate(raw_terms, opts) {
         if (id_info.target_id && filter.has_operator("channel") && filter.has_operator("topic")) {
             const target_message = message_store.get(id_info.target_id);
 
-            function adjusted_terms_if_moved(terms, message) {
+            function adjusted_terms_if_moved(raw_terms, message) {
                 const adjusted_terms = [];
                 let terms_changed = false;
 
-                for (const term of terms) {
+                for (const term of raw_terms) {
                     const adjusted_term = {...term};
                     if (
-                        term.operator === "channel" &&
+                        Filter.canonicalize_operator(term.operator) === "channel" &&
                         !util.lower_same(term.operand, message.display_recipient)
                     ) {
                         adjusted_term.operand = message.display_recipient;
@@ -241,7 +241,7 @@ export function activate(raw_terms, opts) {
                     }
 
                     if (
-                        term.operator === "topic" &&
+                        Filter.canonicalize_operator(term.operator) === "topic" &&
                         !util.lower_same(term.operand, message.topic)
                     ) {
                         adjusted_term.operand = message.topic;
@@ -268,9 +268,9 @@ export function activate(raw_terms, opts) {
                 const narrow_stream_name = filter.operands("channel")[0];
                 const narrow_stream_data = stream_data.get_sub(narrow_stream_name);
                 if (!narrow_stream_data) {
-                    // The id of the target message is correct but the stream name is
-                    // incorrect in the URL. We reconstruct the narrow with the correct
-                    // stream name and narrow.
+                    // The stream name is invalid or incorrect in the URL.
+                    // We reconstruct the narrow with the data from the
+                    // target message ID that we have.
                     const adjusted_terms = adjusted_terms_if_moved(raw_terms, target_message);
 
                     if (adjusted_terms === null) {


### PR DESCRIPTION
In `narrow.activate`, the `adjusted_terms_if_moved` helper uses the raw terms from the URL for checking if a message was moved. If a non-canoncial operator was in the URL for a narrow (e.g. "subject" instead of "topic" and now "stream" instead of "channel"), then the view wasn't updated correctly.

Update `adjusted_terms_if_moved` to use the canonical version of the operator in the URL when adjusting the message history.


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
