### PR TITLE
stars: Fix flaky test due to message list not yet rendered.

### DIFF
--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -34,7 +34,11 @@ async function test_narrow_to_starred_messages(page: Page): Promise<void> {
 
     // Go back to the combined feed view.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
+    const combined_feed_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${combined_feed_id}'] .message_row`,
+        {visible: true},
+    );
 }
 
 async function stars_test(page: Page): Promise<void> {


### PR DESCRIPTION
With combined feed no longer cached, this test became flaky as it took longer for combined feed to load.

Verified that other tests waiting on `.message-list` don't need this change.

discussion: https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/flaky.20star.20message