### PR TITLE
compose_banner: Replace the close button with "Got it" button. 

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -158,7 +158,6 @@ export function send_message_success(request, data) {
             // topic has been automatically unmuted or followed. No need to
             // suggest the user to unmute. Show the banner and return.
             compose_notifications.notify_automatic_new_visibility_policy(request, data);
-            onboarding_steps.post_onboarding_step_as_read("visibility_policy_banner");
             return;
         }
 

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -73,6 +73,8 @@ export function notify_automatic_new_visibility_policy(
             narrow_url,
             followed,
             button_text: $t({defaultMessage: "Change setting"}),
+            hide_close_button: true,
+            is_onboarding_banner: true,
         }),
     );
     compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -18,6 +18,7 @@ import * as flatpickr from "./flatpickr";
 import {$t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as narrow from "./narrow";
+import * as onboarding_steps from "./onboarding_steps";
 import {page_params} from "./page_params";
 import * as poll_modal from "./poll_modal";
 import * as popovers from "./popovers";
@@ -212,13 +213,19 @@ export function initialize() {
         },
     );
 
+    const automatic_new_visibility_policy_banner_selector = `.${CSS.escape(compose_banner.CLASSNAMES.automatic_new_visibility_policy)}`;
     $("body").on(
         "click",
-        `.${CSS.escape(
-            compose_banner.CLASSNAMES.automatic_new_visibility_policy,
-        )} .main-view-banner-action-button`,
+        `${automatic_new_visibility_policy_banner_selector} .main-view-banner-action-button`,
         (event) => {
             event.preventDefault();
+            if ($(event.target).attr("data-action") === "mark-as-read") {
+                $(event.target)
+                    .parents(`${automatic_new_visibility_policy_banner_selector}`)
+                    .remove();
+                onboarding_steps.post_onboarding_step_as_read("visibility_policy_banner");
+                return;
+            }
             window.location.href = "/#settings/notifications";
         },
     );

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -3,7 +3,7 @@
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
   {{#if topic_name}}data-topic-name="{{topic_name}}"{{/if}}>
-    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+    <div class="main-view-banner-elements-wrapper">
         {{#if banner_text}}
         <p class="banner_content">{{banner_text}}</p>
         {{else}}

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -12,6 +12,9 @@
         {{#if button_text}}
         <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
         {{/if}}
+        {{#if is_onboarding_banner}}
+        <button class="main-view-banner-action-button right_edge" data-action="mark-as-read">{{t "Got it"}}</button>
+        {{/if}}
     </div>
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -1,7 +1,7 @@
 <div
   class="main-view-banner success message_scheduled_success_compose_banner"
   data-scheduled-message-id="{{scheduled_message_id}}">
-    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+    <div class="main-view-banner-elements-wrapper">
         <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}
             <a href="#scheduled">{{t "View scheduled messages" }}</a>
         </p>

--- a/web/templates/modal_banner/modal_banner.hbs
+++ b/web/templates/modal_banner/modal_banner.hbs
@@ -1,5 +1,5 @@
 <div class="main-view-banner {{banner_type}} {{classname}}">
-    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+    <div class="main-view-banner-elements-wrapper">
         {{#if banner_text}}
         <p class="banner_content">{{banner_text}}</p>
         {{else}}

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -168,10 +168,6 @@ test_ui("send_message_success", ({override, override_rewire}) => {
         assert.equal(data.automatic_new_visibility_policy, 2);
     });
 
-    override(onboarding_steps, "post_onboarding_step_as_read", (onboarding_step_name) => {
-        assert.equal(onboarding_step_name, "visibility_policy_banner");
-    });
-
     let request = {
         locally_echoed: false,
         local_id: "1001",


### PR DESCRIPTION
* First commit : A small prep commit to remove a stale class.
* Second commit:

    [CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/jumping.20to.20sent.20message.20conversation.20.28experiment.29.20.2329186/near/1789655)
    
    > we should have a standard pattern for these onboarding banners, and replace the x with a "Got it" button like in [#design > explaining message fading](https://chat.zulip.org/#narrow/stream/101-design/topic/explaining.20message.20fading) .



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-05-01 11-25-55](https://github.com/zulip/zulip/assets/56781761/aae2ac52-7fa6-4a34-8a68-39f9c9c07a30)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
