### PR TITLE
topic_popover: Remove additional separators in spectator mode.

### DIFF
--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -8,9 +8,9 @@
                 </li>
             </ul>
         </li>
-        <li class="popover-menu-outer-list-item">
+        <li class="popover-menu-outer-list-item hidden-for-spectators">
             <ul class="popover-menu-inner-list">
-                <li class="popover-menu-inner-list-item hidden-for-spectators">
+                <li class="popover-menu-inner-list-item">
                     <div class="tabs-container">
                         <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
                             <i class="zulip-icon zulip-icon-mute-new"></i>


### PR DESCRIPTION
In spectator mode, the separators encapsulating the topic visibility switcher wasn't being hidden since the `hidden-for-spectators` class was being applied only to the `popover-menu-inner-list-item` element.

This removes the additional separators by shifting the `hidden-for-spectators` class to the `popover-menu-outer-list-item` element instead, which is responsible for showing the separators.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/pull/29785#issuecomment-2079809519 / [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20stream.2Ftopic.20actions.20menu.20popover.20.2329785/near/1789000)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/82862779/f31bed5a-99ca-4753-973e-3992f61b3cde) |  ![image](https://github.com/zulip/zulip/assets/82862779/08f464c1-015e-4f9b-917a-4949f51e3b4e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
