### PR TITLE
popovers: Simplify instructions for moving topics/messages

### DIFF
--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -4,8 +4,8 @@
 <form class="new-style" id="move_topic_form">
     {{#if only_topic_edit }}
     <p>{{t "Rename topic to:" }}</p>
-    {{else}}
-    <p>{{t "Select a channel below or change topic name." }}</p>
+    {{else if from_message_actions_popover}}
+    <p>{{t "Move messages to:" }}</p>
     {{/if}}
     <div class="topic_stream_edit_header">
         {{#unless only_topic_edit}}


### PR DESCRIPTION
Changed the `Select a channel below or change topic name.` instruction in `move topics/move messages` modal. 

1) On the `Move topic` modal, dropped the line
2) On the `Move messages` modal, replaced the line with `Move messages to:`

Fixes #30055

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
-- Instructions on `Move messages/topics` modal after and before changes --

*before changes*
![image](https://github.com/zulip/zulip/assets/94672267/78de11d7-856a-42aa-91e2-2698fcba8193)
![image](https://github.com/zulip/zulip/assets/94672267/a9df8f7c-973e-40c3-a3af-de89657f5a77)

*after changes *
![image](https://github.com/zulip/zulip/assets/94672267/9972826c-4eec-4f36-b6d7-cdb19b7d7aed)
![image](https://github.com/zulip/zulip/assets/94672267/a52e74ed-e3cf-48fd-a615-54e2d93e22b7)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
