### PR TITLE
selected_message: Correct outline colors and align to Figma spec.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -188,6 +188,7 @@
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);
     --color-background-stream-message-content: hsl(0deg 0% 100%);
+    --color-selected-message-outline: hsl(217deg 64% 59%);
     --color-message-list-border: hsl(0deg 0% 0% / 16%);
     --color-message-header-contents-border: hsl(0deg 0% 0% / 10%);
     --color-private-message-header-border: hsl(0deg 0% 0% / 10%);
@@ -510,6 +511,7 @@
     --color-private-message-header-border: hsl(0deg 0% 0% / 48%);
     --color-message-header-contents-border-bottom: hsl(0deg 0% 0% / 50%);
     --color-private-message-header-border-bottom: hsl(0deg 0% 0% / 37%);
+    --color-selected-message-outline: hsl(217deg 64% 59% / 70%);
     --color-message-list-border: hsl(0deg 0% 0% / 40%);
     --color-background: hsl(0deg 0% 11%);
     --color-background-widget-input: hsl(225deg 6% 10%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -188,7 +188,7 @@
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);
     --color-background-stream-message-content: hsl(0deg 0% 100%);
-    --color-selected-message-outline: hsl(217deg 64% 59%);
+    --color-selected-message-outline: hsl(217deg 64% 59% / 60%);
     --color-message-list-border: hsl(0deg 0% 0% / 16%);
     --color-message-header-contents-border: hsl(0deg 0% 0% / 10%);
     --color-private-message-header-border: hsl(0deg 0% 0% / 10%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -804,10 +804,6 @@
         text-shadow: none;
     }
 
-    .selected_message .messagebox-content {
-        border-color: hsl(217deg 64% 59% / 70%);
-    }
-
     #message-edit-history-overlay-container {
         .message_edit_history_content {
             .highlight_text_inserted {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1351,7 +1351,7 @@ td.pointer {
         /* We add an outline and shift it inside the message so that without
            any vertical padding changes, we can have the outline surrounding
            the message without overflowing the boundary of the message in any case. */
-        outline: 1px solid hsl(217deg 64% 59%);
+        outline: 1px solid var(--color-selected-message-outline);
         border-radius: 5px;
         outline-offset: -1px;
     }


### PR DESCRIPTION
This PR fixes an erroneous, dead `border-color` style for the selected-message ring in dark mode and uses variables to express instead the color on `outline` in light and dark modes.

Additionally, this PR includes a commit with an alpha adjustment for light mode that was originally described by @terpimost in #22059, and which seems worth revisiting given the CZO discussion linked to below.

[CZO discussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Blue.20border.20for.20message.20select.20is.20annoying/near/1791223)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![light-selected-before](https://github.com/zulip/zulip/assets/170719/e0d81972-94b7-4e48-986c-9e7128463823) | ![light-selected-after](https://github.com/zulip/zulip/assets/170719/ca5dee5a-2c9b-4c31-bf20-25e21d3aef66) |
| ![dark-selected-before](https://github.com/zulip/zulip/assets/170719/6ffa8536-bf7a-4a85-b847-378783fb029d) | ![dark-selected-after](https://github.com/zulip/zulip/assets/170719/7fd79fad-1a00-453c-8229-953efa97d40e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>