### PR TITLE
narrow: Update hash for moved message even if hash change in progress.

### DIFF
--- a/web/src/reload_setup.js
+++ b/web/src/reload_setup.js
@@ -15,6 +15,7 @@ export function initialize() {
         return;
     }
     const hash_fragment = location.hash.slice("#".length);
+    const trigger = "reload";
 
     // Using the token, recover the saved pre-reload data from local
     // storage.  Afterwards, we clear the reload entry from local
@@ -27,7 +28,7 @@ export function initialize() {
         // exist, but be log it so that it's available for future
         // debugging if an exception happens later.
         blueslip.info("Invalid hash change reload token");
-        narrow.changehash("");
+        narrow.changehash("", trigger);
         return;
     }
     ls.remove(hash_fragment);
@@ -82,5 +83,5 @@ export function initialize() {
     });
 
     activity.set_new_user_input(false);
-    narrow.changehash(vars.oldhash);
+    narrow.changehash(vars.oldhash, trigger);
 }


### PR DESCRIPTION
Adds a new trigger string to use for `narrow.activate` opts when it is called due detecting a message move for the targeted message ID: "retarget message location".

Updates `narrow.save_narrow` and `narrow.hashchange` to accept the `opts.trigger` as a parameter so that, even if the narrow was started via a hash change in the web app, the URL and browser history is updated for the current location of the targeted message.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
