### PR TITLE
topics: Convert topic links to permalinks.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 271**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added support for a new [search/narrow filter](/api/construct-narrow),
+  `with`, which returns messages in the same channel and topic as that
+  of the operand of filter, with the first unread message as anchor.
+
 **Feature level 270**
 
 * `PATCH /realm`, [`POST /register`](/api/register-queue),

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -51,7 +51,10 @@ important optimization when fetching messages in certain cases (e.g.,
 when [adding the `read` flag to a user's personal
 messages](/api/update-message-flags-for-narrow)).
 
-**Changes**: In Zulip 9.0 (feature level 265), support was added for a
+**Changes**: In Zulip 9.0 (feature level 271), narrows gained support
+for a new `with` operator for linking to topics.
+
+In Zulip 9.0 (feature level 265), support was added for a
 new `is:followed` filter, matching messages in topics that the current
 user is [following](/help/follow-a-topic).
 
@@ -88,15 +91,24 @@ filters did.
 
 ### Message IDs
 
-The `near` and `id` operators, documented in the help center, use message
-IDs for their operands.
+The `with` operator is designed to be used in links that should follow
+a topic across being moved. Its operand is a message ID.
 
+The `near` and `id` operators, documented in the help center,
+also use message IDs for their operands.
+
+* `with:12345`: Search for the conversation (stream/topic pair) which
+  contains the message with ID `12345`. If such a message exists, and
+  can be accessed by the user, then the search will be treated as having
+  the `channel`/`topic`/`dm` operators corresponding to the
+  conversation containing that message, replacing any such operators
+  in the original request.
 * `near:12345`: Search messages around the message with ID `12345`.
 * `id:12345`: Search for only message with ID `12345`.
 
-The message ID operand for the `id` operator may be encoded as either a
-number or a string. The message ID operand for the `near` operator must
-be encoded as a string.
+The message ID operand for the `with` and `id` operators may be encoded
+as either a number or a string. The message ID operand for the `near`
+operator must be encoded as a string.
 
 **Changes**: Prior to Zulip 8.0 (feature level 194), the message ID
 operand for the `id` operator needed to be encoded as a string.

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 270  # Last bumped for direct_message_permission_group
+API_FEATURE_LEVEL = 271  # Last bumped for `with` operator.
 
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -127,6 +127,7 @@ export const allowed_web_public_narrows = [
     "search",
     "near",
     "id",
+    "with",
 ];
 
 export function is_spectator_compatible(hash: string): boolean {

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -80,6 +80,9 @@ function process_result(data, opts) {
 
     if (messages.length !== 0) {
         if (opts.msg_list) {
+            if (opts.validate_filter_topic_post_fetch) {
+                opts.msg_list.data.filter.try_adjusting_for_moved_with_target(messages[0]);
+            }
             // Since this adds messages to the MessageList and renders MessageListView,
             // we don't need to call it if msg_list was not defined by the caller.
             message_util.add_old_messages(messages, opts.msg_list);
@@ -394,6 +397,7 @@ export function load_messages_for_narrow(opts) {
         num_after: consts.narrow_after,
         msg_list: opts.msg_list,
         cont: opts.cont,
+        validate_filter_topic_post_fetch: opts.validate_filter_topic_post_fetch,
     });
 }
 

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -87,7 +87,19 @@ export function changehash(newhash, trigger) {
         return;
     }
     message_viewport.stop_auto_scrolling();
-    browser_history.set_hash(newhash);
+
+    if (trigger === "retarget topic location") {
+        // It is important to use `replaceState` rather than `replace`
+        // here for the `back` button to work; we don't want to use
+        // any metadata potentially stored by
+        // update_current_history_state_data associated with an old
+        // URL for the target conversation, and conceptually we want
+        // to replace the inaccurate/old URL for the conversation with
+        // the current/corrected value.
+        window.history.replaceState(null, "", newhash);
+    } else {
+        browser_history.set_hash(newhash);
+    }
 }
 
 export function update_hash_to_match_filter(filter, trigger) {
@@ -132,12 +144,14 @@ function create_and_update_message_list(filter, id_info, opts) {
         });
 
         // Populate the message list if we can apply our filter locally (i.e.
-        // with no backend help) and we have the message we want to select.
+        // with no server help) and we have the message we want to select.
         // Also update id_info accordingly.
-        maybe_add_local_messages({
-            id_info,
-            msg_data,
-        });
+        if (!filter.requires_adjustment_for_moved_with_target) {
+            maybe_add_local_messages({
+                id_info,
+                msg_data,
+            });
+        }
 
         if (!id_info.local_select_id) {
             // If we're not actually ready to select an ID, we need to
@@ -306,6 +320,7 @@ export function show(raw_terms, opts) {
         raw_terms = [{operator: "is", operand: "home"}];
     }
     const filter = new Filter(raw_terms);
+    filter.try_adjusting_for_moved_with_target();
 
     if (try_rendering_locally_for_same_narrow(filter, opts)) {
         return;
@@ -642,7 +657,18 @@ export function show(raw_terms, opts) {
                 }
                 message_fetch.load_messages_for_narrow({
                     anchor,
+                    validate_filter_topic_post_fetch:
+                        filter.requires_adjustment_for_moved_with_target,
                     cont() {
+                        if (
+                            !filter.requires_adjustment_for_moved_with_target &&
+                            filter.has_operator("with")
+                        ) {
+                            // We've already adjusted our filter via
+                            // filter.try_adjusting_for_moved_with_target, and
+                            // should update the URL hash accordingly.
+                            update_hash_to_match_filter(filter, "retarget topic location");
+                        }
                         if (!select_immediately) {
                             render_message_list_with_selected_message({
                                 id_info,

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -206,6 +206,7 @@ run_test("basics", ({override}) => {
             cont: opts.cont,
             msg_list: opts.msg_list,
             anchor: 1000,
+            validate_filter_topic_post_fetch: false,
         });
 
         opts.cont();

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -30,6 +30,7 @@ people.add_active_user(alice);
 
 function set_filter(terms) {
     const filter = new Filter(terms);
+    filter.try_adjusting_for_moved_with_target();
     message_lists.set_current({
         data: {
             filter,
@@ -64,6 +65,7 @@ run_test("get_unread_ids", () => {
         id: 101,
         type: "stream",
         stream_id: sub.stream_id,
+        display_recipient: sub.name,
         topic: "my topic",
         unread: true,
         mentioned: true,
@@ -77,8 +79,20 @@ run_test("get_unread_ids", () => {
         display_recipient: [{id: alice.user_id}],
     };
 
+    const other_topic_message = {
+        id: 103,
+        type: "stream",
+        stream_id: sub.stream_id,
+        display_recipient: sub.name,
+        topic: "another topic",
+        unread: true,
+        mentioned: false,
+        mentioned_me_directly: false,
+    };
+
     message_store.update_message_cache(stream_msg);
     message_store.update_message_cache(private_msg);
+    message_store.update_message_cache(other_topic_message);
 
     stream_data.add_sub(sub);
 
@@ -201,6 +215,41 @@ run_test("get_unread_ids", () => {
     assert_unread_info({
         flavor: "cannot_compute",
     });
+
+    // For a search using `with` operator, our candidate ids
+    // will be the messages present in the channel/topic
+    // containing the message for which the `with` operand
+    // is id to.
+    //
+    // Here we use an empty topic for the operators, and show that
+    // adding the with operator causes us to see unreads in the
+    // destination topic.
+    unread.process_loaded_messages([other_topic_message]);
+    terms = [
+        {operator: "channel", operand: sub.name},
+        {operator: "topic", operand: "another topic"},
+    ];
+    set_filter(terms);
+    unread_ids = candidate_ids();
+    assert.deepEqual(unread_ids, [other_topic_message.id]);
+
+    terms = [
+        {operator: "channel", operand: sub.name},
+        {operator: "topic", operand: "another topic"},
+        {operator: "with", operand: stream_msg.id},
+    ];
+    set_filter(terms);
+    unread_ids = candidate_ids();
+    assert.deepEqual(unread_ids, [stream_msg.id]);
+
+    terms = [
+        {operator: "channel", operand: sub.name},
+        {operator: "topic", operand: "another topic"},
+        {operator: "with", operand: private_msg.id},
+    ];
+    set_filter(terms);
+    unread_ids = candidate_ids();
+    assert.deepEqual(unread_ids, []);
 
     message_lists.set_current(undefined);
     blueslip.expect("error", "unexpected call to get_first_unread_info");

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -21,6 +21,7 @@ from zerver.lib.narrow import (
     is_spectator_compatible,
     is_web_public_narrow,
     parse_anchor_value,
+    update_narrow_terms_containing_with_operator,
 )
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
@@ -114,7 +115,9 @@ def get_messages_backend(
     client_gravatar: Json[bool] = True,
     apply_markdown: Json[bool] = True,
 ) -> HttpResponse:
+    realm = get_valid_realm_from_request(request)
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor_val)
+    narrow = update_narrow_terms_containing_with_operator(realm, maybe_user_profile, narrow)
     if num_before + num_after > MAX_MESSAGES_PER_FETCH:
         raise JsonableError(
             _("Too many messages requested (maximum {max_messages}).").format(
@@ -124,7 +127,6 @@ def get_messages_backend(
     if num_before > 0 and num_after > 0 and not include_anchor:
         raise JsonableError(_("The anchor can only be excluded at an end of the range"))
 
-    realm = get_valid_realm_from_request(request)
     if not maybe_user_profile.is_authenticated:
         # If user is not authenticated, clients must include
         # `streams:web-public` in their narrow query to indicate this


### PR DESCRIPTION
**Commit 1**: adds a new narrow operator -- "with" which expects a string operand of message_id, and returns all the messages in the same channel and topic of the operand, with the first unread message of the topic as anchor.

cherry-picked commits into #30644:
**Commit 2**: Converts #-mention of topics to permalinks.

**Commit 3**: Converts left sidebar topic links and `Copy link to topic` to permalinks.

Fixes: #21505 

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
