### PR TITLE
narrow_state: Fix combined feed narrowing near msg id of muted message.

### DIFF
--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -241,7 +241,7 @@ export function get_first_unread_info(
 
     return {
         flavor: "found",
-        msg_id: unread_ids[0],
+        msg_id,
     };
 }
 


### PR DESCRIPTION
Combined feed always narrowed to the first unread id regardless of if it was muted or not since we were not actually using the msg_id that we found after all the hard work of doing all the checks for it.
