### PR TITLE
composebox_typeahead: Avoid generating broken links.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -1,0 +1,63 @@
+import assert from "minimalistic-assert";
+
+import * as internal_url from "../shared/src/internal_url";
+
+import * as stream_data from "./stream_data";
+
+const invalid_stream_topic_regex = /[*>`]|(\$\$)/g;
+
+export function will_produce_broken_stream_topic_link(word: string): boolean {
+    return invalid_stream_topic_regex.test(word);
+}
+
+function get_stream_name_from_topic_link_syntax(syntax: string): string {
+    const start = syntax.indexOf("#**");
+    const end = syntax.lastIndexOf(">");
+    return syntax.slice(start + 3, end);
+}
+
+export function escape_invalid_stream_topic_characters(text: string): string {
+    switch (text) {
+        case "`":
+            return "&grave;";
+        case ">":
+            return "&gt;";
+        case "*":
+            return "&#42;";
+        case "$$":
+            return "&#36;&#36;";
+        default:
+            return text;
+    }
+}
+
+export function html_escape_markdown_syntax_characters(text: string): string {
+    return text.replaceAll(invalid_stream_topic_regex, escape_invalid_stream_topic_characters);
+}
+
+export function get_fallback_markdown_link(stream_name: string, topic_name?: string): string {
+    const stream = stream_data.get_sub(stream_name);
+    const stream_id = stream?.stream_id;
+    assert(stream_id !== undefined);
+    const escape = html_escape_markdown_syntax_characters;
+    if (topic_name !== undefined) {
+        return `[#${escape(stream_name)}>${escape(topic_name)}](${internal_url.by_stream_topic_url(stream_id, topic_name, () => stream_name)})`;
+    }
+    return `[#${escape(stream_name)}](${internal_url.by_stream_url(stream_id, () => stream_name)})`;
+}
+
+export function get_stream_topic_link_syntax(
+    typed_syntax_text: string,
+    topic_name: string,
+): string {
+    const stream_name = get_stream_name_from_topic_link_syntax(typed_syntax_text);
+    // If the topic name is such that it will generate an invalid #**stream>topic** syntax,
+    // we revert to generating the normal markdown syntax for a link.
+    if (
+        will_produce_broken_stream_topic_link(topic_name) ||
+        will_produce_broken_stream_topic_link(stream_name)
+    ) {
+        return get_fallback_markdown_link(stream_name, topic_name);
+    }
+    return `#**${stream_name}>${topic_name}**`;
+}

--- a/web/tests/topic_link_util.test.js
+++ b/web/tests/topic_link_util.test.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+
+const topic_link_util = zrequire("topic_link_util");
+const stream_data = zrequire("stream_data");
+
+const sweden_stream = {
+    name: "Sweden",
+    description: "Cold, mountains and home decor.",
+    stream_id: 1,
+    subscribed: true,
+    type: "stream",
+};
+
+const denmark_stream = {
+    name: "Denmark",
+    description: "Vikings and boats, in a serene and cold weather.",
+    stream_id: 2,
+    subscribed: true,
+    type: "stream",
+};
+
+const dollar_stream = {
+    name: "$$MONEY$$",
+    description: "Money money money",
+    stream_id: 6,
+    subscribed: true,
+    type: "stream",
+};
+
+stream_data.add_sub(sweden_stream);
+stream_data.add_sub(denmark_stream);
+stream_data.add_sub(dollar_stream);
+
+run_test("stream_topic_link_syntax_test", () => {
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>", "topic"),
+        "#**Sweden>topic**",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>to", "topic"),
+        "#**Sweden>topic**",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "test `test` test"),
+        "[#Sweden>test &grave;test&grave; test](#narrow/stream/1-Sweden/topic/test.20.60test.60.20test)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Denmark>t", "test `test` test`s"),
+        "[#Denmark>test &grave;test&grave; test&grave;s](#narrow/stream/2-Denmark/topic/test.20.60test.60.20test.60s)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>typeah", "error due to *"),
+        "[#Sweden>error due to &#42;](#narrow/stream/1-Sweden/topic/error.20due.20to.20*)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "*asterisk"),
+        "[#Sweden>&#42;asterisk](#narrow/stream/1-Sweden/topic/*asterisk)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>gibberish", "greaterthan>"),
+        "[#Sweden>greaterthan&gt;](#narrow/stream/1-Sweden/topic/greaterthan.3E)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**$$MONEY$$>t", "dollar"),
+        "[#&#36;&#36;MONEY&#36;&#36;>dollar](#narrow/stream/6-.24.24MONEY.24.24/topic/dollar)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "swe$$dish"),
+        "[#Sweden>swe&#36;&#36;dish](#narrow/stream/1-Sweden/topic/swe.24.24dish)",
+    );
+    assert.equal(
+        topic_link_util.get_fallback_markdown_link("Sweden"),
+        "[#Sweden](#narrow/stream/1-Sweden)",
+    );
+
+    assert.equal(
+        topic_link_util.get_fallback_markdown_link("$$MONEY$$"),
+        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/stream/6-.24.24MONEY.24.24)",
+    );
+
+    // Only for full coverage of the module.
+    assert.equal(topic_link_util.escape_invalid_stream_topic_characters("Sweden"), "Sweden");
+});


### PR DESCRIPTION
The `#**stream>topic**` syntax generates broken links for topics containing two backticks or starting/ending with *, because of architectural flaws in the backend markdown processor. So we avoid generating the syntax for such topics and instead generate the normal link syntax in markdown.

Fixes #19873

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/broken.20topic.20link)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Screenshots and Screen Captures</summary>

![67C2DQnjcD](https://github.com/zulip/zulip/assets/88523649/1ee5146b-caf7-494f-9cb4-84ab6427a506)


![chrome_yORpX1Hnrn](https://github.com/zulip/zulip/assets/88523649/0c836072-a75a-45e3-8b67-3aef0742dcc0)



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
