### PR TITLE
Add xonsh language for code block

### DIFF
--- a/tools/setup/lang.json
+++ b/tools/setup/lang.json
@@ -39,6 +39,7 @@
         "csharp": 17,
         "cpp": 14,
         "tex": 10,
-        "vbnet": 9
+        "vbnet": 9,
+        "xonsh": 26
     }
 }


### PR DESCRIPTION
Hey!
The [xonsh shell](https://xon.sh/) core developers and community are going to Zulip - https://xonsh.zulipchat.com/.
It will be cool to have xonsh language for code blocks. At least like a "python3" syntax clone.
Thanks!

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**