### PR TITLE
message_send: Update `do_send_messages` codepath to send event on commit.

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -5,7 +5,7 @@ from zerver.lib.attachments import get_old_unclaimed_attachments, validate_attac
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.upload import claim_attachment, delete_message_attachment
 from zerver.models import Attachment, Message, ScheduledMessage, Stream, UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_attachment_update(
@@ -17,7 +17,7 @@ def notify_attachment_update(
         "attachment": attachment_dict,
         "upload_space_used": user_profile.realm.currently_used_upload_space_bytes(),
     }
-    send_event(user_profile.realm, event, [user_profile.id])
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def do_claim_attachments(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2001,6 +2001,135 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
 
         self.assert_length(lst, expected_num_events)
 
+    @override
+    def send_personal_message(
+        self,
+        from_user: UserProfile,
+        to_user: UserProfile,
+        content: str = "test content",
+        *,
+        read_by_sender: bool = True,
+        skip_capture_on_commit_callbacks: bool = False,
+    ) -> int:
+        """This function is a wrapper on 'send_personal_message',
+        defined in 'ZulipTestCaseMixin' with an extra parameter
+        'skip_capture_on_commit_callbacks'.
+
+        It should be set to 'True' when making a call with either
+        'verify_action' or 'capture_send_event_calls' as context manager
+        because they already have 'self.captureOnCommitCallbacks'
+        (See the comment in 'capture_send_event_calls').
+
+        For all other cases, we should call 'send_personal_message' with
+        'self.captureOnCommitCallbacks' for 'send_event_on_commit' or/and
+        'queue_event_on_commit' to work.
+        """
+        if skip_capture_on_commit_callbacks:
+            message_id = super().send_personal_message(
+                from_user,
+                to_user,
+                content,
+                read_by_sender=read_by_sender,
+            )
+        else:
+            with self.captureOnCommitCallbacks(execute=True):
+                message_id = super().send_personal_message(
+                    from_user,
+                    to_user,
+                    content,
+                    read_by_sender=read_by_sender,
+                )
+        return message_id
+
+    @override
+    def send_huddle_message(
+        self,
+        from_user: UserProfile,
+        to_users: List[UserProfile],
+        content: str = "test content",
+        *,
+        read_by_sender: bool = True,
+        skip_capture_on_commit_callbacks: bool = False,
+    ) -> int:
+        """This function is a wrapper on 'send_huddle_message',
+        defined in 'ZulipTestCaseMixin' with an extra parameter
+        'skip_capture_on_commit_callbacks'.
+
+        It should be set to 'True' when making a call with either
+        'verify_action' or 'capture_send_event_calls' as context manager
+        because they already have 'self.captureOnCommitCallbacks'
+        (See the comment in 'capture_send_event_calls').
+
+        For all other cases, we should call 'send_huddle_message' with
+        'self.captureOnCommitCallbacks' for 'send_event_on_commit' or/and
+        'queue_event_on_commit' to work.
+        """
+        if skip_capture_on_commit_callbacks:
+            message_id = super().send_huddle_message(
+                from_user,
+                to_users,
+                content,
+                read_by_sender=read_by_sender,
+            )
+        else:
+            with self.captureOnCommitCallbacks(execute=True):
+                message_id = super().send_huddle_message(
+                    from_user,
+                    to_users,
+                    content,
+                    read_by_sender=read_by_sender,
+                )
+        return message_id
+
+    @override
+    def send_stream_message(
+        self,
+        sender: UserProfile,
+        stream_name: str,
+        content: str = "test content",
+        topic_name: str = "test",
+        recipient_realm: Optional[Realm] = None,
+        *,
+        allow_unsubscribed_sender: bool = False,
+        read_by_sender: bool = True,
+        skip_capture_on_commit_callbacks: bool = False,
+    ) -> int:
+        """This function is a wrapper on 'send_stream_message',
+        defined in 'ZulipTestCaseMixin' with an extra parameter
+        'skip_capture_on_commit_callbacks'.
+
+        It should be set to 'True' when making a call with either
+        'verify_action' or 'capture_send_event_calls' as context manager
+        because they already have 'self.captureOnCommitCallbacks'
+        (See the comment in 'capture_send_event_calls').
+
+        For all other cases, we should call 'send_stream_message' with
+        'self.captureOnCommitCallbacks' for 'send_event_on_commit' or/and
+        'queue_event_on_commit' to work.
+        """
+        if skip_capture_on_commit_callbacks:
+            message_id = super().send_stream_message(
+                sender,
+                stream_name,
+                content,
+                topic_name,
+                recipient_realm,
+                allow_unsubscribed_sender=allow_unsubscribed_sender,
+                read_by_sender=read_by_sender,
+            )
+        else:
+            with self.captureOnCommitCallbacks(execute=True):
+                message_id = super().send_stream_message(
+                    sender,
+                    stream_name,
+                    content,
+                    topic_name,
+                    recipient_realm,
+                    allow_unsubscribed_sender=allow_unsubscribed_sender,
+                    read_by_sender=read_by_sender,
+                )
+        return message_id
+
 
 def get_row_ids_in_all_tables() -> Iterator[Tuple[str, Set[int]]]:
     all_models = apps.get_models(include_auto_created=True)

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -78,6 +78,7 @@ def get_topic_mutes(
     ]
 
 
+@transaction.atomic(savepoint=False)
 def set_topic_visibility_policy(
     user_profile: UserProfile,
     topics: List[List[str]],
@@ -125,7 +126,6 @@ def get_topic_visibility_policy(
     return visibility_policy
 
 
-@transaction.atomic(savepoint=False)
 def bulk_set_user_topic_visibility_policy_in_database(
     user_profiles: List[UserProfile],
     stream_id: int,

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1154,9 +1154,10 @@ class MissedMessageHookTest(ZulipTestCase):
     def test_disable_external_notifications(self) -> None:
         # The disable_external_notifications parameter, used for messages sent by welcome bot,
         # should result in no email/push notifications being sent regardless of the message type.
-        msg_id = internal_send_private_message(
-            self.iago, self.user_profile, "Test Content", disable_external_notifications=True
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            msg_id = internal_send_private_message(
+                self.iago, self.user_profile, "Test Content", disable_external_notifications=True
+            )
         assert msg_id is not None
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(self.user_profile.id, self.client_descriptor, True)

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -341,16 +341,17 @@ class GetEventsTest(ZulipTestCase):
         self.assert_length(events, 0)
 
         local_id = "10.01"
-        check_send_message(
-            sender=user_profile,
-            client=get_client("whatever"),
-            recipient_type_name="private",
-            message_to=[recipient_email],
-            topic_name=None,
-            message_content="hello",
-            local_id=local_id,
-            sender_queue_id=queue_id,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            check_send_message(
+                sender=user_profile,
+                client=get_client("whatever"),
+                recipient_type_name="private",
+                message_to=[recipient_email],
+                topic_name=None,
+                message_content="hello",
+                local_id=local_id,
+                sender_queue_id=queue_id,
+            )
 
         result = self.tornado_call(
             get_events,
@@ -374,16 +375,17 @@ class GetEventsTest(ZulipTestCase):
         last_event_id = events[0]["id"]
         local_id = "10.02"
 
-        check_send_message(
-            sender=user_profile,
-            client=get_client("whatever"),
-            recipient_type_name="private",
-            message_to=[recipient_email],
-            topic_name=None,
-            message_content="hello",
-            local_id=local_id,
-            sender_queue_id=queue_id,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            check_send_message(
+                sender=user_profile,
+                client=get_client("whatever"),
+                recipient_type_name="private",
+                message_to=[recipient_email],
+                topic_name=None,
+                message_content="hello",
+                local_id=local_id,
+                sender_queue_id=queue_id,
+            )
 
         result = self.tornado_call(
             get_events,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -481,7 +481,12 @@ class NormalActionsTest(BaseAction):
         for i in range(3):
             content = "mentioning... @**" + user.full_name + "** hello " + str(i)
             with self.verify_action():
-                self.send_stream_message(self.example_user("cordelia"), "Verona", content)
+                self.send_stream_message(
+                    self.example_user("cordelia"),
+                    "Verona",
+                    content,
+                    skip_capture_on_commit_callbacks=True,
+                )
 
     def test_automatically_follow_topic_where_mentioned(self) -> None:
         user = self.example_user("hamlet")
@@ -509,24 +514,42 @@ class NormalActionsTest(BaseAction):
         for i in range(3):
             content = "mentioning... @**" + user.full_name + "** hello " + str(i)
             with self.verify_action(num_events=get_num_events()):
-                self.send_stream_message(self.example_user("cordelia"), "Verona", content)
+                self.send_stream_message(
+                    self.example_user("cordelia"),
+                    "Verona",
+                    content,
+                    skip_capture_on_commit_callbacks=True,
+                )
 
     def test_topic_wildcard_mentioned_send_message_events(self) -> None:
         for i in range(3):
             content = "mentioning... @**topic** hello " + str(i)
             with self.verify_action():
-                self.send_stream_message(self.example_user("cordelia"), "Verona", content)
+                self.send_stream_message(
+                    self.example_user("cordelia"),
+                    "Verona",
+                    content,
+                    skip_capture_on_commit_callbacks=True,
+                )
 
     def test_stream_wildcard_mentioned_send_message_events(self) -> None:
         for i in range(3):
             content = "mentioning... @**all** hello " + str(i)
             with self.verify_action():
-                self.send_stream_message(self.example_user("cordelia"), "Verona", content)
+                self.send_stream_message(
+                    self.example_user("cordelia"),
+                    "Verona",
+                    content,
+                    skip_capture_on_commit_callbacks=True,
+                )
 
     def test_pm_send_message_events(self) -> None:
         with self.verify_action():
             self.send_personal_message(
-                self.example_user("cordelia"), self.example_user("hamlet"), "hola"
+                self.example_user("cordelia"),
+                self.example_user("hamlet"),
+                "hola",
+                skip_capture_on_commit_callbacks=True,
             )
 
         # Verify direct message editing - content only edit
@@ -571,7 +594,9 @@ class NormalActionsTest(BaseAction):
             self.example_user("othello"),
         ]
         with self.verify_action():
-            self.send_huddle_message(self.example_user("cordelia"), huddle, "hola")
+            self.send_huddle_message(
+                self.example_user("cordelia"), huddle, "hola", skip_capture_on_commit_callbacks=True
+            )
 
     def test_user_creation_events_on_sending_messages(self) -> None:
         self.set_up_db_for_testing_user_access()
@@ -584,24 +609,28 @@ class NormalActionsTest(BaseAction):
         # for bots as they can access all the bots.
         bot = self.create_test_bot("test2", cordelia, full_name="Test bot")
         with self.verify_action(num_events=1) as events:
-            self.send_personal_message(bot, polonius, "hola")
+            self.send_personal_message(bot, polonius, "hola", skip_capture_on_commit_callbacks=True)
         check_direct_message("events[0]", events[0])
 
         with self.verify_action(num_events=2) as events:
-            self.send_personal_message(cordelia, polonius, "hola")
-        check_direct_message("events[0]", events[0])
-        check_realm_user_add("events[1]", events[1])
-        self.assertEqual(events[1]["person"]["user_id"], cordelia.id)
+            self.send_personal_message(
+                cordelia, polonius, "hola", skip_capture_on_commit_callbacks=True
+            )
+        check_realm_user_add("events[0]", events[0])
+        check_direct_message("events[1]", events[1])
+        self.assertEqual(events[0]["person"]["user_id"], cordelia.id)
 
         othello = self.example_user("othello")
         desdemona = self.example_user("desdemona")
 
         with self.verify_action(num_events=3) as events:
-            self.send_huddle_message(othello, [polonius, desdemona, bot], "hola")
-        check_direct_message("events[0]", events[0])
+            self.send_huddle_message(
+                othello, [polonius, desdemona, bot], "hola", skip_capture_on_commit_callbacks=True
+            )
+        check_realm_user_add("events[0]", events[0])
         check_realm_user_add("events[1]", events[1])
-        check_realm_user_add("events[2]", events[2])
-        user_creation_user_ids = {events[1]["person"]["user_id"], events[2]["person"]["user_id"]}
+        check_direct_message("events[2]", events[2])
+        user_creation_user_ids = {events[0]["person"]["user_id"], events[1]["person"]["user_id"]}
         self.assertEqual(user_creation_user_ids, {othello.id, desdemona.id})
 
     def test_stream_send_message_events(self) -> None:
@@ -687,7 +716,9 @@ class NormalActionsTest(BaseAction):
             # Three events are generated:
             # 2 for following the topic and 1 for the message sent.
             with self.verify_action(client_gravatar=False, num_events=3) as events:
-                self.send_stream_message(hamlet, "Verona", "hello", "topic")
+                self.send_stream_message(
+                    hamlet, "Verona", "hello", "topic", skip_capture_on_commit_callbacks=True
+                )
             verify_events_generated_and_reset_visibility_policy(events, "Verona", "topic")
 
         # action: initiation
@@ -714,7 +745,13 @@ class NormalActionsTest(BaseAction):
             # Three events are generated:
             # 2 for following the topic and 1 for the message sent.
             with self.verify_action(client_gravatar=False, num_events=3) as events:
-                self.send_stream_message(hamlet, "Denmark", "hello", f"new topic {index}")
+                self.send_stream_message(
+                    hamlet,
+                    "Denmark",
+                    "hello",
+                    f"new topic {index}",
+                    skip_capture_on_commit_callbacks=True,
+                )
             verify_events_generated_and_reset_visibility_policy(
                 events, "Denmark", f"new topic {index}"
             )
@@ -744,7 +781,9 @@ class NormalActionsTest(BaseAction):
             # Three events are generated:
             # 2 for unmuting the topic and 1 for the message sent.
             with self.verify_action(client_gravatar=False, num_events=3) as events:
-                self.send_stream_message(hamlet, "core team", "hello", "topic")
+                self.send_stream_message(
+                    hamlet, "core team", "hello", "topic", skip_capture_on_commit_callbacks=True
+                )
             verify_events_generated_and_reset_visibility_policy(events, "core team", "topic")
 
         # If current_visibility_policy is already set to the value the policies would set.
@@ -762,7 +801,9 @@ class NormalActionsTest(BaseAction):
         )
         # 1 event for the message sent
         with self.verify_action(client_gravatar=False, num_events=1) as events:
-            self.send_stream_message(hamlet, "core team", "hello", "new Topic")
+            self.send_stream_message(
+                hamlet, "core team", "hello", "new Topic", skip_capture_on_commit_callbacks=True
+            )
 
         do_change_user_setting(
             user_profile=hamlet,
@@ -772,7 +813,9 @@ class NormalActionsTest(BaseAction):
         )
         # Only one message event is generated
         with self.verify_action(client_gravatar=True) as events:
-            self.send_stream_message(hamlet, "core team", "hello")
+            self.send_stream_message(
+                hamlet, "core team", "hello", skip_capture_on_commit_callbacks=True
+            )
         # event-type: message
         check_message("events[0]", events[0])
         assert isinstance(events[0]["message"]["avatar_url"], str)
@@ -785,7 +828,9 @@ class NormalActionsTest(BaseAction):
         )
 
         with self.verify_action(client_gravatar=True) as events:
-            self.send_stream_message(hamlet, "core team", "hello")
+            self.send_stream_message(
+                hamlet, "core team", "hello", skip_capture_on_commit_callbacks=True
+            )
         check_message("events[0]", events[0])
         assert events[0]["message"]["avatar_url"] is None
 
@@ -800,7 +845,9 @@ class NormalActionsTest(BaseAction):
             visibility_policy=UserTopic.VisibilityPolicy.UNMUTED,
         )
         with self.verify_action(state_change_expected=True):
-            self.send_stream_message(self.example_user("aaron"), "Verona", "hello")
+            self.send_stream_message(
+                self.example_user("aaron"), "Verona", "hello", skip_capture_on_commit_callbacks=True
+            )
 
     def test_stream_update_message_events(self) -> None:
         iago = self.example_user("iago")
@@ -1032,7 +1079,9 @@ class NormalActionsTest(BaseAction):
             "hello 1",
         )
         with self.verify_action(state_change_expected=True):
-            self.send_stream_message(sender, "Verona", "hello 2")
+            self.send_stream_message(
+                sender, "Verona", "hello 2", skip_capture_on_commit_callbacks=True
+            )
 
     def test_events_for_message_from_inaccessible_sender(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()
@@ -1042,7 +1091,11 @@ class NormalActionsTest(BaseAction):
 
         with self.verify_action() as events:
             self.send_stream_message(
-                othello, "test_stream1", "hello 2", allow_unsubscribed_sender=True
+                othello,
+                "test_stream1",
+                "hello 2",
+                allow_unsubscribed_sender=True,
+                skip_capture_on_commit_callbacks=True,
             )
         check_message("events[0]", events[0])
         message_obj = events[0]["message"]
@@ -1053,7 +1106,11 @@ class NormalActionsTest(BaseAction):
         iago = self.example_user("iago")
         with self.verify_action() as events:
             self.send_stream_message(
-                iago, "test_stream1", "hello 2", allow_unsubscribed_sender=True
+                iago,
+                "test_stream1",
+                "hello 2",
+                allow_unsubscribed_sender=True,
+                skip_capture_on_commit_callbacks=True,
             )
         check_message("events[0]", events[0])
         message_obj = events[0]["message"]
@@ -1483,20 +1540,20 @@ class NormalActionsTest(BaseAction):
             self.register("test1@zulip.com", "test1")
         self.assert_length(events, 5)
 
-        check_realm_user_add("events[1]", events[1])
+        check_realm_user_add("events[0]", events[0])
         new_user_profile = get_user_by_delivery_email("test1@zulip.com", self.user_profile.realm)
         self.assertEqual(new_user_profile.delivery_email, "test1@zulip.com")
 
-        check_subscription_peer_add("events[4]", events[4])
+        check_subscription_peer_add("events[3]", events[3])
 
-        check_message("events[0]", events[0])
+        check_message("events[4]", events[4])
         self.assertIn(
             f'data-user-id="{new_user_profile.id}">test1_zulip.com</span> joined this organization.',
-            events[0]["message"]["content"],
+            events[4]["message"]["content"],
         )
 
+        check_user_group_add_members("events[1]", events[1])
         check_user_group_add_members("events[2]", events[2])
-        check_user_group_add_members("events[3]", events[3])
 
     def test_register_events_email_address_visibility(self) -> None:
         realm_user_default = RealmUserDefault.objects.get(realm=self.user_profile.realm)
@@ -1513,20 +1570,20 @@ class NormalActionsTest(BaseAction):
         with self.verify_action(num_events=5) as events:
             self.register("test1@zulip.com", "test1")
         self.assert_length(events, 5)
-        check_realm_user_add("events[1]", events[1])
+        check_realm_user_add("events[0]", events[0])
         new_user_profile = get_user_by_delivery_email("test1@zulip.com", self.user_profile.realm)
         self.assertEqual(new_user_profile.email, f"user{new_user_profile.id}@zulip.testserver")
 
-        check_subscription_peer_add("events[4]", events[4])
+        check_subscription_peer_add("events[3]", events[3])
 
-        check_message("events[0]", events[0])
+        check_message("events[4]", events[4])
         self.assertIn(
             f'data-user-id="{new_user_profile.id}">test1_zulip.com</span> joined this organization',
-            events[0]["message"]["content"],
+            events[4]["message"]["content"],
         )
 
+        check_user_group_add_members("events[1]", events[1])
         check_user_group_add_members("events[2]", events[2])
-        check_user_group_add_members("events[3]", events[3])
 
     def test_register_events_for_restricted_users(self) -> None:
         self.set_up_db_for_testing_user_access()
@@ -3146,7 +3203,13 @@ class NormalActionsTest(BaseAction):
         assert url is not None
         body = f"First message ...[zulip.txt](http://{hamlet.realm.host}" + url + ")"
         with self.verify_action(num_events=2) as events:
-            self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
+            self.send_stream_message(
+                self.example_user("hamlet"),
+                "Denmark",
+                body,
+                "test",
+                skip_capture_on_commit_callbacks=True,
+            )
 
         check_attachment_update("events[0]", events[0])
         self.assertEqual(events[0]["upload_space_used"], 6)

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -382,7 +382,7 @@ class PreviewTestCase(ZulipTestCase):
         url = "http://test.org/"
         # Ensure the cache for this is empty
         cache_delete(preview_url_cache_key(url))
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_personal_message(
                 sender,
                 self.example_user("cordelia"),
@@ -425,7 +425,7 @@ class PreviewTestCase(ZulipTestCase):
         self.login_user(user)
         original_url = "http://test.org/"
         edited_url = "http://edited.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(
                 user, "Denmark", topic_name="foo", content=original_url
             )
@@ -490,7 +490,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -565,7 +565,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -602,7 +602,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_inline_relative_url_embed_preview(self) -> None:
         # Relative URLs should not be sent for URL preview.
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             self.send_personal_message(
                 self.example_user("prospero"),
                 self.example_user("cordelia"),
@@ -661,7 +661,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/audio.mp3"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -693,7 +693,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/foo.html"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -729,7 +729,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/foo.html"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -770,7 +770,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/foo.html"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -808,7 +808,7 @@ class PreviewTestCase(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         url = "http://test.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish") as patched:
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
             msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
             patched.assert_called_once()
             queue = patched.call_args[0][0]
@@ -836,7 +836,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_valid_content_type_error_get_data(self) -> None:
         url = "http://test.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish"):
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit"):
             msg_id = self.send_personal_message(
                 self.example_user("hamlet"),
                 self.example_user("cordelia"),
@@ -881,7 +881,7 @@ class PreviewTestCase(ZulipTestCase):
     def test_invalid_url(self) -> None:
         url = "http://test.org/"
         error_url = "http://test.org/x"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish"):
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit"):
             msg_id = self.send_personal_message(
                 self.example_user("hamlet"),
                 self.example_user("cordelia"),
@@ -918,7 +918,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_safe_oembed_html_url(self) -> None:
         url = "http://test.org/"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish"):
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit"):
             msg_id = self.send_personal_message(
                 self.example_user("hamlet"),
                 self.example_user("cordelia"),
@@ -960,7 +960,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_youtube_url_title_replaces_url(self) -> None:
         url = "https://www.youtube.com/watch?v=eSJTXC7Ixgg"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish"):
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit"):
             msg_id = self.send_personal_message(
                 self.example_user("hamlet"),
                 self.example_user("cordelia"),
@@ -998,7 +998,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_custom_title_replaces_youtube_url_title(self) -> None:
         url = "[YouTube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg)"
-        with mock_queue_publish("zerver.actions.message_send.queue_json_publish"):
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit"):
             msg_id = self.send_personal_message(
                 self.example_user("hamlet"),
                 self.example_user("cordelia"),

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -192,8 +192,8 @@ class MessageMoveTopicTest(ZulipTestCase):
         users_to_be_notified = list(map(notify, [hamlet.id]))
         do_update_message_topic_success(hamlet, message, "Change again", users_to_be_notified)
 
-    @mock.patch("zerver.actions.user_topics.send_event")
-    def test_edit_muted_topic(self, mock_send_event: mock.MagicMock) -> None:
+    @mock.patch("zerver.actions.user_topics.send_event_on_commit")
+    def test_edit_muted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
         stream_name = "Stream 123"
         stream = self.make_stream(stream_name)
         hamlet = self.example_user("hamlet")
@@ -273,7 +273,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         # Here we assert that the expected users are notified properly.
         users_notified_via_muted_topics_event: List[int] = []
         users_notified_via_user_topic_event: List[int] = []
-        for call_args in mock_send_event.call_args_list:
+        for call_args in mock_send_event_on_commit.call_args_list:
             (arg_realm, arg_event, arg_notified_users) = call_args[0]
             if arg_event["type"] == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)
@@ -459,8 +459,8 @@ class MessageMoveTopicTest(ZulipTestCase):
         assert_is_topic_muted(cordelia, new_public_stream.id, "final topic name", muted=False)
         assert_is_topic_muted(aaron, new_public_stream.id, "final topic name", muted=False)
 
-    @mock.patch("zerver.actions.user_topics.send_event")
-    def test_edit_unmuted_topic(self, mock_send_event: mock.MagicMock) -> None:
+    @mock.patch("zerver.actions.user_topics.send_event_on_commit")
+    def test_edit_unmuted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
         stream_name = "Stream 123"
         stream = self.make_stream(stream_name)
 
@@ -535,7 +535,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         # Here we assert that the expected users are notified properly.
         users_notified_via_muted_topics_event: List[int] = []
         users_notified_via_user_topic_event: List[int] = []
-        for call_args in mock_send_event.call_args_list:
+        for call_args in mock_send_event_on_commit.call_args_list:
             (arg_realm, arg_event, arg_notified_users) = call_args[0]
             if arg_event["type"] == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1769,6 +1769,7 @@ class StreamMessagesTest(ZulipTestCase):
                 user,
                 stream_name,
                 content=content,
+                skip_capture_on_commit_callbacks=True,
             )
         users = events[0]["users"]
         user_ids = {u["id"] for u in users}

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -480,8 +480,10 @@ class TestServiceBotEventTriggers(ZulipTestCase):
         )
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
-    def test_trigger_on_stream_mention_from_user(self, mock_queue_json_publish: mock.Mock) -> None:
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
+    def test_trigger_on_stream_mention_from_user(
+        self, mock_queue_event_on_commit: mock.Mock
+    ) -> None:
         content = "@**FooBot** foo bar!!!"
         recipient = "Denmark"
         trigger = "mention"
@@ -501,31 +503,31 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             self.assertEqual(trigger_event["trigger"], trigger)
             self.assertEqual(trigger_event["user_profile_id"], self.bot_profile.id)
 
-        mock_queue_json_publish.side_effect = check_values_passed
+        mock_queue_event_on_commit.side_effect = check_values_passed
 
         self.send_stream_message(self.user_profile, "Denmark", content)
-        self.assertTrue(mock_queue_json_publish.called)
+        self.assertTrue(mock_queue_event_on_commit.called)
 
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
     def test_no_trigger_on_stream_message_without_mention(
-        self, mock_queue_json_publish: mock.Mock
+        self, mock_queue_event_on_commit: mock.Mock
     ) -> None:
         sender = self.user_profile
         self.send_stream_message(sender, "Denmark")
-        self.assertFalse(mock_queue_json_publish.called)
+        self.assertFalse(mock_queue_event_on_commit.called)
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
     def test_no_trigger_on_stream_mention_from_bot(
-        self, mock_queue_json_publish: mock.Mock
+        self, mock_queue_event_on_commit: mock.Mock
     ) -> None:
         self.send_stream_message(self.second_bot_profile, "Denmark", "@**FooBot** foo bar!!!")
-        self.assertFalse(mock_queue_json_publish.called)
+        self.assertFalse(mock_queue_event_on_commit.called)
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
     def test_trigger_on_personal_message_from_user(
-        self, mock_queue_json_publish: mock.Mock
+        self, mock_queue_event_on_commit: mock.Mock
     ) -> None:
         sender = self.user_profile
         recipient = self.bot_profile
@@ -547,24 +549,26 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             self.assertTrue(sender.email in display_recipients)
             self.assertTrue(recipient.email in display_recipients)
 
-        mock_queue_json_publish.side_effect = check_values_passed
+        mock_queue_event_on_commit.side_effect = check_values_passed
 
         self.send_personal_message(sender, recipient, "test")
-        self.assertTrue(mock_queue_json_publish.called)
+        self.assertTrue(mock_queue_event_on_commit.called)
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
     def test_no_trigger_on_personal_message_from_bot(
-        self, mock_queue_json_publish: mock.Mock
+        self, mock_queue_event_on_commit: mock.Mock
     ) -> None:
         sender = self.second_bot_profile
         recipient = self.bot_profile
         self.send_personal_message(sender, recipient)
-        self.assertFalse(mock_queue_json_publish.called)
+        self.assertFalse(mock_queue_event_on_commit.called)
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
-    def test_trigger_on_huddle_message_from_user(self, mock_queue_json_publish: mock.Mock) -> None:
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
+    def test_trigger_on_huddle_message_from_user(
+        self, mock_queue_event_on_commit: mock.Mock
+    ) -> None:
         self.second_bot_profile.bot_type = self.bot_profile.bot_type
         self.second_bot_profile.save()
 
@@ -585,17 +589,17 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
             self.assertEqual(trigger_event["message"]["type"], "private")
 
-        mock_queue_json_publish.side_effect = check_values_passed
+        mock_queue_event_on_commit.side_effect = check_values_passed
 
         self.send_huddle_message(sender, recipients, "test")
-        self.assertEqual(mock_queue_json_publish.call_count, 2)
+        self.assertEqual(mock_queue_event_on_commit.call_count, 2)
 
     @for_all_bot_types
-    @patch_queue_publish("zerver.actions.message_send.queue_json_publish")
+    @patch_queue_publish("zerver.actions.message_send.queue_event_on_commit")
     def test_no_trigger_on_huddle_message_from_bot(
-        self, mock_queue_json_publish: mock.Mock
+        self, mock_queue_event_on_commit: mock.Mock
     ) -> None:
         sender = self.second_bot_profile
         recipients = [self.user_profile, self.bot_profile]
         self.send_huddle_message(sender, recipients)
-        self.assertFalse(mock_queue_json_publish.called)
+        self.assertFalse(mock_queue_event_on_commit.called)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1512,12 +1512,9 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(events[1]["event"]["subscriptions"][0]["stream_id"], stream.id)
         self.assertEqual(events[1]["users"], [desdemona.id])
 
-        # Send a message there logging the reactivation
-        self.assertEqual(events[2]["event"]["type"], "message")
-
         # iago (as an admin) gets to know that desdemona (the owner) is now subscribed.
         self.assertEqual(
-            events[3],
+            events[2],
             {
                 "event": {
                     "op": "peer_add",
@@ -1528,6 +1525,9 @@ class StreamAdminTest(ZulipTestCase):
                 "users": [iago.id],
             },
         )
+
+        # Send a message there logging the reactivation
+        self.assertEqual(events[3]["event"]["type"], "message")
 
         stream = Stream.objects.get(id=stream.id)
         self.assertFalse(stream.deactivated)
@@ -5056,8 +5056,8 @@ class SubscriptionAPITest(ZulipTestCase):
         # Verify that peer_event events are never sent in Zephyr
         # realm. This does generate stream creation events from
         # send_stream_creation_events_for_previously_inaccessible_streams.
-        with self.capture_send_event_calls(expected_num_events=num_streams + 1) as events:
-            with self.assert_database_query_count(num_streams + 11):
+        with self.assert_database_query_count(num_streams + 11):
+            with self.capture_send_event_calls(expected_num_events=num_streams + 1) as events:
                 self.common_subscribe_to_streams(
                     mit_user,
                     stream_names,


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/jump.20to.20topic.20view.20before.20message.20is.20there/near/1793763)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
