### PR TITLE
message_row: Establish clarifying messagebox-includes-sender class.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -253,7 +253,7 @@
     }
 }
 
-.include-sender {
+.messagebox-includes-sender {
     .messagebox-content {
         grid-template-areas:
             "avatar sender    controls . time"

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -1,5 +1,5 @@
 <div id="message-row-{{message_list_id}}-{{msg/id}}" data-message-id="{{msg/id}}"
-  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} include-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
+  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} messagebox-includes-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
   role="listitem">
     {{#if want_date_divider}}
     <div class="unread_marker date_unread_marker"><div class="unread-marker-fill"></div></div>


### PR DESCRIPTION
This restores a degree of context to the includes-sender class.

I opted for `messagebox-includes-sender` to make `includes` sound descriptive, rather than as a command ("Thou shalt include sender, O messagebox.")

**Screenshots and screen captures:**

| Before | After (no change) |
| --- | --- |
| ![sender-class-before](https://github.com/zulip/zulip/assets/170719/cdcb2747-10f2-4afe-805d-d54dedf606bb) | ![sender-class-after](https://github.com/zulip/zulip/assets/170719/095b6139-5ce4-4663-85bc-f0300b0fa6ef) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>