### PR TITLE
widgets: Cache event handler instead of entire jquery for each widget.

### DIFF
--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -42,7 +42,7 @@ export function activate({
     ) => void;
     extra_data: PollWidgetExtraData;
     message: Message;
-}): void {
+}): (events: Event[]) => void {
     const is_my_poll = people.is_my_user_id(message.sender_id);
     const poll_data = new PollData({
         message_sender_id: message.sender_id,
@@ -237,7 +237,7 @@ export function activate({
             });
     }
 
-    $elem.handle_events = function (events: Event[]) {
+    const handle_events = function (events: Event[]): void {
         for (const event of events) {
             poll_data.handle_event(event.sender_id, event.data);
         }
@@ -249,4 +249,6 @@ export function activate({
     build_widget();
     render_question();
     render_results();
+
+    return handle_events;
 }

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -89,7 +89,7 @@ export function get_message_events(message: Message): SubmessageEvents | undefin
 }
 
 export function process_widget_rows_in_list(list: MessageList | undefined): void {
-    for (const message_id of widgetize.widget_contents.keys()) {
+    for (const message_id of widgetize.widget_event_handlers.keys()) {
         if (list?.get(message_id) !== undefined) {
             process_submessages({message_id, $row: list.get_row(message_id)});
         }

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -224,7 +224,7 @@ export function activate({$elem, callback, extra_data, message}) {
     const parse_result = todo_widget_extra_data_schema.safeParse(extra_data);
     if (!parse_result.success) {
         blueslip.warn("invalid todo extra data", parse_result.error.issues);
-        return;
+        return () => {};
     }
     const {data} = parse_result;
     const {task_list_title = "", tasks = []} = data || {};
@@ -383,7 +383,7 @@ export function activate({$elem, callback, extra_data, message}) {
         });
     }
 
-    $elem.handle_events = function (events) {
+    const handle_events = function (events) {
         for (const event of events) {
             task_data.handle_event(event.sender_id, event.data);
         }
@@ -395,4 +395,6 @@ export function activate({$elem, callback, extra_data, message}) {
     build_widget();
     render_task_list_title();
     render_results();
+
+    return handle_events;
 }

--- a/web/tests/poll_widget.test.js
+++ b/web/tests/poll_widget.test.js
@@ -251,7 +251,7 @@ run_test("activate another person poll", ({mock_template}) => {
     set_widget_find_result("button.poll-question-remove");
     set_widget_find_result("input.poll-question");
 
-    poll_widget.activate(opts);
+    const handle_events = poll_widget.activate(opts);
 
     assert.ok($poll_option_container.visible());
     assert.ok($poll_question_header.visible());
@@ -298,7 +298,7 @@ run_test("activate another person poll", ({mock_template}) => {
         },
     ];
 
-    $widget_elem.handle_events(vote_events);
+    handle_events(vote_events);
 
     {
         /* Testing data sent to server on voting */
@@ -318,7 +318,7 @@ run_test("activate another person poll", ({mock_template}) => {
         },
     ];
 
-    $widget_elem.handle_events(add_question_event);
+    handle_events(add_question_event);
 });
 
 run_test("activate own poll", ({mock_template}) => {

--- a/web/tests/widgetize.test.js
+++ b/web/tests/widgetize.test.js
@@ -36,6 +36,7 @@ const sample_events = [
 
 let events;
 let $widget_elem;
+let handle_events;
 let is_event_handled;
 let is_widget_activated;
 
@@ -44,11 +45,12 @@ const fake_poll_widget = {
         is_widget_activated = true;
         $widget_elem = data.$elem;
         assert.ok($widget_elem.hasClass("widget-content"));
-        $widget_elem.handle_events = (e) => {
+        handle_events = (e) => {
             is_event_handled = true;
             assert.deepStrictEqual(e, events);
         };
         data.callback("test_data");
+        return handle_events;
     },
 };
 
@@ -66,6 +68,7 @@ function test(label, f) {
     run_test(label, ({override}) => {
         events = [...sample_events];
         $widget_elem = undefined;
+        handle_events = undefined;
         is_event_handled = false;
         is_widget_activated = false;
         widgetize.clear_for_testing();
@@ -73,10 +76,11 @@ function test(label, f) {
     });
 }
 
-test("activate", () => {
+test("activate", ({override}) => {
     // Both widgetize.activate and widgetize.handle_event are tested
-    // here to use the "caching" of widgets
+    // here to use the "caching" of widget event handlers.
     const $row = $.create("<stub message row>");
+    $row.length = 1;
     $row.attr("id", `message-row-${message_lists.current.id}-2909`);
     const $message_content = $.create(`#message-row-${message_lists.current.id}-2909`);
     $row.set_find_results(".message_content", $message_content);
@@ -106,14 +110,14 @@ test("activate", () => {
     is_widget_elem_inserted = false;
     is_widget_activated = false;
     is_event_handled = false;
-    assert.ok(!widgetize.widget_contents.has(opts.message.id));
+    assert.ok(!widgetize.widget_event_handlers.has(opts.message.id));
 
     widgetize.activate(opts);
 
     assert.ok(is_widget_elem_inserted);
     assert.ok(is_widget_activated);
     assert.ok(is_event_handled);
-    assert.equal(widgetize.widget_contents.get(opts.message.id), $widget_elem);
+    assert.equal(widgetize.widget_event_handlers.get(opts.message.id), handle_events);
 
     message_lists.current = undefined;
     is_widget_elem_inserted = false;
@@ -146,6 +150,7 @@ test("activate", () => {
     assert.ok(!is_event_handled);
 
     /* Testing widgetize.handle_events */
+    message_lists.current = {id: 2};
     const post_activate_event = {
         data: {
             idx: 1,
@@ -154,10 +159,15 @@ test("activate", () => {
         message_id: 2001,
         sender_id: 102,
     };
-    $widget_elem.handle_events = (e) => {
+    handle_events = (e) => {
         is_event_handled = true;
         assert.deepEqual(e, [post_activate_event]);
     };
+    widgetize.widget_event_handlers.set(2001, handle_events);
+    override(message_lists.current, "get_row", (idx) => {
+        assert.equal(idx, 2001);
+        return $row;
+    });
     is_event_handled = false;
     widgetize.handle_event(post_activate_event);
     assert.ok(is_event_handled);


### PR DESCRIPTION
In 61b3c698affb9aebf29300d36f42a1d8440151a6 we stopped restoring widgets from the cache, so the only purpose of the cache remaining was to access the event handler patched onto the widget jquery.

Now instead of the entire jquery object, we cache just the event handler since that's the only thing we need from the cache, and do not patch it onto the widget jquery object.

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Voting.20on.20Polls.20in.20the.20webapp/near/1795125)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
