### PR TITLE
left_sidebar: Apply grid to 'more conversations' DM row.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -305,15 +305,6 @@ li.show-more-topics {
 
         & li#show-more-direct-messages {
             cursor: pointer;
-            padding-right: 26px;
-            /* TODO: Rewrite the show-more and show-less
-               buttons as grids alongside the left sidebar
-               header rewrites. This padding value
-               is a stopgap to provide the same lefthand
-               alignment as the "more topics" text, which
-               aligns with the topic above--just as this
-               aligns with the DM row above. */
-            padding-left: 29px;
 
             & a {
                 font-size: 12px;
@@ -1098,6 +1089,10 @@ li.topic-list-item {
     .conversation-partners-icon {
         grid-area: starting-anchor-element;
         place-self: center;
+    }
+
+    .dm-name {
+        grid-area: row-content;
     }
 
     .user_circle {

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,8 +1,6 @@
-<li id="show-more-direct-messages" class="dm-list-item bottom_left_row {{#unless more_conversations_unread_count}}zero-dm-unreads{{/unless}}">
-    <span>
-        <a class="dm-name" tabindex="0">{{t "more conversations" }}</a>
-        <span class="unread_count {{#unless more_conversations_unread_count}}zero_count{{/unless}}">
-            {{more_conversations_unread_count}}
-        </span>
+<li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#unless more_conversations_unread_count}}zero-dm-unreads{{/unless}}">
+    <a class="dm-name" tabindex="0">{{t "more conversations" }}</a>
+    <span class="unread_count {{#unless more_conversations_unread_count}}zero_count{{/unless}}">
+        {{more_conversations_unread_count}}
     </span>
 </li>


### PR DESCRIPTION
This PR applies the DM-area CSS grid to the 'more conversations' row, and fixes a corner-case unread-count display in the process.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/misaligned.20more.20conversations.20unread.20count.20on.20DMs/near/1792575)

**Screenshots and screen captures:**

| Before | After | After, showing grid |
| --- | --- | --- |
| ![more-convos-before](https://github.com/zulip/zulip/assets/170719/8618b347-4082-4bba-bcf1-47b52654501e) | ![more-convos-after](https://github.com/zulip/zulip/assets/170719/721550a5-1804-417a-8d6b-f6911b2601ac) | ![more-convos-after-showing-grid](https://github.com/zulip/zulip/assets/170719/c452cb1e-c549-4b3b-bd95-09cf53559d18) |

