### PR TITLE
Personal menu

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -14,7 +14,8 @@
         font-size: 17px;
         border: none;
         background-color: transparent;
-        color: hsl(0deg 0% 0%);
+/*      color: hsl(0deg 0% 0%);*/
+        color: hsl(0, 90%, 45%);
         opacity: 0.5;
         cursor: default;
 

--- a/web/templates/personal_menu.hbs
+++ b/web/templates/personal_menu.hbs
@@ -16,16 +16,6 @@
         </header>
         <section class="dropdown-menu-list-section personal-menu-actions" data-user-id="{{user_id}}">
             <ul class="popover-menu-outer-list">
-                {{#if user_time}}
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="text-item hidden-for-spectators popover-menu-inner-list-item">
-                            <i class="popover-menu-icon zulip-icon zulip-icon-clock"></i>
-                            {{#tr}}{user_time} local time{{/tr}}
-                        </li>
-                    </ul>
-                </li>
-                {{/if}}
                 <li class="popover-menu-outer-list-item">
                     <ul class="popover-menu-inner-list">
                         {{#if status_content_available}}

--- a/web/templates/personal_menu.hbs
+++ b/web/templates/personal_menu.hbs
@@ -16,6 +16,16 @@
         </header>
         <section class="dropdown-menu-list-section personal-menu-actions" data-user-id="{{user_id}}">
             <ul class="popover-menu-outer-list">
+                {{#if user_time}}
+                <li class="popover-menu-outer-list-item">
+                    <ul class="popover-menu-inner-list">
+                        <li class="text-item hidden-for-spectators popover-menu-inner-list-item">
+                            <i class="popover-menu-icon zulip-icon zulip-icon-clock"></i>
+                            {{#tr}}{user_time} local time{{/tr}}
+                        </li>
+                    </ul>
+                </li>
+                {{/if}}
                 <li class="popover-menu-outer-list-item">
                     <ul class="popover-menu-inner-list">
                         {{#if status_content_available}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Removing local time on the personal menu. Local time can still be found in the user card.

Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/30044

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
