### PR TITLE
fenced_code.py: Implement error logging for hiliter.

### DIFF
--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -76,6 +76,7 @@ Dependencies:
 
 """
 
+import logging
 import re
 from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence
 
@@ -491,7 +492,11 @@ class FencedBlockPreprocessor(Preprocessor):
                 startinline=True,
             )
 
-            code = highliter.hilite().rstrip("\n")
+            try:
+                code = highliter.hilite().rstrip("\n")
+            except Exception as e:
+                logging.error("Processing fenced code block with lang %s", e)
+                code = CODE_WRAP.format(langclass, self._escape(text))
         else:
             code = CODE_WRAP.format(langclass, self._escape(text))
 


### PR DESCRIPTION
Instead of returning error 400 when pygment library fails to parse we log the error and keep going

Fixes #22287

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

