### PR TITLE
zerver: Use correct flags to check if this is a self hosted server.

### DIFF
--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -33,13 +33,13 @@
                         {% trans %}
                         This organization has been deactivated.
                         {% endtrans %}
-                        {% if is_self_hosting_management_page %}
+                        {% if corporate_enabled %}
                             {% trans %}
-                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a> to reactivate it.
+                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact Zulip support</a> to reactivate it.
                             {% endtrans %}
                         {% else %}
                             {% trans %}
-                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact Zulip support</a> to reactivate it.
+                            If you are an owner of this organization, you can <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a> to reactivate it.
                             {% endtrans %}
                         {% endif %}
                     {% endif %}

--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -16,10 +16,10 @@
             <p>
                 {% trans %}There is no Zulip organization at <b>{{ current_url }}</b>.{% endtrans %}
                 <br />
-                {% if is_self_hosting_management_page %}
-                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
-                {% else %}
+                {% if corporate_enabled %}
                     {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact Zulip support</a>.{% endtrans %}
+                {% else %}
+                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
                 {% endif %}
             </p>
         </div>


### PR DESCRIPTION
`is_self_hosting_management_page` is used to check if user is on `selfhosting.ORG_URL` domain which is not what we want for these pages.


discussion: https://chat.zulip.org/#narrow/stream/3-backend/topic/How.20to.20test.20the.20corporate_enabled.20flag.3F