### PR TITLE
copy_and_paste: Fix bugs surfaced by typescript migration.

### DIFF
--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -292,7 +292,7 @@ function get_end_tr_from_endc($endc: JQuery<Node>): JQuery {
         // This handles the issue that Chrome seems to like selecting
         // the compose_close button when you go off the end of the
         // last message
-        return $(".message_row").last();
+        return rows.last_visible();
     }
 
     // Sometimes (especially when three click selecting in Chrome) the selection
@@ -313,7 +313,7 @@ function get_end_tr_from_endc($endc: JQuery<Node>): JQuery {
         // we can use the last message from the previous recipient_row.
         if ($endc.parents(".message_header").length > 0) {
             const $overflow_recipient_row = $endc.parents(".recipient_row").first();
-            return $overflow_recipient_row.prev(".recipient_row").last();
+            return $overflow_recipient_row.prev(".recipient_row").children(".message_row").last();
         }
         // If somehow we get here, do the default return.
     }


### PR DESCRIPTION
Fixed 2 bugs in the detection of the last message row copied. This fixes the issue where when the mouse was released on the message header after copying multiple messages, the pasted text was not formatted correctly.

Follow up to #30091.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
