### PR TITLE
compose: Fix bug in preview where image at the end would be misaligned.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -884,7 +884,7 @@
         margin-top: 0;
     }
 
-    & > :last-child {
+    & > :last-child:not(.message_inline_image) {
         margin-bottom: 0;
     }
 }


### PR DESCRIPTION
The `margin-bottom` was removed for the last element in the preview in e55f5a1b5903994a65844e8c711989f5ed32e51c to remove vertical shifts when toggling preview mode, but it is not needed for image / video previews, so now `margin-bottom` is not set to 0 for the last inline preview.

Fixes: [CZO issue report](https://chat.zulip.org/#narrow/stream/9-issues/topic/misaligned.20image.20previews.20when.20at.20end.20of.20message.20preview/near/1796347)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![image](https://github.com/zulip/zulip/assets/68962290/13ea86ed-0a11-4d9e-b0f3-864eb7dd882f)
After:
![image](https://github.com/zulip/zulip/assets/68962290/da50419b-af7b-460f-868f-254ea7f41844)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
