### PR TITLE
hashchange: Select the new near id if it is already rendered.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -726,6 +726,28 @@ export class Filter {
         return true;
     }
 
+    equals(filter: Filter, excluded_operators?: string[]): boolean {
+        return _.isEqual(
+            filter.sorted_terms(excluded_operators),
+            this.sorted_terms(excluded_operators),
+        );
+    }
+
+    sorted_terms(excluded_operators?: string[]): NarrowTerm[] {
+        let filter_terms = this._terms;
+        if (excluded_operators) {
+            filter_terms = this._terms.filter(
+                (term) => !excluded_operators.includes(term.operator),
+            );
+        }
+
+        return filter_terms.sort((a, b) => {
+            const a_joined = `${a.negated ? "0" : "1"}-${a.operator}-${a.operand}`;
+            const b_joined = `${b.negated ? "0" : "1"}-${b.operator}-${b.operand}`;
+            return util.strcmp(a_joined, b_joined);
+        });
+    }
+
     predicate(): (message: Message) => boolean {
         if (this._predicate === undefined) {
             this._predicate = this._build_predicate();

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2165,3 +2165,42 @@ run_test("is_in_home", () => {
     ]);
     assert.ok(!filter3.is_in_home());
 });
+
+run_test("equals", () => {
+    let terms = [{operator: "channel", operand: "Foo"}];
+    let filter = new Filter(terms);
+
+    assert.ok(filter.equals(new Filter(terms)));
+    assert.ok(!filter.equals(new Filter([])));
+    assert.ok(!filter.equals(new Filter([{operand: "Bar", operator: "channel"}])));
+    assert.ok(!filter.equals(new Filter([...terms, {operator: "topic", operand: "Bar"}])));
+
+    terms = [
+        {operator: "channel", operand: "Foo"},
+        {operator: "topic", operand: "Bar"},
+    ];
+    filter = new Filter(terms);
+    assert.ok(
+        filter.equals(
+            new Filter([
+                {operator: "topic", operand: "Bar"},
+                {operator: "channel", operand: "Foo"},
+            ]),
+        ),
+    );
+    assert.ok(!filter.equals(new Filter([...terms, {operator: "near", operand: "10"}])));
+
+    // Exclude `near` operator from comparison.
+    assert.ok(filter.equals(new Filter([...terms, {operator: "near", operand: "10"}]), ["near"]));
+    assert.ok(
+        filter.equals(
+            new Filter([
+                {operator: "near", operand: "10"},
+                {operator: "topic", operand: "Bar"},
+                {operator: "channel", operand: "Foo"},
+                {operator: "near", operand: "101"},
+            ]),
+            ["near"],
+        ),
+    );
+});


### PR DESCRIPTION
If in the same narrow, we just want to select a new id which is already rendered, we don't need to call `narrow.activate`, we can just select the new id.
