### PR TITLE
sidebar_ui: Fix right sidebar acting as an overlay even on wide width.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -23,7 +23,19 @@ export function hide_userlist_sidebar(): void {
 }
 
 export function show_userlist_sidebar(): void {
-    $(".app-main .column-right").addClass("expanded");
+    const $userlist_sidebar = $(".app-main .column-right");
+    if ($userlist_sidebar.css("display") !== "none") {
+        // Return early if the right sidebar is already visible.
+        return;
+    }
+
+    if (window.innerWidth >= media_breakpoints_num.xl) {
+        $("body").removeClass("hide-right-sidebar");
+        fix_invite_user_button_flicker();
+        return;
+    }
+
+    $userlist_sidebar.addClass("expanded");
     fix_invite_user_button_flicker();
     resize.resize_page_components();
     right_sidebar_expanded_as_overlay = true;


### PR DESCRIPTION
When user search is active, right sidebar was acting as an overlay since "expanded" class was incorrectly added to it whenever user started a search.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Right.20sidebar.20bugs