### PR TITLE
docs: Add introduction to video call providers doc.

### DIFF
--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -1,9 +1,34 @@
 # Video call providers
 
-This page documents the server-level configuration required to support
-non-default [video call integration
-options](https://zulip.com/help/start-a-call) on a self-hosted Zulip
-server.
+Zulip makes it convenient to [start a
+call](https://zulip.com/help/start-a-call) with the click of a button, using the
+call provider of your choice. The call providers
+supported by Zulip are:
+
+- [Jitsi Meet](https://zulip.com/integrations/doc/jitsi), a fully-encrypted,
+  100% open source video conferencing solution.
+- [Zoom](https://zulip.com/integrations/doc/zoom)
+- [BigBlueButton](https://zulip.com/integrations/doc/big-blue-button)
+
+By default, Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
+as its call provider. This page documents the configurations required to support
+other [video call integration options](https://zulip.com/help/start-a-call) on a
+self-hosted Zulip server.
+
+:::{note}
+It is possible to disable the video and voice call buttons for your
+organization by [setting the call
+provider](https://zulip.com/help/start-a-call#change-your-organizations-call-provider)
+to "None".
+:::
+
+## Jitsi
+
+You can configure Zulip to use a self-hosted
+instance of Jitsi Meet by providing the URL of your self-hosted Jitsi Meet
+server [in organization
+settings](https://zulip.com/help/start-a-call#use-a-self-hosted-instance-of-jitsi-meet).
+No server configuration changes are required.
 
 ## Zoom
 
@@ -40,10 +65,10 @@ follows:
 1. Restart the Zulip server with
    `/home/zulip/deployments/current/scripts/restart-server`.
 
-This enables Zoom support in your Zulip server. Finally, [configure
-Zoom as the video call
-provider](https://zulip.com/help/start-a-call) in the Zulip
-organization(s) where you want to use it.
+This enables Zoom support in your Zulip server. Finally, [configure Zoom as the
+video call
+provider](https://zulip.com/help/start-a-call#change-your-organizations-call-provider)
+in the Zulip organizations where you want to use it.
 
 ## BigBlueButton
 
@@ -73,5 +98,5 @@ Server as follows:
 
 This enables BigBlueButton support in your Zulip server. Finally, [configure
 BigBlueButton as the video call
-provider](https://zulip.com/help/start-a-call) in the Zulip
-organization(s) where you want to use it.
+provider](https://zulip.com/help/start-a-call#change-your-organizations-call-provider)
+in the Zulip organizations where you want to use it.


### PR DESCRIPTION
Talking to a customer made me realize that this page should start by giving an interview and documenting the Jitsi integration, before jumping into Zoom and BigBlueButton instructions.

Before: https://zulip.readthedocs.io/en/latest/production/video-calls.html

After:
![Screenshot 2024-04-29 at 13 44 36@2x](https://github.com/zulip/zulip/assets/2090066/8b809356-0f47-4d83-9385-1f5c90939b78)

