### PR TITLE
Document preview hotkey, and show all hotkeys in compose button tooltips.

### DIFF
--- a/help/preview-your-message-before-sending.md
+++ b/help/preview-your-message-before-sending.md
@@ -9,6 +9,10 @@
 1. Click the **eye** (<i class="zulip-icon zulip-icon-preview"></i>) icon at
    the bottom of the compose box.
 
+!!! keyboard_tip ""
+
+    You can also use <kbd>Alt</kbd> + <kbd>P</kbd> to toggle between previewing and editing your message.
+
 {end_tabs}
 
 Click the **pencil and paper** (<i class="fa fa-edit"></i>) icon to resume editing.

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -1,6 +1,6 @@
 <div class="compose-control-buttons-container order-1">
     <input type="file" class="file_input notvisible" multiple />
-    <div class="compose_control_button_container" data-tippy-content="{{t 'Preview' }}">
+    <div class="compose_control_button_container" data-tooltip-template-id="preview-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="markdown_preview compose_control_button zulip-icon zulip-icon-preview" aria-label="{{t 'Preview' }}" tabindex=0></a>
     </div>
     <div class="compose_control_button_container" data-tippy-content="{{t 'Write' }}">

--- a/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover_2.hbs
+++ b/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover_2.hbs
@@ -1,7 +1,7 @@
 <div class="compose-control-buttons-container preview_mode_disabled {{#if inside_popover}} show_in_popover {{/if}}">
-    <a role="button" data-format-type="link" class="compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Link' }}"></a>
-    <a role="button" data-format-type="bold" class="compose_control_button zulip-icon zulip-icon-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bold' }}"></a>
-    <a role="button" data-format-type="italic" class="compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Italic' }}"></a>
+    <a role="button" data-format-type="link" class="compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="link-tooltip" data-tippy-maxWidth="none"></a>
+    <a role="button" data-format-type="bold" class="compose_control_button zulip-icon zulip-icon-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="bold-tooltip" data-tippy-maxWidth="none"></a>
+    <a role="button" data-format-type="italic" class="compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="italic-tooltip" data-tippy-maxWidth="none"></a>
     <a role="button" data-format-type="strikethrough" class="compose_control_button zulip-icon zulip-icon-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Strikethrough' }}"></a>
     {{#if inside_popover}}
         <div class="divider">|</div>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -53,6 +53,10 @@
     {{t 'Send' }}
     {{tooltip_hotkey_hints "Ctrl" "Enter"}}
 </template>
+<template id="preview-tooltip">
+    {{t 'Preview' }}
+    {{tooltip_hotkey_hints "Alt" "P"}}
+</template>
 <template id="add-global-time-tooltip">
     <div>
         <div>{{t "Add global time" }}</div>
@@ -64,6 +68,18 @@
         <span>{{t "Add poll" }}</span><br/>
         <span class="tooltip-inner-content italic">{{t "A poll must be an entire message." }}</span>
     </div>
+</template>
+<template id="link-tooltip">
+    {{t 'Link' }}
+    {{tooltip_hotkey_hints "Ctrl" "Shift" "L"}}
+</template>
+<template id="bold-tooltip">
+    {{t 'Bold' }}
+    {{tooltip_hotkey_hints "Ctrl" "B"}}
+</template>
+<template id="italic-tooltip">
+    {{t 'Italic' }}
+    {{tooltip_hotkey_hints "Ctrl" "I"}}
 </template>
 <template id="delete-draft-tooltip-template">
     {{t 'Delete draft' }}


### PR DESCRIPTION
compose: Add keyboard shortcuts to compose control buttons' tooltips.

For more discoverability, the keyboard shortcuts for preview, and bold, italic and link formatting are now displayed in the tooltips of those compose buttons.

help: Document keyboard shortcut for previewing message being composed.

Fixes: [CZO issue report](https://chat.zulip.org/#narrow/stream/101-design/topic/key.20combination.20for.20hotkey.20to.20toggle.20compose.20preview/near/1793636)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/47051abc-741c-4364-9bb7-687f9fcd6f10)
![image](https://github.com/zulip/zulip/assets/68962290/0cd76ca0-dfa1-40cd-b984-ecf633ff7da2)
![image](https://github.com/zulip/zulip/assets/68962290/ab441d68-b686-4242-be48-46600765fa88)
![image](https://github.com/zulip/zulip/assets/68962290/aa66abba-29c0-414f-ad87-007845efb67f)
![image](https://github.com/zulip/zulip/assets/68962290/761d45b5-7e0f-4369-ad37-b08ad7275b90)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
