### PR TITLE
left_sidebar: Correct vertical alignment on 'more conversations.'

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -305,6 +305,10 @@ li.show-more-topics {
 
         & li#show-more-direct-messages {
             cursor: pointer;
+            /* The 'more conversations' line has no icons,
+               so vertically align the text with the unread
+               count, when one appears there. */
+            align-items: baseline;
 
             & a {
                 font-size: 12px;


### PR DESCRIPTION
This is a minor fix that was accidentally left off of #29941.

