### PR TITLE
typeahead: Make them look like dropdown widget.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -341,7 +341,7 @@ export class Typeahead<ItemType extends string | object> {
                 // and wraps it if it overflows the visible container.
                 maxWidth: "none",
                 delay: [0, 0],
-                theme: "popover-menu",
+                theme: "dropdown-widget",
                 placement: this.dropup ? "top-start" : "bottom-start",
                 popperOptions: {
                     strategy: "fixed",
@@ -373,7 +373,7 @@ export class Typeahead<ItemType extends string | object> {
                 // We expect the typeahead creator to handle when to hide / show the typeahead.
                 trigger: "manual",
                 arrow: false,
-                offset: [0, 0],
+                offset: [0, 2],
                 // We have event handlers to hide the typeahead, so we
                 // don't want tippy to hide it for us.
                 hideOnClick: false,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -628,10 +628,11 @@
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: hsl(0deg 0% 93%);
 
-    /* Dropdown constants */
+    /* Dropdown / Typeahead constants */
     --color-dropdown-item: hsl(0deg 0% 20%);
     --color-active-dropdown-item: hsl(0deg 0% 0%);
     --background-color-active-dropdown-item: hsl(220deg 12% 4.9% / 5%);
+    --background-color-active-typeahead-item: hsl(221.14deg 89.74% 92.35%);
 }
 
 %dark-theme {
@@ -981,10 +982,13 @@
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: hsl(211.58deg 33.33% 11.18%);
 
-    /* Dropdown constants */
+    /* Dropdown / Typeahead constants */
     --color-dropdown-item: hsl(0deg 0% 75%);
     --color-active-dropdown-item: hsl(0deg 0% 90%);
     --background-color-active-dropdown-item: hsl(220deg 12% 100% / 7%);
+    --background-color-active-typeahead-item: hsl(
+        226.35deg 82.53% 55.1% / 38.82%
+    );
 }
 
 @media screen {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -627,6 +627,11 @@
     --color-background-emoji-picker-emoji-reacted-focus: hsl(195deg 55% 88%);
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: hsl(0deg 0% 93%);
+
+    /* Dropdown constants */
+    --color-dropdown-item: hsl(0deg 0% 20%);
+    --color-active-dropdown-item: hsl(0deg 0% 0%);
+    --background-color-active-dropdown-item: hsl(220deg 12% 4.9% / 5%);
 }
 
 %dark-theme {
@@ -975,6 +980,11 @@
     --color-border-add-subscription-button-focus: hsl(0deg 0% 67%);
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: hsl(211.58deg 33.33% 11.18%);
+
+    /* Dropdown constants */
+    --color-dropdown-item: hsl(0deg 0% 75%);
+    --color-active-dropdown-item: hsl(0deg 0% 90%);
+    --background-color-active-dropdown-item: hsl(220deg 12% 100% / 7%);
 }
 
 @media screen {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1288,12 +1288,9 @@ textarea.new_message_textarea {
 }
 
 .typeahead.dropdown-menu {
-    background: hsl(0deg 0% 100%);
-
     .typeahead-menu {
         list-style: none;
-        margin: 0;
-        background-color: var(--color-background-popover);
+        margin: 4px 0;
     }
 
     .typeahead-header {
@@ -1307,6 +1304,7 @@ textarea.new_message_textarea {
     }
 
     #typeahead-header-text {
+        color: var(--color-dropdown-item);
         font-size: 12px;
     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1295,9 +1295,7 @@ textarea.new_message_textarea {
 
     .typeahead-header {
         margin: 0;
-        padding-left: 20px;
-        padding-right: 20px;
-        padding-top: 4px;
+        padding: 4px 10px;
         border-top: 1px solid hsl(0deg 0% 0% / 20%);
         display: flex;
         align-items: center;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -152,20 +152,6 @@
             0 2px 4px hsl(0deg 0% 0% / 20%);
     }
 
-    .dropdown-list-container .dropdown-list .list-item {
-        &:focus {
-            background-color: hsl(220deg 12% 95.1% / 5%);
-        }
-
-        & > a {
-            color: hsl(0deg 0% 75%);
-
-            &:hover {
-                background-color: hsl(220deg 12% 95.1% / 5%);
-            }
-        }
-    }
-
     #navbar-middle .column-middle-inner,
     .header,
     #message_view_header {
@@ -548,7 +534,6 @@
     }
 
     & div.overlay .flex.overlay-content > div,
-    .dropdown-menu.typeahead,
     #settings_page,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
@@ -904,8 +889,7 @@
         background-color: hsl(0deg 0% 0% / 20%);
     }
 
-    #feedback_container,
-    .typeahead.dropdown-menu {
+    #feedback_container {
         background-color: hsl(212deg 25% 15%);
         border-color: hsl(0deg 0% 0% / 50%);
         color: inherit;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -568,8 +568,12 @@
     width: 220px;
 }
 
-.recent-view-filter-dropdown-list-container .dropdown-list-item-common-styles,
-.inbox-filter-dropdown-list-container .dropdown-list-item-common-styles {
+.recent-view-filter-dropdown-list-container
+    .dropdown-list
+    .dropdown-list-item-common-styles,
+.inbox-filter-dropdown-list-container
+    .dropdown-list
+    .dropdown-list-item-common-styles {
     padding: 5px 10px;
     display: flex;
     flex-direction: column;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -795,7 +795,7 @@ strong {
    + https://github.com/zulip/zulip/commit/7a3a3be7e547d3e8f0ed00820835104867f2433d
    basic idea of this fix is to remove decorations from :hover and apply them only
    on :focus. */
-.typeahead-menu {
+.typeahead.dropdown-menu .typeahead-menu {
     & li {
         word-break: break-word;
 
@@ -805,7 +805,7 @@ strong {
             clear: both;
             font-weight: normal;
             line-height: 20px;
-            color: hsl(0deg 0% 20%);
+            color: var(--color-dropdown-item);
             white-space: nowrap;
 
             /* hidden text just to maintain line height for a blank option */
@@ -816,19 +816,10 @@ strong {
                 }
             }
 
-            &:hover {
-                text-decoration: none;
-            }
-
+            &:hover,
             &:focus {
-                color: hsl(0deg 0% 100%);
                 text-decoration: none;
-                background-color: hsl(200deg 100% 38%);
-                background-image: linear-gradient(
-                    to bottom,
-                    hsl(200deg 100% 40%),
-                    hsl(200deg 100% 35%)
-                );
+                outline: 0;
             }
 
             /* styles defined for user_circle here only deal with positioning of user_presence_circle
@@ -849,23 +840,12 @@ strong {
     }
 
     .active > a {
-        color: hsl(0deg 0% 100%);
-        text-decoration: none;
-        background-color: hsl(200deg 100% 38%);
-        background-image: linear-gradient(
-            to bottom,
-            hsl(200deg 100% 40%),
-            hsl(200deg 100% 35%)
-        );
-        outline: 0;
-
-        .user_circle_empty {
-            border-color: hsl(0deg 0% 25%);
+        &,
+        &:hover,
+        &:focus {
+            color: var(--color-active-dropdown-item);
+            background-color: var(--background-color-active-dropdown-item);
         }
-    }
-
-    .active > a:hover {
-        text-decoration: none;
     }
 }
 
@@ -1362,20 +1342,11 @@ div.focused-message-list {
 }
 
 .typeahead.dropdown-menu {
-    /* Use default color until some other typeahead overrides it. */
-    color: var(--color-text-default);
-
-    a {
-        color: inherit;
-
-        strong.typeahead-strong-section {
-            white-space: pre;
-        }
+    a strong.typeahead-strong-section {
+        white-space: pre;
     }
 
     .active {
-        color: hsl(0deg 0% 100%);
-
         .unsubscribed_icon {
             display: block;
             float: right;
@@ -2273,23 +2244,31 @@ body:not(.hide-left-sidebar) {
         .dropdown-list {
             list-style: none;
             margin: 0;
-
-            .list-item:focus {
-                background-color: hsl(220deg 12% 4.9% / 5%);
-                outline: none;
-            }
         }
+    }
 
-        .no-dropdown-items {
-            color: hsl(0deg 0% 60%);
-            display: none;
-        }
+    .no-dropdown-items {
+        color: hsl(0deg 0% 60%);
+        display: none;
+        padding: 3px 10px 3px 8px;
+        font-weight: 400;
+        line-height: 20px;
+        white-space: normal;
     }
 }
 
-.dropdown-list-container .dropdown-list-item-common-styles {
+.dropdown-list-container .list-item {
+    color: var(--color-dropdown-item);
+
+    &:focus {
+        background-color: var(--background-color-active-dropdown-item);
+        outline: none;
+    }
+}
+
+.dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
     display: block;
-    color: hsl(0deg 0% 20%);
+    color: var(--color-dropdown-item);
     padding: 3px 10px 3px 8px;
     font-weight: 400;
     line-height: 20px;
@@ -2302,13 +2281,11 @@ body:not(.hide-left-sidebar) {
         padding-right: 2px;
     }
 
+    &:focus,
     &:hover {
+        color: var(--color-dropdown-item);
         text-decoration: none;
-        background-color: hsl(220deg 12% 4.9% / 5%);
-    }
-
-    &:focus {
-        text-decoration: none;
+        background-color: var(--background-color-active-dropdown-item);
         outline: none;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -800,9 +800,9 @@ strong {
         word-break: break-word;
 
         & a {
-            display: block;
-            padding: 3px 20px;
-            clear: both;
+            display: flex;
+            padding: 3px 10px;
+            gap: 5px;
             font-weight: normal;
             line-height: 20px;
             color: var(--color-dropdown-item);
@@ -829,12 +829,18 @@ strong {
             .user_circle {
                 width: var(--length-user-status-circle);
                 height: var(--length-user-status-circle);
-                margin: 0 5px 0 -6px;
                 position: relative;
-                float: left;
-                top: 6px;
-                right: 8px;
-                display: inline-block;
+                left: -2px;
+                flex-shrink: 0;
+                align-self: center;
+            }
+
+            .typeahead-text-container {
+                align-self: center;
+
+                & > * {
+                    margin-right: 3px;
+                }
             }
         }
     }
@@ -1366,11 +1372,6 @@ div.focused-message-list {
     display: inline-block;
     height: 21px;
     width: 21px;
-    position: relative;
-    margin-top: -4px;
-    vertical-align: middle;
-    top: 2px;
-    right: 8px;
     border-radius: 4px;
 
     /* For FontAwesome icons and zulip icons used in place of images for some users. */
@@ -1382,8 +1383,7 @@ div.focused-message-list {
     }
 
     &.no-presence-circle {
-        margin-left: 9px;
-        top: 3px;
+        margin-left: 14px;
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -850,7 +850,7 @@ strong {
         &:hover,
         &:focus {
             color: var(--color-active-dropdown-item);
-            background-color: var(--background-color-active-dropdown-item);
+            background-color: var(--background-color-active-typeahead-item);
         }
     }
 }

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -4,7 +4,6 @@
     {{else}}
         <span class='emoji emoji-{{ emoji_code }}'></span>
     {{/if}}
-    &nbsp;&nbsp;
 {{else if is_person}}
     {{#if user_circle_class}}
     <span class="{{user_circle_class}} user_circle"></span>
@@ -17,30 +16,31 @@
 {{else if is_user_group}}
     <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>
 {{/if}}
-<strong class="typeahead-strong-section">
-    {{~#if stream}}
-        {{> inline_decorated_stream_name stream=stream }}
-    {{else}}
-        {{~ primary ~}}
+{{!-- Separate container to ensure overflowing text remains in this container. --}}
+<div class="typeahead-text-container">
+    <strong class="typeahead-strong-section">
+        {{~#if stream}}
+            {{> inline_decorated_stream_name stream=stream }}
+        {{else}}
+            {{~ primary ~}}
+        {{/if}}
+    </strong>
+    {{~#if has_pronouns}}
+        <span class="pronouns">({{pronouns}})</span>
+    {{~/if}}
+    {{~#if should_add_guest_user_indicator}}
+        <i>({{t 'guest'}})</i>
+    {{~/if}}
+    {{~#if has_status}}
+    {{> status_emoji status_emoji_info}}
+    {{~/if}}
+    {{~#if has_secondary}}
+    <small class="autocomplete_secondary">
+        {{~ secondary ~}}
+    </small>
+    {{#if is_unsubscribed}}
+    <span class="fa fa-exclamation-triangle unsubscribed_icon"
+      title="{{t 'You are not currently subscribed to this channel.' }}"></span>
     {{/if}}
-</strong>
-{{~#if has_pronouns}}
-    <span class="pronouns">({{pronouns}})</span>
-{{~/if}}
-{{~#if should_add_guest_user_indicator}}
-    <i>({{t 'guest'}})</i>
-{{~/if}}
-{{~#if has_status}}
-{{> status_emoji status_emoji_info}}
-{{~/if}}
-{{~#if has_secondary}}
-&nbsp;&nbsp;
-<small class="autocomplete_secondary">
-    {{~ secondary ~}}
-</small>
-{{#if is_unsubscribed}}
-&nbsp;
-<span class="fa fa-exclamation-triangle unsubscribed_icon"
-  title="{{t 'You are not currently subscribed to this channel.' }}"></span>
-{{/if}}
-{{~/if}}
+    {{~/if}}
+</div>

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -894,18 +894,24 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 // options.highlighter_html()
                 options.query = "Kro";
                 actual_value = options.highlighter_html("kronor");
-                expected_value = '<strong class="typeahead-strong-section">kronor</strong>';
+                expected_value =
+                    '<div class="typeahead-text-container">\n' +
+                    '    <strong class="typeahead-strong-section">kronor    </strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 // Highlighted content should be escaped.
                 options.query = "<";
                 actual_value = options.highlighter_html("<&>");
-                expected_value = '<strong class="typeahead-strong-section">&lt;&amp;&gt;</strong>';
+                expected_value =
+                    '<div class="typeahead-text-container">\n' +
+                    '    <strong class="typeahead-strong-section">&lt;&amp;&gt;    </strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
                 actual_value = options.highlighter_html("even more ice");
-                expected_value = '<strong class="typeahead-strong-section">even more ice</strong>';
+                expected_value =
+                    '<div class="typeahead-text-container">\n' +
+                    '    <strong class="typeahead-strong-section">even more ice    </strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 // options.sorter()
@@ -1129,8 +1135,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 expected_value =
                     `    <span class="user_circle_empty user_circle"></span>\n` +
                     `    <img class="typeahead-image" src="http://zulip.zulipdev.com/avatar/${othello.user_id}?s&#x3D;50" />\n` +
-                    `<strong class="typeahead-strong-section">Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
-                    `<small class="autocomplete_secondary">othello@zulip.com</small>\n`;
+                    '<div class="typeahead-text-container">\n' +
+                    '    <strong class="typeahead-strong-section">Othello, the Moor of Venice    </strong>    <small class="autocomplete_secondary">othello@zulip.com</small>\n' +
+                    "</div>\n";
                 assert.equal(actual_value, expected_value);
                 // Reset the email such that this does not affect further tests.
                 othello.delivery_email = null;
@@ -1139,7 +1146,10 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ct.get_or_set_token_for_testing("hamletcharacters");
                 actual_value = options.highlighter_html(hamletcharacters);
                 expected_value =
-                    '    <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>\n<strong class="typeahead-strong-section">hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+                    '    <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>\n' +
+                    '<div class="typeahead-text-container">\n' +
+                    '    <strong class="typeahead-strong-section">hamletcharacters    </strong>    <small class="autocomplete_secondary">Characters of Hamlet</small>\n' +
+                    "</div>\n";
                 assert.equal(actual_value, expected_value);
 
                 // matching

--- a/web/third/bootstrap-typeahead/typeahead.css
+++ b/web/third/bootstrap-typeahead/typeahead.css
@@ -1,68 +1,8 @@
 /* CSS for Bootstrap typeahead */
 
 .dropdown-menu {
-  display: none;
-  padding: 5px 0;
   min-width: 160px;
   list-style: none;
-  background-color: #ffffff;
-  -webkit-background-clip: padding-box;
-  -moz-background-clip: padding;
-  background-clip: padding-box;
-}
-.dropdown-menu .divider {
-  height: 1px;
-  margin: 9px 1px;
-  overflow: hidden;
-  background-color: #e5e5e5;
-  border-bottom: 1px solid #ffffff;
-}
-.dropdown-menu > li > a {
-  display: block;
-  padding: 3px 20px;
-  clear: both;
-  font-weight: normal;
-  line-height: 20px;
-  color: #333333;
-  white-space: nowrap;
-}
-.dropdown-menu > li > a:hover,
-.dropdown-menu > li > a:focus {
-  text-decoration: none;
-  color: #ffffff;
-  background-color: #0081c2;
-  background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -o-linear-gradient(top, #0088cc, #0077b3);
-  background-image: linear-gradient(to bottom, #0088cc, #0077b3);
-  background-repeat: repeat-x;
-}
-.dropdown-menu > .active > a,
-.dropdown-menu > .active > a:hover,
-.dropdown-menu > .active > a:focus {
-  color: #ffffff;
-  text-decoration: none;
-  outline: 0;
-  background-color: #0081c2;
-  background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -o-linear-gradient(top, #0088cc, #0077b3);
-  background-image: linear-gradient(to bottom, #0088cc, #0077b3);
-  background-repeat: repeat-x;
-}
-.dropdown-menu > .disabled > a,
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  color: #999999;
-}
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  text-decoration: none;
-  background-color: transparent;
-  background-image: none;
-  cursor: default;
 }
 .open > .dropdown-menu {
   display: block;


### PR DESCRIPTION
This attempts to change background color and text color of typeaheads to be same as dropdown widgets we have in the app.

`active` typeahead color was taken from https://terpimost.github.io/compose-decomposed/

Related issue - #25116

This PR is to help us get the colors we want for the typeaheads, then we can do some of the much needed cleanup work in this space.


Here is a list of all typeaheads:

* Compose box textarea with various triggers - `@`,`#`, `/`, ....
<img width="680" alt="Screenshot 2024-05-13 at 4 01 15 PM" src="https://github.com/zulip/zulip/assets/25124304/befc11cf-fb1b-4507-9bf3-e70bd65973d5">
<img width="680" alt="Screenshot 2024-05-13 at 4 01 27 PM" src="https://github.com/zulip/zulip/assets/25124304/33693825-63f9-4d97-8711-358d8d5c3ecd">
<img width="943" alt="Screenshot 2024-05-13 at 4 08 54 PM" src="https://github.com/zulip/zulip/assets/25124304/947aa262-e3fb-4771-9cb5-d332123baa42">
<img width="943" alt="Screenshot 2024-05-13 at 4 09 26 PM" src="https://github.com/zulip/zulip/assets/25124304/9a4f5047-4f0d-455d-b319-3b2892d9e83a">
<img width="943" alt="Screenshot 2024-05-13 at 4 09 33 PM" src="https://github.com/zulip/zulip/assets/25124304/b7ff01e9-7c86-4249-a46b-e7beeafe69e3">



* Compose box topic / DM
<img width="943" alt="Screenshot 2024-05-13 at 4 02 22 PM" src="https://github.com/zulip/zulip/assets/25124304/11b7209d-069c-4e02-a515-43cb7e2179ae">
<img width="943" alt="Screenshot 2024-05-13 at 4 02 39 PM" src="https://github.com/zulip/zulip/assets/25124304/913a533a-89ae-493f-8be1-dbbd8d0c5a74">
<img width="943" alt="Screenshot 2024-05-13 at 4 09 33 PM" src="https://github.com/zulip/zulip/assets/25124304/74bdbac9-ff21-4ca9-abcd-36b2d8e44491">
<img width="943" alt="Screenshot 2024-05-13 at 4 09 26 PM" src="https://github.com/zulip/zulip/assets/25124304/a7d25f41-2301-4cb6-bce6-0ec54616326f">



* Message edit box
<img width="943" alt="Screenshot 2024-05-13 at 4 04 23 PM" src="https://github.com/zulip/zulip/assets/25124304/2c9a58a6-b6f0-494f-97ac-632d2afeb6f1">
<img width="943" alt="Screenshot 2024-05-13 at 4 08 13 PM" src="https://github.com/zulip/zulip/assets/25124304/cafa453a-6452-4512-b000-89891579e86e">


* Search (No change)

* Playground settings > Language - http://localhost:9991/#organization/playground-settings
<img width="943" alt="Screenshot 2024-05-13 at 4 05 27 PM" src="https://github.com/zulip/zulip/assets/25124304/38ae0d94-3ae6-4f97-8424-2f26a6e5ba14">

<img width="943" alt="Screenshot 2024-05-13 at 4 06 51 PM" src="https://github.com/zulip/zulip/assets/25124304/af7c6ea0-c03f-404a-86c1-9e705df07e85">


* Profile > Mentor - http://localhost:9991/#settings/profile
<img width="943" alt="Screenshot 2024-05-13 at 4 06 20 PM" src="https://github.com/zulip/zulip/assets/25124304/201db2ba-a881-4516-92c9-fb45499507fe">
<img width="943" alt="Screenshot 2024-05-13 at 4 07 04 PM" src="https://github.com/zulip/zulip/assets/25124304/17617a83-3a89-4572-889d-25a989db5749">


* Stream settings > Add subscribers - http://localhost:9991/#channels/21/Denmark/subscribers
<img width="943" alt="Screenshot 2024-05-13 at 4 05 55 PM" src="https://github.com/zulip/zulip/assets/25124304/835cb9b1-bc35-4ba7-b54c-ede98516b48c">

<img width="338" alt="Screenshot 2024-05-13 at 4 07 51 PM" src="https://github.com/zulip/zulip/assets/25124304/d7a1a097-d898-49a0-8f1b-8ca8aa159d69">
