### PR TITLE
popovers: Move from global popover min-width to per-popover basis.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -59,7 +59,9 @@
     --left-sidebar-header-icon-width: 15px;
 
     /* Tippy popover related values */
-    --popover-menu-min-width: 230px;
+    --navbar-popover-menu-min-width: 230px;
+    --message-actions-popover-min-width: 230px;
+    --topic-actions-popover-min-width: 200px;
 
     /* Information density and typography values */
     /* The legacy values here are updated via JavaScript */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1195,7 +1195,6 @@ ul {
     border-radius: 6px;
 
     .simplebar-content {
-        min-width: var(--popover-menu-min-width);
         /* Set the popover menu width equal to the width of the
         longest menu item, thus letting the menu items control
         the width of the menu. */
@@ -1294,6 +1293,29 @@ ul {
     .zulip-icon {
         position: relative;
         top: -1px;
+    }
+}
+
+#help-menu-dropdown,
+#gear-menu-dropdown,
+#personal-menu-dropdown {
+    .simplebar-content {
+        min-width: var(--navbar-popover-menu-min-width);
+    }
+}
+
+#message-actions-menu-dropdown {
+    --popover-menu-max-width: 350px;
+
+    .simplebar-content {
+        min-width: var(--message-actions-popover-min-width);
+    }
+}
+
+#stream-actions-menu-popover,
+#topic-actions-menu-popover {
+    .simplebar-content {
+        min-width: var(--topic-actions-popover-min-width);
     }
 }
 
@@ -1465,8 +1487,4 @@ ul.popover-menu-outer-list {
         outline: 1px solid var(--color-outline-focus) !important;
         outline-offset: -1px;
     }
-}
-
-#message-actions-menu-dropdown {
-    --popover-menu-max-width: 350px;
 }


### PR DESCRIPTION
This removes the common min-width being used across all popovers and instead sets the min-width according to a popover's requirements.

This allows for greater control over the popovers since we have a variety of use cases for them — which a single common min-width cannot accommodate.

<!-- Describe your pull request here.-->

Fixes: [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20stream.2Ftopic.20actions.20menu.20popover.20.2329785/near/1787888)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Navbar popovers</summary>

![image](https://github.com/zulip/zulip/assets/82862779/c05329b9-c16d-47e0-8b36-1f9ba648318e)

![image](https://github.com/zulip/zulip/assets/82862779/57edef9b-1d1f-48a7-a8df-1543c367813c)

![image](https://github.com/zulip/zulip/assets/82862779/7c66cd45-f2e9-4c4b-843c-746781ae79dc)

</details>

<details>
<summary>Message Actions popover</summary>

![image](https://github.com/zulip/zulip/assets/82862779/c05329b9-c16d-47e0-8b36-1f9ba648318e)

![image](https://github.com/zulip/zulip/assets/82862779/57edef9b-1d1f-48a7-a8df-1543c367813c)

![image](https://github.com/zulip/zulip/assets/82862779/7c66cd45-f2e9-4c4b-843c-746781ae79dc)

</details>

<details>
<summary>Stream and Topic popovers</summary>

![image](https://github.com/zulip/zulip/assets/82862779/73c19b05-e90c-4fe0-b4ec-a3786715e877)

![image](https://github.com/zulip/zulip/assets/82862779/801ab5e1-9826-4351-af53-27126c5954ba)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
