### PR TITLE
custom_profile_fields: Improve user validation efficiency.

### DIFF
--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -29,29 +29,28 @@ from zerver.lib.validator import (
     validate_select_field,
 )
 from zerver.models.realms import Realm
-from zerver.models.users import UserProfile, get_user_profile_by_id_in_realm
+from zerver.models.users import UserProfile
 
 
 def check_valid_user_ids(realm_id: int, val: object, allow_deactivated: bool = False) -> List[int]:
     user_ids = check_list(check_int)("User IDs", val)
     realm = Realm.objects.get(id=realm_id)
-    for user_id in user_ids:
-        # TODO: Structurally, we should be doing a bulk fetch query to
-        # get the users here, not doing these in a loop.  But because
-        # this is a rarely used feature and likely to never have more
-        # than a handful of users, it's probably mostly OK.
-        try:
-            user_profile = get_user_profile_by_id_in_realm(user_id, realm)
-        except UserProfile.DoesNotExist:
-            raise ValidationError(_("Invalid user ID: {user_id}").format(user_id=user_id))
+    users = UserProfile.objects.filter(id__in=user_ids, realm=realm)
 
-        if not allow_deactivated and not user_profile.is_active:
+    if len(users) != len(user_ids):
+        invalid_user_ids = set(user_ids) - set(users.values_list("id", flat=True))
+        raise ValidationError(
+            _("Invalid user ID: {user_id}").format(user_id=invalid_user_ids.pop())
+        )
+
+    for user in users:
+        if not allow_deactivated and not user.is_active:
             raise ValidationError(
-                _("User with ID {user_id} is deactivated").format(user_id=user_id)
+                _("User with ID {user_id} is deactivated").format(user_id=user.id)
             )
 
-        if user_profile.is_bot:
-            raise ValidationError(_("User with ID {user_id} is a bot").format(user_id=user_id))
+        if user.is_bot:
+            raise ValidationError(_("User with ID {user_id} is a bot").format(user_id=user.id))
 
     return user_ids
 


### PR DESCRIPTION
Refactor user validation in `check_valid_user_ids` function for custom profile fields in `zerver/models/custom_profile_fields.py`. Instead of individual queries within a loop to fetch user profiles, utilize a bulk fetch query with `UserProfile.objects.filter()` to retrieve user profiles efficiently. This change enhances performance, particularly for scenarios with multiple user IDs, ensuring a smoother user validation process.

The previous implementation iterated over each user ID to retrieve user profiles, resulting in potential performance overhead for large sets of user IDs. This refactor addresses the inefficiency by fetching user profiles in bulk, significantly reducing database queries and improving overall validation speed.

Fixes: <!-- Issue link, or clear description.-->
N/A

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
I am a new contributor and I am working on #29921 (PR #29977)

While Navigating the models, I fell on this note in the `zerver/models/custom_profile_fields.py` file  

![image](https://github.com/zulip/zulip/assets/167233353/b05974d0-8b92-4806-8c2b-9ddb63e9e203)


 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
