### PR TITLE
popover: Fix user pop over not showing when clicked in channels /group settings

### DIFF
--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -111,6 +111,11 @@ export function is_subscribers_section_opened_for_stream(): boolean {
     return hash_components[3] === "subscribers";
 }
 
+export function is_in_specified_hash_category(hash_categories: string[]): boolean {
+    const main_hash = get_hash_category(window.location.hash);
+    return hash_categories.includes(main_hash);
+}
+
 export const allowed_web_public_narrows = [
     "channels",
     "channel",

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -493,6 +493,8 @@ function hashchanged(from_reload, e) {
         return undefined;
     }
 
+    popovers.hide_all();
+
     if (hash_parser.is_overlay_hash(current_hash)) {
         browser_history.state.changing_hash = true;
         do_hashchange_overlay(old_hash);
@@ -503,7 +505,6 @@ function hashchanged(from_reload, e) {
     // We are changing to a "main screen" view.
     overlays.close_for_hash_change();
     sidebar_ui.hide_all();
-    popovers.hide_all();
     modals.close_active_if_any();
     browser_history.state.changing_hash = true;
     const ret = do_hashchange_normal(from_reload);

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -19,6 +19,8 @@ export type InputPillItem<T> = {
     deactivated?: boolean;
     status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
     should_add_guest_user_indicator?: boolean;
+    user_id?: number;
+    group_id?: number;
 } & T;
 
 export type InputPillConfig = {
@@ -63,6 +65,8 @@ type InputPillRenderingDetails = {
     has_status?: boolean;
     status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined;
     should_add_guest_user_indicator: boolean | undefined;
+    user_id?: number | undefined;
+    group_id?: number | undefined;
 };
 
 // These are the functions that are exposed to other modules.
@@ -157,6 +161,13 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 deactivated: item.deactivated,
                 should_add_guest_user_indicator: item.should_add_guest_user_indicator,
             };
+
+            if (item.user_id) {
+                opts.user_id = item.user_id;
+            }
+            if (item.group_id) {
+                opts.group_id = item.group_id;
+            }
 
             if (has_image) {
                 opts.img_src = item.img_src;

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -222,14 +222,9 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         // this would generally be used for DOM-provoked actions, such as a user
         // clicking on a pill to remove it.
         removePill(element: HTMLElement) {
-            let idx: number | undefined;
-            for (let x = 0; x < store.pills.length; x += 1) {
-                if (store.pills[x].$element[0] === element) {
-                    idx = x;
-                }
-            }
+            const idx = store.pills.findIndex((pill) => pill.$element[0] === element);
 
-            if (idx !== undefined) {
+            if (idx !== -1) {
                 store.pills[idx].$element.remove();
                 const pill = store.pills.splice(idx, 1);
                 if (store.onPillRemove !== undefined) {

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -785,7 +785,7 @@ function register_click_handlers() {
         e.preventDefault();
     });
 
-    $("body").on("click", ".view_user_profile", (e) => {
+    $("body").on("click", ".view_user_profile, .person_picker .pill[data-user-id]", (e) => {
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const user = people.get_by_user_id(user_id);
         toggle_user_card_popover(e.target, user);

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -5,7 +5,7 @@ import * as user_groups from "./user_groups";
 
 export type UserGroupPill = {
     type: "user_group";
-    id: number;
+    group_id: number;
     group_name: string;
 };
 
@@ -30,14 +30,14 @@ export function create_item_from_group_name(
         return undefined;
     }
 
-    if (current_items.some((item) => item.type === "user_group" && item.id === group.id)) {
+    if (current_items.some((item) => item.type === "user_group" && item.group_id === group.id)) {
         return undefined;
     }
 
     return {
         type: "user_group",
         display_value: display_pill(group),
-        id: group.id,
+        group_id: group.id,
         group_name: group.name,
     };
 }
@@ -51,7 +51,7 @@ export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillCont
         .items()
         .flatMap((item) =>
             item.type === "user_group"
-                ? [...user_groups.get_user_group_from_id(item.id).members]
+                ? [...user_groups.get_user_group_from_id(item.group_id).members]
                 : [],
         );
     user_ids = [...new Set(user_ids)];
@@ -65,7 +65,7 @@ export function append_user_group(group: UserGroup, pill_widget: CombinedPillCon
     pill_widget.appendValidatedData({
         type: "user_group",
         display_value: display_pill(group),
-        id: group.id,
+        group_id: group.id,
         group_name: group.name,
     });
     pill_widget.clear_text();
@@ -73,7 +73,7 @@ export function append_user_group(group: UserGroup, pill_widget: CombinedPillCon
 
 export function get_group_ids(pill_widget: CombinedPillContainer): number[] {
     const items = pill_widget.items();
-    return items.flatMap((item) => (item.type === "user_group" ? item.id : []));
+    return items.flatMap((item) => (item.type === "user_group" ? item.group_id : []));
 }
 
 export function filter_taken_groups(

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -53,10 +53,12 @@ export function handle_keyboard(key: string): void {
 }
 
 // element is the target element to pop off of;
-// message_id is the message id containing it, which should be selected;
+// the element could be user group pill or mentions in a message;
+// in case of message, message_id is the message id containing it;
+// in case of user group pill, message_id is not used;
 export function toggle_user_group_info_popover(
     element: ReferenceElement,
-    message_id: number,
+    message_id: number | undefined,
 ): void {
     if (is_open()) {
         hide();
@@ -130,6 +132,16 @@ export function register_click_handlers(): void {
             blueslip.info("Unable to find user group in message" + message.sender_id);
         }
     });
+
+    // Show the user_group_popover when pill clicked in subscriber settings.
+    $("body").on(
+        "click",
+        ".person_picker .pill[data-user-group-id]",
+        function (this: HTMLElement, e) {
+            e.stopPropagation();
+            toggle_user_group_info_popover(this, undefined);
+        },
+    );
 }
 
 function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -62,7 +62,7 @@
             margin-right: 3px;
         }
 
-        &:hover .exit {
+        .exit:hover {
             opacity: 1;
         }
     }

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -1,4 +1,4 @@
-<div class='pill {{#if deactivated}} deactivated-pill {{/if}}' tabindex=0>
+<div class='pill {{#if deactivated}} deactivated-pill {{/if}}'{{#if user_id}}data-user-id="{{user_id}}"{{/if}}{{#if group_id}}data-user-group-id="{{group_id}}"{{/if}} tabindex=0>
     {{#if has_image}}
     <img class="pill-image" src="{{img_src}}" />
     {{/if}}

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -178,6 +178,26 @@ run_test("test_is_subscribers_section_opened_for_stream", () => {
     assert.equal(hash_parser.is_subscribers_section_opened_for_stream(), false);
 });
 
+run_test("test_is_in_specified_hash_category", () => {
+    window.location.hash = "#channels/1/Design/subscribers";
+    assert.equal(hash_parser.is_in_specified_hash_category(["channels", "channel"]), true);
+
+    window.location.hash = "#channels/99/.EC.A1.B0.EB.A6.AC.EB.B2.95.20.F0.9F.98.8E/subscribers";
+    assert.equal(hash_parser.is_in_specified_hash_category(["channels", "channel"]), true);
+
+    window.location.hash = "#gro/channels/channel";
+    assert.equal(hash_parser.is_in_specified_hash_category(["stream", "channel", "group"]), false);
+
+    window.location.hash = "#some/stream/channel/group";
+    assert.equal(hash_parser.is_in_specified_hash_category(["stream", "channel", "group"]), false);
+
+    window.location.hash = "#some/stream/channel/group";
+    assert.equal(hash_parser.is_in_specified_hash_category([""]), false);
+
+    window.location.hash = "#some/stream/channel/group";
+    assert.equal(hash_parser.is_in_specified_hash_category([]), false);
+});
+
 run_test("test_parse_narrow", () => {
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "99-frontend"]), [
         {negated: false, operator: "stream", operand: "frontend"},

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -22,13 +22,13 @@ const testers = {
 };
 
 const admins_pill = {
-    id: admins.id,
+    group_id: admins.id,
     group_name: admins.name,
     type: "user_group",
     display_value: admins.name + ": " + admins.members.length + " users",
 };
 const testers_pill = {
-    id: testers.id,
+    group_id: testers.id,
     group_name: testers.name,
     type: "user_group",
     display_value: testers.name + ": " + testers.members.length + " users",


### PR DESCRIPTION
## :bookmark_tabs: Overview
This PR aims to continue where #28820 has left off. The changes introduced in my PR are primarily fixes addressing the comments left by reviewer in the original PR.

Details of the original PR by Ecxtacy: 
- Added css fix for hovering effect on the X icon in user pills.
- Added an optimization refactor to `removePill` function of `input_pill.ts` module as discussed in the [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Input.20pill.20code.20optimization).
- Fixed user pill related components to enable popover effect for user and user group pills in channel and group settings.

New changes in this PR is detailed in the PR comments I've highlighted in the code.  

Fixes: #28687

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>
Popovers on user and group pills in channel and group menu:
</summary>

Relevant commits for this change:
- `input_pill: Pass user_id and group_id to render pill.`
- `settings: Show user_card_popover when pill is clicked.`
- `popovers: Refactor user_group_popover to work with pills.`
- `settings: Show user_group_popover when pill is clicked.`

Popovers on Channel/Stream settings:

| **Before** | **After** |
|---|---|
|![image](https://github.com/zulip/zulip/assets/108744694/80de23bf-701a-4812-b453-91dd5a2d2681)|![image](https://github.com/zulip/zulip/assets/108744694/22ffb0b8-bccb-4ed1-a832-d65fd3a98a27)![image](https://github.com/zulip/zulip/assets/108744694/9977552f-cf09-48c8-a5d1-cbf9de5fde25)|

Popovers on User Groups Settings:

| **Before** | **After** |
|---|---|
|![image](https://github.com/zulip/zulip/assets/108744694/34b76dcb-7b1b-4992-9268-2fe7194eb64b)|![image](https://github.com/zulip/zulip/assets/108744694/c10e3ed7-7606-4caf-9727-4939546157ce)![image](https://github.com/zulip/zulip/assets/108744694/484dd784-eec6-4a98-8aae-ebf1638c1ab8)|
</details>


<details>
<summary> X button hover effect:
</summary>

Relevant commit for this change: `css: Show 'x' button hover styling when hovered over 'x'.`

Before:
X button focuses even only by hovering over the pill and not the button itself.

[Screencast from 04-05-24 16:06:44.webm](https://github.com/zulip/zulip/assets/108744694/f54f928b-18ed-4682-b3b1-bb0754c0d9e0)

After:
X button only focuses if the cursor is on top of it.
![image](https://github.com/zulip/zulip/assets/108744694/808b2797-fd70-4bbd-87a9-0933a6e92790)
![image](https://github.com/zulip/zulip/assets/108744694/304d6611-c532-46e9-a143-5ae3d8bba12e)

[Screencast from 04-05-24 14:38:21.webm](https://github.com/zulip/zulip/assets/108744694/f8bb25c3-38cb-486e-be1a-09736551247d)
</details>

<details>
<summary>Popover closing behavior:
</summary>

Relevant commit for this change: `hashchange: Fix popover not disappearing on overlay hash URL.`

Before: 
Clicking back button in browser doesn't hide popovers

[Screencast from 04-05-24 15:40:48.webm](https://github.com/zulip/zulip/assets/108744694/96971ce5-74ca-4c98-b958-ab29e885676c)

After:

[Screencast from 04-05-24 15:57:19.webm](https://github.com/zulip/zulip/assets/108744694/239b453d-eab9-47b0-abea-d2e78d53ff6d)

[Screencast from 04-05-24 15:57:53.webm](https://github.com/zulip/zulip/assets/108744694/bfd11f44-070d-437a-b107-4cb8ce3cd8a0)

</details>

<details>
<summary>Impacted functions, no regression found:
</summary>

`toggle_user_group_info_popover()` in `user_group_popover.js` still function on mentions in messages:
![image](https://github.com/zulip/zulip/assets/108744694/d402ba6f-087d-46c6-ba49-4ed98df51055)

other user pills in group & channel setting:
![image](https://github.com/zulip/zulip/assets/108744694/dffe1558-094e-40b4-99f1-92e72aa56f2f)

[Screencast from 03-05-24 19:58:05.webm](https://github.com/zulip/zulip/assets/108744694/cb067179-10b5-4188-8fc2-18c02961a994)
</details>

### :factory_worker:  Concerns & Issue Encountered
- inconsistency in `user_group_pill.ts`. I've pointed out the detail [here](https://github.com/zulip/zulip/pull/29898/files#r1588885120)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
