### PR TITLE
Stream->channel renames in zerver/webhooks/ docs

### DIFF
--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -54,7 +54,7 @@ Usually, this involves a few steps:
   screenshot using `manage.py send_webhook_fixture_message`. When generating the
   screenshot of a sample message using this method, give your test bot a nice
   name like "GitHub Bot", use the project's logo as the bot's avatar, and take
-  the screenshot showing the stream/topic bar for the message, not just the
+  the screenshot showing the channel/topic bar for the message, not just the
   message body.
 
 ## Markdown macros
@@ -72,7 +72,7 @@ always create a new macro by adding a new file to that folder.
 Here are a few common macros used to document Zulip's integrations:
 
 - `{!create-channel.md!}` macro - Recommends that users create a dedicated
-  stream for a given integration. Usually the first step is setting up an
+  channel for a given integration. Usually the first step is setting up an
   integration or incoming webhook. For an example rendering, see **Step 1** of
   [the docs for Zulip's GitHub integration][github-integration].
 
@@ -102,9 +102,9 @@ Here are a few common macros used to document Zulip's integrations:
   every incoming webhook by using attributes in the `WebhookIntegration` class
   in [zerver/lib/integrations.py][integrations-file].
 
-- `{!append-channel-name.md!}` macro - Recommends appending `&stream=stream_name`
-  to a URL in cases where supplying a stream name in the URL is optional.
-  Supplying a stream name is optional for most Zulip integrations. If you use
+- `{!append-channel-name.md!}` macro - Recommends appending `&stream=channel_name`
+  to a URL in cases where supplying a channel name in the URL is optional.
+  Supplying a channel name is optional for most Zulip integrations. If you use
   `{!generate-integration-url.md!}`, this macro need not be used.
 
 - `{!append-topic.md!}` macro - Recommends appending `&topic=my_topic` to a URL
@@ -211,9 +211,9 @@ Most doc files should start with a generic sentence about the
 integration, for example, "Get `webhook name` notifications in Zulip!"
 A typical doc will then have the following steps.
 
-##### "Create the stream" step
+##### "Create the channel" step
 
-- Use the `create-stream` macro. This step should be omitted if the
+- Use the `create-channel` macro. This step should be omitted if the
   integration only supports notifications via direct messages.
 
 ##### "Create the bot" step

--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -71,14 +71,14 @@ always create a new macro by adding a new file to that folder.
 
 Here are a few common macros used to document Zulip's integrations:
 
-- `{!create-stream.md!}` macro - Recommends that users create a dedicated
+- `{!create-channel.md!}` macro - Recommends that users create a dedicated
   stream for a given integration. Usually the first step is setting up an
   integration or incoming webhook. For an example rendering, see **Step 1** of
   [the docs for Zulip's GitHub integration][github-integration].
 
 - `{!create-an-incoming-webhook.md!}` macro - Instructs users to create a bot
   for a given integration and select **Incoming webhook** as the **Bot type**.
-  This macro is usually used right after `{!create-stream!}`. For an example
+  This macro is usually used right after `{!create-channel.md!}`. For an example
   rendering, see **Step 2** of [the docs for Zulip's Zendesk integration][zendesk].
 
 - `{!create-a-generic-bot.md!}` macro - Instructs users to create a bot
@@ -87,7 +87,7 @@ Here are a few common macros used to document Zulip's integrations:
 
 - `{!create-an-incoming-webhook.md!}` macro - Instructs users to create a bot
   for a given integration and select **Incoming webhook** as the **Bot type**.
-  This macro is usually used right after `{!create-stream!}`. For an example
+  This macro is usually used right after `{!create-channel.md!}`. For an example
   rendering, see **Step 2** of [the docs for Zulip's GitHub integration][github-integration].
 
   **Note:** If special configuration is

--- a/docs/documentation/integrations.md
+++ b/docs/documentation/integrations.md
@@ -102,7 +102,7 @@ Here are a few common macros used to document Zulip's integrations:
   every incoming webhook by using attributes in the `WebhookIntegration` class
   in [zerver/lib/integrations.py][integrations-file].
 
-- `{!append-stream-name.md!}` macro - Recommends appending `&stream=stream_name`
+- `{!append-channel-name.md!}` macro - Recommends appending `&stream=stream_name`
   to a URL in cases where supplying a stream name in the URL is optional.
   Supplying a stream name is optional for most Zulip integrations. If you use
   `{!generate-integration-url.md!}`, this macro need not be used.

--- a/templates/zerver/integrations/asana.md
+++ b/templates/zerver/integrations/asana.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Asana projects via Zapier!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/templates/zerver/integrations/git.md
+++ b/templates/zerver/integrations/git.md
@@ -4,7 +4,7 @@ Get Zulip notifications for your Git repositories!
 
 1. {!download-python-bindings.md!}
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!change-zulip-config-file.md!}
 

--- a/templates/zerver/integrations/hubot_common.md
+++ b/templates/zerver/integrations/hubot_common.md
@@ -1,6 +1,6 @@
 Get Zulip notifications from {{ integration_display_name }} via Hubot!
 
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  Next, [install Hubot](hubot), and test it to make sure it is working.
 

--- a/templates/zerver/integrations/include/append-channel-name.md
+++ b/templates/zerver/integrations/include/append-channel-name.md
@@ -1,0 +1,3 @@
+To specify the channel, you must explicitly append
+`&stream=channel_name` to the end of the above URL, where
+`channel_name` is the channel you want the notifications sent to.

--- a/templates/zerver/integrations/include/append-stream-name.md
+++ b/templates/zerver/integrations/include/append-stream-name.md
@@ -1,3 +1,0 @@
-To specify the stream, you must explicitly append
-`&stream=stream_name` to the end of the above URL, where
-`stream_name` is the stream you want the notifications sent to.

--- a/templates/zerver/integrations/include/create-channel.md
+++ b/templates/zerver/integrations/include/create-channel.md
@@ -1,0 +1,2 @@
+[Create the channel](/help/create-a-channel) you'd like to use for
+{{ integration_display_name }} notifications.

--- a/templates/zerver/integrations/include/create-stream.md
+++ b/templates/zerver/integrations/include/create-stream.md
@@ -1,2 +1,0 @@
-[Create the stream](/help/create-a-channel) you'd like to use for
-{{ integration_display_name }} notifications.

--- a/templates/zerver/integrations/include/git-webhook-url-with-branches.md
+++ b/templates/zerver/integrations/include/git-webhook-url-with-branches.md
@@ -2,4 +2,4 @@ You can also limit the branches you receive notifications for by
 specifying them in a comma-separated list at the end of the URL,
 like so:
 
-`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream={{ recommended_stream_name }}&branches=main,development`
+`{{ api_url }}{{ integration_url }}?api_key=abcdefgh&stream={{ recommended_channel_name }}&branches=main,development`

--- a/templates/zerver/integrations/jenkins.md
+++ b/templates/zerver/integrations/jenkins.md
@@ -1,4 +1,4 @@
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/templates/zerver/integrations/jira-plugin.md
+++ b/templates/zerver/integrations/jira-plugin.md
@@ -3,7 +3,7 @@ Jira provided by Atlassian, we recommend using the
 [web-hook method](./jira) above instead. This plugin supports older
 versions of Jira.*
 
-{!create-stream.md!}
+{!create-channel.md!}
 
 ### Plugin mechanism
 

--- a/templates/zerver/integrations/jira-plugin.md
+++ b/templates/zerver/integrations/jira-plugin.md
@@ -48,7 +48,7 @@ tell Jira about the certificate.
 ``` Python
 String zulipEmail = "jira-notifications-bot@example.com"
 String zulipAPIKey = "0123456789abcdef0123456789abcdef"
-String zulipStream = "{{ recommended_stream_name }}"
+String zulipStream = "{{ recommended_channel_name }}"
 String issueBaseUrl = "https://jira.COMPANY.com/browse/"
 ```
 

--- a/templates/zerver/integrations/mercurial.md
+++ b/templates/zerver/integrations/mercurial.md
@@ -1,6 +1,6 @@
 Get Zulip notifications when you `hg push`!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/templates/zerver/integrations/nagios.md
+++ b/templates/zerver/integrations/nagios.md
@@ -1,4 +1,4 @@
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  {!download-python-bindings.md!}
 

--- a/templates/zerver/integrations/notion.md
+++ b/templates/zerver/integrations/notion.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Notion database via Zapier!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/templates/zerver/integrations/openshift.md
+++ b/templates/zerver/integrations/openshift.md
@@ -1,7 +1,7 @@
 This integration sends a notification every time a deployment is made
 in an OpenShift instance.
 
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  {!download-python-bindings.md!}
 

--- a/templates/zerver/integrations/rss.md
+++ b/templates/zerver/integrations/rss.md
@@ -8,7 +8,7 @@ RSS integration!
 
 [1]: ./zapier
 
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  {!create-an-incoming-webhook.md!}
 

--- a/templates/zerver/integrations/svn.md
+++ b/templates/zerver/integrations/svn.md
@@ -1,7 +1,7 @@
 It is easy to send Zulips on SVN commits, by configuring a
 post-commit hook. To do this:
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!download-python-bindings.md!}
 

--- a/templates/zerver/integrations/trac.md
+++ b/templates/zerver/integrations/trac.md
@@ -1,4 +1,4 @@
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  {!download-python-bindings.md!}
 

--- a/templates/zerver/integrations/twitter.md
+++ b/templates/zerver/integrations/twitter.md
@@ -2,7 +2,7 @@ Fetch tweets from Twitter in Zulip! This is great for seeing and
 discussing who is talking about you, friends, competitors, or
 important topics in real time.
 
-1.  {!create-stream.md!}
+1.  {!create-channel.md!}
 
 1.  {!create-an-incoming-webhook.md!}
 

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -379,7 +379,7 @@ def integration_doc(request: HttpRequest, integration_name: str = REQ()) -> Http
 
     context["integration_name"] = integration.name
     context["integration_display_name"] = integration.display_name
-    context["recommended_stream_name"] = integration.stream_name
+    context["recommended_channel_name"] = integration.stream_name
     if isinstance(integration, WebhookIntegration):
         context["integration_url"] = integration.url[3:]
         all_event_types = get_all_event_types_for_integration(integration)

--- a/zerver/webhooks/airbrake/doc.md
+++ b/zerver/webhooks/airbrake/doc.md
@@ -4,7 +4,7 @@ Get Zulip notifications for your Airbrake bug tracker!
 
 {start_tabs}
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/alertmanager/doc.md
+++ b/zerver/webhooks/alertmanager/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications from Alertmanager!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/ansibletower/doc.md
+++ b/zerver/webhooks/ansibletower/doc.md
@@ -1,6 +1,6 @@
 Get Ansible Tower notifications in Zulip!
 
- 1. {!create-stream.md!}
+ 1. {!create-channel.md!}
 
  1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/appfollow/doc.md
+++ b/zerver/webhooks/appfollow/doc.md
@@ -1,7 +1,7 @@
 Receive user reviews from your tracked apps on AppFollow
 using the Zulip AppFollow integration!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/appveyor/doc.md
+++ b/zerver/webhooks/appveyor/doc.md
@@ -1,6 +1,6 @@
 Receive AppVeyor notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/azuredevops/doc.md
+++ b/zerver/webhooks/azuredevops/doc.md
@@ -4,7 +4,7 @@ Get Azure DevOps notifications in Zulip!
 
 {start_tabs}
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/basecamp/doc.md
+++ b/zerver/webhooks/basecamp/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with Basecamp and can notify you of
 events in Basecamp.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/beanstalk/doc.md
+++ b/zerver/webhooks/beanstalk/doc.md
@@ -1,6 +1,6 @@
 Zulip supports both SVN and Git notifications from Beanstalk.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/beeminder/doc.md
+++ b/zerver/webhooks/beeminder/doc.md
@@ -1,7 +1,7 @@
 Get Beeminder notifications in Zulip whenever you're going
 to derail from your goal!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/bitbucket/doc.md
+++ b/zerver/webhooks/bitbucket/doc.md
@@ -4,9 +4,9 @@ webhooks used by Bitbucket Enterprise.
 
 {!create-channel.md!}
 
-The integration will use the default stream `commits` if no
-stream is supplied in the hook; you still need to create the
-stream even if you are using this default.
+The integration will use the default channel `commits` if no
+channel is supplied in the hook; you still need to create the
+channel even if you are using this default.
 
 Next, from your repository's web page, go to the **Administration**
 page and choose **Hooks** on the left-hand side. Choose the **POST**
@@ -16,9 +16,9 @@ hook from the list presented and click **Add hook**.
 
 {!git-append-branches.md!}
 
-By default, notifications are sent to the `commits` stream. To
-send notifications to a different stream, append
-`?stream=stream_name` to the URL.
+By default, notifications are sent to the `commits` channel. To
+send notifications to a different channel, append
+`?stream=channel_name` to the URL.
 
 {!congrats.md!}
 

--- a/zerver/webhooks/bitbucket/doc.md
+++ b/zerver/webhooks/bitbucket/doc.md
@@ -2,7 +2,7 @@ Zulip supports both Git and Mercurial notifications from
 Bitbucket. This integration is for the old-style Bitbucket
 webhooks used by Bitbucket Enterprise.
 
-{!create-stream.md!}
+{!create-channel.md!}
 
 The integration will use the default stream `commits` if no
 stream is supplied in the hook; you still need to create the

--- a/zerver/webhooks/bitbucket2/doc.md
+++ b/zerver/webhooks/bitbucket2/doc.md
@@ -6,7 +6,7 @@ For the old-style Bitbucket webhooks used by Bitbucket Enterprise,
 click [here](./bitbucket), and for the new-style webhooks used by
 Bitbucket Server click [here](./bitbucket3).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/bitbucket3/doc.md
+++ b/zerver/webhooks/bitbucket3/doc.md
@@ -6,7 +6,7 @@ For the old-style Bitbucket webhooks used by Bitbucket Enterprise,
 click [here](./bitbucket), and for the new-style webhooks used by
 Bitbucket Cloud (SAAS service) click [here](./bitbucket2).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/buildbot/doc.md
+++ b/zerver/webhooks/buildbot/doc.md
@@ -15,7 +15,7 @@ Get Zulip notifications for your Buildbot builds!
 
         zs = reporters.ZulipStatusPush('{{ zulip_url }}',
                                        token='api_key',
-                                       stream='{{ recommended_stream_name }}')
+                                       stream='{{ recommended_channel_name }}')
         c['services'].append(zs)
 
     When adding the new reporter, modify the code above such that `api_key`

--- a/zerver/webhooks/buildbot/doc.md
+++ b/zerver/webhooks/buildbot/doc.md
@@ -4,7 +4,7 @@ Get Zulip notifications for your Buildbot builds!
 
     This integration requires Buildbot version 2.2.0 or higher.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/buildbot/doc.md
+++ b/zerver/webhooks/buildbot/doc.md
@@ -19,7 +19,7 @@ Get Zulip notifications for your Buildbot builds!
         c['services'].append(zs)
 
     When adding the new reporter, modify the code above such that `api_key`
-    is the API key of your Zulip bot, and `stream` is set to the stream name
+    is the API key of your Zulip bot, and `stream` is set to the channel name
     you want the notifications sent to.
 
 [1]: https://docs.buildbot.net/latest/manual/configuration/reporters/zulip_status.html

--- a/zerver/webhooks/canarytoken/doc.md
+++ b/zerver/webhooks/canarytoken/doc.md
@@ -2,7 +2,7 @@ See your Thinkst Canarytoken alerts in Zulip! This integration works with Canary
 [canarytokens.org][canarytokens], not Thinkst's paid product - see the
 [Thinkst](/integrations/doc/thinkst) integration for those!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/circleci/doc.md
+++ b/zerver/webhooks/circleci/doc.md
@@ -2,7 +2,7 @@ Zulip supports integration with CircleCI and can notify you of your
 job and workflow statuses. This integration currently supports using
 CircleCI with GitHub, BitBucket and GitLab.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/clubhouse/doc.md
+++ b/zerver/webhooks/clubhouse/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Clubhouse Stories and Epics!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/codeship/doc.md
+++ b/zerver/webhooks/codeship/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with Codeship and can notify you of
 your build statuses.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/crashlytics/doc.md
+++ b/zerver/webhooks/crashlytics/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with Crashlytics and can notify you
 about Crashlytics issues.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/delighted/doc.md
+++ b/zerver/webhooks/delighted/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with Delighted and can notify you
 about updates in feedback responses organized by Delighted.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/deskdotcom/doc.md
+++ b/zerver/webhooks/deskdotcom/doc.md
@@ -1,4 +1,4 @@
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
     Keep in mind you still need to create the stream first even
     if you are using this recommendation.

--- a/zerver/webhooks/deskdotcom/doc.md
+++ b/zerver/webhooks/deskdotcom/doc.md
@@ -1,6 +1,6 @@
 1. {!create-channel.md!}
 
-    Keep in mind you still need to create the stream first even
+    Keep in mind you still need to create the channel first even
     if you are using this recommendation.
 
 1. {!create-an-incoming-webhook.md!}
@@ -42,7 +42,7 @@
     {% endraw %}
 
     The "appended URL path" will be the same for every notification —
-    it makes sure the notification goes to the appropriate stream and topic
+    it makes sure the notification goes to the appropriate channel and topic
     within Zulip.
 
 1. Next, copy this template Zulip message into **Message to POST**:
@@ -102,4 +102,4 @@
 ![](/static/images/integrations/desk/009.png)
 
 When a case is updated, you'll see a notification like the one above,
-to the stream `desk`, with a topic that matches the case's subject name.
+to the channel `desk`, with a topic that matches the case's subject name.

--- a/zerver/webhooks/dialogflow/doc.md
+++ b/zerver/webhooks/dialogflow/doc.md
@@ -1,7 +1,7 @@
 Get personal message notifications in Zulip for the results of your
 Dialogflow queries!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/dropbox/doc.md
+++ b/zerver/webhooks/dropbox/doc.md
@@ -1,6 +1,6 @@
 Get Dropbox notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/errbit/doc.md
+++ b/zerver/webhooks/errbit/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for the Errbit error tracker!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/flock/doc.md
+++ b/zerver/webhooks/flock/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications from your Flock channels.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/freshdesk/doc.md
+++ b/zerver/webhooks/freshdesk/doc.md
@@ -1,7 +1,7 @@
 See customer support interactions in Zulip with our Freshdesk
 integration!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/freshping/doc.md
+++ b/zerver/webhooks/freshping/doc.md
@@ -1,6 +1,6 @@
 Receive Freshping notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/freshstatus/doc.md
+++ b/zerver/webhooks/freshstatus/doc.md
@@ -1,6 +1,6 @@
 Receive Freshstatus notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/front/doc.md
+++ b/zerver/webhooks/front/doc.md
@@ -2,7 +2,7 @@ Front lets you manage all of your communication channels in one place,
 and helps your team collaborate around every message. Follow these steps
 to receive Front notifications without leaving Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gci/doc.md
+++ b/zerver/webhooks/gci/doc.md
@@ -2,7 +2,7 @@ If you are a participating organization with
 [Google Code-in](https://developers.google.com/open-source/gci/),
 you can now get Task notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gitea/doc.md
+++ b/zerver/webhooks/gitea/doc.md
@@ -1,6 +1,6 @@
 Receive Gitea notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -1,6 +1,6 @@
 Get GitHub notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/github/githubsponsors.md
+++ b/zerver/webhooks/github/githubsponsors.md
@@ -1,6 +1,6 @@
 Get GitHub Sponsors notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gitlab/doc.md
+++ b/zerver/webhooks/gitlab/doc.md
@@ -4,7 +4,7 @@ Receive GitLab notifications in Zulip!
 
 {start_tabs}
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gocd/doc.md
+++ b/zerver/webhooks/gocd/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with GoCD and can notify you of
 your build statuses.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gogs/doc.md
+++ b/zerver/webhooks/gogs/doc.md
@@ -1,6 +1,6 @@
 Receive Gogs notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/gosquared/doc.md
+++ b/zerver/webhooks/gosquared/doc.md
@@ -1,6 +1,6 @@
 Receive GoSquared notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/grafana/doc.md
+++ b/zerver/webhooks/grafana/doc.md
@@ -1,6 +1,6 @@
 See your Grafana dashboard alerts in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/greenhouse/doc.md
+++ b/zerver/webhooks/greenhouse/doc.md
@@ -1,6 +1,6 @@
 Receive Greenhouse notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/groove/doc.md
+++ b/zerver/webhooks/groove/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Groove events!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/harbor/doc.md
+++ b/zerver/webhooks/harbor/doc.md
@@ -2,7 +2,7 @@ Get Zulip notifications for your [Harbor](https://goharbor.io/) projects!
 
 Harbor's webhooks feature is available in version 1.9 and later.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/hellosign/doc.md
+++ b/zerver/webhooks/hellosign/doc.md
@@ -1,6 +1,6 @@
 Configuring the HelloSign integration is easy!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -3,9 +3,9 @@ Learn how Zulip integrations work with this simple Hello World example!
 This webhook is Zulip's official [example
 integration](/api/incoming-webhooks-walkthrough).
 
-1. The Hello World webhook will use the `test` stream, which is created
+1. The Hello World webhook will use the `test` channel, which is created
     by default in the Zulip development environment. If you are running
-    Zulip in production, you should make sure that this stream exists.
+    Zulip in production, you should make sure that this channel exists.
 
 1. {!create-an-incoming-webhook.md!}
 
@@ -19,13 +19,13 @@ integration](/api/incoming-webhooks-walkthrough).
         (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
         ./manage.py send_webhook_fixture_message \
         > --fixture=zerver/tests/fixtures/helloworld/hello.json \
-        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=abcdefgh&stream=stream%20name;'
+        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=abcdefgh&stream=channel%20name;'
     ```
 
     Or, use curl:
 
     ```
-    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key=abcdefgh&stream=stream%20name;
+    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key=abcdefgh&stream=channel%20name;
     ```
 
 {!congrats.md!}

--- a/zerver/webhooks/heroku/doc.md
+++ b/zerver/webhooks/heroku/doc.md
@@ -1,7 +1,7 @@
 Receive notifications in Zulip whenever a new version of an app
 is pushed to Heroku using the Zulip Heroku plugin!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/homeassistant/doc.md
+++ b/zerver/webhooks/homeassistant/doc.md
@@ -1,4 +1,4 @@
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/homeassistant/doc.md
+++ b/zerver/webhooks/homeassistant/doc.md
@@ -9,7 +9,7 @@
 
 1. The `api_key` parameter should correspond to your bot's key. The `stream`
     parameter is not necessarily required; if not given, it will default to
-    the `homeassistant` stream.
+    the `homeassistant` channel.
 
 1. And the URL under `resource` should start with:
 

--- a/zerver/webhooks/ifttt/doc.md
+++ b/zerver/webhooks/ifttt/doc.md
@@ -3,7 +3,7 @@ IFTTT supports integrations with hundreds of
 dishwashers, cars, web services, and more. Get IFTTT notifications directly
 in Zulip.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/insping/doc.md
+++ b/zerver/webhooks/insping/doc.md
@@ -2,7 +2,7 @@ Get Insping notifications in Zulip! Insping (stylized as !nsping) is a
 simple uptime and performance monitoring tool, which notifies you when
 a website or service is up and running or down.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/intercom/doc.md
+++ b/zerver/webhooks/intercom/doc.md
@@ -1,6 +1,6 @@
 Get Intercom notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/jira/doc.md
+++ b/zerver/webhooks/jira/doc.md
@@ -3,7 +3,7 @@ Get Zulip notifications for your Jira projects!
 These instructions apply to Atlassian Cloud's hosted Jira, and Jira Server version
 5.2 or greater. For older installs, you'll need our [Jira plugin](./jira-plugin).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/jotform/doc.md
+++ b/zerver/webhooks/jotform/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Jotform responses!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/json/doc.md
+++ b/zerver/webhooks/json/doc.md
@@ -3,7 +3,7 @@ particularly useful when you want to capture a webhook payload as part
 of [writing an incoming webhook
 integration](/api/incoming-webhooks-overview).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/librato/doc.md
+++ b/zerver/webhooks/librato/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Librato/AppOptics alerts!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/lidarr/doc.md
+++ b/zerver/webhooks/lidarr/doc.md
@@ -1,6 +1,6 @@
 Receive Lidarr notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/linear/doc.md
+++ b/zerver/webhooks/linear/doc.md
@@ -1,6 +1,6 @@
 Get Linear notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/mention/doc.md
+++ b/zerver/webhooks/mention/doc.md
@@ -1,6 +1,6 @@
 Get Mention notifications within Zulip via Zapier!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/netlify/doc.md
+++ b/zerver/webhooks/netlify/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Netlify deployments!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/newrelic/doc.md
+++ b/zerver/webhooks/newrelic/doc.md
@@ -1,4 +1,4 @@
-New Relic can send messages to a Zulip stream for incidents.
+New Relic can send messages to a Zulip channel for incidents.
 
 1. {!create-channel.md!}
 

--- a/zerver/webhooks/newrelic/doc.md
+++ b/zerver/webhooks/newrelic/doc.md
@@ -1,6 +1,6 @@
 New Relic can send messages to a Zulip stream for incidents.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/opbeat/doc.md
+++ b/zerver/webhooks/opbeat/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Opbeat events!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/opencollective/doc.md
+++ b/zerver/webhooks/opencollective/doc.md
@@ -1,7 +1,7 @@
 This integration currently supports getting notifications to a stream of your Zulip instance,
 when a new member signs-up on an **Open Collective** page.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/opencollective/doc.md
+++ b/zerver/webhooks/opencollective/doc.md
@@ -1,4 +1,4 @@
-This integration currently supports getting notifications to a stream of your Zulip instance,
+This integration currently supports getting notifications to a channel of your Zulip instance,
 when a new member signs-up on an **Open Collective** page.
 
 1. {!create-channel.md!}

--- a/zerver/webhooks/opsgenie/doc.md
+++ b/zerver/webhooks/opsgenie/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Opsgenie events!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/pagerduty/doc.md
+++ b/zerver/webhooks/pagerduty/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your PagerDuty services!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/papertrail/doc.md
+++ b/zerver/webhooks/papertrail/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Papertrail logs!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/patreon/doc.md
+++ b/zerver/webhooks/patreon/doc.md
@@ -1,6 +1,6 @@
 Get Patreon notifications in Zulip!
 
- 1. {!create-stream.md!}
+ 1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/pingdom/doc.md
+++ b/zerver/webhooks/pingdom/doc.md
@@ -1,7 +1,7 @@
 Zulip supports integration with Pingdom and can notify you of
 uptime status changes from your Pingdom dashboard.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/pivotal/doc.md
+++ b/zerver/webhooks/pivotal/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for the stories in your Pivotal Tracker project!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/radarr/doc.md
+++ b/zerver/webhooks/radarr/doc.md
@@ -1,6 +1,6 @@
 Receive Radarr notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/raygun/doc.md
+++ b/zerver/webhooks/raygun/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Raygun events!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/reviewboard/doc.md
+++ b/zerver/webhooks/reviewboard/doc.md
@@ -1,6 +1,6 @@
 Get Review Board notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/rhodecode/doc.md
+++ b/zerver/webhooks/rhodecode/doc.md
@@ -1,6 +1,6 @@
 Get RhodeCode notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/rundeck/doc.md
+++ b/zerver/webhooks/rundeck/doc.md
@@ -1,6 +1,6 @@
 Receive Job Notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/semaphore/doc.md
+++ b/zerver/webhooks/semaphore/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Semaphore builds!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/sentry/doc.md
+++ b/zerver/webhooks/sentry/doc.md
@@ -4,7 +4,7 @@ This integration supports Sentry's Node, Python, and Go
 [platforms](https://sentry.io/platforms/).  [Contact
 us](/help/contact-support) if a platform you care about is missing.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -3,7 +3,7 @@ public channels!
 
 See also the [Slack-compatible webhook](/integrations/doc/slack_incoming).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -10,17 +10,17 @@ See also the [Slack-compatible webhook](/integrations/doc/slack_incoming).
 1. {!generate-integration-url.md!}
 
     If you'd like to map Slack channels to different topics within the same
-    stream, add `&channels_map_to_topics=1` to the end of the URL. Note that
+    channel, add `&channels_map_to_topics=1` to the end of the URL. Note that
     this should be used instead of specifying a topic in the URL. If a topic
     is specified in the URL, then it will be prioritized over the channel to
     topic mapping.
 
-    If you'd like to map Slack channels to different streams, add
+    If you'd like to map Slack channels to different channels, add
     `&channels_map_to_topics=0` to the end of the URL. Make sure you create
-    streams for all your public Slack channels *(see step 1)*, and that the
-    name of each stream is the same as the name of the Slack channel it maps
-    to. Note that in this case, the channel to stream mapping will be
-    prioritized over the stream specified in the URL.
+    channels for all your public Slack channels *(see step 1)*, and that the
+    name of each channel is the same as the name of the Slack channel it maps
+    to. Note that in this case, the channel to channel mapping will be
+    prioritized over the channel specified in the URL.
 
 1. Go to <https://my.slack.com/services/new/outgoing-webhook>
    and click **Add Outgoing WebHooks integration**.

--- a/zerver/webhooks/slack_incoming/doc.md
+++ b/zerver/webhooks/slack_incoming/doc.md
@@ -10,7 +10,7 @@ mirroring content from a Slack instance into Zulip.
      integrations, which take advantage of Zulip's topics. There may also be
      some quirks when Slack's formatting system is translated into Zulip's.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/solano/doc.md
+++ b/zerver/webhooks/solano/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Solano CI builds!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/sonarqube/doc.md
+++ b/zerver/webhooks/sonarqube/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Sonarqube code analysis!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/sonarr/doc.md
+++ b/zerver/webhooks/sonarr/doc.md
@@ -1,6 +1,6 @@
 Receive Sonarr notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/splunk/doc.md
+++ b/zerver/webhooks/splunk/doc.md
@@ -1,6 +1,6 @@
 See your Splunk Search alerts in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/splunk/doc.md
+++ b/zerver/webhooks/splunk/doc.md
@@ -21,8 +21,8 @@ See your Splunk Search alerts in Zulip!
 !!! tip ""
 
     You can create as many search alerts as you like, with whatever
-    stream and topic you choose. Just update your webhook URL as
-    appropriate for each one, and make sure the stream exists.
+    channel and topic you choose. Just update your webhook URL as
+    appropriate for each one, and make sure the channel exists.
 
 {!congrats.md!}
 

--- a/zerver/webhooks/statuspage/doc.md
+++ b/zerver/webhooks/statuspage/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your Statuspage.io subscriptions!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/stripe/doc.md
+++ b/zerver/webhooks/stripe/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for Stripe events!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/taiga/doc.md
+++ b/zerver/webhooks/taiga/doc.md
@@ -1,6 +1,6 @@
 Receive Zulip notifications for your Taiga projects!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/teamcity/doc.md
+++ b/zerver/webhooks/teamcity/doc.md
@@ -1,6 +1,6 @@
 Get Zulip notifications for your TeamCity builds!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/thinkst/doc.md
+++ b/zerver/webhooks/thinkst/doc.md
@@ -2,7 +2,7 @@ See your Thinkst Canary and Canarytoken alerts in Zulip! This integration works 
 Canarytokens from Thinkst's paid product, not [canarytokens.org][canarytokens] - see the
 [Canarytokens](/integrations/doc/canarytoken) integration for those!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/transifex/doc.md
+++ b/zerver/webhooks/transifex/doc.md
@@ -1,6 +1,6 @@
 Get Transifex notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/travis/doc.md
+++ b/zerver/webhooks/travis/doc.md
@@ -1,6 +1,6 @@
 See your Travis CI build notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/trello/doc.md
+++ b/zerver/webhooks/trello/doc.md
@@ -7,7 +7,7 @@ Get Zulip notifications from your Trello boards!
 
 [1]: ./zapier
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/updown/doc.md
+++ b/zerver/webhooks/updown/doc.md
@@ -1,6 +1,6 @@
 See Updown reports in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/uptimerobot/doc.md
+++ b/zerver/webhooks/uptimerobot/doc.md
@@ -1,6 +1,6 @@
 Receive Zulip notifications from UptimeRobot!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/wekan/doc.md
+++ b/zerver/webhooks/wekan/doc.md
@@ -1,6 +1,6 @@
 Get Wekan notifications in Zulip!
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/wordpress/doc.md
+++ b/zerver/webhooks/wordpress/doc.md
@@ -4,7 +4,7 @@ If you're hosting your WordPress blog yourself (i.e., not on WordPress.com),
 first install the
 [HookPress plugin](https://wordpress.org/plugins/hookpress/) (experimental).
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/zabbix/doc.md
+++ b/zerver/webhooks/zabbix/doc.md
@@ -5,7 +5,7 @@ Receive Zabbix notifications in Zulip!
     **Note:** This guide is for Zabbix 5.4 and above; some older Zabbix versions have a
     different workflow for creating an outgoing webhook.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/zapier/doc.md
+++ b/zerver/webhooks/zapier/doc.md
@@ -2,7 +2,7 @@ Zapier supports integrations with
 [hundreds of popular products](https://zapier.com/apps). Get notifications
 sent by Zapier directly in Zulip.
 
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/zendesk/doc.md
+++ b/zerver/webhooks/zendesk/doc.md
@@ -1,4 +1,4 @@
-1. {!create-stream.md!}
+1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 

--- a/zerver/webhooks/zendesk/doc.md
+++ b/zerver/webhooks/zendesk/doc.md
@@ -6,7 +6,7 @@
 
     `{{ api_url }}/v1/external/zendesk?ticket_title={% raw %}{{ ticket.title }}&ticket_id={{ ticket.id }}{% endraw %}`
 
-1. {!append-stream-name.md!}
+1. {!append-channel-name.md!}
 
 1. Next, in Zendesk, open your **Admin** view via gear in the bottom-left
     corner. In the **Admin** view, click on **Extensions**, then click

--- a/zerver/webhooks/zendesk/doc.md
+++ b/zerver/webhooks/zendesk/doc.md
@@ -27,7 +27,7 @@
     ![](/static/images/integrations/zendesk/003.png)
 
 1. Now, select **Test Target** and click **Submit**. A test message should
-    appear in the `zendesk` stream. If the message was received, save the
+    appear in the `zendesk` channel. If the message was received, save the
     target by selecting **Create target** and clicking **Submit**.
 
 1. From here, add a new trigger. You'll do this for every action you want


### PR DESCRIPTION
Note: This doesn't change the occurences in the Zapier integration doc,
since they refer to pieces of the UI in Zapier, which may still be using
the "Stream" terminology.