### PR TITLE
new conversation: Show correct tooltip when dms are disabled.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -134,14 +134,18 @@ export function update_buttons_for_private(): void {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     const is_direct_message_narrow = true;
     const pm_ids_string = narrow_state.pm_ids_string();
+
+    let disable_reply;
+
     if (!pm_ids_string || people.user_can_direct_message(pm_ids_string)) {
-        $("#new_conversation_button").attr("data-conversation-type", "direct");
-        update_buttons(text_stream, is_direct_message_narrow);
-        return;
+        disable_reply = false;
+    } else {
+        // disable the [Message X] button when in a private narrow
+        // if the user cannot dm the current recipient
+        disable_reply = true;
     }
-    // disable the [Message X] button when in a private narrow
-    // if the user cannot dm the current recipient
-    const disable_reply = true;
+    $("#new_conversation_button").attr("data-conversation-type", "direct");
+
     update_buttons(text_stream, is_direct_message_narrow, disable_reply);
 }
 


### PR DESCRIPTION
Earlier when dms were disabled, the `new conversation` button tooltip wasn't being updated, therefore a stale tooltip was being shown.

Earlier the `data-conversation-type` attribute of the `new conversation` button was being set to `direct` only if dms were enabled. As a result a stale tooltip was being shown when dms were disabled.
This commit updates the attribute to `direct` reagardless of dms being enabled or not.
> Note
> 
> A user can always DM themselves or a bot, even when direct messages are disabled in an org — the reason why we don't disable the "Start new conversation" button. (#28412)
> 

Fixes #29916.


### Screenshots and screencaptures
<details>

![image](https://github.com/zulip/zulip/assets/29176437/fc4a1383-ab8c-4a71-8ee9-e567a8868519)

[336899046-5808aa3a-d1ea-4f41-b03f-3c5468cc144b.webm](https://github.com/zulip/zulip/assets/29176437/08c38a30-85af-4659-b1d2-41e6481a3b14)

</details>

