### PR TITLE
org-settings: Update tab for default channel settings.

### DIFF
--- a/web/src/settings_sections.js
+++ b/web/src/settings_sections.js
@@ -67,7 +67,7 @@ export function initialize() {
     load_func_dict.set("org_bots", settings_users.set_up_bots);
     load_func_dict.set("org_users", settings_users.set_up_humans);
     load_func_dict.set("emoji-settings", settings_emoji.set_up);
-    load_func_dict.set("default-streams-list", settings_streams.set_up);
+    load_func_dict.set("default-channels-list", settings_streams.set_up);
     load_func_dict.set("linkifier-settings", settings_linkifiers.set_up);
     load_func_dict.set("playground-settings", settings_playgrounds.set_up);
     load_func_dict.set("invites-list-admin", settings_invites.set_up);

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -91,7 +91,7 @@ export function maybe_disable_widgets() {
         return;
     }
 
-    $(".organization-box [data-name='default-streams-list']")
+    $(".organization-box [data-name='default-channels-list']")
         .find("input:not(.search), button, select")
         .prop("disabled", true);
 }
@@ -120,12 +120,12 @@ export function build_default_stream_table() {
                 scroll_util.reset_scrollbar($table);
             },
         },
-        $parent_container: $("#admin-default-streams-list").expectOne(),
+        $parent_container: $("#admin-default-channels-list").expectOne(),
         init_sort: "name_alphabetic",
         sort_fields: {
             ...ListWidget.generic_sort_functions("alphabetic", ["name"]),
         },
-        $simplebar_container: $("#admin-default-streams-list .progressive-table-wrapper"),
+        $simplebar_container: $("#admin-default-channels-list .progressive-table-wrapper"),
     });
 
     loading.destroy_indicator($("#admin_page_default_streams_loading_indicator"));

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -851,7 +851,7 @@ input[type="checkbox"] {
     width: 100%;
 }
 
-#admin-default-streams-list .progressive-table-wrapper {
+#admin-default-channels-list .progressive-table-wrapper {
     max-height: calc(95vh - 280px);
 }
 

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -13,7 +13,7 @@
     {{else if (not can_subscribe_other_users)}}
     <div class="invite-stream-notice">
         {{#tr}}The users you invite will be automatically added to <z-link>default channels</z-link> for this organization, as you do not have permission to configure which channels new users join.
-        {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="#organization/default-streams-list">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="#organization/default-channels-list">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </div>
     {{/if}}

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -1,4 +1,4 @@
-<div id="admin-default-streams-list" class="settings-section" data-name="default-streams-list">
+<div id="admin-default-channels-list" class="settings-section" data-name="default-channels-list">
     <p>{{t "Configure the default channels new users are subscribed to when joining your organization." }}</p>
 
     <div class="settings_panel_list_header">

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -124,7 +124,7 @@
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{#unless is_guest}}
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-streams-list">
+                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
                         <i class="icon fa fa-exchange" aria-hidden="true"></i>
                         <div class="text">{{t "Default channels" }}</div>
                         {{#unless is_admin}}


### PR DESCRIPTION
Updates instances of `default-streams-list` to instead be `default-channels-list` as the data-section for the organization settings overlay is part of the URL hash.

Did a general sweep for everything returned by `git grep default-streams-list`.

**Screenshots and screen captures:**

![Screenshot from 2024-05-15 20-48-35](https://github.com/zulip/zulip/assets/63245456/7327cc9a-116b-4f7d-b308-174696e8be86)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
