### PR TITLE
migrations: Merge 0517 as a no-op.

### DIFF
--- a/zerver/migrations/0517_resort_edit_history.py
+++ b/zerver/migrations/0517_resort_edit_history.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+# This migration was already run as 0497 on `main`, but was
+# accidentally omitted on 8.x until this point.  This is left as a
+# no-op on `main`, since it has either already run -- either as this
+# migration number, if the user is upgrading from 8.x, or just now as
+# 0497 if the user upgraded from a prior version.
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0501_delete_dangling_usermessages"),
+    ]
+
+    operations = []

--- a/zerver/migrations/0518_merge.py
+++ b/zerver/migrations/0518_merge.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+# See 0517 for the history of this migration merge commit.
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0516_fix_confirmation_preregistrationusers"),
+        ("zerver", "0517_resort_edit_history"),
+    ]
+
+    operations = []


### PR DESCRIPTION
Migration 0517 migration was already run as 0497 on `main`, but was accidentally omitted on 8.x until this point.

Merge the 0517 migration into the migration history.  It is included as a no-op in `main` because it has already run as 0497.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
