### PR TITLE
openapi: Document apns_device_token and android_gcm_reg_id endpoints.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -318,7 +318,7 @@ No changes; feature level used for Zulip 8.0 release.
 
 **Feature level 223**
 
-* `POST /users/me/apns_device_token`:
+* [`POST /users/me/apns_device_token`](/api/add-apns-token):
   The `appid` parameter is now required.
   Previously it defaulted to the server setting `ZULIP_IOS_APP_ID`,
   defaulting to "org.zulip.Zulip".

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -127,3 +127,5 @@
 * [Send a test notification to mobile device(s)](/api/test-notify)
 * [Add an APNs device token](/api/add-apns-token)
 * [Remove an APNs device token](/api/remove-apns-token)
+* [Add an FCM registration token](/api/add-fcm-token)
+* [Remove an FCM registration token](/api/remove-fcm-token)

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -125,3 +125,5 @@
 * [Fetch an API key (production)](/api/fetch-api-key)
 * [Fetch an API key (development only)](/api/dev-fetch-api-key)
 * [Send a test notification to mobile device(s)](/api/test-notify)
+* [Add an APNs device token](/api/add-apns-token)
+* [Remove an APNs device token](/api/remove-apns-token)

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1367,6 +1367,30 @@ def get_stream_topics(client: Client, stream_id: int) -> None:
     validate_against_openapi_schema(result, "/users/me/{stream_id}/topics", "get", "200")
 
 
+@openapi_test_function("/users/me/apns_device_token:post")
+def add_apns_token(client: Client) -> None:
+    # {code_example|start}
+    request = {"token": "apple-tokenbb", "appid": "org.zulip.Zulip"}
+    result = client.call_endpoint(url="/users/me/apns_device_token", method="POST", request=request)
+    # {code_example|end}
+
+    validate_against_openapi_schema(result, "/users/me/apns_device_token", "post", "200")
+
+
+@openapi_test_function("/users/me/apns_device_token:delete")
+def remove_apns_token(client: Client) -> None:
+    # {code_example|start}
+    request = {
+        "token": "apple-tokenbb",
+    }
+    result = client.call_endpoint(
+        url="/users/me/apns_device_token", method="DELETE", request=request
+    )
+    # {code_example|end}
+
+    validate_against_openapi_schema(result, "/users/me/apns_device_token", "delete", "200")
+
+
 @openapi_test_function("/typing:post")
 def set_typing_status(client: Client) -> None:
     ensure_users([10, 11], ["hamlet", "iago"])
@@ -1656,6 +1680,8 @@ def test_users(client: Client, owner_client: Client) -> None:
     get_alert_words(client)
     add_alert_words(client)
     remove_alert_words(client)
+    add_apns_token(client)
+    remove_apns_token(client)
 
 
 def test_streams(client: Client, nonadmin_client: Client) -> None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1391,6 +1391,30 @@ def remove_apns_token(client: Client) -> None:
     validate_against_openapi_schema(result, "/users/me/apns_device_token", "delete", "200")
 
 
+@openapi_test_function("/users/me/android_gcm_reg_id:post")
+def add_fcm_token(client: Client) -> None:
+    # {code_example|start}
+    request = {"token": "android-token"}
+    result = client.call_endpoint(
+        url="/users/me/android_gcm_reg_id", method="POST", request=request
+    )
+    # {code_example|end}
+    validate_against_openapi_schema(result, "/users/me/android_gcm_reg_id", "post", "200")
+
+
+@openapi_test_function("/users/me/android_gcm_reg_id:delete")
+def remove_fcm_token(client: Client) -> None:
+    # {code_example|start}
+    request = {
+        "token": "android-token",
+    }
+    result = client.call_endpoint(
+        url="/users/me/android_gcm_reg_id", method="DELETE", request=request
+    )
+    # {code_example|end}
+    validate_against_openapi_schema(result, "/users/me/android_gcm_reg_id", "delete", "200")
+
+
 @openapi_test_function("/typing:post")
 def set_typing_status(client: Client) -> None:
     ensure_users([10, 11], ["hamlet", "iago"])
@@ -1682,6 +1706,8 @@ def test_users(client: Client, owner_client: Client) -> None:
     remove_alert_words(client)
     add_apns_token(client)
     remove_apns_token(client)
+    add_fcm_token(client)
+    remove_fcm_token(client)
 
 
 def test_streams(client: Client, nonadmin_client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10034,7 +10034,118 @@ paths:
                           }
                         description: |
                           An example JSON response for when the user is not previously muted:
+  /users/me/apns_device_token:
+    post:
+      operationId: add-apns-token
+      summary: Add an APNs device token
+      tags: ["users"]
+      description: |
+        This endpoint adds an APNs device token to register for iOS push notifications.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: |
+                    The token provided by the device.
+                  type: string
+                  example: apple-tokenbb
+                appid:
+                  description: |
+                    The ID of the Zulip app that is making the request.
 
+                    **Changes**: In Zulip 8.0 (feature level 223), this parameter was made
+                    required. Previously, if it was unspecified, the server would use a default
+                    value (based on the `ZULIP_IOS_APP_ID` server setting, which
+                    defaulted to `"org.zulip.Zulip"`).
+                  type: string
+                  example: org.zulip.Zulip
+              required:
+                - token
+                - appid
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          A typical failed JSON response for when the token's length is invalid
+                          or it is empty:
+                        example:
+                          {
+                            "result": "error",
+                            "msg": "Empty or invalid length token",
+                            "code": "BAD_REQUEST",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Invalid APNS token",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for when the APNs token is invalid:
+    delete:
+      operationId: remove-apns-token
+      summary: Remove an APNs device token
+      tags: ["users"]
+      description: |
+        This endpoint removes an APNs device token for iOS push notifications.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: |
+                    The token provided by the device.
+                  type: string
+                  example: apple-tokenbb
+              required:
+                - token
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          A typical failed JSON response for when the token's length is invalid
+                          or it is empty:
+                        example:
+                          {
+                            "result": "error",
+                            "msg": "Empty or invalid length token",
+                            "code": "BAD_REQUEST",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Token does not exist",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for when the token does not exist:
   /users/{user_id}/subscriptions/{stream_id}:
     get:
       operationId: get-subscription-status

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10146,6 +10146,96 @@ paths:
                           }
                         description: |
                           A typical failed JSON response for when the token does not exist:
+  /users/me/android_gcm_reg_id:
+    post:
+      operationId: add-fcm-token
+      summary: Add an FCM registration token
+      tags: ["users"]
+      description: |
+        This endpoint adds an FCM registration token for push notifications.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: |
+                    The token provided by the device.
+                  type: string
+                  example: android-token
+              required:
+                - token
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      A typical failed JSON response for when the token's length is invalid
+                      or is empty:
+                    example:
+                      {
+                        "result": "error",
+                        "msg": "Empty or invalid length token",
+                        "code": "BAD_REQUEST",
+                      }
+    delete:
+      operationId: remove-fcm-token
+      summary: Remove an FCM registration token
+      tags: ["users"]
+      description: |
+        This endpoint removes an FCM registration token for push notifications.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: |
+                    The token provided by the device.
+                  type: string
+                  example: android-token
+              required:
+                - token
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          A typical failed JSON response for when the token's length is invalid
+                          or is empty:
+                        example:
+                          {
+                            "result": "error",
+                            "msg": "Empty or invalid length token",
+                            "code": "BAD_REQUEST",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Token does not exist",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for when the token does not exist:
   /users/{user_id}/subscriptions/{stream_id}:
     get:
       operationId: get-subscription-status

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -248,8 +248,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         #### Mobile-app only endpoints; important for mobile developers.
         # Mobile interface for development environment login
         "/dev_list_users",
-        # Registration for iOS/Android mobile push notifications.
-        "/users/me/android_gcm_reg_id",
         #### These personal settings endpoints have modest value to document:
         "/users/me/avatar",
         "/users/me/api_key/regenerate",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -250,7 +250,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/dev_list_users",
         # Registration for iOS/Android mobile push notifications.
         "/users/me/android_gcm_reg_id",
-        "/users/me/apns_device_token",
         #### These personal settings endpoints have modest value to document:
         "/users/me/avatar",
         "/users/me/api_key/regenerate",


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds API documentation for following endpoints:
- /users/me/apns_device_token
- /users/me/android_gcm_reg_id

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
**Screenshots and screen captures:**

![Screenshot 2024-05-09 093953](https://github.com/zulip/zulip/assets/119798962/7b58edae-174c-44c4-911b-b60e59a24867)
![Screenshot 2024-05-09 094015](https://github.com/zulip/zulip/assets/119798962/82a8295b-50e2-4cc0-a8fd-4d14eb92be08)
![Screenshot 2024-05-10 100149](https://github.com/zulip/zulip/assets/119798962/c3bf2296-964a-4834-9ef1-d5f7da37b238)
![Screenshot 2024-05-10 100135](https://github.com/zulip/zulip/assets/119798962/2e10283d-df84-4329-860e-76d0c01c5441)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
