### PR TITLE
info_density: Calculate values for vertical alignment and apply to emoji.

### DIFF
--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -2,10 +2,81 @@ import $ from "jquery";
 
 import {user_settings} from "./user_settings";
 
+// These are all relative-unit values for Source Sans Pro VF,
+// as opened and inspected in FontForge.
+// Source Sans Prof VF reports an em size of 1000, which is
+// necessary to know to calculate proper em units.
+const BODY_FONT_EM_SIZE = 1000;
+// The Typo Ascent Value is reported as 1024, but both Chrome
+// and Firefox act as though it is 1025, so that value is used
+// here. It represents the portion of the content box above the
+// baseline.
+const BODY_FONT_ASCENT = 1025;
+// The Typo Descent Value is reported as 400. It is the portion
+// of the content box below the baseline.
+const BODY_FONT_DESCENT = 400;
+// The BODY_FONT_CONTENT_BOX size is calculated by adding the
+// Typo Ascent and Typo Descent values. The content box for
+// Source Sans Pro VF exceeds the size of its em box, meaning
+// that the `font-size` value will render text that is smaller
+// than the size of the content area. For example, setting
+// `font-size: 100px` on Source Sans Prof VF produces a content
+// area of 142.5px.
+// Note also that the content box is therefore clipped when the
+// line-height (in ems or as a unitless value) is less than the
+// MAXIMUM_BLOCK_HEIGHT_IN_EMS as calculated below.
+const BODY_FONT_CONTENT_BOX = BODY_FONT_ASCENT + BODY_FONT_DESCENT;
+// The maximum block height is derived from the content area
+// made by an anonymous text node in Source Sans Pro VF.
+// This ensures that even as line heights scale above 1.425,
+// text-adjacent elements can be sized in scale to the text's
+// content area. This is necessary to know, because an element
+// such as a checkbox or emoji looks nice occupying the full
+// line-height, but only when the text's content area is less
+// than the line-height.
+const MAXIMUM_BLOCK_HEIGHT_IN_EMS = BODY_FONT_CONTENT_BOX / BODY_FONT_EM_SIZE;
+
+// Eventually this legacy value and references to it should be removed;
+// but in the awkward stage where legacy values are in play for
+// certain things (e.g., calculating line-height-based offsets for
+// emoji alignment), it's necessary to have access to this value.
+const LEGACY_LINE_HEIGHT_UNITLESS = 1.214;
+
+function set_vertical_alignment_values(line_height_unitless: number): void {
+    // We work in ems to keep this agnostic to the font size.
+    const line_height_in_ems = line_height_unitless;
+    const text_content_box_height_in_ems = MAXIMUM_BLOCK_HEIGHT_IN_EMS;
+    // We calculate the descent area according to the BODY_FONT values. However,
+    // to make that em value relative to the size of the content box, we need
+    // to multiply that by the maximum block height, which is the content
+    // box's em square (versus the em square of the value set on `font-size`).
+    const descent_area_in_ems =
+        (BODY_FONT_DESCENT / BODY_FONT_CONTENT_BOX) * MAXIMUM_BLOCK_HEIGHT_IN_EMS;
+
+    // The height of line-fitted elements, such as inline emoji, is the
+    // lesser of either the line height or the height of the adjacent
+    // text content box.
+    const line_fitted_height_in_ems = Math.min(line_height_in_ems, text_content_box_height_in_ems);
+
+    // We obtain the correct vertical offset by taking the negative value
+    // of the descent area, and adding it to half any non-zero difference
+    // between the content box and the fitted line height.
+    const line_fitted_vertical_align_offset_in_ems =
+        -descent_area_in_ems + (text_content_box_height_in_ems - line_fitted_height_in_ems) / 2;
+
+    $(":root").css("--base-maximum-block-height-em", `${MAXIMUM_BLOCK_HEIGHT_IN_EMS}em`);
+    $(":root").css(
+        "--line-fitted-vertical-align-offset-em",
+        `${line_fitted_vertical_align_offset_in_ems}em`,
+    );
+}
+
 export function set_base_typography_css_variables(): void {
     const font_size_px = user_settings.web_font_size_px;
     const line_height_percent = user_settings.web_line_height_percent;
-    const line_height_unitless = line_height_percent / 100;
+    const line_height_unitless = user_settings.dense_mode
+        ? LEGACY_LINE_HEIGHT_UNITLESS
+        : line_height_percent / 100;
     const line_height_px = line_height_unitless * font_size_px;
     /* This percentage is a legacy value, rounding up from .294;
        additional logic might be useful to make this adjustable;
@@ -20,6 +91,8 @@ export function set_base_typography_css_variables(): void {
         "--markdown-interelement-doubled-space-px",
         `${markdown_interelement_space_px * 2}px`,
     );
+
+    set_vertical_alignment_values(line_height_unitless);
 }
 
 export function initialize(): void {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -85,6 +85,23 @@
        precise heights, and in the case of square elements,
        a matching precise width as well. */
     --length-line-fitted-block: calc(var(--base-line-height-unitless) * 1em);
+    /* Emoji elements are allowed to exceed the perfectly-fit
+       line-height. Classic Zulip emoji sizing is a 20px square
+       emoji at a 14px font-size, for 1.4286em at 14px/1em. */
+    --length-line-oversize-block: 1.4286em;
+    /* To avoid disturbing the flow of text around emoji or other
+       oversize inline blocks, we calculate a negative margin
+       adjustment for offsetting the emoji, top and bottom. */
+    --length-line-oversize-block-margin-adjust: calc(
+        (
+                (
+                        min(
+                            var(--base-maximum-block-height-em),
+                            var(--length-line-fitted-block)
+                        )
+                    ) - var(--length-line-oversize-block)
+            ) / 2
+    );
 
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -74,6 +74,8 @@
     /* The legacy values here are updated via JavaScript */
     --base-font-size-px: 14px;
     --base-line-height-unitless: 1.214;
+    --base-maximum-block-height-em: 1.425em;
+    --base-inline-block-vertical-alignment-em: 0;
     --markdown-interelement-space-px: 5px;
     --markdown-interelement-doubled-space-px: calc(
         var(--markdown-interelement-space-px) * 2

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -75,11 +75,16 @@
     --base-font-size-px: 14px;
     --base-line-height-unitless: 1.214;
     --base-maximum-block-height-em: 1.425em;
-    --base-inline-block-vertical-alignment-em: 0;
+    --line-fitted-vertical-align-offset-em: 0;
     --markdown-interelement-space-px: 5px;
     --markdown-interelement-doubled-space-px: calc(
         var(--markdown-interelement-space-px) * 2
     );
+    /* Certain elements need to be fitted perfectly to
+       the line height; the length here can be used to set
+       precise heights, and in the case of square elements,
+       a matching precise width as well. */
+    --length-line-fitted-block: calc(var(--base-line-height-unitless) * 1em);
 
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -138,16 +138,23 @@
 
     /* Emoji; sized to be easily understood while not overwhelming text. */
     .emoji {
-        height: calc(20em / 14);
-        width: calc(20em / 14);
-        /* "Eyeballed" styles to compensate for inline-block emoji
-          positioning in messages.
-          By coordinating the emoji height and width above with the
-          `line-height` on messages in the future, these properties
-          should no longer be necessary: */
-        position: relative;
-        margin-top: -7px;
-        top: 3px;
+        /* The box for emoji is kept below a certain maximum, regardless
+           of more open line-heights. This prevents emoji from sizing
+           excessively larger than the surrounding text's content area. */
+        height: calc(
+            min(
+                var(--base-maximum-block-height-em),
+                var(--length-line-fitted-block)
+            )
+        );
+        width: calc(
+            min(
+                var(--base-maximum-block-height-em),
+                var(--length-line-fitted-block)
+            )
+        );
+        /* We set the alignment programmatically, as an em value. */
+        vertical-align: var(--line-fitted-vertical-align-offset-em);
     }
 
     /* Mentions and alert words */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -138,22 +138,18 @@
 
     /* Emoji; sized to be easily understood while not overwhelming text. */
     .emoji {
-        /* The box for emoji is kept below a certain maximum, regardless
-           of more open line-heights. This prevents emoji from sizing
-           excessively larger than the surrounding text's content area. */
-        height: calc(
-            min(
-                var(--base-maximum-block-height-em),
-                var(--length-line-fitted-block)
-            )
-        );
-        width: calc(
-            min(
-                var(--base-maximum-block-height-em),
-                var(--length-line-fitted-block)
-            )
-        );
-        /* We set the alignment programmatically, as an em value. */
+        /* The box for emoji is allowed to be larger than the size of the
+           line-height. */
+        height: var(--length-line-oversize-block);
+        width: var(--length-line-oversize-block);
+        /* A negative top and bottom margin adjustment allows emoji
+           to size larger than the size of the line, without disturbing
+           the surrounding lines of text. */
+        margin: var(--length-line-oversize-block-margin-adjust) auto;
+        /* We set the alignment programmatically, as an em value.
+           Because the negative margins above are equal, top and bottom,
+           this vertical offset value works without adjustment for
+           oversize emoji blocks. */
         vertical-align: var(--line-fitted-vertical-align-offset-em);
     }
 


### PR DESCRIPTION
This PR calculates values necessary to properly fit and vertically align inline-block elements within any given line height and font size combination. Those values are then applied as an example to inline emoji, though the techniques and values here are strong candidates to be extended to other blocks appearing within the message area (e.g., todo widget checkboxes, `<time>` elements). 

Additionally, previous fiddly `top` and `margin` values applied to emoji have been removed here, so that similarly fiddly adjustments are made unnecessary as users adjust information density values. A commit added on 11 June 2024 now also restores the oversize-emoji look that Zulip is known for, but critically without disturbing the surrounding lines of text (updated screenshots below).

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/info.20density.3A.20inline.20emoji.20presentation/near/1796448)

**To test this PR in dev**, you'll see the default values just by running dev on this branch. The database-stored legacy font size and line-height equivalents can be made active by deselecting `Dense mode` under Settings > Preferences. To see the 16px/140% version, set those values in the `Message-area font size (px)` and `Message-area line height (%)`. Same with any other reasonable combination of font size and line-height you might be curious to examine.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (oversize, legacy `.more_dense_mode`) |
| --- | --- |
| ![inline-emoji-main-2024-06-11](https://github.com/zulip/zulip/assets/170719/37996ef4-b2d3-415b-a020-0f7bc81a0361) | ![inline-emoji-oversize-legacy](https://github.com/zulip/zulip/assets/170719/e901cd82-fbd4-44dd-b081-85a804f7d8ab) |

_The screenshots here demonstrate that the oversize versions do not disturb the flow of text compared to their line-fitted counterparts._

| Legacy, line-fitted | Legacy, oversize |
| --- | --- |
| ![inline-emoji-line-fitted-legacy](https://github.com/zulip/zulip/assets/170719/91e78449-0d99-41ab-8162-cf29abf1d858) | ![inline-emoji-oversize-legacy](https://github.com/zulip/zulip/assets/170719/7b853455-bf23-4025-8883-fcae4c9c18ac) |

| 14/122, line-fitted | 14/122, oversize |
| --- | --- |
| ![inline-emoji-line-fitted-14-122](https://github.com/zulip/zulip/assets/170719/3afbf33e-87f7-41aa-a888-16359e97929e) | ![inline-emoji-oversize-14-122](https://github.com/zulip/zulip/assets/170719/dd123b5c-8fb2-4841-8f6f-2b31df1b06ea) |

_The change at 16/140 is far less dramatic because the line-fitted size comes much closer to the oversize size._

| 16/140, line-fitted | 16/140, oversize |
| --- | --- |
| ![inline-emoji-oversize-16-140](https://github.com/zulip/zulip/assets/170719/958efbb1-12c3-451a-b7dc-c6bb98daa33c) | ![inline-emoji-line-fitted-16-140](https://github.com/zulip/zulip/assets/170719/6bf0a332-4262-41a9-b4aa-57dd7106ff4f) |

<details>
<summary>Outdated screenshots</summary>
| Before | After (legacy font size/line height values) |
| --- | --- |
| ![legacy-emoji-before](https://github.com/zulip/zulip/assets/170719/6a35ad2a-ddf2-417e-b322-0dcc87e0814b) | ![legacy-emoji-after-calculated-offset](https://github.com/zulip/zulip/assets/170719/af241f8a-4d00-49bc-a9fa-0ac47ab531a5) |

| 16px/140% | 100px/100% (exaggerated, line-fitted) | 100px/300% (exaggerated, font-size-clamped) |
| --- | --- | --- |
| ![emoji-16-140](https://github.com/zulip/zulip/assets/170719/be2bfb54-a023-4eb4-be7c-32ade5cd6479) | ![emoji-100-100](https://github.com/zulip/zulip/assets/170719/7c014f84-2c06-4227-8a9b-a0507553b7f3) | ![emoji-100-300](https://github.com/zulip/zulip/assets/170719/b846b76d-52ed-4345-ad9c-ea4046bf3314) |

## Showing shift-free text at 16px/140%

![16-140-shifts](https://github.com/zulip/zulip/assets/170719/83371327-fce8-4763-bf50-a1dd9f39a86c)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>