### PR TITLE
help: Update plan upgrade instructions

### DIFF
--- a/help/include/plan-upgrade-steps.md
+++ b/help/include/plan-upgrade-steps.md
@@ -1,0 +1,5 @@
+1. Select your preferred option from the **Payment schedule** dropdown.
+
+1. Click **Add card** to enter your payment details.
+
+1. Click the **Purchase** button to complete your purchase.

--- a/help/self-hosted-billing.md
+++ b/help/self-hosted-billing.md
@@ -26,9 +26,9 @@ feature development or integrations, etc., should contact
 Paid plan discounts are available in a variety of situations; see
 [below](#paid-plan-discounts) for details.
 
-### Upgrades for new customers
+## Upgrade to a paid plan
 
-#### Upgrade to Zulip Basic
+### Start a free trial
 
 **New customers** are eligible for a free 30-day trial of Zulip Basic. An
 organization is considered to be a new customer if:
@@ -81,18 +81,20 @@ organization is considered to be a new customer if:
 
 {end_tabs}
 
-#### Upgrade to Zulip Business
+### Upgrade directly to a paid plan
+
+{!self-hosted-billing-multiple-organizations.md!}
 
 {start_tabs}
 
 {tab|v8}
 
-{!register-server.md!}
+{!self-hosted-billing-admin-only.md!}
 
 {!self-hosted-log-in.md!}
 
-1. On the page listing Zulip's self-hosted plans, click the **Upgrade to Business** button
-   at the bottom of the **Business** plan.
+1. On the page listing Zulip's self-hosted plans, click the button at the bottom
+   of the plan you would like to purchase.
 
 1. Select your preferred option from the **Payment schedule** dropdown.
 
@@ -110,12 +112,7 @@ organization is considered to be a new customer if:
 
 {!legacy-log-in-intro.md!}
 
-{!register-server-legacy.md!}
-
 {!legacy-log-in.md!}
-
-1. On the page listing Zulip's self-hosted plans, click the **Upgrade to Business** button
-   at the bottom of the **Business** plan.
 
 1. Select your preferred option from the **Payment schedule** dropdown.
 
@@ -123,16 +120,9 @@ organization is considered to be a new customer if:
 
 1. Click the **Purchase** button to complete your purchase.
 
-!!! tip ""
-
-    Once you start the trial, you can switch between monthly and annual billing
-    on your organization's billing page.
-
 {end_tabs}
 
-### Upgrades for existing customers
-
-#### Do I have to upgrade my server first?
+### Do I have to upgrade my server first?
 
 While upgrading your Zulip server to version 8.0+ makes it more convenient to
 manage your plan, you do not have to upgrade your Zulip installation in order to
@@ -155,49 +145,6 @@ If you upgrade your server after signing up for a plan, you will be able to
 transfer your plan to an organization on your server. If your server has one
 organization on it, this will happen automatically. Otherwise, contact
 [support@zulip.com](mailto:support@zulip.com) for help.
-
-#### Upgrading to a paid plan
-
-{!self-hosted-billing-multiple-organizations.md!}
-
-{start_tabs}
-
-{tab|v8}
-
-{!self-hosted-billing-admin-only.md!}
-
-{!self-hosted-log-in.md!}
-
-1. On the page listing Zulip's self-hosted plans, click the button at the bottom
-   of the plan you would like to purchase.
-
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** or **Schedule upgrade** button to complete your
-   purchase.
-
-!!! warn ""
-
-    If your server hosts more than one organization, commercial
-    support for server-wide configurations requires upgrading the
-    organization with the largest number of users.
-
-{tab|all-versions}
-
-{!legacy-log-in-intro.md!}
-
-{!legacy-log-in.md!}
-
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** or **Schedule upgrade** button to complete your
-   purchase.
-
-{end_tabs}
 
 ## Manage billing
 

--- a/help/self-hosted-billing.md
+++ b/help/self-hosted-billing.md
@@ -96,11 +96,7 @@ organization is considered to be a new customer if:
 1. On the page listing Zulip's self-hosted plans, click the button at the bottom
    of the plan you would like to purchase.
 
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** button to complete your purchase.
+{!plan-upgrade-steps.md!}
 
 !!! warn ""
 
@@ -114,11 +110,7 @@ organization is considered to be a new customer if:
 
 {!legacy-log-in.md!}
 
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click the **Purchase** button to complete your purchase.
+{!plan-upgrade-steps.md!}
 
 {end_tabs}
 

--- a/help/zulip-cloud-billing.md
+++ b/help/zulip-cloud-billing.md
@@ -14,11 +14,7 @@ don't hesitate to reach out at [sales@zulip.com](mailto:sales@zulip.com).
 
 1. Under the **Cloud Standard** pricing plan, click **Upgrade to Standard**.
 
-1. Select your preferred option from the **Payment schedule** dropdown.
-
-1. Click **Add card** to enter your payment details.
-
-1. Click **Purchase Zulip Cloud Standard**.
+{!plan-upgrade-steps.md!}
 
 {tab|zulip-cloud-plus}
 

--- a/help/zulip-cloud-billing.md
+++ b/help/zulip-cloud-billing.md
@@ -8,19 +8,12 @@ don't hesitate to reach out at [sales@zulip.com](mailto:sales@zulip.com).
 
 {start_tabs}
 
-{tab|zulip-cloud-standard}
-
 {relative|gear|plans}
 
-1. Under the **Cloud Standard** pricing plan, click **Upgrade to Standard**.
+1. On the page listing Zulip Cloud plans, click the button at the bottom
+   of the plan you would like to purchase.
 
 {!plan-upgrade-steps.md!}
-
-{tab|zulip-cloud-plus}
-
-{relative|gear|plans}
-
-1. Under the **Cloud Plus** pricing plan, click **Contact sales**.
 
 {end_tabs}
 


### PR DESCRIPTION
Now that we don't need to document upgrades for legacy customers (which had an additional scheduled upgrade option), we can consolidate instructions.

We weren't linking to any of the removed anchor links.

Current: https://zulip.com/help/self-hosted-billing
<details>
<summary>
Updated
</summary>

![Screenshot 2024-05-03 at 10 59 46@2x](https://github.com/zulip/zulip/assets/2090066/5a0e46a3-e779-446a-b59f-9e8eccfc0499)
![Screenshot 2024-05-03 at 11 00 13@2x](https://github.com/zulip/zulip/assets/2090066/0794c74f-a787-408c-af22-e3de1ba0eb2d)



</details>


Current: https://zulip.com/help/zulip-cloud-billing
<details>
<summary>
Updated
</summary>

![Screenshot 2024-05-03 at 11 07 19@2x](https://github.com/zulip/zulip/assets/2090066/977d988f-f6c6-4352-b8cd-10f06a4a9e85)

</details>


