### PR TITLE
contributor docs: Update links to PR guides.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,10 +245,14 @@ faster as you build experience.
 
 ### Submitting a pull request
 
-See the [pull request review
-process](https://zulip.readthedocs.io/en/latest/contributing/review-process.html)
-guide for detailed instructions on how to submit a pull request, and information
-on the stages of review your PR will go through.
+See the [guide on submitting a pull
+request](https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html)
+for detailed instructions on how to present your proposed changes to Zulip.
+
+The [pull request review process
+guide](https://zulip.readthedocs.io/en/latest/contributing/review-process.html)
+explains the stages of review your PR will go through, and offers guidance on
+how to help the review process move forward.
 
 ### Beyond the first issue
 


### PR DESCRIPTION
Follow-up to restructuring PR guide pages.

Before:
![Screenshot 2024-05-06 at 13 04 50](https://github.com/zulip/zulip/assets/2090066/237829f7-9064-4d40-9eea-d53bdca649e6)


After:
![Screenshot 2024-05-06 at 13 05 25](https://github.com/zulip/zulip/assets/2090066/79cd8e9f-9ac1-4d78-abe8-33b4f5cc6539)

