### PR TITLE
requirements: Drop the --no-binary for lxml and xmlsec.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -128,14 +128,12 @@ social-auth-app-django
 social-auth-core[azuread,openidconnect,saml]
 python3-saml
 xmlsec<1.3.14  # https://github.com/xmlsec/python-xmlsec/issues/314
---no-binary=xmlsec
 
 # For encrypting a login token to the desktop app
 cryptography
 
 # Needed for messages' rendered content parsing in push notifications.
 lxml
---no-binary=lxml
 
 # Needed for 2-factor authentication
 django-two-factor-auth[call,phonenumberslite,sms]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,9 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
---no-binary lxml
---no-binary xmlsec
-
 aioapns==3.2 \
     --hash=sha256:40f6b2428816f7bb1a32668f50fe71d0289777a429b60fce44e8a08b90123508 \
     --hash=sha256:99416ed2916fb6302294188a2caf85ec2b8ea3b988f466add73f9dc2c7ca5dc2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,9 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
---no-binary lxml
---no-binary xmlsec
-
 aioapns==3.2 \
     --hash=sha256:40f6b2428816f7bb1a32668f50fe71d0289777a429b60fce44e8a08b90123508 \
     --hash=sha256:99416ed2916fb6302294188a2caf85ec2b8ea3b988f466add73f9dc2c7ca5dc2


### PR DESCRIPTION
Building these libraries from source requires too much memory, and causes OOMs on a host with 4GB of RAM when still running Zulip.

Building from source was enabled in `main` to work around xmlsec/python-xmlsec#320, which does not occur with the xmlsec version in the 8.x branch, as xmlsec/python-xmlsec#314 (incompatibilities with Ubuntu 20.04) causes us to pin xmlsec<1.3.14.

As such, we switch back to using prebuilt wheels.  The version mismatch from xmlsec/python-xmlsec#320, if real, is not new, so this exposes us to no more risk than before.
