### PR TITLE
Start removing use of jQuery `.data()`

### DIFF
--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -729,8 +729,10 @@ class TestSupportEndpoint(ZulipTestCase):
                 [
                     f"<b>Admins</b>: {self.example_email('iago')}\n",
                     f"<b>Owners</b>: {self.example_email('desdemona')}\n",
-                    'class="copy-button" data-copytext="{}">'.format(self.example_email("iago")),
-                    'class="copy-button" data-copytext="{}">'.format(
+                    'class="copy-button" data-clipboard-text="{}">'.format(
+                        self.example_email("iago")
+                    ),
+                    'class="copy-button" data-clipboard-text="{}">'.format(
                         self.example_email("desdemona")
                     ),
                 ],

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -8,7 +8,7 @@
     {% set owner_emails_string = get_realm_owner_emails_as_string(realm) %}
     <b>Owners</b>: {{ owner_emails_string }}
     {% if owner_emails_string %}
-    <a title="Copy emails" class="copy-button" data-copytext="{{ owner_emails_string }}">
+    <a title="Copy emails" class="copy-button" data-clipboard-text="{{ owner_emails_string }}">
         <i class="fa fa-copy"></i>
     </a>
     {% endif %}
@@ -16,7 +16,7 @@
     {% set admin_emails_string = get_realm_admin_emails_as_string(realm) %}
     <b>Admins</b>: {{ admin_emails_string }}
     {% if admin_emails_string %}
-    <a title="Copy emails" class="copy-button" data-copytext="{{ admin_emails_string }}">
+    <a title="Copy emails" class="copy-button" data-clipboard-text="{{ admin_emails_string }}">
         <i class="fa fa-copy"></i>
     </a>
     {% endif %}
@@ -24,7 +24,7 @@
     {% set first_human_user = realm.get_first_human_user() %}
     {% if first_human_user %}
     <b>First human user</b>: {{ first_human_user.delivery_email  }}
-    <a title="Copy emails" class="copy-button" data-copytext="{{ first_human_user.delivery_email }}">
+    <a title="Copy emails" class="copy-button" data-clipboard-text="{{ first_human_user.delivery_email }}">
         <i class="fa fa-copy"></i>
     </a>
     {% else %}

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -21,7 +21,7 @@
         {% set billing_emails_string = get_remote_realm_billing_user_emails(remote_realm) %}
         <b>Billing users</b>: {{ billing_emails_string }}
         {% if billing_emails_string %}
-        <a title="Copy emails" class="copy-button" data-copytext="{{ billing_emails_string }}">
+        <a title="Copy emails" class="copy-button" data-clipboard-text="{{ billing_emails_string }}">
             <i class="fa fa-copy"></i>
         </a>
         {% endif %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -50,14 +50,14 @@
                         <p class="support-section-header">Has a discount 💸</p>
                     {% endif %}
                     <b>Contact email</b>: {{ remote_server.contact_email }}
-                    <a title="Copy email" class="copy-button" data-copytext="{{ remote_server.contact_email }}">
+                    <a title="Copy email" class="copy-button" data-clipboard-text="{{ remote_server.contact_email }}">
                         <i class="fa fa-copy"></i>
                     </a>
                     <br />
                     {% set billing_emails_string = get_remote_server_billing_user_emails(remote_server) %}
                     <b>Billing users</b>: {{ billing_emails_string }}
                     {% if billing_emails_string %}
-                    <a title="Copy emails" class="copy-button" data-copytext="{{ billing_emails_string }}">
+                    <a title="Copy emails" class="copy-button" data-clipboard-text="{{ billing_emails_string }}">
                         <i class="fa fa-copy"></i>
                     </a>
                     {% endif %}

--- a/templates/corporate/support/support.html
+++ b/templates/corporate/support/support.html
@@ -100,7 +100,7 @@
                 <b>Email</b>: {{ email }}<br />
                 {% endif %}
                 <b>Link</b>: {{ confirmation.url }}
-                <a title="Copy link" class="copy-button" data-copytext="{{ confirmation.url }}">
+                <a title="Copy link" class="copy-button" data-clipboard-text="{{ confirmation.url }}">
                     <i class="fa fa-copy"></i>
                 </a><br />
                 <b>Expires in</b>: {{ confirmation.expires_in }}<br />

--- a/web/src/activity/activity.ts
+++ b/web/src/activity/activity.ts
@@ -1,9 +1,0 @@
-import $ from "jquery";
-
-import * as common from "../common";
-
-$(() => {
-    $("a.envelope-link").on("click", function () {
-        common.copy_data_attribute_value($(this), "admin-emails");
-    });
-});

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -83,7 +83,7 @@ export function searching(): boolean {
 }
 
 export function render_empty_user_list_message_if_needed($container: JQuery): void {
-    const empty_list_message = $container.data("search-results-empty");
+    const empty_list_message = $container.attr("data-search-results-empty");
 
     if (!empty_list_message || $container.children().length) {
         return;

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -287,8 +287,8 @@ export class BuddyList extends BuddyListConf {
             }
         }
 
-        $("#buddy-list-users-matching-view").data(
-            "search-results-empty",
+        $("#buddy-list-users-matching-view").attr(
+            "data-search-results-empty",
             matching_view_empty_list_message,
         );
         if ($("#buddy-list-users-matching-view .empty-list-message").length) {
@@ -298,7 +298,10 @@ export class BuddyList extends BuddyListConf {
             $("#buddy-list-users-matching-view").html(empty_list_widget_html);
         }
 
-        $("#buddy-list-other-users").data("search-results-empty", other_users_empty_list_message);
+        $("#buddy-list-other-users").attr(
+            "data-search-results-empty",
+            other_users_empty_list_message,
+        );
         if ($("#buddy-list-other-users .empty-list-message").length) {
             const empty_list_widget_html = render_empty_list_widget_for_list({
                 other_users_empty_list_message,

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -25,18 +25,6 @@ export function phrase_match(query: string, phrase: string): boolean {
     return false;
 }
 
-export function copy_data_attribute_value($elem: JQuery, key: string): void {
-    // function to copy the value of data-key
-    // attribute of the element to clipboard
-    const $temp = $(document.createElement("input"));
-    $("body").append($temp);
-    $temp.val($elem.data(key)).trigger("select");
-    document.execCommand("copy");
-    $temp.remove();
-    $elem.fadeOut(250);
-    $elem.fadeIn(1000);
-}
-
 const keys_map = new Map([
     ["Backspace", "Delete"],
     ["Enter", "Return"],

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -116,7 +116,7 @@ export function toggle(opts: {
     }
 
     meta.$ind_tab.on("click", function () {
-        const idx = $(this).data("tab-id");
+        const idx = Number($(this).attr("data-tab-id"));
         select_tab(idx);
     });
 

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -255,10 +255,10 @@ export function reify_message_id(opts: {old_id: number; new_id: number}): void {
     // update that link as well
     for (const e of $("#compose_banners a")) {
         const $elem = $(e);
-        const message_id = $elem.data("message-id");
+        const message_id = Number($elem.attr("data-message-id"));
 
         if (message_id === old_id) {
-            $elem.data("message-id", new_id);
+            $elem.attr("data-message-id", new_id);
             compose_banner.set_scroll_to_message_banner_message_id(new_id);
         }
     }
@@ -273,7 +273,7 @@ export function initialize(opts: {
         "click",
         ".narrow_to_recipient .above_compose_banner_action_link, .automatic_new_visibility_policy .above_compose_banner_action_link",
         (e) => {
-            const message_id = $(e.currentTarget).data("message-id");
+            const message_id = Number($(e.currentTarget).attr("data-message-id"));
             on_narrow_to_recipient(message_id);
             e.stopPropagation();
             e.preventDefault();
@@ -284,7 +284,7 @@ export function initialize(opts: {
         ".sent_scroll_to_view .above_compose_banner_action_link",
         (e) => {
             assert(message_lists.current !== undefined);
-            const message_id = $(e.currentTarget).data("message-id");
+            const message_id = Number($(e.currentTarget).attr("data-message-id"));
             message_lists.current.select_id(message_id);
             on_click_scroll_to_selected();
             compose_banner.clear_message_sent_banners(false);

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -252,7 +252,7 @@ export function initialize() {
             const {$banner_container} = get_input_info(event);
             const $invite_row = $(event.target).parents(".main-view-banner");
 
-            const user_id = Number.parseInt($invite_row.data("user-id"), 10);
+            const user_id = Number($invite_row.attr("data-user-id"));
             const stream_id = Number($invite_row.attr("data-stream-id"));
 
             function success() {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -253,7 +253,7 @@ export function initialize() {
             const $invite_row = $(event.target).parents(".main-view-banner");
 
             const user_id = Number.parseInt($invite_row.data("user-id"), 10);
-            const stream_id = Number.parseInt($invite_row.data("stream-id"), 10);
+            const stream_id = Number($invite_row.attr("data-stream-id"));
 
             function success() {
                 $invite_row.remove();

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -183,7 +183,7 @@ export function warn_if_private_stream_is_linked(
     );
 
     const existing_stream_warnings = [...$existing_stream_warnings_area].map((stream_row) =>
-        Number.parseInt($(stream_row).data("stream-id"), 10),
+        Number($(stream_row).attr("data-stream-id")),
     );
 
     if (!existing_stream_warnings.includes(linked_stream.stream_id)) {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -223,7 +223,7 @@ export function warn_if_mentioning_unsubscribed_user(
         );
 
         const existing_invites = [...$existing_invites_area].map((user_row) =>
-            Number.parseInt($(user_row).data("user-id"), 10),
+            Number($(user_row).attr("data-user-id")),
         );
 
         const can_subscribe_other_users = settings_data.user_can_subscribe_other_users();

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -241,7 +241,7 @@ export function is_emoji_present_in_text(text, emoji_dict) {
 function filter_emojis() {
     const $elt = $(".emoji-popover-filter").expectOne();
     const query = $elt.val().trim().toLowerCase();
-    const message_id = $(".emoji-search-results-container").data("message-id");
+    const message_id = Number($(".emoji-search-results-container").attr("data-message-id"));
     const search_results_visible = $(".emoji-search-results-container").is(":visible");
     if (query !== "") {
         const categories = complete_emoji_catalog;

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -104,7 +104,8 @@ function beforeSend(): void {
     // aren't in the right domain, etc.)
     //
     // OR, you could just let the server do it. Probably my temptation.
-    const loading_text = $("#invite-user-modal .dialog_submit_button").data("loading-text");
+    const loading_text = $("#invite-user-modal .dialog_submit_button").attr("data-loading-text");
+    assert(loading_text !== undefined);
     $("#invite-user-modal .dialog_submit_button").text(loading_text);
     $("#invite-user-modal .dialog_submit_button").prop("disabled", true);
 }
@@ -376,10 +377,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             );
             if ($("#invitee_emails_container").is(":visible")) {
                 $button.text($t({defaultMessage: "Invite"}));
-                $button.data("loading-text", $t({defaultMessage: "Inviting..."}));
+                $button.attr("data-loading-text", $t({defaultMessage: "Inviting..."}));
             } else {
                 $button.text($t({defaultMessage: "Generate invite link"}));
-                $button.data("loading-text", $t({defaultMessage: "Generating link..."}));
+                $button.attr("data-loading-text", $t({defaultMessage: "Generating link..."}));
             }
         }
 

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -260,7 +260,7 @@ function display_image(payload: Payload): void {
     $(".media-description .title")
         .text(payload.title ?? "N/A")
         .attr("aria-label", payload.title ?? "N/A")
-        .prop("data-filename", filename ?? "N/A");
+        .attr("data-filename", filename ?? "N/A");
     if (payload.user !== undefined) {
         $(".media-description .user").text(payload.user).prop("title", payload.user);
     }
@@ -305,7 +305,7 @@ function display_video(payload: Payload): void {
         $(".media-description .title")
             .text(payload.title ?? "N/A")
             .attr("aria-label", payload.title ?? "N/A")
-            .prop("data-filename", filename ?? "N/A");
+            .attr("data-filename", filename ?? "N/A");
         if (payload.user !== undefined) {
             $(".media-description .user").text(payload.user).prop("title", payload.user);
         }

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -582,8 +582,9 @@ export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>)
             <th data-sort="status"></th>
         </thead>
         */
-    const sort_type: string = $th.data("sort");
-    const prop_name: string = $th.data("sort-prop");
+    const sort_type = $th.attr("data-sort");
+    const prop_name = $th.attr("data-sort-prop");
+    assert(sort_type !== undefined);
 
     if ($th.hasClass("active")) {
         if (!$th.hasClass("descend")) {

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -213,7 +213,7 @@ export function render_empty_list_message_if_needed(
     $container: JQuery,
     filter_value: string,
 ): void {
-    let empty_list_message = $container.data("empty");
+    let empty_list_message = $container.attr("data-empty");
 
     const empty_search_results_message = $container.attr("data-search-results-empty");
     if (filter_value && empty_search_results_message) {

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -215,7 +215,7 @@ export function render_empty_list_message_if_needed(
 ): void {
     let empty_list_message = $container.data("empty");
 
-    const empty_search_results_message = $container.data("search-results-empty");
+    const empty_search_results_message = $container.attr("data-search-results-empty");
     if (filter_value && empty_search_results_message) {
         empty_list_message = empty_search_results_message;
     }

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -74,12 +74,6 @@ export function destroy_indicator($container: JQuery): void {
         return;
     }
     $container.data("destroying", true);
-
-    const spinner = $container.data("spinner_obj");
-    if (spinner !== undefined) {
-        spinner.stop();
-    }
-    $container.removeData("spinner_obj");
     $container.empty();
     $container.css({width: 0, height: 0});
 }

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -125,7 +125,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".popover_edit_message, .popover_view_source", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 assert(message_lists.current !== undefined);
                 const $row = message_lists.current.get_row(message_id);
                 message_edit.start($row);
@@ -135,7 +135,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".popover_move_message", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 assert(message_lists.current !== undefined);
                 message_lists.current.select_id(message_id);
                 const message = message_lists.current.get(message_id);
@@ -151,7 +151,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".mark_as_unread", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 unread_ops.mark_as_unread_from_here(message_id);
                 e.preventDefault();
                 e.stopPropagation();
@@ -159,7 +159,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".popover_toggle_collapse", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 assert(message_lists.current !== undefined);
                 const message = message_lists.current.get(message_id);
                 assert(message !== undefined);
@@ -174,7 +174,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".rehide_muted_user_message", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 assert(message_lists.current !== undefined);
                 const $row = message_lists.current.get_row(message_id);
                 const message = message_lists.current.get(rows.id($row));
@@ -190,7 +190,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".view_read_receipts", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 read_receipts.show_user_list(message_id);
                 e.preventDefault();
                 e.stopPropagation();
@@ -198,7 +198,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".delete_message", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 message_edit.delete_message(message_id);
                 e.preventDefault();
                 e.stopPropagation();
@@ -206,7 +206,7 @@ export function initialize() {
             });
 
             $popper.one("click", ".reaction_button", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
+                const message_id = Number($(e.currentTarget).attr("data-message-id"));
                 // Don't propagate the click event since `toggle_emoji_popover` opens a
                 // emoji_picker which we don't want to hide after actions popover is hidden.
                 e.stopPropagation();

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -314,7 +314,7 @@ export function initialize(): void {
     message_list_tooltip(".view_user_card_tooltip", {
         delay: LONG_HOVER_DELAY,
         onShow(instance) {
-            const is_bot = $(instance.reference).data("is-bot");
+            const is_bot = $(instance.reference).attr("data-is-bot") === "true";
             if (is_bot) {
                 instance.setContent(parse_html($("#view-bot-card-tooltip-template").html()));
             } else {

--- a/web/src/password_quality.ts
+++ b/web/src/password_quality.ts
@@ -24,8 +24,8 @@ export function password_quality(
     $bar: JQuery | undefined,
     $password_field: JQuery,
 ): boolean {
-    const min_length = $password_field.data("minLength");
-    const min_guesses = $password_field.data("minGuesses");
+    const min_length = Number($password_field.attr("data-min-length"));
+    const min_guesses = Number($password_field.attr("data-min-guesses"));
 
     const result = zxcvbn(password);
     const acceptable = password.length >= min_length && result.guesses >= min_guesses;
@@ -51,7 +51,7 @@ export function password_quality(
 }
 
 export function password_warning(password: string, $password_field: JQuery): string {
-    const min_length = $password_field.data("minLength");
+    const min_length = Number($password_field.attr("data-min-length"));
 
     if (password.length < min_length) {
         return $t(

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -98,9 +98,11 @@ function register_click_handlers(): void {
             const $view_in_playground_button = $(this);
             const $codehilite_div = $(this).closest(".codehilite");
             e.stopPropagation();
-            const playground_info = realm_playground.get_playground_info_for_languages(
-                $codehilite_div.data("code-language"),
-            );
+            const language = $codehilite_div.attr("data-code-language");
+            if (language === undefined) {
+                return;
+            }
+            const playground_info = realm_playground.get_playground_info_for_languages(language);
             if (playground_info === undefined) {
                 return;
             }

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -278,7 +278,7 @@ export const update_elements = ($content: JQuery): void => {
     $content.find("div.codehilite").each(function (): void {
         const $codehilite = $(this);
         const $pre = $codehilite.find("pre");
-        const fenced_code_lang = $codehilite.data("code-language");
+        const fenced_code_lang = $codehilite.attr("data-code-language");
         let playground_info;
         if (fenced_code_lang !== undefined) {
             playground_info = realm_playground.get_playground_info_for_languages(fenced_code_lang);

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -658,7 +658,9 @@ function get_input_type($input_elem: JQuery, input_type?: string): string {
     if (input_type !== undefined && ["boolean", "string", "number"].includes(input_type)) {
         return input_type;
     }
-    return $input_elem.data("setting-widget-type");
+    input_type = $input_elem.attr("data-setting-widget-type");
+    assert(input_type !== undefined);
+    return input_type;
 }
 
 export function get_input_element_value(

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -741,9 +741,9 @@ export function get_auth_method_list_data(): Record<string, boolean> {
     const $auth_method_rows = $("#id_realm_authentication_methods").find("div.method_row");
 
     for (const method_row of $auth_method_rows) {
-        new_auth_methods[$(method_row).data("method")] = $(method_row)
-            .find("input")
-            .prop("checked");
+        const method = $(method_row).attr("data-method");
+        assert(method !== undefined);
+        new_auth_methods[method] = $(method_row).find("input").prop("checked");
     }
 
     return new_auth_methods;

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -29,7 +29,7 @@ function get_chosen_default_streams() {
     // Return the set of stream id's of streams chosen in the default stream modal.
     return new Set(
         $("#default-stream-choices .choice-row .dropdown_widget_value")
-            .map((_i, elem) => $(elem).data("stream-id")?.toString())
+            .map((_i, elem) => Number($(elem).attr("data-stream-id")).toString())
             .get(),
     );
 }
@@ -58,7 +58,7 @@ function create_choice_row() {
         const $stream_dropdown_widget = $(`#${CSS.escape(stream_dropdown_widget_name)}_widget`);
         const $stream_name = $stream_dropdown_widget.find(".dropdown_widget_value");
         $stream_name.text(selected_stream_name);
-        $stream_name.data("stream-id", selected_stream_id);
+        $stream_name.attr("data-stream-id", selected_stream_id);
 
         add_choice_row($stream_dropdown_widget);
         dropdown.hide();

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -441,7 +441,7 @@ function handle_deactivation($tbody) {
         e.stopPropagation();
 
         const $row = $(e.target).closest(".user_row");
-        const user_id = $row.data("user-id");
+        const user_id = Number($row.attr("data-user-id"));
 
         function handle_confirm() {
             const url = "/json/users/" + encodeURIComponent(user_id);

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -209,7 +209,7 @@ export function initialize_right_sidebar(): void {
     $("#buddy-list-users-matching-view").on("mouseenter", ".user_sidebar_entry", (e) => {
         const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status-emoji");
         if ($status_emoji.length) {
-            const animated_url = $status_emoji.data("animated-url");
+            const animated_url = $status_emoji.attr("data-animated-url");
             if (animated_url) {
                 $status_emoji.attr("src", animated_url);
             }
@@ -219,7 +219,7 @@ export function initialize_right_sidebar(): void {
     $("#buddy-list-users-matching-view").on("mouseleave", ".user_sidebar_entry", (e) => {
         const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status-emoji");
         if ($status_emoji.length) {
-            const still_url = $status_emoji.data("still-url");
+            const still_url = $status_emoji.attr("data-still-url");
             if (still_url) {
                 $status_emoji.attr("src", still_url);
             }

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -599,7 +599,7 @@ export function initialize() {
         }
 
         function do_archive_stream() {
-            const stream_id = $(".dialog_submit_button").data("stream-id");
+            const stream_id = Number($(".dialog_submit_button").attr("data-stream-id"));
             if (!stream_id) {
                 ui_report.client_error(
                     $t_html({defaultMessage: "Invalid channel ID"}),
@@ -692,7 +692,9 @@ export function initialize() {
             const $save_button = $(e.currentTarget);
             const $subsection_elem = $save_button.closest(".settings-subsection-parent");
 
-            const stream_id = $save_button.closest(".subscription_settings.show").data("stream-id");
+            const stream_id = Number(
+                $save_button.closest(".subscription_settings.show").attr("data-stream-id"),
+            );
             const sub = sub_store.get(stream_id);
             const data = settings_org.populate_data_for_request($subsection_elem, false, sub);
 
@@ -724,7 +726,9 @@ export function initialize() {
             e.preventDefault();
             e.stopPropagation();
 
-            const stream_id = $(e.target).closest(".subscription_settings.show").data("stream-id");
+            const stream_id = Number(
+                $(e.target).closest(".subscription_settings.show").attr("data-stream-id"),
+            );
             const sub = sub_store.get(stream_id);
 
             const $subsection = $(e.target).closest(".settings-subsection-parent");

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -313,7 +313,7 @@ export function update_notification_setting_checkbox(notification_name) {
     if (!$stream_row.length) {
         return;
     }
-    const stream_id = $stream_row.data("stream-id");
+    const stream_id = Number($stream_row.attr("data-stream-id"));
     $(`#${CSS.escape(notification_name)}_${CSS.escape(stream_id)}`).prop(
         "checked",
         stream_data.receives_notifications(stream_id, notification_name),

--- a/web/src/support/support.ts
+++ b/web/src/support/support.ts
@@ -1,6 +1,5 @@
+import ClipboardJS from "clipboard";
 import $ from "jquery";
-
-import * as common from "../common";
 
 $(() => {
     $("body").on("click", ".scrub-realm-button", function (e) {
@@ -43,7 +42,5 @@ $(() => {
         }
     });
 
-    $("a.copy-button").on("click", function () {
-        common.copy_data_attribute_value($(this), "copytext");
-    });
+    new ClipboardJS("a.copy-button");
 });

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -277,7 +277,7 @@ export function initialize(): void {
             if (title === undefined) {
                 return false;
             }
-            const filename = $(instance.reference).prop("data-filename");
+            const filename = $(instance.reference).attr("data-filename");
             const $markup = $("<span>").text(title);
             if (title !== filename) {
                 // If the image title is the same as the filename, there's no reason

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -79,7 +79,7 @@ function compare_by_name(a, b) {
 
 export function get_user_id_if_user_profile_modal_open() {
     if (modals.any_active() && modals.active_modal() === "#user-profile-modal") {
-        const user_id = $("#user-profile-modal").data("user-id");
+        const user_id = Number($("#user-profile-modal").attr("data-user-id"));
         return user_id;
     }
     return undefined;
@@ -675,7 +675,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
         $("#bot-edit-form").on("click", ".deactivate_bot_button", (e) => {
             e.preventDefault();
             e.stopPropagation();
-            const bot_id = $("#bot-edit-form").data("user-id");
+            const bot_id = Number($("#bot-edit-form").attr("data-user-id"));
             function handle_confirm() {
                 const url = "/json/bots/" + encodeURIComponent(bot_id);
                 dialog_widget.submit_api_request(channel.del, url, {});
@@ -687,7 +687,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
         $("#bot-edit-form").on("click", ".reactivate_user_button", (e) => {
             e.preventDefault();
             e.stopPropagation();
-            const user_id = $("#bot-edit-form").data("user-id");
+            const user_id = Number($("#bot-edit-form").attr("data-user-id"));
             function handle_confirm() {
                 const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
                 dialog_widget.submit_api_request(channel.post, url, {});
@@ -787,7 +787,7 @@ export function show_edit_user_info_modal(user_id, $container) {
     $("#edit-user-form").on("click", ".deactivate_user_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const user_id = $("#edit-user-form").data("user-id");
+        const user_id = Number($("#edit-user-form").attr("data-user-id"));
         function handle_confirm() {
             const url = "/json/users/" + encodeURIComponent(user_id);
             dialog_widget.submit_api_request(channel.del, url, {});
@@ -799,7 +799,7 @@ export function show_edit_user_info_modal(user_id, $container) {
     $("#edit-user-form").on("click", ".reactivate_user_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const user_id = $("#edit-user-form").data("user-id");
+        const user_id = Number($("#edit-user-form").attr("data-user-id"));
         function handle_confirm() {
             const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
             dialog_widget.submit_api_request(channel.post, url, {});

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -489,7 +489,8 @@ test("render_empty_user_list_message", ({override, mock_template}) => {
         append($data) {
             $appended_data = $data;
         },
-        data() {
+        attr(name) {
+            assert.equal(name, "data-search-results-empty");
             return empty_list_message;
         },
         children: () => [],

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -28,49 +28,6 @@ run_test("phrase_match", () => {
     assert.ok(!common.phrase_match("tes", "hostess"));
 });
 
-run_test("copy_data_attribute_value", ({override}) => {
-    const admin_emails_val = "iago@zulip.com";
-
-    const $input = $.create("input");
-
-    let removed;
-    $input.remove = () => {
-        removed = true;
-    };
-
-    override(document, "createElement", () => $input);
-    override(document, "execCommand", noop);
-
-    $("body").append = noop;
-    $input.val = (arg) => {
-        assert.equal(arg, admin_emails_val);
-        return {
-            trigger: noop,
-        };
-    };
-
-    const $elem = {};
-    let faded_in = false;
-    let faded_out = false;
-
-    $elem.data = (key) => {
-        assert.equal(key, "admin-emails");
-        return admin_emails_val;
-    };
-    $elem.fadeOut = (val) => {
-        assert.equal(val, 250);
-        faded_out = true;
-    };
-    $elem.fadeIn = (val) => {
-        assert.equal(val, 1000);
-        faded_in = true;
-    };
-    common.copy_data_attribute_value($elem, "admin-emails");
-    assert.ok(removed);
-    assert.ok(faded_in);
-    assert.ok(faded_out);
-});
-
 run_test("adjust_mac_kbd_tags non-mac", ({override}) => {
     override(navigator, "platform", "Windows");
 

--- a/web/tests/components.test.js
+++ b/web/tests/components.test.js
@@ -33,8 +33,8 @@ function make_tab(i) {
         return tokens.includes(c);
     };
 
-    $self.data = (name) => {
-        assert.equal(name, "tab-id");
+    $self.attr = (name) => {
+        assert.equal(name, "data-tab-id");
         return i;
     };
 

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -647,10 +647,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
 
     // Simulate that the row was added to the DOM.
     const $warning_row = $("#compose_banners .private_stream_warning");
-    $warning_row.data = (key) =>
-        ({
-            "stream-id": "22",
-        })[key];
+    $warning_row.attr("data-stream-id", "22");
     $("#compose_banners .private_stream_warning").length = 1;
     $("#compose_banners .private_stream_warning")[0] = $warning_row;
 
@@ -738,8 +735,8 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     $warning_row.data = (key) =>
         ({
             "user-id": "34",
-            "stream-id": "111",
         })[key];
+    $warning_row.attr("data-stream-id", "111");
     $("#compose_banners .recipient_not_subscribed").length = 1;
     $("#compose_banners .recipient_not_subscribed")[0] = $warning_row;
 

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -732,10 +732,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     // Simulate that the row was added to the DOM.
     const $warning_row = $("#compose_banners .recipient_not_subscribed");
-    $warning_row.data = (key) =>
-        ({
-            "user-id": "34",
-        })[key];
+    $warning_row.attr("data-user-id", "34");
     $warning_row.attr("data-stream-id", "111");
     $("#compose_banners .recipient_not_subscribed").length = 1;
     $("#compose_banners .recipient_not_subscribed")[0] = $warning_row;

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -315,15 +315,15 @@ function sort_button(opts) {
     // don't have any abstraction for the button and its
     // siblings other than direct jQuery actions.
 
-    function data(sel) {
-        switch (sel) {
-            case "sort":
+    function attr(name) {
+        switch (name) {
+            case "data-sort":
                 return opts.sort_type;
-            case "sort-prop":
+            case "data-sort-prop":
                 return opts.prop_name;
             /* istanbul ignore next */
             default:
-                throw new Error("unknown selector: " + sel);
+                throw new Error("unknown attribute: " + name);
         }
     }
 
@@ -337,7 +337,7 @@ function sort_button(opts) {
     const classList = new Set();
 
     const $button = {
-        data,
+        attr,
         closest: lookup(".progressive-table-wrapper", {
             data: lookup("list-widget", opts.list_name),
         }),

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -45,6 +45,7 @@ const ListWidget = zrequire("list_widget");
 
 function make_container() {
     const $container = {};
+    $container.attr = noop;
     $container.empty = noop;
     $container.data = noop;
 

--- a/web/tests/password.test.js
+++ b/web/tests/password.test.js
@@ -10,15 +10,15 @@ const {password_quality, password_warning} = zrequire("password_quality");
 function password_field(min_length, min_guesses) {
     const self = {};
 
-    self.data = (field) => {
-        switch (field) {
-            case "minLength":
+    self.attr = (name) => {
+        switch (name) {
+            case "data-min-length":
                 return min_length;
-            case "minGuesses":
+            case "data-min-guesses":
                 return min_guesses;
             /* istanbul ignore next */
             default:
-                throw new Error(`Unknown field ${field}`);
+                throw new Error(`Unknown attribute ${name}`);
         }
     };
 

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -547,7 +547,7 @@ function test_code_playground(mock_template, viewing_code) {
     $content.set_find_results("div.codehilite", $array([$hilite]));
     $hilite.set_find_results("pre", $pre);
 
-    $hilite.data("code-language", "javascript");
+    $hilite.attr("data-code-language", "javascript");
 
     const $code_buttons_container = $.create("code_buttons_container", {
         children: ["copy-code-stub", "view-code-stub"],

--- a/web/tests/support.test.js
+++ b/web/tests/support.test.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 const {JSDOM} = require("jsdom");
 
-const {zrequire} = require("./lib/namespace");
+const {mock_cjs, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
@@ -16,6 +16,8 @@ const template = fs.readFileSync(
 );
 const dom = new JSDOM(template, {pretendToBeVisual: true});
 const document = dom.window.document;
+
+mock_cjs("clipboard", class Clipboard {});
 
 zrequire("../src/support/support");
 

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -10,10 +10,10 @@ const {realm} = require("./lib/zpage_params");
 const fake_buddy_list = {
     scroll_container_selector: "#whatever",
     $users_matching_view_container: {
-        data() {},
+        attr() {},
     },
     $other_users_container: {
-        data() {},
+        attr() {},
     },
     find_li() {},
     first_key() {},

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -3,7 +3,6 @@
         "./third/bootstrap/css/bootstrap.portico.css",
         "./src/bundles/common",
         "sorttable",
-        "./src/activity/activity",
         "./styles/portico/activity.css"
     ],
     "billing": [
@@ -109,7 +108,6 @@
         "./third/bootstrap/css/bootstrap.portico.css",
         "./src/bundles/common",
         "sorttable",
-        "./src/activity/activity",
         "./styles/portico/activity.css",
         "./src/support/support"
     ],


### PR DESCRIPTION
From a [discussion on #frontend](https://chat.zulip.org/#narrow/stream/6-frontend/topic/typescript.20migration/near/1792147):

> For the linter to catch this, we need to enable the `@typescript-eslint/no-unsafe-argument`, `@typescript-eslint/no-unsafe-assignment`, `@typescript-eslint/no-unsafe-call`, `@typescript-eslint/no-unsafe-member-access`, `@typescript-eslint/no-unsafe-return` rules that we currently [disable](https://github.com/zulip/zulip/blob/da675cb6412867eab7e14dace9cb25d00d14bdd9/.eslintrc.json#L190-L194). We should enable them, but it will take some work to fix the 355 existing violations.

A significant chunk of those violations have to do with jQuery’s `.data()` returning `any`. This PR removes 48 of them by converting `.data()` to `.attr()`.