### PR TITLE
unread_ops: Fix unable to mark messages as read in Inbox view.

### DIFF
--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -22,6 +22,7 @@ import * as overlays from "./overlays";
 import * as people from "./people";
 import * as recent_view_ui from "./recent_view_ui";
 import type {NarrowTerm} from "./state_data";
+import * as stream_data from "./stream_data";
 import * as ui_report from "./ui_report";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
@@ -590,20 +591,22 @@ export function process_visible(): void {
 }
 
 export function mark_stream_as_read(stream_id: number): void {
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "channel", operand: stream_id.toString()},
+            {operator: "channel", operand: stream_name},
         ],
         "add",
     );
 }
 
 export function mark_topic_as_read(stream_id: number, topic: string): void {
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "channel", operand: stream_id.toString()},
+            {operator: "channel", operand: stream_name},
             {operator: "topic", operand: topic},
         ],
         "add",
@@ -611,9 +614,10 @@ export function mark_topic_as_read(stream_id: number, topic: string): void {
 }
 
 export function mark_topic_as_unread(stream_id: number, topic: string): void {
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
-            {operator: "channel", operand: stream_id.toString()},
+            {operator: "channel", operand: stream_name},
             {operator: "topic", operand: topic},
         ],
         "remove",


### PR DESCRIPTION
Converting stream_id to string invalidates the
value as our narrow parser expects integer as valid stream_id and stream name if it is string.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Marking.20topic.20as.20read.20doesn't.20work
