### PR TITLE
Fixed search query overflowing from screen

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -37,6 +37,8 @@ function retrieve_search_query_data(): SearchData {
     const search_string_result: SearchData = {
         query_words: [],
         has_stop_word: false,
+        size: 0,
+        query_words_shortened: "",
     };
 
     // Add in stream:foo and topic:bar if present
@@ -53,6 +55,8 @@ function retrieve_search_query_data(): SearchData {
 
     // Gather information about each query word
     for (const query_word of query_words) {
+        search_string_result.size += query_word.length;
+        search_string_result.query_words_shortened += query_word + " ";
         if (realm.stop_words.includes(query_word)) {
             search_string_result.has_stop_word = true;
             search_string_result.query_words.push({
@@ -67,8 +71,14 @@ function retrieve_search_query_data(): SearchData {
         }
     }
 
+    if (search_string_result.size > 60) {
+        search_string_result.query_words_shortened
+         = search_string_result.query_words_shortened.substring(0, 60) + "...";
+        search_string_result.size = 0;
+    }
+
     return search_string_result;
-}
+} 
 
 function pick_empty_narrow_banner(): NarrowBannerData {
     const default_banner = {

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -10,6 +10,8 @@ export type SearchData = {
     has_stop_word: boolean;
     stream_query?: string;
     topic_query?: string;
+    size: number;
+    query_words_shortened: string;
 };
 
 export type NarrowBannerData = {

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -9,6 +9,7 @@
             {{#if search_data.topic_query}}
             <span>topic: {{search_data.topic_query}}</span>
             {{/if}}
+            {{#if search_data.size}}
             {{#each search_data.query_words}}
                 {{#if is_stop_word}}
                 <del>{{query_word}}</del>
@@ -16,6 +17,9 @@
                 <span>{{query_word}}</span>
                 {{/if}}
             {{/each}}
+            {{else}}
+                <span>{{search_data.query_words_shortened}}</span>
+            {{/if}}
         {{else}}
             {{{ html }}}
         {{/if}}

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -164,6 +164,29 @@ run_test("empty_narrow_html", ({mock_template}) => {
 </div>
 `,
     );
+
+    const search_data_with_long_query = {
+        has_stop_word: false,
+        query_words: [],
+        size: 0,
+        query_words_shortened: "this is a really big query and should not be fully displayed...",
+    };
+    actual_html = empty_narrow_html(
+        "No search results.",
+        undefined,
+        search_data_with_long_query,
+    );
+    assert.equal(
+        actual_html,
+        `<div class="empty_feed_notice">
+    <h4 class="empty-feed-notice-title"> No search results. </h4>
+    <div class="empty-feed-notice-description">
+            You searched for:
+                <span>this is a really big query and should not be fully displayed...</span>
+    </div>
+</div>
+`,
+    );
 });
 
 run_test("urls", () => {

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -565,6 +565,7 @@ test("sort_recipients dup alls direct message", () => {
 
 test("sort_recipients subscribers", () => {
     // b_user_2 is a subscriber and b_user_1 is not.
+    peer_data.add_subscriber(dev_sub.stream_id, b_user_2.user_id);
     const small_matches = [b_user_2, b_user_1];
     const recipients = th.sort_recipients({
         users: small_matches,
@@ -580,6 +581,7 @@ test("sort_recipients subscribers", () => {
 test("sort_recipients pm partners", () => {
     // b_user_3 is a pm partner and b_user_2 is not and
     // both are not subscribed to the stream Linux.
+    pm_conversations.set_partner(b_user_3.user_id);
     const small_matches = [b_user_3, b_user_2];
     const recipients = th.sort_recipients({
         users: small_matches,


### PR DESCRIPTION
Fixed a UI presentation bug where a string was overlapping the right sidebar.

Fixes: #29568

**Screenshots and screen captures:**
![Opera Instantâneo_2024-05-19_154345_localhost](https://github.com/zulip/zulip/assets/116162726/32141d78-5e2b-4876-9012-124b81836c3b)

<details>
<summary>Self-review checklist</summary>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
