### PR TITLE
recent_view: Complete TODO to use first unmuted unread message id.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -475,7 +475,11 @@ export function activate(raw_terms, opts) {
         // This needs to be called at the same time as updating the
         // current message list so that we don't need to think about
         // bugs related to the URL fragment/hash being desynced from
-        // mesasge_lists.current.
+        // message_lists.current.
+        //
+        // It's fine for the hash change to happen anytime before updating
+        // the current message list as we are trying to emulate the `hashchange`
+        // workflow we have which calls `narrow.activate` after hash is updated.
         if (opts.change_hash) {
             update_hash_to_match_filter(filter, opts.trigger);
         }

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -86,11 +86,11 @@ export function changehash(newhash, trigger) {
     browser_history.set_hash(newhash);
 }
 
-export function save_narrow(terms, trigger) {
+export function update_hash_to_match_filter(filter, trigger) {
     if (browser_history.state.changing_hash && trigger !== "retarget message location") {
         return;
     }
-    const new_hash = hash_util.search_terms_to_hash(terms);
+    const new_hash = hash_util.search_terms_to_hash(filter.terms());
     changehash(new_hash, trigger);
 }
 
@@ -477,7 +477,7 @@ export function activate(raw_terms, opts) {
         // bugs related to the URL fragment/hash being desynced from
         // mesasge_lists.current.
         if (opts.change_hash) {
-            save_narrow(terms, opts.trigger);
+            update_hash_to_match_filter(filter, opts.trigger);
         }
 
         // Show the new set of messages. It is important to set message_lists.current to

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1632,7 +1632,7 @@ export function initialize({
     on_click_participant: (avatar_element: Element, participant_user_id: number) => void;
     on_mark_pm_as_read: (user_ids_string: string) => void;
     on_mark_topic_as_read: (stream_id: number, topic: string) => void;
-    maybe_load_older_messages: () => void;
+    maybe_load_older_messages: (first_unread_unmuted_message_id: number) => void;
 }): void {
     load_filters();
 
@@ -1813,7 +1813,7 @@ export function initialize({
             $(".recent-view-load-more-container .fetch-messages-button .loading-indicator"),
             {width: 20},
         );
-        maybe_load_older_messages();
+        maybe_load_older_messages(unread.first_unread_unmuted_message_id);
     });
 
     $(document).on("compose_canceled.zulip", () => {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -733,17 +733,14 @@ export function initialize_everything(state_data) {
         },
         on_mark_pm_as_read: unread_ops.mark_pm_as_read,
         on_mark_topic_as_read: unread_ops.mark_topic_as_read,
-        maybe_load_older_messages() {
+        maybe_load_older_messages(first_unread_message_id) {
             recent_view_ui.set_backfill_in_progress(true);
             message_fetch.maybe_load_older_messages({
                 msg_list_data: all_messages_data,
                 recent_view: true,
                 // To have a hard anchor on our target of first unread message id,
                 // we pass it from here, otherwise it might get updated and lead to confusion.
-                //
-                // TODO: Ideally, muted unread messages would not
-                // count for this purpose.
-                first_unread_message_id: unread.get_all_msg_ids()[0],
+                first_unread_message_id,
             });
         },
     });

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -369,13 +369,13 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     helper.assert_events([[ui_util, "blur_active_element"]]);
 });
 
-run_test("save_narrow", ({override, override_rewire}) => {
+run_test("update_hash_to_match_filter", ({override, override_rewire}) => {
     const helper = test_helper({override, override_rewire});
 
     let terms = [{operator: "is", operand: "dm"}];
 
     blueslip.expect("error", "browser does not support pushState");
-    narrow.save_narrow(terms);
+    narrow.update_hash_to_match_filter(new Filter(terms));
 
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(window.location.hash, "#narrow/is/dm");
@@ -388,7 +388,7 @@ run_test("save_narrow", ({override, override_rewire}) => {
     terms = [{operator: "is", operand: "starred"}];
 
     helper.clear_events();
-    narrow.save_narrow(terms);
+    narrow.update_hash_to_match_filter(new Filter(terms));
     helper.assert_events([[message_viewport, "stop_auto_scrolling"]]);
     assert.equal(url_pushed, "http://zulip.zulipdev.com/#narrow/is/starred");
 });


### PR DESCRIPTION
We already had the data at initial request, so we just add some plumbing to make it available.

Followup to https://github.com/zulip/zulip/pull/30008#discussion_r1597265650