### PR TITLE
Misc bug fixes related to restoring narrow state.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -87,6 +87,8 @@ export function by_stream_topic_url(stream_id: number, topic: string): string {
 // corresponding hash: the # component
 // of the narrow URL
 export function search_terms_to_hash(terms?: NarrowTerm[]): string {
+    // Note: This does not return the correct hash for combined feed, recent and inbox view.
+    // These views can have multiple hashes that lead to them, so this function cannot support them.
     let hash = "#";
 
     if (terms !== undefined) {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -156,7 +156,7 @@ export function search_public_streams_notice_url(terms: NarrowTerm[]): string {
     return search_terms_to_hash([public_operator, ...terms]);
 }
 
-export function parse_narrow(hash: string): NarrowTerm[] | undefined {
+export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
     // This will throw an exception when passed an invalid hash
     // at the decodeHashComponent call, handle appropriately.
     let i;

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -60,6 +60,8 @@ function show_all_message_view() {
     narrow.activate([{operator: "in", operand: "home"}], {
         trigger: "hashchange",
         change_hash: false,
+        then_select_id: history.state?.narrow_pointer,
+        then_select_offset: history.state?.narrow_offset,
     });
 }
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -72,7 +72,7 @@ function is_somebody_else_profile_open() {
     );
 }
 
-export function set_hash_to_home_view() {
+export function set_hash_to_home_view(triggered_by_escape_key = false) {
     let home_view_hash = `#${user_settings.web_home_view}`;
     if (home_view_hash === "#recent_topics") {
         home_view_hash = "#recent";
@@ -83,6 +83,20 @@ export function set_hash_to_home_view() {
     }
 
     if (window.location.hash !== home_view_hash) {
+        const hash_before_current = browser_history.old_hash();
+        if (
+            triggered_by_escape_key &&
+            home_view_hash === "#feed" &&
+            (hash_before_current === "" || hash_before_current === "#feed")
+        ) {
+            // If the previous view was the user's Combined Feed home
+            // view, and this change was triggered by escape keypress,
+            // then we simulate the back button in order to reuse
+            // existing code for restoring the user's scroll position.
+            window.history.back();
+            return;
+        }
+
         // We want to set URL with no hash here. It is not possible
         // to do so with `window.location.hash` since it will set an empty
         // hash. So, we use `pushState` which simply updates the current URL

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -385,7 +385,8 @@ export function process_escape_key(e) {
     /* The Ctrl+[ hotkey navigates to the home view
      * unconditionally; Esc's behavior depends on a setting. */
     if (user_settings.web_escape_navigates_to_home_view || e.which === 219) {
-        hashchange.set_hash_to_home_view();
+        const triggered_by_escape_key = true;
+        hashchange.set_hash_to_home_view(triggered_by_escape_key);
         return true;
     }
 

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -82,6 +82,10 @@ export class MessageList {
         return this;
     }
 
+    is_current_message_list() {
+        return this.view.is_current_message_list();
+    }
+
     prevent_reading() {
         this.reading_prevented = true;
     }
@@ -117,14 +121,14 @@ export class MessageList {
             render_info = this.append_to_view(bottom_messages, opts);
         }
 
-        if (!this.visibly_empty()) {
+        if (!this.visibly_empty() && this.is_current_message_list()) {
             // If adding some new messages to the message tables caused
             // our current narrow to no longer be empty, hide the empty
             // feed placeholder text.
             narrow_banner.hide_empty_narrow_message();
         }
 
-        if (!this.visibly_empty() && this.selected_id() === -1) {
+        if (!this.visibly_empty() && this.selected_id() === -1 && this.is_current_message_list()) {
             // The message list was previously empty, but now isn't
             // due to adding these messages, and we need to select a
             // message. Regardless of whether the messages are new or

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -380,6 +380,10 @@ export class MessageListView {
         message_container.modified = true;
     }
 
+    is_current_message_list() {
+        return this.list === message_lists.current;
+    }
+
     set_calculated_message_container_variables(message_container, is_revealed) {
         set_timestr(message_container);
 

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -1,6 +1,5 @@
 import $ from "jquery";
 
-import * as blueslip from "./blueslip";
 import * as inbox_util from "./inbox_util";
 import type {MessageListData} from "./message_list_data";
 import type {Message} from "./message_store";
@@ -39,7 +38,6 @@ export type MessageList = {
     selected_idx: () => number;
     all_messages: () => Message[];
     get: (id: number) => Message | undefined;
-    pre_narrow_offset?: number;
     can_mark_messages_read_without_setting: () => boolean;
     rerender_view: () => void;
     resume_reading: () => void;
@@ -107,31 +105,6 @@ export function update_recipient_bar_background_color(): void {
         msg_list.view.update_recipient_bar_background_color();
     }
     inbox_util.update_stream_colors();
-}
-
-export function save_pre_narrow_offset_for_reload(): void {
-    // Only save the pre_narrow_offset if the message list will be cached if user
-    // switches to a different narrow, otherwise the pre_narrow_offset would just be lost when
-    // user switches to a different narrow. In case of a reload, offset for the current
-    // message is captured and restored by `reload` library.
-    if (!current?.preserve_rendered_state) {
-        return;
-    }
-
-    if (current.selected_id() !== -1) {
-        if (current.selected_row().length === 0) {
-            const current_message = current.get(current.selected_id());
-            blueslip.debug("narrow.activate missing selected row", {
-                selected_id: current.selected_id(),
-                selected_idx: current.selected_idx(),
-                selected_idx_exact:
-                    current_message && current.all_messages().indexOf(current_message),
-                render_start: current.view._render_win_start,
-                render_end: current.view._render_win_end,
-            });
-        }
-        current.pre_narrow_offset = current.selected_row().get_offset_to_window().top;
-    }
 }
 
 export function calculate_timestamp_widths(): void {

--- a/web/src/narrow_history.ts
+++ b/web/src/narrow_history.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
-import * as hash_util from "./hash_util";
+import * as browser_history from "./browser_history";
 import * as message_lists from "./message_lists";
 import * as narrow_state from "./narrow_state";
 
@@ -17,7 +17,7 @@ function _save_narrow_state(): void {
     assert(message_lists.current !== undefined);
     // We don't want to save state in the middle of a narrow change
     // to the wrong hash.
-    if (hash_util.search_terms_to_hash(current_filter.terms()) !== window.location.hash) {
+    if (browser_history.state.changing_hash) {
         return;
     }
 

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -25,12 +25,6 @@ import * as util from "./util";
 // See https://zulip.readthedocs.io/en/latest/subsystems/pointer.html
 // for more details on how this system is designed.
 
-export let messages_read_in_narrow = false;
-
-export function set_messages_read_in_narrow(value: boolean): void {
-    messages_read_in_narrow = value;
-}
-
 export let old_unreads_missing = false;
 
 export function clear_old_unreads_missing(): void {

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -311,11 +311,6 @@ export function process_read_messages_event(message_ids) {
     if (message_ids.length === 0) {
         return;
     }
-    if (message_lists.current?.narrowed) {
-        // I'm not sure this entirely makes sense for all server
-        // notifications.
-        unread.set_messages_read_in_narrow(true);
-    }
 
     for (const message_id of message_ids) {
         unread.mark_as_read(message_id);
@@ -338,10 +333,6 @@ export function process_unread_messages_event({message_ids, message_details}) {
     message_ids = unread.get_read_message_ids(message_ids);
     if (message_ids.length === 0) {
         return;
-    }
-
-    if (message_lists.current?.narrowed) {
-        unread.set_messages_read_in_narrow(false);
     }
 
     for (const message_id of message_ids) {
@@ -419,10 +410,6 @@ export function notify_server_messages_read(messages, options = {}) {
     }
 
     message_flags.send_read(messages);
-
-    if (message_lists.current?.narrowed) {
-        unread.set_messages_read_in_narrow(true);
-    }
 
     for (const message of messages) {
         unread.mark_as_read(message.id);

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -72,8 +72,6 @@ export function show(opts: {
     complete_rerender: () => void;
     is_recent_view?: boolean;
 }): void {
-    message_lists.save_pre_narrow_offset_for_reload();
-
     if (opts.is_visible()) {
         // If we're already visible, E.g. because the user hit Esc
         // while already in the view, do nothing.

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -15,6 +15,7 @@ function MessageListView() {
         maybe_rerender: noop,
         append: noop,
         prepend: noop,
+        is_current_message_list: () => true,
     };
 }
 mock_esm("../src/message_list_view", {

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -33,6 +33,7 @@ function MessageListView() {
         append: noop,
         prepend: noop,
         clear_rendering_state: noop,
+        is_current_message_list: () => true,
     };
 }
 mock_esm("../src/message_list_view", {

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -103,7 +103,6 @@ function test_helper({override}) {
     stub(narrow_history, "save_narrow_state_and_flush");
     stub(message_feed_loading, "hide_indicators");
     stub(message_feed_top_notices, "hide_top_of_narrow_notices");
-    stub(message_lists, "save_pre_narrow_offset_for_reload");
     stub(narrow_title, "update_narrow_title");
     stub(stream_list, "handle_narrow_activated");
     stub(message_view_header, "render_title_area");
@@ -225,7 +224,6 @@ run_test("basics", ({override}) => {
         [message_feed_top_notices, "hide_top_of_narrow_notices"],
         [message_feed_loading, "hide_indicators"],
         [compose_banner, "clear_message_sent_banners"],
-        [message_lists, "save_pre_narrow_offset_for_reload"],
         [compose_actions, "on_narrow"],
         [unread_ops, "process_visible"],
         [narrow_history, "save_narrow_state_and_flush"],


### PR DESCRIPTION
This effectively makes the narrow pointer and offset restoration behaviour for combined feed view same as other narrows which is to only restore narrow state when using browser back button.

See https://github.com/zulip/zulip/pull/29740#discussion_r1579784395 