### PR TITLE
WIP: Calculate Inline emoji dimensions.

### DIFF
--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -7,6 +7,10 @@ export function set_base_typography_css_variables(): void {
     const line_height_percent = user_settings.web_line_height_percent;
     const line_height_unitless = line_height_percent / 100;
     const line_height_px = line_height_unitless * font_size_px;
+    /* This pixel value is necessary to ensure that elements that take
+       particular heights (e.g., inline emoji, or vote counts on polls)
+       will always fit within a particular line height. */
+    const line_height_px_min = Math.floor(line_height_px);
     /* This percentage is a legacy value, rounding up from .294;
        additional logic might be useful to make this adjustable;
        likewise with the doubled value. */
@@ -15,6 +19,7 @@ export function set_base_typography_css_variables(): void {
 
     $(":root").css("--base-line-height-unitless", line_height_unitless);
     $(":root").css("--base-font-size-px", `${font_size_px}px`);
+    $(":root").css("--line-height-fitted-length-px", `${line_height_px_min}px`);
     $(":root").css("--markdown-interelement-space-px", `${markdown_interelement_space_px}px`);
     $(":root").css(
         "--markdown-interelement-doubled-space-px",

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -76,6 +76,10 @@
     --markdown-interelement-doubled-space-px: calc(
         var(--markdown-interelement-space-px) * 2
     );
+    /* We do not enforce a minimum box size for inline
+       emoji outside of legacy .more-dense-mode */
+    --inline-emoji-min-height: 0;
+    --inline-emoji-min-width: 0;
 
     .more-dense-mode {
         /* The legacy values here are not altered by JavaScript */
@@ -84,6 +88,8 @@
         --markdown-interelement-space-px: 5px;
         --markdown-interelement-doubled-space-px: 10px;
         --message-box-markdown-aligned-vertical-space: 5px;
+        --inline-emoji-min-height: 20px;
+        --inline-emoji-min-width: 20px;
     }
 
     /*

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -67,6 +67,11 @@
     /* The legacy values here are updated via JavaScript */
     --base-font-size-px: 14px;
     --base-line-height-unitless: 1.214;
+    /* This length value is for establishing heights, possibly
+       also widths in the case of square elements, that will always
+       fit with the line-height (e.g., inline emoji, or vote counts
+       on polls) */
+    --line-height-fitted-length-px: 16px;
     --markdown-interelement-space-px: 5px;
     --markdown-interelement-doubled-space-px: calc(
         var(--markdown-interelement-space-px) * 2

--- a/web/styles/legacy_more_dense_mode.css
+++ b/web/styles/legacy_more_dense_mode.css
@@ -1,0 +1,10 @@
+.more-dense-mode {
+    .rendered_markdown .emoji {
+        /* "Eyeballed" styles to compensate for inline-block emoji
+          positioning in messages where the height of the emoji
+          exceeds the line-height in the message area. */
+        position: relative;
+        margin-top: -7px;
+        top: 3px;
+    }
+}

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -138,16 +138,10 @@
 
     /* Emoji; sized to be easily understood while not overwhelming text. */
     .emoji {
-        height: calc(20em / 14);
-        width: calc(20em / 14);
-        /* "Eyeballed" styles to compensate for inline-block emoji
-          positioning in messages.
-          By coordinating the emoji height and width above with the
-          `line-height` on messages in the future, these properties
-          should no longer be necessary: */
-        position: relative;
-        margin-top: -7px;
-        top: 3px;
+        min-height: var(--inline-emoji-min-height);
+        min-width: var(--inline-emoji-min-width);
+        height: var(--line-height-fitted-length-px);
+        width: var(--line-height-fitted-length-px);
     }
 
     /* Mentions and alert words */


### PR DESCRIPTION
This draft PR uses inline emoji (a square element) to propose an approach to calculate length values (height, width) that will participate nicely within the message area's baseline (and the baselines of other parts of the UI that eventually take the same baseline).

This technique is important to get right, as there are other elements (todo widget checkboxes; poll widget counters; as well as `<time>` and even codespan blocks) that will need various dimensions adjusted, or perhaps expressed as em or rem units, to keep them in harmony with the line-height in play.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/info.20density.3A.20inline.20emoji.20presentation/near/1795881)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy inline emoji | 16px/1.4 line height setting | 14px/1.22 line height setting |
| --- | --- | --- |
| ![legacy-inline-emoji](https://github.com/zulip/zulip/assets/170719/0f798f33-2bfa-40a4-9cdd-4284478e7e8c) | ![16-140-inline-emoji](https://github.com/zulip/zulip/assets/170719/67ee65cf-6b13-419a-8da5-71683100902d) | ![14-122-inline-emoji](https://github.com/zulip/zulip/assets/170719/e6a8126f-5866-44cb-98c2-e0d069e415cd) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>