### PR TITLE
apt-repos: Deprioritize libgroonga0 14.0.3-1

### DIFF
--- a/scripts/setup/apt-repos/zulip/zulip.pref
+++ b/scripts/setup/apt-repos/zulip/zulip.pref
@@ -1,0 +1,4 @@
+# libarrow1600 is missing on Debian 12
+Package: libgroonga0
+Pin: version 14.0.3-1
+Pin-Priority: 499


### PR DESCRIPTION
It depends libarrow1600, which is missing from the PGroonga repository on Debian 12.

[Discussion](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/libgroonga.20installation/near/1797208).