### PR TITLE
todo: Require space after colon to separate task title from description.

### DIFF
--- a/help/collaborative-to-do-lists.md
+++ b/help/collaborative-to-do-lists.md
@@ -12,7 +12,7 @@
 
 2. Type `/todo` followed by a space, and the title of the to-do list.
 
-3. _(optional)_ Type each task on a new line, with its description, if any, after a <kbd>:</kbd>.
+3. _(optional)_ Type each task on a new line, with its description, if any, after a <kbd>:</kbd> and blank space.
 
 4. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
    use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -56,8 +56,8 @@ def parse_todo_extra_data(content: str) -> Any:
         task_data = re.sub(r"(\s*[-*]?\s*)", "", line.strip(), count=1)
         if len(task_data) > 0:
             # a task and its description (optional) are separated
-            # by the (first) `:` character
-            task_data_array = task_data.split(":", 1)
+            # by the (first) `: ` substring
+            task_data_array = task_data.split(": ", 1)
             tasks.append(
                 {
                     "task": task_data_array[0].strip(),


### PR DESCRIPTION
This fixes the annoying behaviour where a task title with a url in it, for example, "Fix issue https://github/com/zulip/zulip/issues/1234" would be wrongly split into a description at the `:` in the url.

Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/extra.20space.20in.20todo.20list.20URL/near/1790012)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
