### PR TITLE
requirements: Upgrade Python requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -223,19 +223,19 @@ boltons==21.0.0 \
     #   face
     #   glom
     #   semgrep
-boto3==1.34.98 \
-    --hash=sha256:030e43b8efe22b4cf10b9f3ef9e30cd4cf9ef9784b26efe9a4583339f2b2bcec \
-    --hash=sha256:28c10956033fa79e64529f48c3b62db86d5e4b77024a7343764b6bde6b553543
+boto3==1.34.100 \
+    --hash=sha256:016f6d66900bb1a835dea2063f1e91fc7057dbf7fb7df8add0706f0da9492631 \
+    --hash=sha256:bbe2bb0dfcd92380da2a2fa2c2f586ba06c118b796380b2d0f3d0ebd103ec28d
     # via
     #   -r requirements/common.in
     #   moto
-boto3-stubs[s3,ses,sns,sqs]==1.34.98 \
-    --hash=sha256:2e1902e700662016b7339c0ec02a82a8bfa12770dcd866b55a8598f80ee7354b \
-    --hash=sha256:a0cbb21bc2221e888bc98c4879a4c8f16a4070c4b409d78642c3aaf65adcd5ea
+boto3-stubs[s3,ses,sns,sqs]==1.34.99 \
+    --hash=sha256:b8e54ac867d9f60cec221a8bb6c9b2963ce3e297134f181d429d34dd40d61969 \
+    --hash=sha256:d9df5d457cdedf46fc8ce223d82360ccc227cebec4c3294ddf87cb013042cad6
     # via -r requirements/mypy.in
-botocore==1.34.98 \
-    --hash=sha256:4cee65df02f4b0be08ad1401965cc89efafebc50ef0727d2d17083c7f1ed2831 \
-    --hash=sha256:631c0031d8ce922b5752ab395ead896a0281b0dc74745a754d0351a27c5d83de
+botocore==1.34.100 \
+    --hash=sha256:513bea60c6531af8e1ae1fdb2947e3ef99712f39c58f4656b5efef9cb6f75a13 \
+    --hash=sha256:ee516fb9e9e906d311f2a9921afaf79c594db239a5b4b626e89e6960401aad0b
     # via
     #   boto3
     #   moto
@@ -606,9 +606,9 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via zulip
-django[argon2]==5.0.5 \
-    --hash=sha256:8af4f166dc9a2bb822f9374cd78e34a10c286b402597fe2c7fb97c131656ba65 \
-    --hash=sha256:dc95c9cb2a37ba54599d9d1c8faf81609d36f3e74cd04395ce1300573e57baf9
+django[argon2]==5.0.6 \
+    --hash=sha256:8363ac062bb4ef7c3f12d078f6fa5d154031d129a15170a1066412af49d30905 \
+    --hash=sha256:ff1b61005004e476e0aeea47c7f79b85864c70124030e95146315396f1e7951f
     # via
     #   -r requirements/common.in
     #   django-auth-ldap
@@ -960,9 +960,9 @@ isodate==0.6.1 \
     # via
     #   openapi-core
     #   python3-saml
-itemadapter==0.8.0 \
-    --hash=sha256:2ac1fbcc363b789a18639935ca322e50a65a0a7dfdd8d973c34e2c468e6c0f94 \
-    --hash=sha256:77758485fb0ac10730d4b131363e37d65cb8db2450bfec7a57c3f3271f4a48a9
+itemadapter==0.9.0 \
+    --hash=sha256:cfd108c9d5205d056fcac402ec8f8e9d799ce9066911eec1cd521ea442f87af1 \
+    --hash=sha256:e4f958a6b6b6f5831fa207373010031a0bd7ed0429ddd09b51979c011475cafd
     # via
     #   itemloaders
     #   scrapy

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -169,13 +169,13 @@ beautifulsoup4==4.12.3 \
     #   -r requirements/common.in
     #   pyoembed
     #   zulip-bots
-boto3==1.34.98 \
-    --hash=sha256:030e43b8efe22b4cf10b9f3ef9e30cd4cf9ef9784b26efe9a4583339f2b2bcec \
-    --hash=sha256:28c10956033fa79e64529f48c3b62db86d5e4b77024a7343764b6bde6b553543
+boto3==1.34.100 \
+    --hash=sha256:016f6d66900bb1a835dea2063f1e91fc7057dbf7fb7df8add0706f0da9492631 \
+    --hash=sha256:bbe2bb0dfcd92380da2a2fa2c2f586ba06c118b796380b2d0f3d0ebd103ec28d
     # via -r requirements/common.in
-botocore==1.34.98 \
-    --hash=sha256:4cee65df02f4b0be08ad1401965cc89efafebc50ef0727d2d17083c7f1ed2831 \
-    --hash=sha256:631c0031d8ce922b5752ab395ead896a0281b0dc74745a754d0351a27c5d83de
+botocore==1.34.100 \
+    --hash=sha256:513bea60c6531af8e1ae1fdb2947e3ef99712f39c58f4656b5efef9cb6f75a13 \
+    --hash=sha256:ee516fb9e9e906d311f2a9921afaf79c594db239a5b4b626e89e6960401aad0b
     # via
     #   boto3
     #   s3transfer
@@ -429,9 +429,9 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via zulip
-django[argon2]==5.0.5 \
-    --hash=sha256:8af4f166dc9a2bb822f9374cd78e34a10c286b402597fe2c7fb97c131656ba65 \
-    --hash=sha256:dc95c9cb2a37ba54599d9d1c8faf81609d36f3e74cd04395ce1300573e57baf9
+django[argon2]==5.0.6 \
+    --hash=sha256:8363ac062bb4ef7c3f12d078f6fa5d154031d129a15170a1066412af49d30905 \
+    --hash=sha256:ff1b61005004e476e0aeea47c7f79b85864c70124030e95146315396f1e7951f
     # via
     #   -r requirements/common.in
     #   django-auth-ldap


### PR DESCRIPTION
## `prod.txt` upgrades
* boto3: 1.34.98 → 1.34.100
* botocore: 1.34.98 → 1.34.100
* django[argon2]: 5.0.5 → 5.0.6
  - 5.0.5 was [yanked](https://pypi.org/project/Django/5.0.5/) due to a minor packaging error.

## Other upgrades
* boto3-stubs[s3,ses,sns,sqs]: 1.34.98 → 1.34.99
* itemadapter: 0.8.0 → 0.9.0
