### PR TITLE
hashchange: Fix infinite home view <-> narrow loop on escape keypress.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -73,6 +73,12 @@ function is_somebody_else_profile_open() {
 }
 
 export function set_hash_to_home_view(triggered_by_escape_key = false) {
+    const current_hash = window.location.hash;
+    if (current_hash === "") {
+        // Empty hash for home view is always valid.
+        return;
+    }
+
     let home_view_hash = `#${user_settings.web_home_view}`;
     if (home_view_hash === "#recent_topics") {
         home_view_hash = "#recent";
@@ -82,7 +88,7 @@ export function set_hash_to_home_view(triggered_by_escape_key = false) {
         home_view_hash = "#feed";
     }
 
-    if (window.location.hash !== home_view_hash) {
+    if (current_hash !== home_view_hash) {
         const hash_before_current = browser_history.old_hash();
         if (
             triggered_by_escape_key &&


### PR DESCRIPTION
Reproducer:
* Start with empty hash and combined feed as home view.
* Go to any narrow.
* Keep pressing escape key.

You will keep switching between narrow view and home view while you should just stop at home view. This was due to `set_hash_to_home_view` not considering empty hash as a valid home view hash.

Introduced in f07ed8b6b309dc56cad7ed58bbf62e6883115443
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Esc.20key.20loop.20with.20combined.20feed

