### PR TITLE
narrow: Fix combined feed selecting random messages on narrow.

### DIFF
--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -100,6 +100,14 @@ export class MessageListData {
         return this._all_items.at(-1);
     }
 
+    msg_id_in_fetched_range(msg_id: number): boolean {
+        if (this.empty()) {
+            return false;
+        }
+
+        return this.first().id <= msg_id && msg_id <= this.last()!.id;
+    }
+
     ids_greater_or_equal_than(my_id: number): number[] {
         const result = [];
 
@@ -284,13 +292,20 @@ export class MessageListData {
     }
 
     first_unread_message_id(): number | undefined {
+        // NOTE: This function returns the first unread that was fetched and is not
+        // necessarily the first unread for the narrow. There could be more unread messages.
+        // See https://github.com/zulip/zulip/pull/30008#discussion_r1597279862 for how
+        // ideas on how to possibly improve this.
+        // before `first_unread` calculated below that we haven't fetched yet.
         const first_unread = this._items.find((message) => unread.message_unread(message));
 
         if (first_unread) {
             return first_unread.id;
         }
 
-        // if no unread, return the bottom message
+        // If no unread, return the bottom message
+        // NOTE: This is only valid if we have found the latest message for the narrow as
+        // there could be more message that we haven't fetched yet.
         return this.last()?.id;
     }
 

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -102,9 +102,15 @@ function create_and_update_message_list(filter, id_info, opts) {
     // we need to add a `is_equal` function to `Filter` to compare the filters.
     let msg_list;
     let restore_rendered_list = false;
+    const is_combined_feed_global_view = filter.is_in_home();
     for (const list of message_lists.all_rendered_message_lists()) {
-        if (filter.is_in_home() && list.preserve_rendered_state) {
-            assert(list.data.filter.is_in_home());
+        if (is_combined_feed_global_view && list.data.filter.is_in_home()) {
+            if (opts.then_select_id > 0 && !list.msg_id_in_fetched_range(opts.then_select_id)) {
+                // We don't have the target message in the current rendered list.
+                // Read MessageList.should_preserve_current_rendered_state for details.
+                break;
+            }
+
             msg_list = list;
             restore_rendered_list = true;
             break;

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -26,6 +26,8 @@ import * as util from "./util";
 // for more details on how this system is designed.
 
 export let old_unreads_missing = false;
+// Note this doesn't handle the case of `old_unreads_missing` because
+// it is simpler and we as a client are not expected to.
 export let first_unread_unmuted_message_id = Number.POSITIVE_INFINITY;
 
 export function clear_old_unreads_missing(): void {


### PR DESCRIPTION
Opened for further discussion after https://github.com/zulip/zulip/pull/30008#discussion_r1597279862

https://github.com/zulip/zulip/pull/30008#discussion_r1597279862 still needs to be fixed.


https://chat.zulip.org/#narrow/stream/6-frontend/topic/fetching.20message.20history


Reproducer:

* Have some unreads in the Combined feed view.
* Scroll up and select a message that was not part of initial fetch.
* Reload.
* Go a another narrow.
* Come back to combined feed to find your at a random message. This message is actually last message of the current fetch of combined feed view which was returned via `first_unread_message_id`.

