### PR TITLE
Fix various implicit uses of the `any` type

### DIFF
--- a/web/shared/src/poll_data.ts
+++ b/web/shared/src/poll_data.ts
@@ -148,7 +148,7 @@ export class PollData {
                     }
 
                     const key = `${sender_id},${idx}`;
-                    const votes = new Map();
+                    const votes = new Map<number, number>();
 
                     this.key_to_option.set(key, {
                         option,

--- a/web/src/blueslip.ts
+++ b/web/src/blueslip.ts
@@ -112,15 +112,8 @@ export function error(msg: string, more_info?: object | undefined, original_erro
 if (page_params.development_environment) {
     $(window).on("error", (event: JQuery.TriggeredEvent) => {
         const {originalEvent} = event;
-        if (!(originalEvent instanceof ErrorEvent)) {
-            return;
+        if (originalEvent instanceof ErrorEvent && originalEvent.error instanceof Error) {
+            void display_stacktrace(originalEvent.error);
         }
-
-        const ex = originalEvent.error;
-        if (!ex) {
-            return;
-        }
-
-        void display_stacktrace(ex);
     });
 }

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -154,75 +154,79 @@ export class BuddyList extends BuddyListConf {
     $other_users_container = $(this.other_user_list_selector);
 
     initialize_tooltips(): void {
-        $("#right-sidebar").on("mouseenter", ".buddy-list-heading", (e) => {
-            e.stopPropagation();
-            const $elem = $(e.currentTarget);
-            let placement: "left" | "auto" = "left";
-            if (window.innerWidth < media_breakpoints_num.md) {
-                // On small devices display tooltips based on available space.
-                // This will default to "bottom" placement for this tooltip.
-                placement = "auto";
-            }
-            tippy($elem[0], {
-                // Because the buddy list subheadings are potential click targets
-                // for purposes having nothing to do with the subscriber count
-                // (collapsing/expanding), we delay showing the tooltip until the
-                // user lingers a bit longer.
-                delay: INTERACTIVE_HOVER_DELAY,
-                // Don't show tooltip on touch devices (99% mobile) since touch
-                // pressing on users in the left or right sidebar leads to narrow
-                // being changed and the sidebar is hidden. So, there is no user
-                // displayed to show tooltip for. It is safe to show the tooltip
-                // on long press but it not worth the inconvenience of having a
-                // tooltip hanging around on a small mobile screen if anything
-                // going wrong.
-                touch: false,
-                arrow: true,
-                placement,
-                showOnCreate: true,
-                onShow(instance) {
-                    let tooltip_text;
-                    const current_sub = narrow_state.stream_sub();
-                    const pm_ids_set = narrow_state.pm_ids_set();
-                    const subscriber_count = total_subscriber_count(current_sub, pm_ids_set);
-                    const elem_id = $elem.attr("id");
-                    if (elem_id === "buddy-list-users-matching-view-section-heading") {
-                        if (current_sub) {
-                            tooltip_text = $t(
-                                {
-                                    defaultMessage:
-                                        "{N, plural, one {# subscriber} other {# subscribers}}",
-                                },
-                                {N: subscriber_count},
-                            );
+        $("#right-sidebar").on(
+            "mouseenter",
+            ".buddy-list-heading",
+            function (this: HTMLElement, e) {
+                e.stopPropagation();
+                const $elem = $(this);
+                let placement: "left" | "auto" = "left";
+                if (window.innerWidth < media_breakpoints_num.md) {
+                    // On small devices display tooltips based on available space.
+                    // This will default to "bottom" placement for this tooltip.
+                    placement = "auto";
+                }
+                tippy($elem[0], {
+                    // Because the buddy list subheadings are potential click targets
+                    // for purposes having nothing to do with the subscriber count
+                    // (collapsing/expanding), we delay showing the tooltip until the
+                    // user lingers a bit longer.
+                    delay: INTERACTIVE_HOVER_DELAY,
+                    // Don't show tooltip on touch devices (99% mobile) since touch
+                    // pressing on users in the left or right sidebar leads to narrow
+                    // being changed and the sidebar is hidden. So, there is no user
+                    // displayed to show tooltip for. It is safe to show the tooltip
+                    // on long press but it not worth the inconvenience of having a
+                    // tooltip hanging around on a small mobile screen if anything
+                    // going wrong.
+                    touch: false,
+                    arrow: true,
+                    placement,
+                    showOnCreate: true,
+                    onShow(instance) {
+                        let tooltip_text;
+                        const current_sub = narrow_state.stream_sub();
+                        const pm_ids_set = narrow_state.pm_ids_set();
+                        const subscriber_count = total_subscriber_count(current_sub, pm_ids_set);
+                        const elem_id = $elem.attr("id");
+                        if (elem_id === "buddy-list-users-matching-view-section-heading") {
+                            if (current_sub) {
+                                tooltip_text = $t(
+                                    {
+                                        defaultMessage:
+                                            "{N, plural, one {# subscriber} other {# subscribers}}",
+                                    },
+                                    {N: subscriber_count},
+                                );
+                            } else {
+                                tooltip_text = $t(
+                                    {
+                                        defaultMessage:
+                                            "{N, plural, one {# participant} other {# participants}}",
+                                    },
+                                    {N: subscriber_count},
+                                );
+                            }
                         } else {
+                            const total_user_count = people.get_active_human_count();
+                            const other_users_count = total_user_count - subscriber_count;
                             tooltip_text = $t(
                                 {
                                     defaultMessage:
-                                        "{N, plural, one {# participant} other {# participants}}",
+                                        "{N, plural, one {# other user} other {# other users}}",
                                 },
-                                {N: subscriber_count},
+                                {N: other_users_count},
                             );
                         }
-                    } else {
-                        const total_user_count = people.get_active_human_count();
-                        const other_users_count = total_user_count - subscriber_count;
-                        tooltip_text = $t(
-                            {
-                                defaultMessage:
-                                    "{N, plural, one {# other user} other {# other users}}",
-                            },
-                            {N: other_users_count},
-                        );
-                    }
-                    instance.setContent(tooltip_text);
-                },
-                onHidden(instance) {
-                    instance.destroy();
-                },
-                appendTo: () => document.body,
-            });
-        });
+                        instance.setContent(tooltip_text);
+                    },
+                    onHidden(instance) {
+                        instance.destroy();
+                    },
+                    appendTo: () => document.body,
+                });
+            },
+        );
     }
 
     populate(opts: {all_user_ids: number[]}): void {

--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -1,7 +1,7 @@
 import {realm} from "./state_data";
 
 export const zoom_token_callbacks = new Map();
-export const video_call_xhrs = new Map();
+export const video_call_xhrs = new Map<string, JQuery.jqXHR<unknown>>();
 
 export function get_jitsi_server_url(): string | null {
     return realm.realm_jitsi_server_url ?? realm.server_jitsi_server_url;
@@ -9,8 +9,9 @@ export function get_jitsi_server_url(): string | null {
 
 export function abort_video_callbacks(edit_message_id = ""): void {
     zoom_token_callbacks.delete(edit_message_id);
-    if (video_call_xhrs.has(edit_message_id)) {
-        video_call_xhrs.get(edit_message_id).abort();
+    const xhr = video_call_xhrs.get(edit_message_id);
+    if (xhr !== undefined) {
+        xhr.abort();
         video_call_xhrs.delete(edit_message_id);
     }
 }

--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -259,7 +259,7 @@ export function condense_and_collapse(elems: JQuery): void {
 }
 
 export function initialize(): void {
-    $("#message_feed_container").on("click", ".message_expander", function (e) {
+    $("#message_feed_container").on("click", ".message_expander", function (this: HTMLElement, e) {
         // Expanding a message can mean either uncollapsing or
         // uncondensing it.
         const $row = $(this).closest(".message_row");
@@ -284,7 +284,7 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    $("#message_feed_container").on("click", ".message_condenser", function (e) {
+    $("#message_feed_container").on("click", ".message_condenser", function (this: HTMLElement, e) {
         const $row = $(this).closest(".message_row");
         const id = rows.id($row);
         // Focus on the condensed message.

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -161,9 +161,13 @@ export function launch(conf: DialogWidgetConfig): void {
         $inputs.each(function () {
             const property_name = $(this).attr("name")!;
             if (property_name) {
-                if ($(this).is("input[type='file']") && $(this).prop("files")?.length) {
+                if (
+                    this instanceof HTMLInputElement &&
+                    this.type === "file" &&
+                    this.files?.length
+                ) {
                     // If the input is a file input and a file has been selected, set value to file object
-                    current_values[property_name] = $(this).prop("files")[0];
+                    current_values[property_name] = this.files[0];
                 } else if (property_name === "edit_bot_owner") {
                     current_values[property_name] = $(this).find(".dropdown_widget_value").text();
                 } else {

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -43,7 +43,7 @@ export function show_flatpickr(
         disableMobile: true,
         time_24hr: user_settings.twenty_four_hour_time,
         minuteIncrement: 1,
-        onKeyDown(_selectedDates, _dateStr, instance, event) {
+        onKeyDown(_selectedDates, _dateStr, instance, event: KeyboardEvent) {
             // See also the keydown handler below.
             //
             // TODO: Add a clear explanation of exactly how key
@@ -64,6 +64,7 @@ export function show_flatpickr(
                     ...(user_settings.twenty_four_hour_time ? [] : [instance.amPM]),
                     $(".flatpickr-confirm")[0],
                 ];
+                assert(event.target instanceof HTMLElement);
                 const i = elems.indexOf(event.target);
                 const n = elems.length;
                 const remain = (i + (event.shiftKey ? -1 : 1)) % n;

--- a/web/src/hotspots.ts
+++ b/web/src/hotspots.ts
@@ -289,14 +289,14 @@ function is_hotspot_displayed(hotspot_name: string): number {
     return $(`#hotspot_${hotspot_name}_overlay`).length;
 }
 
-export function close_hotspot_icon(elem: JQuery): void {
-    $(elem).animate(
+export function close_hotspot_icon($elem: JQuery): void {
+    $elem.animate(
         {opacity: 0},
         {
             duration: 300,
-            done: function () {
-                $(elem).css({display: "none"});
-            }.bind(elem),
+            done() {
+                $elem.css({display: "none"});
+            },
         },
     );
 }
@@ -356,9 +356,9 @@ export function initialize(): void {
     load_new(onboarding_steps.filter_new_hotspots(current_user.onboarding_steps));
 
     // open
-    $("body").on("click", ".hotspot-icon", function (e) {
+    $("body").on("click", ".hotspot-icon", function (this: HTMLElement, e) {
         // hide icon
-        close_hotspot_icon(this);
+        close_hotspot_icon($(this));
 
         // show popover
         const match_array = /^hotspot_(.*)_icon$/.exec(

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -37,7 +37,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         let integration_input_dropdown_widget: DropdownWidget;
         let previous_selected_integration = "";
 
-        const $override_topic = $("#integration-url-override-topic");
+        const $override_topic = $<HTMLInputElement>("input#integration-url-override-topic");
         const $topic_input = $<HTMLInputElement>("input#integration-url-topic-input");
         const $integration_url = $("#generate-integration-url-modal .integration-url");
         const $dialog_submit_button = $("#generate-integration-url-modal .dialog_submit_button");
@@ -56,7 +56,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         });
 
         $override_topic.on("change", function () {
-            const checked = $(this).prop("checked");
+            const checked = this.checked;
             $topic_input.parent().toggleClass("hide", !checked);
         });
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -297,7 +297,8 @@ function set_custom_time_inputs_visibility(): void {
 }
 
 function set_streams_to_join_list_visibility(): void {
-    const default_streams_selected = $("#invite_select_default_streams").prop("checked");
+    const default_streams_selected = $<HTMLInputElement>("input#invite_select_default_streams")[0]
+        .checked;
     if (default_streams_selected) {
         $("#streams_to_add .invite-stream-controls").hide();
         $("#invite-stream-checkboxes").hide();

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -202,11 +202,9 @@ export function clear_for_testing(): void {
 
 export function render_lightbox_media_list(preview_source: string): void {
     if (!is_open) {
-        const media_list = Array.prototype.slice.call(
-            $(
-                ".focused-message-list .message_inline_image img, .focused-message-list .message_inline_video video",
-            ),
-        );
+        const media_list = $(
+            ".focused-message-list .message_inline_image img, .focused-message-list .message_inline_video video",
+        ).toArray();
         const $media_list = $("#lightbox_overlay .image-list").empty();
 
         for (const media of media_list) {
@@ -605,7 +603,7 @@ export function initialize(): void {
         this.blur();
     });
 
-    $("#lightbox_overlay").on("click", ".image-list .image", function () {
+    $("#lightbox_overlay").on("click", ".image-list .image", function (this: HTMLElement) {
         const $media_list = $(this).parent();
         let $original_media_element;
         const is_video = $(this).hasClass("lightbox_video");
@@ -628,7 +626,7 @@ export function initialize(): void {
         $(".image-list .image.selected").removeClass("selected");
         $(this).addClass("selected");
 
-        const parentOffset = this.parentNode.clientWidth + this.parentNode.scrollLeft;
+        const parentOffset = this.parentElement!.clientWidth + this.parentElement!.scrollLeft;
         // this is the left and right of the image compared to its parent.
         const coords = {
             left: this.offsetLeft,
@@ -639,11 +637,11 @@ export function initialize(): void {
             // add 2px margin
             $media_list.animate(
                 {
-                    scrollLeft: coords.right - this.parentNode.clientWidth + 2,
+                    scrollLeft: coords.right - this.parentElement!.clientWidth + 2,
                 },
                 100,
             );
-        } else if (coords.left < this.parentNode.scrollLeft) {
+        } else if (coords.left < this.parentElement!.scrollLeft) {
             // subtract 2px margin
             $media_list.animate({scrollLeft: coords.left - 2}, 100);
         }

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -433,9 +433,13 @@ export function create<Key, Item = Key>(
             });
 
             if (opts.$parent_container) {
-                opts.$parent_container.on("click.list_widget_sort", "[data-sort]", function () {
-                    handle_sort($(this), widget);
-                });
+                opts.$parent_container.on(
+                    "click.list_widget_sort",
+                    "[data-sort]",
+                    function (this: HTMLElement) {
+                        handle_sort($(this), widget);
+                    },
+                );
             }
 
             opts.filter?.$element?.on("input.list_widget_filter", function () {

--- a/web/src/localstorage.ts
+++ b/web/src/localstorage.ts
@@ -54,14 +54,12 @@ const ls = {
 
     getData(version: number, name: string): FormData | undefined {
         const key = this.formGetter(version, name);
-        let data;
         try {
             const raw_data = localStorage.getItem(key);
             if (raw_data === null) {
                 return undefined;
             }
-            data = JSON.parse(raw_data);
-            data = formDataSchema.parse(data);
+            const data = formDataSchema.parse(JSON.parse(raw_data));
             if (
                 // JSON forms of data with `Infinity` turns into `null`,
                 // so if null then it hasn't expired since nothing was specified.
@@ -220,17 +218,15 @@ export const localstorage = function (): LocalStorage {
         ): T | undefined {
             return ls.migrate(name, v1, v2, callback);
         },
-    };
 
-    // set a new master version for the LocalStorage instance.
-    Object.defineProperty(prototype, "version", {
-        get() {
+        // set a new master version for the LocalStorage instance.
+        get version() {
             return _data.VERSION;
         },
-        set(version) {
+        set version(version) {
             _data.VERSION = version;
         },
-    });
+    };
 
     return prototype;
 };

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -289,11 +289,11 @@ export function initialize(): void {
         }
     });
 
-    $("body").on("click", ".message_edit_notice", (e) => {
+    $("body").on("click", ".message_edit_notice", function (this: HTMLElement, e) {
         e.stopPropagation();
         e.preventDefault();
 
-        const message_id = rows.id($(e.currentTarget).closest(".message_row"));
+        const message_id = rows.id($(this).closest(".message_row"));
         assert(message_lists.current !== undefined);
         const $row = message_lists.current.get_row(message_id);
         const row_id = rows.id($row);

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -100,7 +100,7 @@ export function get_max_message_id_in_stream(stream_id: number): number {
 }
 
 export function get_topics_for_message_ids(message_ids: number[]): Map<string, [number, string]> {
-    const topics = new Map(); // key = stream_id:topic
+    const topics = new Map<string, [number, string]>(); // key = stream_id:topic
     for (const msg_id of message_ids) {
         // message_store still has data on deleted messages when this runs.
         const message = message_store.get(msg_id);

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -77,7 +77,7 @@ export function message_viewport_info(): MessageViewportInfo {
 // the server are not considered.
 export function at_rendered_bottom(): boolean {
     const bottom = scrollTop() + height();
-    const full_height = $scroll_container.prop("scrollHeight");
+    const full_height = $scroll_container[0].scrollHeight;
 
     // We only know within a pixel or two if we're
     // exactly at the bottom, due to browser quirkiness,

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -55,11 +55,11 @@ export function search_string(filter?: Filter): string {
     return Filter.unparse(search_terms(filter));
 }
 
-// Collect terms which appear only once into an object,
+// Collect terms which appear only once into a map,
 // and discard those which appear more than once.
 function collect_single(terms: NarrowTerm[]): Map<string, string> {
-    const seen = new Map();
-    const result = new Map();
+    const seen = new Set<string>();
+    const result = new Map<string, string>();
 
     for (const term of terms) {
         const key = term.operator;
@@ -67,7 +67,7 @@ function collect_single(terms: NarrowTerm[]): Map<string, string> {
             result.delete(key);
         } else {
             result.set(key, term.operand);
-            seen.set(key, true);
+            seen.add(key);
         }
     }
 

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import * as common from "../common";
 import {$t} from "../i18n";
@@ -231,8 +232,9 @@ $(() => {
     });
 
     // GitHub auth
-    $("body").on("click", "#choose_email .choose-email-box", function () {
-        this.parentNode.submit();
+    $("body").on("click", "#choose_email .choose-email-box", function (this: HTMLElement) {
+        assert(this.parentElement instanceof HTMLFormElement);
+        this.parentElement.submit();
     });
 
     $("#new-user-email-address-visibility .change_email_address_visibility").on("click", () => {

--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -91,7 +91,7 @@ function add_stream_message(opts: {
     message_id: number;
 }): void {
     const {stream_id, sender_id, message_id} = opts;
-    const sender_dict = stream_senders.get(stream_id) ?? new Map();
+    const sender_dict = stream_senders.get(stream_id) ?? new Map<number, IdTracker>();
     const id_tracker = sender_dict.get(sender_id) ?? new IdTracker();
     stream_senders.set(stream_id, sender_dict);
     sender_dict.set(sender_id, id_tracker);
@@ -106,7 +106,7 @@ function add_topic_message(opts: {
 }): void {
     const {stream_id, topic, sender_id, message_id} = opts;
     const topic_dict = topic_senders.get(stream_id) ?? new FoldDict();
-    const sender_dict = topic_dict.get(topic) ?? new Map();
+    const sender_dict = topic_dict.get(topic) ?? new Map<number, IdTracker>();
     const id_tracker = sender_dict.get(sender_id) ?? new IdTracker();
     topic_senders.set(stream_id, topic_dict);
     topic_dict.set(topic, sender_dict);
@@ -253,7 +253,7 @@ export function process_private_message(opts: {
     id: number;
 }): void {
     const {to_user_ids, sender_id, id} = opts;
-    const sender_dict = pm_senders.get(to_user_ids) ?? new Map();
+    const sender_dict = pm_senders.get(to_user_ids) ?? new Map<number, IdTracker>();
     const id_tracker = sender_dict.get(sender_id) ?? new IdTracker();
     pm_senders.set(to_user_ids, sender_dict);
     sender_dict.set(sender_id, id_tracker);

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -70,7 +70,7 @@ export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch
     // (It's a bit of legacy that we have an object with only one important
     // field.  There's also a "search_string" field on each element that actually
     // just represents the key of the hash, so it's redundant.)
-    let search_map = new Map();
+    let search_map = new Map<string, search_suggestion.Suggestion>();
 
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $search_query_box,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -24,7 +24,7 @@ type UserPillItem = {
 
 type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
 
-type Suggestion = {
+export type Suggestion = {
     description_html: string;
     search_string: string;
     is_person?: boolean;

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import emoji_codes from "../../static/generated/emoji/emoji_codes.json";
 import render_confirm_deactivate_custom_emoji from "../templates/confirm_dialog/confirm_deactivate_custom_emoji.hbs";
@@ -262,9 +263,9 @@ function show_modal(): void {
         }
 
         const formData = new FormData();
-        for (const [i, file] of Array.prototype.entries.call(
-            $<HTMLInputElement>("input#emoji_file_input")[0].files,
-        )) {
+        const files = $<HTMLInputElement>("input#emoji_file_input")[0].files;
+        assert(files !== null);
+        for (const [i, file] of [...files].entries()) {
             formData.append("file-" + i, file);
         }
 

--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -235,16 +235,16 @@ export function on_load_success(
     if (!initialize_event_handlers) {
         return;
     }
-    $(".admin_invites_table").on("click", ".revoke", (e) => {
+    $(".admin_invites_table").on("click", ".revoke", function (this: HTMLElement, e) {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active` in `settings.js`.
         e.preventDefault();
         e.stopPropagation();
-        const $row = $(e.target).closest(".invite_row");
+        const $row = $(this).closest(".invite_row");
         const email = $row.find(".email").text();
         const referred_by = $row.find(".referred_by").text();
-        const invite_id = $(e.currentTarget).attr("data-invite-id")!;
-        const is_multiuse = $(e.currentTarget).attr("data-is-multiuse")!;
+        const invite_id = $(this).attr("data-invite-id")!;
+        const is_multiuse = $(this).attr("data-is-multiuse")!;
         const ctx = {
             is_multiuse: is_multiuse === "true",
             email,
@@ -266,15 +266,15 @@ export function on_load_success(
         $(".dialog_submit_button").attr("data-is-multiuse", is_multiuse);
     });
 
-    $(".admin_invites_table").on("click", ".resend", (e) => {
+    $(".admin_invites_table").on("click", ".resend", function (this: HTMLElement, e) {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active` in `settings.js`.
         e.preventDefault();
         e.stopPropagation();
 
-        const $row = $(e.target).closest(".invite_row");
+        const $row = $(this).closest(".invite_row");
         const email = $row.find(".email").text();
-        const invite_id = $(e.currentTarget).attr("data-invite-id")!;
+        const invite_id = $(this).attr("data-invite-id")!;
         const html_body = render_settings_resend_invite_modal({email});
 
         confirm_dialog.launch({

--- a/web/src/spoilers.ts
+++ b/web/src/spoilers.ts
@@ -21,7 +21,7 @@ function expand_spoiler($spoiler: JQuery): void {
     // of the content). CSS animations do not work with properties set to
     // `auto`, so we get the actual height of the content here and temporarily
     // put it explicitly on the element styling to allow the transition to work.
-    const spoiler_height: number = $spoiler.prop("scrollHeight");
+    const spoiler_height = $spoiler[0].scrollHeight;
     $spoiler.height(`${spoiler_height}px`);
     // The `spoiler-content-open` class has CSS animations defined on it which
     // will trigger on the frame after this class change.
@@ -49,7 +49,7 @@ export const hide_spoilers_in_notification = ($content: JQuery): JQuery => {
 };
 
 export function initialize(): void {
-    $("body").on("click", ".spoiler-header", function (e) {
+    $("body").on("click", ".spoiler-header", function (this: HTMLElement, e) {
         const $button = $(this).children(".spoiler-button");
         const $arrow = $button.children(".spoiler-arrow");
         const $spoiler_content = $(this).siblings(".spoiler-content");

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -173,13 +173,13 @@ export function update_count_in_dom(
 }
 
 class StreamSidebar {
-    rows = new Map(); // stream id -> row widget
+    rows = new Map<number, StreamSidebarRow>(); // stream id -> row widget
 
     set_row(stream_id: number, widget: StreamSidebarRow): void {
         this.rows.set(stream_id, widget);
     }
 
-    get_row(stream_id: number): StreamSidebarRow {
+    get_row(stream_id: number): StreamSidebarRow | undefined {
         return this.rows.get(stream_id);
     }
 
@@ -254,6 +254,7 @@ export function build_stream_list(force_rerender: boolean): void {
 
     function add_sidebar_li(stream_id: number): void {
         const sidebar_row = stream_sidebar.get_row(stream_id);
+        assert(sidebar_row !== undefined);
         sidebar_row.update_whether_active();
         elems.push(sidebar_row.get_li());
     }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
+import type {ReferenceElement} from "tippy.js";
 import tippy, {delegate} from "tippy.js";
 
 import render_buddy_list_title_tooltip from "../templates/buddy_list/title_tooltip.hbs";
@@ -234,11 +235,11 @@ export function initialize(): void {
     $("body").on(
         "blur",
         ".message_control_button, .delete-selected-drafts-button-container",
-        (e) => {
+        function (this: ReferenceElement) {
             // Remove tooltip when user is trying to tab through all the icons.
             // If user tabs slowly, tooltips are displayed otherwise they are
             // destroyed before they can be displayed.
-            e.currentTarget?._tippy?.destroy();
+            this._tippy?.destroy();
         },
     );
 

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -112,10 +112,10 @@ export function toggle_user_group_info_popover(
 }
 
 export function register_click_handlers(): void {
-    $("#main_div").on("click", ".user-group-mention", (e) => {
+    $("#main_div").on("click", ".user-group-mention", function (this: HTMLElement, e) {
         e.stopPropagation();
 
-        const $elt = $(e.currentTarget);
+        const $elt = $(this);
         const $row = $elt.closest(".message_row");
         const message_id = rows.id($row);
 
@@ -124,7 +124,7 @@ export function register_click_handlers(): void {
         assert(message !== undefined);
 
         try {
-            toggle_user_group_info_popover(e.currentTarget, message.id);
+            toggle_user_group_info_popover(this, message.id);
         } catch {
             // This user group has likely been deleted.
             blueslip.info("Unable to find user group in message" + message.sender_id);


### PR DESCRIPTION
From a [discussion on #frontend](https://chat.zulip.org/#narrow/stream/6-frontend/topic/typescript.20migration/near/1792147):

> For the linter to catch this, we need to enable the `@typescript-eslint/no-unsafe-argument`, `@typescript-eslint/no-unsafe-assignment`, `@typescript-eslint/no-unsafe-call`, `@typescript-eslint/no-unsafe-member-access`, `@typescript-eslint/no-unsafe-return` rules that we currently [disable](https://github.com/zulip/zulip/blob/da675cb6412867eab7e14dace9cb25d00d14bdd9/.eslintrc.json#L190-L194). We should enable them, but it will take some work to fix the 355 existing violations.

This PR removes 89 of those violations.