### PR TITLE
compose_recipients: Fix broken compose state after restore draft.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -12,7 +12,7 @@ import * as compose_fade from "./compose_fade";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
-import type {ComposePlaceholderOptions, ComposeTriggeredOptions} from "./compose_ui";
+import type {ComposeTriggeredOptions} from "./compose_ui";
 import * as compose_validate from "./compose_validate";
 import * as drafts from "./drafts";
 import * as dropdown_widget from "./dropdown_widget";
@@ -362,22 +362,21 @@ export function update_placeholder_text(): void {
         return;
     }
     const message_type = compose_state.get_message_type();
-    assert(message_type !== undefined);
 
-    let opts: ComposePlaceholderOptions;
+    let placeholder = compose_ui.DEFAULT_COMPOSE_PLACEHOLDER;
     if (message_type === "stream") {
         const stream_id = compose_state.stream_id();
-        opts = {
+        placeholder = compose_ui.compute_placeholder_text({
             message_type,
             stream_id,
             topic: compose_state.topic(),
-        };
-    } else {
-        opts = {
+        });
+    } else if (message_type === "private") {
+        placeholder = compose_ui.compute_placeholder_text({
             message_type,
             direct_message_user_ids: compose_pm_pill.get_user_ids(),
-        };
+        });
     }
 
-    $("textarea#compose-textarea").attr("placeholder", compose_ui.compute_placeholder_text(opts));
+    $("textarea#compose-textarea").attr("placeholder", placeholder);
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -22,6 +22,8 @@ import * as stream_data from "./stream_data";
 import * as user_status from "./user_status";
 import * as util from "./util";
 
+export const DEFAULT_COMPOSE_PLACEHOLDER = $t({defaultMessage: "Compose your message here"});
+
 export type ComposeTriggeredOptions = {
     trigger: string;
 } & (
@@ -333,7 +335,7 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
         }
         return $t({defaultMessage: "Message {recipient_names}"}, {recipient_names});
     }
-    return $t({defaultMessage: "Compose your message here"});
+    return DEFAULT_COMPOSE_PLACEHOLDER;
 }
 
 export function set_compose_box_top(set_top: boolean): void {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -410,9 +410,20 @@ li.show-more-topics {
     }
 }
 
-#login-link-container .login_button {
+#login-link-container {
+    color: var(--color-text-url);
     display: flex;
     align-items: center;
+
+    &:hover {
+        cursor: pointer;
+        color: var(--color-text-url-hover);
+
+        &.login_button .login-text {
+            color: var(--color-text-url-hover);
+            text-decoration: underline;
+        }
+    }
 }
 
 ul.filters {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -183,12 +183,14 @@
                 {{#unless is_guest }}
                     <div id="subscribe-to-more-streams"></div>
                 {{/unless}}
-                <div id="login-link-container" class="only-visible-for-spectators">
-                    <a class="login_button">
+                <div class="only-visible-for-spectators">
+                    <div id="login-link-container" class="login_button">
                         <i class="zulip-icon zulip-icon-log-in" aria-hidden="true"></i>
                         {{~!-- squash whitespace --~}}
-                        {{t 'Log in to browse more channels'}}
-                    </a>
+                        <a class="login-text">
+                            {{t 'Log in to browse more channels'}}
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
After restoring a draft with no recipient, compose was broken as this assertion fails.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Assertion.20failed.20when.20restoring.20draft.20with.20no.20stream