### PR TITLE
Improve pages when there is no organization or it has been deactivated

### DIFF
--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -16,23 +16,33 @@
         <div class="inline-block">
 
             <div class="get-started">
-                <h1>{{ _("Deactivated organization") }}</h1>
+                {% if deactivated_redirect %}
+                    <h1>{{ _("Organization moved") }}</h1>
+                {% else %}
+                    <h1>{{ _("Deactivated organization") }}</h1>
+                {% endif %}
             </div>
 
             <div class="white-box deactivated-realm-container">
                 <p>
-                    {% trans %}
-                    The organization you are trying to join, {{ deactivated_domain_name }}, has been deactivated.
-                    {% endtrans %}
                     {% if deactivated_redirect %}
                         {% trans %}
-                        It has moved to <a href="{{ deactivated_redirect }}">{{ deactivated_redirect }}</a>.
+                        This organization has moved to <a href="{{ deactivated_redirect }}">{{ deactivated_redirect }}</a>.
                         {% endtrans %}
+                    {% else %}
+                        {% trans %}
+                        This organization has been deactivated.
+                        {% endtrans %}
+                        {% if is_self_hosting_management_page %}
+                            {% trans %}
+                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a> to reactivate it.
+                            {% endtrans %}
+                        {% else %}
+                            {% trans %}
+                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact Zulip support</a> to reactivate it.
+                            {% endtrans %}
+                        {% endif %}
                     {% endif %}
-                    {% trans %}
-                    Please contact <a href="mailto:{{ support_email }}">{{ support_email }}</a> to reactivate
-                    this group.
-                    {% endtrans %}
                 </p>
             </div>
 

--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -1,21 +1,27 @@
 {% extends "zerver/portico.html" %}
 
 {% block title %}
-<title>{{ _("Organization does not exist") }} | Zulip</title>
+<title>{{ _("No organization found") }} | Zulip</title>
 {% endblock %}
 
 {% block portico_content %}
 
-<div class="app find-account-page flex full-page">
+<div class="app find-account-page flex full-page account-creation">
     <div class="inline-block new-style">
         <div class="lead">
-            <h1 class="get-started">{{ _('Organization does not exist') }}…</h1>
+            <h1 class="get-started">{{ _('No organization found') }}</h1>
         </div>
 
         <div class="app-main white-box">
-            {{ _('Hi there! Thank you for your interest in Zulip.') }}
-            <br />
-            {% trans %}There is no Zulip organization hosted at this subdomain.{% endtrans %}
+            <p>
+                {% trans %}There is no Zulip organization at <b>{{ current_url }}</b>.{% endtrans %}
+                <br />
+                {% if is_self_hosting_management_page %}
+                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
+                {% else %}
+                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact Zulip support</a>.{% endtrans %}
+                {% endif %}
+            </p>
         </div>
     </div>
 </div>

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -569,7 +569,10 @@ class HostDomainMiddleware(MiddlewareMixin):
                 # organizations even if it does not host a realm.
                 return None
 
-            return render(request, "zerver/invalid_realm.html", status=404)
+            context = {
+                "current_url": request.get_host(),
+            }
+            return render(request, "zerver/invalid_realm.html", status=404, context=context)
 
         set_tag("realm", request_notes.realm.string_id)
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1220,7 +1220,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
     def test_user_cannot_log_into_nonexisting_realm(self) -> None:
         account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
         result = self.social_auth_test(account_data_dict, subdomain="nonexistent")
-        self.assert_in_response("There is no Zulip organization hosted at this subdomain.", result)
+        self.assert_in_response("There is no Zulip organization at", result)
         self.assertEqual(result.status_code, 404)
 
     def test_user_cannot_log_into_wrong_subdomain(self) -> None:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1568,9 +1568,7 @@ class TestRequestNotes(ZulipTestCase):
         with mock.patch("zerver.views.home.zulip_login_required") as mock_home_real:
             result = self.client_get("/", subdomain="invalid")
             self.assertEqual(result.status_code, 404)
-            self.assert_in_response(
-                "There is no Zulip organization hosted at this subdomain.", result
-            )
+            self.assert_in_response("There is no Zulip organization at", result)
             mock_home_real.assert_not_called()
 
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -516,7 +516,7 @@ class PlansPageTest(ZulipTestCase):
         non_existent_domain = "moo"
         result = self.client_get("/plans/", subdomain=non_existent_domain)
         self.assertEqual(result.status_code, 404)
-        self.assert_in_response("does not exist", result)
+        self.assert_in_response("There is no Zulip organization at", result)
 
         realm = get_realm("zulip")
         realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -169,7 +169,7 @@ class DeactivationNoticeTestCase(ZulipTestCase):
 
         result = self.client_get("/login/", follow=True)
         self.assertEqual(result.redirect_chain[-1], ("/accounts/deactivated/", 302))
-        self.assertIn("Zulip Dev, has been deactivated.", result.content.decode())
+        self.assertIn("This organization has been deactivated.", result.content.decode())
         self.assertNotIn("It has moved to", result.content.decode())
 
     def test_deactivation_notice_when_deactivated_and_deactivated_redirect_is_set(self) -> None:
@@ -180,7 +180,7 @@ class DeactivationNoticeTestCase(ZulipTestCase):
 
         result = self.client_get("/login/", follow=True)
         self.assertIn(
-            'It has moved to <a href="http://example.zulipchat.com">http://example.zulipchat.com</a>.',
+            'This organization has moved to <a href="http://example.zulipchat.com">http://example.zulipchat.com</a>.',
             result.content.decode(),
         )
 
@@ -190,7 +190,7 @@ class DeactivationNoticeTestCase(ZulipTestCase):
 
         result = self.client_get("/login/", follow=True)
         self.assertIn(
-            'It has moved to <a href="http://new-subdomain-name.testserver">http://new-subdomain-name.testserver</a>.',
+            'This organization has moved to <a href="http://new-subdomain-name.testserver">http://new-subdomain-name.testserver</a>.',
             result.content.decode(),
         )
 
@@ -215,7 +215,7 @@ class DeactivationNoticeTestCase(ZulipTestCase):
 
         result = self.client_get("/login/", follow=True)
         self.assertIn(
-            'It has moved to <a href="http://new-name-1.testserver">http://new-name-1.testserver</a>.',
+            'This organization has moved to <a href="http://new-name-1.testserver">http://new-name-1.testserver</a>.',
             result.content.decode(),
         )
 
@@ -223,7 +223,7 @@ class DeactivationNoticeTestCase(ZulipTestCase):
         do_change_realm_subdomain(realm, "new-name-2", acting_user=None)
         result = self.client_get("/login/", follow=True)
         self.assertIn(
-            'It has moved to <a href="http://new-name-2.testserver">http://new-name-2.testserver</a>.',
+            'This organization has moved to <a href="http://new-name-2.testserver">http://new-name-2.testserver</a>.',
             result.content.decode(),
         )
 
@@ -660,7 +660,8 @@ class PasswordResetTest(ZulipTestCase):
 
         # check the redirect link telling you to check mail for password reset link
         self.assertEqual(result.status_code, 404)
-        self.assert_in_response("There is no Zulip organization hosted at this subdomain.", result)
+        self.assert_in_response("There is no Zulip organization at", result)
+        self.assert_in_response("Please try a different URL", result)
 
         from django.core.mail import outbox
 
@@ -899,7 +900,8 @@ class LoginTest(ZulipTestCase):
     def test_login_invalid_subdomain(self) -> None:
         result = self.login_with_return(self.example_email("hamlet"), "xxx", subdomain="invalid")
         self.assertEqual(result.status_code, 404)
-        self.assert_in_response("There is no Zulip organization hosted at this subdomain.", result)
+        self.assert_in_response("There is no Zulip organization at", result)
+        self.assert_in_response("Please try a different URL", result)
         self.assert_logged_in_user_id(None)
 
     def test_register(self) -> None:

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -160,7 +160,10 @@ def home(request: HttpRequest) -> HttpResponse:
         return redirect(reverse("remote_billing_legacy_server_login"))
     realm = get_realm_from_request(request)
     if realm is None:
-        return render(request, "zerver/invalid_realm.html", status=404)
+        context = {
+            "current_url": request.get_host(),
+        }
+        return render(request, "zerver/invalid_realm.html", status=404, context=context)
     if realm.allow_web_public_streams_access():
         return web_public_view(home_real)(request)
     return zulip_login_required(home_real)(request)


### PR DESCRIPTION
This ended up being more tangly than I expected, so I'm putting up this WIP PR, which will require some work to complete.

## No organization 

<details>
<summary>
PR screenshot
</summary>

![Screenshot 2024-05-10 at 16 15 58@2x](https://github.com/zulip/zulip/assets/2090066/87a3d0bb-344e-4886-a038-865b04e69910)

</details>

**To do:**

- [x] Fill in the URL (e.g., "something.zuplichat.com")
- [x] For self-hosted organizations, "contact Zulip support" -> "contact this Zulip server's administrators".
- [x] Fix the CSS so that it looks like the deactivated organization page.

## Deactivated organization

<details>
<summary>
PR screenshot
</summary>

![Screenshot 2024-05-10 at 16 20 02@2x](https://github.com/zulip/zulip/assets/2090066/f540708f-8130-4c60-a9ba-e0aac54b3aa2)

</details>

**To do:**

- [x] Split the moved organization content into a separate template, so that it can have its own title ("Organization moved"). (Edit: Added an if condition to do it in the same template)
- [x] For self-hosted organizations, "contact Zulip support" -> "contact this Zulip server's administrators".


