### PR TITLE
portico: Correct help navigation outlines.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -240,11 +240,24 @@ html {
             );
             padding-right: calc(var(--help-sidebar-padding));
 
+            &:focus {
+                /* Zero out shoddy Bootstrap styles. */
+                outline: 0;
+            }
+
+            &:focus-visible {
+                /* We set an outline on focus-visible that works
+                   cross-browser. For the sake of accessibility,
+                   especially for keyboard users, this should
+                   NOT be zeroed out for the .highlighted row,
+                   as the focused navbar element retains focus
+                   even after navigating to a new section. */
+                outline: 2px solid hsl(0deg 0% 100%);
+                outline-offset: -2px;
+            }
+
             &.highlighted {
                 background-color: hsl(152deg 40% 42%);
-
-                /* Don't show the focus outline for the highlighted page. */
-                outline: 0;
             }
         }
     }

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -224,25 +224,22 @@ html {
             line-height: 1.7;
 
             cursor: pointer;
-
-            & a {
-                color: inherit;
-                display: block;
-
-                /* Extend to entire width of sidebar, not just link area */
-                margin-left: calc(
-                    0px - var(--help-sidebar-padding) -
-                        var(--help-sidebar-indent)
-                );
-                margin-right: calc(0px - var(--help-sidebar-padding));
-                padding-left: calc(
-                    var(--help-sidebar-padding) + var(--help-sidebar-indent)
-                );
-                padding-right: calc(var(--help-sidebar-padding));
-            }
         }
 
         & a {
+            color: inherit;
+            display: block;
+
+            /* Extend to entire width of sidebar, not just link area */
+            margin-left: calc(
+                0px - var(--help-sidebar-padding) - var(--help-sidebar-indent)
+            );
+            margin-right: calc(0px - var(--help-sidebar-padding));
+            padding-left: calc(
+                var(--help-sidebar-padding) + var(--help-sidebar-indent)
+            );
+            padding-right: calc(var(--help-sidebar-padding));
+
             &.highlighted {
                 background-color: hsl(152deg 40% 42%);
 


### PR DESCRIPTION
This PR corrects an ugly focus ring in the help navbars. It consolidates the CSS to make it applicable to all sidebar navigation items (not just those in list items), and uses `:focus-visible` to make a more consistent and accessible presentation of focused elements--including the currently-highlighted element.

It also now makes navbar-item highlighting uniform across Firefox and Chrome.

Note that this is a good opportunity for a design pass on the highlighted and focus styles, which may well be overwrought.

Fixes: #28745.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Chrome, Before | Chrome, After |
| --- | --- |
| ![Screenshot 2024-05-16 at 4 35 17 PM](https://github.com/zulip/zulip/assets/170719/fbffc348-3deb-4e93-a020-6deb5dde141e) | ![Screenshot 2024-05-16 at 4 36 27 PM](https://github.com/zulip/zulip/assets/170719/54081a15-ce15-4ddf-a100-63e697baede2) |
| ![Screenshot 2024-05-16 at 4 41 12 PM](https://github.com/zulip/zulip/assets/170719/2620ae29-c3a4-41bc-80f5-88830b9c75fd) | ![Screenshot 2024-05-16 at 4 33 34 PM](https://github.com/zulip/zulip/assets/170719/ed7fa2f7-388a-4b8f-91ce-32619dd7c367) |

| Firefox, Before | Firefox, After |
| --- | --- |
| ![Screenshot 2024-05-16 at 4 36 07 PM](https://github.com/zulip/zulip/assets/170719/62367901-13d3-47e7-83df-b9fc76b5d2f5) | ![Screenshot 2024-05-16 at 4 36 27 PM](https://github.com/zulip/zulip/assets/170719/733ec367-17aa-4462-8fc3-7999d5f51de5) |
| ![Screenshot 2024-05-16 at 4 34 53 PM](https://github.com/zulip/zulip/assets/170719/f9c74265-6111-4ae6-a9d2-8db6637db0af) | ![Screenshot 2024-05-16 at 4 34 33 PM](https://github.com/zulip/zulip/assets/170719/a6f0ebb1-ec5e-488f-a82a-c6bf0b5760a1) |
