### PR TITLE
exceptions: Add IncompatibleParametersError as a JsonableError.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -190,6 +190,18 @@ class StreamWithIDDoesNotExistError(JsonableError):
         return _("Channel with ID '{stream_id}' does not exist")
 
 
+class IncompatibleParametersError(JsonableError):
+    data_fields = ["parameters"]
+
+    def __init__(self, parameters: List[str]) -> None:
+        self.parameters = ", ".join(parameters)
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Unsupported parameter combination: {parameters}")
+
+
 class CannotDeactivateLastUserError(JsonableError):
     code = ErrorCode.CANNOT_DEACTIVATE_LAST_USER
     data_fields = ["is_last_owner", "entity"]

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.exceptions import (
+    IncompatibleParametersError,
     JsonableError,
     OrganizationAdministratorRequiredError,
     OrganizationOwnerRequiredError,
@@ -326,7 +327,7 @@ def check_for_exactly_one_stream_arg(stream_id: Optional[int], stream: Optional[
         raise JsonableError(error)
 
     if stream_id is not None and stream is not None:
-        raise JsonableError(_("Please supply only one channel parameter: name or ID."))
+        raise IncompatibleParametersError(["stream_id", "stream"])
 
 
 def check_stream_access_for_delete_or_update(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18862,6 +18862,7 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/InvalidApiKeyError"
                   - $ref: "#/components/schemas/MissingArgumentError"
+                  - $ref: "#/components/schemas/IncompatibleParametersError"
                   - $ref: "#/components/schemas/UserNotAuthorizedError"
         "401":
           description: |
@@ -21394,6 +21395,31 @@ components:
               "msg": "Missing 'content' argument",
               "result": "error",
               "var_name": "content",
+            }
+    IncompatibleParametersError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          description: |
+            ## Incompatible request parameters
+
+            A typical failed JSON response for when two or more, optional
+            parameters are supplied that are incompatible with each other.
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            parameters:
+              type: string
+              description: |
+                A string containing the parameters, separated by commas,
+                that are incompatible.
+          example:
+            {
+              "code": "BAD_REQUEST",
+              "msg": "Unsupported parameter combination: object_id, object_name",
+              "result": "error",
+              "parameters": "object_id, object_name",
             }
     UserNotAuthorizedError:
       allOf:

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -198,7 +198,7 @@ class MutedTopicsTestsDeprecated(ZulipTestCase):
 
         data = {"stream": stream.name, "stream_id": stream.id, "topic": "Verona3", "op": "add"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please supply only one channel parameter: name or ID.")
+        self.assert_json_error(result, "Unsupported parameter combination: stream_id, stream")
 
         data = {"stream_id": stream.id, "topic": "a" * (MAX_TOPIC_NAME_LENGTH + 1), "op": "add"}
         result = self.api_patch(user, url, data)
@@ -238,7 +238,7 @@ class MutedTopicsTestsDeprecated(ZulipTestCase):
 
         data = {"stream": stream.name, "stream_id": stream.id, "topic": "Verona3", "op": "remove"}
         result = self.api_patch(user, url, data)
-        self.assert_json_error(result, "Please supply only one channel parameter: name or ID.")
+        self.assert_json_error(result, "Unsupported parameter combination: stream_id, stream")
 
         data = {"stream_id": stream.id, "topic": "a" * (MAX_TOPIC_NAME_LENGTH + 1), "op": "remove"}
         result = self.api_patch(user, url, data)


### PR DESCRIPTION
Creates an `IncompatibleParametersError` to be used in cases where there are two (or more) optional parameters for an endpoint that are incompatible with each other, e.g. there's a parameter for a user name and a user ID but only one should be sent in the request to identify the user.

Documents the error on the `/api/rest-error-handling` article.

Updates the `PATCH users/me/subscriptions/muted_topics` endpoint to use this error when both the stream and stream_id parameters are passed (note this endpoint is currently deprecated).

**Notes**:
- This eliminates the need for a specific translated string for these errors in different endpoints where the parameters that are incompatible have specific names.
- See [relevant CZO #api design](https://chat.zulip.org/#narrow/stream/378-api-design/topic/error.20for.20unsupported.20parameter.20combination/near/1785509) discussion.

**Screenshots and screen captures:**

![Screenshot from 2024-04-29 16-06-51](https://github.com/zulip/zulip/assets/63245456/c588fd5a-cad4-4606-afa9-1170b42e5c9c)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
