### PR TITLE
Add `Not subscribe` tab in channels settings.

### DIFF
--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -540,7 +540,7 @@ export async function open_streams_modal(page: Page): Promise<void> {
 
     await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
     const url = await page_url_with_fragment(page);
-    assert.ok(url.includes("#channels/all"));
+    assert.ok(url.includes("#channels/notsubscribed"));
 }
 
 export async function open_personal_menu(page: Page): Promise<void> {

--- a/web/e2e-tests/subscribe_toggle.test.ts
+++ b/web/e2e-tests/subscribe_toggle.test.ts
@@ -3,6 +3,9 @@ import type {ElementHandle, Page} from "puppeteer";
 import * as common from "./lib/common";
 
 async function test_subscription_button(page: Page): Promise<void> {
+    const all_stream_selector = "[data-tab-key='all-streams']";
+    await page.waitForSelector(all_stream_selector, {visible: true});
+    await page.click(all_stream_selector);
     const stream_selector = "[data-stream-name='Venice']";
     const button_selector = `${stream_selector} .sub_unsub_button`;
     const subscribed_selector = `${button_selector}.checked`;

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -198,7 +198,7 @@ export function channels_settings_edit_url(
 }
 
 export function channels_settings_section_url(section = "subscribed"): string {
-    const valid_section_values = new Set(["new", "subscribed", "all"]);
+    const valid_section_values = new Set(["new", "subscribed", "all", "notsubscribed"]);
     if (!valid_section_values.has(section)) {
         blueslip.warn("invalid section for channels settings: " + section);
         return "#channels/subscribed";

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -43,12 +43,22 @@ export function setup_subscriptions_tab_hash(tab_key_value) {
     if ($("#subscription_overlay .right").hasClass("show")) {
         return;
     }
-    if (tab_key_value === "all-streams") {
-        browser_history.update("#channels/all");
-    } else if (tab_key_value === "subscribed") {
-        browser_history.update("#channels/subscribed");
-    } else {
-        blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+    switch (tab_key_value) {
+        case "all-streams": {
+            browser_history.update("#channels/all");
+            break;
+        }
+        case "subscribed": {
+            browser_history.update("#channels/subscribed");
+            break;
+        }
+        case "not-subscribed": {
+            browser_history.update("#channels/notsubscribed");
+            break;
+        }
+        default: {
+            blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+        }
     }
 }
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -431,6 +431,10 @@ export function update_empty_left_panel_message() {
         has_streams =
             stream_data.subscribed_subs().length ||
             $("#channels_overlay_container .stream-row:not(.notdisplayed)").length;
+    } else if (stream_ui_updates.is_not_subscribed_stream_tab_active()) {
+        has_streams =
+            stream_data.unsubscribed_subs().length ||
+            $("#channels_overlay_container .stream-row:not(.notdisplayed)").length;
     } else {
         has_streams = stream_data.get_unsorted_subs().length;
     }
@@ -438,11 +442,12 @@ export function update_empty_left_panel_message() {
         $(".no-streams-to-show").hide();
         return;
     }
+    $(".no-streams-to-show").children().hide();
     if (stream_ui_updates.is_subscribed_stream_tab_active()) {
-        $(".all_streams_tab_empty_text").hide();
         $(".subscribed_streams_tab_empty_text").show();
+    } else if (stream_ui_updates.is_not_subscribed_stream_tab_active()) {
+        $(".not_subscribed_streams_tab_empty_text").show();
     } else {
-        $(".subscribed_streams_tab_empty_text").hide();
         $(".all_streams_tab_empty_text").show();
     }
     $(".no-streams-to-show").show();

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -348,7 +348,7 @@ export function update_settings_for_unsubscribed(slim_sub) {
 }
 
 function triage_stream(left_panel_params, sub) {
-    if (left_panel_params.subscribed_only && !sub.subscribed) {
+    if (left_panel_params.show_subscribed && !sub.subscribed) {
         // reject non-subscribed streams
         return "rejected";
     }
@@ -443,7 +443,7 @@ export function update_empty_left_panel_message() {
     $(".no-streams-to-show").show();
 }
 
-// LeftPanelParams { input: String, subscribed_only: Boolean, sort_order: String }
+// LeftPanelParams { input: String, show_subscribed: Boolean, sort_order: String }
 export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
     // We only get left_panel_params passed in from tests.  Real
     // code calls get_left_panel_params().
@@ -507,7 +507,7 @@ export function get_left_panel_params() {
     const input = $search_box.expectOne().val().trim();
     const params = {
         input,
-        subscribed_only: stream_ui_updates.subscribed_only,
+        show_subscribed: stream_ui_updates.show_subscribed,
         sort_order,
     };
     return params;
@@ -524,9 +524,9 @@ export function switch_stream_tab(tab_name) {
     */
 
     if (tab_name === "all-streams") {
-        stream_ui_updates.set_subscribed_only(false);
+        stream_ui_updates.set_show_subscribed(false);
     } else if (tab_name === "subscribed") {
-        stream_ui_updates.set_subscribed_only(true);
+        stream_ui_updates.set_show_subscribed(true);
     }
 
     redraw_left_panel();
@@ -597,7 +597,7 @@ export function setup_page(callback) {
 
         // Reset our internal state to reflect that we're initially in
         // the "Subscribed" tab if we're reopening "Stream settings".
-        stream_ui_updates.set_subscribed_only(true);
+        stream_ui_updates.set_show_subscribed(true);
         toggler = components.toggle({
             child_wants_focus: true,
             values: [

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -872,14 +872,27 @@ export function toggle_view(event) {
     const active_data = stream_settings_components.get_active_data();
     const stream_filter_tab = active_data.$tabs.first().text();
 
-    if (event === "right_arrow" && stream_filter_tab === "Subscribed") {
-        toggler.goto("not-subscribed");
-    } else if (event === "right_arrow" && stream_filter_tab === "Not subscribed") {
-        toggler.goto("all-streams");
-    } else if (event === "left_arrow" && stream_filter_tab === "Not subscribed") {
-        toggler.goto("subscribed");
-    } else if (event === "left_arrow" && stream_filter_tab === "All channels") {
-        toggler.goto("not-subscribed");
+    switch (event) {
+        case "right_arrow":
+            switch (stream_filter_tab) {
+                case "Subscribed":
+                    toggler.goto("not-subscribed");
+                    break;
+                case "Not subscribed":
+                    toggler.goto("all-streams");
+                    break;
+            }
+            break;
+        case "left_arrow":
+            switch (stream_filter_tab) {
+                case "Not subscribed":
+                    toggler.goto("subscribed");
+                    break;
+                case "All channels":
+                    toggler.goto("not-subscribed");
+                    break;
+            }
+            break;
     }
 }
 

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -28,16 +28,16 @@ function settings_button_for_sub(sub) {
     );
 }
 
-export let subscribed_only = true;
+export let show_subscribed = true;
 
 export function is_subscribed_stream_tab_active() {
     // Returns true if "Subscribed" tab in stream settings is open
     // otherwise false.
-    return subscribed_only;
+    return show_subscribed;
 }
 
-export function set_subscribed_only(value) {
-    subscribed_only = value;
+export function set_show_subscribed(value) {
+    show_subscribed = value;
 }
 
 export function update_web_public_stream_privacy_option_state($container) {

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -29,6 +29,7 @@ function settings_button_for_sub(sub) {
 }
 
 export let show_subscribed = true;
+export let show_not_subscribed = false;
 
 export function is_subscribed_stream_tab_active() {
     // Returns true if "Subscribed" tab in stream settings is open
@@ -36,8 +37,18 @@ export function is_subscribed_stream_tab_active() {
     return show_subscribed;
 }
 
+export function is_not_subscribed_stream_tab_active() {
+    // Returns true if "not-subscribed" tab in stream settings is open
+    // otherwise false.
+    return show_not_subscribed;
+}
+
 export function set_show_subscribed(value) {
     show_subscribed = value;
+}
+
+export function set_show_not_subscribed(value) {
+    show_not_subscribed = value;
 }
 
 export function update_web_public_stream_privacy_option_state($container) {
@@ -324,15 +335,20 @@ export function update_stream_row_in_settings_tab(sub) {
     // This is in the left panel.
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.
-    // If user is subscribed to stream, it will show sub row under
-    // "Subscribed" tab, otherwise if stream is not public hide
-    // stream row under tab.
-    if (is_subscribed_stream_tab_active()) {
-        const $sub_row = row_for_stream_id(sub.stream_id);
-        if (sub.subscribed) {
-            $sub_row.removeClass("notdisplayed");
+    // If user is subscribed or unsubscribed to stream, it will show sub or unsub
+    // row under "Subscribed" or "Not subscribed" (only if the stream is public) tab, otherwise
+    // if stream is not public hide stream row under tab.
+
+    if (is_subscribed_stream_tab_active() || is_not_subscribed_stream_tab_active()) {
+        const $row = row_for_stream_id(sub.stream_id);
+
+        if (
+            (is_subscribed_stream_tab_active() && sub.subscribed) ||
+            (is_not_subscribed_stream_tab_active() && !sub.subscribed)
+        ) {
+            $row.removeClass("notdisplayed");
         } else if (sub.invite_only || current_user.is_guest) {
-            $sub_row.addClass("notdisplayed");
+            $row.addClass("notdisplayed");
         }
     }
 }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -389,6 +389,20 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: [
+            "[data-tab-key='not-subscribed'].disabled",
+            "[data-tab-key='all-streams'].disabled",
+        ].join(","),
+        content: $t({
+            defaultMessage: "You can only view channels that you are subscribed to.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".default-stream.default_stream_private_tooltip",
         content: $t({
             defaultMessage: "Private channels cannot be default channels for new users.",

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
@@ -1,6 +1,6 @@
 <ul class="nav nav-list">
     <li>
-        <a href="#channels/all" class="navigate_and_close_popover">
+        <a href="#channels/notsubscribed" class="navigate_and_close_popover">
             {{t "Browse channels" }}
         </a>
     </li>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -35,6 +35,12 @@
                             {{/if}}
                         </span>
                     </div>
+                    <div class="not_subscribed_streams_tab_empty_text">
+                        <span>
+                            {{t 'No channels to show.'}}
+                            <a href="#channels/all">{{t 'View all channels'}}</a>
+                        </span>
+                    </div>
                     <div class="all_streams_tab_empty_text">
                         <span>
                             {{t 'There are no channels you can view in this organization.'}}

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,10 +1,10 @@
 {{#if exactly_one_unsubscribed_stream}}
-    <a href="#channels/all">
+    <a href="#channels/notsubscribed">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse 1 more channel" ~}}
     </a>
 {{else if can_subscribe_stream_count}}
-    <a href="#channels/all">
+    <a href="#channels/notsubscribed">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse {can_subscribe_stream_count} more channels" ~}}
     </a>

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -154,33 +154,33 @@ run_test("redraw_left_panel", ({mock_template}) => {
     }
 
     // Search with single keyword
-    test_filter({input: "Po", subscribed_only: false}, [poland, pomona]);
+    test_filter({input: "Po", show_subscribed: false}, [poland, pomona]);
     assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
     assert.ok($denmark_row.hasClass("active"));
 
     // Search with multiple keywords
-    test_filter({input: "Denmark, Pol", subscribed_only: false}, [denmark, poland]);
-    test_filter({input: "Den, Pol", subscribed_only: false}, [denmark, poland]);
+    test_filter({input: "Denmark, Pol", show_subscribed: false}, [denmark, poland]);
+    test_filter({input: "Den, Pol", show_subscribed: false}, [denmark, poland]);
 
     // Search is case-insensitive
-    test_filter({input: "po", subscribed_only: false}, [poland, pomona]);
+    test_filter({input: "po", show_subscribed: false}, [poland, pomona]);
 
     // Search handles unusual characters like C++
-    test_filter({input: "c++", subscribed_only: false}, [cpp]);
+    test_filter({input: "c++", show_subscribed: false}, [cpp]);
 
     // Search subscribed streams only
-    test_filter({input: "d", subscribed_only: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true}, [poland]);
 
     // Search terms match stream description
-    test_filter({input: "Co", subscribed_only: false}, [denmark, pomona]);
+    test_filter({input: "Co", show_subscribed: false}, [denmark, pomona]);
 
     // Search names AND descriptions
-    test_filter({input: "Mon", subscribed_only: false}, [pomona, poland]);
+    test_filter({input: "Mon", show_subscribed: false}, [pomona, poland]);
 
     // Explicitly order streams by name
-    test_filter({input: "", subscribed_only: false, sort_order: "by-stream-name"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-stream-name"}, [
         cpp,
         denmark,
         poland,
@@ -189,7 +189,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Order streams by subscriber count
-    test_filter({input: "", subscribed_only: false, sort_order: "by-subscriber-count"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-subscriber-count"}, [
         poland,
         cpp,
         zzyzx,
@@ -198,7 +198,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Order streams by weekly traffic
-    test_filter({input: "", subscribed_only: false, sort_order: "by-weekly-traffic"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-weekly-traffic"}, [
         poland,
         cpp,
         zzyzx,
@@ -207,7 +207,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Sort for subscribed only.
-    test_filter({input: "", subscribed_only: true, sort_order: "by-subscriber-count"}, [
+    test_filter({input: "", show_subscribed: true, sort_order: "by-subscriber-count"}, [
         poland,
         cpp,
         zzyzx,
@@ -225,7 +225,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         $(".stream-row-denmark").removeClass("active");
     };
 
-    test_filter({input: "d", subscribed_only: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true}, [poland]);
     assert.ok($(".stream-row-denmark").hasClass("active"));
 
     stream_settings_ui.switch_stream_tab("subscribed");

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -105,8 +105,47 @@ run_test("redraw_left_panel", ({mock_template}) => {
         date_created: 1691057093,
         creator_id: null,
     };
+    const abcd = {
+        elem: "abcd",
+        subscribed: false,
+        name: "Abcd",
+        stream_id: 106,
+        description: "India town",
+        subscribers: [1, 2, 3],
+        stream_weekly_traffic: 0,
+        color: "red",
+        can_remove_subscribers_group: admins_group.id,
+        date_created: 1691057093,
+        creator_id: null,
+    };
+    const utopia = {
+        elem: "utopia",
+        subscribed: false,
+        name: "Utopia",
+        stream_id: 107,
+        description: "movie",
+        subscribers: [1, 2, 3, 4],
+        stream_weekly_traffic: 8,
+        color: "red",
+        can_remove_subscribers_group: admins_group.id,
+        date_created: 1691057093,
+        creator_id: null,
+    };
+    const jerry = {
+        elem: "jerry",
+        subscribed: false,
+        name: "Jerry",
+        stream_id: 108,
+        description: "cat",
+        subscribers: [1],
+        stream_weekly_traffic: 4,
+        color: "red",
+        can_remove_subscribers_group: admins_group.id,
+        date_created: 1691057093,
+        creator_id: null,
+    };
 
-    const sub_row_data = [denmark, poland, pomona, cpp, zzyzx];
+    const sub_row_data = [denmark, poland, pomona, cpp, zzyzx, abcd, utopia, jerry];
 
     for (const sub of sub_row_data) {
         stream_data.create_sub_from_server_data(sub);
@@ -154,65 +193,106 @@ run_test("redraw_left_panel", ({mock_template}) => {
     }
 
     // Search with single keyword
-    test_filter({input: "Po", show_subscribed: false}, [poland, pomona]);
+    test_filter({input: "Po", show_subscribed: false, show_not_subscribed: false}, [
+        poland,
+        pomona,
+    ]);
     assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
     assert.ok($denmark_row.hasClass("active"));
 
     // Search with multiple keywords
-    test_filter({input: "Denmark, Pol", show_subscribed: false}, [denmark, poland]);
-    test_filter({input: "Den, Pol", show_subscribed: false}, [denmark, poland]);
+    test_filter({input: "Denmark, Pol", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        poland,
+    ]);
+    test_filter({input: "Den, Pol", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        poland,
+    ]);
 
     // Search is case-insensitive
-    test_filter({input: "po", show_subscribed: false}, [poland, pomona]);
+    test_filter({input: "po", show_subscribed: false, show_not_subscribed: false}, [
+        poland,
+        pomona,
+    ]);
 
     // Search handles unusual characters like C++
-    test_filter({input: "c++", show_subscribed: false}, [cpp]);
+    test_filter({input: "c++", show_subscribed: false, show_not_subscribed: false}, [cpp]);
 
     // Search subscribed streams only
-    test_filter({input: "d", show_subscribed: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true, show_not_subscribed: false}, [poland]);
+
+    // Search unsubscribed streams only
+    test_filter({input: "d", show_subscribed: false, show_not_subscribed: true}, [abcd, denmark]);
 
     // Search terms match stream description
-    test_filter({input: "Co", show_subscribed: false}, [denmark, pomona]);
+    test_filter({input: "Co", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        pomona,
+    ]);
 
     // Search names AND descriptions
-    test_filter({input: "Mon", show_subscribed: false}, [pomona, poland]);
+    test_filter({input: "Mon", show_subscribed: false, show_not_subscribed: false}, [
+        pomona,
+        poland,
+    ]);
 
     // Explicitly order streams by name
-    test_filter({input: "", show_subscribed: false, sort_order: "by-stream-name"}, [
-        cpp,
-        denmark,
-        poland,
-        pomona,
-        zzyzx,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-stream-name",
+        },
+        [abcd, cpp, denmark, jerry, poland, pomona, utopia, zzyzx],
+    );
 
     // Order streams by subscriber count
-    test_filter({input: "", show_subscribed: false, sort_order: "by-subscriber-count"}, [
-        poland,
-        cpp,
-        zzyzx,
-        denmark,
-        pomona,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-subscriber-count",
+        },
+        [utopia, abcd, poland, cpp, zzyzx, denmark, jerry, pomona],
+    );
 
     // Order streams by weekly traffic
-    test_filter({input: "", show_subscribed: false, sort_order: "by-weekly-traffic"}, [
-        poland,
-        cpp,
-        zzyzx,
-        pomona,
-        denmark,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-weekly-traffic",
+        },
+        [poland, utopia, cpp, zzyzx, jerry, abcd, pomona, denmark],
+    );
 
     // Sort for subscribed only.
-    test_filter({input: "", show_subscribed: true, sort_order: "by-subscriber-count"}, [
-        poland,
-        cpp,
-        zzyzx,
-        pomona,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: true,
+            show_not_subscribed: false,
+            sort_order: "by-subscriber-count",
+        },
+        [poland, cpp, zzyzx, pomona],
+    );
+
+    // Sort for unsubscribed only.
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: true,
+            sort_order: "by-subscriber-count",
+        },
+        [utopia, abcd, denmark, jerry],
+    );
 
     // active stream-row is not included in results
     $(".stream-row-denmark").addClass("active");


### PR DESCRIPTION
# PR summary:

- [x] Add a `Not Subscribed tab` to the channels settings that will contain all the channels the user is not subscribed to.
- [X] Display the text `No Channels to show. View all channels.` when no channels is available to show.
- [X] Changes the redirect links for `Browse channel` and `Browse 1 more channels` to the `Not subscribed` tab.
- [X] Hide the `Not subscribed` tab if the user is a guest user.
- [X] Add a tooltip for for the disabled tabs for guests. ( _Originally posted by @alya in https://github.com/zulip/zulip/issues/26049#issuecomment-1743624100_ ) 


---
Fixes: #21869

Continuing the works of: #26049

----



https://github.com/zulip/zulip/assets/73663475/9d79038c-c1a3-444f-8b4e-b9e27f0c1aa2


---

| tooltip| 
|------|
| ![image](https://github.com/zulip/zulip/assets/73663475/9b1eac5f-8e68-4537-aa27-566099ef73d0) |

| Empty view|
|------|
| ![image](https://github.com/zulip/zulip/assets/73663475/06a8b59e-b6e4-46bd-ae3f-dc7f236cd02b) |


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
