### PR TITLE
settings: Add synchronization in deactivating users.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -95,6 +95,10 @@ export function update_view_on_deactivate(user_id) {
     $button.empty().append($("<i>").addClass(["fa", "fa-user-plus"]).attr("aria-hidden", "true"));
     $row.removeClass("reactivated_user");
     $row.addClass("deactivated_user");
+
+    if (!people.is_valid_bot_user(user_id)) {
+        redraw_non_active_users_list();
+    }
 }
 
 function update_view_on_reactivate($row) {
@@ -418,6 +422,26 @@ export function redraw_bots_list() {
     const bot_user_ids = people.get_bot_ids();
     bot_list_widget.replace_list_data(bot_user_ids);
     bot_list_widget.hard_redraw();
+}
+
+export function redraw_active_users_list() {
+    if (!section.active.list_widget) {
+        return;
+    }
+
+    const active_user_ids = people.get_realm_active_human_user_ids();
+    section.active.list_widget.replace_list_data(active_user_ids);
+    section.active.list_widget.hard_redraw();
+}
+
+function redraw_non_active_users_list() {
+    if (!section.deactivated.list_widget) {
+        return;
+    }
+
+    const non_active_user_ids = people.get_non_active_human_ids();
+    section.deactivated.list_widget.replace_list_data(non_active_user_ids);
+    section.deactivated.list_widget.hard_redraw();
 }
 
 function start_data_load() {

--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -169,6 +169,9 @@ export const update_person = function update(person) {
     if (Object.hasOwn(person, "is_active")) {
         if (person.is_active) {
             people.add_active_user(person_obj);
+            if (!people.is_valid_bot_user(person.user_id)) {
+                settings_users.redraw_active_users_list();
+            }
         } else {
             people.deactivate(person_obj);
             stream_events.remove_deactivated_user_from_all_streams(person.user_id);

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -271,6 +271,7 @@ run_test("updates", ({override}) => {
     assert.ok(!people.is_person_active(isaac.user_id));
     assert.ok(user_removed_from_streams);
 
+    override(settings_users, "redraw_active_users_list", noop);
     user_events.update_person({user_id: isaac.user_id, is_active: true});
     assert.ok(people.is_person_active(isaac.user_id));
 


### PR DESCRIPTION
Previously, when a user is activated or deactivated through the "Organization Settings", the corresponding tables of deactivated or activated users are not updated until the modal is re rendered.

This is fixed by updating the table with new entries every time a new event to either activate or deactivate the user is received.

Fixes #29891

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
