### PR TITLE
message_row: Extract selectors from .message_row

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -53,30 +53,7 @@
         }
     }
 
-    .messagebox {
-        grid-area: messagebox;
-        word-wrap: break-word;
-        cursor: pointer;
-        border: none;
-        /* The left padding value accounts for a 2px
-          unread marker, ensuring a uniform 5px of
-          padding on either side of the message box. */
-        padding: 0 5px 0 3px;
-
-        &:hover .message_controls,
-        &:hover .message_failed {
-            .empty-star:hover {
-                cursor: pointer;
-            }
-
-            > div {
-                opacity: 1;
-                visibility: visible;
-            }
-        }
-    }
-
-    .messagebox .messagebox-content {
+    .messagebox-content {
         display: grid;
         align-items: baseline;
         padding-left: 10px;
@@ -244,7 +221,7 @@
     }
 
     &.include-sender {
-        .messagebox .messagebox-content {
+        .messagebox-content {
             grid-template-areas:
                 "avatar sender    controls . time"
                 "avatar message   .        . .   "
@@ -470,6 +447,29 @@
 
         &:hover {
             background: var(--color-exit-button-background-interactive);
+        }
+    }
+}
+
+.messagebox {
+    grid-area: messagebox;
+    word-wrap: break-word;
+    cursor: pointer;
+    border: none;
+    /* The left padding value accounts for a 2px
+      unread marker, ensuring a uniform 5px of
+      padding on either side of the message box. */
+    padding: 0 5px 0 3px;
+
+    &:hover .message_controls,
+    &:hover .message_failed {
+        .empty-star:hover {
+            cursor: pointer;
+        }
+
+        > div {
+            opacity: 1;
+            visibility: visible;
         }
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -53,321 +53,6 @@
         }
     }
 
-    .messagebox-content {
-        display: grid;
-        align-items: baseline;
-        padding-left: 10px;
-        /* Prevent the message column from overflowing the 1fr
-           space allotted by specifying `minmax(0,1fr)`, which
-           sets 0 as the minimum size, not the grid default of
-           `auto`.
-
-            The calculated `--message-box-timestamp-column-width`
-            should match `max-content` exactly, but `max-content`
-            ensures the timestamp will always have enough space
-            in the column. */
-        grid-template:
-            var(--message-box-icon-height) repeat(3, auto) /
-            var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
-                3 * var(--message-box-icon-width)
-            )
-            8px minmax(var(--message-box-timestamp-column-width), max-content);
-        /* Named grid areas provide flexibility for positioning grid items
-           reliably, even if the row or column definitions of the grid change. */
-        grid-template-areas:
-            "edited message   controls . time"
-            ".      message   .        . .   "
-            ".      more      .        . .   "
-            ".      reactions .        . .   ";
-
-        &.content_edit_mode {
-            cursor: default;
-            /* Set the controls area to 0 to give more space
-               to the edit/source view area. */
-            grid-template-columns:
-                var(--message-box-avatar-column-width) minmax(0, 1fr)
-                0 8px minmax(
-                    var(--message-box-timestamp-column-width),
-                    max-content
-                );
-        }
-
-        @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-            grid-template-columns:
-                var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
-                    2 * var(--message-box-icon-width)
-                )
-                8px minmax(
-                    var(--message-box-timestamp-column-width),
-                    max-content
-                );
-        }
-
-        .message_controls {
-            grid-area: controls;
-
-            @media (width < $sm_min),
-                ((width >= $md_min) and (width < $mc_min)) {
-                /* This is intended to target the first message_controls child
-                   when there are 3 displayed. 4 = 3 + hidden message_failed element. */
-                .message_control_button:nth-last-child(4) {
-                    display: none;
-                }
-            }
-        }
-
-        .message_edit_notice {
-            grid-area: edited;
-        }
-
-        .slow-send-spinner {
-            display: none;
-            justify-self: end;
-            margin-right: 10px;
-            text-align: end;
-            grid-area: time;
-        }
-
-        .message_content {
-            grid-area: message;
-            /*
-            Space between two single line messages is kept in
-            lockstep with adjacent Markdown elements.
-            */
-            padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
-            color: var(--color-text-message-default);
-            font-size: var(--base-font-size-px);
-            line-height: var(--base-line-height-unitless);
-            min-height: 17px;
-            display: block;
-            position: relative;
-            overflow: hidden;
-
-            &:empty {
-                display: none;
-            }
-
-            &.condensed {
-                max-height: 8.5em;
-                min-height: 0;
-                overflow: hidden;
-                mask-image: linear-gradient(
-                    to top,
-                    hsl(0deg 0% 100% / 0%) 0%,
-                    hsl(0deg 0% 100%) 60px
-                );
-                mask-size: cover;
-            }
-
-            &.collapsed {
-                padding: 0;
-                max-height: 0;
-                min-height: 0;
-                overflow: hidden;
-            }
-        }
-
-        .message_reactions {
-            grid-area: reactions;
-            display: flex;
-            /* Allow reactions to wrap in mobile viewports */
-            flex-wrap: wrap;
-            /* Keep reactions aligned to start (top), so that the
-               margin on the reaction button doesn't appear to
-               stretch the reactions taller. */
-            align-items: flex-start;
-            /* Control reaction spacing with a gap */
-            gap: 4px;
-        }
-
-        .message_edit {
-            grid-area: message;
-            /* Align self to start, rather than baseline, so the baseline
-              is preserved from the message itself--keeping the time,
-              edit message, and controls at the same vertical alignment. */
-            align-self: start;
-            margin-top: var(--message-box-vertical-margin);
-        }
-
-        .message_length_controller {
-            grid-area: more;
-        }
-
-        .collapsed ~ .message_length_controller {
-            /* When content is collapsed, the length controller
-               should occupy the space ordinarily assigned to
-               the message. */
-            grid-area: message;
-            /* However, don't let the SHOW MORE button participate
-               in the baseline group. */
-            align-self: start;
-
-            .message_length_toggle {
-                /* Ensure that a collapsed message maintains the
-                   same space around the toggle button as any other
-                   message-row content. */
-                margin: 4px 0;
-            }
-        }
-
-        &.content_edit_mode .message_length_controller {
-            /* If entering edit mode on a collapsed message,
-               just hide the controller area. This preserves
-               the collapsed state of the message, which need
-               not be touched. We just need to hide the button.
-               This works for condensed messages, too. */
-            display: none;
-        }
-    }
-
-    &.include-sender {
-        .messagebox-content {
-            grid-template-areas:
-                "avatar sender    controls . time"
-                "avatar message   .        . .   "
-                ".      more      .        . .   "
-                ".      reactions .        . .   ";
-
-            .message_edit {
-                /* No top margin when there's a sender row */
-                margin-top: 0;
-            }
-
-            &.is-me-message {
-                grid-template-areas:
-                    "avatar sender    controls . time"
-                    "avatar sender    .        . .   "
-                    ".      more      .        . .   "
-                    ".      reactions .        . .   ";
-
-                .message-avatar {
-                    /* Set the line-height to match the height of the avatar image
-                       to center me-messages within the baseline group. */
-                    line-height: var(--message-box-avatar-height);
-                    align-self: baseline;
-                }
-
-                .message_sender {
-                    /* Don't display message sender as flexbox for me-messages. */
-                    display: block;
-                    /* Set the same line-height as on message content for
-                       me-messages. */
-                    line-height: var(--base-line-height-unitless);
-                    /* Ensure the same spacing below messages as for any other
-                       paragraph. */
-                    padding-bottom: var(
-                        --message-box-markdown-aligned-vertical-space
-                    );
-
-                    /* Display message components inline, with wrapping white-space,
-                       so the sender name and message display as a continuous line
-                       of wrapping text. */
-                    .sender_name {
-                        white-space: normal;
-                        display: inline;
-                    }
-
-                    .sender_name_text {
-                        max-width: 100%;
-                    }
-                }
-
-                &.content_edit_mode {
-                    .message_sender {
-                        /* Keep the me-message participating in the baseline */
-                        visibility: hidden;
-                    }
-
-                    .message_edit {
-                        /* Use the sender grid area for the me-message edit/view-source box */
-                        grid-area: sender;
-                        margin-top: var(--message-box-vertical-margin);
-                    }
-                }
-            }
-
-            .message-avatar {
-                grid-area: avatar;
-                /* The picture should not participate in the baseline group. */
-                align-self: start;
-                /* Because the avatar may be the tallest element in a
-                  single-line me message, this margin preserves the
-                  overall height of the message box. */
-                margin: var(--message-box-vertical-margin) 0;
-            }
-
-            .status-message {
-                font-weight: normal;
-            }
-
-            .message_content {
-                /* Top padding is reduced when there is a sender line. */
-                padding-top: 3px;
-                grid-area: message;
-            }
-
-            .slow-send-spinner {
-                align-self: center;
-                position: unset;
-                margin-top: 1px;
-            }
-
-            .message_edit_notice {
-                /* When the edit notice is inline, as on edited me-messages,
-                  the inline-block and accompanying vertical-align styles will
-                  apply */
-                display: inline-block;
-                vertical-align: baseline;
-                /* A bit of margin here helps these not look associated with the name. */
-                margin-left: 4px;
-            }
-
-            .message_sender {
-                overflow: hidden;
-                text-overflow: ellipsis;
-                grid-area: sender;
-                display: flex;
-                /* A generous line-height on the sender name is necessary
-                   for internationalization and non-Western Latin character
-                   sets. */
-                line-height: var(--message-box-sender-line-height);
-                /* Ensure flexed sender info (name, status emoji, inline EDITED)
-                   forms a baseline group, which will participate with the
-                   message-box grid's baseline group, too. */
-                align-items: baseline;
-
-                .zulip-icon.zulip-icon-bot {
-                    font-size: 12px;
-                    align-self: center;
-                    padding: 0 0 0 5px;
-                }
-
-                .sender_name {
-                    display: inline-flex;
-                    font-weight: 700;
-                    color: var(--color-text-sender-name);
-                    column-gap: 3px;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                    outline: none;
-                    align-self: baseline;
-
-                    .sender_name_text {
-                        overflow: hidden;
-                        white-space: nowrap;
-                        display: inline-flex;
-
-                        .user-name {
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     &.sender_info_hovered {
         .sender_name {
             cursor: pointer;
@@ -470,6 +155,317 @@
         > div {
             opacity: 1;
             visibility: visible;
+        }
+    }
+}
+
+.messagebox-content {
+    display: grid;
+    align-items: baseline;
+    padding-left: 10px;
+    /* Prevent the message column from overflowing the 1fr
+       space allotted by specifying `minmax(0,1fr)`, which
+       sets 0 as the minimum size, not the grid default of
+       `auto`.
+
+        The calculated `--message-box-timestamp-column-width`
+        should match `max-content` exactly, but `max-content`
+        ensures the timestamp will always have enough space
+        in the column. */
+    grid-template:
+        var(--message-box-icon-height) repeat(3, auto) /
+        var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
+            3 * var(--message-box-icon-width)
+        )
+        8px minmax(var(--message-box-timestamp-column-width), max-content);
+    /* Named grid areas provide flexibility for positioning grid items
+       reliably, even if the row or column definitions of the grid change. */
+    grid-template-areas:
+        "edited message   controls . time"
+        ".      message   .        . .   "
+        ".      more      .        . .   "
+        ".      reactions .        . .   ";
+
+    &.content_edit_mode {
+        cursor: default;
+        /* Set the controls area to 0 to give more space
+           to the edit/source view area. */
+        grid-template-columns:
+            var(--message-box-avatar-column-width) minmax(0, 1fr)
+            0 8px minmax(
+                var(--message-box-timestamp-column-width),
+                max-content
+            );
+    }
+
+    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
+        grid-template-columns:
+            var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
+                2 * var(--message-box-icon-width)
+            )
+            8px minmax(var(--message-box-timestamp-column-width), max-content);
+    }
+
+    .message_controls {
+        grid-area: controls;
+
+        @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
+            /* This is intended to target the first message_controls child
+               when there are 3 displayed. 4 = 3 + hidden message_failed element. */
+            .message_control_button:nth-last-child(4) {
+                display: none;
+            }
+        }
+    }
+
+    .message_edit_notice {
+        grid-area: edited;
+    }
+
+    .slow-send-spinner {
+        display: none;
+        justify-self: end;
+        margin-right: 10px;
+        text-align: end;
+        grid-area: time;
+    }
+
+    .message_content {
+        grid-area: message;
+        /*
+        Space between two single line messages is kept in
+        lockstep with adjacent Markdown elements.
+        */
+        padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
+        color: var(--color-text-message-default);
+        font-size: var(--base-font-size-px);
+        line-height: var(--base-line-height-unitless);
+        min-height: 17px;
+        display: block;
+        position: relative;
+        overflow: hidden;
+
+        &:empty {
+            display: none;
+        }
+
+        &.condensed {
+            max-height: 8.5em;
+            min-height: 0;
+            overflow: hidden;
+            mask-image: linear-gradient(
+                to top,
+                hsl(0deg 0% 100% / 0%) 0%,
+                hsl(0deg 0% 100%) 60px
+            );
+            mask-size: cover;
+        }
+
+        &.collapsed {
+            padding: 0;
+            max-height: 0;
+            min-height: 0;
+            overflow: hidden;
+        }
+    }
+
+    .message_reactions {
+        grid-area: reactions;
+        display: flex;
+        /* Allow reactions to wrap in mobile viewports */
+        flex-wrap: wrap;
+        /* Keep reactions aligned to start (top), so that the
+           margin on the reaction button doesn't appear to
+           stretch the reactions taller. */
+        align-items: flex-start;
+        /* Control reaction spacing with a gap */
+        gap: 4px;
+    }
+
+    .message_edit {
+        grid-area: message;
+        /* Align self to start, rather than baseline, so the baseline
+          is preserved from the message itself--keeping the time,
+          edit message, and controls at the same vertical alignment. */
+        align-self: start;
+        margin-top: var(--message-box-vertical-margin);
+    }
+
+    .message_length_controller {
+        grid-area: more;
+    }
+
+    .collapsed ~ .message_length_controller {
+        /* When content is collapsed, the length controller
+           should occupy the space ordinarily assigned to
+           the message. */
+        grid-area: message;
+        /* However, don't let the SHOW MORE button participate
+           in the baseline group. */
+        align-self: start;
+
+        .message_length_toggle {
+            /* Ensure that a collapsed message maintains the
+               same space around the toggle button as any other
+               message-row content. */
+            margin: 4px 0;
+        }
+    }
+
+    &.content_edit_mode .message_length_controller {
+        /* If entering edit mode on a collapsed message,
+           just hide the controller area. This preserves
+           the collapsed state of the message, which need
+           not be touched. We just need to hide the button.
+           This works for condensed messages, too. */
+        display: none;
+    }
+}
+
+.include-sender {
+    .messagebox-content {
+        grid-template-areas:
+            "avatar sender    controls . time"
+            "avatar message   .        . .   "
+            ".      more      .        . .   "
+            ".      reactions .        . .   ";
+
+        .message_edit {
+            /* No top margin when there's a sender row */
+            margin-top: 0;
+        }
+
+        &.is-me-message {
+            grid-template-areas:
+                "avatar sender    controls . time"
+                "avatar sender    .        . .   "
+                ".      more      .        . .   "
+                ".      reactions .        . .   ";
+
+            .message-avatar {
+                /* Set the line-height to match the height of the avatar image
+                   to center me-messages within the baseline group. */
+                line-height: var(--message-box-avatar-height);
+                align-self: baseline;
+            }
+
+            .message_sender {
+                /* Don't display message sender as flexbox for me-messages. */
+                display: block;
+                /* Set the same line-height as on message content for
+                   me-messages. */
+                line-height: var(--base-line-height-unitless);
+                /* Ensure the same spacing below messages as for any other
+                   paragraph. */
+                padding-bottom: var(
+                    --message-box-markdown-aligned-vertical-space
+                );
+
+                /* Display message components inline, with wrapping white-space,
+                   so the sender name and message display as a continuous line
+                   of wrapping text. */
+                .sender_name {
+                    white-space: normal;
+                    display: inline;
+                }
+
+                .sender_name_text {
+                    max-width: 100%;
+                }
+            }
+
+            &.content_edit_mode {
+                .message_sender {
+                    /* Keep the me-message participating in the baseline */
+                    visibility: hidden;
+                }
+
+                .message_edit {
+                    /* Use the sender grid area for the me-message edit/view-source box */
+                    grid-area: sender;
+                    margin-top: var(--message-box-vertical-margin);
+                }
+            }
+        }
+
+        .message-avatar {
+            grid-area: avatar;
+            /* The picture should not participate in the baseline group. */
+            align-self: start;
+            /* Because the avatar may be the tallest element in a
+              single-line me message, this margin preserves the
+              overall height of the message box. */
+            margin: var(--message-box-vertical-margin) 0;
+        }
+
+        .status-message {
+            font-weight: normal;
+        }
+
+        .message_content {
+            /* Top padding is reduced when there is a sender line. */
+            padding-top: 3px;
+            grid-area: message;
+        }
+
+        .slow-send-spinner {
+            align-self: center;
+            position: unset;
+            margin-top: 1px;
+        }
+
+        .message_edit_notice {
+            /* When the edit notice is inline, as on edited me-messages,
+              the inline-block and accompanying vertical-align styles will
+              apply */
+            display: inline-block;
+            vertical-align: baseline;
+            /* A bit of margin here helps these not look associated with the name. */
+            margin-left: 4px;
+        }
+
+        .message_sender {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            grid-area: sender;
+            display: flex;
+            /* A generous line-height on the sender name is necessary
+               for internationalization and non-Western Latin character
+               sets. */
+            line-height: var(--message-box-sender-line-height);
+            /* Ensure flexed sender info (name, status emoji, inline EDITED)
+               forms a baseline group, which will participate with the
+               message-box grid's baseline group, too. */
+            align-items: baseline;
+
+            .zulip-icon.zulip-icon-bot {
+                font-size: 12px;
+                align-self: center;
+                padding: 0 0 0 5px;
+            }
+
+            .sender_name {
+                display: inline-flex;
+                font-weight: 700;
+                color: var(--color-text-sender-name);
+                column-gap: 3px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                outline: none;
+                align-self: baseline;
+
+                .sender_name_text {
+                    overflow: hidden;
+                    white-space: nowrap;
+                    display: inline-flex;
+
+                    .user-name {
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
+                }
+            }
         }
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -65,62 +65,6 @@
             cursor: pointer;
         }
     }
-
-    /* Message-editing styles */
-    .message-edit-buttons-and-timer {
-        margin-top: 5px;
-        display: flex;
-        gap: 5px;
-        /* Allow items to occupy full height.
-           This is especially important for
-           buttons that are flex items. */
-        align-items: stretch;
-    }
-
-    .message-actions-button {
-        box-sizing: border-box;
-        /* Display the actions buttons as
-           flex containers for positioning
-           text and spinners. */
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 28px;
-        padding: 0 10px;
-        border-radius: 4px;
-        border: 0;
-        line-height: 1;
-    }
-
-    .message_edit_save {
-        /* Match Save button's basic colors to
-           the compose box Send button. */
-        color: var(--color-compose-send-button-icon-color);
-        background-color: var(--color-compose-send-button-background);
-
-        &:hover {
-            background-color: var(
-                --color-compose-send-button-background-interactive
-            );
-        }
-
-        &:disabled {
-            /* Replicate the `.new-style` disabled values,
-               without any color shifts. */
-            cursor: not-allowed;
-            opacity: 0.5;
-        }
-    }
-
-    .message_edit_cancel,
-    .message_edit_close {
-        color: var(--color-exit-button-text);
-        background: var(--color-exit-button-background);
-
-        &:hover {
-            background: var(--color-exit-button-background-interactive);
-        }
-    }
 }
 
 .messagebox {
@@ -531,7 +475,61 @@
     }
 }
 
-/* Additional message-editing UI styles. */
+/* Message-editing styles */
+.message-edit-buttons-and-timer {
+    margin-top: 5px;
+    display: flex;
+    gap: 5px;
+    /* Allow items to occupy full height.
+       This is especially important for
+       buttons that are flex items. */
+    align-items: stretch;
+}
+
+.message-actions-button {
+    box-sizing: border-box;
+    /* Display the actions buttons as
+       flex containers for positioning
+       text and spinners. */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 28px;
+    padding: 0 10px;
+    border-radius: 4px;
+    border: 0;
+    line-height: 1;
+}
+
+.message_edit_save {
+    /* Match Save button's basic colors to
+       the compose box Send button. */
+    color: var(--color-compose-send-button-icon-color);
+    background-color: var(--color-compose-send-button-background);
+
+    &:hover {
+        background-color: var(
+            --color-compose-send-button-background-interactive
+        );
+    }
+
+    &:disabled {
+        /* Replicate the `.new-style` disabled values,
+           without any color shifts. */
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+}
+
+.message_edit_cancel,
+.message_edit_close {
+    color: var(--color-exit-button-text);
+    background: var(--color-exit-button-background);
+
+    &:hover {
+        background: var(--color-exit-button-background-interactive);
+    }
+}
 
 .message_edit_content {
     max-height: 24em;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -66,19 +66,6 @@
         }
     }
 
-    /* Locally echoed messages. */
-    &.locally-echoed .message-time {
-        opacity: 0;
-        /* Don't show pointer when message-time doesn't have a link. */
-        cursor: default;
-    }
-
-    /* Show the spinner only for messages that are still locally echoed. */
-    &.locally-echoed .slow-send-spinner {
-        display: unset !important;
-        cursor: default;
-    }
-
     /* Message-editing styles */
     .message-edit-buttons-and-timer {
         margin-top: 5px;
@@ -680,6 +667,19 @@ of the base style defined for a read-only textarea in dark mode. */
 
 .message_edit_notice_hover:hover {
     opacity: 1;
+}
+
+/* Locally echoed messages. */
+.locally-echoed .message-time {
+    opacity: 0;
+    /* Don't show pointer when message-time doesn't have a link. */
+    cursor: default;
+}
+
+/* Show the spinner only for messages that are still locally echoed. */
+.locally-echoed .slow-send-spinner {
+    display: unset !important;
+    cursor: default;
 }
 
 .recipient_row {


### PR DESCRIPTION
This PR makes a significant set of changes to the structure of CSS in `message_row.css`. It flattens a number of selectors, and reduces the `.message_row` selector only to selectors that represent additional classes.

A follow-up PR to this will further flatten the selectors inside of `.include-sender` and `.messagebox-content`, but that's too much churn to add into this already quite massive refactor.

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| ![viewing-light-before](https://github.com/zulip/zulip/assets/170719/2293e828-e86b-46b9-ae50-9e64c00a7325) | ![viewing-light-after](https://github.com/zulip/zulip/assets/170719/94a7f1c5-db76-47fe-80ed-74dd620c266d) |
| ![viewing-dark-before](https://github.com/zulip/zulip/assets/170719/2d4e4fe2-af8f-4e23-a4dc-9e6b92a42aa4) | ![viewing-dark-after](https://github.com/zulip/zulip/assets/170719/4d89b174-3a4d-4671-ac6c-371ee25d7a42) |
| ![editing-light-before](https://github.com/zulip/zulip/assets/170719/a9fb3c1e-e5f0-4e4c-bc58-d3a3d1ebd946) | ![editing-light-after](https://github.com/zulip/zulip/assets/170719/ca38a34c-8f6f-4ff2-9df2-d969c80f36eb) |
| ![editing-dark-before](https://github.com/zulip/zulip/assets/170719/00a5a768-9f02-41fb-a894-f4353551823e) | ![editing-dark-after](https://github.com/zulip/zulip/assets/170719/e04deb0c-aa83-42a1-8ffb-d6f96f9a7ff6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>