### PR TITLE
invite: Fix invite modal bug for users who can't subscribe others.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -364,7 +364,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
 
         set_custom_time_inputs_visibility();
         set_expires_on_text();
-        set_streams_to_join_list_visibility();
+
+        if (settings_data.user_can_subscribe_other_users()) {
+            set_streams_to_join_list_visibility();
+        }
 
         $("#invite-user-modal").on("click", ".setup-tips-container .banner_content a", () => {
             dialog_widget.close();

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -537,7 +537,6 @@ div.overlay {
     border: 1px solid hsl(49deg 20% 84%);
     border-radius: 4px;
     padding: 10px;
-    margin: 10px 0;
     font-size: 1rem;
     line-height: 1.5;
     color: hsl(0deg 0% 40%);
@@ -548,6 +547,16 @@ div.overlay {
         font-family: FontAwesome;
         font-weight: 600;
     }
+}
+
+.upgrade-tip,
+.upgrade-or-sponsorship-tip,
+.tip {
+    margin: 10px 0;
+}
+
+.invite-stream-notice {
+    margin-bottom: 20px;
 }
 
 .tip::before {

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -12,7 +12,7 @@
     </div>
     {{else if (not can_subscribe_other_users)}}
     <div class="invite-stream-notice">
-        {{#tr}}The users you invite will be automatically added to <z-link>default streams</z-link> for this organization, as you do not have permission to configure which streams new users join.
+        {{#tr}}The users you invite will be automatically added to <z-link>default channels</z-link> for this organization, as you do not have permission to configure which channels new users join.
         {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="#organization/default-streams-list">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </div>


### PR DESCRIPTION
- First commit fixes the bug of invite modal not opening for users who cannot subscribe others.
- Second commit is to fix the UI.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
