### PR TITLE
onboarding: Fixes bugs from #29421.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -582,7 +582,8 @@ def do_create_user(
     if realm_creation:
         from zerver.lib.onboarding import send_initial_realm_messages
 
-        send_initial_realm_messages(realm)
+        with override_language(realm.default_language):
+            send_initial_realm_messages(realm)
 
     return user_profile
 

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -475,7 +475,9 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
     # This is a bit hacky, but works and is kinda a 1-off thing.
     greetings_message = (
         Message.objects.select_for_update()
-        .filter(id__in=message_ids, content__icontains="a great place to say “hi”")
+        .filter(
+            id__in=message_ids, content=remove_single_newlines(content1_of_greetings_topic_name)
+        )
         .first()
     )
     assert greetings_message is not None

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -271,28 +271,27 @@ def send_initial_realm_messages(realm: Realm) -> None:
     # at least one message.
     welcome_bot = get_system_bot(settings.WELCOME_BOT, realm.id)
 
-    with override_language(realm.default_language):
-        # Content is declared here to apply translation properly.
-        #
-        # remove_single_newlines needs to be called on any multiline
-        # strings for them to render properly.
-        content1_of_moving_messages_topic_name = (
-            _("""
+    # Content is declared here to apply translation properly.
+    #
+    # remove_single_newlines needs to be called on any multiline
+    # strings for them to render properly.
+    content1_of_moving_messages_topic_name = (
+        _("""
 If anything is out of place, it’s easy to [move messages]({move_content_another_topic_help_url}),
 [rename]({rename_topic_help_url}) and [split]({move_content_another_topic_help_url}) topics,
 or even move a topic [to a different channel]({move_content_another_channel_help_url}).
 """)
-        ).format(
-            move_content_another_topic_help_url="/help/move-content-to-another-topic",
-            rename_topic_help_url="/help/rename-a-topic",
-            move_content_another_channel_help_url="/help/move-content-to-another-channel",
-        )
+    ).format(
+        move_content_another_topic_help_url="/help/move-content-to-another-topic",
+        rename_topic_help_url="/help/rename-a-topic",
+        move_content_another_channel_help_url="/help/move-content-to-another-channel",
+    )
 
-        content2_of_moving_messages_topic_name = _("""
+    content2_of_moving_messages_topic_name = _("""
 :point_right: Try moving this message to another topic and back.
 """)
 
-        content1_of_welcome_to_zulip_topic_name = _("""
+    content1_of_welcome_to_zulip_topic_name = _("""
 Zulip is organized to help you communicate more efficiently. Conversations are
 labeled with topics, which summarize what the conversation is about.
 
@@ -300,41 +299,41 @@ For example, this message is in the “{topic_name}” topic in the
 #**{zulip_discussion_channel_name}** channel, as you can see in the left sidebar
 and above.
 """).format(
-            zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
-            topic_name=_("welcome to Zulip!"),
-        )
+        zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
+        topic_name=_("welcome to Zulip!"),
+    )
 
-        content2_of_welcome_to_zulip_topic_name = _("""
+    content2_of_welcome_to_zulip_topic_name = _("""
 You can read Zulip one conversation at a time, seeing each message in context,
 no matter how many other conversations are going on.
 """)
 
-        content3_of_welcome_to_zulip_topic_name = _("""
+    content3_of_welcome_to_zulip_topic_name = _("""
 :point_right: When you're ready, check out your [Inbox](/#inbox) for other
 conversations with unread messages.
 """)
 
-        content1_of_start_conversation_topic_name = _("""
+    content1_of_start_conversation_topic_name = _("""
 To kick off a new conversation, click **Start new conversation** below.
 The new conversation thread will be labeled with its own topic.
 """)
 
-        content2_of_start_conversation_topic_name = _("""
+    content2_of_start_conversation_topic_name = _("""
 For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”
 """)
 
-        content3_of_start_conversation_topic_name = _("""
+    content3_of_start_conversation_topic_name = _("""
 :point_right: Try starting a new conversation in this channel.
 """)
 
-        content1_of_experiments_topic_name = (
-            _("""
+    content1_of_experiments_topic_name = (
+        _("""
 :point_right:  Use this topic to try out [Zulip's messaging features]({format_message_help_url}).
 """)
-        ).format(format_message_help_url="/help/format-your-message-using-markdown")
+    ).format(format_message_help_url="/help/format-your-message-using-markdown")
 
-        content2_of_experiments_topic_name = (
-            _("""
+    content2_of_experiments_topic_name = (
+        _("""
 ```spoiler Want to see some examples?
 
 ````python
@@ -347,21 +346,21 @@ print("code blocks")
 Link to a conversation: #**{zulip_discussion_channel_name}>{topic_name}**
 ```
 """)
-        ).format(
-            zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
-            topic_name=_("welcome to Zulip!"),
-        )
+    ).format(
+        zulip_discussion_channel_name=str(Realm.ZULIP_DISCUSSION_CHANNEL_NAME),
+        topic_name=_("welcome to Zulip!"),
+    )
 
-        content1_of_greetings_topic_name = _("""
+    content1_of_greetings_topic_name = _("""
 This **greetings** topic is a great place to say “hi” :wave: to your teammates.
 """)
 
-        content2_of_greetings_topic_name = _("""
+    content2_of_greetings_topic_name = _("""
 :point_right: Click on this message to start a new message in the same conversation.
 """)
 
-        content_of_zulip_update_announcements_topic_name = (
-            _("""
+    content_of_zulip_update_announcements_topic_name = (
+        _("""
 Welcome! To help you learn about new features and configuration options,
 this topic will receive messages about important changes in Zulip.
 
@@ -369,11 +368,11 @@ You can read these update messages whenever it's convenient, or
 [mute]({mute_topic_help_url}) this topic if you are not interested.
 If your organization does not want to receive these announcements,
 they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
-            """)
-        ).format(
-            zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
-            mute_topic_help_url="/help/mute-a-topic",
-        )
+        """)
+    ).format(
+        zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
+        mute_topic_help_url="/help/mute-a-topic",
+    )
 
     welcome_messages: List[Dict[str, str]] = []
 


### PR DESCRIPTION
First commit: Third commit from #30063 somehow got dropped.
Second commit: https://github.com/zulip/zulip/pull/29421#issuecomment-2103382711
> I'm not convinced that the topics are being translated properly; they're computed outside the with override_language block. Do we want to just call send_initial_realm_messages inside a with override_language block in the caller, rather than indenting everything? Seems timely but not a blocker since none of these new strings are actually translated yet.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
