### PR TITLE
dark_theme_css: Fix border color for tables in message/chat.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -339,6 +339,7 @@
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
 
     /* Markdown colors */
+    --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
 
     /* Markdown code colors */
@@ -687,6 +688,9 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+
+    /* Markdown color */
+    --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -691,6 +691,7 @@
 
     /* Markdown color */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
+    --color-border-rendered-markdown-table: hsl(0deg 0% 100% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -338,6 +338,9 @@
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
 
+    /* Markdown colors */
+    --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
+
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
     --color-markdown-code-background: hsl(0deg 0% 0% / 6%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -757,9 +757,7 @@
     #subscription_overlay .settings-radio-input-parent,
     #settings_page .sidebar-wrapper,
     #settings_page .sidebar-wrapper *,
-    table,
-    table th,
-    table td {
+    #recent_view_table table td {
         border-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -509,7 +509,6 @@
     }
 
     .new-style .tab-switcher .ind-tab.selected,
-    div.message_content thead,
     .table-striped thead th {
         background-color: hsl(0deg 0% 0% / 50%);
         border-color: hsl(0deg 0% 0% / 90%);
@@ -709,8 +708,7 @@
         background-color: hsl(228deg 11% 17%);
     }
 
-    & thead,
-    .drafts-container .drafts-header,
+    & .drafts-container .drafts-header,
     .nav > li > a:focus,
     .nav > li > a:hover,
     .subscriptions-container .subscriptions-header,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -117,7 +117,7 @@
     }
 
     & thead {
-        background-color: hsl(0deg 0% 93%);
+        background-color: var(--color-background-rendered-markdown-thead);
     }
 
     & tr {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -126,13 +126,13 @@
     }
 
     & tr th {
-        border: 1px solid hsl(0deg 0% 80%);
+        border: 1px solid var(--color-border-rendered-markdown-table);
         padding: 4px;
         text-align: left;
     }
 
     & tr td {
-        border: 1px solid hsl(0deg 0% 80%);
+        border: 1px solid var(--color-border-rendered-markdown-table);
         padding: 4px;
     }
 


### PR DESCRIPTION
### :bookmark_tabs: Overview 


<details>

<summary>

Currently, there's a block of css rule that sets a group of elements to have a dark border color in `dark_theme.css` :
</summary>

![image](https://github.com/zulip/zulip/assets/108744694/1593360f-f90c-4472-b1d9-d730ec4a0d9e)


</details>

This PR adds a new rule that overrides that specific css rule. This new rule specifically targets tables inside message/ chat and set a brighter color border for them.

Fixes zulip#29856
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/table's.20border.20color.20is.20still.20black.20in.20darkmode)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
> _last updated: **2 May 2024**_

The new dark mode table is under these new effect(s): `opacity: 0.2`
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/zulip/zulip/assets/108744694/b8debaba-c3fa-4392-8371-f0170fe79738) | ![image](https://github.com/zulip/zulip/assets/108744694/6601a66b-16a1-4f86-bdc6-c8579905846f)|

<details>

<summary>

#### **On different elements:**
</summary>

> _last updated: **2 May 2024**_

_in draft:_
![image](https://github.com/zulip/zulip/assets/108744694/d6328c2c-a62c-411b-a87a-c67d3be4b35c)

_in preview:_
![image](https://github.com/zulip/zulip/assets/108744694/e93dea2a-44b4-41b1-b9e6-b7095949c5ae)


_inside spoiler:_
![image](https://github.com/zulip/zulip/assets/108744694/b1bee633-29d2-46e4-99b3-05d7d1123e12)

</details>

<details>

<summary>

#### Markdown table css in light mode is still preserved:
</summary>

> _last updated: **2 May 2024**_

_in channel, sent:_
![image](https://github.com/zulip/zulip/assets/108744694/f9ebfb05-583c-4f30-bd2d-1dcded105b63)

_in draft:_
![image](https://github.com/zulip/zulip/assets/108744694/cbbc4f1a-94b4-4eaa-becc-1f058aeeae0e)

_in preview:_
![image](https://github.com/zulip/zulip/assets/108744694/4e251d83-9531-43bc-b3c1-5f3431c90754)

</details>

### :factory_worker:  Concerns & Issue Encountered

<details>

<summary>

#### The thead background color for markdown table in preview are different from the ones rendered in channel or in draft menu.
</summary>
I've highlighted where is the css rule that causes this in one of my comment. In one of my prep commit I've also added a change to make all thead background color consistent at all place. Let me know if this isn't needed or should be moved into a different commit.

_different thead background color:_
![image](https://github.com/zulip/zulip/assets/108744694/37325dc8-b0d7-4349-aa51-456f32db4348)

_in this PR, all thead background color are the same:_
![image](https://github.com/zulip/zulip/assets/108744694/28157a8c-adfb-4d6f-873c-04c31c749574)

_if the background color from the preview table is used instead:_
![image](https://github.com/zulip/zulip/assets/108744694/878f6fb4-0bc4-41d7-930f-a0fef0051698)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
