### PR TITLE
Fix `escape` key not working to close compose edit state.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -185,7 +185,7 @@ export function initialize() {
         assert(message_lists.current !== undefined);
         message_lists.current.select_id(id);
 
-        if (message_edit.is_editing(id)) {
+        if (message_edit.currently_editing_messages.has(id)) {
             // Clicks on a message being edited shouldn't trigger a reply.
             return;
         }

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -103,8 +103,6 @@ export function initialize() {
     const update_compose_max_height = new ResizeObserver(resize.reset_compose_message_max_height);
     update_compose_max_height.observe(document.querySelector("#compose"));
 
-    upload.feature_check($("#compose .compose_upload_file"));
-
     function get_input_info(event) {
         const $edit_banners_container = $(event.target).closest(".edit_form_banners");
         const is_edit_input = Boolean($edit_banners_container.length);

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -46,7 +46,7 @@ export function toggle_message_actions_menu(message) {
         return true;
     }
 
-    if (message.locally_echoed || message_edit.is_editing(message.id)) {
+    if (message.locally_echoed || message_edit.currently_editing_messages.has(message.id)) {
         // Don't open the popup for locally echoed messages for now.
         // It creates bugs with things like keyboard handlers when
         // we get the server response.

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -50,7 +50,7 @@ import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
 
-const currently_editing_messages = new Map();
+export const currently_editing_messages = new Map();
 let currently_deleting_messages = [];
 let currently_topic_editing_messages = [];
 const currently_echoing_messages = new Map();
@@ -789,10 +789,6 @@ export function start_inline_topic_edit($recipient_row) {
     );
 }
 
-export function is_editing(id) {
-    return currently_editing_messages.has(id);
-}
-
 export function end_inline_topic_edit($row) {
     assert(message_lists.current !== undefined);
     message_lists.current.hide_edit_topic_on_recipient_row($row);
@@ -1088,7 +1084,7 @@ export function save_message_row_edit($row) {
                     });
 
                     $row = message_lists.current.get_row(message_id);
-                    if (!is_editing(message_id)) {
+                    if (!currently_editing_messages.has(message_id)) {
                         // Return to the message editing open UI state with the edited content.
                         start_edit_maintaining_scroll($row, echo_data.raw_content);
                     }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -453,7 +453,7 @@ function edit_message($row, raw_content) {
     const max_file_upload_size = realm.max_file_upload_size_mib;
     let file_upload_enabled = false;
 
-    if (max_file_upload_size > 0) {
+    if (max_file_upload_size > 0 && upload.feature_check()) {
         file_upload_enabled = true;
     }
 
@@ -483,7 +483,6 @@ function edit_message($row, raw_content) {
     $form
         .find(".message-edit-feature-group .audio_link")
         .toggle(compose_call.compute_show_audio_chat_button());
-    upload.feature_check($(`#edit_form_${CSS.escape(rows.id($row))} .compose_upload_file`));
 
     const $message_edit_content = $row.find("textarea.message_edit_content");
     const $message_edit_countdown_timer = $row.find(".message_edit_countdown_timer");

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -392,14 +392,16 @@ export class MessageList {
         this.rerender();
     }
 
-    show_edit_message($row, edit_obj) {
+    show_edit_message($row, $form) {
         if ($row.find(".message_edit_form form").length !== 0) {
             return;
         }
-        $row.find(".message_edit_form").append(edit_obj.$form);
+        $row.find(".message_edit_form").append($form);
         $row.find(".message_content, .status-message, .message_controls").hide();
         $row.find(".messagebox-content").addClass("content_edit_mode");
         $row.find(".message_edit").css("display", "block");
+        // autosize will not change the height of the textarea if the `$row` is not
+        // rendered in DOM yet. So, we call `autosize.update` post render.
         autosize($row.find(".message_edit_content"));
     }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1365,7 +1365,7 @@ export class MessageListView {
 
         // If this list not currently displayed, we don't need to select the message.
         if (was_selected && this.list === message_lists.current) {
-            this.list.reselect_selected_id(message_container.msg.id);
+            this.list.reselect_selected_id();
         }
     }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1,3 +1,4 @@
+import autosize from "autosize";
 import $ from "jquery";
 import _ from "lodash";
 
@@ -978,6 +979,9 @@ export class MessageListView {
             this.$list.append($rendered_groups);
             condense.condense_and_collapse($dom_messages);
         }
+
+        // After all the messages are rendered, resize any message edit textarea if required.
+        autosize.update(this.$list.find(".message_edit_content"));
 
         restore_scroll_position();
 

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -54,6 +54,10 @@ export function watch_manual_resize(element: string): (() => void)[] | undefined
         return undefined;
     }
 
+    return watch_manual_resize_for_element(box);
+}
+
+export function watch_manual_resize_for_element(box: Element): (() => void)[] {
     let height: number;
     let mousedown = false;
 
@@ -71,7 +75,7 @@ export function watch_manual_resize(element: string): (() => void)[] | undefined
             mousedown = false;
             if (height !== box.clientHeight) {
                 height = box.clientHeight;
-                autosize.destroy($(element)).height(height + "px");
+                autosize.destroy($(box)).height(height + "px");
             }
         }
     };

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -176,7 +176,7 @@ function initialize_compose_box() {
         $(
             render_compose({
                 embedded: $("#compose").attr("data-embedded") === "",
-                file_upload_enabled: realm.max_file_upload_size_mib > 0,
+                file_upload_enabled: realm.max_file_upload_size_mib > 0 && upload.feature_check(),
                 giphy_enabled: giphy.is_giphy_enabled(),
                 max_stream_name_length: realm.max_stream_name_length,
                 max_topic_length: realm.max_topic_length,

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -26,11 +26,9 @@ export function compose_upload_cancel() {
     compose_upload_object.cancelAll();
 }
 
-// Show the upload button only if the browser supports it.
-export function feature_check($upload_button) {
-    if (window.XMLHttpRequest && new window.XMLHttpRequest().upload) {
-        $upload_button.removeClass("notdisplayed");
-    }
+export function feature_check() {
+    // Show the upload button only if the browser supports it.
+    return window.XMLHttpRequest && new window.XMLHttpRequest().upload;
 }
 
 export function get_translated_status(file) {

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -8,7 +8,7 @@
     </div>
     {{#if file_upload_enabled }}
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Upload files' }}">
-        <a role="button" class="compose_control_button compose_upload_file zulip-icon zulip-icon-attachment notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0></a>
+        <a role="button" class="compose_control_button compose_upload_file zulip-icon zulip-icon-attachment" aria-label="{{t 'Upload files' }}" tabindex=0></a>
     </div>
     {{/if}}
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add video call' }}">

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -123,7 +123,6 @@ function test_ui(label, f) {
 function initialize_handlers({override}) {
     override(realm, "realm_available_video_chat_providers", {disabled: {id: 0}});
     override(realm, "realm_video_chat_provider", 0);
-    override(upload, "feature_check", noop);
     override(resize, "watch_manual_resize", noop);
     compose_setup.initialize();
 }
@@ -510,7 +509,6 @@ test_ui("initialize", ({override}) => {
     override(upload, "compose_upload_cancel", () => {
         uppy_cancel_all_called = true;
     });
-    override(upload, "feature_check", noop);
 
     compose_setup.initialize();
 

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -4,14 +4,13 @@ const {strict: assert} = require("assert");
 
 const events = require("./lib/events");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
-const {run_test, noop} = require("./lib/test");
+const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 const channel = mock_esm("../src/channel");
 const compose_closed_ui = mock_esm("../src/compose_closed_ui");
 const compose_ui = mock_esm("../src/compose_ui");
-const upload = mock_esm("../src/upload");
 mock_esm("../src/resize", {
     watch_manual_resize() {},
 });
@@ -69,8 +68,6 @@ function test(label, f) {
 
 test("videos", ({override}) => {
     realm.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
-
-    override(upload, "feature_check", noop);
 
     stub_out_video_calls();
 
@@ -245,26 +242,20 @@ test("videos", ({override}) => {
     })();
 });
 
-test("test_video_chat_button_toggle disabled", ({override}) => {
-    override(upload, "feature_check", noop);
-
+test("test_video_chat_button_toggle disabled", () => {
     realm.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle no url", ({override}) => {
-    override(upload, "feature_check", noop);
-
+test("test_video_chat_button_toggle no url", () => {
     realm.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle enabled", ({override}) => {
-    override(upload, "feature_check", noop);
-
+test("test_video_chat_button_toggle enabled", () => {
     realm.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     realm.realm_jitsi_server_url = "https://meet.jit.si";
     compose_setup.initialize();

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -40,14 +40,10 @@ function test(label, f) {
 }
 
 test("feature_check", ({override}) => {
-    const $upload_button = $.create("upload-button-stub");
-    $upload_button.addClass("notdisplayed");
-    upload.feature_check($upload_button);
-    assert.ok($upload_button.hasClass("notdisplayed"));
+    assert.ok(!upload.feature_check());
 
     override(window, "XMLHttpRequest", () => ({upload: true}));
-    upload.feature_check($upload_button);
-    assert.ok(!$upload_button.hasClass("notdisplayed"));
+    assert.ok(upload.feature_check());
 });
 
 test("get_item", () => {


### PR DESCRIPTION
This was due to event handlers being lost when restoring a message edit state. To avoid it, we recreate the form and attach event handlers to it which also correctly update the current state of the edit form buttons based on settings.

Just edit a message -> go to a different narrow -> click browser back button -> focus on the edit form and try to press escape (it doesn't work)


discussion: https://github.com/zulip/zulip/pull/29383#discussion_r1546776263