### PR TITLE
Fix 29655: Page reloads on hitting enter key while moving message over topics

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -175,6 +175,7 @@ export function launch(conf: DialogWidgetConfig): string {
     }
 
     const $submit_button = $dialog.find(".dialog_submit_button");
+    const $dialog_form = $dialog.find('.modal__content');
 
     function get_current_values($inputs: JQuery): Record<string, unknown> {
         const current_values: Record<string, unknown> = {};
@@ -222,6 +223,28 @@ export function launch(conf: DialogWidgetConfig): string {
     if (conf.form_id) {
         $submit_button.attr("form", conf.form_id);
     }
+
+    $dialog_form.on("keydown", (e) => {
+        if (e.keyCode !== 13) {
+            return
+        }
+        e.preventDefault();
+
+        if ($submit_button.prop("disabled")) {
+            return;
+        }
+
+        if (conf.validate_input && !conf.validate_input(e)) {
+            return;
+        }
+        if (conf.loading_spinner) {
+            show_dialog_spinner();
+        } else if (conf.close_on_submit) {
+            close();
+        }
+        $("#dialog_error").hide();
+        conf.on_click(e);
+    })
 
     // Set up handlers.
     $submit_button.on("click", (e) => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #29655 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Changes
The problem arose from the form's default behavior, which causes the page to reload when the Enter key is pressed. To address this, I implemented functionality to handle the Enter key press specifically when the move message dialog box is active. This ensures that the form can be submitted without reloading the page, while other key presses are ignored.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ x] Explains differences from previous plans (e.g., issue description).
- [ x] Highlights technical choices and bugs encountered.
- [ x] Calls out remaining decisions and concerns.
- [ x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x] Each commit is a coherent idea.
- [ x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x ] Visual appearance of the changes.
- [ x] Responsiveness and internationalization.
- [ x] Strings and tooltips.
- [ x] End-to-end functionality of buttons, interactions and flows.
- [ x] Corner cases, error conditions, and easily imagined bugs.
</details>
