### PR TITLE
zulip_test: Convert module to TypeScript

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -290,7 +290,7 @@ EXEMPT_FILES = make_set(
         "web/src/zcommand.ts",
         "web/src/zform.js",
         "web/src/zulip.js",
-        "web/src/zulip_test.js",
+        "web/src/zulip_test.ts",
         "web/tests/lib/mdiff.js",
         "web/tests/lib/real_jquery.js",
         "web/tests/lib/zjquery_element.js",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -112,7 +112,7 @@ EXEMPT_FILES = make_set(
         "web/src/flatpickr.ts",
         "web/src/gear_menu.js",
         "web/src/giphy.js",
-        "web/src/global.d.ts",
+        "web/src/global.ts",
         "web/src/hash_util.ts",
         "web/src/hashchange.js",
         "web/src/hbs.d.ts",

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -78,10 +78,9 @@ async function test_reply_by_click_prepopulates_private_message_recipient(
     assert.ok(private_message !== null);
     await private_message.click();
     await page.waitForSelector("#private_message_recipient", {visible: true});
-    await common.pm_recipient.expect(
-        page,
-        await common.get_internal_email_from_name(page, "cordelia"),
-    );
+    const email = await common.get_internal_email_from_name(page, "cordelia");
+    assert(email !== undefined);
+    await common.pm_recipient.expect(page, email);
     await close_compose_box(page);
 }
 

--- a/web/e2e-tests/mention.test.ts
+++ b/web/e2e-tests/mention.test.ts
@@ -20,7 +20,7 @@ async function test_mention(page: Page): Promise<void> {
 
     console.log("Checking for all everyone warning");
     const stream_size = await page.evaluate(() =>
-        zulip_test.get_subscriber_count(zulip_test.get_sub("Verona").stream_id),
+        zulip_test.get_subscriber_count(zulip_test.get_sub("Verona")!.stream_id),
     );
     const threshold = await page.evaluate(() => {
         zulip_test.set_wildcard_mention_threshold(5);

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -6,6 +6,7 @@ import * as common from "./lib/common";
 
 async function get_stream_li(page: Page, stream_name: string): Promise<string> {
     const stream_id = await common.get_stream_id(page, stream_name);
+    assert(stream_id !== undefined);
     return `#stream_filters [data-stream-id="${CSS.escape(stream_id.toString())}"]`;
 }
 

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -64,12 +64,15 @@ async function navigate_to_private_messages(page: Page): Promise<void> {
 }
 
 async function test_reload_hash(page: Page): Promise<void> {
-    const initial_page_load_time = await page.evaluate((): number => zulip_test.page_load_time);
+    const initial_page_load_time = await page.evaluate(() => zulip_test.page_load_time);
+    assert(initial_page_load_time !== undefined);
     console.log(`initial load time: ${initial_page_load_time}`);
 
     const initial_hash = await page.evaluate(() => window.location.hash);
 
-    await page.evaluate(() => zulip_test.initiate_reload({immediate: true}));
+    await page.evaluate(() => {
+        zulip_test.initiate_reload({immediate: true});
+    });
     await page.waitForNavigation();
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
@@ -77,6 +80,7 @@ async function test_reload_hash(page: Page): Promise<void> {
     });
 
     const page_load_time = await page.evaluate(() => zulip_test.page_load_time);
+    assert(page_load_time !== undefined);
     assert.ok(page_load_time > initial_page_load_time, "Page not reloaded.");
 
     const hash = await page.evaluate(() => window.location.hash);
@@ -88,7 +92,7 @@ async function navigation_tests(page: Page): Promise<void> {
 
     await navigate_to_settings(page);
 
-    const verona_id = await page.evaluate((): number => zulip_test.get_stream_id("Verona"));
+    const verona_id = await page.evaluate(() => zulip_test.get_stream_id("Verona"));
     const verona_narrow = `narrow/stream/${verona_id}-Verona`;
 
     await navigate_using_left_sidebar(page, verona_narrow);

--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -22,7 +22,9 @@ async function await_user_hidden(page: Page, name: string): Promise<void> {
 
 async function add_user_to_stream(page: Page, name: string): Promise<void> {
     const user_id = await common.get_user_id_from_name(page, name);
-    await page.evaluate((user_id) => zulip_test.add_user_id_to_new_stream(user_id), user_id);
+    await page.evaluate((user_id) => {
+        zulip_test.add_user_id_to_new_stream(user_id);
+    }, user_id);
     await await_user_visible(page, name);
 }
 

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -19,6 +19,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
 
 async function user_row(page: Page, name: string): Promise<string> {
     const user_id = await common.get_user_id_from_name(page, name);
+    assert(user_id !== undefined);
     return `.user_row[data-user-id="${CSS.escape(user_id.toString())}"]`;
 }
 

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="spectrum" />
 
-declare let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+export {};
 
 type JQueryCaretRange = {
     start: number;
@@ -22,34 +22,38 @@ type JQueryIdleOptions = Partial<{
     keepTracking: boolean;
 }>;
 
-declare namespace JQueryValidation {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-    interface ValidationOptions {
-        // This is only defined so that this.defaultShowErrors!() can be called from showErrors.
-        // It isn't really a validation option to be supplied.
-        defaultShowErrors?: () => void;
+declare global {
+    let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    namespace JQueryValidation {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+        interface ValidationOptions {
+            // This is only defined so that this.defaultShowErrors!() can be called from showErrors.
+            // It isn't really a validation option to be supplied.
+            defaultShowErrors?: () => void;
+        }
     }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface JQuery {
+        expectOne: () => this;
+        get_offset_to_window: () => DOMRect;
+        tab: (action?: string) => this; // From web/third/bootstrap
+
+        // Types for jquery-caret-plugin
+        caret: (() => number) & ((arg: number | string) => this);
+        range: (() => JQueryCaretRange) &
+            ((start: number, end?: number) => this) &
+            ((text: string) => this);
+        selectAll: () => this;
+        deselectAll: () => this;
+
+        // Types for jquery-idle plugin
+        idle: (opts: JQueryIdleOptions) => {
+            cancel: () => void;
+            reset: () => void;
+        };
+    }
+
+    const ZULIP_VERSION: string;
 }
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-interface JQuery {
-    expectOne: () => this;
-    get_offset_to_window: () => DOMRect;
-    tab: (action?: string) => this; // From web/third/bootstrap
-
-    // Types for jquery-caret-plugin
-    caret: (() => number) & ((arg: number | string) => this);
-    range: (() => JQueryCaretRange) &
-        ((start: number, end?: number) => this) &
-        ((text: string) => this);
-    selectAll: () => this;
-    deselectAll: () => this;
-
-    // Types for jquery-idle plugin
-    idle: (opts: JQueryIdleOptions) => {
-        cancel: () => void;
-        reset: () => void;
-    };
-}
-
-declare const ZULIP_VERSION: string;

--- a/web/src/global.ts
+++ b/web/src/global.ts
@@ -1,11 +1,6 @@
-// These declarations tell the TypeScript compiler about the existence
-// of the global variables for our untyped JavaScript modules.  Please
-// remove each declaration when the corresponding module is migrated
-// to TS.
-
 /// <reference types="spectrum" />
 
-export {};
+import type * as zulip_test_module from "./zulip_test";
 
 type JQueryCaretRange = {
     start: number;
@@ -23,7 +18,7 @@ type JQueryIdleOptions = Partial<{
 }>;
 
 declare global {
-    let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const zulip_test: typeof zulip_test_module;
 
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace JQueryValidation {

--- a/web/src/global.ts
+++ b/web/src/global.ts
@@ -25,6 +25,7 @@ type JQueryIdleOptions = Partial<{
 declare global {
     let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+    // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace JQueryValidation {
         // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
         interface ValidationOptions {

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -48,6 +48,7 @@ export type MessageList = {
         messages: Message[],
         append_opts: {messages_are_new: boolean},
     ) => RenderInfo | undefined;
+    last: () => Message | undefined;
 };
 
 export let current: MessageList | undefined;

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -114,6 +114,7 @@ export type Message = (
     clean_reactions: Map<string, MessageCleanReaction>;
 
     locally_echoed?: boolean;
+    raw_content?: string;
 
     // Added in `message_helper.process_new_message`.
     sent_by_me: boolean;

--- a/web/src/zulip_test.ts
+++ b/web/src/zulip_test.ts
@@ -10,7 +10,9 @@ export {get_by_user_id as get_person_by_user_id, get_user_id_from_name} from "./
 export {last_visible as last_visible_row, id as row_id} from "./rows";
 export {cancel as cancel_compose} from "./compose_actions";
 export {page_params, page_params_parse_time} from "./base_page_params";
+// @ts-expect-error We haven't converted reload.js yet
 export {initiate as initiate_reload} from "./reload";
 export {page_load_time} from "./setup";
 export {current_user, realm} from "./state_data";
+// @ts-expect-error We haven't converted stream_create_subscribers.js yet
 export {add_user_id_to_new_stream} from "./stream_create_subscribers";


### PR DESCRIPTION
We haven’t yet converted two of its dependencies `reload` and `stream_create_subscribers`. However, the Puppeteer tests that use `zulip_test` are already TypeScript, and having a type for `zulip_test` fixes 67 implicit uses of `any` within them. So I’m skipping the line here using evil `// @ts-expect-error` comments.