### PR TITLE
input_pill: Add test for `input` event handler.

### DIFF
--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -640,7 +640,7 @@ run_test("appendValue/clear", ({mock_template}) => {
     assert.equal($pill_input[0].textContent, "");
 });
 
-run_test("getCurrentText/onTextInputHook", ({mock_template}) => {
+run_test("getCurrentText", ({mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
         return html;
@@ -656,15 +656,10 @@ run_test("getCurrentText/onTextInputHook", ({mock_template}) => {
     widget.appendValue("blue,red");
     assert.deepEqual(widget.items(), [items.blue, items.red]);
 
-    const onTextInputHook = () => {
-        assert.deepEqual(widget.items(), [items.blue, items.red]);
-    };
-    widget.onTextInputHook(onTextInputHook);
-
     $pill_input.text("yellow");
     assert.equal(widget.getCurrentText(), "yellow");
 
-    const key_handler = $container.get_on_handler("input", ".input");
+    const key_handler = $container.get_on_handler("keydown", ".input");
     key_handler({
         key: " ",
         preventDefault: noop,
@@ -674,5 +669,35 @@ run_test("getCurrentText/onTextInputHook", ({mock_template}) => {
         preventDefault: noop,
     });
 
-    assert.deepEqual(widget.items(), [items.blue, items.red]);
+    assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
+});
+
+run_test("onTextInputHook", () => {
+    const info = set_up();
+    const config = info.config;
+    const widget = input_pill.create(config);
+    const $container = info.$container;
+    const $pill_input = info.$pill_input;
+
+    let hookCalled = false;
+    let currentText = "re";
+    const onTextInputHook = () => {
+        hookCalled = true;
+
+        // Test that the hook always gets the correct updated text.
+        assert.equal(widget.getCurrentText(), currentText);
+    };
+
+    widget.onTextInputHook(onTextInputHook);
+
+    const input_handler = $container.get_on_handler("input", ".input");
+
+    $pill_input.text(currentText);
+    input_handler();
+
+    currentText += "d";
+    $pill_input.text(currentText);
+    input_handler();
+
+    assert.ok(hookCalled);
 });


### PR DESCRIPTION
Added a test for newly added `input` event handler for `input_pill.ts` module.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
