### PR TITLE
server_events: Fix infinite loading indicator on page load.

### DIFF
--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -1,7 +1,4 @@
-import $ from "jquery";
-
 import {all_messages_data} from "./all_messages_data";
-import * as loading from "./loading";
 import type {MessageListData} from "./message_list_data";
 import type {MessageList, RenderInfo} from "./message_lists";
 import * as message_store from "./message_store";
@@ -27,8 +24,6 @@ export function add_messages(
     if (!messages) {
         return undefined;
     }
-
-    loading.destroy_indicator($("#page_loading_indicator"));
 
     const render_info = msg_list.add_messages(messages, append_to_view_opts);
 

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as echo from "./echo";
+import * as loading from "./loading";
 import * as message_events from "./message_events";
 import {page_params} from "./page_params";
 import * as reload from "./reload";
@@ -282,6 +283,8 @@ export function force_get_events() {
 export function finished_initial_fetch() {
     waiting_on_initial_fetch = false;
     get_events_success([]);
+    // Destroy loading indicator after we added fetched messages.
+    loading.destroy_indicator($("#page_loading_indicator"));
 }
 
 export function initialize(params) {

--- a/web/tests/server_events.test.js
+++ b/web/tests/server_events.test.js
@@ -7,6 +7,9 @@ const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const {page_params} = require("./lib/zpage_params");
 
+mock_esm("../src/loading", {
+    destroy_indicator: noop,
+});
 set_global("addEventListener", noop);
 
 const channel = mock_esm("../src/channel");


### PR DESCRIPTION
Hiding the loading indicator was based on us adding some messages into the view which was no always the case.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/message.20loading.20spinner.20keeps.20spinning

Reproducer: populate database with no messages

Do we even need this indicator?
