### PR TITLE
Use `html` as scroll container for recent view.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -231,15 +231,26 @@
                 <div id="recent_view">
                     <div class="recent_view_container">
                         <div id="recent_view_table"></div>
-                        <div id="recent_view_bottom_whitespace">
-                            <div class="bottom-messages-logo">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
-                                    <circle cx="386.56" cy="386.56" r="386.56"/>
-                                    <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"/>
-                                </svg>
-                            </div>
-                            <div id="recent_view_loading_messages_indicator"></div>
+                    </div>
+                    <table id="recent-view-content-table">
+                        <tbody data-empty="{{ _('No conversations match your filters.') }}" id="recent-view-content-tbody"></tbody>
+                    </table>
+                    <div id="recent_view_bottom_whitespace">
+                        <div class="bottom-messages-logo">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
+                                <circle cx="386.56" cy="386.56" r="386.56"/>
+                                <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"/>
+                            </svg>
                         </div>
+                        <div id="recent_view_loading_messages_indicator"></div>
+                    </div>
+                    <!-- Don't show the banner until we have some messages loaded. -->
+                    <div class="recent-view-load-more-container main-view-banner info notvisible">
+                        <div class="last-fetched-message banner_content">{{ _('This view is still loading messages.') }}</div>
+                        <button class="fetch-messages-button main-view-banner-action-button right_edge notvisible">
+                            <div class="loading-indicator"></div>
+                            <span class="button-label">{{ _('Load more') }}</span>
+                        </button>
                     </div>
                 </div>
                 <div id="inbox-view">

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1177,7 +1177,10 @@ function recenter_focus_if_off_screen(): void {
         const topic_center_y = (position.top + position.bottom) / 2;
 
         const topic_element = document.elementFromPoint(topic_center_x, topic_center_y);
-        if (topic_element === null) {
+        if (
+            topic_element === null ||
+            $(topic_element).parents("#recent-view-content-tbody").length === 0
+        ) {
             // There are two theoretical reasons that the center
             // element might be null. One is that we haven't rendered
             // the view yet; but in that case, we should have returned

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -456,7 +456,6 @@ export function revive_current_focus(): boolean {
 
 export function show_loading_indicator(): void {
     loading.make_indicator($("#recent_view_loading_messages_indicator"));
-    $("#recent_view_table tbody").removeClass("required-text");
 }
 
 export function hide_loading_indicator(): void {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -263,6 +263,16 @@
     --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
     --color-border-sidebar: hsl(0deg 0% 87%);
 
+    /* Recent view */
+    --color-border-recent-view-row: hsl(0deg 0% 87%);
+    --color-border-recent-view-table: hsl(0deg 0% 0% / 60%);
+    --color-background-recent-view-row: hsl(100deg 11% 96%);
+    --color-background-recent-view-row-hover: hsl(210deg 100% 97%);
+    --color-background-recent-view-unread-row: hsl(0deg 0% 100%);
+    --color-background-recent-view-unread-row-hover: hsl(210deg 100% 97%);
+    --color-recent-view-link: hsl(205deg 47% 42%);
+    --color-recent-view-link-hover: hsl(214deg 40% 58%);
+
     /* Compose box colors */
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
     --color-compose-send-button-background: hsl(240deg 96% 68%);
@@ -590,6 +600,16 @@
     --color-background-alert-word: hsl(22deg 70% 35%);
     --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
+
+    /* Recent view */
+    --color-border-recent-view-row: hsl(0deg 0% 0% / 20%);
+    --color-border-recent-view-table: hsl(0deg 0% 88%);
+    --color-background-recent-view-row: hsl(0deg 0% 11%);
+    --color-background-recent-view-row-hover: hsl(208deg 26% 11% / 60%);
+    --color-background-recent-view-unread-row: hsl(212deg 30% 22% / 40%);
+    --color-background-recent-view-unread-row-hover: hsl(212deg 30% 22% / 60%);
+    --color-recent-view-link: hsl(206deg 89% 74%);
+    --color-recent-view-link-hover: hsl(208deg 64% 52%);
 
     /* Compose box colors */
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -689,22 +689,6 @@
         }
     }
 
-    #recent_view_table tr {
-        background-color: var(--color-background);
-
-        &:hover {
-            background-color: hsl(208deg 26% 11% / 60%);
-        }
-    }
-
-    #recent_view_table .unread_topic {
-        background-color: hsl(212deg 30% 22% / 40%);
-
-        &:hover {
-            background-color: hsl(212deg 30% 22% / 60%);
-        }
-    }
-
     .btn-recent-selected,
     #recent_view_table thead th {
         background-color: hsl(228deg 11% 17%) !important;
@@ -714,18 +698,7 @@
         }
     }
 
-    #recent_view_table td a {
-        color: hsl(206deg 89% 74%);
-        text-decoration: none;
-
-        &:hover {
-            color: hsl(208deg 64% 52%);
-        }
-    }
-
     #recent_view_table {
-        border-color: hsl(0deg 0% 0% / 60%);
-
         .fa-envelope,
         .fa-group {
             opacity: 0.7;
@@ -788,8 +761,7 @@
     #settings_page .sidebar-wrapper *,
     table,
     table th,
-    table td,
-    #recent_view_table table td {
+    table td {
         border-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -4,548 +4,519 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    max-height: 100vh;
-
-    #recent_view_table {
-        max-width: 100%;
-        overflow: hidden !important;
-        display: flex;
-        flex-direction: column;
-        border-style: solid;
-        border-color: hsl(0deg 0% 88%);
-        border-width: 0 1px;
-        border-radius: 0;
-        /* To make the table span full height
-         * when rows don't reach bottom of the
-         * window. This makes the border span
-         * fully to bottom in that case.
-         */
-        min-height: 100vh;
-
-        & td {
-            vertical-align: middle;
-            padding: 3px 8px;
-        }
-
-        .recent_view_focusable {
-            /* Use flexbox to align icons vertically */
-            display: flex;
-            align-items: center;
-
-            .filter-icon {
-                /* Maintain righthand space between icon
-                   and stream name. */
-                margin-right: 3px;
-            }
-
-            & > * {
-                outline: 0;
-            }
-
-            &:focus-within {
-                /* Use the same color as the message feed pointer */
-                box-shadow: 0 3px 0 var(--color-outline-focus);
-            }
-
-            &.change_visibility_policy.visibility-policy-popover-visible {
-                .zulip-icon-inherit {
-                    opacity: 0.4;
-                }
-            }
-
-            &.change_visibility_policy .zulip-icon-inherit {
-                opacity: 0;
-
-                &:focus {
-                    opacity: 0.2;
-                }
-            }
-        }
-
-        & a {
-            color: hsl(205deg 47% 42%);
-            text-decoration: none;
-
-            &:hover {
-                color: hsl(214deg 40% 58%);
-            }
-        }
-
-        .empty-table-message {
-            background-color: var(--color-background);
-            padding: 3em 1em;
-        }
-
-        .fa-check-square-o,
-        .fa-square-o {
-            padding: 0 2px;
-            width: 10px;
-        }
-
-        .fa-envelope {
-            font-size: 0.7rem;
-            margin-right: 2px;
-            position: relative;
-            top: -1px;
-            opacity: 0.6;
-        }
-
-        .table_fix_head {
-            padding: 0 !important;
-            max-height: calc(
-                100vh - var(--recent-topics-filters-height) -
-                    var(--navbar-fixed-height)
-            );
-        }
-
-        .recent-view-container {
-            /*
-            Add margin bottom equal to `#bottom-whitespace`. This helps us keep
-            #compose visible at its max-height without overlapping with any visible
-            topics.
-
-            Alternative is to adjust the max-height of `table_fix_head` based on compose height which is an
-            expensive repaint. The downside of not doing so is that the scrollbar is not visible to user when
-            user is at the bottom of scroll container when the compose box is open.
-            */
-            margin-bottom: var(--max-unexpanded-compose-height);
-        }
-
-        .recent-view-load-more-container {
-            margin: 20px 10px;
-            align-items: center;
-        }
-
-        .fetch-messages-button {
-            display: grid;
-            justify-items: center;
-
-            .loading_indicator_spinner {
-                height: 20px;
-                width: 20px;
-            }
-
-            path {
-                fill: var(--color-recent-view-loading-spinner);
-            }
-        }
-
-        .table_fix_head table {
-            /* To keep border properties to the thead th. */
-            border-collapse: separate;
-
-            border-spacing: 0;
-            width: 100%;
-
-            th {
-                padding: 8px;
-                text-align: left;
-            }
-
-            .unread_sort {
-                padding-left: 6px;
-
-                .zulip-icon-unread {
-                    position: absolute;
-                    right: 30px;
-                    top: 11px;
-                }
-
-                &::after {
-                    right: 15px;
-                    top: 7px;
-                }
-            }
-
-            td {
-                border-top: 1px solid hsl(0deg 0% 87%);
-            }
-        }
-
-        #recent_view_filter_buttons {
-            padding-top: 12px;
-            margin: 0 10px;
-            display: flex;
-            /* Search box has no height without this in safari. */
-            flex: 0 0 auto;
-            flex-wrap: wrap;
-            justify-content: flex-start;
-        }
-
-        .search_group {
-            display: flex;
-            flex-grow: 1;
-            margin: 0 -27px 10px 0;
-        }
-
-        #recent_view_search {
-            flex-grow: 1;
-            padding-right: 20px;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
-
-        .clear_search_button {
-            /* Overrides app_components.css property. */
-            padding-top: 4px !important;
-        }
-
-        .btn-recent-filters {
-            border-radius: 40px;
-            margin: 0 5px 10px 0;
-
-            &:focus {
-                background-color: hsl(0deg 0% 80%);
-                outline: 0;
-            }
-
-            &.fake_disabled_button {
-                cursor: not-allowed;
-                opacity: 0.5;
-
-                &:hover {
-                    background-color: hsl(0deg 0% 100%);
-                    border-color: hsl(0deg 0% 80%);
-                }
-            }
-        }
-
-        .btn-recent-selected {
-            background-color: hsl(0deg 11% 93%);
-        }
-
-        .unread_count {
-            /* Focus underline can only occupy the total length of the unread count */
-            margin-right: 1px;
-            margin-left: 1px;
-            align-self: center;
-            background-color: hsl(105deg 2% 50%);
-        }
-
-        .unread_mention_info:not(:empty) {
-            /* Zero out right margin from left sidebar presentation. */
-            margin-right: 0;
-            /* Match with its font-size. */
-            line-height: 14px;
-            /* Present a default/arrow cursor */
-            cursor: default;
-        }
-
-        .unread_hidden {
-            visibility: hidden;
-        }
-
-        .flex_container_pm {
-            /* Flex container to fit in user circle and group icon */
-            display: flex;
-            justify-content: space-between;
-
-            .tippy-content {
-                font-weight: 400;
-            }
-        }
-
-        .flex_container {
-            display: flex;
-            align-items: center;
-        }
-
-        .flex_container .right_part {
-            margin-left: auto;
-            display: inline-flex;
-            align-items: center;
-        }
-
-        .recent_topic_actions {
-            /* Add spacing between mention marker, unread count
-               and mute icon */
-            margin-left: 5px;
-            display: flex;
-            flex-flow: row nowrap;
-        }
-
-        .mention_in_unread {
-            opacity: 0.7;
-        }
-
-        .recent_topic_actions.dummy_action_button {
-            visibility: hidden;
-        }
-
-        .recent_topic_actions .recent_view_focusable {
-            /* Keep a uniform distance from the focus-within
-               indicator at bottom. */
-            padding-bottom: 3px;
-            /* But push down with margin by the same amount,
-               so as to preserve vertical alignment introduced
-               by the parent flexbox. */
-            margin-top: 3px;
-        }
-
-        .recent_topic_actions .recipient_bar_icon {
-            /* Zero out padding used in recipient bar. */
-            padding-right: 0;
-            padding-left: 0;
-        }
-
-        .recent_view_participants {
-            display: inline-flex; /* Causes LI items to display in row. */
-            list-style-type: none;
-            margin: auto; /* Centers vertically / horizontally in flex container. */
-            height: 24px;
-            padding: 4px;
-            border-radius: 6px;
-            overflow: hidden;
-
-            /*
-                By using the row-reverse layout, the visual ordering will be opposite of
-                the DOM ordering. This will allows us to stack the items in the opposite
-                direction of the natural stacking order without having to mess with the
-                zIndex value. The MAJOR DOWNSIDE is that the HTML itself now reads
-                backwards, which super janky.
-            */
-            flex-direction: row-reverse;
-        }
-
-        .recent_view_participant_item {
-            height: 24px;
-            margin: 0;
-            padding: 0 1.5px;
-            position: relative;
-            min-width: 24px;
-            cursor: pointer;
-
-            .fa-user {
-                opacity: 0.7;
-            }
-        }
-
-        .recent_view_participant_avatar,
-        .recent_view_participant_overflow {
-            border: 0;
-            border-radius: 6px;
-            color: hsl(0deg 0% 100%);
-            display: block;
-            height: 24px;
-            text-align: center;
-            background-color: hsl(0deg 0% 88%);
-        }
-
-        .recent_view_participant_overflow {
-            color: hsl(0deg 0% 0%);
-            line-height: 24px;
-        }
-
-        & tr {
-            background-color: hsl(100deg 11% 96%);
-
-            &:hover {
-                background-color: hsl(210deg 100% 97%);
-
-                .change_visibility_policy .zulip-icon-inherit {
-                    opacity: 0.4;
-                }
-            }
-        }
-
-        .unread_topic {
-            background-color: hsl(0deg 0% 100%);
-        }
-
-        .last_msg_time {
-            float: left;
-            margin-right: 5px;
-        }
-
-        & thead th {
-            background-color: hsl(0deg 0% 100%);
-            color: inherit;
-            border-top: 1px solid hsl(0deg 0% 0% / 20%) !important;
-            border-bottom: 1px solid hsl(0deg 0% 0% / 20%) !important;
-            position: sticky;
-            top: 0;
-            z-index: 1;
-
-            &.active::after,
-            &[data-sort]:hover::after {
-                content: " \f0d8";
-                white-space: pre;
-                display: inline-block;
-                position: absolute;
-                padding-top: 3px;
-                font: normal normal normal 12px/1 FontAwesome;
-                font-size: inherit;
-            }
-
-            &.active {
-                opacity: 1;
-                transition: opacity 100ms ease-out;
-
-                &.descend::after {
-                    content: " \f0d7";
-                }
-            }
-
-            &[data-sort]:hover {
-                cursor: pointer;
-                background-color: hsl(0deg 0% 95%);
-                transition: background-color 100ms ease-in-out;
-
-                &:not(.active)::after {
-                    opacity: 0.3;
-                }
-            }
-        }
-
-        /* These fixed column widths prevent column widths from being adjusted
-           as new messages arrive from the server. */
-        .recent_topic_stream {
-            width: 25%;
-            padding: 8px 0 8px 8px;
-
-            & a {
-                word-break: break-word;
-                hyphens: auto;
-            }
-        }
-
-        .recent_topic_name {
-            width: 40%;
-
-            & a {
-                word-break: break-word;
-                /* No hyphes for word break since it caused hyphens to appear before
-                   the ellipsis `longText-...` which is not desirable. Ellipsis appears due
-                   to the line clamp applied below.
-                */
-            }
-
-            .line_clamp {
-                /* This -webkit-box display property is webkit-specific, but
-                   it appears that line clamping works fine for this component
-                   on Firefox anyway. */
-                /* stylelint-disable-next-line value-no-vendor-prefix */
-                display: -webkit-box;
-                -webkit-line-clamp: 2;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
-            }
-        }
-
-        .recent_topic_users {
-            width: 20%;
-        }
-
-        .recent_topic_timestamp {
-            width: 15%;
-        }
-
-        & thead .last_msg_time_header {
-            /* The responsive table of bootstrap
-               somehow ignores the width of ::after
-               element. This ensures it is always visible.
-               20px = space occupied by ::after (icon) +
-               some extra padding.
-            */
-            padding-right: 20px;
-        }
-
-        @media (width < $md_min) {
-            /* Hide participants and last message time
-               on smaller screens. This ensures user always
-               has a nice UI experience. */
-            .recent_topic_users,
-            .recent_topic_timestamp,
-            thead .participants_header,
-            thead .last_msg_time_header {
-                display: none;
-            }
-
-            .recent_topic_actions {
-                margin-right: 5px;
-                font-size: 15px;
-            }
-        }
-
-        .private_conversation_row {
-            .recent_topic_stream {
-                /* Reduce padding of stream section so that user status
-                   icon can have more padding without impacting height of the row */
-                padding: 5px 0 5px 8px;
-            }
-
-            .pm_status_icon {
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                /* Increasing vertical padding any further will increase
-                the height of the row. */
-                padding: 8px;
-                position: relative;
-                right: -8px; /* To cancel padding-right */
-                /* To accommodate fa-group icon */
-                width: 14px;
-                height: 14px;
-
-                .fa-group,
-                .zulip-icon.zulip-icon-bot {
-                    font-size: 0.8rem;
-                    opacity: 0.6;
-                }
-
-                .user_circle {
-                    /* Shrink the user activity circle for the Recent Conversations context. */
-                    min-width: 7px;
-                    height: 7px;
-                    float: left;
-                    position: unset;
-                }
-            }
-        }
-    }
-
-    #recent_view_bottom_whitespace {
-        /* For visual reasons, in a message feed, we require a large
-         * bottom_whitespace to make it convenient to display new
-         * messages as they come in and prevent occluding the last
-         * message with an open compose box. Here, the bottom item
-         * is rarely interesting context for a message one is
-         * composing, but we do need at least 41px to allow the
-         * close-compose-box UI element (including border) to not
-         * overlap content. Add some more margin so that user
-         * can clearly see the end of the topics.
-         */
-        height: 120px;
-
-        #recent_view_loading_messages_indicator,
-        .bottom-messages-logo {
-            display: block;
-            position: absolute;
-            top: 200px;
-            left: 0;
-            right: 0;
-            margin: auto;
-
-            .loading_indicator_spinner {
-                position: relative;
-                top: -7px;
-            }
-        }
-    }
-
-    .stream-privacy {
-        .zulip-icon {
-            position: relative;
-            left: -1px;
-            top: 1.5px;
-        }
-    }
+    position: sticky;
+    top: var(--navbar-fixed-height);
+    z-index: 1;
+}
+
+.recent_view_container #recent_view_table {
+    max-width: 100%;
+    overflow: hidden !important;
+    display: flex;
+    flex-direction: column;
+    border: 0;
+}
+
+#recent_view_table .table,
+#recent-view-content-table {
+    /* To keep border properties to the thead th. */
+    border-collapse: separate;
+
+    border-spacing: 0;
+    width: 100%;
 }
 
 #recent_view {
     display: none;
-    position: relative;
+    padding-top: var(--navbar-fixed-height);
+    /* Add bottom padding equal to `#bottom-whitespace`. This helps us keep #compose visible
+       at its max-height without overlapping with any visible topics. */
+    padding-bottom: var(--max-unexpanded-compose-height);
+
+    & td {
+        vertical-align: middle;
+        padding: 3px 8px;
+        border-top: 1px solid var(--color-border-recent-view-row);
+    }
+
+    .recent_view_focusable {
+        /* Use flexbox to align icons vertically */
+        display: flex;
+        align-items: center;
+
+        .filter-icon {
+            /* Maintain righthand space between icon
+                and stream name. */
+            margin-right: 3px;
+        }
+
+        & > * {
+            outline: 0;
+        }
+
+        &:focus-within {
+            /* Use the same color as the message feed pointer */
+            box-shadow: 0 3px 0 var(--color-outline-focus);
+        }
+
+        &.change_visibility_policy.visibility-policy-popover-visible {
+            .zulip-icon-inherit {
+                opacity: 0.4;
+            }
+        }
+
+        &.change_visibility_policy .zulip-icon-inherit {
+            opacity: 0;
+
+            &:focus {
+                opacity: 0.2;
+            }
+        }
+    }
+
+    & a {
+        color: var(--color-recent-view-link);
+        text-decoration: none;
+
+        &:hover {
+            color: var(--color-recent-view-link-hover);
+        }
+    }
+
+    .empty-table-message {
+        background-color: var(--color-background);
+        padding: 3em 1em;
+    }
+
+    .fa-check-square-o,
+    .fa-square-o {
+        padding: 0 2px;
+        width: 10px;
+    }
+
+    .fa-envelope {
+        font-size: 0.7rem;
+        margin-right: 2px;
+        position: relative;
+        top: -1px;
+        opacity: 0.6;
+    }
+
+    .table_fix_head {
+        padding: 0 !important;
+    }
+
+    .recent-view-load-more-container {
+        margin: 20px 10px;
+        align-items: center;
+    }
+
+    .fetch-messages-button {
+        display: grid;
+        justify-items: center;
+
+        .loading_indicator_spinner {
+            height: 20px;
+            width: 20px;
+        }
+
+        path {
+            fill: var(--color-recent-view-loading-spinner);
+        }
+    }
+
+    .table_fix_head table th {
+        padding: 8px;
+        text-align: left;
+    }
+
+    #recent_view_filter_buttons {
+        padding: 12px 10px 0;
+        display: flex;
+        /* Search box has no height without this in safari. */
+        flex: 0 0 auto;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        background: var(--color-background);
+    }
+
+    .search_group {
+        display: flex;
+        flex-grow: 1;
+        margin: 0 -27px 10px 0;
+    }
+
+    #recent_view_search {
+        flex-grow: 1;
+        padding-right: 20px;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
+    .clear_search_button {
+        /* Overrides app_components.css property. */
+        padding-top: 4px !important;
+    }
+
+    .btn-recent-filters {
+        border-radius: 40px;
+        margin: 0 5px 10px 0;
+
+        &:focus {
+            background-color: hsl(0deg 0% 80%);
+            outline: 0;
+        }
+
+        &.fake_disabled_button {
+            cursor: not-allowed;
+            opacity: 0.5;
+
+            &:hover {
+                background-color: hsl(0deg 0% 100%);
+                border-color: hsl(0deg 0% 80%);
+            }
+        }
+    }
+
+    .btn-recent-selected {
+        background-color: hsl(0deg 11% 93%);
+    }
+
+    .unread_count {
+        /* Focus underline can only occupy the total length of the unread count */
+        margin-right: 1px;
+        margin-left: 1px;
+        align-self: center;
+        background-color: hsl(105deg 2% 50%);
+    }
+
+    .unread_mention_info:not(:empty) {
+        /* Zero out right margin from left sidebar presentation. */
+        margin-right: 0;
+        /* Match with its font-size. */
+        line-height: 14px;
+        /* Present a default/arrow cursor */
+        cursor: default;
+    }
+
+    .unread_hidden {
+        visibility: hidden;
+    }
+
+    .flex_container_pm {
+        /* Flex container to fit in user circle and group icon */
+        display: flex;
+        justify-content: space-between;
+
+        .tippy-content {
+            font-weight: 400;
+        }
+    }
+
+    .flex_container {
+        display: flex;
+        align-items: center;
+    }
+
+    .flex_container .right_part {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .recent_topic_actions {
+        /* Add spacing between mention marker, unread count
+            and mute icon */
+        margin-left: 5px;
+        display: flex;
+        flex-flow: row nowrap;
+    }
+
+    .mention_in_unread {
+        opacity: 0.7;
+    }
+
+    .recent_topic_actions.dummy_action_button {
+        visibility: hidden;
+    }
+
+    .recent_topic_actions .recent_view_focusable {
+        /* Keep a uniform distance from the focus-within
+            indicator at bottom. */
+        padding-bottom: 3px;
+        /* But push down with margin by the same amount,
+            so as to preserve vertical alignment introduced
+            by the parent flexbox. */
+        margin-top: 3px;
+    }
+
+    .recent_topic_actions .recipient_bar_icon {
+        /* Zero out padding used in recipient bar. */
+        padding-right: 0;
+        padding-left: 0;
+    }
+
+    .recent_view_participants {
+        display: inline-flex; /* Causes LI items to display in row. */
+        list-style-type: none;
+        margin: auto; /* Centers vertically / horizontally in flex container. */
+        height: 24px;
+        padding: 4px;
+        border-radius: 6px;
+        overflow: hidden;
+
+        /*
+            By using the row-reverse layout, the visual ordering will be opposite of
+            the DOM ordering. This will allows us to stack the items in the opposite
+            direction of the natural stacking order without having to mess with the
+            zIndex value. The MAJOR DOWNSIDE is that the HTML itself now reads
+            backwards, which super janky.
+        */
+        flex-direction: row-reverse;
+    }
+
+    .recent_view_participant_item {
+        height: 24px;
+        margin: 0;
+        padding: 0 1.5px;
+        position: relative;
+        min-width: 24px;
+        cursor: pointer;
+
+        .fa-user {
+            opacity: 0.7;
+        }
+    }
+
+    .recent_view_participant_avatar,
+    .recent_view_participant_overflow {
+        border: 0;
+        border-radius: 6px;
+        color: hsl(0deg 0% 100%);
+        display: block;
+        height: 24px;
+        text-align: center;
+        background-color: hsl(0deg 0% 88%);
+    }
+
+    .recent_view_participant_overflow {
+        color: hsl(0deg 0% 0%);
+        line-height: 24px;
+    }
+
+    & tr {
+        background-color: var(--color-background-recent-view-row);
+
+        &:hover {
+            background-color: var(--color-background-recent-view-row-hover);
+
+            .change_visibility_policy .zulip-icon-inherit {
+                opacity: 0.4;
+            }
+        }
+    }
+
+    .unread_topic {
+        background-color: var(--color-background-recent-view-unread-row);
+
+        &:hover {
+            background-color: var(
+                --color-background-recent-view-unread-row-hover
+            );
+        }
+    }
+
+    .last_msg_time {
+        float: left;
+        margin-right: 5px;
+    }
+
+    & thead th {
+        background-color: hsl(0deg 0% 100%);
+        color: inherit;
+        border-top: 1px solid hsl(0deg 0% 0% / 20%) !important;
+        border-bottom: 1px solid hsl(0deg 0% 0% / 20%) !important;
+        z-index: 1;
+
+        &.active::after,
+        &[data-sort]:hover::after {
+            content: " \f0d8";
+            white-space: pre;
+            display: inline-block;
+            position: absolute;
+            padding-top: 3px;
+            font: normal normal normal 12px/1 FontAwesome;
+            font-size: inherit;
+        }
+
+        &.active {
+            opacity: 1;
+            transition: opacity 100ms ease-out;
+
+            &.descend::after {
+                content: " \f0d7";
+            }
+        }
+
+        &[data-sort]:hover {
+            cursor: pointer;
+            background-color: hsl(0deg 0% 95%);
+            transition: background-color 100ms ease-in-out;
+
+            &:not(.active)::after {
+                opacity: 0.3;
+            }
+        }
+    }
+
+    .recent_topic_stream,
+    .recent-view-stream-header {
+        width: 25%;
+    }
+
+    .recent-view-topic-header {
+        width: 35%;
+    }
+
+    .recent-view-unread-header {
+        width: 5%;
+
+        .zulip-icon-unread {
+            position: relative;
+            top: 3px;
+        }
+    }
+
+    .recent_topic_users,
+    .recent-view-participants-header {
+        width: 20%;
+    }
+
+    .recent_topic_timestamp,
+    .recent-view-last-msg-time-header {
+        width: 15%;
+    }
+
+    /* These fixed column widths prevent column widths from being adjusted
+        as new messages arrive from the server. */
+    .recent_topic_stream {
+        padding: 8px 0 8px 8px;
+
+        & a {
+            word-break: break-word;
+            hyphens: auto;
+        }
+    }
+
+    .recent_topic_name {
+        width: 40%;
+
+        & a {
+            word-break: break-word;
+            /* No hyphes for word break since it caused hyphens to appear before
+                the ellipsis `longText-...` which is not desirable. Ellipsis appears due
+                to the line clamp applied below.
+            */
+        }
+
+        .line_clamp {
+            /* This -webkit-box display property is webkit-specific, but
+                it appears that line clamping works fine for this component
+                on Firefox anyway. */
+            /* stylelint-disable-next-line value-no-vendor-prefix */
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+    }
+
+    & thead .last_msg_time_header {
+        /* The responsive table of bootstrap
+            somehow ignores the width of ::after
+            element. This ensures it is always visible.
+            20px = space occupied by ::after (icon) +
+            some extra padding.
+        */
+        padding-right: 20px;
+    }
+
+    @media (width < $md_min) {
+        /* Hide participants and last message time
+            on smaller screens. This ensures user always
+            has a nice UI experience. */
+        .recent_topic_users,
+        .recent_topic_timestamp,
+        thead .participants_header,
+        thead .last_msg_time_header {
+            display: none;
+        }
+
+        .recent_topic_actions {
+            margin-right: 5px;
+            font-size: 15px;
+        }
+    }
+
+    .private_conversation_row {
+        .recent_topic_stream {
+            /* Reduce padding of stream section so that user status
+                icon can have more padding without impacting height of the row */
+            padding: 5px 0 5px 8px;
+        }
+
+        .pm_status_icon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            /* Increasing vertical padding any further will increase
+            the height of the row. */
+            padding: 8px;
+            position: relative;
+            right: -8px; /* To cancel padding-right */
+            /* To accommodate fa-group icon */
+            width: 14px;
+            height: 14px;
+
+            .fa-group,
+            .zulip-icon.zulip-icon-bot {
+                font-size: 0.8rem;
+                opacity: 0.6;
+            }
+
+            .user_circle {
+                /* Shrink the user activity circle for the Recent Conversations context. */
+                min-width: 7px;
+                height: 7px;
+                float: left;
+                position: unset;
+            }
+        }
+    }
+
+    .stream-privacy .zulip-icon {
+        position: relative;
+        left: -1px;
+        top: 1.5px;
+    }
+}
+
+#recent_view_bottom_whitespace {
+    #recent_view_loading_messages_indicator,
+    .bottom-messages-logo {
+        display: block;
+        position: absolute;
+        top: 200px;
+        left: 0;
+        right: 0;
+        margin: auto;
+
+        .loading_indicator_spinner {
+            position: relative;
+            top: -7px;
+        }
+    }
 }
 
 #recent-view-filter_widget {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -323,10 +323,6 @@ p.n-margin {
     }
 }
 
-.recent_view_container #recent_view_table {
-    margin-top: var(--navbar-fixed-height);
-}
-
 .app {
     min-width: 100%;
     min-height: 100%;

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -12,7 +12,7 @@
 <div class="table_fix_head" data-simplebar>
     <div class="recent-view-container">
         <table class="table table-responsive">
-            <tbody data-empty="{{t 'No conversations match your filters.' }}" class="required-text"></tbody>
+            <tbody data-empty="{{t 'No conversations match your filters.' }}"></tbody>
             <thead>
                 <tr>
                     <th data-sort="stream_sort">{{t 'Channel' }}</th>

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -9,29 +9,20 @@
         </button>
     </div>
 </div>
-<div class="table_fix_head" data-simplebar>
+<div class="table_fix_head">
     <div class="recent-view-container">
         <table class="table table-responsive">
-            <tbody data-empty="{{t 'No conversations match your filters.' }}"></tbody>
-            <thead>
+            <thead id="recent-view-table-headers">
                 <tr>
-                    <th data-sort="stream_sort">{{t 'Channel' }}</th>
-                    <th data-sort="topic_sort">{{t 'Topic' }}</th>
-                    <th data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="unread_sort tippy-zulip-delayed-tooltip hidden-for-spectators">
+                    <th class="recent-view-stream-header" data-sort="stream_sort">{{t 'Channel' }}</th>
+                    <th class="recent-view-topic-header" data-sort="topic_sort">{{t 'Topic' }}</th>
+                    <th data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="recent-view-unread-header unread_sort tippy-zulip-delayed-tooltip hidden-for-spectators">
                         <i class="zulip-icon zulip-icon-unread"></i>
                     </th>
-                    <th class='participants_header'>{{t 'Participants' }}</th>
-                    <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
+                    <th class='recent-view-participants-header participants_header'>{{t 'Participants' }}</th>
+                    <th data-sort="numeric" data-sort-prop="last_msg_id" class="recent-view-last-msg-time-header last_msg_time_header active descend">{{t 'Time' }}</th>
                 </tr>
             </thead>
         </table>
-        {{!-- Don't show the banner until we have some messages loaded. --}}
-        <div class="recent-view-load-more-container main-view-banner info notvisible">
-            <div class="last-fetched-message banner_content">{{t "This view is still loading messages."}}</div>
-            <button class="fetch-messages-button main-view-banner-action-button right_edge notvisible">
-                <div class="loading-indicator"></div>
-                <span class="button-label">{{t "Load more"}}</span>
-            </button>
-        </div>
     </div>
 </div>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -20,7 +20,7 @@
                     {{/if}}
                 </tr>
             </thead>
-            <tbody id="admin_profile_fields_table" class="required-text" data-empty="{{t 'No custom profile field configured for this organization.' }}"></tbody>
+            <tbody id="admin_profile_fields_table" data-empty="{{t 'No custom profile field configured for this organization.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -76,6 +76,7 @@ function make_scroll_container() {
         assert.equal(ev, "scroll.list_widget_container");
         $scroll_container.cleared = true;
     };
+    $scroll_container.is = () => false;
 
     return $scroll_container;
 }

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -7,6 +7,7 @@ const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {page_params} = require("./lib/zpage_params");
 
+window.scrollTo = noop;
 const test_url = () => "https://www.example.com";
 
 // We assign this in our test() wrapper.


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20conversations.20loses.20filter.20checkboxes

Things I tested:
* No topics
* only 1 topic
* Filters work as expected.
* Compose reply works
* Page up / down works
* focus changes correctly when navigating rows at the edge of visible area.
* load more works correctly.
* Recent view -> messages narrow -> recent view correctly preserves row focus
* Loading to `Combined feed` -> recent view correctly sets focus to first row.
* Initial loading indicator when no messages are fetched is displayed correctly.

<img width="1213" alt="Screenshot 2024-05-20 at 4 48 14 PM" src="https://github.com/zulip/zulip/assets/25124304/325ee216-0755-485f-a883-d7035cb7e0df">
