### PR TITLE
info_density: Express Markdown and message-box spacing as CSS variables.

### DIFF
--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -6,9 +6,20 @@ export function set_base_typography_css_variables(): void {
     const font_size_px = user_settings.web_font_size_px;
     const line_height_percent = user_settings.web_line_height_percent;
     const line_height_unitless = line_height_percent / 100;
+    const line_height_px = line_height_unitless * font_size_px;
+    /* This percentage is a legacy value, rounding up from .294;
+       additional logic might be useful to make this adjustable;
+       likewise with the doubled value. */
+    const markdown_interelement_space_fraction = 0.3;
+    const markdown_interelement_space_px = line_height_px * markdown_interelement_space_fraction;
 
     $(":root").css("--base-line-height-unitless", line_height_unitless);
     $(":root").css("--base-font-size-px", `${font_size_px}px`);
+    $(":root").css("--markdown-interelement-space-px", `${markdown_interelement_space_px}px`);
+    $(":root").css(
+        "--markdown-interelement-doubled-space-px",
+        `${markdown_interelement_space_px * 2}px`,
+    );
 }
 
 export function initialize(): void {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -65,11 +65,17 @@
     /* The legacy values here are updated via JavaScript */
     --base-font-size-px: 14px;
     --base-line-height-unitless: 1.214;
+    --markdown-interelement-space-px: 5px;
+    --markdown-interelement-doubled-space-px: calc(
+        var(--markdown-interelement-space-px) * 2
+    );
 
     .more-dense-mode {
         /* The legacy values here are not altered by JavaScript */
         --base-font-size-px: 14px;
         --base-line-height-unitless: 1.214;
+        --markdown-interelement-space-px: 5px;
+        --markdown-interelement-doubled-space-px: 10px;
     }
 
     /*

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -76,6 +76,7 @@
         --base-line-height-unitless: 1.214;
         --markdown-interelement-space-px: 5px;
         --markdown-interelement-doubled-space-px: 10px;
+        --message-box-markdown-aligned-vertical-space: 5px;
     }
 
     /*
@@ -87,6 +88,9 @@
     /* 6px appears to provide 5px of space between the avatar
        and the selected-message outline, which is offset by -1px. */
     --message-box-vertical-margin: 6px;
+    --message-box-markdown-aligned-vertical-space: var(
+        --markdown-interelement-space-px
+    );
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;
     /* The line-height on the sender line should coordinate with the

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -198,10 +198,10 @@
         .message_content {
             grid-area: message;
             /*
-            Space between two single line messages is 10px, which is maintained
-            by setting 5px of padding above messages without a sender.
+            Space between two single line messages is kept in
+            lockstep with adjacent Markdown elements.
             */
-            padding: 5px 0 0;
+            padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
             color: var(--color-text-message-default);
             font-size: var(--base-font-size-px);
             line-height: var(--base-line-height-unitless);
@@ -321,9 +321,10 @@
                        me-messages. */
                     line-height: var(--base-line-height-unitless);
                     /* Ensure the same spacing below messages as for any other
-                       paragraph.
-                       TODO: Coordinate this with other info-density variables. */
-                    padding-bottom: 5px;
+                       paragraph. */
+                    padding-bottom: var(
+                        --message-box-markdown-aligned-vertical-space
+                    );
 
                     /* Display message components inline, with wrapping white-space,
                        so the sender name and message display as a continuous line

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1,17 +1,17 @@
 .rendered_markdown {
     & p {
-        margin: 0 0 5px;
+        margin: 0 0 var(--markdown-interelement-space-px);
     }
 
-    /* The spacing between two paragraphs is significantly larger.  We
-       arrange things so that this spacing matches the spacing between
-       paragraphs in two consecutive 1-line messages. */
+    /* The spacing between two paragraphs is double the usual value.
+       We coordinate this spacing matches so that it matches the
+       spacing between paragraphs in two consecutive 1-line messages. */
     & p + p {
-        margin-top: 10px;
+        margin-top: var(--markdown-interelement-doubled-space-px);
     }
 
     & ul {
-        margin: 0 0 5px 20px;
+        margin: 0 0 var(--markdown-interelement-space-px) 20px;
     }
 
     /* Swap the left and right margins of bullets for Right-To-Left languages */
@@ -21,7 +21,7 @@
     }
 
     & ol {
-        margin: 0 0 5px 20px;
+        margin: 0 0 var(--markdown-interelement-space-px) 20px;
     }
 
     /* Swap the left and right margins of ordered list for Right-To-Left languages */
@@ -48,7 +48,7 @@
            space they require, but are zeroed out below when they open
            a message. */
         margin-top: 15px;
-        margin-bottom: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
     }
 
     /* Headings: Ensure that messages that start with a heading don't have
@@ -91,7 +91,7 @@
     /* Formatting for blockquotes */
     & blockquote {
         padding-left: 5px;
-        margin: 0 0 5px 10px;
+        margin: 0 0 var(--markdown-interelement-space-px) 10px;
         border-left: 5px solid hsl(0deg 0% 87%);
     }
 
@@ -107,7 +107,7 @@
     /* Formatting for Markdown tables */
     & table {
         padding-right: 10px;
-        margin: 0 5px 5px;
+        margin: 0 5px var(--markdown-interelement-space-px);
         width: 99%;
         display: block;
         max-width: fit-content;
@@ -237,7 +237,7 @@
         border-radius: 10px;
         /* Space any subsequent Markdown content the same
            distance as adjacent paragraphs are spaced. */
-        margin: 0 0 10px;
+        margin: 0 0 var(--markdown-interelement-doubled-space-px);
 
         .spoiler-header {
             /* We use flexbox to display the spoiler message
@@ -335,7 +335,7 @@
         /* A spoiler block at the end of a message, or as
            a message's only content, gets the same bottom
            margin as other elements. */
-        margin-bottom: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
     }
 
     /* embedded link previews */
@@ -346,7 +346,7 @@
     .twitter-image,
     .message_inline_image {
         position: relative;
-        margin-bottom: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
         margin-right: 5px;
 
         /* Sizing CSS for inline images requires care, because images load
@@ -482,7 +482,7 @@
     }
 
     .message_inline_ref {
-        margin-bottom: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
         margin-left: 5px;
         height: 50px;
         display: block !important;
@@ -584,7 +584,7 @@
     .message_embed {
         display: block;
         position: relative;
-        margin: 0 0 5px;
+        margin: 0 0 var(--markdown-interelement-space-px);
         border: none;
         border-left: 3px solid hsl(0deg 0% 93%);
         height: 80px;
@@ -687,7 +687,7 @@
         overflow-x: auto;
         word-break: break-all;
         word-wrap: normal;
-        margin: 0 0 5px;
+        margin: 0 0 var(--markdown-interelement-space-px);
         padding: 5px 7px 3px;
         display: block;
         border-radius: 4px;

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -1,7 +1,5 @@
 .widget-content {
-    /* TODO: Coordinate this value with other Markdown
-       element spacing, as a variable. */
-    margin-bottom: 5px;
+    margin-bottom: var(--markdown-interelement-space-px);
 }
 
 .widget-choices {


### PR DESCRIPTION
This PR introduces variables for the 5px and 10px inter-element spacing variables found in the Markdown area. It preserves the legacy values inside `.more-dense-mode`, and calculates the database-stored values outside of that.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/rendered.20Markdown.20CSS.20adjustments/near/1788573)

**Screenshots and screen captures:**

| Before | After, legacy vars (no change) | After, db vars |
| --- | --- | --- |
| ![single-line-markdown-main](https://github.com/zulip/zulip/assets/170719/e7bd778e-4ecf-4f47-b1e7-d34765c2abb0) | ![single-line-markdown-legacy-vars](https://github.com/zulip/zulip/assets/170719/6dc8c66e-876a-4e03-884e-a05afa0eb36a) | ![single-line-markdown-legacy-db-vars](https://github.com/zulip/zulip/assets/170719/5f081ded-9c1c-44d1-83f9-8f4709fb1303) |
| ![markdown-widget-main](https://github.com/zulip/zulip/assets/170719/65fa5705-9158-493b-a872-4e43db7a132b) | ![markdown-widget-legacy-vars](https://github.com/zulip/zulip/assets/170719/eb4c7f06-6ed6-4599-bfa3-8c910e7852de) | ![markdown-widget-db-vars](https://github.com/zulip/zulip/assets/170719/67ed9955-573b-4871-b11f-116b47fcf0e8) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
