### PR TITLE
compose: Move row of formatting buttons into the textbox.

### DIFF
--- a/web/src/css_variables.js
+++ b/web/src/css_variables.js
@@ -19,11 +19,11 @@ const mc = 849; // Middle column as wide as it appears after the `sm` breakpoint
 
 // Breakpoints for showing and hiding compose buttons which do not always fit in
 // a single row below the compose box
-const cb1 = 1296;
-const cb2 = 1054;
-const cb3 = 794;
-const cb4 = 732;
-const cb5 = 486;
+const cb1 = 1314;
+const cb2 = 1072;
+const cb3 = 860;
+const cb4 = 750;
+const cb5 = 504;
 
 module.exports = {
     media_breakpoints: {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -156,6 +156,7 @@
     flex item. 2.1786em is 30.5px at 14px/1em.
     */
     --compose-recipient-box-min-height: 2.1786em;
+    --compose-formatting-buttons-row-height: 28px;
 
     /*
     Width of the area where the compose box buttons are placed, "inside"
@@ -164,7 +165,7 @@
     expand / collapse buttons area, but keep the text from showing under the
     the buttons.
     */
-    --composebox-buttons-width: 25px;
+    --composebox-buttons-width: 24px;
 
     /*
     Width of the send menu area with the Send button, Draft(s) button
@@ -370,6 +371,10 @@
     --color-composebox-button-hover: var(--color-text-default);
     --color-composebox-button-background: hsl(0deg 100% 100% / 60%);
     --color-composebox-button-background-hover: hsl(0deg 0% 95%);
+    --color-message-formatting-controls-container: hsl(232deg 30% 96%);
+    --color-message-content-container-border: hsl(0deg 0% 0% / 10%);
+    --color-message-content-container-border-focus: hsl(0deg 0% 57%);
+    --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -720,6 +725,10 @@
     --color-composebox-button: hsl(0deg 100% 100% / 55%);
     --color-composebox-button-background: hsl(231deg 8% 13.5% / 80%);
     --color-composebox-button-background-hover: hsl(231deg 12% 18%);
+    --color-message-formatting-controls-container: hsl(0deg 0% 0% / 8%);
+    --color-message-content-container-border: hsl(0deg 0% 0% / 80%);
+    --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
+    --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -267,7 +267,6 @@
             "message-content-container message-send-controls-container"
             "message-formatting-controls-container message-send-controls-container";
         gap: 0 6px;
-        margin-top: 5px;
     }
 
     .message_content {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -260,13 +260,13 @@
         /* Vlad's design calls for 122px for the send column
            at its widest; 112px accounts for 6px of gap and
            4px outside padding. */
-        grid-template: minmax(0, 1fr) 32px / minmax(0, 1fr) var(
-                --compose-send-controls-width
-            );
+        grid-template:
+            minmax(0, 1fr) var(--compose-formatting-buttons-row-height)
+            / minmax(0, 1fr) var(--compose-send-controls-width);
         grid-template-areas:
             "message-content-container message-send-controls-container"
-            "message-formatting-controls-container . ";
-        gap: 4px 6px;
+            "message-formatting-controls-container message-send-controls-container";
+        gap: 0 6px;
         margin-top: 5px;
     }
 
@@ -282,6 +282,28 @@
             --composebox-buttons-width
         );
     grid-template-areas: "message-content composebox-buttons";
+    border-radius: 4px;
+    border: 1px solid var(--color-message-content-container-border);
+    transition: border 0.2s ease;
+
+    &:has(.new_message_textarea:focus) {
+        border-color: var(--color-message-content-container-border-focus);
+    }
+
+    &:has(.new_message_textarea.over_limit),
+    &:has(.new_message_textarea.over_limit:focus) {
+        box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
+
+        &.flash {
+            animation: message-limit-flash 0.5s ease-in-out infinite;
+        }
+    }
+
+    &:has(.new_message_textarea.invalid),
+    &:has(.new_message_textarea.invalid:focus) {
+        border-color: hsl(3deg 57% 33%);
+        box-shadow: 0 0 2px hsl(3deg 57% 33%);
+    }
 }
 
 #message-content-container .composebox-buttons {
@@ -289,8 +311,6 @@
     /* z-index is needed to avoid flickering of cursor and the
     button when hovering it in preview mode. */
     z-index: 1;
-    padding-top: 1px;
-    padding-right: 1px;
     height: max-content;
 
     button {
@@ -339,6 +359,24 @@
     padding-right: var(--composebox-buttons-width);
 }
 
+.surround-formatting-buttons-row {
+    /* This is to extend it under the formatting buttons
+       row, so that any border / box-shadow styles applied
+       to it surround the formatting buttons row as well. */
+    padding-bottom: var(--compose-formatting-buttons-row-height);
+    /* The extra 1px of margin-bottom is to ensure the 1px of
+       border-bottom shows below the formatting buttons row. */
+    margin-bottom: calc(
+        (var(--compose-formatting-buttons-row-height) + 1px) * -1
+    );
+
+    textarea {
+        /* Flatten the bottom edge of the textarea to
+           merge with the flat top edge of the buttons row */
+        border-radius: 3px 3px 0 0;
+    }
+}
+
 #preview-message-area-container {
     /* Keep preview container invisible outside
        of preview mode. */
@@ -370,6 +408,11 @@
 
 #message-formatting-controls-container {
     grid-area: message-formatting-controls-container;
+    border-radius: 0 0 3px 3px;
+    background-color: var(--color-message-formatting-controls-container);
+    /* margin on either side to let the border of
+       .message-content-container show through. */
+    margin: 0 1px;
 }
 
 #compose-limit-indicator:not(:empty) {
@@ -778,19 +821,15 @@ textarea.new_message_textarea {
     max-height: 22em;
     margin: 0;
     resize: vertical !important;
-    border-radius: 4px;
-    color: hsl(0deg 0% 33%);
+    border-radius: 3px 3px 0 0;
+    border: none;
     background-color: hsl(0deg 0% 100%);
     scrollbar-width: thin;
     scrollbar-color: hsl(0deg 0% 50%) transparent;
+    box-shadow: none;
 
-    &.over_limit,
-    &.over_limit:focus {
-        box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
-
-        &.flash {
-            animation: message-limit-flash 0.5s ease-in-out infinite;
-        }
+    &:focus {
+        outline: 0;
     }
 
     &:read-only,
@@ -798,26 +837,11 @@ textarea.new_message_textarea {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
     }
-
-    &.invalid,
-    &.invalid:focus {
-        border: 1px solid hsl(3deg 57% 33%);
-        box-shadow: 0 0 2px hsl(3deg 57% 33%);
-    }
 }
 
-textarea.new_message_textarea,
+#message-content-container,
 #compose_recipient_box {
-    border: 1px solid hsl(0deg 0% 0% / 20%);
-    box-shadow: none;
-    transition: border 0.2s ease;
     color: var(--color-text-default);
-
-    &:focus {
-        outline: 0;
-        border: 1px solid hsl(0deg 0% 67%);
-        box-shadow: none;
-    }
 }
 
 #compose_recipient_box {
@@ -825,16 +849,16 @@ textarea.new_message_textarea,
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: stretch;
     flex: 1 1 0;
+    border: 1px solid hsl(0deg 0% 0% / 20%);
     border-radius: 3px;
+    transition: border 0.2s ease;
     background: hsl(0deg 0% 100%);
 
     /* Give the recipient box, a `<div>`, the
        correct styles when focus is in the
        #stream_message_recipient_topic `<input>` */
     &:focus-within {
-        outline: 0;
         border: 1px solid hsl(0deg 0% 67%);
-        box-shadow: none;
     }
 
     #stream_message_recipient_topic,
@@ -1039,7 +1063,7 @@ textarea.new_message_textarea,
     align-items: center;
 
     .compose_control_button {
-        height: 28px;
+        height: var(--compose-formatting-buttons-row-height);
         width: 30px;
         display: flex;
         align-items: center;
@@ -1048,11 +1072,12 @@ textarea.new_message_textarea,
         color: inherit;
         text-decoration: none;
         font-size: 22px;
-        border-radius: 3px;
 
         &:hover {
             opacity: 1;
-            background-color: hsl(0deg 0% 0% / 10%);
+            background-color: var(
+                --color-compose-control-button-background-hover
+            );
         }
     }
 
@@ -1110,6 +1135,7 @@ textarea.new_message_textarea,
         color: hsl(0deg 0% 75%);
         font-size: 20px;
         margin: 0 3px;
+        height: var(--compose-formatting-buttons-row-height);
     }
 
     .compose_draft_button {
@@ -1207,8 +1233,7 @@ textarea.new_message_textarea,
     min-height: 42px;
     overflow: auto;
 
-    border: 1px solid hsl(0deg 0% 67%);
-    border-radius: 4px;
+    border-radius: 3px 3px 0 0;
     background-color: hsl(0deg 0% 100%);
     cursor: not-allowed;
 }
@@ -1358,12 +1383,9 @@ textarea.new_message_textarea,
         width: 30px;
         /* This reduces the vdots button so that
            it and the send button fit within the
-           54px height the compose textarea occupies.
-           TODO: Should formatting buttons become part
-           of the textarea, the height here and its
-           participation in the columnar flexbox
-           should get a rewrite. */
-        height: 26px;
+           53px height the compose textarea occupies,
+           including its top border. */
+        height: 25px;
         margin-left: 0;
         border-radius: 4px;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -120,10 +120,6 @@
         .tippy-content a,
         p {
             color: hsl(236deg 33% 90%);
-
-            &.compose_control_button:hover {
-                color: hsl(200deg 79% 66%);
-            }
         }
     }
 
@@ -514,7 +510,7 @@
     }
 
     .compose_control_button:hover {
-        background-color: hsl(0deg 0% 100% / 10%);
+        color: inherit;
     }
 
     #compose-content {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -534,36 +534,39 @@
     }
 }
 
+.edit-content-container {
+    border-radius: 4px;
+    border: 1px solid var(--color-message-content-container-border);
+    transition: border 0.2s ease;
+
+    &:has(.message_edit_content:focus) {
+        border-color: var(--color-message-content-container-border-focus);
+    }
+}
+
 .message_edit_content {
     max-height: 24em;
     width: 100%;
     min-width: 206px;
+    min-height: 52px;
     box-sizing: border-box;
     /* Setting resize as none hides the bottom right diagonal box
        (which even has a background color of its own!). */
     resize: none !important;
     color: hsl(0deg 0% 33%);
     background-color: hsl(0deg 0% 100%);
-    border-radius: 4px;
+    border-radius: 3px;
     vertical-align: middle;
-    border: 1px solid hsl(0deg 0% 80%);
+    border: none;
     /* Match textarea padding to compose box and
        message-edit preview area. */
     padding: 5px;
-    margin: 0 0 10px;
+    margin: 0;
 
-    box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
-    transition:
-        border linear 0.2s,
-        box-shadow linear 0.2s;
+    box-shadow: none;
 
     &:focus {
-        border-color: hsl(206.5deg 80% 62% / 80%);
         outline: 0;
-
-        box-shadow:
-            inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-            0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
 
     &:read-only,
@@ -600,8 +603,12 @@ of the base style defined for a read-only textarea in dark mode. */
 
 .message-edit-feature-group {
     display: flex;
-    margin: 0;
     align-items: baseline;
+    border-radius: 0 0 3px 3px;
+    background-color: var(--color-message-formatting-controls-container);
+    /* margin on either side to let the border of
+       .edit-content-container show through. */
+    margin: 0 1px;
 }
 
 .message_edit_save .loader {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -69,7 +69,7 @@
                         </div>
                     </div>
                     <div class="messagebox">
-                        <div id="message-content-container">
+                        <div id="message-content-container" class="surround-formatting-buttons-row">
                             <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
                             <div id="preview-message-area-container">
                                 <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -2,7 +2,7 @@
 
 <form id="edit_form_{{message_id}}" class="new-style">
     <div class="edit_form_banners"></div>
-    <div class="edit-controls">
+    <div class="edit-controls edit-content-container {{#if is_editable}}surround-formatting-buttons-row{{/if}}">
         {{> copy_message_button message_id=this.message_id}}
         <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
         <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">


### PR DESCRIPTION
The row of buttons is placed using CSS grid template areas so that visually it is now inside the bottom edge of the textbox. The color of the buttons row and individual buttons is changed to match the color of the textbox. All textbox border / box shadow properties are now applied to its parent instead which is extended under the buttons' row, so that its border snuggly fits around the buttons row too.

Notable side effects:
- In dark mode the textbox in focused state now has a light border which does not match the recipient input's current border which doesn't change when focused. Likely, the recipient input should be updated to match the textbox's border color.
- The dividers in the formatting buttons row are not vertically centered now. This should be figured out soon.

Known concern:
- The textbox resize handle still shows, breaking the illusion of the buttons row being inside the textbox. It will be removed when enabling a 3 stage resizeable textbox.

Fixes: #28702.

### Screenshots and screen captures:
**Light Mode**
![image](https://github.com/zulip/zulip/assets/68962290/e37e609a-aba8-40a9-8e98-6d992293b968)
Hovering a button:
![image](https://github.com/zulip/zulip/assets/68962290/4e9a3297-6ba8-4460-84ce-7a5b8e26eea3)
Focus in textbox:
![image](https://github.com/zulip/zulip/assets/68962290/76e8aea4-898b-44a8-9eab-fd7a26500d72)
Preview mode:
![image](https://github.com/zulip/zulip/assets/68962290/5e4f884f-b2a6-4e41-9901-ef9ffa00b2b9)

**Dark Mode**
![image](https://github.com/zulip/zulip/assets/68962290/b70cba89-512f-4804-8edb-7184457bffa8)
Hovering a button:
![image](https://github.com/zulip/zulip/assets/68962290/83f334d1-d4c0-4675-abe4-4137845d57df)
Focus in textbox:
![image](https://github.com/zulip/zulip/assets/68962290/4929a4db-eb05-4b52-ae01-e1e6a8e0a538)
Preview mode:
![image](https://github.com/zulip/zulip/assets/68962290/a9918b23-cf3c-43d7-a011-28a06f18e8c4)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
