### PR TITLE
right_sidebar: Avoid 'user' word in class name.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -42,7 +42,7 @@ async function click_create_new_stream(page: Page): Promise<void> {
 }
 
 async function clear_ot_filter_with_backspace(page: Page): Promise<void> {
-    await page.click(".add-user-list-filter");
+    await page.click(".add-people-list-filter");
     await page.keyboard.press("Backspace");
     await page.keyboard.press("Backspace");
 }

--- a/web/src/stream_create_subscribers.js
+++ b/web/src/stream_create_subscribers.js
@@ -47,7 +47,7 @@ export function create_handlers($container) {
     $container.on("click", ".add_all_users_to_stream", (e) => {
         e.preventDefault();
         add_all_users();
-        $(".add-user-list-filter").trigger("focus");
+        $(".add-people-list-filter").trigger("focus");
     });
 
     $container.on("click", ".remove_potential_subscriber", (e) => {
@@ -107,7 +107,7 @@ export function build_widgets() {
             ...ListWidget.generic_sort_functions("alphabetic", ["full_name"]),
         },
         filter: {
-            $element: $("#people_to_add .add-user-list-filter"),
+            $element: $("#people_to_add .add-people-list-filter"),
             predicate(user, search_term) {
                 return people.build_person_matcher(search_term)(user);
             },

--- a/web/src/user_group_create_members.js
+++ b/web/src/user_group_create_members.js
@@ -55,7 +55,7 @@ export function create_handlers($container) {
     $container.on("click", ".add_all_users_to_user_group", (e) => {
         e.preventDefault();
         add_all_users();
-        $(".add-user-list-filter").trigger("focus");
+        $(".add-people-list-filter").trigger("focus");
     });
 
     $container.on("click", ".remove_potential_subscriber", (e) => {
@@ -110,7 +110,7 @@ export function build_widgets() {
             return render_new_user_group_user(item);
         },
         filter: {
-            $element: $("#people_to_add_in_group .add-user-list-filter"),
+            $element: $("#people_to_add_in_group .add-people-list-filter"),
             predicate(user, search_term) {
                 return people.build_person_matcher(search_term)(user);
             },

--- a/web/src/user_search.ts
+++ b/web/src/user_search.ts
@@ -12,7 +12,7 @@ export class UserSearch {
     // details of populating the list when we change.
 
     $widget = $("#user_search_section").expectOne();
-    $input = $<HTMLInputElement>("input.user-list-filter").expectOne();
+    $input = $<HTMLInputElement>("input.people-list-filter").expectOne();
     _reset_items: () => void;
     _update_list: () => void;
     _on_focus: () => void;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -762,7 +762,7 @@ h4.user_group_setting_subsection_title {
             }
         }
 
-        .add-user-list-filter {
+        .add-people-list-filter {
             width: 140px;
             float: right;
         }

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -8,7 +8,7 @@
                 <i id="user_filter_icon" class="fa fa-search"></i>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
-                <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
+                <input class="people-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -13,7 +13,7 @@
 
 <div class="create_stream_subscriber_list_header">
     <h4 class="stream_setting_subsection_title">{{t 'Subscribers' }}</h4>
-    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
+    <input class="add-people-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter subscribers' }}" />
 </div>
 

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -8,7 +8,7 @@
 
 <div class="create_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members' }}</h4>
-    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
+    <input class="add-people-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter members' }}" />
 </div>
 

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -240,7 +240,7 @@ test("presence_list_full_update", ({override, mock_template}) => {
         return "<presence-rows-stub>";
     });
 
-    $("input.user-list-filter").trigger("focus");
+    $("input.people-list-filter").trigger("focus");
 
     const user_ids = activity_ui.build_user_sidebar();
 
@@ -259,7 +259,7 @@ test("presence_list_full_update", ({override, mock_template}) => {
 });
 
 function simulate_right_column_buddy_list() {
-    $("input.user-list-filter").closest = (selector) => {
+    $("input.people-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
         return $.create("right-sidebar").addClass("column-right");
     };
@@ -354,7 +354,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
             stopPropagation() {},
         };
 
-        const handler = $("input.user-list-filter").get_on_handler("focus");
+        const handler = $("input.people-list-filter").get_on_handler("focus");
         handler(e);
     })();
 
@@ -373,7 +373,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
     (function test_enter_key() {
         init();
 
-        $("input.user-list-filter").val("al");
+        $("input.people-list-filter").val("al");
         narrowed = false;
         activity_ui.user_cursor.go_to(alice.user_id);
         filter_key_handlers.Enter();
@@ -396,7 +396,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
     (function test_blur_filter() {
         init();
         const e = {};
-        const handler = $("input.user-list-filter").get_on_handler("blur");
+        const handler = $("input.people-list-filter").get_on_handler("blur");
         handler(e);
     })();
 });
@@ -680,7 +680,7 @@ test("insert_unfiltered_user_with_filter", () => {
     // This test only tests that we do not explode when
     // try to insert Fred into a list where he does not
     // match the search filter.
-    const $user_filter = $("input.user-list-filter");
+    const $user_filter = $("input.people-list-filter");
     $user_filter.val("do-not-match-filter");
     activity_ui.redraw_user(fred.user_id);
 });

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -87,8 +87,8 @@ function test(label, f) {
 }
 
 function set_input_val(val) {
-    $("input.user-list-filter").val(val);
-    $("input.user-list-filter").trigger("input");
+    $("input.people-list-filter").val(val);
+    $("input.people-list-filter").trigger("input");
 }
 
 function stub_buddy_list_empty_list_message_lengths() {
@@ -116,7 +116,7 @@ test("clear_search", ({override}) => {
         assert.deepEqual(user_ids, {all_user_ids: ordered_user_ids});
     });
     $("#clear_search_people_button").trigger("click");
-    assert.equal($("input.user-list-filter").val(), "");
+    assert.equal($("input.people-list-filter").val(), "");
     $("#clear_search_people_button").trigger("click");
     assert.ok($("#user_search_section").hasClass("notdisplayed"));
 });
@@ -130,7 +130,7 @@ test("escape_search", ({override}) => {
 
     set_input_val("somevalue");
     activity_ui.escape_search();
-    assert.equal($("input.user-list-filter").val(), "");
+    assert.equal($("input.people-list-filter").val(), "");
     activity_ui.escape_search();
     assert.ok($("#user_search_section").hasClass("notdisplayed"));
 
@@ -144,15 +144,15 @@ test("blur search right", ({override}) => {
     override(resize, "resize_sidebars", noop);
     mock_setTimeout();
 
-    $("input.user-list-filter").closest = (selector) => {
+    $("input.people-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
         return $.create("right-sidebar").addClass("column-right");
     };
 
-    $("input.user-list-filter").trigger("blur");
-    assert.equal($("input.user-list-filter").is_focused(), false);
+    $("input.people-list-filter").trigger("blur");
+    assert.equal($("input.people-list-filter").is_focused(), false);
     activity_ui.initiate_search();
-    assert.equal($("input.user-list-filter").is_focused(), true);
+    assert.equal($("input.people-list-filter").is_focused(), true);
 });
 
 test("blur search left", ({override}) => {
@@ -161,15 +161,15 @@ test("blur search left", ({override}) => {
     override(resize, "resize_sidebars", noop);
     mock_setTimeout();
 
-    $("input.user-list-filter").closest = (selector) => {
+    $("input.people-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
         return $.create("right-sidebar").addClass("column-left");
     };
 
-    $("input.user-list-filter").trigger("blur");
-    assert.equal($("input.user-list-filter").is_focused(), false);
+    $("input.people-list-filter").trigger("blur");
+    assert.equal($("input.people-list-filter").is_focused(), false);
     activity_ui.initiate_search();
-    assert.equal($("input.user-list-filter").is_focused(), true);
+    assert.equal($("input.people-list-filter").is_focused(), true);
 });
 
 test("filter_user_ids", ({override}) => {
@@ -184,7 +184,7 @@ test("filter_user_ids", ({override}) => {
 
     function test_filter(search_text, expected_users) {
         const expected_user_ids = expected_users.map((user) => user.user_id);
-        $("input.user-list-filter").val(search_text);
+        $("input.people-list-filter").val(search_text);
         const filter_text = activity_ui.get_filter_text();
         assert.deepEqual(
             buddy_data.get_filtered_and_sorted_user_ids(filter_text),
@@ -227,7 +227,7 @@ test("filter_user_ids", ({override}) => {
 });
 
 test("click on user header to toggle display", ({override}) => {
-    const $user_filter = $("input.user-list-filter");
+    const $user_filter = $("input.people-list-filter");
 
     override(popovers, "hide_all", noop);
     override(sidebar_ui, "show_userlist_sidebar", noop);
@@ -243,7 +243,7 @@ test("click on user header to toggle display", ({override}) => {
     assert.ok($("#user_search_section").hasClass("notdisplayed"));
     assert.equal($user_filter.val(), "");
 
-    $("input.user-list-filter").closest = (selector) => {
+    $("input.people-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
         return $.create("sidebar").addClass("column-right");
     };
@@ -254,8 +254,8 @@ test("click on user header to toggle display", ({override}) => {
 
 test("searching", () => {
     assert.equal(activity_ui.searching(), false);
-    $("input.user-list-filter").trigger("focus");
+    $("input.people-list-filter").trigger("focus");
     assert.equal(activity_ui.searching(), true);
-    $("input.user-list-filter").trigger("blur");
+    $("input.people-list-filter").trigger("blur");
     assert.equal(activity_ui.searching(), false);
 });


### PR DESCRIPTION
Having 'user' name is class name make chrome treat it as username field and chrome tries to autofill it.

Reproducer:
* Go to settings > accounts & privacy
* Click manage your API key
* Try to autofill your password.

Along with the password being autofilled, right sidebar search is filled with your email.
