### PR TITLE
api_documentation: Document "/invites/multiuse/{invite_id}" endpoint.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -470,9 +470,9 @@ No changes; feature level used for Zulip 8.0 release.
   therefore the response did not include reusable invitation links for these
   users.
 
-* `DELETE /invites/multiuse/{invite_id}`: Non-admin users can now revoke
-  reusable invitation links they have created. Previously, only admin users could
-  create and revoke reusable invitation links.
+* [`DELETE /invites/multiuse/{invite_id}`](/api/revoke-invite-link): Non-admin
+  users can now revoke reusable invitation links they have created. Previously,
+  only admin users could create and revoke reusable invitation links.
 
 * [`GET /events`](/api/get-events): When the set of invitations in an
   organization changes, an `invites_changed` event is now sent to the

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -94,6 +94,7 @@
 * [Send invitations](/api/send-invites)
 * [Create a reusable invitation link](/api/create-invite-link)
 * [Revoke an email invitation](/api/revoke-email-invite)
+* [Revoke a reusable invitation link](/api/revoke-invite-link)
 
 #### Server & organizations
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -363,6 +363,24 @@ def revoke_email_invitation(client: Client) -> None:
     validate_against_openapi_schema(result, "/invites/{invite_id}", "delete", "200")
 
 
+@openapi_test_function("/invites/multiuse/{invite_id}:delete")
+def revoke_reusable_invitation_link(client: Client) -> None:
+    request = {
+        "invite_expires_in_minutes": 14400,  # 10 days
+        "invite_as": 400,
+        "stream_ids": [1, 8, 9],
+    }
+    result = client.call_endpoint(url="/invites/multiuse", method="POST", request=request)
+
+    # {code_example|start}
+    # Revoke reusable invitation link
+    invite_id = 2
+    result = client.call_endpoint(url=f"/invites/multiuse/{invite_id}", method="DELETE")
+    # {code_example|end}
+
+    validate_against_openapi_schema(result, "/invites/multiuse/{invite_id}", "delete", "200")
+
+
 @openapi_test_function("/users/{user_id}:get")
 def get_single_user(client: Client) -> None:
     ensure_users([8], ["cordelia"])
@@ -1722,6 +1740,7 @@ def test_invitations(client: Client) -> None:
     send_invitations(client)
     revoke_email_invitation(client)
     create_reusable_invitation_link(client)
+    revoke_reusable_invitation_link(client)
     get_invitations(client)
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12218,6 +12218,58 @@ paths:
                           }
                         description: |
                           A typical failed JSON response for an invalid email invitation ID:
+  /invites/multiuse/{invite_id}:
+    delete:
+      operationId: revoke-invite-link
+      summary: Revoke a reusable invitation link
+      tags: ["invites"]
+      description: |
+        Revoke a [reusable invitation link](/help/invite-new-users#create-a-reusable-invitation-link).
+
+        A user can only revoke [invitations that they can
+        manage](/help/invite-new-users#manage-pending-invitations).
+
+        **Changes**: Prior to Zulip 8.0 (feature level 209), only organization
+        administrators were able to create and revoke reusable invitation links.
+      parameters:
+        - name: invite_id
+          in: path
+          description: |
+            The ID of the reusable invitation link to be revoked.
+          schema:
+            type: integer
+          example: 1
+          required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "No such invitation",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for an invalid invitation link ID:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Invitation has already been revoked",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for when the invitation link has already
+                          been revoked:
   /register:
     post:
       operationId: register-queue

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -240,7 +240,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/default_stream_groups/{group_id}/streams",
         # Administer invitations
         "/invites/{prereg_id}/resend",
-        "/invites/multiuse/{invite_id}",
         # Single-stream settings alternative to the bulk endpoint
         # users/me/subscriptions/properties; probably should just be a
         # section of the same page.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds API documentation for "/invites/multiuse{invite_id}" endpoint.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2024-05-08 120402](https://github.com/zulip/zulip/assets/119798962/3599aa81-12c0-4bed-95d9-a8deeb212810)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
