### PR TITLE
onboarding: Modify content on onboarding messages.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -289,40 +289,34 @@ or even move a topic [to a different channel]({move_content_another_channel_help
         )
 
         content2_of_moving_messages_topic_name = _("""
-:point_right: Try moving this message to another topic and back!
+:point_right: Try moving this message to another topic and back.
 """)
 
         content1_of_welcome_to_zulip_topic_name = _("""
-Zulip is organized to help you communicate more efficiently.
-""")
+Zulip is organized to help you communicate more efficiently. Conversations are
+labeled with topics, which summarize what the conversation is about.
 
-        content2_of_welcome_to_zulip_topic_name = (
-            _("""
-In Zulip, **channels** determine who gets a message.
-
-Each conversation in a channel is labeled with a **topic**.  This message is in
-the #**{zulip_discussion_channel_name}** channel, in the "{topic_name}" topic, as you can
-see in the left sidebar and above.
-""")
-        ).format(
+For example, this message is in the “{topic_name}” topic in the
+#**{zulip_discussion_channel_name}** channel, as you can see in the left sidebar
+and above.
+""").format(
             zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
             topic_name=_("welcome to Zulip!"),
         )
 
-        content3_of_welcome_to_zulip_topic_name = _("""
+        content2_of_welcome_to_zulip_topic_name = _("""
 You can read Zulip one conversation at a time, seeing each message in context,
 no matter how many other conversations are going on.
 """)
 
-        content4_of_welcome_to_zulip_topic_name = _("""
+        content3_of_welcome_to_zulip_topic_name = _("""
 :point_right: When you're ready, check out your [Inbox](/#inbox) for other
-conversations with unread messages. You can come back to this conversation
-if you need to from your **Starred** messages.
+conversations with unread messages.
 """)
 
         content1_of_start_conversation_topic_name = _("""
 To kick off a new conversation, click **Start new conversation** below.
-The new conversation thread won’t interrupt ongoing discussions.
+The new conversation thread will be labeled with its own topic.
 """)
 
         content2_of_start_conversation_topic_name = _("""
@@ -359,11 +353,11 @@ Link to a conversation: #**{zulip_discussion_channel_name}>{topic_name}**
         )
 
         content1_of_greetings_topic_name = _("""
-This **greetings** topic is a great place to say "hi" :wave: to your teammates.
+This **greetings** topic is a great place to say “hi” :wave: to your teammates.
 """)
 
         content2_of_greetings_topic_name = _("""
-:point_right:  Click on any message to start a reply in the same topic.
+:point_right: Click on this message to start a new message in the same conversation.
 """)
 
         content_of_zulip_update_announcements_topic_name = (
@@ -412,6 +406,17 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
         ]
     ]
 
+    # Suggestion to test messaging features.
+    # Dependency on knowing how to send messages.
+    welcome_messages += [
+        {
+            "channel_name": str(realm.ZULIP_SANDBOX_CHANNEL_NAME),
+            "topic_name": _("experiments"),
+            "content": content,
+        }
+        for content in [content1_of_experiments_topic_name, content2_of_experiments_topic_name]
+    ]
+
     # Suggestion to start your first new conversation.
     welcome_messages += [
         {
@@ -424,17 +429,6 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             content2_of_start_conversation_topic_name,
             content3_of_start_conversation_topic_name,
         ]
-    ]
-
-    # Suggestion to test messaging features.
-    # Dependency on knowing how to send messages.
-    welcome_messages += [
-        {
-            "channel_name": str(realm.ZULIP_SANDBOX_CHANNEL_NAME),
-            "topic_name": _("experiments"),
-            "content": content,
-        }
-        for content in [content1_of_experiments_topic_name, content2_of_experiments_topic_name]
     ]
 
     # Suggestion to send first message as a hi to your team.
@@ -458,7 +452,6 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             content1_of_welcome_to_zulip_topic_name,
             content2_of_welcome_to_zulip_topic_name,
             content3_of_welcome_to_zulip_topic_name,
-            content4_of_welcome_to_zulip_topic_name,
         ]
     ]
 
@@ -482,7 +475,7 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
     # This is a bit hacky, but works and is kinda a 1-off thing.
     greetings_message = (
         Message.objects.select_for_update()
-        .filter(id__in=message_ids, content__icontains='a great place to say "hi"')
+        .filter(id__in=message_ids, content__icontains="a great place to say “hi”")
         .first()
     )
     assert greetings_message is not None

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -276,18 +276,16 @@ def send_initial_realm_messages(realm: Realm) -> None:
         #
         # remove_single_newlines needs to be called on any multiline
         # strings for them to render properly.
-        content1_of_moving_messages_topic_name = remove_single_newlines(
-            (
-                _("""
+        content1_of_moving_messages_topic_name = (
+            _("""
 If anything is out of place, it’s easy to [move messages]({move_content_another_topic_help_url}),
 [rename]({rename_topic_help_url}) and [split]({move_content_another_topic_help_url}) topics,
 or even move a topic [to a different channel]({move_content_another_channel_help_url}).
 """)
-            ).format(
-                move_content_another_topic_help_url="/help/move-content-to-another-topic",
-                rename_topic_help_url="/help/rename-a-topic",
-                move_content_another_channel_help_url="/help/move-content-to-another-channel",
-            )
+        ).format(
+            move_content_another_topic_help_url="/help/move-content-to-another-topic",
+            rename_topic_help_url="/help/rename-a-topic",
+            move_content_another_channel_help_url="/help/move-content-to-another-channel",
         )
 
         content2_of_moving_messages_topic_name = _("""
@@ -298,42 +296,34 @@ or even move a topic [to a different channel]({move_content_another_channel_help
 Zulip is organized to help you communicate more efficiently.
 """)
 
-        content2_of_welcome_to_zulip_topic_name = remove_single_newlines(
-            (
-                _("""
+        content2_of_welcome_to_zulip_topic_name = (
+            _("""
 In Zulip, **channels** determine who gets a message.
 
 Each conversation in a channel is labeled with a **topic**.  This message is in
 the #**{zulip_discussion_channel_name}** channel, in the "{topic_name}" topic, as you can
 see in the left sidebar and above.
 """)
-            ).format(
-                zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
-                topic_name=_("welcome to Zulip!"),
-            )
+        ).format(
+            zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
+            topic_name=_("welcome to Zulip!"),
         )
 
-        content3_of_welcome_to_zulip_topic_name = remove_single_newlines(
-            _("""
+        content3_of_welcome_to_zulip_topic_name = _("""
 You can read Zulip one conversation at a time, seeing each message in context,
 no matter how many other conversations are going on.
 """)
-        )
 
-        content4_of_welcome_to_zulip_topic_name = remove_single_newlines(
-            _("""
+        content4_of_welcome_to_zulip_topic_name = _("""
 :point_right: When you're ready, check out your [Inbox](/#inbox) for other
 conversations with unread messages. You can come back to this conversation
 if you need to from your **Starred** messages.
 """)
-        )
 
-        content1_of_start_conversation_topic_name = remove_single_newlines(
-            _("""
+        content1_of_start_conversation_topic_name = _("""
 To kick off a new conversation, click **Start new conversation** below.
 The new conversation thread won’t interrupt ongoing discussions.
 """)
-        )
 
         content2_of_start_conversation_topic_name = _("""
 For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”
@@ -376,9 +366,8 @@ This **greetings** topic is a great place to say "hi" :wave: to your teammates.
 :point_right:  Click on any message to start a reply in the same topic.
 """)
 
-        content_of_zulip_update_announcements_topic_name = remove_single_newlines(
-            (
-                _("""
+        content_of_zulip_update_announcements_topic_name = (
+            _("""
 Welcome! To help you learn about new features and configuration options,
 this topic will receive messages about important changes in Zulip.
 
@@ -387,10 +376,9 @@ You can read these update messages whenever it's convenient, or
 If your organization does not want to receive these announcements,
 they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             """)
-            ).format(
-                zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
-                mute_topic_help_url="/help/mute-a-topic",
-            )
+        ).format(
+            zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
+            mute_topic_help_url="/help/mute-a-topic",
         )
 
     welcome_messages: List[Dict[str, str]] = []
@@ -482,7 +470,7 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
             welcome_bot,
             message["channel_name"],
             message["topic_name"],
-            message["content"],
+            remove_single_newlines(message["content"]),
         )
         for message in welcome_messages
     ]

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1304,7 +1304,7 @@ class RealmCreationTest(ZulipTestCase):
         # Check welcome messages
         for stream_name, text, message_count in [
             (str(Realm.DEFAULT_NOTIFICATION_STREAM_NAME), "learn about new features", 3),
-            (str(Realm.ZULIP_SANDBOX_CHANNEL_NAME), "new conversation thread", 5),
+            (str(Realm.ZULIP_SANDBOX_CHANNEL_NAME), "Use this topic to try out", 5),
         ]:
             stream = get_stream(stream_name, realm)
             recipient = stream.recipient


### PR DESCRIPTION
#30056

* First commit: Adds a prep commit to avoid `remove_single_newlines` repetition.
* Second commit: #30056 
* Third commit: https://github.com/zulip/zulip/pull/30056#issuecomment-2105341642

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
