### PR TITLE
settings_components: Split functions to improve type checking.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1012,13 +1012,10 @@ export function populate_data_for_request(
     return data;
 }
 
-function switching_to_private(
-    properties_elements: HTMLElement[],
-    for_realm_default_settings: boolean,
-): boolean {
+function switching_to_private(properties_elements: HTMLElement[]): boolean {
     for (const elem of properties_elements) {
         const $elem = $(elem);
-        const property_name = extract_property_name($elem, for_realm_default_settings);
+        const property_name = extract_property_name($elem);
         if (property_name !== "stream_privacy") {
             continue;
         }
@@ -1056,7 +1053,7 @@ export function save_discard_widget_status_handler(
         button_state === "unsaved" &&
         !sub.invite_only &&
         !sub.subscribed &&
-        switching_to_private(properties_elements, for_realm_default_settings)
+        switching_to_private(properties_elements)
     ) {
         if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
             return;

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -97,63 +97,9 @@ type StreamSettingProperties = keyof StreamSubscription | "stream_privacy" | "is
 
 type valueof<T> = T[keyof T];
 
-export function get_property_value(
-    property_name:
-        | RealmSettingProperties
-        | StreamSettingProperties
-        | keyof UserGroup
-        | keyof CustomProfileField
-        | RealmUserSettingDefaultProperties,
-    for_realm_default_settings?: boolean,
-    sub?: StreamSubscription,
-    group?: UserGroup,
-    custom_profile_field?: CustomProfileField,
-):
-    | valueof<RealmSetting>
-    | valueof<StreamSubscription>
-    | valueof<UserGroup>
-    | valueof<CustomProfileField>
-    | valueof<RealmUserSettingDefaultType> {
-    if (for_realm_default_settings) {
-        // realm_user_default_settings are stored in a separate object.
-        if (property_name === "twenty_four_hour_time") {
-            return JSON.stringify(realm_user_settings_defaults.twenty_four_hour_time);
-        }
-        if (
-            property_name === "email_notifications_batching_period_seconds" ||
-            property_name === "email_notification_batching_period_edit_minutes"
-        ) {
-            return realm_user_settings_defaults.email_notifications_batching_period_seconds;
-        }
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        return realm_user_settings_defaults[property_name as keyof RealmUserSettingDefaultType];
-    }
-
-    if (sub) {
-        if (property_name === "stream_privacy") {
-            return stream_data.get_stream_privacy_policy(sub.stream_id);
-        }
-        if (property_name === "is_default_stream") {
-            return stream_data.is_default_stream_id(sub.stream_id);
-        }
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        return sub[property_name as keyof StreamSubscription];
-    }
-
-    if (group) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        return group[property_name as keyof UserGroup];
-    }
-
-    if (custom_profile_field) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const value = custom_profile_field[property_name as keyof CustomProfileField];
-        if (property_name === "display_in_profile_summary" && value === undefined) {
-            return false;
-        }
-        return value;
-    }
-
+export function get_realm_settings_property_value(
+    property_name: RealmSettingProperties,
+): valueof<RealmSetting> {
     if (property_name === "realm_org_join_restrictions") {
         if (realm.realm_emails_restricted_to_domains) {
             return "only_selected_domain";
@@ -167,9 +113,53 @@ export function get_property_value(
     if (property_name === "realm_authentication_methods") {
         return JSON.stringify(realm_authentication_methods_to_boolean_dict());
     }
+    return realm[property_name];
+}
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return realm[property_name as keyof RealmSetting] as valueof<RealmSetting>;
+export function get_stream_settings_property_value(
+    property_name: StreamSettingProperties,
+    sub: StreamSubscription,
+): valueof<StreamSubscription> {
+    if (property_name === "stream_privacy") {
+        return stream_data.get_stream_privacy_policy(sub.stream_id);
+    }
+    if (property_name === "is_default_stream") {
+        return stream_data.is_default_stream_id(sub.stream_id);
+    }
+    return sub[property_name];
+}
+
+export function get_group_property_value(
+    property_name: keyof UserGroup,
+    group: UserGroup,
+): valueof<UserGroup> {
+    return group[property_name];
+}
+
+export function get_custom_profile_property_value(
+    property_name: keyof CustomProfileField,
+    custom_profile_field: CustomProfileField,
+): valueof<CustomProfileField> {
+    const value = custom_profile_field[property_name];
+    if (property_name === "display_in_profile_summary" && value === undefined) {
+        return false;
+    }
+    return value;
+}
+
+export function get_realm_default_setting_property_value(
+    property_name: RealmUserSettingDefaultProperties,
+): valueof<RealmUserSettingDefaultType> {
+    if (property_name === "twenty_four_hour_time") {
+        return JSON.stringify(realm_user_settings_defaults.twenty_four_hour_time);
+    }
+    if (
+        property_name === "email_notifications_batching_period_seconds" ||
+        property_name === "email_notification_batching_period_edit_minutes"
+    ) {
+        return realm_user_settings_defaults.email_notifications_batching_period_seconds;
+    }
+    return realm_user_settings_defaults[property_name];
 }
 
 export function realm_authentication_methods_to_boolean_dict(): Record<string, boolean> {
@@ -235,7 +225,7 @@ export function set_property_dropdown_value(
     property_name: keyof simple_dropdown_realm_settings,
 ): void {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const property_value = get_property_value(
+    const property_value = get_realm_settings_property_value(
         property_name,
     ) as valueof<simple_dropdown_realm_settings>;
     $(`#id_${CSS.escape(property_name)}`).val(property_value);
@@ -820,36 +810,13 @@ function get_time_limit_setting_value(
     return parse_time_limit($custom_input_elem);
 }
 
-type setting_property_type =
-    | RealmSettingProperties
-    | StreamSettingProperties
-    | keyof UserGroup
-    | keyof CustomProfileField
-    | RealmUserSettingDefaultProperties;
-
-export function check_property_changed(
-    elem: HTMLElement,
-    for_realm_default_settings: boolean,
-    sub: StreamSubscription | undefined,
-    group: UserGroup | undefined,
-    custom_profile_field: CustomProfileField | undefined,
-): boolean {
+export function check_realm_settings_property_changed(elem: HTMLElement): boolean {
     const $elem = $(elem);
+
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const property_name = extract_property_name(
-        $elem,
-        for_realm_default_settings,
-    ) as setting_property_type;
-    const current_val = get_property_value(
-        property_name,
-        for_realm_default_settings,
-        sub,
-        group,
-        custom_profile_field,
-    );
-
+    const property_name = extract_property_name($elem) as RealmSettingProperties;
+    const current_val = get_realm_settings_property_value(property_name);
     let proposed_val;
-
     switch (property_name) {
         case "realm_authentication_methods":
             proposed_val = get_input_element_value(elem, "auth-methods");
@@ -858,13 +825,10 @@ export function check_property_changed(
         case "realm_signup_announcements_stream_id":
         case "realm_zulip_update_announcements_stream_id":
         case "realm_default_code_block_language":
-        case "can_remove_subscribers_group":
         case "realm_create_multiuse_invite_group":
-        case "can_mention_group":
         case "realm_can_access_all_users_group":
             proposed_val = get_dropdown_list_widget_setting_value($elem);
             break;
-        case "email_notifications_batching_period_seconds":
         case "realm_message_content_edit_limit_seconds":
         case "realm_message_content_delete_limit_seconds":
         case "realm_move_messages_between_streams_limit_seconds":
@@ -874,7 +838,6 @@ export function check_property_changed(
             proposed_val = get_time_limit_setting_value($(elem), false);
             break;
         case "realm_message_retention_days":
-        case "message_retention_days":
             assert(elem instanceof HTMLSelectElement);
             proposed_val = get_message_retention_setting_value($(elem), false);
             break;
@@ -887,13 +850,99 @@ export function check_property_changed(
                 "#org-notifications .language_selection_widget .language_selection_button span",
             ).attr("data-language-code");
             break;
-        case "emojiset":
-        case "user_list_style":
+        default:
+            if (current_val !== undefined) {
+                proposed_val = get_input_element_value(elem, typeof current_val);
+            } else {
+                blueslip.error("Element refers to unknown property", {property_name});
+            }
+    }
+    return current_val !== proposed_val;
+}
+
+export function check_stream_settings_property_changed(
+    elem: HTMLElement,
+    sub: StreamSubscription,
+): boolean {
+    const $elem = $(elem);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const property_name = extract_property_name($elem) as StreamSettingProperties;
+    const current_val = get_stream_settings_property_value(property_name, sub);
+    let proposed_val;
+    switch (property_name) {
+        case "can_remove_subscribers_group":
+            proposed_val = get_dropdown_list_widget_setting_value($elem);
+            break;
+        case "message_retention_days":
+            assert(elem instanceof HTMLSelectElement);
+            proposed_val = get_message_retention_setting_value($(elem), false);
+            break;
         case "stream_privacy":
             proposed_val = get_input_element_value(elem, "radio-group");
             break;
-        case "field_data":
-            proposed_val = get_input_element_value(elem, "field-data-setting");
+        default:
+            if (current_val !== undefined) {
+                proposed_val = get_input_element_value(elem, typeof current_val);
+            } else {
+                blueslip.error("Element refers to unknown property", {property_name});
+            }
+    }
+    return current_val !== proposed_val;
+}
+
+export function check_group_property_changed(elem: HTMLElement, group: UserGroup): boolean {
+    const $elem = $(elem);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const property_name = extract_property_name($elem) as keyof UserGroup;
+    const current_val = get_group_property_value(property_name, group);
+    let proposed_val;
+    switch (property_name) {
+        case "can_mention_group":
+            proposed_val = get_dropdown_list_widget_setting_value($elem);
+            break;
+        default:
+            if (current_val !== undefined) {
+                proposed_val = get_input_element_value(elem, typeof current_val);
+            } else {
+                blueslip.error("Element refers to unknown property", {property_name});
+            }
+    }
+    return current_val !== proposed_val;
+}
+
+export function check_custom_profile_property_changed(
+    elem: HTMLElement,
+    custom_profile_field: CustomProfileField,
+): boolean {
+    const $elem = $(elem);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const property_name = extract_property_name($elem) as keyof CustomProfileField;
+    const current_val = get_custom_profile_property_value(property_name, custom_profile_field);
+    let proposed_val;
+    if (property_name === "field_data") {
+        proposed_val = get_input_element_value(elem, "field-data-setting");
+    } else if (current_val !== undefined) {
+        proposed_val = get_input_element_value(elem, typeof current_val);
+    } else {
+        blueslip.error("Element refers to unknown property", {property_name});
+    }
+    return current_val !== proposed_val;
+}
+
+export function check_realm_default_settings_property_changed(elem: HTMLElement): boolean {
+    const $elem = $(elem);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const property_name = extract_property_name($elem, true) as RealmUserSettingDefaultProperties;
+    const current_val = get_realm_default_setting_property_value(property_name);
+    let proposed_val;
+    switch (property_name) {
+        case "emojiset":
+        case "user_list_style":
+            proposed_val = get_input_element_value(elem, "radio-group");
+            break;
+        case "email_notifications_batching_period_seconds":
+            assert(elem instanceof HTMLSelectElement);
+            proposed_val = get_time_limit_setting_value($(elem), false);
             break;
         default:
             if (current_val !== undefined) {
@@ -931,37 +980,18 @@ function get_request_data_for_org_join_restrictions(selected_val: string): {
     }
 }
 
-export function populate_data_for_request(
+export function populate_data_for_realm_settings_request(
     $subsection_elem: JQuery,
-    for_realm_default_settings: boolean,
-    sub: StreamSubscription | undefined,
-    group: UserGroup | undefined,
-    custom_profile_field?: CustomProfileField | undefined,
 ): Record<string, string | boolean | number> {
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
         const $input_elem = $(input_elem);
-        if (
-            check_property_changed(
-                input_elem,
-                for_realm_default_settings,
-                sub,
-                group,
-                custom_profile_field,
-            )
-        ) {
+        if (check_realm_settings_property_changed(input_elem)) {
             const input_value = get_input_element_value(input_elem);
             if (input_value !== undefined && input_value !== null) {
                 let property_name: string;
-                if (
-                    for_realm_default_settings ||
-                    sub !== undefined ||
-                    group !== undefined ||
-                    custom_profile_field !== undefined
-                ) {
-                    property_name = extract_property_name($input_elem, for_realm_default_settings);
-                } else if ($input_elem.attr("id")!.startsWith("id_authmethod")) {
+                if ($input_elem.attr("id")!.startsWith("id_authmethod")) {
                     // Authentication Method component IDs include authentication method name
                     // for uniqueness, anchored to "id_authmethod" prefix, e.g. "id_authmethodapple_<property_name>".
                     // We need to strip that whole construct down to extract the actual property name.
@@ -979,6 +1009,32 @@ export function populate_data_for_request(
                     property_name = match_array[1];
                 }
 
+                if (property_name === "org_join_restrictions") {
+                    data = {
+                        ...data,
+                        ...get_request_data_for_org_join_restrictions(input_value.toString()),
+                    };
+                    continue;
+                }
+                data[property_name] = input_value;
+            }
+        }
+    }
+    return data;
+}
+
+export function populate_data_for_stream_settings_request(
+    $subsection_elem: JQuery,
+    sub: StreamSubscription,
+): Record<string, string | boolean | number> {
+    let data: Record<string, string | boolean | number> = {};
+    const properties_elements = get_subsection_property_elements($subsection_elem);
+    for (const input_elem of properties_elements) {
+        const $input_elem = $(input_elem);
+        if (check_stream_settings_property_changed(input_elem, sub)) {
+            const input_value = get_input_element_value(input_elem);
+            if (input_value !== undefined && input_value !== null) {
+                const property_name = extract_property_name($input_elem);
                 if (property_name === "stream_privacy") {
                     data = {
                         ...data,
@@ -988,22 +1044,65 @@ export function populate_data_for_request(
                     };
                     continue;
                 }
+                data[property_name] = input_value;
+            }
+        }
+    }
+    return data;
+}
 
-                if (property_name === "can_mention_group") {
-                    data[property_name] = JSON.stringify({
-                        new: input_value,
-                        old: group!.can_mention_group,
-                    });
-                    continue;
-                }
+export function populate_data_for_group_request(
+    $subsection_elem: JQuery,
+    group: UserGroup,
+): Record<string, string | boolean | number> {
+    const data: Record<string, string | boolean | number> = {};
+    const properties_elements = get_subsection_property_elements($subsection_elem);
+    for (const input_elem of properties_elements) {
+        const $input_elem = $(input_elem);
+        if (check_group_property_changed(input_elem, group)) {
+            const input_value = get_input_element_value(input_elem);
+            if (input_value !== undefined && input_value !== null) {
+                const property_name = extract_property_name($input_elem);
+                data[property_name] = JSON.stringify({
+                    new: input_value,
+                    old: group.can_mention_group,
+                });
+            }
+        }
+    }
+    return data;
+}
 
-                if (property_name === "org_join_restrictions") {
-                    data = {
-                        ...data,
-                        ...get_request_data_for_org_join_restrictions(input_value.toString()),
-                    };
-                    continue;
-                }
+export function populate_data_for_custom_profile_field_request(
+    $subsection_elem: JQuery,
+    custom_profile_field: CustomProfileField,
+): Record<string, string | boolean | number> {
+    const data: Record<string, string | boolean | number> = {};
+    const properties_elements = get_subsection_property_elements($subsection_elem);
+    for (const input_elem of properties_elements) {
+        const $input_elem = $(input_elem);
+        if (check_custom_profile_property_changed(input_elem, custom_profile_field)) {
+            const input_value = get_input_element_value(input_elem);
+            if (input_value !== undefined && input_value !== null) {
+                const property_name = extract_property_name($input_elem);
+                data[property_name] = input_value;
+            }
+        }
+    }
+    return data;
+}
+
+export function populate_data_for_default_realm_settings_request(
+    $subsection_elem: JQuery,
+): Record<string, string | boolean | number> {
+    const data: Record<string, string | boolean | number> = {};
+    const properties_elements = get_subsection_property_elements($subsection_elem);
+    for (const input_elem of properties_elements) {
+        const $input_elem = $(input_elem);
+        if (check_realm_default_settings_property_changed(input_elem)) {
+            const input_value = get_input_element_value(input_elem);
+            if (input_value !== undefined && input_value !== null) {
+                const property_name: string = extract_property_name($input_elem, true);
                 data[property_name] = input_value;
             }
         }
@@ -1025,30 +1124,38 @@ function switching_to_private(properties_elements: HTMLElement[]): boolean {
     return false;
 }
 
-export function save_discard_widget_status_handler(
+export function save_discard_realm_settings_widget_status_handler($subsection: JQuery): void {
+    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".save-button").show();
+    const properties_elements = get_subsection_property_elements($subsection);
+    const show_change_process_button = properties_elements.some((elem) =>
+        check_realm_settings_property_changed(elem),
+    );
+
+    const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
+    const button_state = show_change_process_button ? "unsaved" : "discarded";
+    change_save_button_state($save_btn_controls, button_state);
+}
+
+export function save_discard_stream_settings_widget_status_handler(
     $subsection: JQuery,
-    for_realm_default_settings: boolean,
-    sub: StreamSubscription | undefined,
-    group: UserGroup | undefined,
+    sub: StreamSubscription,
 ): void {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
     const show_change_process_button = properties_elements.some((elem) =>
-        check_property_changed(elem, for_realm_default_settings, sub, group, undefined),
+        check_stream_settings_property_changed(elem, sub),
     );
 
     const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
 
-    // If this widget is for a stream, and the stream isn't currently private
-    // but being changed to private, and the user changing this setting isn't
-    // subscribed, we show a warning that they won't be able to access the
-    // stream after making it private unless they subscribe.
-    if (!sub) {
-        return;
-    }
+    // If the stream isn't currently private but being changed to private,
+    // and the user changing this setting isn't subscribed, we show a
+    // warning that they won't be able to access the stream after
+    // making it private unless they subscribe.
     if (
         button_state === "unsaved" &&
         !sub.invite_only &&
@@ -1074,6 +1181,36 @@ export function save_discard_widget_status_handler(
     } else {
         $("#stream_permission_settings .stream-permissions-warning-banner").empty();
     }
+}
+
+export function save_discard_group_widget_status_handler(
+    $subsection: JQuery,
+    group: UserGroup,
+): void {
+    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".save-button").show();
+    const properties_elements = get_subsection_property_elements($subsection);
+    const show_change_process_button = properties_elements.some((elem) =>
+        check_group_property_changed(elem, group),
+    );
+    const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
+    const button_state = show_change_process_button ? "unsaved" : "discarded";
+    change_save_button_state($save_btn_controls, button_state);
+}
+
+export function save_discard_default_realm_settings_widget_status_handler(
+    $subsection: JQuery,
+): void {
+    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".save-button").show();
+    const properties_elements = get_subsection_property_elements($subsection);
+    const show_change_process_button = properties_elements.some((elem) =>
+        check_realm_default_settings_property_changed(elem),
+    );
+
+    const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
+    const button_state = show_change_process_button ? "unsaved" : "discarded";
+    change_save_button_state($save_btn_controls, button_state);
 }
 
 function check_maximum_valid_value(

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -564,6 +564,8 @@ export function discard_property_element_changes(elem, for_realm_default_setting
             set_jitsi_server_url_dropdown();
             break;
         case "realm_message_retention_days":
+            set_message_retention_setting_dropdown(undefined);
+            break;
         case "message_retention_days":
             set_message_retention_setting_dropdown(sub);
             break;

--- a/web/src/settings_preferences.js
+++ b/web/src/settings_preferences.js
@@ -76,7 +76,9 @@ function org_notification_default_language_modal_post_render() {
             );
             $language_element.text(new_language);
             $language_element.attr("data-language-code", setting_value);
-            settings_components.save_discard_widget_status_handler($("#org-notifications"));
+            settings_components.save_discard_realm_settings_widget_status_handler(
+                $("#org-notifications"),
+            );
         });
 }
 

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -377,11 +377,8 @@ function disable_submit_btn_if_no_property_changed(
     $profile_field_form: JQuery,
     field: CustomProfileField,
 ): void {
-    const data = settings_components.populate_data_for_request(
+    const data = settings_components.populate_data_for_custom_profile_field_request(
         $profile_field_form,
-        false,
-        undefined,
-        undefined,
         field,
     );
     let save_changes_button_disabled = false;
@@ -518,11 +515,8 @@ function open_edit_form_modal(this: HTMLElement): void {
     function submit_form(): void {
         const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
 
-        const data = settings_components.populate_data_for_request(
+        const data = settings_components.populate_data_for_custom_profile_field_request(
             $profile_field_form,
-            false,
-            undefined,
-            undefined,
             field,
         );
 

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -211,9 +211,8 @@ function setup_dropdown(sub, slim_sub) {
             event.preventDefault();
             event.stopPropagation();
             can_remove_subscribers_group_widget.render();
-            settings_components.save_discard_widget_status_handler(
+            settings_components.save_discard_stream_settings_widget_status_handler(
                 $("#stream_permission_settings"),
-                false,
                 slim_sub,
             );
         },
@@ -683,7 +682,7 @@ export function initialize() {
         const stream_id = get_stream_id(e.target);
         const sub = sub_store.get(stream_id);
         const $subsection = $(e.target).closest(".settings-subsection-parent");
-        settings_components.save_discard_widget_status_handler($subsection, false, sub);
+        settings_components.save_discard_stream_settings_widget_status_handler($subsection, sub);
         if (sub) {
             stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
         }
@@ -703,9 +702,8 @@ export function initialize() {
                 $save_button.closest(".subscription_settings.show").attr("data-stream-id"),
             );
             const sub = sub_store.get(stream_id);
-            const data = settings_components.populate_data_for_request(
+            const data = settings_components.populate_data_for_stream_settings_request(
                 $subsection_elem,
-                false,
                 sub,
             );
 
@@ -744,7 +742,7 @@ export function initialize() {
 
             const $subsection = $(e.target).closest(".settings-subsection-parent");
             for (const elem of settings_components.get_subsection_property_elements($subsection)) {
-                settings_org.discard_property_element_changes(elem, false, sub);
+                settings_org.discard_stream_property_element_changes(elem, sub);
             }
             stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
             const $save_btn_controls = $(e.target).closest(".save-button-controls");

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -382,7 +382,7 @@ export function update_setting_element(sub, setting_name) {
     }
 
     const $elem = $(`#id_${CSS.escape(setting_name)}`);
-    settings_org.discard_property_element_changes($elem, false, sub);
+    settings_org.discard_stream_property_element_changes($elem, sub);
 }
 
 export function enable_or_disable_add_subscribers_elements(

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -29,10 +29,8 @@ export function setup_permissions_dropdown(group: UserGroup, for_group_creation:
             event.stopPropagation();
             can_mention_group_widget.render();
             if (!for_group_creation) {
-                settings_components.save_discard_widget_status_handler(
+                settings_components.save_discard_group_widget_status_handler(
                     $("#group_permission_settings"),
-                    false,
-                    undefined,
                     group,
                 );
             }

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -251,12 +251,7 @@ export function update_settings_pane(group) {
     $edit_container.find(".group-name").text(group.name);
     $edit_container.find(".group-description").text(group.description);
 
-    settings_org.discard_property_element_changes(
-        $("#id_can_mention_group"),
-        false,
-        undefined,
-        group,
-    );
+    settings_org.discard_group_property_element_changes($("#id_can_mention_group"), group);
 }
 
 function update_toggler_for_group_setting() {
@@ -928,10 +923,8 @@ export function initialize() {
 
             const group_id = $save_button.closest(".user_group_settings_wrapper").data("group-id");
             const group = user_groups.get_user_group_from_id(group_id);
-            const data = settings_components.populate_data_for_request(
+            const data = settings_components.populate_data_for_group_request(
                 $subsection_elem,
-                false,
-                undefined,
                 group,
             );
 
@@ -952,7 +945,7 @@ export function initialize() {
 
             const $subsection = $(e.target).closest(".settings-subsection-parent");
             for (const elem of settings_components.get_subsection_property_elements($subsection)) {
-                settings_org.discard_property_element_changes(elem, false, undefined, group);
+                settings_org.discard_group_property_element_changes(elem, group);
             }
             const $save_btn_controls = $(e.target).closest(".save-button-controls");
             settings_components.change_save_button_state($save_btn_controls, "discarded");


### PR DESCRIPTION
Refactor get_property_value and check_property_changed to improve type checking and code readability.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
