### PR TITLE
recent_view: Remove side borders.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -724,8 +724,6 @@
     }
 
     #recent_view_table {
-        border-color: hsl(0deg 0% 0% / 60%);
-
         .fa-envelope,
         .fa-group {
             opacity: 0.7;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -11,10 +11,6 @@
         overflow: hidden !important;
         display: flex;
         flex-direction: column;
-        border-style: solid;
-        border-color: hsl(0deg 0% 88%);
-        border-width: 0 1px;
-        border-radius: 0;
         /* To make the table span full height
          * when rows don't reach bottom of the
          * window. This makes the border span
@@ -164,7 +160,6 @@
 
         #recent_view_filter_buttons {
             padding-top: 12px;
-            margin: 0 10px;
             display: flex;
             /* Search box has no height without this in safari. */
             flex: 0 0 auto;
@@ -175,7 +170,9 @@
         .search_group {
             display: flex;
             flex-grow: 1;
-            margin: 0 -27px 10px 0;
+            /* The negative margin here is to move the
+               clear search icon inside the search input. */
+            margin: 0 -23px 10px 4px;
         }
 
         #recent_view_search {
@@ -558,6 +555,7 @@
     }
 
     &:focus {
+        outline-offset: -2px;
         outline: 2px solid var(--color-outline-focus);
     }
 }


### PR DESCRIPTION
| before | after |
| --- | --- |
| <img width="1218" alt="Screenshot 2024-05-16 at 10 00 22 AM" src="https://github.com/zulip/zulip/assets/25124304/11946263-1330-4c80-85c6-2538a0ad2c0f"> | <img width="1217" alt="Screenshot 2024-05-16 at 10 00 37 AM" src="https://github.com/zulip/zulip/assets/25124304/7aa7e1b8-75e7-4ecb-8a1f-c9d6baf5cea4"> |

| before | after |
| --- | --- |
| <img width="1215" alt="Screenshot 2024-05-16 at 9 59 44 AM" src="https://github.com/zulip/zulip/assets/25124304/62a21e19-0bf1-49b3-994d-3d23b538b9ff"> | <img width="1218" alt="Screenshot 2024-05-16 at 9 59 30 AM" src="https://github.com/zulip/zulip/assets/25124304/e6fd038b-550d-4aef-be8f-ce1d4693f2cc"> |


Ensuring focus borders don't break

<img width="598" alt="Screenshot 2024-05-16 at 10 15 01 AM" src="https://github.com/zulip/zulip/assets/25124304/5cc49036-5f47-4ee5-b532-91f6c5df66af">
<img width="739" alt="Screenshot 2024-05-16 at 10 14 47 AM" src="https://github.com/zulip/zulip/assets/25124304/030f4e49-0c9c-4848-84c4-15b1a651960b">
<img width="743" alt="Screenshot 2024-05-16 at 10 14 30 AM" src="https://github.com/zulip/zulip/assets/25124304/deeb2741-2849-4fb8-ab49-004fc22e32fd">
