### PR TITLE
Use tippy to position typeaheads

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -46,7 +46,11 @@ async function create_stream_message_draft(page: Page): Promise<void> {
 async function test_restore_stream_message_draft_by_opening_compose_box(page: Page): Promise<void> {
     await page.click(".search_icon");
     await page.waitForSelector("#search_query", {visible: true});
-    await common.select_item_via_typeahead(page, "#search_query", "stream:Denmark topic:tests", "");
+    await common.clear_and_type(page, "#search_query", "stream:Denmark topic:tests");
+    // Wait for narrow to complete.
+    const wait_for_change = true;
+    await common.get_current_msg_list_id(page, wait_for_change);
+    await page.keyboard.press("Enter");
 
     await page.click("#left_bar_compose_reply_button_big");
     await page.waitForSelector("#send_message_form", {visible: true});

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -34,14 +34,12 @@ export const pm_recipient = {
         // a flake where the typeahead doesn't show up.
         await page.type("#private_message_recipient", recipient, {delay: 100});
 
-        // We use [style*="display: block"] here to distinguish
-        // the visible typeahead menu from the invisible ones
-        // meant for something else; e.g., the direct message
-        // input typeahead is different from the topic input
-        // typeahead but both can be present in the DOM.
-        const entry = await page.waitForSelector('.typeahead[style*="display: block"] .active a', {
+        // PM typeaheads always have an image. This ensures we are waiting for the right typeahead to appear.
+        const entry = await page.waitForSelector(".typeahead .active a .typeahead-image", {
             visible: false,
         });
+        // log entry in puppeteer logs
+        console.log(await entry!.evaluate((el) => el.textContent));
         await entry!.click();
     },
 
@@ -584,9 +582,7 @@ export async function select_item_via_typeahead(
     console.log(`Looking in ${field_selector} to select ${str}, ${item}`);
     await clear_and_type(page, field_selector, str);
     const entry = await page.waitForSelector(
-        `xpath///*[${has_class_x(
-            "typeahead",
-        )} and contains(@style, "display: block")]//li[contains(normalize-space(), "${item}")]//a`,
+        `xpath///*[${has_class_x("typeahead")}]//li[contains(normalize-space(), "${item}")]//a`,
         {visible: true},
     );
     assert.ok(entry);

--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -16,8 +16,18 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
     const admin_playground_status_selector = "div#admin-playground-status";
     await page.waitForSelector(admin_playground_status_selector, {hidden: true});
 
+    await common.select_item_via_typeahead(
+        page,
+        "#playground_pygments_language",
+        payload.pygments_language,
+        payload.pygments_language,
+    );
+
     // Now we can fill and click the submit button.
-    await common.fill_form(page, "form.admin-playground-form", payload);
+    await common.fill_form(page, "form.admin-playground-form", {
+        playground_name: payload.playground_name,
+        url_template: payload.url_template,
+    });
     // Not sure why, but page.click() doesn't seem to always click the submit button.
     // So we resort to using eval with the button ID instead.
     await page.$eval("button#submit_playground_button", (el) => {

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -209,7 +209,6 @@ export class Typeahead<ItemType extends string | object> {
     $header: JQuery;
     source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
     dropup: boolean;
-    fixed: boolean;
     automated: () => boolean;
     trigger_selection: (event: JQuery.KeyDownEvent) => boolean;
     on_escape?: () => void;
@@ -248,7 +247,6 @@ export class Typeahead<ItemType extends string | object> {
         this.$header = $(HEADER_ELEMENT_HTML).appendTo(this.$container);
         this.source = options.source;
         this.dropup = options.dropup ?? false;
-        this.fixed = options.fixed ?? false;
         this.automated = options.automated ?? (() => false);
         this.trigger_selection = options.trigger_selection ?? (() => false);
         this.on_escape = options.on_escape;
@@ -266,9 +264,6 @@ export class Typeahead<ItemType extends string | object> {
         this.parentElement = options.parentElement;
         this.values = new WeakMap();
 
-        if (this.fixed) {
-            this.$container.css("position", "fixed");
-        }
         // The naturalSearch option causes arrow keys to immediately
         // update the search box with the underlying values from the
         // search suggestions.
@@ -329,12 +324,7 @@ export class Typeahead<ItemType extends string | object> {
         if (this.parentElement === undefined) {
             let pos;
 
-            if (this.fixed) {
-                // Relative to screen instead of to page
-                pos = this.input_element.$element[0].getBoundingClientRect();
-            } else {
-                pos = this.input_element.$element.offset();
-            }
+            pos = this.input_element.$element[0].getBoundingClientRect();
 
             pos = $.extend({}, pos, {
                 height: this.input_element.$element[0].offsetHeight,
@@ -709,7 +699,6 @@ type TypeaheadOptions<ItemType> = {
     automated?: () => boolean;
     closeInputFieldOnHide?: () => void;
     dropup?: boolean;
-    fixed?: boolean;
     header_html?: () => string | false;
     helpOnEmptyStrings?: boolean;
     matcher?: (item: ItemType, query: string) => boolean;

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -346,6 +346,27 @@ export class Typeahead<ItemType extends string | object> {
             maxWidth: "none",
             theme: "popover-menu",
             placement: this.dropup ? "top-start" : "bottom-start",
+            popperOptions: {
+                modifiers: [
+                    {
+                        // This will only work if there is enough space on the fallback placement, otherwise
+                        // `preventOverflow` will be used to position it in the visible space.
+                        name: "flip",
+                        options: {
+                            fallbackPlacements: ["top-start", "bottom-start"],
+                        },
+                    },
+                    {
+                        name: "preventOverflow",
+                        options: {
+                            // This seems required to prevent overflow, maybe because our placements are
+                            // not the usual top, bottom, left, right.
+                            // https://popper.js.org/docs/v2/modifiers/prevent-overflow/#altaxis
+                            altAxis: true,
+                        },
+                    },
+                ],
+            },
             interactive: true,
             appendTo: () => document.body,
             showOnCreate: true,

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -347,6 +347,7 @@ export class Typeahead<ItemType extends string | object> {
             theme: "popover-menu",
             placement: this.dropup ? "top-start" : "bottom-start",
             popperOptions: {
+                strategy: "fixed",
                 modifiers: [
                     {
                         // This will only work if there is enough space on the fallback placement, otherwise

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -10,6 +10,7 @@ import {
     wrapFieldSelection,
 } from "text-field-edit";
 
+import type {Typeahead} from "./bootstrap_typeahead";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as common from "./common";
 import {$t} from "./i18n";
@@ -58,7 +59,12 @@ type SelectedLinesSections = {
 export let compose_spinner_visible = false;
 export let shift_pressed = false; // true or false
 export let code_formatting_button_triggered = false; // true or false
+export let compose_textarea_typeahead: Typeahead<object> | undefined;
 let full_size_status = false; // true or false
+
+export function set_compose_textarea_typeahead(typeahead: Typeahead<object>): void {
+    compose_textarea_typeahead = typeahead;
+}
 
 export function set_code_formatting_button_triggered(value: boolean): void {
     code_formatting_button_triggered = value;
@@ -67,6 +73,10 @@ export function set_code_formatting_button_triggered(value: boolean): void {
 // Some functions to handle the full size status explicitly
 export function set_full_size(is_full: boolean): void {
     full_size_status = is_full;
+    // Show typeahead at bottom of textarea on compose full size.
+    if (compose_textarea_typeahead) {
+        compose_textarea_typeahead.dropup = !is_full;
+    }
 }
 
 export function is_full_size(): boolean {

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -1109,7 +1109,6 @@ export function initialize_topic_edit_typeahead(form_field, stream_name, dropup)
         type: "input",
     };
     return new Typeahead(bootstrap_typeahead_input, {
-        fixed: true,
         dropup,
         highlighter_html(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
@@ -1161,7 +1160,6 @@ export function initialize_compose_typeahead(selector) {
     new Typeahead(bootstrap_typeahead_input, {
         items: max_num_items,
         dropup: true,
-        fixed: true,
         // Performance note: We have trivial matcher/sorters to do
         // matching and sorting inside the `source` field to avoid
         // O(n) behavior in the number of users in the organization
@@ -1196,7 +1194,6 @@ export function initialize({on_enter_send}) {
             return topics_seen_for(compose_state.stream_id());
         },
         items: 3,
-        fixed: true,
         highlighter_html(item) {
             return typeahead_helper.render_typeahead_item({primary: item});
         },
@@ -1224,7 +1221,6 @@ export function initialize({on_enter_send}) {
         source: get_pm_people,
         items: max_num_items,
         dropup: true,
-        fixed: true,
         highlighter_html(item) {
             return typeahead_helper.render_person_or_user_group(item);
         },

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -1157,27 +1157,30 @@ export function initialize_compose_typeahead(selector) {
         $element: $(selector),
         type: "textarea",
     };
-    new Typeahead(bootstrap_typeahead_input, {
-        items: max_num_items,
-        dropup: true,
-        // Performance note: We have trivial matcher/sorters to do
-        // matching and sorting inside the `source` field to avoid
-        // O(n) behavior in the number of users in the organization
-        // inside the typeahead library.
-        source: get_sorted_filtered_items,
-        highlighter_html: content_highlighter_html,
-        matcher() {
-            return true;
-        },
-        sorter(items) {
-            return items;
-        },
-        updater: content_typeahead_selected,
-        stopAdvance: true, // Do not advance to the next field on a Tab or Enter
-        automated: compose_automated_selection,
-        trigger_selection: compose_trigger_selection,
-        header_html: get_header_html,
-    });
+
+    compose_ui.set_compose_textarea_typeahead(
+        new Typeahead(bootstrap_typeahead_input, {
+            items: max_num_items,
+            dropup: true,
+            // Performance note: We have trivial matcher/sorters to do
+            // matching and sorting inside the `source` field to avoid
+            // O(n) behavior in the number of users in the organization
+            // inside the typeahead library.
+            source: get_sorted_filtered_items,
+            highlighter_html: content_highlighter_html,
+            matcher() {
+                return true;
+            },
+            sorter(items) {
+                return items;
+            },
+            updater: content_typeahead_selected,
+            stopAdvance: true, // Do not advance to the next field on a Tab or Enter
+            automated: compose_automated_selection,
+            trigger_selection: compose_trigger_selection,
+            header_html: get_header_html,
+        }),
+    );
 }
 
 export function initialize({on_enter_send}) {

--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -172,7 +172,6 @@ export function initialize_custom_pronouns_type_fields(element_id) {
     };
     new Typeahead(bootstrap_typeahead_input, {
         items: 3,
-        fixed: true,
         helpOnEmptyStrings: true,
         source() {
             return commonly_used_pronouns;

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -55,7 +55,6 @@ export function set_up(
     };
     new Typeahead(bootstrap_typeahead_input, {
         items: 5,
-        fixed: true,
         dropup: true,
         source(query: string): TypeaheadItem[] {
             let source: TypeaheadItem[] = [];

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -170,7 +170,6 @@ function build_page(): void {
             return [...language_labels.keys()];
         },
         items: 5,
-        fixed: true,
         helpOnEmptyStrings: true,
         highlighter_html: (item: string): string =>
             render_typeahead_item({primary: language_labels.get(item)}),

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -89,6 +89,7 @@
 
     > .tippy-content {
         padding: 0;
+        font-size: 14px;
     }
 
     > .tippy-arrow {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1360,11 +1360,14 @@ div.focused-message-list {
     font-size: 0;
 }
 
-.typeahead.dropdown-menu a {
-    color: inherit;
-}
-
 .typeahead.dropdown-menu {
+    /* Use default color until some other typeahead overrides it. */
+    color: var(--color-text-default);
+
+    a {
+        color: inherit;
+    }
+
     .active {
         color: hsl(0deg 0% 100%);
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -17,6 +17,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
     },
     cursor_inside_code_block: () => false,
     set_code_formatting_button_triggered: noop,
+    set_compose_textarea_typeahead: noop,
 });
 const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -162,7 +162,6 @@ run_test("set_up", ({mock_template, override, override_rewire}) => {
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
         assert.equal(config.items, 5);
-        assert.ok(config.fixed);
         assert.ok(config.dropup);
         assert.ok(config.stopAdvance);
 

--- a/web/third/bootstrap-typeahead/typeahead.css
+++ b/web/third/bootstrap-typeahead/typeahead.css
@@ -1,25 +1,10 @@
 /* CSS for Bootstrap typeahead */
 
 .dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  display: none;
-  float: left;
-  min-width: 160px;
   padding: 5px 0;
-  margin: 2px 0 0;
+  min-width: 160px;
   list-style: none;
   background-color: #ffffff;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-border-radius: 6px;
-  -moz-border-radius: 6px;
-  border-radius: 6px;
-  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding;
   background-clip: padding-box;
@@ -83,8 +68,4 @@
 }
 .typeahead {
   z-index: 1051;
-  margin-top: 2px;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
 }


### PR DESCRIPTION
No visual changes, just used tippy to position elements.

Next steps here would to use start using the new styles while renaming the clases for typeahead and dropdown-menu to ensure we are not using any bootstrap styles.