### PR TITLE
left_sidebar: Add colon `:` to the list of stream word separators.

### DIFF
--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -90,8 +90,8 @@ type StreamListSortResult = {
 
 export function sort_groups(stream_ids: number[], search_term: string): StreamListSortResult {
     const stream_id_to_name = (stream_id: number): string => sub_store.get(stream_id)!.name;
-    // Use -, _ and / as word separators apart from the default space character
-    const word_separator_regex = /[\s/_-]/;
+    // Use -, _, : and / as word separators apart from the default space character
+    const word_separator_regex = /[\s/:_-]/;
     stream_ids = util.filter_by_word_prefix_match(
         stream_ids,
         search_term,

--- a/web/tests/stream_list_sort.test.js
+++ b/web/tests/stream_list_sort.test.js
@@ -54,9 +54,9 @@ const weaving = {
     stream_id: 5,
     pin_to_top: false,
 };
-const stream_hyphen_underscore_slash = {
+const stream_hyphen_underscore_slash_colon = {
     subscribed: true,
-    name: "stream-hyphen_underscore/slash",
+    name: "stream-hyphen_underscore/slash:colon",
     stream_id: 6,
     pin_to_top: false,
 };
@@ -106,7 +106,7 @@ test("basics", ({override_rewire}) => {
     stream_data.add_sub(pneumonia);
     stream_data.add_sub(clarinet);
     stream_data.add_sub(weaving);
-    stream_data.add_sub(stream_hyphen_underscore_slash);
+    stream_data.add_sub(stream_hyphen_underscore_slash_colon);
     stream_data.add_sub(muted_active);
     stream_data.add_sub(muted_pinned);
 
@@ -118,7 +118,7 @@ test("basics", ({override_rewire}) => {
     assert.deepEqual(sorted.normal_streams, [
         clarinet.stream_id,
         fast_tortoise.stream_id,
-        stream_hyphen_underscore_slash.stream_id,
+        stream_hyphen_underscore_slash_colon.stream_id,
     ]);
     assert.deepEqual(sorted.muted_pinned_streams, [muted_pinned.stream_id]);
     assert.deepEqual(sorted.muted_active_streams, [muted_active.stream_id]);
@@ -133,15 +133,15 @@ test("basics", ({override_rewire}) => {
 
     assert.equal(
         stream_list_sort.next_stream_id(fast_tortoise.stream_id),
-        stream_hyphen_underscore_slash.stream_id,
+        stream_hyphen_underscore_slash_colon.stream_id,
     );
     assert.equal(
-        stream_list_sort.next_stream_id(stream_hyphen_underscore_slash.stream_id),
+        stream_list_sort.next_stream_id(stream_hyphen_underscore_slash_colon.stream_id),
         muted_active.stream_id,
     );
     assert.equal(
         stream_list_sort.next_stream_id(fast_tortoise.stream_id),
-        stream_hyphen_underscore_slash.stream_id,
+        stream_hyphen_underscore_slash_colon.stream_id,
     );
     assert.equal(stream_list_sort.next_stream_id(muted_active.stream_id), pneumonia.stream_id);
     assert.equal(stream_list_sort.next_stream_id(pneumonia.stream_id), undefined);
@@ -149,7 +149,7 @@ test("basics", ({override_rewire}) => {
     // Test filtering
     sorted = sort_groups("s");
     assert.deepEqual(sorted.pinned_streams, [scalene.stream_id]);
-    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash_colon.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 
     assert.equal(stream_list_sort.prev_stream_id(clarinet.stream_id), undefined);
@@ -177,18 +177,22 @@ test("basics", ({override_rewire}) => {
     // Test searching part of stream name with non space word separators
     sorted = sort_groups("hyphen");
     assert.deepEqual(sorted.pinned_streams, []);
-    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash_colon.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 
     sorted = sort_groups("hyphen_underscore");
     assert.deepEqual(sorted.pinned_streams, []);
-    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash_colon.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 
-    // Test searching part of stream name with non space word separators
+    sorted = sort_groups("colon");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash_colon.stream_id]);
+    assert.deepEqual(sorted.dormant_streams, []);
+
     sorted = sort_groups("underscore");
     assert.deepEqual(sorted.pinned_streams, []);
-    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash_colon.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 });
 


### PR DESCRIPTION
Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/138-user-questions/topic/stream.20search.20broken.20on.20zulip.20cloud.3F)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/2001f9d6-0c8d-4cb3-ad49-68e91737ea0a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
