### PR TITLE
Prep commits to removing discount percentage.

### DIFF
--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -103,18 +103,13 @@
         </form>
         {% endif %}
 
-        <form method="POST" class="support-discount-form support-form">
-            <b>Discount (use 85 for nonprofits)</b>:<br />
-            {{ csrf_input }}
-            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-            {% if realm_support_data[realm.id].plan_data.current_plan and realm_support_data[realm.id].plan_data.current_plan.fixed_price %}
-            <input type="number" name="discount" value="{{ format_discount(realm_support_data[realm.id].sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
-            <button type="submit" class="support-submit-button" disabled>Update</button>
-            {% else %}
-            <input type="number" name="discount" value="{{ format_discount(realm_support_data[realm.id].sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" required />
-            <button type="submit" class="support-submit-button">Update</button>
-            {% endif %}
-        </form>
+        {% with %}
+            {% set sponsorship_data = realm_support_data[realm.id].sponsorship_data %}
+            {% set PLAN_TYPES = REALM_PLAN_TYPES_FOR_DISCOUNT %}
+            {% set remote_id = realm.id %}
+            {% set remote_type = "realm_id" %}
+            {% include 'corporate/support/sponsorship_discount_forms.html' %}
+        {% endwith %}
 
         {% if realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}
             {% with %}

--- a/templates/corporate/support/sponsorship_discount_forms.html
+++ b/templates/corporate/support/sponsorship_discount_forms.html
@@ -1,0 +1,48 @@
+<form method="POST" class="remote-form">
+    <b>Required plan tier for discounts and fixed prices</b>:<br />
+    <i>Updates will not change any pre-existing plans or scheduled upgrades.</i><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <select name="required_plan_tier">
+        {% for plan_tier in REMOTE_PLAN_TIERS %}
+            {% if sponsorship_data.required_plan_tier == plan_tier.value %}
+                <option value="{{ plan_tier.value }}" selected>{{ plan_tier.name }}</option>
+            {% else %}
+                <option value="{{ plan_tier.value }}">{{ plan_tier.name }}</option>
+            {% endif %}
+        {% endfor %}
+    </select>
+    <button type="submit" class="support-submit-button">Update</button>
+</form>
+
+<form method="POST" class="remote-form">
+    <b>Discount percentage</b>:<br />
+    <i>Needs required plan tier to be set.</i><br />
+    <i>Updates will change pre-existing plans and scheduled upgrades.</i><br />
+    <i>Any prorated licenses for the current billing cycle will be billed at the updated discounted rate.</i><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    {% if has_fixed_price %}
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
+    <button type="submit" class="support-submit-button" disabled>Update</button>
+    {% else %}
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99"
+      {% if sponsorship_data.required_plan_tier %}
+      required
+      {% else %}
+      disabled
+      {% endif %}
+      />
+    <button type="submit" class="support-submit-button">Update</button>
+    {% endif %}
+</form>
+
+{% if not has_fixed_price and (sponsorship_data.default_discount or sponsorship_data.minimum_licenses) %}
+<form method="POST" class="remote-form">
+    <b>Minimum licenses</b>:<br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <input type="number" name="minimum_licenses" value="{{ sponsorship_data.minimum_licenses }}" required />
+    <button type="submit" class="support-submit-button">Update</button>
+</form>
+{% endif %}

--- a/templates/corporate/support/sponsorship_discount_forms.html
+++ b/templates/corporate/support/sponsorship_discount_forms.html
@@ -4,7 +4,7 @@
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <select name="required_plan_tier">
-        {% for plan_tier in REMOTE_PLAN_TIERS %}
+        {% for plan_tier in PLAN_TYPES %}
             {% if sponsorship_data.required_plan_tier == plan_tier.value %}
                 <option value="{{ plan_tier.value }}" selected>{{ plan_tier.name }}</option>
             {% else %}

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -21,31 +21,6 @@
 {% endif %}
 
 <form method="POST" class="remote-form">
-    <b>Discount percentage</b>:<br />
-    <i>Updates will change pre-existing plans and scheduled upgrades.</i><br />
-    <i>Any prorated licenses for the current billing cycle will be billed at the updated discounted rate.</i><br />
-    {{ csrf_input }}
-    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    {% if has_fixed_price %}
-    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
-    <button type="submit" class="support-submit-button" disabled>Update</button>
-    {% else %}
-    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" required />
-    <button type="submit" class="support-submit-button">Update</button>
-    {% endif %}
-</form>
-
-{% if not has_fixed_price and (sponsorship_data.default_discount or sponsorship_data.minimum_licenses) %}
-<form method="POST" class="remote-form">
-    <b>Minimum licenses</b>:<br />
-    {{ csrf_input }}
-    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    <input type="number" name="minimum_licenses" value="{{ sponsorship_data.minimum_licenses }}" required />
-    <button type="submit" class="support-submit-button">Update</button>
-</form>
-{% endif %}
-
-<form method="POST" class="remote-form">
     <b>Required plan tier for discounts and fixed prices</b>:<br />
     <i>Updates will not change any pre-existing plans or scheduled upgrades.</i><br />
     {{ csrf_input }}
@@ -61,6 +36,38 @@
     </select>
     <button type="submit" class="support-submit-button">Update</button>
 </form>
+
+<form method="POST" class="remote-form">
+    <b>Discount percentage</b>:<br />
+    <i>Needs required plan tier to be set.</i><br />
+    <i>Updates will change pre-existing plans and scheduled upgrades.</i><br />
+    <i>Any prorated licenses for the current billing cycle will be billed at the updated discounted rate.</i><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    {% if has_fixed_price %}
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
+    <button type="submit" class="support-submit-button" disabled>Update</button>
+    {% else %}
+    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99"
+      {% if sponsorship_data.required_plan_tier %}
+      required
+      {% else %}
+      disabled
+      {% endif %}
+      />
+    <button type="submit" class="support-submit-button">Update</button>
+    {% endif %}
+</form>
+
+{% if not has_fixed_price and (sponsorship_data.default_discount or sponsorship_data.minimum_licenses) %}
+<form method="POST" class="remote-form">
+    <b>Minimum licenses</b>:<br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <input type="number" name="minimum_licenses" value="{{ sponsorship_data.minimum_licenses }}" required />
+    <button type="submit" class="support-submit-button">Update</button>
+</form>
+{% endif %}
 
 {% if sponsorship_data.sponsorship_pending %}
     {% with %}

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -20,7 +20,10 @@
 </form>
 {% endif %}
 
-{% include 'corporate/support/sponsorship_discount_forms.html' %}
+{% with %}
+    {% set PLAN_TYPES = REMOTE_PLAN_TIERS %}
+    {% include 'corporate/support/sponsorship_discount_forms.html' %}
+{% endwith %}
 
 {% if sponsorship_data.sponsorship_pending %}
     {% with %}

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -20,54 +20,7 @@
 </form>
 {% endif %}
 
-<form method="POST" class="remote-form">
-    <b>Required plan tier for discounts and fixed prices</b>:<br />
-    <i>Updates will not change any pre-existing plans or scheduled upgrades.</i><br />
-    {{ csrf_input }}
-    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    <select name="required_plan_tier">
-        {% for plan_tier in REMOTE_PLAN_TIERS %}
-            {% if sponsorship_data.required_plan_tier == plan_tier.value %}
-                <option value="{{ plan_tier.value }}" selected>{{ plan_tier.name }}</option>
-            {% else %}
-                <option value="{{ plan_tier.value }}">{{ plan_tier.name }}</option>
-            {% endif %}
-        {% endfor %}
-    </select>
-    <button type="submit" class="support-submit-button">Update</button>
-</form>
-
-<form method="POST" class="remote-form">
-    <b>Discount percentage</b>:<br />
-    <i>Needs required plan tier to be set.</i><br />
-    <i>Updates will change pre-existing plans and scheduled upgrades.</i><br />
-    <i>Any prorated licenses for the current billing cycle will be billed at the updated discounted rate.</i><br />
-    {{ csrf_input }}
-    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    {% if has_fixed_price %}
-    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99" disabled />
-    <button type="submit" class="support-submit-button" disabled>Update</button>
-    {% else %}
-    <input type="number" name="discount" value="{{ format_discount(sponsorship_data.default_discount) }}" step="0.01" min="0" max="99.99"
-      {% if sponsorship_data.required_plan_tier %}
-      required
-      {% else %}
-      disabled
-      {% endif %}
-      />
-    <button type="submit" class="support-submit-button">Update</button>
-    {% endif %}
-</form>
-
-{% if not has_fixed_price and (sponsorship_data.default_discount or sponsorship_data.minimum_licenses) %}
-<form method="POST" class="remote-form">
-    <b>Minimum licenses</b>:<br />
-    {{ csrf_input }}
-    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
-    <input type="number" name="minimum_licenses" value="{{ sponsorship_data.minimum_licenses }}" required />
-    <button type="submit" class="support-submit-button">Update</button>
-</form>
-{% endif %}
+{% include 'corporate/support/sponsorship_discount_forms.html' %}
 
 {% if sponsorship_data.sponsorship_pending %}
     {% with %}


### PR DESCRIPTION
This PR just adds required plan tier field to clould support page and make the field required for setting discount.


Disabled until a required plan tier is set.
<img width="525" alt="Screenshot 2024-04-29 at 5 12 24 PM" src="https://github.com/zulip/zulip/assets/25124304/c2818ad2-3aa0-432c-8a47-92152a3badb5">

<img width="835" alt="Screenshot 2024-04-29 at 5 12 01 PM" src="https://github.com/zulip/zulip/assets/25124304/df9ec2c2-de8a-4b30-891e-9923fecfde9b">