### PR TITLE
api_docs: Make events collapsible in API documentation.

### DIFF
--- a/web/src/bundles/portico.ts
+++ b/web/src/bundles/portico.ts
@@ -1,4 +1,5 @@
 import "./common";
+import "../portico/events_api_docs";
 import "../portico/header";
 import "../portico/google-analytics";
 import "../portico/portico_modals";

--- a/web/src/portico/events_api_docs.js
+++ b/web/src/portico/events_api_docs.js
@@ -1,0 +1,12 @@
+import $ from "jquery";
+
+$(() => {
+    $(".event-heading").on("click", (e) => {
+        const $events_content = $(e.currentTarget).siblings(".event-content");
+        var $icon = $(e.currentTarget).find(".event-dropdown-icon");
+        if ($events_content.length) {
+            $icon.toggleClass("fa-chevron-down fa-chevron-up");
+            $events_content.slideToggle(250);
+        }
+    })
+})

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1404,6 +1404,36 @@ label.label-title {
     }
 }
 
+.event-heading {
+    display: grid;
+    grid-template-columns: 98% auto;
+    justify-content: space-between;
+    border-radius: 5px;
+    background-color: rgb(211 210 210 / 71%);
+    padding: 5px 10px;
+    margin: 15px 0 5px;
+}
+
+.event-heading:hover {
+    background-color: rgba(211, 210, 210, 0.893);
+}
+
+.event-name {
+    margin: 7px 0 5px !important;
+}
+
+.event-dropdown-icon {
+    margin-top: 12px;
+}
+
+.event-content {
+    display: none;
+}
+
+.line {
+    width: 100%;
+}
+
 .api-field-type {
     color: hsl(176deg 46.4% 41%);
 }

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -195,8 +195,8 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
         # Use argument section design for better visuals
         # Directly using `###` for subheading causes errors so use h3 with made up id.
         argument_template = (
-            '<div class="api-argument"><p class="api-argument-name"><h3 id="{h3_id}">'
-            "{event_type} {op}</h3></p></div> \n{description}\n\n\n"
+            '<div markdown="1"><div class="event-heading"><div class="api-argument"><p class="api-argument-name"><h3 id="{h3_id}" class="event-name">'
+            '{event_type} {op}</h3></p></div><i class="fa fa-chevron-down event-dropdown-icon"></i></div> \n{description}\n\n\n'
         )
         for events in events_dict["oneOf"]:
             event_type: Dict[str, Any] = events["properties"]["type"]
@@ -216,6 +216,7 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                     event_type=event_type_str, op=op_str, description=description, h3_id=h3_id
                 )
             )
+            text += [f'<div markdown="1" class="event-content" id="{h3_id}">\n']
             text += self.render_table(events["properties"], 0)
             # This part is for adding examples of individual events
             text.append("**Example**")
@@ -223,6 +224,8 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             example = json.dumps(events["example"], indent=4, sort_keys=True)
             text.append(example)
             text.append("```\n\n")
+            text.append("</div>")
+            text.append('<hr class="line"></div>')
         return text
 
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR intends to complete the work started in #19595. It changes the UI of  API documentation to make the documentation of events collapsible.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
