### PR TITLE
compose: Make conversation arrow double as a go-to-conversation button.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -73,7 +73,7 @@ export function update_narrow_to_recipient_visibility(): void {
             !composing_to_current_topic_narrow() &&
             compose_state.has_full_recipient()
         ) {
-            $(".narrow_to_compose_recipients").toggleClass("invisible", false);
+            $(".conversation-arrow").toggleClass("narrow_to_compose_recipients", true);
             return;
         }
     } else if (message_type === "private") {
@@ -83,11 +83,11 @@ export function update_narrow_to_recipient_visibility(): void {
             !composing_to_current_private_message_narrow() &&
             compose_state.has_full_recipient()
         ) {
-            $(".narrow_to_compose_recipients").toggleClass("invisible", false);
+            $(".conversation-arrow").toggleClass("narrow_to_compose_recipients", true);
             return;
         }
     }
-    $(".narrow_to_compose_recipients").toggleClass("invisible", true);
+    $(".conversation-arrow").toggleClass("narrow_to_compose_recipients", false);
 }
 
 function update_fade(): void {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -295,6 +295,12 @@
     --color-compose-chevron-arrow: hsl(0deg 0% 58%);
     --color-limit-indicator: hsl(38deg 100% 36%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 40%);
+    --color-narrow-to-compose-recipients-background: hsl(227deg 100% 70% / 25%);
+    --color-narrow-to-compose-recipients-background-hover: hsl(
+        227deg 100% 70% / 35%
+    );
+    --color-narrow-to-compose-recipients: hsl(227deg 76% 64%);
+    --color-narrow-to-compose-recipients-hover: hsl(227deg 78% 59%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -615,6 +621,12 @@
     --color-background-popover: hsl(212deg 32% 14%);
     --color-limit-indicator: hsl(38deg 100% 70%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 60%);
+    --color-narrow-to-compose-recipients-background: hsl(227deg 80% 60% / 25%);
+    --color-narrow-to-compose-recipients-background-hover: hsl(
+        227deg 80% 60% / 35%
+    );
+    --color-narrow-to-compose-recipients: hsl(224deg 28% 81%);
+    --color-narrow-to-compose-recipients-hover: hsl(221deg 100% 95%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -174,26 +174,31 @@
             flex: 0 0 auto;
             height: var(--compose-recipient-box-min-height);
 
-            .zulip-icon-chevron-right {
+            .conversation-arrow {
                 font-size: 16px;
+                line-height: 16px;
+                border-radius: 50%;
+                padding: 2px;
+                margin: 0 3px;
                 color: var(--color-compose-chevron-arrow);
-            }
-        }
+                text-decoration: none;
+                cursor: default;
+                transition: all 0.2s ease-in-out;
 
-        & a.narrow_to_compose_recipients {
-            background: transparent;
-            font-size: 18px;
-            padding: 0 1px;
-            align-self: center;
-            line-height: 20px;
-            opacity: 0.7;
-            border: 0;
-            margin-left: 3px;
-            text-decoration: none;
-            color: inherit;
+                &.narrow_to_compose_recipients {
+                    background: var(
+                        --color-narrow-to-compose-recipients-background
+                    );
+                    color: var(--color-narrow-to-compose-recipients);
+                    cursor: pointer;
 
-            &:hover {
-                opacity: 1;
+                    &:hover {
+                        background: var(
+                            --color-narrow-to-compose-recipients-background-hover
+                        );
+                        color: var(--color-narrow-to-compose-recipients-hover);
+                    }
+                }
             }
         }
     }
@@ -349,18 +354,17 @@
     align-items: center;
     height: var(--compose-recipient-box-min-height);
     /* Align to compose controls; that's 112px width,
-       minus 23px for the narrow indicator, but then
-       add back 6px of grid gap for 95px here.
+       plus 6px of grid gap for 118px here.
 
        TODO: Make variables here; expanded use of grid
        on the compose box will make these unnecessary,
        eventually. */
-    width: calc(112px - 23px + 6px);
+    width: calc(112px + 6px);
     justify-content: flex-end;
 
     @media ((width >= $sm_min) and (width < $mc_min)) {
         /* Align to compose controls at narrower widths */
-        width: calc(62px - 23px + 6px);
+        width: calc(62px + 6px);
     }
 
     @media (width < $sm_min) {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -55,13 +55,10 @@
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip_template"></button>
                         </div>
                         <div id="compose-recipient" class="order-1">
-                            <div class="topic-marker-container order-1">
-                                <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
-                            </div>
                             {{> dropdown_widget_wrapper
                               widget_name="compose_select_recipient"}}
                             <div class="topic-marker-container">
-                                <i class="zulip-icon zulip-icon-chevron-right" aria-hidden="true"></i>
+                                <a role="button" class="conversation-arrow zulip-icon zulip-icon-chevron-right"></a>
                             </div>
                             <div id="compose_recipient_box">
                                 <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />


### PR DESCRIPTION
The chevron arrow icon before the topic / dm user field now also acts as a go to conversation button. Whenever the functionality is available, the plain icon changes to look and behave like a button. The old go to conversation button on the right of the field is removed.

Fixes: #28697.

(Alternative to #28915)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

### Screenshots and screen captures:
**When the go to conversation functionality isn't available:**
Light:
![image](https://github.com/zulip/zulip/assets/68962290/61db2673-5510-46a8-a1f6-67b95ba592da)

Dark:
![image](https://github.com/zulip/zulip/assets/68962290/767038bc-962a-4bfb-940e-4800d0776111)

**When it is available:**
Light:
![image](https://github.com/zulip/zulip/assets/68962290/16e05c24-24bb-4bd5-9bb4-e209c0dd557e)
![image](https://github.com/zulip/zulip/assets/68962290/b14469a4-b79b-4dfb-9f2d-5884ebedf650)

Dark:
![image](https://github.com/zulip/zulip/assets/68962290/4500f51e-8faa-491c-b9e6-c871341c4005)
![image](https://github.com/zulip/zulip/assets/68962290/dfc42051-debd-49e6-9eb8-9dd41aa69dcd)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
