### PR TITLE
message_header: Bring over control hover selectors.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -229,6 +229,31 @@
     }
 }
 
+.always_visible_topic_edit,
+.on_hover_topic_read,
+.stream_unmuted.on_hover_topic_unmute,
+.stream_muted.on_hover_topic_mute {
+    opacity: 0.7;
+
+    &:hover {
+        cursor: pointer;
+        opacity: 1;
+    }
+}
+
+.on_hover_topic_edit,
+.on_hover_topic_unresolve,
+.on_hover_topic_resolve,
+.stream_unmuted.on_hover_topic_mute,
+.stream_muted.on_hover_topic_unmute {
+    opacity: 0.2;
+
+    &:hover {
+        cursor: pointer;
+        opacity: 0.7;
+    }
+}
+
 .recipient_row_date {
     color: var(--color-date);
     font-size: calc(12em / 14);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1095,31 +1095,6 @@ td.pointer {
     }
 }
 
-.always_visible_topic_edit,
-.on_hover_topic_read,
-.stream_unmuted.on_hover_topic_unmute,
-.stream_muted.on_hover_topic_mute {
-    opacity: 0.7;
-
-    &:hover {
-        cursor: pointer;
-        opacity: 1;
-    }
-}
-
-.on_hover_topic_edit,
-.on_hover_topic_unresolve,
-.on_hover_topic_resolve,
-.stream_unmuted.on_hover_topic_mute,
-.stream_muted.on_hover_topic_unmute {
-    opacity: 0.2;
-
-    &:hover {
-        cursor: pointer;
-        opacity: 0.7;
-    }
-}
-
 /* Make the action icon on the message row
    always visible while the popover is open */
 .has_actions_popover .actions_hover {


### PR DESCRIPTION
[At Tim's suggestion](https://github.com/zulip/zulip/pull/29915#issuecomment-2091516907), this moves a few more message-header selectors into the `message_header.css` file.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>