### PR TITLE
is-resolved: Ok to include history.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -903,7 +903,7 @@ def ok_to_include_history(
         # that's a property on the UserMessage table.  There cannot be
         # historical messages in these cases anyway.
         for term in narrow:
-            if term["operator"] == "is":
+            if term["operator"] == "is" and term["operand"] not in {"resolved"}:
                 include_history = False
 
     return include_history

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1103,7 +1103,7 @@ class IncludeHistoryTest(ZulipTestCase):
             dict(operator="channels", operand="public"),
             dict(operator="is", operand="resolved"),
         ]
-        self.assertFalse(ok_to_include_history(narrow, user_profile, False))
+        self.assertTrue(ok_to_include_history(narrow, user_profile, False))
 
         # simple True case
         narrow = [


### PR DESCRIPTION
Fix issue with `is:resolved streams:public` only fetching rows from `zerver_usermessage`.