### PR TITLE
api-docs: Update feature level 261 documentation.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,16 +22,17 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 261**
 
-* [`POST /invites`](/api/send-invites), [`POST
-  /invites/multiuse`](/api/create-invite-link): Newly created user is
-  now subscribed to the default streams in the organization even when
-  the user sending the invite is not allowed to subscribe others.
-* [`POST /invites`](/api/send-invites), [`POST
-  /invites/multiuse`](/api/create-invite-link): Added
-  `include_realm_default_subscriptions` parameter to indicate whether to
-  subscribe the invited user to default streams when creating the new
-  user account instead of passing the stream IDs of default streams
-  in `stream_ids` parameter.
+* [`POST /invites`](/api/send-invites),
+  [`POST /invites/multiuse`](/api/create-invite-link): Added
+  `include_realm_default_subscriptions` parameter to indicate whether
+  the newly created user will be automatically subscribed to [default
+  channels](/help/set-default-channels-for-new-users) in the
+  organization. Previously, the default channel IDs needed to be included
+  in the `stream_ids` parameter. This also allows a newly created user
+  to be automatically subscribed to the default channels in an
+  organization when the user creating the invitation does not generally
+  have permission to [subscribe other users to
+  channels](/help/configure-who-can-invite-to-channels).
 
 **Feature level 260**:
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 260
+API_FEATURE_LEVEL = 261
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12160,34 +12160,43 @@ paths:
                   $ref: "#/components/schemas/InviteRoleParameter"
                 stream_ids:
                   description: |
-                    A list containing the [IDs of the streams](/api/get-stream-id) that
-                    the newly created user will be automatically subscribed to if the
-                    invitation is accepted, in addition to default streams configured via
-                    the `include_realm_default_subscriptions` setting.
+                    A list containing the [IDs of the channels](/api/get-stream-id) that the
+                    newly created user will be automatically subscribed to if the invitation
+                    is accepted, in addition to any default channels that the new user may
+                    be subscribed to based on the `include_realm_default_subscriptions`
+                    parameter.
 
-                    This parameter must be the empty list if the current user has the
-                    unlikely configuration of being able to generate invitations while
-                    lacking permission to subscribe other users to streams.
-
-                    **Changes**: Prior to Zulip 9.0 (feature level 261), if the user was not
-                    allowed to subscribe others to stream, the newly created user was not
-                    subscribed to any streams.
+                    This list must be empty if the current user has the unlikely
+                    configuration of being able to send invitations while lacking
+                    permission to [subscribe other users to channels][can-subscribe-others].
 
                     **Changes**: Before Zulip 7.0 (feature level 180), specifying `stream_ids`
                     as an empty list resulted in an error.
+
+                    [can-subscribe-others]: /help/configure-who-can-invite-to-channels
                   type: array
                   items:
                     type: integer
                   example: [1, 10]
                 include_realm_default_subscriptions:
                   description: |
-                    Boolean indicating that the newly created user should be subscribed
-                    to the [default streams][default-streams] for the organization.
+                    Boolean indicating whether the newly created user should be subscribed
+                    to the [default channels][default-channels] for the organization.
 
-                    **Changes**: New in Zulip 9.0 (feature level 261).
+                    Note that this parameter can be `true` even if the user creating the
+                    invitation does not generally have permission to [subscribe other
+                    users to channels][can-subscribe-others].
 
-                    [default-streams]: /help/set-default-streams-for-new-users
+                    **Changes**: New in Zulip 9.0 (feature level 261). Previous versions
+                    of Zulip behaved as though this parameter was always `false`; clients
+                    needed to include the organization's default streams in the
+                    `stream_ids` parameter for a newly created user to be automatically
+                    subscribed to them.
+
+                    [default-channels]: /help/set-default-channels-for-new-users
+                    [can-subscribe-others]: /help/configure-who-can-invite-to-channels
                   type: boolean
+                  default: false
                   example: false
               required:
                 - invitee_emails
@@ -12318,19 +12327,18 @@ paths:
                   $ref: "#/components/schemas/InviteRoleParameter"
                 stream_ids:
                   description: |
-                    A list containing the [IDs of the streams](/api/get-stream-id) that the
+                    A list containing the [IDs of the channels](/api/get-stream-id) that the
                     newly created user will be automatically subscribed to if the invitation
-                    is accepted. If unspecified, it will be set to empty list. If the list is
-                    empty, then the new user will not be subscribed to any streams.
+                    is accepted, in addition to any default channels that the new user may
+                    be subscribed to based on the `include_realm_default_subscriptions`
+                    parameter.
 
-                    If the user is not allowed to subscribe others, then this list should
-                    be empty but the newly created user will still be subscribed to default
-                    streams in the organization depending on the `include_realm_default_subscriptions`
-                    value.
+                    This list must be empty if the current user has the unlikely
+                    configuration of being able to create reusable invitation links while
+                    lacking permission to [subscribe other users to
+                    channels][can-subscribe-others].
 
-                    **Changes**: Prior to Zulip 9.0 (feature level 261), if the user was not
-                    allowed to subscribe others to stream, the newly created user was not
-                    subscribed to any streams.
+                    [can-subscribe-others]: /help/configure-who-can-invite-to-channels
                   type: array
                   items:
                     type: integer
@@ -12338,13 +12346,23 @@ paths:
                   example: [1, 10]
                 include_realm_default_subscriptions:
                   description: |
-                    Boolean indicating that the newly created user should be subscribed
-                    to the [default streams][default-streams] for the organization.
+                    Boolean indicating whether the newly created user should be subscribed
+                    to the [default channels][default-channels] for the organization.
 
-                    **Changes**: New in Zulip 9.0 (feature level 261).
+                    Note that this parameter can be `true` even if the current user does
+                    not generally have permission to [subscribe other users to
+                    channels][can-subscribe-others].
 
-                    [default-streams]: /help/set-default-streams-for-new-users
+                    **Changes**: New in Zulip 9.0 (feature level 261). Previous versions
+                    of Zulip behaved as though this parameter was always `false`; clients
+                    needed to include the organization's default streams in the
+                    `stream_ids` parameter for a newly created user to be automatically
+                    subscribed to them.
+
+                    [default-channels]: /help/set-default-channels-for-new-users
+                    [can-subscribe-others]: /help/configure-who-can-invite-to-channels
                   type: boolean
+                  default: false
                   example: false
             encoding:
               invite_expires_in_minutes:


### PR DESCRIPTION
The original changes for this feature level are in commits a6be1d101 and 7b42c802b.

Some notes on updates:
- Bumps the API feature level in version.py
- Uses channel in descriptive text instead of stream in these changes so that I don't have merge conflicts with my general changes in the API documentation for that rename.

**Screenshots and screen captures:**

<details>
<summary>Updated API changelog entry</summary>

![Screenshot from 2024-05-15 15-57-43](https://github.com/zulip/zulip/assets/63245456/89f3daa4-9f97-4f56-a56c-af28faf1dd23)
</details>
<details>
<summary>Updated parameter descriptions for email invite endpoint</summary>

![Screenshot from 2024-05-15 15-58-18](https://github.com/zulip/zulip/assets/63245456/4688633a-2ef9-424a-8b27-dc2e8043d5aa)
</details>
<details>
<summary>Updated parameter descriptions for reusable link endpoint</summary>

![Screenshot from 2024-05-15 15-58-43](https://github.com/zulip/zulip/assets/63245456/5951174c-f4df-4a61-a8c5-1456f34b0ad5)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
