### PR TITLE
recent_view: Fix filter input focused on load.

### DIFF
--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -96,6 +96,12 @@ let dropdown_filters = new Set();
 
 const recent_conversation_key_prefix = "recent_conversation:";
 
+let is_initial_message_fetch_pending = true;
+
+export function set_initial_message_fetch_status(value) {
+    is_initial_message_fetch_pending = value;
+}
+
 export function clear_for_tests() {
     filters.clear();
     dropdown_filters.clear();
@@ -340,6 +346,12 @@ export function revive_current_focus() {
     // After re-render, the current_focus_elem is no longer linked
     // to the focused element, this function attempts to revive the
     // link and focus to the element prior to the rerender.
+
+    // We want to set focus on table by default, but we have to wait for
+    // initial fetch for rows to appear otherwise focus is set to search input.
+    if (is_initial_message_fetch_pending) {
+        return false;
+    }
 
     // We try to avoid setting focus when user
     // is not focused on Recent Conversations.

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -799,7 +799,11 @@ export function initialize_everything(state_data) {
     reload_setup.initialize();
     unread.initialize(unread_params);
     bot_data.initialize(bot_params); // Must happen after people.initialize()
-    message_fetch.initialize(server_events.finished_initial_fetch);
+    message_fetch.initialize(() => {
+        recent_view_ui.set_initial_message_fetch_status(false);
+        recent_view_ui.revive_current_focus();
+        server_events.finished_initial_fetch();
+    });
     message_scroll.initialize();
     markdown.initialize(markdown_config.get_helpers());
     linkifiers.initialize(realm.realm_linkifiers);


### PR DESCRIPTION
Since there are no rows to set focus in recent view before initial fetch, we were falling back to set focus on input filter after rendering recent view.

Waiting for initial fetch to complete helps us set focus on the table easily while recent view is also open for user to play with if the load takes longer.
