### PR TITLE
Presence `last_update_id` API 

### DIFF
--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -126,7 +126,6 @@ export function send_presence_to_server(redraw?: () => void): void {
             status: compute_active_status(),
             ping_only: !redraw,
             new_user_input,
-            slim_presence: true,
             last_update_id: presence.presence_last_update_id,
         },
         success(response) {

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -10,6 +10,13 @@ import * as watchdog from "./watchdog";
 const post_presence_response_schema = z.object({
     msg: z.string(),
     result: z.string(),
+    // A bunch of these fields below are .optional() due to the fact
+    // that we have two modes of querying the presence endpoint:
+    // ping_only mode and a mode where we also fetch presence data
+    // for the realm.
+    // For ping_only requests, these fields are not returned in the
+    // response. If we're fetching presence data however, they should
+    // all be present, and send_presence_to_server() will validate that.
     server_timestamp: z.number().optional(),
     zephyr_mirror_active: z.boolean().optional(),
     presences: z
@@ -21,6 +28,7 @@ const post_presence_response_schema = z.object({
             }),
         )
         .optional(),
+    presence_last_update_id: z.number().optional(),
 });
 
 /* Keep in sync with views.py:update_active_status_backend() */
@@ -119,6 +127,7 @@ export function send_presence_to_server(redraw?: () => void): void {
             ping_only: !redraw,
             new_user_input,
             slim_presence: true,
+            last_update_id: presence.presence_last_update_id,
         },
         success(response) {
             const data = post_presence_response_schema.parse(response);
@@ -141,7 +150,16 @@ export function send_presence_to_server(redraw?: () => void): void {
                     data.server_timestamp !== undefined,
                     "Server timestamp should be present if not a ping only presence request",
                 );
-                presence.set_info(data.presences, data.server_timestamp);
+                assert(
+                    data.presence_last_update_id !== undefined,
+                    "Presence last update id should be present if not a ping only presence request",
+                );
+
+                presence.set_info(
+                    data.presences,
+                    data.server_timestamp,
+                    data.presence_last_update_id,
+                );
                 redraw();
             }
         },

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -78,6 +78,16 @@ export function redraw_user(user_id: number): void {
     });
 }
 
+export function check_should_redraw_new_user(user_id: number): boolean {
+    if (realm.realm_presence_disabled) {
+        return false;
+    }
+
+    const user_is_in_presence_info = presence.presence_info.has(user_id);
+    const user_not_yet_known = people.maybe_get_user_by_id(user_id, true) === undefined;
+    return user_is_in_presence_info && user_not_yet_known;
+}
+
 export function searching(): boolean {
     return user_filter?.searching() ?? false;
 }

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -1,4 +1,3 @@
-import * as blueslip from "./blueslip";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as muted_users from "./muted_users";
@@ -312,10 +311,11 @@ function filter_user_ids(user_filter_text: string, user_ids: number[]): number[]
     // This first filter is for whether the user is eligible to be
     // displayed in the right sidebar at all.
     user_ids = user_ids.filter((user_id) => {
-        const person = people.maybe_get_user_by_id(user_id);
+        const person = people.maybe_get_user_by_id(user_id, true);
 
         if (!person) {
-            blueslip.warn("Got user_id in presence but not people: " + user_id);
+            // See the comments in presence.set_info for details, but this is an expected race.
+            // User IDs for whom we have presence but no user metadata should be skipped.
             return false;
         }
 

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -34,10 +34,16 @@ export type PresenceInfoFromEvent = {
 const raw_info = new Map<number, RawPresence>();
 export const presence_info = new Map<number, PresenceStatus>();
 
-// We use this internally and export it for testing convenience.
+// An integer that is updated whenever we get new presence data.
+// TODO: Improve this comment.
+export let presence_last_update_id = -1;
+
+// We keep and export this for testing convenience.
 export function clear_internal_data(): void {
     raw_info.clear();
     presence_info.clear();
+
+    presence_last_update_id = -1;
 }
 
 const BIG_REALM_COUNT = 250;
@@ -166,6 +172,7 @@ export function update_info_from_event(
 export function set_info(
     presences: Record<number, Omit<RawPresence, "server_timestamp">>,
     server_timestamp: number,
+    last_update_id: number,
 ): void {
     /*
         Example `presences` data:
@@ -177,7 +184,8 @@ export function set_info(
         }
     */
 
-    clear_internal_data();
+    presence_last_update_id = last_update_id;
+
     for (const [user_id_str, info] of Object.entries(presences)) {
         const user_id = Number.parseInt(user_id_str, 10);
 
@@ -190,19 +198,14 @@ export function set_info(
         // new users were created in the meantime, we may see user IDs
         // not yet present in people.js if server_events doesn't have
         // current data (or we've been offline, our event queue was
-        // GC'ed, and we're about to reload).  Such user_ids being
-        // present could, in turn, create spammy downstream exceptions
-        // when rendering the buddy list.  To address this, we check
-        // if the user ID is not yet present in people.js, and if it
-        // is, we skip storing that user (we'll see them again in the
-        // next presence request in 1 minute anyway).
-        //
-        // It's important to check both suspect_offline and
-        // reload_state.is_in_progress, because races where presence
-        // returns data on users not yet received via the server_events
-        // system are common in both situations.
+        // GC'ed, and we're about to reload).
+        // Despite that, we still add the presence data to our structures,
+        // and it is the job of the code using them to correctly
+        // ignore these until we receive the basic metadata on this user.
+        // We skip inaccessible users here, as we do in other places;
+        // presence info for them is not used.
         const person = people.maybe_get_user_by_id(user_id, true);
-        if (person === undefined || person.is_inaccessible_user) {
+        if (person?.is_inaccessible_user) {
             // There are a number of situations where it is expected
             // that we get presence data for a user ID that we do
             // not have in our user database, including when we're
@@ -212,8 +215,8 @@ export function set_info(
             // and whenever presence wins a race with the events system
             // for events regarding a newly created or visible user.
             //
-            // Either way, we deal by skipping this user and
-            // continuing with processing everyone else.
+            // Either way, we still record the information unless
+            // we're dealing with an inaccessible user.
             continue;
         }
 
@@ -281,6 +284,7 @@ export function last_active_date(user_id: number): Date | undefined {
 export function initialize(params: {
     presences: Record<number, Omit<RawPresence, "server_timestamp">>;
     server_timestamp: number;
+    presence_last_update_id: number;
 }): void {
-    set_info(params.presences, params.server_timestamp);
+    set_info(params.presences, params.server_timestamp, params.presence_last_update_id);
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -454,13 +454,24 @@ export function dispatch_normal_event(event) {
 
         case "realm_user":
             switch (event.op) {
-                case "add":
+                case "add": {
+                    // There may be presence data we already received from the server
+                    // before getting this event. Check if we need to redraw.
+                    const should_redraw = activity_ui.check_should_redraw_new_user(
+                        event.person.user_id,
+                    );
+
                     people.add_active_user(event.person);
                     settings_account.maybe_update_deactivate_account_button();
                     if (event.person.is_bot) {
                         settings_users.redraw_bots_list();
                     }
+
+                    if (should_redraw) {
+                        activity_ui.redraw_user(event.person.user_id);
+                    }
                     break;
+                }
                 case "update":
                     user_events.update_person(event.person);
                     settings_account.maybe_update_deactivate_account_button();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -480,7 +480,7 @@ export function initialize_everything(state_data) {
 
     const pm_conversations_params = pop_fields("recent_private_conversations");
 
-    const presence_params = pop_fields("presences", "server_timestamp");
+    const presence_params = pop_fields("presences", "server_timestamp", "presence_last_update_id");
 
     const starred_messages_params = pop_fields("starred_messages");
     const stream_data_params = pop_fields(

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -805,6 +805,7 @@ test("initialize", ({override, mock_template}) => {
         msg: "",
         result: "success",
         server_timestamp: 0,
+        presence_last_update_id: -1,
     });
     $(window).trigger("focus");
     clear();
@@ -829,6 +830,7 @@ test("initialize", ({override, mock_template}) => {
         msg: "",
         result: "success",
         server_timestamp: 0,
+        presence_last_update_id: -1,
     });
 
     assert.ok($("#zephyr-mirror-error").hasClass("show"));
@@ -880,4 +882,21 @@ test("electron_bridge", ({override_rewire}) => {
 test("test_send_or_receive_no_presence_for_spectator", () => {
     page_params.is_spectator = true;
     activity.send_presence_to_server();
+});
+
+test("check_should_redraw_new_user", () => {
+    presence.presence_info.set(9999, {status: "active"});
+
+    // A user that wasn't yet known, but has presence info should be redrawn
+    // when being added.
+    assert.equal(activity_ui.check_should_redraw_new_user(9999), true);
+
+    // We don't even build the user sidebar if realm_presence_disabled is true,
+    // so nothing to redraw.
+    realm.realm_presence_disabled = true;
+    assert.equal(activity_ui.check_should_redraw_new_user(9999), false);
+
+    realm.realm_presence_disabled = false;
+    // A new user that didn't have presence info should not be redrawn.
+    assert.equal(activity_ui.check_should_redraw_new_user(99999), false);
 });

--- a/web/tests/example4.test.js
+++ b/web/tests/example4.test.js
@@ -86,6 +86,7 @@ run_test("add users with event", ({override}) => {
     // We need to override a stub here before dispatching the event.
     // Keep reading to see how overriding works!
     override(settings_users, "redraw_bots_list", noop);
+    override(activity_ui, "check_should_redraw_new_user", noop);
     // Let's simulate dispatching our event!
     server_events_dispatch.dispatch_normal_event(event);
 

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -213,10 +213,10 @@ def get_presences_for_realm(
     slim_presence: bool,
     last_update_id_fetched_by_client: Optional[int],
     requesting_user_profile: UserProfile,
-) -> Tuple[Dict[str, Dict[str, Dict[str, Any]]], Optional[int]]:
+) -> Tuple[Dict[str, Dict[str, Dict[str, Any]]], int]:
     if realm.presence_disabled:
         # Return an empty dict if presence is disabled in this realm
-        return defaultdict(dict), None
+        return defaultdict(dict), -1
 
     return get_presence_dict_by_realm(
         realm,

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -490,6 +490,7 @@ class UserPresenceTests(ZulipTestCase):
         result = self.client_post("/json/users/me/presence", {"status": "idle"}, subdomain="zephyr")
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["presences"], {})
+        self.assertEqual(response_dict["presence_last_update_id"], -1)
 
     def test_mirror_presence(self) -> None:
         """Zephyr mirror realms find out the status of their mirror bot"""


### PR DESCRIPTION
Implements a prototype for the API discussed in https://chat.zulip.org/#narrow/stream/378-api-design/topic/presence.20rewrite/near/1586819

Commit 1 Adds the necessary `last_update_id` column and `PresenceSequence` model, commit message elaborates on the migration plan
Commit 2 The backend+frontend parts of the system using the above data structure.

This is WIP, so no tests and only tested in the webapp.
What this has:
- Adds the `last_update_id` param and plumbing in the API through the backend and frontend
- Implements what is intended to be an efficient locking mechanism inside `do_update_user_presence`, updating `PresenceSequence` and the related `UserPresence` update in a single SQL query, at the very end of the transaction, ensuring the hot lock only gets held as briefly as possible.
- Verified the core mechanism seems to work; the webapp only fetches the recently updated presence data and updates its buddy list with the incremental info

What this does NOT have:
- [x] Doesn't handle the discussed case of getting presence info about a user the webapp doesn't know yet (https://chat.zulip.org/#narrow/stream/378-api-design/topic/presence.20rewrite/near/1586828) EDIT: Fixed
- [ ] Doesn't remove the `user_presence` query worker, which we probably want to do, moving presence updates in-process
- [x] `PresenceSequence` for the realm doesn't get created in the import codepath. EDIT: Fixed