### PR TITLE
onboarding: Don't send zulip update message during new realm creation.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -359,21 +359,6 @@ This **greetings** topic is a great place to say “hi” :wave: to your teammat
 :point_right: Click on this message to start a new message in the same conversation.
 """)
 
-    content_of_zulip_update_announcements_topic_name = (
-        _("""
-Welcome! To help you learn about new features and configuration options,
-this topic will receive messages about important changes in Zulip.
-
-You can read these update messages whenever it's convenient, or
-[mute]({mute_topic_help_url}) this topic if you are not interested.
-If your organization does not want to receive these announcements,
-they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
-        """)
-    ).format(
-        zulip_update_announcements_help_url="/help/configure-automated-notices#zulip-update-announcements",
-        mute_topic_help_url="/help/mute-a-topic",
-    )
-
     welcome_messages: List[Dict[str, str]] = []
 
     # Messages added to the "welcome messages" list last will be most
@@ -382,15 +367,6 @@ they can be disabled. [Learn more]({zulip_update_announcements_help_url}).
     # which are sorted newest-first.
     #
     # Initial messages are configured below.
-
-    # Zulip updates system advertisement.
-    welcome_messages += [
-        {
-            "channel_name": str(Realm.DEFAULT_NOTIFICATION_STREAM_NAME),
-            "topic_name": str(Realm.ZULIP_UPDATE_ANNOUNCEMENTS_TOPIC_NAME),
-            "content": content_of_zulip_update_announcements_topic_name,
-        },
-    ]
 
     # Advertising moving messages.
     welcome_messages += [

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1305,7 +1305,7 @@ class RealmCreationTest(ZulipTestCase):
 
         # Check welcome messages
         for stream_name, text, message_count in [
-            (str(Realm.DEFAULT_NOTIFICATION_STREAM_NAME), "learn about new features", 3),
+            (str(Realm.DEFAULT_NOTIFICATION_STREAM_NAME), "a great place to say “hi”", 2),
             (str(Realm.ZULIP_SANDBOX_CHANNEL_NAME), "Use this topic to try out", 5),
         ]:
             stream = get_stream(stream_name, realm)

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -122,9 +122,10 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
                 recipient__type_id=verona.id,
                 date_sent__gte=now + timedelta(days=10),
             ).order_by("id")
-            self.assert_length(stream_messages, 2)
-            self.assertEqual(stream_messages[0].content, "Announcement message 3.")
-            self.assertEqual(stream_messages[1].content, "Announcement message 4.")
+            self.assert_length(stream_messages, 3)
+            self.assertIn("To help you learn about new features", stream_messages[0].content)
+            self.assertEqual(stream_messages[1].content, "Announcement message 3.")
+            self.assertEqual(stream_messages[2].content, "Announcement message 4.")
             self.assertEqual(realm.zulip_update_announcements_level, 4)
 
     def test_send_zulip_update_announcements_with_stream_configured(self) -> None:


### PR DESCRIPTION
To help users focus on the onboarding experience, we no longer send the introductory "Zulip updates" message as a part of onboarding.

Now, we send the introductory message just before the first update message.

Fixes: #30053.

We diverted a bit from what the issue suggests after discussion -- [CZO Discussion
](https://chat.zulip.org/#narrow/stream/101-design/topic/New.20feature.20notification.20system.20.2328604/near/1799805)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-05-15 10-32-18](https://github.com/zulip/zulip/assets/56781761/f4b9b8f9-4272-447c-8ff9-1a4a22371194)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
