### PR TITLE
settings: Enable separate dropdowns for each pronoun field in profile overlay.

### DIFF
--- a/web/src/custom_profile_fields_ui.js
+++ b/web/src/custom_profile_fields_ui.js
@@ -161,27 +161,32 @@ export function initialize_custom_date_type_fields(element_id) {
 }
 
 export function initialize_custom_pronouns_type_fields(element_id) {
-    const commonly_used_pronouns = [
-        $t({defaultMessage: "he/him"}),
-        $t({defaultMessage: "she/her"}),
-        $t({defaultMessage: "they/them"}),
-    ];
-    const bootstrap_typeahead_input = {
-        $element: $(element_id).find(".pronouns_type_field"),
-        type: "input",
-    };
-    new Typeahead(bootstrap_typeahead_input, {
-        items: 3,
-        fixed: true,
-        helpOnEmptyStrings: true,
-        source() {
-            return commonly_used_pronouns;
-        },
-        sorter(items, query) {
-            return bootstrap_typeahead.defaultSorter(items, query);
-        },
-        highlighter_html(item) {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
+
+    $(element_id).find(".pronouns_type_field").each((_, pronounField) => {
+        const commonly_used_pronouns = [
+            $t({defaultMessage: "he/him"}),
+            $t({defaultMessage: "she/her"}),
+            $t({defaultMessage: "they/them"}),
+        ];
+
+        const bootstrap_typeahead_input = {
+            $element: $(pronounField),
+            type: "input",
+        };
+
+        bootstrap_typeahead.create(bootstrap_typeahead_input, {
+            items: 3,
+            fixed: true,
+            helpOnEmptyStrings: true,
+            source() {
+                return commonly_used_pronouns;
+            },
+            sorter(items, query) {
+                return bootstrap_typeahead.defaultSorter(items, query);
+            },
+            highlighter_html(item) {
+                return typeahead_helper.render_typeahead_item({primary: item});
+            },
+        });
     });
 }


### PR DESCRIPTION
This commit modifies the initialize_custom_pronouns_type_fields function to ensure that each pronoun input field in the profile overlay has its own unique dropdown for selecting pronouns. Previously, if multiple custom profile fields with the "pronoun" type were created in an organization, only one field could be updated in the Personal settings / Profile overlay tab. Now, each field can be set to a separate value, and each field has its own dropdown with the field options.

The function now iterates over each pronoun input field individually and creates a separate typeahead for each field. This change ensures that users can update each pronoun field independently, without interference from other pronoun fields.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before 
https://github.com/zulip/zulip/assets/167233353/2b17a479-cf5f-4bfc-a6b9-c1ead4b8424a 

After  
[Solution Screencast](https://github.com/zulip/zulip/assets/167233353/a5001cf7-83ae-448b-b6b8-01e3ffa95d85)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
