### PR TITLE
Do the simple stream->channel renames in zerver/webhooks/

### DIFF
--- a/api_docs/incoming-webhooks-walkthrough.md
+++ b/api_docs/incoming-webhooks-walkthrough.md
@@ -328,7 +328,7 @@ class `HelloWorldHookTests`:
 
 ```python
 class HelloWorldHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}&stream={stream}"
     DIRECT_MESSAGE_URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}"
     WEBHOOK_DIR_NAME = "helloworld"
@@ -347,14 +347,14 @@ class HelloWorldHookTests(WebhookTestCase):
         )
 ```
 
-In the above example, `STREAM_NAME`, `URL_TEMPLATE`, and `WEBHOOK_DIR_NAME` refer
+In the above example, `CHANNEL_NAME`, `URL_TEMPLATE`, and `WEBHOOK_DIR_NAME` refer
 to class attributes from the base class, `WebhookTestCase`. These are needed by
 the helper function `check_webhook` to determine how to execute
-your test. `STREAM_NAME` should be set to your default stream. If it doesn't exist,
+your test. `CHANNEL_NAME` should be set to your default stream. If it doesn't exist,
 `check_webhook` will create it while executing your test.
 
 If your test expects a stream name from a test fixture, the value in the fixture
-and the value you set for `STREAM_NAME` must match. The test helpers use `STREAM_NAME`
+and the value you set for `CHANNEL_NAME` must match. The test helpers use `CHANNEL_NAME`
 to create the destination stream, and then create the message to send using the
 value from the fixture. If these don't match, the test will fail.
 
@@ -532,10 +532,10 @@ def test_unknown_action_no_data(self) -> None:
     # return if no params are sent. The fixture for this test is an empty file.
 
     # subscribe to the target stream
-    self.subscribe(self.test_user, self.STREAM_NAME)
+    self.subscribe(self.test_user, self.CHANNEL_NAME)
 
     # post to the webhook url
-    post_params = {'stream_name': self.STREAM_NAME,
+    post_params = {'stream_name': self.CHANNEL_NAME,
                    'content_type': 'application/x-www-form-urlencoded'}
     result = self.client_post(self.url, 'unknown_action', **post_params)
 
@@ -549,7 +549,7 @@ the webhook returns an error, the test fails. Instead, explicitly do the
 setup it would have done, and check the result yourself.
 
 Here, `subscribe_to_stream` is a test helper that uses `TEST_USER_EMAIL` and
-`STREAM_NAME` (attributes from the base class) to register the user to receive
+`CHANNEL_NAME` (attributes from the base class) to register the user to receive
 messages in the given stream. If the stream doesn't exist, it creates it.
 
 `client_post`, another helper, performs the HTTP POST that calls the incoming
@@ -592,7 +592,7 @@ attribute `TOPIC` as a keyword argument to `build_webhook_url`, like so:
 ```python
 class QuerytestHookTests(WebhookTestCase):
 
-    STREAM_NAME = 'querytest'
+    CHANNEL_NAME = 'querytest'
     TOPIC = "Default topic"
     URL_TEMPLATE = "/api/v1/external/querytest?api_key={api_key}&stream={stream}"
     FIXTURE_DIR_NAME = 'querytest'

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2148,7 +2148,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
             self.patch.start()
             self.addCleanup(self.patch.stop)
 
-    def api_stream_message(
+    def api_channel_message(
         self,
         user: UserProfile,
         fixture_name: str,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2232,14 +2232,14 @@ one or more new messages.
             )
         assert expected_message is not None and expected_topic_name is not None
 
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=expected_topic_name,
             content=expected_message,
         )
 
-    def assert_stream_message(
+    def assert_channel_message(
         self,
         message: Message,
         stream_name: str,

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2234,7 +2234,7 @@ one or more new messages.
 
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=expected_topic_name,
             content=expected_message,
         )
@@ -2242,11 +2242,11 @@ one or more new messages.
     def assert_channel_message(
         self,
         message: Message,
-        stream_name: str,
+        channel_name: str,
         topic_name: str,
         content: str,
     ) -> None:
-        self.assert_message_stream_name(message, stream_name)
+        self.assert_message_stream_name(message, channel_name)
         self.assertEqual(message.topic_name(), topic_name)
         self.assertEqual(message.content, content)
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2080,7 +2080,7 @@ class WebhookTestCase(ZulipTestCase):
       important for ensuring we document all fully supported event types.
     """
 
-    STREAM_NAME: Optional[str] = None
+    CHANNEL_NAME: Optional[str] = None
     TEST_USER_EMAIL = "webhook-bot@zulip.com"
     URL_TEMPLATE: str
     WEBHOOK_DIR_NAME: Optional[str] = None
@@ -2185,7 +2185,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         We use `fixture_name` to find the payload data in of our test
         fixtures.  Then we verify that a message gets sent to a stream:
 
-            self.STREAM_NAME: stream name
+            self.CHANNEL_NAME: stream name
             expected_topic_name: topic name
             expected_message: content
 
@@ -2197,8 +2197,8 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
 
         When no message is expected to be sent, set `expect_noop` to True.
         """
-        assert self.STREAM_NAME is not None
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        assert self.CHANNEL_NAME is not None
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
 
         payload = self.get_payload(fixture_name)
         if content_type is not None:
@@ -2234,7 +2234,7 @@ one or more new messages.
 
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=expected_topic_name,
             content=expected_message,
         )
@@ -2291,9 +2291,9 @@ one or more new messages.
         url = self.URL_TEMPLATE
         if url.find("api_key") >= 0:
             api_key = get_api_key(self.test_user)
-            url = self.URL_TEMPLATE.format(api_key=api_key, stream=self.STREAM_NAME)
+            url = self.URL_TEMPLATE.format(api_key=api_key, stream=self.CHANNEL_NAME)
         else:
-            url = self.URL_TEMPLATE.format(stream=self.STREAM_NAME)
+            url = self.URL_TEMPLATE.format(stream=self.CHANNEL_NAME)
 
         has_arguments = kwargs or args
         if has_arguments and url.find("?") == -1:

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -175,7 +175,7 @@ class WebhookURLConfigurationTestCase(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name="helloworld_renamed",
+            channel_name="helloworld_renamed",
             topic_name=expected_topic_name,
             content=expected_message,
         )

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -144,25 +144,25 @@ class WebhooksCommonTestCase(ZulipTestCase):
 
 
 class WebhookURLConfigurationTestCase(WebhookTestCase):
-    STREAM_NAME = "helloworld"
+    CHANNEL_NAME = "helloworld"
     WEBHOOK_DIR_NAME = "helloworld"
     URL_TEMPLATE = "/api/v1/external/helloworld?stream={stream}&api_key={api_key}"
 
     @override
     def setUp(self) -> None:
         super().setUp()
-        stream = self.subscribe(self.test_user, self.STREAM_NAME)
+        stream = self.subscribe(self.test_user, self.CHANNEL_NAME)
 
         # In actual webhook tests, we will not need to use stream id.
-        # We assign stream id to STREAM_NAME for testing URL configuration only.
-        self.STREAM_NAME = str(stream.id)
+        # We assign stream id to CHANNEL_NAME for testing URL configuration only.
+        self.CHANNEL_NAME = str(stream.id)
         do_rename_stream(stream, "helloworld_renamed", self.test_user)
 
         self.url = self.build_webhook_url()
 
     def test_trigger_stream_message_by_id(self) -> None:
         # check_webhook cannot be used here as it
-        # subscribes the test user to self.STREAM_NAME
+        # subscribes the test user to self.CHANNEL_NAME
         payload = self.get_body("hello")
 
         self.send_webhook_payload(
@@ -182,13 +182,13 @@ class WebhookURLConfigurationTestCase(WebhookTestCase):
 
 
 class MissingEventHeaderTestCase(WebhookTestCase):
-    STREAM_NAME = "groove"
+    CHANNEL_NAME = "groove"
     URL_TEMPLATE = "/api/v1/external/groove?stream={stream}&api_key={api_key}"
 
     # This tests the validate_extract_webhook_http_header function with
     # an actual webhook, instead of just making a mock
     def test_missing_event_header(self) -> None:
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         with self.assertLogs("zulip.zerver.webhooks.anomalous", level="INFO") as webhook_logs:
             result = self.client_post(
                 self.url,

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -173,7 +173,7 @@ class WebhookURLConfigurationTestCase(WebhookTestCase):
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Marilyn Monroe](https://en.wikipedia.org/wiki/Marilyn_Monroe)**"
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name="helloworld_renamed",
             topic_name=expected_topic_name,

--- a/zerver/webhooks/airbrake/tests.py
+++ b/zerver/webhooks/airbrake/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class AirbrakeHookTests(WebhookTestCase):
-    STREAM_NAME = "airbrake"
+    CHANNEL_NAME = "airbrake"
     URL_TEMPLATE = "/api/v1/external/airbrake?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "airbrake"
 

--- a/zerver/webhooks/alertmanager/tests.py
+++ b/zerver/webhooks/alertmanager/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class AlertmanagerHookTests(WebhookTestCase):
-    STREAM_NAME = "alertmanager"
+    CHANNEL_NAME = "alertmanager"
     URL_TEMPLATE = "/api/v1/external/alertmanager?&api_key={api_key}&stream={stream}&name=topic&desc=description"
     WEBHOOK_DIR_NAME = "alertmanager"
 

--- a/zerver/webhooks/ansibletower/tests.py
+++ b/zerver/webhooks/ansibletower/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class AnsibletowerHookTests(WebhookTestCase):
-    STREAM_NAME = "ansibletower"
+    CHANNEL_NAME = "ansibletower"
     URL_TEMPLATE = "/api/v1/external/ansibletower?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "ansibletower"
 

--- a/zerver/webhooks/appfollow/tests.py
+++ b/zerver/webhooks/appfollow/tests.py
@@ -3,7 +3,7 @@ from zerver.webhooks.appfollow.view import convert_markdown
 
 
 class AppFollowHookTests(WebhookTestCase):
-    STREAM_NAME = "appfollow"
+    CHANNEL_NAME = "appfollow"
     URL_TEMPLATE = "/api/v1/external/appfollow?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "appfollow"
 

--- a/zerver/webhooks/appveyor/tests.py
+++ b/zerver/webhooks/appveyor/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class AppveyorHookTests(WebhookTestCase):
-    STREAM_NAME = "appveyor"
+    CHANNEL_NAME = "appveyor"
     URL_TEMPLATE = "/api/v1/external/appveyor?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "appveyor"
 

--- a/zerver/webhooks/azuredevops/tests.py
+++ b/zerver/webhooks/azuredevops/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.webhooks.git import COMMITS_LIMIT
 
 
 class AzuredevopsHookTests(WebhookTestCase):
-    STREAM_NAME = "azure-devops"
+    CHANNEL_NAME = "azure-devops"
     URL_TEMPLATE = "/api/v1/external/azuredevops?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "azuredevops"
 

--- a/zerver/webhooks/basecamp/tests.py
+++ b/zerver/webhooks/basecamp/tests.py
@@ -4,7 +4,7 @@ TOPIC_NAME = "Zulip HQ"
 
 
 class BasecampHookTests(WebhookTestCase):
-    STREAM_NAME = "basecamp"
+    CHANNEL_NAME = "basecamp"
     URL_TEMPLATE = "/api/v1/external/basecamp?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "basecamp"
 

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -8,7 +8,7 @@ from zerver.lib.webhooks.git import COMMITS_LIMIT
 
 
 class BeanstalkHookTests(WebhookTestCase):
-    STREAM_NAME = "commits"
+    CHANNEL_NAME = "commits"
     URL_TEMPLATE = "/api/v1/external/beanstalk?stream={stream}"
 
     def test_git_single(self) -> None:

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -16,7 +16,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_singlecommit",
             expected_topic_name,
@@ -30,7 +30,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
 * add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_singlecommit",
             expected_topic_name,
@@ -45,7 +45,7 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_multiple_committers",
             expected_topic_name,
@@ -61,7 +61,7 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_multiple_committers",
             expected_topic_name,
@@ -76,7 +76,7 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user, "git_multiple", expected_topic_name, expected_message, content_type=None
         )
 
@@ -88,7 +88,7 @@ class BeanstalkHookTests(WebhookTestCase):
 * Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
 * Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
 * More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user, "git_multiple", expected_topic_name, expected_message, content_type=None
         )
 
@@ -98,7 +98,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = f"""Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {(commits_info * COMMITS_LIMIT)}[and {50 - COMMITS_LIMIT} more commit(s)]"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_morethanlimitcommits",
             expected_topic_name,
@@ -113,7 +113,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = f"""Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
 {(commits_info * COMMITS_LIMIT)}[and {50 - COMMITS_LIMIT} more commit(s)]"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "git_morethanlimitcommits",
             expected_topic_name,
@@ -166,7 +166,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi pushed [revision 3](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/3):
 
 > Removed a file and added another one!"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "svn_addremove",
             expected_topic_name,
@@ -179,7 +179,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_message = """Leo Franchi pushed [revision 2](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/2):
 
 > Added some code"""
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "svn_changefile",
             expected_topic_name,

--- a/zerver/webhooks/beeminder/tests.py
+++ b/zerver/webhooks/beeminder/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class BeeminderHookTests(WebhookTestCase):
-    STREAM_NAME = "beeminder"
+    CHANNEL_NAME = "beeminder"
     URL_TEMPLATE = "/api/v1/external/beeminder?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "beeminder"
 

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -16,7 +16,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
-        self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_event_without_user_info(self) -> None:
         fixture_name = "push_without_user_info"
@@ -25,7 +25,7 @@ class BitbucketHookTests(WebhookTestCase):
         expected_message = (
             f"Someone pushed 1 commit to branch master. Commits by eeshangarg (1).\n\n{commit_info}"
         )
-        self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_event_filtered_by_branches(self) -> None:
         fixture_name = "push"
@@ -34,14 +34,14 @@ class BitbucketHookTests(WebhookTestCase):
         )
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
-        self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_commits_above_limit_event(self) -> None:
         fixture_name = "push_commits_above_limit"
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
-        self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_commits_above_limit_event_filtered_by_branches(self) -> None:
         fixture_name = "push_commits_above_limit"
@@ -50,7 +50,7 @@ class BitbucketHookTests(WebhookTestCase):
         )
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
-        self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_force_push_event(self) -> None:
         fixture_name = "force_push"
@@ -58,7 +58,7 @@ class BitbucketHookTests(WebhookTestCase):
         expected_message = (
             "kolaszek [force pushed](https://bitbucket.org/kolaszek/repository-name)."
         )
-        self.api_stream_message(self.test_user, fixture_name, TOPIC, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC, expected_message)
 
     def test_bitbucket_on_force_push_event_without_user_info(self) -> None:
         fixture_name = "force_push_without_user_info"
@@ -66,7 +66,7 @@ class BitbucketHookTests(WebhookTestCase):
         expected_message = (
             "Someone [force pushed](https://bitbucket.org/kolaszek/repository-name/)."
         )
-        self.api_stream_message(self.test_user, fixture_name, TOPIC, expected_message)
+        self.api_channel_message(self.test_user, fixture_name, TOPIC, expected_message)
 
     @patch("zerver.webhooks.bitbucket.view.check_send_webhook_message")
     def test_bitbucket_on_push_event_filtered_by_branches_ignore(

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -7,7 +7,7 @@ TOPIC_BRANCH_EVENTS = "Repository name / master"
 
 
 class BitbucketHookTests(WebhookTestCase):
-    STREAM_NAME = "bitbucket"
+    CHANNEL_NAME = "bitbucket"
     URL_TEMPLATE = "/api/v1/external/bitbucket?stream={stream}"
     WEBHOOK_DIR_NAME = "bitbucket"
 

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -16,7 +16,9 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
-        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(
+            self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message
+        )
 
     def test_bitbucket_on_push_event_without_user_info(self) -> None:
         fixture_name = "push_without_user_info"
@@ -25,7 +27,9 @@ class BitbucketHookTests(WebhookTestCase):
         expected_message = (
             f"Someone pushed 1 commit to branch master. Commits by eeshangarg (1).\n\n{commit_info}"
         )
-        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(
+            self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message
+        )
 
     def test_bitbucket_on_push_event_filtered_by_branches(self) -> None:
         fixture_name = "push"
@@ -34,14 +38,18 @@ class BitbucketHookTests(WebhookTestCase):
         )
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
-        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(
+            self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message
+        )
 
     def test_bitbucket_on_push_commits_above_limit_event(self) -> None:
         fixture_name = "push_commits_above_limit"
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
-        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(
+            self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message
+        )
 
     def test_bitbucket_on_push_commits_above_limit_event_filtered_by_branches(self) -> None:
         fixture_name = "push_commits_above_limit"
@@ -50,7 +58,9 @@ class BitbucketHookTests(WebhookTestCase):
         )
         commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
-        self.api_channel_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
+        self.api_channel_message(
+            self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message
+        )
 
     def test_bitbucket_on_force_push_event(self) -> None:
         fixture_name = "force_push"

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -292,7 +292,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content=expected_message.format(name="a"),
         )
@@ -300,7 +300,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content=expected_message.format(name="b"),
         )
@@ -320,7 +320,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
             content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
@@ -328,7 +328,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )
@@ -350,7 +350,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
             content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
@@ -358,7 +358,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -290,7 +290,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_second_to_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
@@ -298,7 +298,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
@@ -318,7 +318,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_second_to_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
@@ -326,7 +326,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
@@ -348,7 +348,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_second_to_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
@@ -356,7 +356,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -14,7 +14,7 @@ TOPIC_BRANCH_EVENTS = "Repository name / master"
 
 
 class Bitbucket2HookTests(WebhookTestCase):
-    STREAM_NAME = "bitbucket2"
+    CHANNEL_NAME = "bitbucket2"
     URL_TEMPLATE = "/api/v1/external/bitbucket2?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "bitbucket2"
 
@@ -278,7 +278,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_push_more_than_one_tag_event(self) -> None:
         expected_message = "Tomasz pushed tag [{name}](https://bitbucket.org/kolaszek/repository-name/commits/tag/{name})."
 
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         payload = self.get_body("push_more_than_one_tag")
 
         msg = self.send_webhook_payload(
@@ -292,7 +292,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content=expected_message.format(name="a"),
         )
@@ -300,13 +300,13 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content=expected_message.format(name="b"),
         )
 
     def test_bitbucket2_on_more_than_one_push_event(self) -> None:
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         payload = self.get_body("more_than_one_push_event")
 
         msg = self.send_webhook_payload(
@@ -320,7 +320,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
             content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
@@ -328,7 +328,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )
@@ -336,7 +336,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_more_than_one_push_event_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
 
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         payload = self.get_body("more_than_one_push_event")
 
         msg = self.send_webhook_payload(
@@ -350,7 +350,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
             content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
@@ -358,7 +358,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC,
             content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -5,7 +5,7 @@ TOPIC_BRANCH_EVENTS = "sandbox / {branch}"
 
 
 class Bitbucket3HookTests(WebhookTestCase):
-    STREAM_NAME = "bitbucket3"
+    CHANNEL_NAME = "bitbucket3"
     URL_TEMPLATE = "/api/v1/external/bitbucket3?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "bitbucket3"
 
@@ -81,7 +81,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         branch1_content = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
         master_content = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
 
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         payload = self.get_body("repo_push_update_multiple_branches")
 
         msg = self.send_webhook_payload(
@@ -94,7 +94,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="branch1"),
             content=branch1_content,
         )
@@ -102,7 +102,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="master"),
             content=master_content,
         )

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -92,7 +92,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         )
 
         msg = self.get_second_to_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="branch1"),
@@ -100,7 +100,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         )
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="master"),

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -94,7 +94,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="branch1"),
             content=branch1_content,
         )
@@ -102,7 +102,7 @@ class Bitbucket3HookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=TOPIC_BRANCH_EVENTS.format(branch="master"),
             content=master_content,
         )

--- a/zerver/webhooks/buildbot/tests.py
+++ b/zerver/webhooks/buildbot/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class BuildbotHookTests(WebhookTestCase):
-    STREAM_NAME = "buildbot"
+    CHANNEL_NAME = "buildbot"
     URL_TEMPLATE = "/api/v1/external/buildbot?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "buildbot"
 

--- a/zerver/webhooks/canarytoken/tests.py
+++ b/zerver/webhooks/canarytoken/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class CanarytokensHookTests(WebhookTestCase):
-    STREAM_NAME = "canarytoken"
+    CHANNEL_NAME = "canarytoken"
     URL_TEMPLATE = "/api/v1/external/canarytoken?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "canarytoken"
 

--- a/zerver/webhooks/circleci/tests.py
+++ b/zerver/webhooks/circleci/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class CircleCiHookTests(WebhookTestCase):
-    STREAM_NAME = "circleci"
+    CHANNEL_NAME = "circleci"
     URL_TEMPLATE = "/api/v1/external/circleci?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "circleci"
 

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ClubhouseWebhookTest(WebhookTestCase):
-    STREAM_NAME = "clubhouse"
+    CHANNEL_NAME = "clubhouse"
     URL_TEMPLATE = "/api/v1/external/clubhouse?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "clubhouse"
 

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -684,7 +684,7 @@ def get_name_template(entity: str) -> str:
     return EPIC_NAME_TEMPLATE
 
 
-def send_stream_messages_for_actions(
+def send_channel_messages_for_actions(
     request: HttpRequest,
     user_profile: UserProfile,
     payload: WildValue,
@@ -786,8 +786,8 @@ def api_clubhouse_webhook(
         if event in EVENTS_SECONDARY_ACTIONS_FUNCTION_MAPPER:
             sec_actions_func = EVENTS_SECONDARY_ACTIONS_FUNCTION_MAPPER[event]
             for sec_action in sec_actions_func(payload):
-                send_stream_messages_for_actions(request, user_profile, payload, sec_action, event)
+                send_channel_messages_for_actions(request, user_profile, payload, sec_action, event)
         else:
-            send_stream_messages_for_actions(request, user_profile, payload, primary_action, event)
+            send_channel_messages_for_actions(request, user_profile, payload, primary_action, event)
 
     return json_success(request)

--- a/zerver/webhooks/codeship/tests.py
+++ b/zerver/webhooks/codeship/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class CodeshipHookTests(WebhookTestCase):
-    STREAM_NAME = "codeship"
+    CHANNEL_NAME = "codeship"
     URL_TEMPLATE = "/api/v1/external/codeship?stream={stream}&api_key={api_key}"
     TOPIC_NAME = "codeship/docs"
     WEBHOOK_DIR_NAME = "codeship"

--- a/zerver/webhooks/crashlytics/tests.py
+++ b/zerver/webhooks/crashlytics/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class CrashlyticsHookTests(WebhookTestCase):
-    STREAM_NAME = "crashlytics"
+    CHANNEL_NAME = "crashlytics"
     URL_TEMPLATE = "/api/v1/external/crashlytics?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "crashlytics"
 

--- a/zerver/webhooks/delighted/tests.py
+++ b/zerver/webhooks/delighted/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class DelightedHookTests(WebhookTestCase):
-    STREAM_NAME = "delighted"
+    CHANNEL_NAME = "delighted"
     URL_TEMPLATE = "/api/v1/external/delighted?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "delighted"
 

--- a/zerver/webhooks/deskdotcom/tests.py
+++ b/zerver/webhooks/deskdotcom/tests.py
@@ -22,7 +22,7 @@ class DeskDotComHookTests(WebhookTestCase):
         expected_topic_name = "static text notification"
         expected_message = "This is a custom action."
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "static_text",
             expected_topic_name,
@@ -38,7 +38,7 @@ class DeskDotComHookTests(WebhookTestCase):
             "I have a question</a>"
         )
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "case_updated",
             expected_topic_name,
@@ -54,7 +54,7 @@ class DeskDotComHookTests(WebhookTestCase):
             "Il mio hovercraft è pieno di anguille.</a>"
         )
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "unicode_text_italian",
             expected_topic_name,
@@ -70,7 +70,7 @@ class DeskDotComHookTests(WebhookTestCase):
             "私のホバークラフトは鰻でいっぱいです</a>"
         )
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "unicode_text_japanese",
             expected_topic_name,

--- a/zerver/webhooks/deskdotcom/tests.py
+++ b/zerver/webhooks/deskdotcom/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 # Tests for the Desk.com webhook integration.
 #
-# The stream name must be provided in the URL-encoded test fixture data,
+# The channel name must be provided in the URL-encoded test fixture data,
 # and must match CHANNEL_NAME set here.
 #
 # Example:

--- a/zerver/webhooks/deskdotcom/tests.py
+++ b/zerver/webhooks/deskdotcom/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.test_classes import WebhookTestCase
 # Tests for the Desk.com webhook integration.
 #
 # The stream name must be provided in the URL-encoded test fixture data,
-# and must match STREAM_NAME set here.
+# and must match CHANNEL_NAME set here.
 #
 # Example:
 #
@@ -14,7 +14,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class DeskDotComHookTests(WebhookTestCase):
-    STREAM_NAME = "deskdotcom"
+    CHANNEL_NAME = "deskdotcom"
     URL_TEMPLATE = "/api/v1/external/deskdotcom?stream={stream}"
     WEBHOOK_DIR_NAME = "deskdotcom"
 

--- a/zerver/webhooks/dropbox/tests.py
+++ b/zerver/webhooks/dropbox/tests.py
@@ -3,7 +3,7 @@ from zerver.lib.users import get_api_key
 
 
 class DropboxHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/dropbox?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "dropbox"
 
@@ -19,8 +19,8 @@ class DropboxHookTests(WebhookTestCase):
         )
 
     def test_verification_request(self) -> None:
-        self.subscribe(self.test_user, self.STREAM_NAME)
-        get_params = {"stream_name": self.STREAM_NAME, "api_key": get_api_key(self.test_user)}
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
+        get_params = {"stream_name": self.CHANNEL_NAME, "api_key": get_api_key(self.test_user)}
         result = self.client_get(self.url, get_params)
         self.assert_json_error(result, "Missing 'challenge' argument", 400)
 

--- a/zerver/webhooks/errbit/tests.py
+++ b/zerver/webhooks/errbit/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ErrBitHookTests(WebhookTestCase):
-    STREAM_NAME = "errbit"
+    CHANNEL_NAME = "errbit"
     URL_TEMPLATE = "/api/v1/external/errbit?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "errbit"
 

--- a/zerver/webhooks/flock/tests.py
+++ b/zerver/webhooks/flock/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class FlockHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/flock?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "flock"
 

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class FreshdeskHookTests(WebhookTestCase):
-    STREAM_NAME = "freshdesk"
+    CHANNEL_NAME = "freshdesk"
     URL_TEMPLATE = "/api/v1/external/freshdesk?stream={stream}"
     WEBHOOK_DIR_NAME = "freshdesk"
 

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -26,7 +26,7 @@ Test ticket description ☃.
 * **Status**: Pending
 """.strip()
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "ticket_created",
             expected_topic_name,
@@ -46,7 +46,7 @@ Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zz
 * **Status**: Resolved -> Waiting on Customer
 """.strip()
 
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "status_changed",
             expected_topic_name,
@@ -65,7 +65,7 @@ Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zz
 
 * **Priority**: High -> Low
 """.strip()
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "priority_changed",
             expected_topic_name,
@@ -99,7 +99,7 @@ Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zz
 Requester Bob <requester-bob@example.com> added a {} note to \
 [ticket #11](http://test1234zzz.freshdesk.com/helpdesk/tickets/11).
 """.strip().format(note_type)
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             fixture,
             expected_topic_name,
@@ -123,7 +123,7 @@ Requester Bob <requester-bob@example.com> added a {} note to \
         expected_message = """
 Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n``` quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs.\nExhibit 1:\n\n  \n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png)\n```\n\n* **Type**: Problem\n* **Priority**: Urgent\n* **Status**: Open
 """.strip()
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "inline_images",
             expected_topic_name,

--- a/zerver/webhooks/freshping/tests.py
+++ b/zerver/webhooks/freshping/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class FreshpingHookTests(WebhookTestCase):
-    STREAM_NAME = "freshping"
+    CHANNEL_NAME = "freshping"
     URL_TEMPLATE = "/api/v1/external/freshping?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "freshping"
 

--- a/zerver/webhooks/freshstatus/tests.py
+++ b/zerver/webhooks/freshstatus/tests.py
@@ -5,7 +5,7 @@ from zerver.webhooks.freshstatus.view import MISCONFIGURED_PAYLOAD_ERROR_MESSAGE
 
 
 class FreshstatusHookTests(WebhookTestCase):
-    STREAM_NAME = "freshstatus"
+    CHANNEL_NAME = "freshstatus"
     URL_TEMPLATE = "/api/v1/external/freshstatus?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "freshstatus"
 

--- a/zerver/webhooks/front/tests.py
+++ b/zerver/webhooks/front/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class FrontHookTests(WebhookTestCase):
-    STREAM_NAME = "front"
+    CHANNEL_NAME = "front"
     URL_TEMPLATE = "/api/v1/external/front?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "front"
 

--- a/zerver/webhooks/gci/tests.py
+++ b/zerver/webhooks/gci/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GoogleCodeInTests(WebhookTestCase):
-    STREAM_NAME = "gci"
+    CHANNEL_NAME = "gci"
     URL_TEMPLATE = "/api/v1/external/gci?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "gci"
 

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GiteaHookTests(WebhookTestCase):
-    STREAM_NAME = "commits"
+    CHANNEL_NAME = "commits"
     URL_TEMPLATE = "/api/v1/external/gitea?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "gitea"
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -17,7 +17,7 @@ TOPIC_SPONSORS = "sponsors"
 
 
 class GitHubWebhookTest(WebhookTestCase):
-    STREAM_NAME = "github"
+    CHANNEL_NAME = "github"
     URL_TEMPLATE = "/api/v1/external/github?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "github"
 
@@ -535,7 +535,7 @@ A temporary team so that I can get some webhook fixtures!
             self.verify_post_is_ignored(payload, event)
 
     def test_team_edited_with_unsupported_keys(self) -> None:
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
 
         event = "team"
         payload = dict(
@@ -560,7 +560,7 @@ A temporary team so that I can get some webhook fixtures!
 
         self.assert_stream_message(
             message=stream_message,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name="team My Team",
             content="Team has changes to `bogus_key1/bogus_key2` data.",
         )
@@ -595,7 +595,7 @@ A temporary team so that I can get some webhook fixtures!
 
 
 class GitHubSponsorsHookTests(WebhookTestCase):
-    STREAM_NAME = "github"
+    CHANNEL_NAME = "github"
     URL_TEMPLATE = "/api/v1/external/githubsponsors?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "github"
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -550,7 +550,7 @@ A temporary team so that I can get some webhook fixtures!
         log_mock = patch("zerver.decorator.webhook_unsupported_events_logger.exception")
 
         with log_mock as m:
-            stream_message = self.send_webhook_payload(
+            channel_message = self.send_webhook_payload(
                 self.test_user,
                 self.url,
                 payload,
@@ -559,7 +559,7 @@ A temporary team so that I can get some webhook fixtures!
             )
 
         self.assert_channel_message(
-            message=stream_message,
+            message=channel_message,
             channel_name=self.CHANNEL_NAME,
             topic_name="team My Team",
             content="Team has changes to `bogus_key1/bogus_key2` data.",

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -558,7 +558,7 @@ A temporary team so that I can get some webhook fixtures!
                 content_type="application/json",
             )
 
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=stream_message,
             stream_name=self.CHANNEL_NAME,
             topic_name="team My Team",

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -560,7 +560,7 @@ A temporary team so that I can get some webhook fixtures!
 
         self.assert_channel_message(
             message=stream_message,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name="team My Team",
             content="Team has changes to `bogus_key1/bogus_key2` data.",
         )

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.webhooks.git import COMMITS_LIMIT
 
 
 class GitlabHookTests(WebhookTestCase):
-    STREAM_NAME = "gitlab"
+    CHANNEL_NAME = "gitlab"
     URL_TEMPLATE = "/api/v1/external/gitlab?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "gitlab"
 

--- a/zerver/webhooks/gocd/tests.py
+++ b/zerver/webhooks/gocd/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GocdHookTests(WebhookTestCase):
-    STREAM_NAME = "gocd"
+    CHANNEL_NAME = "gocd"
     URL_TEMPLATE = "/api/v1/external/gocd?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "gocd"
     TOPIC_NAME = "https://github.com/gocd/gocd"

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.webhooks.git import COMMITS_LIMIT
 
 
 class GogsHookTests(WebhookTestCase):
-    STREAM_NAME = "commits"
+    CHANNEL_NAME = "commits"
     URL_TEMPLATE = "/api/v1/external/gogs?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "gogs"
 

--- a/zerver/webhooks/gosquared/tests.py
+++ b/zerver/webhooks/gosquared/tests.py
@@ -3,7 +3,7 @@ from zerver.webhooks.gosquared.view import CHAT_MESSAGE_TEMPLATE
 
 
 class GoSquaredHookTests(WebhookTestCase):
-    STREAM_NAME = "gosquared"
+    CHANNEL_NAME = "gosquared"
     URL_TEMPLATE = "/api/v1/external/gosquared?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "gosquared"
 

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GrafanaHookTests(WebhookTestCase):
-    STREAM_NAME = "grafana"
+    CHANNEL_NAME = "grafana"
     URL_TEMPLATE = "/api/v1/external/grafana?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "grafana"
 

--- a/zerver/webhooks/greenhouse/tests.py
+++ b/zerver/webhooks/greenhouse/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GreenhouseHookTests(WebhookTestCase):
-    STREAM_NAME = "greenhouse"
+    CHANNEL_NAME = "greenhouse"
     URL_TEMPLATE = "/api/v1/external/greenhouse?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "greenhouse"
     CONTENT_TYPE = "application/x-www-form-urlencoded"

--- a/zerver/webhooks/groove/tests.py
+++ b/zerver/webhooks/groove/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class GrooveHookTests(WebhookTestCase):
-    STREAM_NAME = "groove"
+    CHANNEL_NAME = "groove"
     URL_TEMPLATE = "/api/v1/external/groove?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "groove"
 
@@ -64,7 +64,7 @@ The content of the body goes here.
     # This simulates the condition when a ticket
     # is assigned to no one.
     def test_groove_ticket_assigned_no_one(self) -> None:
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         result = self.client_post(
             self.url,
             self.get_body("ticket_assigned__no_one"),

--- a/zerver/webhooks/harbor/tests.py
+++ b/zerver/webhooks/harbor/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class HarborHookTests(WebhookTestCase):
-    STREAM_NAME = "harbor"
+    CHANNEL_NAME = "harbor"
     URL_TEMPLATE = "/api/v1/external/harbor?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "harbor"
 

--- a/zerver/webhooks/hellosign/tests.py
+++ b/zerver/webhooks/hellosign/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class HelloSignHookTests(WebhookTestCase):
-    STREAM_NAME = "hellosign"
+    CHANNEL_NAME = "hellosign"
     URL_TEMPLATE = "/api/v1/external/hellosign?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "hellosign"
 

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -6,7 +6,7 @@ from zerver.models.users import get_system_bot
 
 
 class HelloWorldHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}&stream={stream}"
     DIRECT_MESSAGE_URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}"
     WEBHOOK_DIR_NAME = "helloworld"
@@ -50,7 +50,7 @@ class HelloWorldHookTests(WebhookTestCase):
 
     def test_stream_error_pm_to_bot_owner(self) -> None:
         # Note that this is really just a test for check_send_webhook_message
-        self.STREAM_NAME = "nonexistent"
+        self.CHANNEL_NAME = "nonexistent"
         self.url = self.build_webhook_url()
         realm = get_realm("zulip")
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT, realm.id)

--- a/zerver/webhooks/heroku/tests.py
+++ b/zerver/webhooks/heroku/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class HerokuHookTests(WebhookTestCase):
-    STREAM_NAME = "heroku"
+    CHANNEL_NAME = "heroku"
     URL_TEMPLATE = "/api/v1/external/heroku?stream={stream}&api_key={api_key}"
 
     def test_deployment(self) -> None:

--- a/zerver/webhooks/homeassistant/tests.py
+++ b/zerver/webhooks/homeassistant/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class HomeAssistantHookTests(WebhookTestCase):
-    STREAM_NAME = "homeassistant"
+    CHANNEL_NAME = "homeassistant"
     URL_TEMPLATE = "/api/v1/external/homeassistant?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "homeassistant"
 

--- a/zerver/webhooks/ifttt/tests.py
+++ b/zerver/webhooks/ifttt/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class IFTTTHookTests(WebhookTestCase):
-    STREAM_NAME = "ifttt"
+    CHANNEL_NAME = "ifttt"
     URL_TEMPLATE = "/api/v1/external/ifttt?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "ifttt"
     VIEW_FUNCTION_NAME = "api_iftt_app_webhook"

--- a/zerver/webhooks/insping/tests.py
+++ b/zerver/webhooks/insping/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class InspingHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/insping?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "insping"
 

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class IntercomWebHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/intercom?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "intercom"
 

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -26,7 +26,7 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
 * **Priority**: Major
 * **Assignee**: no one
 """.strip()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name="jira_custom",
             topic_name="BUG-15: New bug with hook",

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.users import get_api_key
 
 
 class JiraHookTests(WebhookTestCase):
-    STREAM_NAME = "jira"
+    CHANNEL_NAME = "jira"
     URL_TEMPLATE = "/api/v1/external/jira?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "jira"
 
@@ -65,9 +65,9 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
             self.assert_json_success(result)
 
     def test_created_with_stream_with_spaces_escaped(self) -> None:
-        self.STREAM_NAME = quote("jira alerts")
+        self.CHANNEL_NAME = quote("jira alerts")
         self.url = self.build_webhook_url()
-        self.subscribe(self.test_user, unquote(self.STREAM_NAME))
+        self.subscribe(self.test_user, unquote(self.CHANNEL_NAME))
 
         payload = self.get_body("created_v1")
         result = self.client_post(self.url, payload, content_type="application/json")
@@ -86,9 +86,9 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
         self.assertEqual(msg.topic_name(), expected_topic_name)
 
     def test_created_with_stream_with_spaces_double_escaped(self) -> None:
-        self.STREAM_NAME = quote(quote("jira alerts"))
+        self.CHANNEL_NAME = quote(quote("jira alerts"))
         self.url = self.build_webhook_url()
-        self.subscribe(self.test_user, unquote(unquote(self.STREAM_NAME)))
+        self.subscribe(self.test_user, unquote(unquote(self.CHANNEL_NAME)))
 
         payload = self.get_body("created_v1")
         result = self.client_post(self.url, payload, content_type="application/json")

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -10,7 +10,7 @@ class JiraHookTests(WebhookTestCase):
     URL_TEMPLATE = "/api/v1/external/jira?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "jira"
 
-    def test_custom_stream(self) -> None:
+    def test_custom_channel(self) -> None:
         api_key = get_api_key(self.test_user)
         self.subscribe(self.test_user, "jira_custom")
         url = f"/api/v1/external/jira?api_key={api_key}&stream=jira_custom"
@@ -64,7 +64,7 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
             self.assertFalse(m.called)
             self.assert_json_success(result)
 
-    def test_created_with_stream_with_spaces_escaped(self) -> None:
+    def test_created_with_channel_with_spaces_escaped(self) -> None:
         self.CHANNEL_NAME = quote("jira alerts")
         self.url = self.build_webhook_url()
         self.subscribe(self.test_user, unquote(self.CHANNEL_NAME))
@@ -85,7 +85,7 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
         self.assertEqual(msg.content, expected_message)
         self.assertEqual(msg.topic_name(), expected_topic_name)
 
-    def test_created_with_stream_with_spaces_double_escaped(self) -> None:
+    def test_created_with_channel_with_spaces_double_escaped(self) -> None:
         self.CHANNEL_NAME = quote(quote("jira alerts"))
         self.url = self.build_webhook_url()
         self.subscribe(self.test_user, unquote(unquote(self.CHANNEL_NAME)))

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -28,7 +28,7 @@ Leo Franchi created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/
 """.strip()
         self.assert_channel_message(
             message=msg,
-            stream_name="jira_custom",
+            channel_name="jira_custom",
             topic_name="BUG-15: New bug with hook",
             content=expected_content,
         )

--- a/zerver/webhooks/jotform/tests.py
+++ b/zerver/webhooks/jotform/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class JotformHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/jotform?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "jotform"
 

--- a/zerver/webhooks/json/tests.py
+++ b/zerver/webhooks/json/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class JsonHookTests(WebhookTestCase):
-    STREAM_NAME = "json"
+    CHANNEL_NAME = "json"
     URL_TEMPLATE = "/api/v1/external/json?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "json"
 

--- a/zerver/webhooks/librato/tests.py
+++ b/zerver/webhooks/librato/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class LibratoHookTests(WebhookTestCase):
-    STREAM_NAME = "librato"
+    CHANNEL_NAME = "librato"
     URL_TEMPLATE = "/api/v1/external/librato?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "librato"
     IS_ATTACHMENT = False

--- a/zerver/webhooks/lidarr/tests.py
+++ b/zerver/webhooks/lidarr/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class LidarrHookTests(WebhookTestCase):
-    STREAM_NAME = "lidarr"
+    CHANNEL_NAME = "lidarr"
     URL_TEMPLATE = "/api/v1/external/lidarr?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "lidarr"
 

--- a/zerver/webhooks/linear/tests.py
+++ b/zerver/webhooks/linear/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class LinearHookTests(WebhookTestCase):
-    STREAM_NAME = "Linear"
+    CHANNEL_NAME = "Linear"
     URL_TEMPLATE = "/api/v1/external/linear?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "linear"
 

--- a/zerver/webhooks/mention/tests.py
+++ b/zerver/webhooks/mention/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class MentionHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/mention?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "mention"
 

--- a/zerver/webhooks/netlify/tests.py
+++ b/zerver/webhooks/netlify/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class NetlifyHookTests(WebhookTestCase):
-    STREAM_NAME = "netlify"
+    CHANNEL_NAME = "netlify"
     URL_TEMPLATE = "/api/v1/external/netlify?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "netlify"
 

--- a/zerver/webhooks/newrelic/tests.py
+++ b/zerver/webhooks/newrelic/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class NewRelicHookTests(WebhookTestCase):
-    STREAM_NAME = "newrelic"
+    CHANNEL_NAME = "newrelic"
     URL_TEMPLATE = "/api/v1/external/newrelic?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "newrelic"
 

--- a/zerver/webhooks/opbeat/tests.py
+++ b/zerver/webhooks/opbeat/tests.py
@@ -4,7 +4,7 @@ from zerver.webhooks.opbeat.view import get_value
 
 
 class OpbeatHookTests(WebhookTestCase):
-    STREAM_NAME = "opbeat"
+    CHANNEL_NAME = "opbeat"
     URL_TEMPLATE = "/api/v1/external/opbeat?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "opbeat"
 

--- a/zerver/webhooks/opencollective/tests.py
+++ b/zerver/webhooks/opencollective/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class OpenCollectiveHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/opencollective?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "opencollective"
 

--- a/zerver/webhooks/opsgenie/tests.py
+++ b/zerver/webhooks/opsgenie/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class OpsgenieHookTests(WebhookTestCase):
-    STREAM_NAME = "opsgenie"
+    CHANNEL_NAME = "opsgenie"
     URL_TEMPLATE = "/api/v1/external/opsgenie?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "opsgenie"
 

--- a/zerver/webhooks/pagerduty/tests.py
+++ b/zerver/webhooks/pagerduty/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class PagerDutyHookTests(WebhookTestCase):
-    STREAM_NAME = "pagerduty"
+    CHANNEL_NAME = "pagerduty"
     URL_TEMPLATE = "/api/v1/external/pagerduty?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "pagerduty"
 

--- a/zerver/webhooks/papertrail/tests.py
+++ b/zerver/webhooks/papertrail/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class PapertrailHookTests(WebhookTestCase):
-    STREAM_NAME = "papertrail"
+    CHANNEL_NAME = "papertrail"
     URL_TEMPLATE = "/api/v1/external/papertrail?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "papertrail"
 

--- a/zerver/webhooks/patreon/tests.py
+++ b/zerver/webhooks/patreon/tests.py
@@ -13,7 +13,7 @@ IGNORED_EVENTS = [
 
 
 class PatreonHookTests(WebhookTestCase):
-    STREAM_NAME = "Patreon"
+    CHANNEL_NAME = "Patreon"
     URL_TEMPLATE = "/api/v1/external/patreon?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "patreon"
 

--- a/zerver/webhooks/pingdom/tests.py
+++ b/zerver/webhooks/pingdom/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class PingdomHookTests(WebhookTestCase):
-    STREAM_NAME = "pingdom"
+    CHANNEL_NAME = "pingdom"
     URL_TEMPLATE = "/api/v1/external/pingdom?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "pingdom"
 

--- a/zerver/webhooks/pivotal/tests.py
+++ b/zerver/webhooks/pivotal/tests.py
@@ -9,7 +9,7 @@ from zerver.webhooks.pivotal.view import api_pivotal_webhook_v5
 
 
 class PivotalV3HookTests(WebhookTestCase):
-    STREAM_NAME = "pivotal"
+    CHANNEL_NAME = "pivotal"
     URL_TEMPLATE = "/api/v1/external/pivotal?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "pivotal"
 
@@ -112,7 +112,7 @@ class PivotalV3HookTests(WebhookTestCase):
 
 
 class PivotalV5HookTests(WebhookTestCase):
-    STREAM_NAME = "pivotal"
+    CHANNEL_NAME = "pivotal"
     URL_TEMPLATE = "/api/v1/external/pivotal?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "pivotal"
 

--- a/zerver/webhooks/radarr/tests.py
+++ b/zerver/webhooks/radarr/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class RadarrHookTests(WebhookTestCase):
-    STREAM_NAME = "radarr"
+    CHANNEL_NAME = "radarr"
     URL_TEMPLATE = "/api/v1/external/radarr?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "radarr"
 

--- a/zerver/webhooks/raygun/tests.py
+++ b/zerver/webhooks/raygun/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class RaygunHookTests(WebhookTestCase):
-    STREAM_NAME = "raygun"
+    CHANNEL_NAME = "raygun"
     URL_TEMPLATE = "/api/v1/external/raygun?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "raygun"
 

--- a/zerver/webhooks/reviewboard/tests.py
+++ b/zerver/webhooks/reviewboard/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ReviewBoardHookTests(WebhookTestCase):
-    STREAM_NAME = "reviewboard"
+    CHANNEL_NAME = "reviewboard"
     URL_TEMPLATE = "/api/v1/external/reviewboard?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "reviewboard"
 

--- a/zerver/webhooks/rhodecode/tests.py
+++ b/zerver/webhooks/rhodecode/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.webhooks.git import COMMITS_LIMIT
 
 
 class RhodecodeHookTests(WebhookTestCase):
-    STREAM_NAME = "rhodecode"
+    CHANNEL_NAME = "rhodecode"
     URL_TEMPLATE = "/api/v1/external/rhodecode?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "rhodecode"
 

--- a/zerver/webhooks/rundeck/tests.py
+++ b/zerver/webhooks/rundeck/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class RundeckHookTests(WebhookTestCase):
-    STREAM_NAME = "Rundeck"
+    CHANNEL_NAME = "Rundeck"
     TOPIC_NAME = "Global Log Filter Usage"
     URL_TEMPLATE = "/api/v1/external/rundeck?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "rundeck"

--- a/zerver/webhooks/semaphore/tests.py
+++ b/zerver/webhooks/semaphore/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SemaphoreHookTests(WebhookTestCase):
-    STREAM_NAME = "semaphore"
+    CHANNEL_NAME = "semaphore"
     URL_TEMPLATE = "/api/v1/external/semaphore?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "semaphore"
 

--- a/zerver/webhooks/sentry/tests.py
+++ b/zerver/webhooks/sentry/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SentryHookTests(WebhookTestCase):
-    STREAM_NAME = "sentry"
+    CHANNEL_NAME = "sentry"
     URL_TEMPLATE = "/api/v1/external/sentry?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "sentry"
 

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -7,7 +7,7 @@ EXPECTED_MESSAGE = "**slack_user**: test"
 
 
 class SlackWebhookTests(WebhookTestCase):
-    STREAM_NAME = "slack"
+    CHANNEL_NAME = "slack"
     URL_TEMPLATE = "/api/v1/external/slack?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "slack"
 
@@ -50,7 +50,7 @@ class SlackWebhookTests(WebhookTestCase):
         )
 
     def test_slack_channels_map_to_topics_false(self) -> None:
-        self.STREAM_NAME = "general"
+        self.CHANNEL_NAME = "general"
         self.url = self.build_webhook_url(channels_map_to_topics="0")
         self.check_webhook(
             "message_info",
@@ -60,7 +60,7 @@ class SlackWebhookTests(WebhookTestCase):
         )
 
     def test_slack_channels_map_to_topics_false_and_user_specified_topic(self) -> None:
-        self.STREAM_NAME = "general"
+        self.CHANNEL_NAME = "general"
         self.url = self.build_webhook_url(topic="test", channels_map_to_topics="0")
         expected_topic_name = "test"
         self.check_webhook(

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -47,8 +47,8 @@ def api_slack_webhook(
             content,
         )
     elif channels_map_to_topics == VALID_OPTIONS["SHOULD_NOT_BE_MAPPED"]:
-        # This stream-channel mapping will be used even if
-        # there is a stream specified in the webhook URL.
+        # This channel-channel mapping will be used even if
+        # there is a channel specified in the webhook URL.
         check_send_webhook_message(
             request,
             user_profile,

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -37,7 +37,7 @@ Hello, world.
                 payload,
                 content_type="application/json",
             )
-            self.assert_stream_message(
+            self.assert_channel_message(
                 message=msg,
                 stream_name=self.CHANNEL_NAME,
                 topic_name="(no topic)",

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SlackIncomingHookTests(WebhookTestCase):
-    STREAM_NAME = "slack_incoming"
+    CHANNEL_NAME = "slack_incoming"
     URL_TEMPLATE = "/api/v1/external/slack_incoming?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "slack_incoming"
 
@@ -28,7 +28,7 @@ Hello, world.
             ("*foo*a*bar*", "*foo*a*bar*"),
             ("some _foo_ word", "some *foo* word"),
         ]
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         for input_value, output_value in tests:
             payload = {"text": input_value}
             msg = self.send_webhook_payload(
@@ -39,7 +39,7 @@ Hello, world.
             )
             self.assert_stream_message(
                 message=msg,
-                stream_name=self.STREAM_NAME,
+                stream_name=self.CHANNEL_NAME,
                 topic_name="(no topic)",
                 content=output_value,
             )

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -39,7 +39,7 @@ Hello, world.
             )
             self.assert_channel_message(
                 message=msg,
-                stream_name=self.CHANNEL_NAME,
+                channel_name=self.CHANNEL_NAME,
                 topic_name="(no topic)",
                 content=output_value,
             )

--- a/zerver/webhooks/solano/tests.py
+++ b/zerver/webhooks/solano/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SolanoHookTests(WebhookTestCase):
-    STREAM_NAME = "solano labs"
+    CHANNEL_NAME = "solano labs"
     URL_TEMPLATE = "/api/v1/external/solano?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "solano"
 

--- a/zerver/webhooks/sonarqube/tests.py
+++ b/zerver/webhooks/sonarqube/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SonarqubeHookTests(WebhookTestCase):
-    STREAM_NAME = "SonarQube"
+    CHANNEL_NAME = "SonarQube"
     URL_TEMPLATE = "/api/v1/external/sonarqube?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "sonarqube"
 

--- a/zerver/webhooks/sonarr/tests.py
+++ b/zerver/webhooks/sonarr/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SonarrHookTests(WebhookTestCase):
-    STREAM_NAME = "sonarr"
+    CHANNEL_NAME = "sonarr"
     URL_TEMPLATE = "/api/v1/external/sonarr?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "sonarr"
 

--- a/zerver/webhooks/splunk/tests.py
+++ b/zerver/webhooks/splunk/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class SplunkHookTests(WebhookTestCase):
-    STREAM_NAME = "splunk"
+    CHANNEL_NAME = "splunk"
     URL_TEMPLATE = "/api/v1/external/splunk?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "splunk"
 

--- a/zerver/webhooks/statuspage/tests.py
+++ b/zerver/webhooks/statuspage/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class StatuspageHookTests(WebhookTestCase):
-    STREAM_NAME = "statuspage-test"
+    CHANNEL_NAME = "statuspage-test"
     URL_TEMPLATE = "/api/v1/external/statuspage?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "statuspage"
 

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -5,7 +5,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class StripeHookTests(WebhookTestCase):
-    STREAM_NAME = "test"
+    CHANNEL_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/stripe?&api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "stripe"
 

--- a/zerver/webhooks/taiga/tests.py
+++ b/zerver/webhooks/taiga/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class TaigaHookTests(WebhookTestCase):
-    STREAM_NAME = "taiga"
+    CHANNEL_NAME = "taiga"
     TOPIC_NAME = "subject"
     URL_TEMPLATE = "/api/v1/external/taiga?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "taiga"

--- a/zerver/webhooks/teamcity/tests.py
+++ b/zerver/webhooks/teamcity/tests.py
@@ -9,7 +9,7 @@ from zerver.webhooks.teamcity.view import MISCONFIGURED_PAYLOAD_TYPE_ERROR_MESSA
 
 
 class TeamCityHookTests(WebhookTestCase):
-    STREAM_NAME = "teamcity"
+    CHANNEL_NAME = "teamcity"
     URL_TEMPLATE = "/api/v1/external/teamcity?stream={stream}&api_key={api_key}"
     TOPIC_NAME = "Project :: Compile"
     WEBHOOK_DIR_NAME = "teamcity"

--- a/zerver/webhooks/thinkst/tests.py
+++ b/zerver/webhooks/thinkst/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ThinkstHookTests(WebhookTestCase):
-    STREAM_NAME = "thinkst"
+    CHANNEL_NAME = "thinkst"
     URL_TEMPLATE = "/api/v1/external/thinkst?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "thinkst"
 

--- a/zerver/webhooks/transifex/tests.py
+++ b/zerver/webhooks/transifex/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class TransifexHookTests(WebhookTestCase):
-    STREAM_NAME = "transifex"
+    CHANNEL_NAME = "transifex"
     URL_TEMPLATE = "/api/v1/external/transifex?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "transifex"
 

--- a/zerver/webhooks/travis/tests.py
+++ b/zerver/webhooks/travis/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class TravisHookTests(WebhookTestCase):
-    STREAM_NAME = "travis"
+    CHANNEL_NAME = "travis"
     URL_TEMPLATE = "/api/v1/external/travis?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "travis"
     TOPIC_NAME = "builds"

--- a/zerver/webhooks/trello/tests.py
+++ b/zerver/webhooks/trello/tests.py
@@ -7,7 +7,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class TrelloHookTests(WebhookTestCase):
-    STREAM_NAME = "trello"
+    CHANNEL_NAME = "trello"
     URL_TEMPLATE = "/api/v1/external/trello?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "trello"
 

--- a/zerver/webhooks/updown/tests.py
+++ b/zerver/webhooks/updown/tests.py
@@ -38,7 +38,7 @@ class UpdownHookTests(WebhookTestCase):
         )
 
         msg = self.get_second_to_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=topic_name,
@@ -46,7 +46,7 @@ class UpdownHookTests(WebhookTestCase):
         )
 
         msg = self.get_last_message()
-        self.assert_stream_message(
+        self.assert_channel_message(
             message=msg,
             stream_name=self.CHANNEL_NAME,
             topic_name=topic_name,

--- a/zerver/webhooks/updown/tests.py
+++ b/zerver/webhooks/updown/tests.py
@@ -40,7 +40,7 @@ class UpdownHookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=topic_name,
             content=down_content,
         )
@@ -48,7 +48,7 @@ class UpdownHookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_channel_message(
             message=msg,
-            stream_name=self.CHANNEL_NAME,
+            channel_name=self.CHANNEL_NAME,
             topic_name=topic_name,
             content=up_content,
         )

--- a/zerver/webhooks/updown/tests.py
+++ b/zerver/webhooks/updown/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class UpdownHookTests(WebhookTestCase):
-    STREAM_NAME = "updown"
+    CHANNEL_NAME = "updown"
     URL_TEMPLATE = "/api/v1/external/updown?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "updown"
 
@@ -27,7 +27,7 @@ class UpdownHookTests(WebhookTestCase):
         down_content = "Service is `down`. It returned a 500 error at 2016-02-07 13:11:43 UTC."
         up_content = "Service is `up` again after 1 second."
 
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         payload = self.get_body("check_multiple_events")
 
         msg = self.send_webhook_payload(
@@ -40,7 +40,7 @@ class UpdownHookTests(WebhookTestCase):
         msg = self.get_second_to_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=topic_name,
             content=down_content,
         )
@@ -48,7 +48,7 @@ class UpdownHookTests(WebhookTestCase):
         msg = self.get_last_message()
         self.assert_stream_message(
             message=msg,
-            stream_name=self.STREAM_NAME,
+            stream_name=self.CHANNEL_NAME,
             topic_name=topic_name,
             content=up_content,
         )

--- a/zerver/webhooks/uptimerobot/tests.py
+++ b/zerver/webhooks/uptimerobot/tests.py
@@ -5,7 +5,7 @@ from zerver.webhooks.uptimerobot.view import MISCONFIGURED_PAYLOAD_ERROR_MESSAGE
 
 
 class UptimeRobotHookTests(WebhookTestCase):
-    STREAM_NAME = "uptimerobot"
+    CHANNEL_NAME = "uptimerobot"
     URL_TEMPLATE = "/api/v1/external/uptimerobot?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "uptimerobot"
 

--- a/zerver/webhooks/wekan/tests.py
+++ b/zerver/webhooks/wekan/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class WekanHookTests(WebhookTestCase):
-    STREAM_NAME = "wekan"
+    CHANNEL_NAME = "wekan"
     URL_TEMPLATE = "/api/v1/external/wekan?stream={stream}&api_key={api_key}"
     FIXTURE_DIR_NAME = "wekan"
 

--- a/zerver/webhooks/wordpress/tests.py
+++ b/zerver/webhooks/wordpress/tests.py
@@ -83,7 +83,7 @@ class WordPressHookTests(WebhookTestCase):
         # we are testing. The value of result is the error message the webhook should
         # return if no params are sent. The fixture for this test is an empty file.
 
-        # subscribe to the target stream
+        # subscribe to the target channel
         self.subscribe(self.test_user, self.CHANNEL_NAME)
 
         # post to the webhook url

--- a/zerver/webhooks/wordpress/tests.py
+++ b/zerver/webhooks/wordpress/tests.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class WordPressHookTests(WebhookTestCase):
-    STREAM_NAME = "wordpress"
+    CHANNEL_NAME = "wordpress"
     URL_TEMPLATE = "/api/v1/external/wordpress?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "wordpress"
 
@@ -84,7 +84,7 @@ class WordPressHookTests(WebhookTestCase):
         # return if no params are sent. The fixture for this test is an empty file.
 
         # subscribe to the target stream
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
 
         # post to the webhook url
         result = self.client_post(
@@ -100,7 +100,7 @@ class WordPressHookTests(WebhookTestCase):
         # Similar to unknown_action_no_data, except the fixture contains valid blog post
         # params but without the hook parameter. This should also return an error.
 
-        self.subscribe(self.test_user, self.STREAM_NAME)
+        self.subscribe(self.test_user, self.CHANNEL_NAME)
         result = self.client_post(
             self.url,
             self.get_body("unknown_action_no_hook_provided"),

--- a/zerver/webhooks/zabbix/tests.py
+++ b/zerver/webhooks/zabbix/tests.py
@@ -5,7 +5,7 @@ from zerver.webhooks.zabbix.view import MISCONFIGURED_PAYLOAD_ERROR_MESSAGE
 
 
 class ZabbixHookTests(WebhookTestCase):
-    STREAM_NAME = "zabbix"
+    CHANNEL_NAME = "zabbix"
     URL_TEMPLATE = "/api/v1/external/zabbix?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "zabbix"
 

--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -2,7 +2,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ZapierHookTests(WebhookTestCase):
-    STREAM_NAME = "zapier"
+    CHANNEL_NAME = "zapier"
     URL_TEMPLATE = "/api/v1/external/zapier?stream={stream}&api_key={api_key}"
     WEBHOOK_DIR_NAME = "zapier"
 
@@ -25,7 +25,7 @@ class ZapierHookTests(WebhookTestCase):
 
 
 class ZapierZulipAppTests(WebhookTestCase):
-    STREAM_NAME = "zapier"
+    CHANNEL_NAME = "zapier"
     URL_TEMPLATE = "/api/v1/external/zapier?api_key={api_key}&stream={stream}"
     WEBHOOK_DIR_NAME = "zapier"
 

--- a/zerver/webhooks/zendesk/tests.py
+++ b/zerver/webhooks/zendesk/tests.py
@@ -19,7 +19,7 @@ class ZenDeskHookTests(WebhookTestCase):
         }
 
     def do_test(self, expected_topic: str, expected_message: str) -> None:
-        self.api_stream_message(
+        self.api_channel_message(
             self.test_user,
             "",
             expected_topic,

--- a/zerver/webhooks/zendesk/tests.py
+++ b/zerver/webhooks/zendesk/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class ZenDeskHookTests(WebhookTestCase):
-    STREAM_NAME = "zendesk"
+    CHANNEL_NAME = "zendesk"
     URL_TEMPLATE = "/api/v1/external/zendesk?stream={stream}"
 
     @override
@@ -15,7 +15,7 @@ class ZenDeskHookTests(WebhookTestCase):
             "ticket_title": self.TICKET_TITLE,
             "ticket_id": str(self.TICKET_ID),
             "message": self.MESSAGE,
-            "stream": self.STREAM_NAME,
+            "stream": self.CHANNEL_NAME,
         }
 
     def do_test(self, expected_topic: str, expected_message: str) -> None:


### PR DESCRIPTION
Renames the `stream` references in variable, function, arg names  and comments in `zerver/webhooks/`. There's still a bunch of noise coming from having `stream={stream}` in the webhook URLs in tests, but that's harder to clean up since we probably need some backward-compatible transition for that param name.