### PR TITLE
composebox_typeahead: Clean up initalize method to take JQuery object.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1250,9 +1250,9 @@ function get_header_html(): string | false {
     return `<em>${_.escape(tip_text)}</em>`;
 }
 
-export function initialize_compose_typeahead(selector: string): void {
+export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElement>): void {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
-        $element: $(selector),
+        $element,
         type: "textarea",
     };
 
@@ -1365,5 +1365,5 @@ export function initialize({
         stopAdvance: true, // Do not advance to the next field on a Tab or Enter
     });
 
-    initialize_compose_typeahead("textarea#compose-textarea");
+    initialize_compose_typeahead($("textarea#compose-textarea"));
 }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -500,7 +500,7 @@ function edit_message($row, raw_content) {
     } else {
         $copy_message.remove();
         resize.watch_manual_resize_for_element($message_edit_content[0]);
-        composebox_typeahead.initialize_compose_typeahead($message_edit_content[0]);
+        composebox_typeahead.initialize_compose_typeahead($message_edit_content);
         compose_ui.handle_keyup(null, $message_edit_content);
         $message_edit_content.on("keydown", (event) => {
             compose_ui.handle_keydown(event, $message_edit_content);


### PR DESCRIPTION
Followup to https://github.com/zulip/zulip/pull/30086#discussion_r1600536580