### PR TITLE
can_mention_group commits extracted from #29937

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -26,6 +26,9 @@ format used by the Zulip server that they are interacting with.
   /register`](/api/register-queue): `can_mention_group` field can now
   either be an ID of a named user group with the permission, or an
   object describing the set of users and groups with the permission.
+* [`POST /user_groups/create`](/api/create-user-group): The
+  `can_mention_group` parameter can now either be an ID of a named
+  user group or an object describing a set of users and groups.
 
 **Feature level 257**:
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -26,7 +26,8 @@ format used by the Zulip server that they are interacting with.
   /register`](/api/register-queue): `can_mention_group` field can now
   either be an ID of a named user group with the permission, or an
   object describing the set of users and groups with the permission.
-* [`POST /user_groups/create`](/api/create-user-group): The
+* [`POST /user_groups/create`](/api/create-user-group), [`PATCH
+  /user_groups/{user_group_id}`](/api/update-user-group): The
   `can_mention_group` parameter can now either be an ID of a named
   user group or an object describing a set of users and groups.
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 258**:
+
+* [`GET /user_groups`](/api/get-user-groups), [`POST
+  /register`](/api/register-queue): `can_mention_group` field can now
+  either be an ID of a named user group with the permission, or an
+  object describing the set of users and groups with the permission.
+
 **Feature level 257**:
 
 * [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 257
+API_FEATURE_LEVEL = 258
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.user_groups import (
+    get_group_setting_value_for_api,
     get_role_based_system_groups_dict,
     set_defaults_for_group_settings,
 )
@@ -175,7 +176,7 @@ def do_send_create_user_group_event(
             id=user_group.id,
             is_system_group=user_group.is_system_group,
             direct_subgroup_ids=[direct_subgroup.id for direct_subgroup in direct_subgroups],
-            can_mention_group=user_group.can_mention_group_id,
+            can_mention_group=get_group_setting_value_for_api(user_group.can_mention_group),
         ),
     )
     send_event(user_group.realm, event, active_user_ids(user_group.realm_id))

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1857,7 +1857,7 @@ user_group_data_type = DictType(
     optional_keys=[
         ("name", str),
         ("description", str),
-        ("can_mention_group", int),
+        ("can_mention_group", group_setting_type),
     ],
 )
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1790,6 +1790,18 @@ update_message_flags_remove_event = event_dict_type(
 check_update_message_flags_remove = make_checker(update_message_flags_remove_event)
 
 
+group_setting_type = UnionType(
+    [
+        int,
+        DictType(
+            required_keys=[
+                ("direct_members", ListType(int)),
+                ("direct_subgroups", ListType(int)),
+            ]
+        ),
+    ]
+)
+
 group_type = DictType(
     required_keys=[
         ("id", int),
@@ -1798,7 +1810,7 @@ group_type = DictType(
         ("direct_subgroup_ids", ListType(int)),
         ("description", str),
         ("is_system_group", bool),
-        ("can_mention_group", int),
+        ("can_mention_group", group_setting_type),
     ]
 )
 

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -242,9 +242,7 @@ def update_or_create_user_group_for_setting(
     direct_subgroups: List[int],
     current_setting_value: Optional[UserGroup],
 ) -> UserGroup:
-    if current_setting_value is not None and not hasattr(
-        current_setting_value, "named_user_group"
-    ):  # nocoverage
+    if current_setting_value is not None and not hasattr(current_setting_value, "named_user_group"):
         # We do not create a new group if the setting was already set
         # to an anonymous group. The memberships of existing group
         # itself are updated.

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -269,14 +269,18 @@ def user_groups_in_realm_serialized(realm: Realm) -> List[UserGroupDict]:
             can_mention_group=user_group.can_mention_group_id,
         )
 
-    membership = UserGroupMembership.objects.filter(user_group__realm=realm).values_list(
-        "user_group_id", "user_profile_id"
+    membership = (
+        UserGroupMembership.objects.filter(user_group__realm=realm)
+        .exclude(user_group__named_user_group=None)
+        .values_list("user_group_id", "user_profile_id")
     )
     for user_group_id, user_profile_id in membership:
         group_dicts[user_group_id]["members"].append(user_profile_id)
 
-    group_membership = GroupGroupMembership.objects.filter(subgroup__realm=realm).values_list(
-        "subgroup_id", "supergroup_id"
+    group_membership = (
+        GroupGroupMembership.objects.filter(subgroup__realm=realm)
+        .exclude(supergroup__named_user_group=None)
+        .values_list("subgroup_id", "supergroup_id")
     )
     for subgroup_id, supergroup_id in group_membership:
         group_dicts[supergroup_id]["direct_subgroup_ids"].append(subgroup_id)

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -241,8 +241,10 @@ def update_or_create_user_group_for_setting(
     direct_members: List[int],
     direct_subgroups: List[int],
     current_setting_value: Optional[UserGroup],
-) -> UserGroup:  # nocoverage
-    if current_setting_value is not None and not hasattr(current_setting_value, "named_user_group"):
+) -> UserGroup:
+    if current_setting_value is not None and not hasattr(
+        current_setting_value, "named_user_group"
+    ):  # nocoverage
         # We do not create a new group if the setting was already set
         # to an anonymous group. The memberships of existing group
         # itself are updated.
@@ -287,16 +289,16 @@ def access_user_group_for_setting(
 
     # The API would not allow passing the setting parameter as a Dict
     # if require_system_group is true for a setting.
-    assert permission_configuration.require_system_group is False  # nocoverage
+    assert permission_configuration.require_system_group is False
 
     user_group = update_or_create_user_group_for_setting(
         user_profile.realm,
         setting_user_group.direct_members,
         setting_user_group.direct_subgroups,
         current_setting_value,
-    )  # nocoverage
+    )
 
-    return user_group  # nocoverage
+    return user_group
 
 
 def check_user_group_name(group_name: str) -> str:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3174,17 +3174,22 @@ paths:
                                         The new description of the group. Only present if the description
                                         changed.
                                     can_mention_group:
-                                      type: integer
-                                      description: |
-                                        ID of the new user group whose members are allowed to mention the
-                                        group.
+                                      allOf:
+                                        - $ref: "#/components/schemas/CanMentionGroup"
+                                        - description: |
+                                            Either the ID of a named user group that has permission
+                                            to mention the group, or an object describing the set of
+                                            users and groups who have permission mention the group.
 
-                                        **Changes**: Before Zulip 8.0 (feature level 198),
-                                        the `can_mention_group` setting
-                                        was named `can_mention_group_id`.
+                                            **Changes**: Before Zulip 9.0 (feature level 258), the
+                                            `can_mention_group` field was always an integer.
 
-                                        New in Zulip 8.0 (feature level 191). Previously, groups
-                                        could be mentioned if and only if they were not system groups.
+                                            **Changes**: Before Zulip 8.0 (feature level 198),
+                                            the `can_mention_group` setting
+                                            was named `can_mention_group_id`.
+
+                                            New in Zulip 8.0 (feature level 191). Previously, groups
+                                            could be mentioned if and only if they were not system groups.
                               example:
                                 {
                                   "type": "user_group",
@@ -18544,19 +18549,24 @@ paths:
                   type: string
                   example: The marketing team.
                 can_mention_group:
-                  description: |
-                    ID of the new user group whose members are allowed to mention the
-                    group.
+                  allOf:
+                    - description: |
+                        Either the ID of a named user group that has permission to
+                        mention the group, or an object describing the set of users
+                        and groups who have permission mention the group.
 
-                    This setting cannot be set to `"role:internet"` and `"role:owners"`
-                    system groups.
+                        This setting cannot be set to `"role:internet"` and `"role:owners"`
+                        system groups.
 
-                    **Changes**: Before Zulip 8.0 (feature level 198),
-                    the `can_mention_group` setting was named `can_mention_group_id`.
+                        **Changes**: Before Zulip 9.0 (feature level 258), the
+                        `can_mention_group` this field was always an integer.
 
-                    New in Zulip 8.0 (feature level 191). Previously, groups
-                    could be mentioned if and only if they were not system groups.
-                  type: integer
+                        **Changes**: Before Zulip 8.0 (feature level 198),
+                        the `can_mention_group` setting was named `can_mention_group_id`.
+
+                        New in Zulip 8.0 (feature level 191). Previously, groups
+                        could be mentioned if and only if they were not system groups.
+                    - $ref: "#/components/schemas/CanMentionGroup"
                   example: 12
             encoding:
               can_mention_group:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18672,15 +18672,21 @@ paths:
 
                                 **Changes**: New in Zulip 5.0 (feature level 93).
                             can_mention_group:
-                              type: integer
-                              description: |
-                                ID of the user group whose members are allowed to mention the group.
+                              allOf:
+                                - $ref: "#/components/schemas/CanMentionGroup"
+                                - description: |
+                                    Either the ID of a named user group that has permission to
+                                    mention the group, or an object describing the set of users
+                                    and groups who have permission to mention the group.
 
-                                **Changes**: Before Zulip 8.0 (feature level 198),
-                                the `can_mention_group` setting was named `can_mention_group_id`.
+                                    **Changes**: Before Zulip 9.0 (feature level 258), the
+                                    `can_mention_group` field was always an integer.
 
-                                New in Zulip 8.0 (feature level 191). Previously, groups
-                                could be mentioned if and only if they were not system groups.
+                                    **Changes**: Before Zulip 8.0 (feature level 198),
+                                    the `can_mention_group` setting was named `can_mention_group_id`.
+
+                                    New in Zulip 8.0 (feature level 191). Previously, groups
+                                    could be mentioned if and only if they were not system groups.
                         description: |
                           A list of `user_group` objects.
                     example:
@@ -19878,15 +19884,41 @@ components:
 
             **Changes**: New in Zulip 5.0 (feature level 93).
         can_mention_group:
-          type: integer
-          description: |
-            ID of the user group whose members are allowed to mention the group.
+          allOf:
+            - $ref: "#/components/schemas/CanMentionGroup"
+            - description: |
+                Either the ID of a named user group that has permission to
+                mention the group, or an object describing the set of users
+                and groups who have permission mention the group.
 
-            **Changes**: Before Zulip 8.0 (feature level 198),
-            the `can_mention_group` setting was named `can_mention_group_id`.
+                **Changes**: Before Zulip 9.0 (feature level 258), the
+                `can_mention_group` field was always an integer.
 
-            New in Zulip 8.0 (feature level 191). Previously, groups
-            could be mentioned if and only if they were not system groups.
+                **Changes**: Before Zulip 8.0 (feature level 198),
+                the `can_mention_group` setting was named `can_mention_group_id`.
+
+                New in Zulip 8.0 (feature level 191). Previously, groups
+                could be mentioned if and only if they were not system groups.
+    CanMentionGroup:
+      oneOf:
+        - type: object
+          additionalProperties: false
+          properties:
+            direct_members:
+              description: |
+                The list of user IDs that have permission to
+                mention the group.
+              type: array
+              items:
+                type: integer
+            direct_subgroups:
+              description: |
+                The list of user group IDs that have permission
+                to mention the group.
+              type: array
+              items:
+                type: integer
+        - type: integer
     Invite:
       type: object
       description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18389,19 +18389,24 @@ paths:
                     type: integer
                   example: [1, 2, 3, 4]
                 can_mention_group:
-                  description: |
-                    ID of the user group whose members are allowed to mention the new
-                    user group.
+                  allOf:
+                    - description: |
+                        Either the ID of a named user group that has permission to
+                        mention the group, or an object describing the set of users
+                        and groups who have permission mention the new group.
 
-                    This setting cannot be set to `"role:internet"` and `"role:owners"`
-                    system groups.
+                        This setting cannot be set to `"role:internet"` and
+                        `"role:owners"` system groups.
 
-                    **Changes**: Before Zulip 8.0 (feature level 198),
-                    the `can_mention_group` setting was named `can_mention_group_id`.
+                        **Changes**: Before Zulip 9.0 (feature level 258), the
+                        `can_mention_group` setting could only be set to an integer.
 
-                    New in Zulip 8.0 (feature level 191). Previously, groups
-                    could be mentioned if and only if they were not system groups.
-                  type: integer
+                        **Changes**: Before Zulip 8.0 (feature level 198),
+                        the `can_mention_group` setting was named `can_mention_group_id`.
+
+                        New in Zulip 8.0 (feature level 191). Previously, groups
+                        could be mentioned if and only if they were not system groups.
+                    - $ref: "#/components/schemas/CanMentionGroup"
                   example: 11
               required:
                 - name

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1155,7 +1155,7 @@ class FetchQueriesTest(ZulipTestCase):
 
         self.login_user(user)
 
-        with self.assert_database_query_count(41):
+        with self.assert_database_query_count(43):
             with mock.patch("zerver.lib.events.always_want") as want_mock:
                 fetch_initial_state_data(user)
 
@@ -1180,7 +1180,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_linkifiers=0,
             realm_playgrounds=1,
             realm_user=3,
-            realm_user_groups=3,
+            realm_user_groups=5,
             realm_user_settings_defaults=1,
             recent_private_conversations=1,
             scheduled_messages=1,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1745,6 +1745,22 @@ class NormalActionsTest(BaseAction):
                 backend, "can_mention_group", moderators_group, acting_user=None
             )
         check_user_group_update("events[0]", events[0], "can_mention_group")
+        self.assertEqual(events[0]["data"]["can_mention_group"], moderators_group.id)
+
+        setting_group = UserGroup.objects.create(realm=self.user_profile.realm)
+        setting_group.direct_members.set([othello.id])
+        setting_group.direct_subgroups.set([moderators_group.id])
+        with self.verify_action() as events:
+            do_change_user_group_permission_setting(
+                backend, "can_mention_group", setting_group, acting_user=None
+            )
+        check_user_group_update("events[0]", events[0], "can_mention_group")
+        self.assertEqual(
+            events[0]["data"]["can_mention_group"],
+            AnonymousSettingGroupDict(
+                direct_members=[othello.id], direct_subgroups=[moderators_group.id]
+            ),
+        )
 
         # Test add members
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -257,7 +257,7 @@ class HomeTest(ZulipTestCase):
         self.client_post("/json/bots", bot_info)
 
         # Verify succeeds once logged-in
-        with self.assert_database_query_count(51):
+        with self.assert_database_query_count(53):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page(stream="Denmark")
                 self.check_rendered_logged_in_app(result)
@@ -562,7 +562,7 @@ class HomeTest(ZulipTestCase):
     def test_num_queries_for_realm_admin(self) -> None:
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
-        with self.assert_database_query_count(51):
+        with self.assert_database_query_count(53):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
@@ -593,7 +593,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(46):
+        with self.assert_database_query_count(48):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
This contains all the commits responsible for the main can_mention_group setting API change in #29937.

(The `_previous` detail is still under discussion and will merge with another feature level).