### PR TITLE
onboarding: Modify content on onboarding messages.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -291,21 +291,18 @@ or even move a topic [to a different channel]({move_content_another_channel_help
         )
 
         content2_of_moving_messages_topic_name = _("""
-:point_right: Try moving this message to another topic and back!
+:point_right: Try moving this message to another topic and back.
 """)
 
-        content1_of_welcome_to_zulip_topic_name = _("""
-Zulip is organized to help you communicate more efficiently.
-""")
-
-        content2_of_welcome_to_zulip_topic_name = remove_single_newlines(
+        content1_of_welcome_to_zulip_topic_name = remove_single_newlines(
             (
                 _("""
-In Zulip, **channels** determine who gets a message.
+Zulip is organized to help you communicate more efficiently. Conversations are
+labeled with topics, which summarize what the conversation is about.
 
-Each conversation in a channel is labeled with a **topic**.  This message is in
-the #**{zulip_discussion_channel_name}** channel, in the "{topic_name}" topic, as you can
-see in the left sidebar and above.
+For example, this message is in the “{topic_name}” topic in the
+#**{zulip_discussion_channel_name}** channel, as you can see in the left sidebar
+and above.
 """)
             ).format(
                 zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
@@ -313,25 +310,24 @@ see in the left sidebar and above.
             )
         )
 
-        content3_of_welcome_to_zulip_topic_name = remove_single_newlines(
+        content2_of_welcome_to_zulip_topic_name = remove_single_newlines(
             _("""
 You can read Zulip one conversation at a time, seeing each message in context,
 no matter how many other conversations are going on.
 """)
         )
 
-        content4_of_welcome_to_zulip_topic_name = remove_single_newlines(
+        content3_of_welcome_to_zulip_topic_name = remove_single_newlines(
             _("""
 :point_right: When you're ready, check out your [Inbox](/#inbox) for other
-conversations with unread messages. You can come back to this conversation
-if you need to from your **Starred** messages.
+conversations with unread messages.
 """)
         )
 
         content1_of_start_conversation_topic_name = remove_single_newlines(
             _("""
 To kick off a new conversation, click **Start new conversation** below.
-The new conversation thread won’t interrupt ongoing discussions.
+The new conversation thread will be labeled with its own topic.
 """)
         )
 
@@ -369,11 +365,11 @@ Link to a conversation: #**{zulip_discussion_channel_name}>{topic_name}**
         )
 
         content1_of_greetings_topic_name = _("""
-This **greetings** topic is a great place to say "hi" :wave: to your teammates.
+This **greetings** topic is a great place to say “hi” :wave: to your teammates.
 """)
 
         content2_of_greetings_topic_name = _("""
-:point_right:  Click on any message to start a reply in the same topic.
+:point_right: Click on this message to start a new message in the same conversation.
 """)
 
         content_of_zulip_update_announcements_topic_name = remove_single_newlines(
@@ -424,6 +420,17 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
         ]
     ]
 
+    # Suggestion to test messaging features.
+    # Dependency on knowing how to send messages.
+    welcome_messages += [
+        {
+            "channel_name": str(realm.ZULIP_SANDBOX_CHANNEL_NAME),
+            "topic_name": _("experiments"),
+            "content": content,
+        }
+        for content in [content1_of_experiments_topic_name, content2_of_experiments_topic_name]
+    ]
+
     # Suggestion to start your first new conversation.
     welcome_messages += [
         {
@@ -436,17 +443,6 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             content2_of_start_conversation_topic_name,
             content3_of_start_conversation_topic_name,
         ]
-    ]
-
-    # Suggestion to test messaging features.
-    # Dependency on knowing how to send messages.
-    welcome_messages += [
-        {
-            "channel_name": str(realm.ZULIP_SANDBOX_CHANNEL_NAME),
-            "topic_name": _("experiments"),
-            "content": content,
-        }
-        for content in [content1_of_experiments_topic_name, content2_of_experiments_topic_name]
     ]
 
     # Suggestion to send first message as a hi to your team.
@@ -470,7 +466,6 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             content1_of_welcome_to_zulip_topic_name,
             content2_of_welcome_to_zulip_topic_name,
             content3_of_welcome_to_zulip_topic_name,
-            content4_of_welcome_to_zulip_topic_name,
         ]
     ]
 
@@ -494,7 +489,7 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
     # This is a bit hacky, but works and is kinda a 1-off thing.
     greetings_message = (
         Message.objects.select_for_update()
-        .filter(id__in=message_ids, content__icontains='a great place to say "hi"')
+        .filter(id__in=message_ids, content__icontains="a great place to say “hi”")
         .first()
     )
     assert greetings_message is not None


### PR DESCRIPTION
- Tighten up the content.
- Use pretty quotes.
- Reorder "experiments" topic to appear after "start a conversation in Inbox.
- Drop reference to messages being starred (not implemented yet). **[bug fix]**

<details>
<summary>
Screenshots: messages in streams
</summary>

![Screenshot 2024-05-10 at 15 14 05@2x](https://github.com/zulip/zulip/assets/2090066/7e77088a-0399-4e5d-96ba-8c991ce9f1eb)
![Screenshot 2024-05-10 at 15 14 19@2x](https://github.com/zulip/zulip/assets/2090066/1c7677c9-b4bb-40bd-8bce-96cce34ed983)
![Screenshot 2024-05-10 at 15 16 08@2x](https://github.com/zulip/zulip/assets/2090066/552d5ce1-1421-48f5-a200-62d4eb7aba91)


</details>

<details>
<summary>
Screenshot: Recent conversations
</summary>

![Screenshot 2024-05-10 at 15 21 49@2x](https://github.com/zulip/zulip/assets/2090066/981aea7d-939e-4c04-b9a9-a5fa9fe1b63d)


</details>

<details>
<summary>
Screenshot: Inbox
</summary>

![Screenshot 2024-05-10 at 15 23 05@2x](https://github.com/zulip/zulip/assets/2090066/9c5a3ed2-05bd-45bf-b856-87f80743a7ca)


</details>

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/onboarding.20messages/near/1797520)