### PR TITLE
streams-settings-overlay: Update hash for stream to channel rename.

### DIFF
--- a/docs/subsystems/hashchange-system.md
+++ b/docs/subsystems/hashchange-system.md
@@ -8,9 +8,9 @@ be used to deep-link into the application and allow the browser's
 Some examples are:
 
 - `/#settings/your-bots`: Bots section of the settings overlay.
-- `/#streams`: Streams overlay, where the user manages streams
+- `/#channels`: Streams overlay, where the user manages streams
   (subscription etc.)
-- `/#streams/11/announce`: Streams overlay with stream ID 11 (called
+- `/#channels/11/announce`: Streams overlay with stream ID 11 (called
   "announce") selected.
 - `/#narrow/stream/42-android/topic/fun`: Message feed showing stream
   "android" and topic "fun". (The `42` represents the id of the
@@ -25,7 +25,7 @@ different flows:
 - The user clicking on an in-app link, which in turn opens an overlay.
   For example the streams overlay opens when the user clicks the small
   cog symbol on the left sidebar, which is in fact a link to
-  `/#streams`. This makes it easy to have simple links around the app
+  `/#channels`. This makes it easy to have simple links around the app
   without custom click handlers for each one.
 - The user uses the "back" button in their browser (basically
   equivalent to the previous one, as a _link_ out of the browser history

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -141,7 +141,7 @@
 </div>
 
 <div id="tooltip-templates-container"></div>
-<div id="streams_overlay_container"></div>
+<div id="channels_overlay_container"></div>
 <div id="groups_overlay_container"></div>
 <div id="drafts_table"></div>
 <div id="scheduled_messages_overlay_container"></div>

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -544,7 +544,7 @@ export async function open_streams_modal(page: Page): Promise<void> {
 
     await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
     const url = await page_url_with_fragment(page);
-    assert.ok(url.includes("#streams/all"));
+    assert.ok(url.includes("#channels/all"));
 }
 
 export async function open_personal_menu(page: Page): Promise<void> {

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -488,7 +488,7 @@ async function test_users_search(page: Page): Promise<void> {
 
 async function test_narrow_public_streams(page: Page): Promise<void> {
     const stream_id = await common.get_stream_id(page, "Denmark");
-    await page.goto(`http://zulip.zulipdev.com:9981/#streams/${stream_id}/Denmark`);
+    await page.goto(`http://zulip.zulipdev.com:9981/#channels/${stream_id}/Denmark`);
     await page.waitForSelector("button.sub_unsub_button", {visible: true});
     await page.click("button.sub_unsub_button");
     await page.waitForSelector(

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -42,7 +42,7 @@ async function navigate_to_subscriptions(page: Page): Promise<void> {
 
     await open_menu(page);
 
-    const manage_streams_selector = '.link-item a[href^="#streams"]';
+    const manage_streams_selector = '.link-item a[href^="#channels"]';
     await page.waitForSelector(manage_streams_selector, {visible: true});
     await page.click(manage_streams_selector);
 

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -19,7 +19,7 @@ export function initialize(): void {
             if (!can_create_streams) {
                 // If the user can't create streams, we directly
                 // navigate them to the Stream settings subscribe UI.
-                window.location.assign("#streams/all");
+                window.location.assign("#channels/all");
                 // Returning false from an onShow handler cancels the show.
                 return false;
             }

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -475,7 +475,10 @@ export class BuddyList extends BuddyListConf {
             stream_data.can_view_subscribers(current_sub) &&
             has_inactive_users_matching_view
         ) {
-            const stream_edit_hash = hash_util.stream_edit_url(current_sub, "subscribers");
+            const stream_edit_hash = hash_util.channels_settings_edit_url(
+                current_sub,
+                "subscribers",
+            );
             $("#buddy-list-users-matching-view-container").append(
                 $(
                     render_view_all_subscribers({

--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -59,7 +59,7 @@ The menu itself has the selector
 The items with the prefix of "hash:" are in-page
 links:
 
-    #streams
+    #channels
     #settings
     #organization
     #about-zulip

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -1,11 +1,11 @@
 export function get_hash_category(hash?: string): string {
-    // given "#streams/subscribed", returns "streams"
+    // given "#channels/subscribed", returns "channels"
     return hash ? hash.replace(/^#/, "").split(/\//)[0] : "";
 }
 
 export function get_hash_section(hash?: string): string {
     // given "#settings/profile", returns "profile"
-    // given '#streams/5/social", returns "5"
+    // given '#channels/5/social", returns "5"
     if (!hash) {
         return "";
     }
@@ -17,7 +17,7 @@ export function get_hash_section(hash?: string): string {
 
 function get_nth_hash_section(hash: string, n: number): string {
     // given "#settings/profile" and n=1, returns "profile"
-    // given '#streams/5/social" and n=2, returns "social"
+    // given '#channels/5/social" and n=2, returns "social"
     const parts = hash.replace(/\/$/, "").split(/\//);
     return parts.at(n) ?? "";
 }
@@ -49,7 +49,13 @@ export function is_same_server_message_link(url: string): boolean {
 export function is_overlay_hash(hash: string): boolean {
     // Hash changes within this list are overlays and should not unnarrow (etc.)
     const overlay_list = [
+        // In 2024, stream was renamed to channel in the Zulip API and UI.
+        // Because pre-change Welcome Bot and Notification Bot messages
+        // included links to "/#streams/all" and "/#streams/new", we'll
+        // need to support "streams" as an overlay hash as an alias for
+        // "channels" permanently.
         "streams",
+        "channels",
         "drafts",
         "groups",
         "settings",
@@ -72,7 +78,7 @@ export function is_overlay_hash(hash: string): boolean {
 export function is_editing_stream(desired_stream_id: number): boolean {
     const hash_components = window.location.hash.slice(1).split(/\//);
 
-    if (hash_components[0] !== "streams") {
+    if (hash_components[0] !== "channels") {
         return false;
     }
 
@@ -88,7 +94,7 @@ export function is_editing_stream(desired_stream_id: number): boolean {
 }
 
 export function is_create_new_stream_narrow(): boolean {
-    return window.location.hash === "#streams/new";
+    return window.location.hash === "#channels/new";
 }
 
 // This checks whether the user is in the stream settings menu
@@ -96,7 +102,7 @@ export function is_create_new_stream_narrow(): boolean {
 export function is_subscribers_section_opened_for_stream(): boolean {
     const hash_components = window.location.hash.slice(1).split(/\//);
 
-    if (hash_components[0] !== "streams") {
+    if (hash_components[0] !== "channels") {
         return false;
     }
     if (!hash_components[3]) {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -145,7 +145,7 @@ export function by_conversation_and_time_url(message: Message): string {
 }
 
 export function stream_edit_url(sub: StreamSubscription, right_side_tab: string): string {
-    return `#streams/${sub.stream_id}/${internal_url.encodeHashComponent(
+    return `#channels/${sub.stream_id}/${internal_url.encodeHashComponent(
         sub.name,
     )}/${right_side_tab}`;
 }
@@ -192,7 +192,16 @@ export function parse_narrow(hash: string): NarrowTerm[] | undefined {
     return terms;
 }
 
-export function validate_stream_settings_hash(hash: string): string {
+export function channels_settings_section_url(section = "subscribed"): string {
+    const valid_section_values = new Set(["new", "subscribed", "all"]);
+    if (!valid_section_values.has(section)) {
+        blueslip.warn("invalid section for channels settings: " + section);
+        return "#channels/subscribed";
+    }
+    return `#channels/${section}`;
+}
+
+export function validate_channels_settings_hash(hash: string): string {
     const hash_components = hash.slice(1).split(/\//);
     const section = hash_components[1];
 
@@ -201,7 +210,7 @@ export function validate_stream_settings_hash(hash: string): string {
         settings_data.user_can_create_web_public_streams() ||
         settings_data.user_can_create_private_streams();
     if (section === "new" && !can_create_streams) {
-        return "#streams/subscribed";
+        return channels_settings_section_url();
     }
 
     if (/\d+/.test(section)) {
@@ -216,27 +225,18 @@ export function validate_stream_settings_hash(hash: string): string {
         //
         // In all these cases we redirect the user to 'subscribed' tab.
         if (sub === undefined || (page_params.is_guest && !stream_data.is_subscribed(stream_id))) {
-            return "#streams/subscribed";
+            return channels_settings_section_url();
         }
 
-        const stream_name = hash_components[2];
         let right_side_tab = hash_components[3];
         const valid_right_side_tab_values = new Set(["general", "personal", "subscribers"]);
-        if (sub.name === stream_name && valid_right_side_tab_values.has(right_side_tab)) {
-            return hash;
-        }
         if (!valid_right_side_tab_values.has(right_side_tab)) {
             right_side_tab = "general";
         }
         return stream_edit_url(sub, right_side_tab);
     }
 
-    const valid_section_values = ["new", "subscribed", "all"];
-    if (!valid_section_values.includes(section)) {
-        blueslip.warn("invalid section for streams: " + section);
-        return "#streams/subscribed";
-    }
-    return hash;
+    return channels_settings_section_url(section);
 }
 
 export function validate_group_settings_hash(hash: string): string {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -144,12 +144,6 @@ export function by_conversation_and_time_url(message: Message): string {
     return absolute_url + people.pm_perma_link(message) + suffix;
 }
 
-export function stream_edit_url(sub: StreamSubscription, right_side_tab: string): string {
-    return `#channels/${sub.stream_id}/${internal_url.encodeHashComponent(
-        sub.name,
-    )}/${right_side_tab}`;
-}
-
 export function group_edit_url(group: UserGroup, right_side_tab: string): string {
     const hash = `#groups/${group.id}/${internal_url.encodeHashComponent(group.name)}/${right_side_tab}`;
     return hash;
@@ -190,6 +184,15 @@ export function parse_narrow(hash: string): NarrowTerm[] | undefined {
         terms.push({negated, operator, operand});
     }
     return terms;
+}
+
+export function channels_settings_edit_url(
+    sub: StreamSubscription,
+    right_side_tab: string,
+): string {
+    return `#channels/${sub.stream_id}/${internal_url.encodeHashComponent(
+        sub.name,
+    )}/${right_side_tab}`;
 }
 
 export function channels_settings_section_url(section = "subscribed"): string {
@@ -233,7 +236,7 @@ export function validate_channels_settings_hash(hash: string): string {
         if (!valid_right_side_tab_values.has(right_side_tab)) {
             right_side_tab = "general";
         }
-        return stream_edit_url(sub, right_side_tab);
+        return channels_settings_edit_url(sub, right_side_tab);
     }
 
     return channels_settings_section_url(section);

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -82,7 +82,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
             rendered_narrow_description: current_stream.rendered_description,
             sub_count,
             stream: current_stream,
-            stream_settings_link: hash_util.stream_edit_url(current_stream, "general"),
+            stream_settings_link: hash_util.channels_settings_edit_url(current_stream, "general"),
         };
     }
     return icon_data;

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 import render_message_view_header from "../templates/message_view_header.hbs";
 
 import type {Filter} from "./filter";
+import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as inbox_util from "./inbox_util";
 import * as narrow_state from "./narrow_state";
@@ -81,8 +82,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
             rendered_narrow_description: current_stream.rendered_description,
             sub_count,
             stream: current_stream,
-            stream_settings_link:
-                "#streams/" + current_stream.stream_id + "/" + current_stream.name + "/general",
+            stream_settings_link: hash_util.stream_edit_url(current_stream, "general"),
         };
     }
     return icon_data;

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -44,9 +44,9 @@ export function setup_subscriptions_tab_hash(tab_key_value) {
         return;
     }
     if (tab_key_value === "all-streams") {
-        browser_history.update("#streams/all");
+        browser_history.update("#channels/all");
     } else if (tab_key_value === "subscribed") {
-        browser_history.update("#streams/subscribed");
+        browser_history.update("#channels/subscribed");
     } else {
         blueslip.debug("Unknown tab_key_value: " + tab_key_value);
     }

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -275,7 +275,7 @@ export function show_settings_for(node) {
     stream_ui_updates.enable_or_disable_permission_settings_in_edit_panel(sub);
     setup_dropdown(sub, slim_sub);
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".stream-creation-confirmation-banner .main-view-banner-close-button",
         (e) => {
@@ -438,7 +438,7 @@ export function initialize() {
         stream_settings_components.sub_or_unsub(sub);
     });
 
-    $("#streams_overlay_container").on("click", "#open_stream_info_modal", (e) => {
+    $("#channels_overlay_container").on("click", "#open_stream_info_modal", (e) => {
         e.preventDefault();
         e.stopPropagation();
         const stream_id = get_stream_id(e.target);
@@ -468,7 +468,7 @@ export function initialize() {
         });
     });
 
-    $("#streams_overlay_container").on("keypress", "#change_stream_description", (e) => {
+    $("#channels_overlay_container").on("keypress", "#change_stream_description", (e) => {
         // Stream descriptions cannot be multiline, so disable enter key
         // to prevent new line
         if (keydown_util.is_enter_event(e)) {
@@ -477,7 +477,7 @@ export function initialize() {
         return true;
     });
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".stream-permissions-warning-banner .main-view-banner-close-button",
         (event) => {
@@ -486,7 +486,7 @@ export function initialize() {
         },
     );
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".stream-permissions-warning-banner .main-view-banner-action-button",
         (event) => {
@@ -497,7 +497,7 @@ export function initialize() {
             const stream_id = Number.parseInt($target.attr("data-stream-id"), 10);
             // Makes sure we take the correct stream_row.
             const $stream_row = $(
-                `#streams_overlay_container div.stream-row[data-stream-id='${CSS.escape(
+                `#channels_overlay_container div.stream-row[data-stream-id='${CSS.escape(
                     stream_id,
                 )}']`,
             );
@@ -525,7 +525,7 @@ export function initialize() {
         dialog_widget.submit_api_request(channel.patch, url, data);
     }
 
-    $("#streams_overlay_container").on("click", ".copy_email_button", (e) => {
+    $("#channels_overlay_container").on("click", ".copy_email_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -547,13 +547,13 @@ export function initialize() {
         });
     });
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".subsection-parent .reset-stream-notifications-button",
         stream_notification_reset,
     );
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "change",
         ".sub_setting_checkbox .sub_setting_control",
         stream_setting_changed,
@@ -561,7 +561,7 @@ export function initialize() {
 
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
-    $("#streams_overlay_container").on("click", ".sub_unsub_button", (e) => {
+    $("#channels_overlay_container").on("click", ".sub_unsub_button", (e) => {
         if ($(e.currentTarget).hasClass("disabled")) {
             // We do not allow users to subscribe themselves to private streams.
             return;
@@ -570,7 +570,7 @@ export function initialize() {
         const sub = get_sub_for_target(e.target);
         // Makes sure we take the correct stream_row.
         const $stream_row = $(
-            `#streams_overlay_container div.stream-row[data-stream-id='${CSS.escape(
+            `#channels_overlay_container div.stream-row[data-stream-id='${CSS.escape(
                 sub.stream_id,
             )}']`,
         );
@@ -585,7 +585,7 @@ export function initialize() {
         e.stopPropagation();
     });
 
-    $("#streams_overlay_container").on("click", ".deactivate", (e) => {
+    $("#channels_overlay_container").on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -648,13 +648,13 @@ export function initialize() {
         $(".dialog_submit_button").attr("data-stream-id", stream_id);
     });
 
-    $("#streams_overlay_container").on("click", ".stream-row", function (e) {
+    $("#channels_overlay_container").on("click", ".stream-row", function (e) {
         if ($(e.target).closest(".check, .subscription_settings").length === 0) {
             open_edit_panel_for_row(this);
         }
     });
 
-    $("#streams_overlay_container").on("change", ".stream_message_retention_setting", (e) => {
+    $("#channels_overlay_container").on("change", ".stream_message_retention_setting", (e) => {
         const message_retention_setting_dropdown_value = e.target.value;
         settings_components.change_element_block_display_property(
             "stream_message_retention_custom_input",
@@ -662,7 +662,7 @@ export function initialize() {
         );
     });
 
-    $("#streams_overlay_container").on("change input", "input, select, textarea", (e) => {
+    $("#channels_overlay_container").on("change input", "input, select, textarea", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -683,7 +683,7 @@ export function initialize() {
         return true;
     });
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".subsection-header .subsection-changes-save button",
         (e) => {
@@ -717,7 +717,7 @@ export function initialize() {
         },
     );
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".subsection-header .subsection-changes-discard button",
         (e) => {

--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -389,13 +389,13 @@ export function rerender_subscribers_list(sub) {
 export function initialize() {
     add_subscribers_pill.set_up_handlers({
         get_pill_widget: () => pill_widget,
-        $parent_container: $("#streams_overlay_container"),
+        $parent_container: $("#channels_overlay_container"),
         pill_selector: ".edit_subscribers_for_stream .pill-container",
         button_selector: ".edit_subscribers_for_stream .add-subscriber-button",
         action: subscribe_new_users,
     });
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "submit",
         ".edit_subscribers_for_stream .subscriber_list_remove form",
         (e) => {

--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -29,7 +29,7 @@ export function setup_toggler(): void {
             const stream_id = Number.parseInt($stream_header.attr("data-stream-id") ?? "", 10);
             const sub = sub_store.get(stream_id);
             if (sub) {
-                const hash = hash_util.stream_edit_url(sub, select_tab);
+                const hash = hash_util.channels_settings_edit_url(sub, select_tab);
                 browser_history.update(hash);
             }
         },

--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -25,7 +25,7 @@ export function setup_toggler(): void {
             $(".stream_section").hide();
             $(`[data-stream-section="${CSS.escape(key)}"]`).show();
             select_tab = key;
-            const $stream_header = $("#streams_overlay_container .stream_settings_header");
+            const $stream_header = $("#channels_overlay_container .stream_settings_header");
             const stream_id = Number.parseInt($stream_header.attr("data-stream-id") ?? "", 10);
             const sub = sub_store.get(stream_id);
             if (sub) {

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -121,7 +121,7 @@ function build_stream_popover(opts) {
                 const sub = stream_popover_sub(e);
                 hide_stream_popover();
 
-                const stream_edit_hash = hash_util.stream_edit_url(sub, "general");
+                const stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
                 browser_history.go_to_location(stream_edit_hash);
             });
 

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -210,7 +210,9 @@ export function unsubscribe_from_private_stream(sub) {
         let $stream_row;
         if (overlays.streams_open()) {
             $stream_row = $(
-                "#streams_overlay_container div.stream-row[data-stream-id='" + sub.stream_id + "']",
+                "#channels_overlay_container div.stream-row[data-stream-id='" +
+                    sub.stream_id +
+                    "']",
             );
         }
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -731,7 +731,7 @@ function show_right_section() {
 }
 
 export function change_state(section, left_side_tab, right_side_tab) {
-    // if in #streams/new form.
+    // if in #channels/new form.
     if (section === "new") {
         do_open_create_stream();
         show_right_section();
@@ -880,7 +880,7 @@ export function do_open_create_stream() {
 
 export function open_create_stream() {
     do_open_create_stream();
-    browser_history.update("#streams/new");
+    browser_history.update("#channels/new");
 }
 
 export function update_stream_privacy_choices(policy) {

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -226,7 +226,7 @@ export function add_sub_to_table(sub) {
         sub: stream_settings_data.get_sub_for_settings(sub),
     });
     scroll_util
-        .get_content_element($("#streams_overlay_container .settings"))
+        .get_content_element($("#channels_overlay_container .settings"))
         .append($(settings_html));
 
     if (stream_create.get_name() === sub.name) {
@@ -412,7 +412,7 @@ export function render_left_panel_superset() {
         subscriptions: stream_settings_data.get_updated_unsorted_subs(),
     });
 
-    scroll_util.get_content_element($("#streams_overlay_container .streams-list")).html(html);
+    scroll_util.get_content_element($("#channels_overlay_container .streams-list")).html(html);
 }
 
 export function update_empty_left_panel_message() {
@@ -425,7 +425,7 @@ export function update_empty_left_panel_message() {
         // displayed in panel or not.
         has_streams =
             stream_data.subscribed_subs().length ||
-            $("#streams_overlay_container .stream-row:not(.notdisplayed)").length;
+            $("#channels_overlay_container .stream-row:not(.notdisplayed)").length;
     } else {
         has_streams = stream_data.get_unsorted_subs().length;
     }
@@ -457,7 +457,7 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
 
     const stream_ids = [];
 
-    for (const row of $("#streams_overlay_container .stream-row")) {
+    for (const row of $("#channels_overlay_container .stream-row")) {
         const stream_id = stream_id_for_row(row);
         stream_ids.push(stream_id);
     }
@@ -472,7 +472,7 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
         hidden_ids.add(stream_id);
     }
 
-    for (const row of $("#streams_overlay_container .stream-row")) {
+    for (const row of $("#channels_overlay_container .stream-row")) {
         const stream_id = stream_id_for_row(row);
 
         // Below code goes away if we don't do sort-DOM-in-place.
@@ -491,7 +491,7 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
 
     for (const stream_id of all_stream_ids) {
         scroll_util
-            .get_content_element($("#streams_overlay_container .streams-list"))
+            .get_content_element($("#channels_overlay_container .streams-list"))
             .append(widgets.get(stream_id));
     }
     update_empty_left_panel_message();
@@ -593,7 +593,7 @@ export function setup_page(callback) {
             },
         });
 
-        sort_toggler.get().prependTo("#streams_overlay_container .list-toggler-container");
+        sort_toggler.get().prependTo("#channels_overlay_container .list-toggler-container");
 
         // Reset our internal state to reflect that we're initially in
         // the "Subscribed" tab if we're reopening "Stream settings".
@@ -611,7 +611,7 @@ export function setup_page(callback) {
 
         if (should_list_all_streams()) {
             const $toggler_elem = toggler.get();
-            $("#streams_overlay_container .list-toggler-container").prepend($toggler_elem);
+            $("#channels_overlay_container .list-toggler-container").prepend($toggler_elem);
         }
         if (current_user.is_guest) {
             toggler.disable_tab("all-streams");
@@ -622,7 +622,7 @@ export function setup_page(callback) {
     }
 
     function populate_and_fill() {
-        $("#streams_overlay_container").empty();
+        $("#channels_overlay_container").empty();
 
         // TODO: Ideally we'd indicate in some way what stream types
         // the user can create, by showing other options as disabled.
@@ -658,7 +658,7 @@ export function setup_page(callback) {
         };
 
         const rendered = render_stream_settings_overlay(template_data);
-        $("#streams_overlay_container").append($(rendered));
+        $("#channels_overlay_container").append($(rendered));
 
         render_left_panel_superset();
         initialize_components();
@@ -910,12 +910,12 @@ export function update_stream_privacy_choices(policy) {
 }
 
 export function initialize() {
-    $("#streams_overlay_container").on("click", ".create_stream_button", (e) => {
+    $("#channels_overlay_container").on("click", ".create_stream_button", (e) => {
         e.preventDefault();
         open_create_stream();
     });
 
-    $("#streams_overlay_container").on("click", "#stream_creation_form [data-dismiss]", (e) => {
+    $("#channels_overlay_container").on("click", "#stream_creation_form [data-dismiss]", (e) => {
         e.preventDefault();
         // we want to make sure that the click is not just a simulated
         // click; this fixes an issue where hitting "Enter" would
@@ -925,17 +925,17 @@ export function initialize() {
         }
     });
 
-    $("#streams_overlay_container").on("click", ".email-address", function () {
+    $("#channels_overlay_container").on("click", ".email-address", function () {
         selectText(this);
     });
 
-    $("#streams_overlay_container").on(
+    $("#channels_overlay_container").on(
         "click",
         ".stream-row, .create_stream_button",
         show_right_section,
     );
 
-    $("#streams_overlay_container").on("click", ".fa-chevron-left", () => {
+    $("#channels_overlay_container").on("click", ".fa-chevron-left", () => {
         $(".right").removeClass("show");
         $(".subscriptions-header").removeClass("slide-left");
     });

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -309,7 +309,7 @@ export function update_permissions_banner(sub) {
 
 export function update_notification_setting_checkbox(notification_name) {
     // This is in the right panel (Personal settings).
-    const $stream_row = $("#streams_overlay_container .stream-row.active");
+    const $stream_row = $("#channels_overlay_container .stream-row.active");
     if (!$stream_row.length) {
         return;
     }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -196,7 +196,7 @@ function format_user_stream_list_item_html(stream, user) {
         show_unsubscribe_button,
         show_private_stream_unsub_tooltip,
         show_last_user_in_private_stream_unsub_tooltip,
-        stream_edit_url: hash_util.stream_edit_url(stream, "general"),
+        stream_edit_url: hash_util.channels_settings_edit_url(stream, "general"),
     });
 }
 
@@ -927,7 +927,7 @@ export function initialize() {
             (people.is_my_user_id(target_user_id) ||
                 peer_data.get_subscriber_count(stream_id) === 1)
         ) {
-            const new_hash = hash_util.stream_edit_url(sub, "general");
+            const new_hash = hash_util.channels_settings_edit_url(sub, "general");
             hide_user_profile();
             browser_history.go_to_location(new_hash);
             return;

--- a/web/templates/compose_banner/stream_does_not_exist_error.hbs
+++ b/web/templates/compose_banner/stream_does_not_exist_error.hbs
@@ -3,7 +3,7 @@
         {{#tr}}
         The channel <b>#{channel_name}</b> does not exist. Manage your subscriptions
         <z-link>on your Channels page</z-link>.
-        {{#*inline "z-link"}}<a href='#streams/all'>{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-link"}}<a href='#channels/all'>{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/templates/gear_menu_popover.hbs
+++ b/web/templates/gear_menu_popover.hbs
@@ -55,7 +55,7 @@
         <li class="popover-menu-outer-list-item">
             <ul class="popover-menu-inner-list">
                 <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a href="#streams/subscribed" class="navigate-link-on-enter popover-menu-link">
+                    <a href="#channels/subscribed" class="navigate-link-on-enter popover-menu-link">
                         <i class="popover-menu-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Channel settings' }}</span>
                     </a>

--- a/web/templates/popovers/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar_stream_setting_popover.hbs
@@ -1,11 +1,11 @@
 <ul class="nav nav-list">
     <li>
-        <a href="#streams/all" class="navigate_and_close_popover">
+        <a href="#channels/all" class="navigate_and_close_popover">
             {{t "Browse channels" }}
         </a>
     </li>
     <li>
-        <a href="#streams/new" class="navigate_and_close_popover">
+        <a href="#channels/new" class="navigate_and_close_popover">
             {{t "Create a channel" }}
         </a>
     </li>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -31,7 +31,7 @@
                         <span>
                             {{t 'You are not subscribed to any channels.'}}
                             {{#if can_view_all_streams}}
-                            <a href="#streams/all">{{t 'View all channels'}}</a>
+                            <a href="#channels/all">{{t 'View all channels'}}</a>
                             {{/if}}
                         </span>
                     </div>
@@ -39,7 +39,7 @@
                         <span>
                             {{t 'There are no channels you can view in this organization.'}}
                             {{#if can_create_streams}}
-                                <a href="#streams/new">{{t 'Create a channel'}}</a>
+                                <a href="#channels/new">{{t 'Create a channel'}}</a>
                             {{/if}}
                         </span>
                     </div>

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,15 +1,15 @@
 {{#if exactly_one_unsubscribed_stream}}
-    <a href="#streams/all">
+    <a href="#channels/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse 1 more channel" ~}}
     </a>
 {{else if can_subscribe_stream_count}}
-    <a href="#streams/all">
+    <a href="#channels/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse {can_subscribe_stream_count} more channels" ~}}
     </a>
 {{else if can_create_streams}}
-    <a href="#streams/new">
+    <a href="#channels/new">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Create a channel" ~}}
     </a>

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1588,7 +1588,7 @@ test("tokenizing", () => {
 
     // The following cases are kinda judgment calls...
     assert.equal(ct.tokenize_compose_str("foo @toomanycharactersisridiculoustocomplete"), "");
-    assert.equal(ct.tokenize_compose_str("foo #streams@foo"), "#streams@foo");
+    assert.equal(ct.tokenize_compose_str("foo #bar@foo"), "#bar@foo");
 });
 
 test("content_highlighter_html", ({override_rewire}) => {

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -53,7 +53,7 @@ run_test("hash_util", () => {
 });
 
 run_test("test_get_hash_category", () => {
-    assert.deepEqual(hash_parser.get_hash_category("streams/subscribed"), "streams");
+    assert.deepEqual(hash_parser.get_hash_category("channels/subscribed"), "channels");
     assert.deepEqual(hash_parser.get_hash_category("#settings/preferences"), "settings");
     assert.deepEqual(hash_parser.get_hash_category("#drafts"), "drafts");
     assert.deepEqual(hash_parser.get_hash_category("invites"), "invites");
@@ -63,7 +63,7 @@ run_test("test_get_hash_category", () => {
 });
 
 run_test("test_get_hash_section", () => {
-    assert.equal(hash_parser.get_hash_section("streams/subscribed"), "subscribed");
+    assert.equal(hash_parser.get_hash_section("channels/subscribed"), "subscribed");
     assert.equal(hash_parser.get_hash_section("#settings/profile"), "profile");
 
     assert.equal(hash_parser.get_hash_section("settings/10/general/"), "10");
@@ -138,15 +138,15 @@ run_test("build_reload_url", () => {
 });
 
 run_test("test is_editing_stream", () => {
-    window.location.hash = "#streams/1/announce";
+    window.location.hash = "#channels/1/announce";
     assert.equal(hash_parser.is_editing_stream(1), true);
     assert.equal(hash_parser.is_editing_stream(2), false);
 
     // url is missing name at end
-    window.location.hash = "#streams/1";
+    window.location.hash = "#channels/1";
     assert.equal(hash_parser.is_editing_stream(1), false);
 
-    window.location.hash = "#streams/bogus/bogus";
+    window.location.hash = "#channels/bogus/bogus";
     assert.equal(hash_parser.is_editing_stream(1), false);
 
     window.location.hash = "#test/narrow";
@@ -154,7 +154,7 @@ run_test("test is_editing_stream", () => {
 });
 
 run_test("test_is_create_new_stream_narrow", () => {
-    window.location.hash = "#streams/new";
+    window.location.hash = "#channels/new";
     assert.equal(hash_parser.is_create_new_stream_narrow(), true);
 
     window.location.hash = "#some/random/hash";
@@ -162,13 +162,13 @@ run_test("test_is_create_new_stream_narrow", () => {
 });
 
 run_test("test_is_subscribers_section_opened_for_stream", () => {
-    window.location.hash = "#streams/1/Design/subscribers";
+    window.location.hash = "#channels/1/Design/subscribers";
     assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), true);
 
-    window.location.hash = "#streams/99/.EC.A1.B0.EB.A6.AC.EB.B2.95.20.F0.9F.98.8E/subscribers";
+    window.location.hash = "#channels/99/.EC.A1.B0.EB.A6.AC.EB.B2.95.20.F0.9F.98.8E/subscribers";
     assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), true);
 
-    window.location.hash = "#streams/random/subscribers";
+    window.location.hash = "#channels/random/subscribers";
     assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), false);
 
     window.location.hash = "#some/random/place/subscribers";
@@ -203,7 +203,7 @@ run_test("test_stream_edit_url", () => {
     };
     assert.equal(
         hash_util.stream_edit_url(sub, "general"),
-        "#streams/42/research.20.26.20development/general",
+        "#channels/42/research.20.26.20development/general",
     );
 });
 

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -196,13 +196,13 @@ run_test("test_parse_narrow", () => {
     ]);
 });
 
-run_test("test_stream_edit_url", () => {
+run_test("test_channels_settings_edit_url", () => {
     const sub = {
         name: "research & development",
         stream_id: 42,
     };
     assert.equal(
-        hash_util.stream_edit_url(sub, "general"),
+        hash_util.channels_settings_edit_url(sub, "general"),
         "#channels/42/research.20.26.20development/general",
     );
 });

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -296,7 +296,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [ui_report, "error"],
     ]);
 
-    window.location.hash = "#streams/subscribed";
+    window.location.hash = "#channels/subscribed";
 
     helper.clear_events();
     $window_stub.trigger("hashchange");

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -314,7 +314,7 @@ test("marked_subscribed (normal)", ({override}) => {
     });
     override(user_profile, "update_user_profile_streams_list_for_users", noop);
 
-    $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+    $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
     stream_events.mark_subscribed(sub, [], "blue");
 
@@ -345,7 +345,7 @@ test("marked_subscribed (color)", ({override}) => {
     override(color_data, "pick_color", () => "green");
     override(user_profile, "update_user_profile_streams_list_for_users", noop);
 
-    $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+    $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
     // narrow state is undefined
     {
@@ -376,7 +376,7 @@ test("marked_subscribed (emails)", ({override}) => {
     override(stream_settings_ui, "update_settings_for_subscribed", subs_stub.f);
     override(user_profile, "update_user_profile_streams_list_for_users", noop);
 
-    $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+    $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
     assert.ok(!stream_data.is_subscribed_by_name(sub.name));
 
@@ -403,7 +403,7 @@ test("mark_unsubscribed (update_settings_for_unsubscribed)", ({override}) => {
     override(unread_ui, "update_unread_counts", noop);
     override(user_profile, "update_user_profile_streams_list_for_users", noop);
 
-    $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+    $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
     stream_events.mark_unsubscribed(sub);
     const args = stub.get_args("sub");
@@ -431,7 +431,7 @@ test("mark_unsubscribed (render_title_area)", ({override}) => {
     override(user_profile, "update_user_profile_streams_list_for_users", noop);
     override(buddy_list, "populate", noop);
 
-    $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+    $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
     stream_events.mark_unsubscribed(sub);
 

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -130,7 +130,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         $(sub_row).detach = () => sub_row;
     }
 
-    $.create("#streams_overlay_container .stream-row", {children: sub_stubs});
+    $.create("#channels_overlay_container .stream-row", {children: sub_stubs});
 
     let ui_called = false;
     scroll_util.reset_scrollbar = ($elem) => {
@@ -145,7 +145,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     assert.ok(!$denmark_row.hasClass("active"));
 
     function test_filter(params, expected_streams) {
-        $("#streams_overlay_container .stream-row:not(.notdisplayed)").length = 0;
+        $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
         const stream_ids = stream_settings_ui.redraw_left_panel(params);
         assert.deepEqual(
             stream_ids,

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1471,7 +1471,7 @@ def send_pm_if_empty_stream(
                     arg_dict = {
                         **arg_dict,
                         "channel_name": f"#**{stream_name}**",
-                        "new_channel_link": "#streams/new",
+                        "new_channel_link": "#channels/new",
                     }
                     content = _(
                         "Your bot {bot_identity} tried to send a message to channel "

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -21,7 +21,7 @@ gear_info = {
     # link is used for relative links: `Select [name](link).`
     "stream-settings": [
         '<i class="zulip-icon zulip-icon-hash"></i> Stream settings',
-        "/#streams/subscribed",
+        "/#channels/subscribed",
     ],
     "settings": [
         '<i class="zulip-icon zulip-icon-tool"></i> Personal Settings',
@@ -98,7 +98,7 @@ def help_handle_match(key: str) -> str:
 
 
 stream_info = {
-    "all": ["All streams", "/#streams/all"],
+    "all": ["All streams", "/#channels/all"],
 }
 
 stream_all_instructions = """

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -177,7 +177,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
                 )
                 + "\n\n",
                 _("[Browse and subscribe to channels]({settings_link}).").format(
-                    settings_link="#streams/all"
+                    settings_link="#channels/all"
                 ),
             ]
         )
@@ -279,7 +279,7 @@ def send_initial_realm_messages(realm: Realm) -> None:
                 "and click on `{initial_private_channel_name}`."
             )
         ).format(
-            channel_settings_url="#streams/subscribed",
+            channel_settings_url="#channels/subscribed",
             initial_private_channel_name=Realm.INITIAL_PRIVATE_STREAM_NAME,
         )
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -426,7 +426,7 @@ class HelpTest(ZulipTestCase):
     def test_help_relative_links_for_stream(self) -> None:
         result = self.client_get("/help/message-a-stream-by-email")
         self.assertIn(
-            '<a href="/#streams/subscribed"><i class="zulip-icon zulip-icon-hash"></i> Stream settings</a>',
+            '<a href="/#channels/subscribed"><i class="zulip-icon zulip-icon-hash"></i> Stream settings</a>',
             str(result.content),
         )
         self.assertEqual(result.status_code, 200)
@@ -438,7 +438,7 @@ class HelpTest(ZulipTestCase):
             '<strong><i class="zulip-icon zulip-icon-hash"></i> Stream settings</strong>',
             str(result.content),
         )
-        self.assertNotIn("/#streams", str(result.content))
+        self.assertNotIn("/#channels", str(result.content))
 
 
 class IntegrationTest(ZulipTestCase):

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3175,11 +3175,11 @@ class MarkdownTest(ZulipTestCase):
         realm = get_realm("zulip")
         sender_user_profile = self.example_user("othello")
         message = Message(sender=sender_user_profile, sending_client=get_client("test"))
-        msg = "http://zulip.testserver/#streams/all"
+        msg = "http://zulip.testserver/#channels/all"
 
         self.assertEqual(
             markdown_convert(msg, message_realm=realm, message=message).rendered_content,
-            '<p><a href="#streams/all">http://zulip.testserver/#streams/all</a></p>',
+            '<p><a href="#channels/all">http://zulip.testserver/#channels/all</a></p>',
         )
 
     def test_md_relative_link(self) -> None:

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -94,7 +94,7 @@ class TutorialTests(ZulipTestCase):
             self.send_personal_message(user, bot, content)
             expected_response = (
                 "In Zulip, channels [determine who gets a message](/help/streams-and-topics).\n\n"
-                "[Browse and subscribe to channels](#streams/all)."
+                "[Browse and subscribe to channels](#channels/all)."
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -54,7 +54,7 @@ class HelloWorldHookTests(WebhookTestCase):
         self.url = self.build_webhook_url()
         realm = get_realm("zulip")
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
-        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to channel #**nonexistent**, but that channel does not exist. Click [here](#streams/new) to create it."
+        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to channel #**nonexistent**, but that channel does not exist. Click [here](#channels/new) to create it."
         self.send_and_test_private_message(
             "goodbye",
             expected_message=expected_message,


### PR DESCRIPTION
Updates the base hash for the streams setting overlay to be "channels" instead of "streams".

**Relevant CZO conversations**:
- https://chat.zulip.org/#narrow/stream/438-release-management/topic/rename.20.22stream.22.20to.20.22channel.22.20project.2C.20.2328468/near/1784298
- https://chat.zulip.org/#narrow/stream/378-api-design/topic/URLs.20for.20stream.20to.20channel.20rename/near/1784291

**Notes**:
- 2 prep commits:
  - Clean-up of a test string that's not testing the streams settings overlay.
  - Update message view header to use `hash_util.stream_edit_url` for the link to the streams settings overlay; see before/after screenshots.
- Because there are Welcome Bot and Notification Bot messages that would have been sent with the "/#streams" hash, we will need to support parsing those overlay hashes as an alias for "/#channels" permanently.
- 2 refactor commits after main changes:
  - One to rename `hash_util.stream_edit_url` to `hash_util.channels_settings_edit_url`, so that function name is clearer and updated for the stream/channel rename.
  - One to update the overlay container ID to be `channels_overlay_container`, so that's done for the rename and it's easier to review remaining instances of `#streams` in the `web/` directory; see git-grep below.
- Manually tested old Welcome Bot and Notification Bot messages in the dev environment; see screenshots.

<details>
<summary>git-grep for #streams after changes</summary>

```console
$ git grep '#streams' web/
web/e2e-tests/message-basics.test.ts:    await page.click("#streams_header .left-sidebar-title");
web/e2e-tests/message-basics.test.ts:    await page.click("#streams_header .left-sidebar-title");
web/e2e-tests/message-basics.test.ts:    await page.waitForSelector("#streams_list .input-append.notdisplayed", {hidden: true});
web/e2e-tests/message-basics.test.ts:    await page.click("#streams_header .left-sidebar-title");
web/src/add_stream_options_popover.ts:    popover_menus.register_popover_menu("#streams_inline_icon", {
web/src/hash_parser.ts:        // included links to "/#streams/all" and "/#streams/new", we'll
web/src/hashchange.js:        case "#streams":
web/src/hashchange.js:    // included links to "/#streams/all" and "/#streams/new", we'll
web/src/hotspots.ts:            element: "#streams_header .left-sidebar-title .streams-tooltip-target",
web/src/invite.ts:        $("#streams_to_add .invite-stream-controls").hide();
web/src/invite.ts:        $("#streams_to_add .invite-stream-controls").show();
web/src/left_sidebar_navigation_area.ts:    const $streams_header = $("#streams_header");
web/src/pm_list.ts:    $("#streams_list").hide();
web/src/pm_list.ts:    $("#streams_list").show();
web/src/stream_list.ts:    $("#streams_list").expectOne().removeClass("zoom-out").addClass("zoom-in");
web/src/stream_list.ts:    $("#streams_list").expectOne().removeClass("zoom-in").addClass("zoom-out");
web/src/stream_list.ts:    const $streams_header = $("#streams_header");
web/src/stream_list.ts:    $("#streams_header")
web/src/stream_list.ts:    $("#streams_header").addClass("showing-stream-search-section");
web/src/stream_list.ts:    $("#streams_header").removeClass("showing-stream-search-section");
web/src/stream_list.ts:    const stream_header_height = $("#streams_header").outerHeight();
web/src/tippyjs.ts:            "#streams_header .streams-tooltip-target",
web/styles/dark_theme.css:    #streams_header,
web/styles/left_sidebar.css:#streams_list .stream-privacy {
web/styles/left_sidebar.css:#streams_inline_icon,
web/styles/left_sidebar.css:#streams_header,
web/styles/left_sidebar.css:#streams_header {
web/styles/left_sidebar.css:.spectator-view #streams_header {
web/styles/left_sidebar.css:    #streams_header,
web/tests/left_sidebar_navigation_area.test.js:    make_elem($("#streams_header"), "<stream-count>");
web/tests/stream_list.test.js:    assert.ok($("#streams_list").hasClass("zoom-in"));
web/tests/stream_list.test.js:    assert.ok($("#streams_list").hasClass("zoom-out"));
web/tests/stream_list.test.js:    $("#streams_header").outerHeight = () => 0;
web/tests/stream_list.test.js:    $("#streams_header").outerHeight = () => 0;
```
</details>

**Screenshots and screen captures:**

<details>
<summary>Welcome bot message</summary>

![Screenshot from 2024-04-30 15-57-05](https://github.com/zulip/zulip/assets/63245456/b27cbd85-f10e-4edc-9e68-e7164a385367)
![Screenshot from 2024-04-30 15-57-29](https://github.com/zulip/zulip/assets/63245456/11d5f7bd-73d7-4e3a-981a-b2a7fd0922d8)
</details>
<details>
<summary>Notification bot message</summary>

![Screenshot from 2024-04-30 15-58-06](https://github.com/zulip/zulip/assets/63245456/92e64453-144b-45c4-998e-61751219f04f)
![Screenshot from 2024-04-30 15-58-23](https://github.com/zulip/zulip/assets/63245456/98b39e61-ea3b-4e90-8ab5-a01805b01555)
</details>
<details>
<summary>Message view header - link to stream settings edit</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-04-30 16-01-38](https://github.com/zulip/zulip/assets/63245456/389b0938-e210-4859-83b2-10e2fe58ff3b) | ![Screenshot from 2024-04-30 16-00-48](https://github.com/zulip/zulip/assets/63245456/bc3766ab-9b69-4bcf-9255-1e90da3adf2d)

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
