### PR TITLE
outgoing-webhook: separate command and text fields for slack outgoing webhook

### DIFF
--- a/api_docs/outgoing-webhooks.md
+++ b/api_docs/outgoing-webhooks.md
@@ -150,6 +150,10 @@ Here's how we fill in the fields that a Slack-format webhook expects:
             <td><code>text</code></td>
             <td>The content of the message (in Markdown)</td>
         </tr>
+         <tr>
+            <td><code>command</code></td>
+            <td>The bot mention</td>
+        </tr>
         <tr>
             <td><code>trigger_word</code></td>
             <td>Trigger method</td>
@@ -173,7 +177,8 @@ The above data is posted as list of tuples (not JSON), here's an example:
  ('timestamp', 1532078950),
  ('user_id', 'U21'),
  ('user_name', 'Full Name'),
- ('text', '@**test**'),
+ ('command', '/test'),
+ ('text', 'content'),
  ('trigger_word', 'mention'),
  ('service_id', 27)]
 ```

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import logging
+import re
 from contextlib import suppress
 from time import perf_counter
 from typing import Any, AnyStr, Dict, Optional
@@ -125,6 +126,21 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # text=googlebot: What is the air-speed velocity of an unladen swallow?
         # trigger_word=googlebot:
 
+        # https://api.slack.com/interactivity/slash-commands
+        # documents the format of Slack slash commands format
+        # For better compatibility, if message starts with a bot mention:
+        #
+        # we separate the message into command and text fields
+        # transform the mention (@**mybot**) to a slash command (/mybot)
+
+        slash_command = ""
+        command_re = r"(@\*\*[\w]+\*\*)"
+        text = event["command"]
+        message_parts = re.split(command_re, text)
+        if re.fullmatch(command_re, message_parts[1]):
+            slash_command = "/" + message_parts[1][3:-2]
+            text = message_parts[2].strip()
+
         request_data = [
             ("token", self.token),
             ("team_id", f"T{realm.id}"),
@@ -135,7 +151,8 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("command", slash_command),
+            ("text", text),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -161,7 +161,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         super().setUp()
         self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
         self.stream_message_event = {
-            "command": "@**test**",
+            "command": "@**test** content",
             "user_profile_id": 12,
             "service_name": "test-service",
             "trigger": "mention",
@@ -222,9 +222,10 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         self.assertEqual(request_data[6][1], 123456)  # timestamp
         self.assertEqual(request_data[7][1], "U21")  # user_id
         self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
-        self.assertEqual(request_data[10][1], "mention")  # trigger_word
-        self.assertEqual(request_data[11][1], 12)  # user_profile_id
+        self.assertEqual(request_data[9][1], "/test")  # command
+        self.assertEqual(request_data[10][1], "content")  # text
+        self.assertEqual(request_data[11][1], "mention")  # trigger_word
+        self.assertEqual(request_data[12][1], 12)  # user_profile_id
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This commit separates the slack legacy text field for slack-compatible outgoing webhook into command and text fields.
The command field contains the bot mention and the text field contains the content of the message after the bot mention.
For better compatibility, the bot mention is transformed into Slack's slash command. e.g @**mybot** is transformed into /mybot
Test cases for TestSlackOutgoingWebhookService are updated and api docs on the Slack-compatible format is updated.

Fixes: #19589 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
