### PR TITLE
help: Remove description of transition from self-hosted billing page.

### DIFF
--- a/help/self-hosted-billing.md
+++ b/help/self-hosted-billing.md
@@ -26,106 +26,6 @@ feature development or integrations, etc., should contact
 Paid plan discounts are available in a variety of situations; see
 [below](#paid-plan-discounts) for details.
 
-### Upgrades for legacy customers
-
-On December 15, 2023, it was
-[announced](https://blog.zulip.com/2023/12/15/new-plans-for-self-hosted-customers/)
-that self-hosted customers will no longer get unlimited free access to Zulip's
-[Mobile Push Notification
-Service](https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html).
-Legacy customers can continue using the notification service for free (no action
-required) until February 15, 2024.
-
-To continue using the service after that date, organizations with more than 10
-users must upgrade to a paid plan or the Community plan. When you upgrade to a
-paid plan, you can start the plan right away (if you‘d like your technical
-support to start immediately), or schedule a February 15 start date.
-
-If your organization needs more time to sign up for a plan, please contact
-[sales@zulip.com](mailto:sales@zulip.com) to request extended free access to the
-Mobile Push Notification Service.
-
-!!! tip ""
-    An email announcing this change was sent to the registered contact email
-    address for all legacy customers. If you did not receive this email, please
-    [update](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#updating-your-server-s-registration)
-    your contact information.
-
-Any Zulip server that registered for Zulip's [Mobile Push Notification
-Service](https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html)
-prior to December 15, 2023 is considered to be a legacy customer.
-
-#### Do I have to upgrade my server first?
-
-While upgrading your Zulip server to version 8.0+ makes it more convenient to
-manage your plan, you do not have to upgrade your Zulip installation in order to
-sign up for a plan. **The same plans are offered for all Zulip versions.**
-
-In addition to hundreds of other improvements, upgrading to Zulip Server 8.0+ lets
-you:
-
-- Easily log in to Zulip plan management, without an additional server
-  authentication step.
-
-- Separately manage plans for all the organizations on your server.
-
-- Upload only the [basic
-  metadata](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata)
-  required for the service, without also [uploading usage
-  statistics](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-usage-statistics).
-
-If you upgrade your server after signing up for a plan, you will be able to
-transfer your plan to an organization on your server. If your server has one
-organization on it, this will happen automatically. Otherwise, contact
-[support@zulip.com](mailto:support@zulip.com) for help.
-
-#### Upgrading to a paid plan
-
-{!self-hosted-billing-multiple-organizations.md!}
-
-{start_tabs}
-
-{tab|v8}
-
-{!self-hosted-billing-admin-only.md!}
-
-{!self-hosted-log-in.md!}
-
-1. On the page listing Zulip's self-hosted plans, click the button at the bottom
-   of the plan you would like to purchase.
-
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Under **Plan start date**, select **February 15, 2024** or **Today**.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** or **Schedule upgrade** button to complete your
-   purchase.
-
-!!! warn ""
-
-    If your server hosts more than one organization, commercial
-    support for server-wide configurations requires upgrading the
-    organization with the largest number of users.
-
-{tab|all-versions}
-
-{!legacy-log-in-intro.md!}
-
-{!legacy-log-in.md!}
-
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Under **Plan start date**, select **February 15, 2024** or **Today**.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** or **Schedule upgrade** button to complete your
-   purchase.
-
-{end_tabs}
-
 ### Upgrades for new customers
 
 #### Upgrade to Zulip Basic
@@ -138,8 +38,6 @@ organization is considered to be a new customer if:
   prior to December 12, 2023, and
 - It has never previously signed up for a self-hosted Zulip plan (Basic, Business,
   Community or Enterprise).
-
-{!self-hosted-billing-multiple-organizations.md!}
 
 {start_tabs}
 
@@ -185,8 +83,6 @@ organization is considered to be a new customer if:
 
 #### Upgrade to Zulip Business
 
-{!self-hosted-billing-multiple-organizations.md!}
-
 {start_tabs}
 
 {tab|v8}
@@ -234,6 +130,74 @@ organization is considered to be a new customer if:
 
 {end_tabs}
 
+### Upgrades for existing customers
+
+#### Do I have to upgrade my server first?
+
+While upgrading your Zulip server to version 8.0+ makes it more convenient to
+manage your plan, you do not have to upgrade your Zulip installation in order to
+sign up for a plan. **The same plans are offered for all Zulip versions.**
+
+In addition to hundreds of other improvements, upgrading to Zulip Server 8.0+ lets
+you:
+
+- Easily log in to Zulip plan management, without an additional server
+  authentication step.
+
+- Separately manage plans for all the organizations on your server.
+
+- Upload only the [basic
+  metadata](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata)
+  required for the service, without also [uploading usage
+  statistics](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-usage-statistics).
+
+If you upgrade your server after signing up for a plan, you will be able to
+transfer your plan to an organization on your server. If your server has one
+organization on it, this will happen automatically. Otherwise, contact
+[support@zulip.com](mailto:support@zulip.com) for help.
+
+#### Upgrading to a paid plan
+
+{!self-hosted-billing-multiple-organizations.md!}
+
+{start_tabs}
+
+{tab|v8}
+
+{!self-hosted-billing-admin-only.md!}
+
+{!self-hosted-log-in.md!}
+
+1. On the page listing Zulip's self-hosted plans, click the button at the bottom
+   of the plan you would like to purchase.
+
+1. Select your preferred option from the **Payment schedule** dropdown.
+
+1. Click **Add card** to enter your payment details.
+
+1. Click the **Purchase** or **Schedule upgrade** button to complete your
+   purchase.
+
+!!! warn ""
+
+    If your server hosts more than one organization, commercial
+    support for server-wide configurations requires upgrading the
+    organization with the largest number of users.
+
+{tab|all-versions}
+
+{!legacy-log-in-intro.md!}
+
+{!legacy-log-in.md!}
+
+1. Select your preferred option from the **Payment schedule** dropdown.
+
+1. Click **Add card** to enter your payment details.
+
+1. Click the **Purchase** or **Schedule upgrade** button to complete your
+   purchase.
+
+{end_tabs}
 
 ## Manage billing
 


### PR DESCRIPTION
Notes:
- I also removed the server version banners from the new customers section, since new customers are expected to be on 8.0+ in any case.

Current: https://zulip.com/help/self-hosted-billing#upgrades-for-legacy-customers

<details>
<summary>
Updated


</summary>

![Screenshot 2024-05-03 at 08 49 21](https://github.com/zulip/zulip/assets/2090066/9c366247-a71c-49d7-9a5a-d87a98a5da99)
![Screenshot 2024-05-03 at 08 49 34](https://github.com/zulip/zulip/assets/2090066/2a65184a-ca51-480d-b5ec-773b24823208)

</details>

