### PR TITLE
api-docs: Update descriptive text for stream to channel rename.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -1,18 +1,18 @@
 # Construct a narrow
 
 A **narrow** is a set of filters for Zulip messages, that can be based
-on many different factors (like sender, stream, topic, search
+on many different factors (like sender, channel, topic, search
 keywords, etc.). Narrows are used in various places in the the Zulip
 API (most importantly, in the API for fetching messages).
 
 It is simplest to explain the algorithm for encoding a search as a
 narrow using a single example. Consider the following search query
 (written as it would be entered in the Zulip web app's search box).
-It filters for messages sent to stream `announce`, not sent by
+It filters for messages sent to channel `announce`, not sent by
 `iago@zulip.com`, and containing the words `cool` and `sunglasses`:
 
 ```
-stream:announce -sender:iago@zulip.com cool sunglasses
+channel:announce -sender:iago@zulip.com cool sunglasses
 ```
 
 This query would be JSON-encoded for use in the Zulip API using JSON
@@ -21,7 +21,7 @@ as a list of simple objects, as follows:
 ```json
 [
     {
-        "operator": "stream",
+        "operator": "channel",
         "operand": "announce"
     },
     {
@@ -40,7 +40,7 @@ The Zulip help center article on [searching for messages](/help/search-for-messa
 documents the majority of the search/narrow options supported by the
 Zulip API.
 
-Note that many narrows, including all that lack a `stream` or `streams`
+Note that many narrows, including all that lack a `channel` or `channels`
 operator, search the current user's personal message history. See
 [searching shared history](/help/search-for-messages#searching-shared-history)
 for details.
@@ -52,7 +52,7 @@ when [adding the `read` flag to a user's personal
 messages](/api/update-message-flags-for-narrow)).
 
 **Changes**: In Zulip 9.0 (feature level 250), support was added for
-two filters related to stream messages: `channel` and `channels`. The
+two filters related to channel messages: `channel` and `channels`. The
 `channel` operator is an alias for the `stream` operator. The `channels`
 operator is an alias for the `streams` operator. Both `channel` and
 `channels` return the same exact results as `stream` and `streams`
@@ -107,13 +107,13 @@ operand for the `id` operator needed to be encoded as a string.
 ]
 ```
 
-### Stream and user IDs
+### Channel and user IDs
 
 There are a few additional narrow/search options (new in Zulip 2.1)
-that use either stream IDs or user IDs that are not documented in the
+that use either channel IDs or user IDs that are not documented in the
 help center because they are primarily useful to API clients:
 
-* `stream:1234`: Search messages sent to the stream with ID `1234`.
+* `channel:1234`: Search messages sent to the channel with ID `1234`.
 * `sender:1234`: Search messages sent by user ID `1234`.
 * `dm:1234`: Search the direct message conversation between
   you and user ID `1234`.
@@ -125,8 +125,8 @@ help center because they are primarily useful to API clients:
 !!! tip ""
 
     A user ID can be found by [viewing a user's profile][view-profile]
-    in the web or desktop apps. A stream ID can be found when [browsing
-    streams][browse-streams] in the web or desktop apps.
+    in the web or desktop apps. A channel ID can be found when [browsing
+    channels][browse-channels] in the web or desktop apps.
 
 The operands for these search options must be encoded either as an
 integer ID or a JSON list of integer IDs. For example, to query
@@ -147,4 +147,4 @@ user 1234, and user 5678, the correct JSON-encoded query is:
 ```
 
 [view-profile]: /help/view-someones-profile
-[browse-streams]: /help/introduction-to-channels#browse-and-subscribe-to-channels
+[browse-channels]: /help/introduction-to-channels#browse-and-subscribe-to-channels

--- a/api_docs/create-scheduled-message.md
+++ b/api_docs/create-scheduled-message.md
@@ -11,7 +11,7 @@
 {tab|curl}
 
 ``` curl
-# Create a scheduled stream message
+# Create a scheduled channel message
 curl -X POST {{ api_url }}/v1/scheduled_messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=stream \

--- a/api_docs/create-stream.md
+++ b/api_docs/create-stream.md
@@ -1,6 +1,6 @@
-# Create a stream
+# Create a channel
 
-You can create a stream using Zulip's REST API by submitting a
-[subscribe](/api/subscribe) request with a stream name that
+You can create a channel using Zulip's REST API by submitting a
+[subscribe](/api/subscribe) request with a channel name that
 doesn't yet exist and passing appropriate parameters to define
-the initial configuration of the new stream.
+the initial configuration of the new channel.

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -15,7 +15,7 @@
 * [Update personal message flags](/api/update-message-flags)
 * [Update personal message flags for narrow](/api/update-message-flags-for-narrow)
 * [Mark all messages as read](/api/mark-all-as-read)
-* [Mark messages in a stream as read](/api/mark-stream-as-read)
+* [Mark messages in a channel as read](/api/mark-stream-as-read)
 * [Mark messages in a topic as read](/api/mark-topic-as-read)
 * [Get a message's read receipts](/api/get-read-receipts)
 
@@ -33,27 +33,27 @@
 * [Edit a draft](/api/edit-draft)
 * [Delete a draft](/api/delete-draft)
 
-#### Streams
+#### Channels
 
-* [Get subscribed streams](/api/get-subscriptions)
-* [Subscribe to a stream](/api/subscribe)
-* [Unsubscribe from a stream](/api/unsubscribe)
+* [Get subscribed channels](/api/get-subscriptions)
+* [Subscribe to a channel](/api/subscribe)
+* [Unsubscribe from a channel](/api/unsubscribe)
 * [Get subscription status](/api/get-subscription-status)
 * [Get all subscribers](/api/get-subscribers)
 * [Update subscription settings](/api/update-subscription-settings)
-* [Get all streams](/api/get-streams)
-* [Get a stream by ID](/api/get-stream-by-id)
-* [Get stream ID](/api/get-stream-id)
-* [Create a stream](/api/create-stream)
-* [Update a stream](/api/update-stream)
-* [Archive a stream](/api/archive-stream)
-* [Get stream's email address](/api/get-stream-email-address)
-* [Get topics in a stream](/api/get-stream-topics)
+* [Get all channels](/api/get-streams)
+* [Get a channel by ID](/api/get-stream-by-id)
+* [Get channel ID](/api/get-stream-id)
+* [Create a channel](/api/create-stream)
+* [Update a channel](/api/update-stream)
+* [Archive a channel](/api/archive-stream)
+* [Get channel's email address](/api/get-stream-email-address)
+* [Get topics in a channel](/api/get-stream-topics)
 * [Topic muting](/api/mute-topic)
 * [Update personal preferences for a topic](/api/update-user-topic)
 * [Delete a topic](/api/delete-topic)
-* [Add a default stream](/api/add-default-stream)
-* [Remove a default stream](/api/remove-default-stream)
+* [Add a default channel](/api/add-default-stream)
+* [Remove a default channel](/api/remove-default-stream)
 
 #### Users
 

--- a/api_docs/incoming-webhooks-overview.md
+++ b/api_docs/incoming-webhooks-overview.md
@@ -137,7 +137,7 @@ below are for a webhook named `MyWebHook`.
 * Integrations that don't match a team's workflow can often be
   uselessly spammy.  Give careful thought to providing options for
   triggering Zulip messages only for certain message types, certain
-  projects, or sending different messages to different streams/topics,
+  projects, or sending different messages to different channels/topics,
   to make it easy for teams to configure the integration to support
   their workflow.
 
@@ -180,20 +180,20 @@ bot's API key, see the [API keys](/api/api-keys) documentation.
 
 ### stream
 
-The stream for the integration to send notifications to. Can be either
-the stream ID or the [URL-encoded][url-encoder] stream name. By default
+The channel for the integration to send notifications to. Can be either
+the channel ID or the [URL-encoded][url-encoder] channel name. By default
 the integration will send direct messages to the bot's owner.
 
 !!! tip ""
 
-    A stream ID can be found when [browsing streams][browse-streams]
+    A channel ID can be found when [browsing channels][browse-channels]
     in the web or desktop apps.
 
 ### topic
 
-The topic in the specified stream for the integration to send
+The topic in the specified channel for the integration to send
 notifications to. The topic should also be [URL-encoded][url-encoder].
-By default the integration will have a topic configured for stream
+By default the integration will have a topic configured for channel
 messages.
 
 ### only_events, exclude_events
@@ -212,7 +212,7 @@ For example, `test*` matches every event that starts with `test`.
     For a list of supported events, see a specific [integration's
     documentation](/integrations) page.
 
-[browse-streams]: /help/introduction-to-channels#browse-and-subscribe-to-channels
+[browse-channels]: /help/introduction-to-channels#browse-and-subscribe-to-channels
 [add-bot]: /help/add-a-bot-or-integration
 [url-encoder]: https://www.urlencoder.org/
 

--- a/api_docs/incoming-webhooks-walkthrough.md
+++ b/api_docs/incoming-webhooks-walkthrough.md
@@ -2,7 +2,7 @@
 
 Below, we explain each part of a simple incoming webhook integration,
 called **Hello World**.  This integration sends a "hello" message to the `test`
-stream and includes a link to the Wikipedia article of the day, which
+channel and includes a link to the Wikipedia article of the day, which
 it formats from json data it receives in the http request.
 
 Use this walkthrough to learn how to write your first webhook
@@ -151,7 +151,7 @@ define additional parameters using the `REQ` object.
 In the example above, we have defined `payload` which is populated
 from the body of the http request, `stream` with a default of `test`
 (available by default in the Zulip development environment), and
-`topic` with a default of `Hello World`. If your webhook uses a custom stream,
+`topic` with a default of `Hello World`. If your webhook uses a custom channel,
 it must exist before a message can be created in it. (See
 [Step 4: Create automated tests](#step-5-create-automated-tests) for how to handle this in tests.)
 
@@ -170,7 +170,7 @@ link to the Wikipedia article of the day as provided by the json payload.
 Then we send a message with `check_send_webhook_message`, which will
 validate the message and do the following:
 
-* Send a public (stream) message if the `stream` query parameter is
+* Send a public (channel) message if the `stream` query parameter is
   specified in the webhook URL.
 * If the `stream` query parameter isn't specified, it will send a direct
   message to the owner of the webhook bot.
@@ -350,12 +350,12 @@ class HelloWorldHookTests(WebhookTestCase):
 In the above example, `CHANNEL_NAME`, `URL_TEMPLATE`, and `WEBHOOK_DIR_NAME` refer
 to class attributes from the base class, `WebhookTestCase`. These are needed by
 the helper function `check_webhook` to determine how to execute
-your test. `CHANNEL_NAME` should be set to your default stream. If it doesn't exist,
+your test. `CHANNEL_NAME` should be set to your default channel. If it doesn't exist,
 `check_webhook` will create it while executing your test.
 
-If your test expects a stream name from a test fixture, the value in the fixture
+If your test expects a channel name from a test fixture, the value in the fixture
 and the value you set for `CHANNEL_NAME` must match. The test helpers use `CHANNEL_NAME`
-to create the destination stream, and then create the message to send using the
+to create the destination channel, and then create the message to send using the
 value from the fixture. If these don't match, the test will fail.
 
 `URL_TEMPLATE` defines how the test runner will call your incoming webhook, in the same way
@@ -438,9 +438,9 @@ Second, you need to write the actual documentation content in
 ```md
 Learn how Zulip integrations work with this simple Hello World example!
 
-1.  The Hello World webhook will use the `test` stream, which is created
+1.  The Hello World webhook will use the `test` channel, which is created
     by default in the Zulip development environment. If you are running
-    Zulip in production, you should make sure that this stream exists.
+    Zulip in production, you should make sure that this channel exists.
 
 1. {!create-an-incoming-webhook.md!}
 
@@ -531,7 +531,7 @@ def test_unknown_action_no_data(self) -> None:
     # we are testing. The value of result is the error message the webhook should
     # return if no params are sent. The fixture for this test is an empty file.
 
-    # subscribe to the target stream
+    # subscribe to the target channel
     self.subscribe(self.test_user, self.CHANNEL_NAME)
 
     # post to the webhook url
@@ -550,7 +550,7 @@ setup it would have done, and check the result yourself.
 
 Here, `subscribe_to_stream` is a test helper that uses `TEST_USER_EMAIL` and
 `CHANNEL_NAME` (attributes from the base class) to register the user to receive
-messages in the given stream. If the stream doesn't exist, it creates it.
+messages in the given channel. If the channel doesn't exist, it creates it.
 
 `client_post`, another helper, performs the HTTP POST that calls the incoming
 webhook. As long as `self.url` is correct, you don't need to construct the webhook

--- a/api_docs/integrations-overview.md
+++ b/api_docs/integrations-overview.md
@@ -34,7 +34,7 @@ Zulip.
   [Slack-compatible webhook API](/integrations/slack/slack_incoming).
 
 * If the product can send email notifications, you can
-  [send those emails to a stream](/help/message-a-channel-by-email).
+  [send those emails to a channel](/help/message-a-channel-by-email).
 
 ## Write your own integration
 

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -52,4 +52,4 @@ inconsistent syntax, were removed.
 [help-spoilers]: /help/spoilers
 [help-global-time]: /help/global-times
 [help-mentions]: /help/mention-a-user-or-group
-[help-mention-all]: /help/mention-a-user-or-group#mention-everyone-on-a-stream
+[help-mention-all]: /help/mention-a-user-or-group#mention-everyone-on-a-channel

--- a/api_docs/outgoing-webhooks.md
+++ b/api_docs/outgoing-webhooks.md
@@ -29,8 +29,8 @@ To register an outgoing webhook:
 
 There are currently two ways to trigger an outgoing webhook:
 
-*  **@-mention** the bot user in a stream.  If the bot replies, its
-    reply will be sent to that stream and topic.
+*  **@-mention** the bot user in a channel.  If the bot replies, its
+    reply will be sent to that channel and topic.
 *  **Send a direct message** with the bot as one of the recipients.
     If the bot replies, its reply will be sent to that thread.
 
@@ -124,11 +124,11 @@ Here's how we fill in the fields that a Slack-format webhook expects:
         </tr>
         <tr>
             <td><code>channel_id</code></td>
-            <td>Stream ID prefixed by "C"</td>
+            <td>Channel ID prefixed by "C"</td>
         </tr>
         <tr>
             <td><code>channel_name</code></td>
-            <td>Stream name</td>
+            <td>Channel name</td>
         </tr>
         <tr>
             <td><code>thread_ts</code></td>

--- a/api_docs/real-time-events.md
+++ b/api_docs/real-time-events.md
@@ -4,7 +4,7 @@ Zulip's real-time events API lets you write software that reacts
 immediately to events happening in Zulip.  This API is what powers the
 real-time updates in the Zulip web and mobile apps.  As a result, the
 events available via this API cover all changes to data displayed in
-the Zulip product, from new messages to stream descriptions to
+the Zulip product, from new messages to channel descriptions to
 emoji reactions to changes in user or organization-level settings.
 
 ## Using the events API

--- a/api_docs/roles-and-permissions.md
+++ b/api_docs/roles-and-permissions.md
@@ -76,7 +76,7 @@ event](/api/get-events#realm_user-add), and the
 Many areas of Zulip are customizable by the roles
 above, such as (but not limited to) [restricting message editing and
 deletion](/help/restrict-message-editing-and-deletion) and
-[streams permissions](/help/channel-permissions). The potential
+[channels permissions](/help/channel-permissions). The potential
 permission levels are:
 
 * Everyone / Any user including Guests (least restrictive)

--- a/api_docs/running-bots.md
+++ b/api_docs/running-bots.md
@@ -43,7 +43,7 @@ You'll need:
         INFO:root:starting message handling...
 
 1. Test your setup by [starting a new direct message](/help/starting-a-new-direct-message)
-   with the bot or [mentioning](/help/mention-a-user-or-group) the bot on a stream.
+   with the bot or [mentioning](/help/mention-a-user-or-group) the bot on a channel.
 
 !!! tip ""
 

--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -11,7 +11,7 @@
 {tab|curl}
 
 ``` curl
-# For stream messages
+# For channel messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=stream \
@@ -34,7 +34,7 @@ You can use `zulip-send`
 the command-line, providing the message content via STDIN.
 
 ```bash
-# For stream messages
+# For channel messages
 zulip-send --stream Denmark --subject Castle \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 

--- a/api_docs/writing-bots.md
+++ b/api_docs/writing-bots.md
@@ -191,7 +191,7 @@ def usage(self):
         This plugin will allow users to flag messages
         as being follow-up items.  Users should preface
         messages with "@followup".
-        Before running this, make sure to create a stream
+        Before running this, make sure to create a channel
         called "followup" that your API user can send to.
         '''
 ```
@@ -247,7 +247,7 @@ about where the message is sent to.
 ```python
 bot_handler.send_message(dict(
     type='stream', # can be 'stream' or 'private'
-    to=stream_name, # either the stream name or user's email
+    to=channel_name, # either the channel name or user's email
     subject=subject, # message subject
     content=message, # content of the sent message
 ))

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9853,7 +9853,7 @@ paths:
         [mute a topic](/help/mute-a-topic) and related features.
 
         This endpoint can be used to update the visibility policy for the single
-        stream and topic pair indicated by the parameters for a user.
+        channel and topic pair indicated by the parameters for a user.
 
         **Changes**: New in Zulip 7.0 (feature level 170). Previously,
         toggling whether a topic was muted or unmuted was managed by the
@@ -9867,7 +9867,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the stream to access.
+                    The ID of the channel to access.
                   type: integer
                   example: 1
                 topic:
@@ -9886,11 +9886,11 @@ paths:
                     Controls which visibility policy to set.
 
                     - 0 = None. Removes the visibility policy previously set for the topic.
-                    - 1 = Muted. [Mutes the topic](/help/mute-a-topic) in a stream.
-                    - 2 = Unmuted. [Unmutes the topic](/help/mute-a-topic) in a muted stream.
+                    - 1 = Muted. [Mutes the topic](/help/mute-a-topic) in a channel.
+                    - 2 = Unmuted. [Unmutes the topic](/help/mute-a-topic) in a muted channel.
                     - 3 = Followed. [Follows the topic](/help/follow-a-topic).
 
-                    In an unmuted stream, a topic visibility policy of unmuted will have the
+                    In an unmuted channel, a topic visibility policy of unmuted will have the
                     same effect as the "None" visibility policy.
 
                     **Changes**: In Zulip 7.0 (feature level 219), added followed as

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17857,10 +17857,10 @@ paths:
   /streams/{stream_id}/members:
     get:
       operationId: get-subscribers
-      summary: Get the subscribers of a stream
+      summary: Get the subscribers of a channel
       tags: ["streams"]
       description: |
-        Get all users subscribed to a stream.
+        Get all users subscribed to a channel.
       parameters:
         - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
@@ -17882,7 +17882,7 @@ paths:
                           type: integer
                         description: |
                           A list containing the IDs of all active users who are subscribed
-                          to the stream.
+                          to the channel.
                     example:
                       {"result": "success", "msg": "", "subscribers": [11, 26]}
         "400":
@@ -17893,8 +17893,8 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
-                      An example JSON response for when the requested stream does not exist,
-                      or where the user does not have permission to access the target stream:
+                      An example JSON response for when the requested channel does not exist,
+                      or where the user does not have permission to access the target channel:
   /streams:
     get:
       operationId: get-streams

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9141,10 +9141,10 @@ paths:
   /users/me/subscriptions:
     get:
       operationId: get-subscriptions
-      summary: Get subscribed streams
+      summary: Get subscribed channels
       tags: ["streams"]
       description: |
-        Get all streams that the user is subscribed to.
+        Get all channels that the user is subscribed to.
       # operationId can be used to record which view function
       # corresponds to an endpoint.  TODO: Add these for more
       # endpoints, and perhaps use this to provide links to implementations.
@@ -9182,7 +9182,7 @@ paths:
                         type: array
                         description: |
                           A list of dictionaries where each dictionary contains
-                          information about one of the subscribed streams.
+                          information about one of the subscribed channels.
 
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9934,7 +9934,7 @@ paths:
         - Clients should exclude muted users from presence lists or other UI
           for viewing or composing one-on-one direct messages. One-on-one direct
           messages sent by muted users should be hidden everywhere in the Zulip UI.
-        - Stream messages and group direct messages sent by the muted
+        - Channel messages and group direct messages sent by the muted
           user should avoid displaying the content and name/avatar,
           but should display that N messages by a muted user were
           hidden (so that it is possible to interpret the messages by
@@ -9944,8 +9944,8 @@ paths:
           showing their name, in lists of such conversations, along with using
           a blank grey avatar where avatars are displayed.
         - Administrative/settings UI elements for showing "All users that exist
-          on this stream or realm", e.g. for organization
-          administration or showing stream subscribers, should display
+          on this channel or realm", e.g. for organization
+          administration or showing channel subscribers, should display
           the user's name as normal.
 
         **Changes**: New in Zulip 4.0 (feature level 48).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5095,15 +5095,15 @@ paths:
   /get_stream_id:
     get:
       operationId: get-stream-id
-      summary: Get stream ID
+      summary: Get channel ID
       tags: ["streams"]
       description: |
-        Get the unique ID of a given stream.
+        Get the unique ID of a given channel.
       parameters:
         - name: stream
           in: query
           description: |
-            The name of the stream to access.
+            The name of the channel to access.
           schema:
             type: string
           example: Denmark
@@ -5124,7 +5124,7 @@ paths:
                       stream_id:
                         type: integer
                         description: |
-                          The ID of the given stream.
+                          The ID of the given channel.
                     example: {"msg": "", "result": "success", "stream_id": 15}
         "400":
           description: Bad request.
@@ -5140,7 +5140,7 @@ paths:
                         "result": "error",
                       }
                     description: |
-                      An example JSON response for when the supplied stream does not exist:
+                      An example JSON response for when the supplied channel does not exist:
   /mark_all_as_read:
     post:
       deprecated: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5688,7 +5688,7 @@ paths:
                 type:
                   description: |
                     The type of scheduled message to be sent. `"direct"` for a direct
-                    message and `"stream"` or `"channel"` for a stream message.
+                    message and `"stream"` or `"channel"` for a channel message.
 
                     Note that, while `"private"` is supported for scheduling direct
                     messages, clients are encouraged to use to the modern convention of
@@ -5696,7 +5696,7 @@ paths:
                     `"private"` may eventually be removed.
 
                     **Changes**: In Zulip 9.0 (feature level 248), `"channel"` was added as
-                    an additional value for this parameter to indicate the type of a stream
+                    an additional value for this parameter to indicate the type of a channel
                     message.
                   type: string
                   enum:
@@ -5709,7 +5709,7 @@ paths:
                   description: |
                     The scheduled message's tentative target audience.
 
-                    For stream messages, the integer ID of the stream.
+                    For channel messages, the integer ID of the channel.
                     For direct messages, a list containing integer user IDs.
                   oneOf:
                     - type: integer
@@ -5722,8 +5722,8 @@ paths:
                   $ref: "#/components/schemas/RequiredContent"
                 topic:
                   description: |
-                    The topic of the message. Only required for stream messages
-                    (`"type": "stream"`), ignored otherwise.
+                    The topic of the message. Only required for channel messages
+                    (`"type": "stream"` or `"type": "channel"`), ignored otherwise.
 
                     Clients should use the `max_topic_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
@@ -5792,8 +5792,8 @@ paths:
                   - allOf:
                       - $ref: "#/components/schemas/NonExistingChannelIdError"
                       - description: |
-                          A typical failed JSON response for when a stream message is scheduled
-                          to be sent to a stream that does not exist:
+                          A typical failed JSON response for when a channel message is scheduled
+                          to be sent to a channel that does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12632,11 +12632,11 @@ paths:
                   example: false
                 include_subscribers:
                   description: |
-                    Whether each returned stream object should include a `subscribers`
+                    Whether each returned channel object should include a `subscribers`
                     field containing a list of the user IDs of its subscribers.
 
                     (This may be significantly slower in organizations with
-                    thousands of users subscribed to many streams.)
+                    thousands of users subscribed to many channels.)
 
                     Passing `true` in an [unauthenticated
                     request](/help/public-access-option) is an error.
@@ -12669,12 +12669,12 @@ paths:
 
                     - `notification_settings_null`: Boolean for whether the
                       client can handle the current API with `null` values for
-                      stream-level notification settings (which means the stream
+                      channel-level notification settings (which means the channel
                       is not customized and should inherit the user's global
-                      notification settings for stream messages).
+                      notification settings for channel messages).
                       <br />
                       **Changes**: New in Zulip 2.1.0. In earlier Zulip releases,
-                      stream-level notification settings were simple booleans.
+                      channel-level notification settings were simple booleans.
 
                     - `bulk_message_deletion`: Boolean for whether the client's
                       handler for the `delete_message` event type has been
@@ -12698,7 +12698,7 @@ paths:
                       **Changes**: New in Zulip 3.0 (feature level 18).
 
                     - `stream_typing_notifications`: Boolean for whether the client
-                      supports stream typing notifications.
+                      supports channel typing notifications.
                       <br />
                       **Changes**: New in Zulip 4.0 (feature level 58). This capability is
                       for backwards-compatibility; it will be required in a
@@ -12952,7 +12952,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a stream name, in Unicode code
+                          The maximum allowed length for a channel name, in Unicode code
                           points. Clients should use this property rather than hardcoding
                           field sizes.
 
@@ -12964,7 +12964,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a stream description, in Unicode
+                          The maximum allowed length for a channel description, in Unicode
                           code points. Clients should use this property rather than hardcoding
                           field sizes.
 
@@ -13068,7 +13068,7 @@ paths:
                           Present if `muted_topics` is present in `fetch_event_types`.
 
                           Array of tuples, where each tuple describes a muted topic.
-                          The first element of the tuple is the stream name in which the topic
+                          The first element of the tuple is the channel name in which the topic
                           has to be muted, the second element is the topic name to be muted
                           and the third element is an integer UNIX timestamp representing
                           when the topic was muted.
@@ -13366,8 +13366,8 @@ paths:
                           Present if `subscription` is present in `fetch_event_types`.
 
                           A array of dictionaries where each dictionary describes the properties
-                          of a stream the user is subscribed to (as well as that user's
-                          personal per-stream settings).
+                          of a channel the user is subscribed to (as well as that user's
+                          personal per-channel settings).
 
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
@@ -13382,11 +13382,11 @@ paths:
                           Present if `subscription` is present in `fetch_event_types`.
 
                           A array of dictionaries where each dictionary describes one of the
-                          streams the user has unsubscribed from but was previously subscribed to
+                          channels the user has unsubscribed from but was previously subscribed to
                           along with the subscription details.
 
                           Unlike `never_subscribed`, the user might have messages in their personal
-                          message history that were sent to these streams.
+                          message history that were sent to these channels.
 
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
@@ -13421,10 +13421,10 @@ paths:
                                   type: integer
                                   nullable: true
                                   description: |
-                                    The average number of messages sent to the stream per week, as
+                                    The average number of messages sent to the channel per week, as
                                     estimated based on recent weeks, rounded to the nearest integer.
 
-                                    If `null`, the stream was recently created and there is
+                                    If `null`, the channel was recently created and there is
                                     insufficient data to estimate the average traffic.
                                 subscribers:
                                   type: array
@@ -13432,10 +13432,10 @@ paths:
                                     type: integer
                                   description: |
                                     A list of user IDs of users who are subscribed
-                                    to the stream. Included only if `include_subscribers` is `true`.
+                                    to the channel. Included only if `include_subscribers` is `true`.
 
                                     If a user is not allowed to know the subscribers for
-                                    a stream, we will send an empty array. API authors
+                                    a channel, we will send an empty array. API authors
                                     should use other data to determine whether users like
                                     guest users are forbidden to know the subscribers.
 
@@ -13443,10 +13443,10 @@ paths:
                           Present if `subscription` is present in `fetch_event_types`.
 
                           A array of dictionaries where each dictionary describes one of the
-                          streams that is visible to the user and the user has never been subscribed
+                          channels that is visible to the user and the user has never been subscribed
                           to.
 
-                          Important for clients containing UI where one can browse streams to subscribe
+                          Important for clients containing UI where one can browse channels to subscribe
                           to.
                       unread_msgs:
                         type: object
@@ -13464,7 +13464,7 @@ paths:
                             type: integer
                             description: |
                               The total number of unread messages to display. This includes one-on-one and group
-                              direct messages, as well as stream messages that are not [muted](/help/mute-a-topic).
+                              direct messages, as well as channel messages that are not [muted](/help/mute-a-topic).
 
                               **Changes**: Before Zulip 8.0 (feature level 213), the unmute and follow
                               topic features were not handled correctly in calculating this field.
@@ -13513,7 +13513,7 @@ paths:
                             type: array
                             description: |
                               An array of dictionaries where each dictionary contains details of all
-                              unread messages of a single subscribed stream. This includes muted streams
+                              unread messages of a single subscribed channel. This includes muted channels
                               and muted topics, even though those messages are excluded from `count`.
 
                               **Changes**: Prior to Zulip 5.0 (feature level 90), these objects
@@ -13530,11 +13530,11 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The ID of the stream to which the messages were sent.
+                                    The ID of the channel to which the messages were sent.
                                 unread_message_ids:
                                   type: array
                                   description: |
-                                    The message IDs of the recent unread messages sent in this stream,
+                                    The message IDs of the recent unread messages sent in this channel,
                                     sorted in ascending order.
                                   items:
                                     type: integer
@@ -13601,13 +13601,13 @@ paths:
                           Present if `stream` is present in `fetch_event_types`.
 
                           Array of dictionaries where each dictionary contains details about
-                          a single stream in the organization that is visible to the user.
+                          a single channel in the organization that is visible to the user.
 
-                          For organization administrators, this will include all private streams
+                          For organization administrators, this will include all private channels
                           in the organization.
 
                           **Changes**: As of Zulip 8.0 (feature level 205), this will include all
-                          web-public streams in the organization as well.
+                          web-public channels in the organization as well.
                       realm_default_streams:
                         type: array
                         items:
@@ -13616,7 +13616,7 @@ paths:
                           Present if `default_streams` is present in `fetch_event_types`.
 
                           An array of dictionaries where each dictionary contains details
-                          about a single [default stream](/help/set-default-channels-for-new-users)
+                          about a single [default channel](/help/set-default-channels-for-new-users)
                           for the Zulip organization.
                       realm_default_stream_groups:
                         type: array
@@ -13626,10 +13626,10 @@ paths:
                           Present if `default_stream_groups` is present in `fetch_event_types`.
 
                           An array of dictionaries where each dictionary contains details
-                          about a single default stream group configured for this
+                          about a single default channel group configured for this
                           Zulip organization.
 
-                          Default stream groups are an experimental feature.
+                          Default channel groups are an experimental feature.
                       stop_words:
                         type: array
                         items:
@@ -13865,7 +13865,7 @@ paths:
                           demote_inactive_streams:
                             type: integer
                             description: |
-                              Whether to [demote inactive streams](/help/manage-inactive-channels) in the left sidebar.
+                              Whether to [demote inactive channels](/help/manage-inactive-channels) in the left sidebar.
 
                               - 1 - Automatic
                               - 2 - Always
@@ -13883,13 +13883,13 @@ paths:
                           web_stream_unreads_count_display_policy:
                             type: integer
                             description: |
-                              Configuration for which streams should be displayed with a numeric unread count in the left sidebar.
-                              Streams that do not have an unread count will have a simple dot indicator for whether there are any
+                              Configuration for which channels should be displayed with a numeric unread count in the left sidebar.
+                              Channels that do not have an unread count will have a simple dot indicator for whether there are any
                               unread messages.
 
-                              - 1 - All streams
-                              - 2 - Unmuted streams and topics
-                              - 3 - No streams
+                              - 1 - All channels
+                              - 2 - Unmuted channels and topics
+                              - 3 - No channels
 
                               **Changes**: New in Zulip 8.0 (feature level 210).
                           timezone:
@@ -13913,19 +13913,19 @@ paths:
                           enable_stream_desktop_notifications:
                             type: boolean
                             description: |
-                              Enable visual desktop notifications for stream messages.
+                              Enable visual desktop notifications for channel messages.
                           enable_stream_email_notifications:
                             type: boolean
                             description: |
-                              Enable email notifications for stream messages.
+                              Enable email notifications for channel messages.
                           enable_stream_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notifications for stream messages.
+                              Enable mobile notifications for channel messages.
                           enable_stream_audible_notifications:
                             type: boolean
                             description: |
-                              Enable audible desktop notifications for stream messages.
+                              Enable audible desktop notifications for channel messages.
                           notification_sound:
                             type: string
                             description: |
@@ -14055,7 +14055,7 @@ paths:
                           automatically_unmute_topics_in_muted_streams_policy:
                             type: integer
                             description: |
-                              Which [topics to unmute automatically in muted streams](/help/mute-a-topic).
+                              Which [topics to unmute automatically in muted channels](/help/mute-a-topic).
 
                               - 1 - Topics the user participates in
                               - 2 - Topics the user sends a message to
@@ -14122,8 +14122,8 @@ paths:
                             description: |
                               Whether the user has chosen to send [typing
                               notifications](/help/typing-notifications)
-                              when composing stream messages. The client should send typing
-                              notifications for stream messages if and only if this setting is enabled.
+                              when composing channel messages. The client should send typing
+                              notifications for channel messages if and only if this setting is enabled.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
                           send_read_receipts:
@@ -14151,7 +14151,7 @@ paths:
                             stream_id:
                               type: integer
                               description: |
-                                The ID of the stream to which the topic belongs.
+                                The ID of the channel to which the topic belongs.
                             topic_name:
                               type: string
                               description: |
@@ -14608,7 +14608,7 @@ paths:
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
-                          Whether the user has chosen to demote inactive streams.
+                          Whether the user has chosen to demote inactive channels.
 
                           See [PATCH /settings](/api/update-settings) for details on
                           the meaning of this setting.
@@ -14956,7 +14956,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The [policy][permission-level] for which users can create public streams
+                          The [policy][permission-level] for which users can create public channels
                           in this organization.
 
                           - 1 = Members only
@@ -14965,7 +14965,7 @@ paths:
                           - 4 = Admins and moderators only
 
                           **Changes**: Before Zulip 5.0 (feature level 102), permission to
-                          create streams was controlled by the `realm_create_stream_policy` setting.
+                          create channels was controlled by the `realm_create_stream_policy` setting.
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -14974,7 +14974,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The [policy][permission-level] for which users can create private streams
+                          The [policy][permission-level] for which users can create private channels
                           in this organization.
 
                           - 1 = Members only
@@ -14983,7 +14983,7 @@ paths:
                           - 4 = Admins and moderators only
 
                           **Changes**: Before Zulip 5.0 (feature level 102), permission to
-                          create streams was controlled by the `realm_create_stream_policy` setting.
+                          create channels was controlled by the `realm_create_stream_policy` setting.
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -14998,7 +14998,7 @@ paths:
                           the `enable_spectator_access` realm setting.
 
                           The [policy][permission-level] for which users can create web
-                          public streams in this organization. Allowed
+                          public channels in this organization. Allowed
                           values are:
 
                           - 2 = Admins only
@@ -15015,27 +15015,27 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           The [policy](/api/roles-and-permissions#permission-levels)
-                          for which users can add other users to streams in this organization.
+                          for which users can add other users to channels in this organization.
                       realm_wildcard_mention_policy:
                         type: integer
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
                           The [policy][permission-level] for who can use wildcard mentions
-                          in large streams.
+                          in large channels.
 
-                          - 1 = Any user can use wildcard mentions in large streams.
-                          - 2 = Only members can use wildcard mentions in large streams.
-                          - 3 = Only [full members][calc-full-member] can use wildcard mentions in large streams.
-                          - 5 = Only organization administrators can use wildcard mentions in large streams.
-                          - 6 = Nobody can use wildcard mentions in large streams.
-                          - 7 = Only organization administrators and moderators can use wildcard mentions in large streams.
+                          - 1 = Any user can use wildcard mentions in large channels.
+                          - 2 = Only members can use wildcard mentions in large channels.
+                          - 3 = Only [full members][calc-full-member] can use wildcard mentions in large channels.
+                          - 5 = Only organization administrators can use wildcard mentions in large channels.
+                          - 6 = Nobody can use wildcard mentions in large channels.
+                          - 7 = Only organization administrators and moderators can use wildcard mentions in large channels.
 
                           All users will receive a warning/reminder when using
-                          mentions in large streams, even when permitted to do so.
+                          mentions in large channels, even when permitted to do so.
 
                           **Changes**: New in Zulip 4.0 (feature level 33). Moderators option added in
-                          Zulip 4.0 (feature level 62). Stream administrators option removed in
+                          Zulip 4.0 (feature level 62). Channel administrators option removed in
                           Zulip 6.0 (feature level 133).
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
@@ -15120,7 +15120,7 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           The [policy][permission-level] for which users can move messages
-                          from one stream to another.
+                          from one channel to another.
 
                           - 1 = Members only
                           - 2 = Administrators only
@@ -15233,7 +15233,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Whether web-public streams and related anonymous access APIs/features
+                          Whether web-public channels and related anonymous access APIs/features
                           are enabled in this organization.
 
                           Can only be enabled if the `WEB_PUBLIC_STREAMS_ENABLED`
@@ -15440,7 +15440,7 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           Messages sent more than this many seconds ago cannot be moved within a
-                          stream to another topic by users who have permission to do so based on this
+                          channel to another topic by users who have permission to do so based on this
                           organization's [topic edit policy](/help/restrict-moving-messages). This
                           setting does not affect moderators and administrators.
 
@@ -15457,7 +15457,7 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           Messages sent more than this many seconds ago cannot be moved between
-                          streams by users who have permission to do so based on this organization's
+                          channels by users who have permission to do so based on this organization's
                           [message move policy](/help/restrict-moving-messages). This setting does
                           not affect moderators and administrators.
 
@@ -15465,7 +15465,7 @@ paths:
                           regardless of how long ago they were sent.
 
                           **Changes**: New in Zulip 7.0 (feature level 162). Previously, there was
-                          no time limit for moving messages between streams for users with permission
+                          no time limit for moving messages between channels for users with permission
                           to do so.
                       realm_enable_read_receipts:
                         type: boolean
@@ -15943,11 +15943,11 @@ paths:
 
                           The value of the `WEB_PUBLIC_STREAMS_ENABLED` Zulip server level
                           setting. A server that has disabled this setting intends to not offer [web
-                          public streams](/help/public-access-option) to realms it hosts. (Zulip Cloud
+                          public channels](/help/public-access-option) to realms it hosts. (Zulip Cloud
                           defaults to `true`; self-hosted servers default to `false`).
 
                           Clients should use this to determine whether to offer UI for the
-                          realm-level setting for enabling web-public streams
+                          realm-level setting for enabling web-public channels
                           (`realm_enable_spectator_access`).
 
                           **Changes**: New in Zulip 5.0 (feature level 110).
@@ -15999,15 +15999,15 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The ID of the stream to which automated messages announcing the
-                          [creation of new streams][new-stream-announce] are sent.
+                          The ID of the channel to which automated messages announcing the
+                          [creation of new channels][new-channel-announce] are sent.
 
                           Will be `-1` if such automated messages are disabled.
 
                           Since these automated messages are sent by the server, this field is
                           primarily relevant to clients containing UI for changing it.
 
-                          [new-stream-announce]: /help/configure-automated-notices#new-channel-announcements
+                          [new-channel-announce]: /help/configure-automated-notices#new-channel-announcements
 
                           **Changes**: In Zulip 9.0 (feature level 241), renamed 'realm_notifications_stream_id'
                           to `realm_new_stream_announcements_stream_id`.
@@ -16016,7 +16016,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The ID of the stream to which automated messages announcing
+                          The ID of the channel to which automated messages announcing
                           that [new users have joined the organization][new-user-announce] are sent.
 
                           Will be `-1` if such automated messages are disabled.
@@ -16033,7 +16033,7 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The ID of the stream to which automated messages announcing
+                          The ID of the channel to which automated messages announcing
                           new features or other end-user updates about the Zulip software are sent.
 
                           Will be `-1` if such automated messages are disabled.
@@ -16201,7 +16201,7 @@ paths:
                           demote_inactive_streams:
                             type: integer
                             description: |
-                              Whether to [demote inactive streams](/help/manage-inactive-channels) in the left sidebar.
+                              Whether to [demote inactive channels](/help/manage-inactive-channels) in the left sidebar.
 
                               - 1 - Automatic
                               - 2 - Always
@@ -16219,31 +16219,31 @@ paths:
                           web_stream_unreads_count_display_policy:
                             type: integer
                             description: |
-                              Configuration for which streams should be displayed with a numeric unread count in the left sidebar.
-                              Streams that do not have an unread count will have a simple dot indicator for whether there are any
+                              Configuration for which channels should be displayed with a numeric unread count in the left sidebar.
+                              Channels that do not have an unread count will have a simple dot indicator for whether there are any
                               unread messages.
 
-                              - 1 - All streams
-                              - 2 - Unmuted streams and topics
-                              - 3 - No streams
+                              - 1 - All channels
+                              - 2 - Unmuted channels and topics
+                              - 3 - No channels
 
                               **Changes**: New in Zulip 8.0 (feature level 210).
                           enable_stream_desktop_notifications:
                             type: boolean
                             description: |
-                              Enable visual desktop notifications for stream messages.
+                              Enable visual desktop notifications for channel messages.
                           enable_stream_email_notifications:
                             type: boolean
                             description: |
-                              Enable email notifications for stream messages.
+                              Enable email notifications for channel messages.
                           enable_stream_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notifications for stream messages.
+                              Enable mobile notifications for channel messages.
                           enable_stream_audible_notifications:
                             type: boolean
                             description: |
-                              Enable audible desktop notifications for stream messages.
+                              Enable audible desktop notifications for channel messages.
                           notification_sound:
                             type: string
                             description: |
@@ -16368,7 +16368,7 @@ paths:
                           automatically_unmute_topics_in_muted_streams_policy:
                             type: integer
                             description: |
-                              Which [topics to unmute automatically in muted streams](/help/mute-a-topic).
+                              Which [topics to unmute automatically in muted channels](/help/mute-a-topic).
 
                               - 1 - Topics the user participates in
                               - 2 - Topics the user sends a message to
@@ -16451,7 +16451,7 @@ paths:
                             type: boolean
                             description: |
                               Whether [typing notifications](/help/typing-notifications) be sent when composing
-                              stream messages.
+                              channel messages.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
                           send_read_receipts:
@@ -16532,14 +16532,14 @@ paths:
                           Present if `realm_user` is present in `fetch_event_types`.
 
                           Whether the current user is allowed to create at least one type
-                          of stream with the organization's [stream creation
+                          of channel with the organization's [channel creation
                           policy](/help/configure-who-can-create-channels). Its value will
                           always equal `can_create_public_streams || can_create_private_streams`.
 
                           **Changes**: Deprecated in Zulip 5.0 (feature level 102), when
                           the new `create_private_stream_policy` and
                           `create_public_stream_policy` properties introduced the
-                          possibility that a user could only create one type of stream.
+                          possibility that a user could only create one type of channel.
 
                           This field will be removed in a future release.
                       can_create_public_streams:
@@ -16547,30 +16547,30 @@ paths:
                         description: |
                           Present if `realm_user` is present in `fetch_event_types`.
 
-                          Whether the current user is allowed to create public streams with
-                          the organization's [stream creation policy](/help/configure-who-can-create-channels).
+                          Whether the current user is allowed to create public channels with
+                          the organization's [channel creation policy](/help/configure-who-can-create-channels).
 
                           **Changes**: New in Zulip 5.0 (feature level 102). In older
                           versions, the deprecated `can_create_streams` property should be
-                          used to determine whether the user can create public streams.
+                          used to determine whether the user can create public channels.
                       can_create_private_streams:
                         type: boolean
                         description: |
                           Present if `realm_user` is present in `fetch_event_types`.
 
-                          Whether the current user is allowed to create private streams with
-                          the organization's [stream creation policy](/help/configure-who-can-create-channels).
+                          Whether the current user is allowed to create private channels with
+                          the organization's [channel creation policy](/help/configure-who-can-create-channels).
 
                           **Changes**: New in Zulip 5.0 (feature level 102). In older
                           versions, the deprecated `can_create_streams` property should be
-                          used to determine whether the user can create private streams.
+                          used to determine whether the user can create private channels.
                       can_create_web_public_streams:
                         type: boolean
                         description: |
                           Present if `realm_user` is present in `fetch_event_types`.
 
-                          Whether the current user is allowed to create public streams with
-                          the organization's [stream creation policy](/help/configure-who-can-create-channels).
+                          Whether the current user is allowed to create public channels with
+                          the organization's [channel creation policy](/help/configure-who-can-create-channels).
 
                           Note that this will be false if the Zulip server does not have the
                           `WEB_PUBLIC_STREAMS_ENABLED` setting enabled or if the organization has
@@ -16582,8 +16582,8 @@ paths:
                         description: |
                           Present if `realm_user` is present in `fetch_event_types`.
 
-                          Whether the current user is allowed to subscribe other users to streams with
-                          the organization's [streams policy](/help/configure-who-can-invite-to-channels).
+                          Whether the current user is allowed to subscribe other users to channels with
+                          the organization's [channels policy](/help/configure-who-can-invite-to-channels).
                       can_invite_others_to_realm:
                         type: boolean
                         description: |
@@ -16733,7 +16733,7 @@ paths:
                           stream:
                             type: object
                             description: |
-                              Configuration for stream level group permission settings.
+                              Configuration for channel level group permission settings.
                             additionalProperties:
                               $ref: "#/components/schemas/GroupPermissionSetting"
                           group:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18351,10 +18351,10 @@ paths:
   /streams/{stream_id}/email_address:
     get:
       operationId: get-stream-email-address
-      summary: Get the email address of a stream
+      summary: Get the email address of a channel
       tags: ["streams"]
       description: |
-        Get email address of a stream.
+        Get email address of a channel.
 
         **Changes**: New in Zulip 8.0 (feature level 226).
       parameters:
@@ -18375,12 +18375,12 @@ paths:
                       email:
                         type: string
                         description: |
-                          Email address of the stream.
+                          Email address of the channel.
                     example:
                       {
                         "result": "success",
                         "msg": "",
-                        "email": "test_stream.af64447e9e39374841063747ade8e6b0.show-sender@testserver",
+                        "email": "test.af64447e9e39374841063747ade8e6b0.show-sender@testserver",
                       }
         "400":
           description: Bad request.
@@ -18390,8 +18390,8 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
-                      An example JSON response for when the requested stream does not exist,
-                      or where the user does not have permission to access the target stream:
+                      An example JSON response for when the requested channel does not exist,
+                      or where the user does not have permission to access the target channel:
   /streams/{stream_id}/delete_topic:
     post:
       operationId: delete-topic

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -643,7 +643,7 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to a user's clients when that user's stream subscriptions
+                                Event sent to a user's clients when that user's channel subscriptions
                                 have changed (either the set of subscriptions or their properties).
                               properties:
                                 id:
@@ -661,7 +661,7 @@ paths:
                                   type: array
                                   description: |
                                     A list of dictionaries where each dictionary contains
-                                    information about one of the subscribed streams.
+                                    information about one of the subscribed channels.
 
                                     **Changes**: Removed `email_address` field from the dictionary
                                     in Zulip 8.0 (feature level 226).
@@ -678,7 +678,7 @@ paths:
                                   "subscriptions":
                                     [
                                       {
-                                        "name": "test_stream",
+                                        "name": "test",
                                         "stream_id": 9,
                                         "creator_id": null,
                                         "description": "",
@@ -709,7 +709,7 @@ paths:
                             - type: object
                               description: |
                                 Event sent to a user's clients when that user has been unsubscribed
-                                from one or more streams.
+                                from one or more channels.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -726,37 +726,37 @@ paths:
                                   type: array
                                   description: |
                                     A list of dictionaries, where each dictionary contains
-                                    information about one of the newly unsubscribed streams.
+                                    information about one of the newly unsubscribed channels.
                                   items:
                                     type: object
                                     additionalProperties: false
                                     description: |
-                                      Dictionary containing details about the unsubscribed stream.
+                                      Dictionary containing details about the unsubscribed channel.
                                     properties:
                                       stream_id:
                                         type: integer
                                         description: |
-                                          The ID of the stream.
+                                          The ID of the channel.
                                       name:
                                         type: string
                                         description: |
-                                          The name of the stream.
+                                          The name of the channel.
                               additionalProperties: false
                               example:
                                 {
                                   "type": "subscription",
                                   "op": "remove",
                                   "subscriptions":
-                                    [{"name": "test_stream", "stream_id": 9}],
+                                    [{"name": "test", "stream_id": 9}],
                                   "id": 0,
                                 }
                             - type: object
                               description: |
                                 Event sent to a user's clients when a property of the user's
-                                subscription to a stream has been updated. This event is used
+                                subscription to a channel has been updated. This event is used
                                 only for personal properties like `is_muted` or `pin_to_top`.
-                                See the [stream update event](/api/get-events#stream-update)
-                                for updates to global properties of a stream.
+                                See the [`stream op: update` event](/api/get-events#stream-update)
+                                for updates to global properties of a channel.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -772,7 +772,7 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The ID of the stream whose subscription details have changed.
+                                    The ID of the channel whose subscription details have changed.
                                 property:
                                   type: string
                                   description: |
@@ -808,32 +808,32 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent when another user subscribes to a stream, or their
+                                Event sent when another user subscribes to a channel, or their
                                 subscription is newly visible to the current user.
 
-                                When a user subscribes to a stream, the current user will receive this
-                                event only if they [have permission to see the stream's subscriber
+                                When a user subscribes to a channel, the current user will receive this
+                                event only if they [have permission to see the channel's subscriber
                                 list](/help/channel-permissions). When the current user gains permission
-                                to see a given stream's subscriber list, they will receive this event
-                                for the existing subscriptions to the stream.
+                                to see a given channel's subscriber list, they will receive this event
+                                for the existing subscriptions to the channel.
 
                                 **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
                                 incorrectly not sent to guest users when subscribers to web-public
-                                streams and subscribed public streams changed.
+                                channels and subscribed public channels changed.
 
                                 Prior to Zulip 8.0 (feature level 205), this event was not sent when
-                                a user gained access to a stream due to their [role
+                                a user gained access to a channel due to their [role
                                 changing](/help/roles-and-permissions).
 
                                 Prior to Zulip 6.0 (feature level 134), this event was not sent when a
-                                private stream was made public.
+                                private channel was made public.
 
                                 In Zulip 4.0 (feature level 35), the singular `user_id` and `stream_id`
                                 integers included in this event were replaced with plural `user_ids` and
                                 `stream_ids` integer arrays.
 
                                 In Zulip 3.0 (feature level 19), the `stream_id` field was added to
-                                identify the stream the user subscribed to, replacing the `name` field.
+                                identify the channel the user subscribed to, replacing the `name` field.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -849,7 +849,7 @@ paths:
                                 stream_ids:
                                   type: array
                                   description: |
-                                    The IDs of streams that have new or updated subscriber data.
+                                    The IDs of channels that have new or updated subscriber data.
 
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
                                     the `stream_id` integer.
@@ -859,7 +859,7 @@ paths:
                                   type: array
                                   description: |
                                     The IDs of the users who are newly visible as subscribed to
-                                    the specified streams.
+                                    the specified channels.
 
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
                                     the `user_id` integer.
@@ -877,19 +877,19 @@ paths:
                             - type: object
                               description: |
                                 Event sent to other users when users have been unsubscribed
-                                from streams. Sent to all users if the stream is public or to only
-                                the existing subscribers if the stream is private.
+                                from channels. Sent to all users if the channel is public or to only
+                                the existing subscribers if the channel is private.
 
                                 **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
                                 incorrectly not sent to guest users when subscribers to web-public
-                                streams and subscribed public streams changed.
+                                channels and subscribed public channels changed.
 
                                 In Zulip 4.0 (feature level 35), the singular `user_id` and
                                 `stream_id` integers included in this event were replaced
                                 with plural `user_ids` and `stream_ids` integer arrays.
 
                                 In Zulip 3.0 (feature level 19), the `stream_id` field was
-                                added to identify the stream the user unsubscribed from,
+                                added to identify the channel the user unsubscribed from,
                                 replacing the `name` field.
                               properties:
                                 id:
@@ -906,7 +906,7 @@ paths:
                                 stream_ids:
                                   type: array
                                   description: |
-                                    The IDs of the streams from which the users have been
+                                    The IDs of the channels from which the users have been
                                     unsubscribed from.
 
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
@@ -1269,31 +1269,31 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent when a new stream is created to users who can see
-                                the new stream exists (for private streams, only subscribers and
+                                Event sent when a new channel is created to users who can see
+                                the new channel exists (for private channels, only subscribers and
                                 organization administrators will receive this event).
 
-                                This event is also sent when a user gains access to a stream they
+                                This event is also sent when a user gains access to a channel they
                                 previously [could not access](/help/channel-permissions), such as
                                 when their [role](/help/roles-and-permissions) changes, a
-                                private stream is made public, or a guest user is subscribed
-                                to a public (or private) stream.
+                                private channel is made public, or a guest user is subscribed
+                                to a public (or private) channel.
 
                                 Note that organization administrators who are not subscribed will
-                                not be able to see content on the stream; just that it exists.
+                                not be able to see content on the channel; just that it exists.
 
                                 **Changes**: Prior to Zulip 8.0 (feature level 220), this event was
-                                incorrectly not sent to guest users a web-public stream was created.
+                                incorrectly not sent to guest users a web-public channel was created.
 
                                 Prior to Zulip 8.0 (feature level 205), this event was not sent
-                                when a user gained access to a stream due to their role changing.
+                                when a user gained access to a channel due to their role changing.
 
                                 Prior to Zulip 8.0 (feature level 192), this event was not sent
-                                when guest users gained access to a public stream by being
+                                when guest users gained access to a public channel by being
                                 subscribed.
 
                                 Prior to Zulip 6.0 (feature level 134), this event was not sent
-                                when a private stream was made public.
+                                when a private channel was made public.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -1309,8 +1309,8 @@ paths:
                                 streams:
                                   type: array
                                   description: |
-                                    Array of stream objects, each containing
-                                    details about the newly added stream(s).
+                                    Array of objects, each containing
+                                    details about the newly added channel(s).
                                   items:
                                     $ref: "#/components/schemas/BasicStream"
                               additionalProperties: false
@@ -1342,15 +1342,15 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to all users who can see a stream when it is deactivated.
+                                Event sent to all users who can see a channel when it is deactivated.
 
-                                This event is also sent when a user loses access to a stream they
+                                This event is also sent when a user loses access to a channel they
                                 previously [could access](/help/channel-permissions) because they
-                                are unsubscribed from a private stream or their [role](/help/roles-and-permissions)
+                                are unsubscribed from a private channel or their [role](/help/roles-and-permissions)
                                 has changed.
 
                                 **Changes**: Prior to Zulip 8.0 (feature level 205), this event was
-                                not sent when a user lost access to a stream due to their role
+                                not sent when a user lost access to a channel due to their role
                                 changing.
                               properties:
                                 id:
@@ -1367,8 +1367,8 @@ paths:
                                 streams:
                                   type: array
                                   description: |
-                                    Array of stream objects, each containing
-                                    details about a stream that was deleted.
+                                    Array of objects, each containing
+                                    details about a channel that was deleted.
                                   items:
                                     $ref: "#/components/schemas/BasicStream"
                               additionalProperties: false
@@ -1400,8 +1400,8 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to all users who can see that a stream exists
-                                when a property of that stream changes.
+                                Event sent to all users who can see that a channel exists
+                                when a property of that channel changes.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -1417,17 +1417,17 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The ID of the stream whose details have changed.
+                                    The ID of the channel whose details have changed.
                                 name:
                                   type: string
                                   description: |
-                                    The name of the stream whose details have changed.
+                                    The name of the channel whose details have changed.
                                 property:
                                   type: string
                                   description: |
-                                    The property of the stream which has changed. See
-                                    [/stream GET](/api/get-streams) for details on the various
-                                    properties of a stream.
+                                    The property of the channel which has changed. See
+                                    [GET /stream](/api/get-streams) for details on the various
+                                    properties of a channel.
 
                                     Clients should handle an "unknown" property received here without
                                     crashing, since that can happen when connecting to a server running a
@@ -1444,8 +1444,8 @@ paths:
                                   description: |
                                     Note: Only present if the changed property was `description`.
 
-                                    The short description of the stream rendered as HTML, intended to
-                                    be used when displaying the stream description in a UI.
+                                    The short description of the channel rendered as HTML, intended to
+                                    be used when displaying the channel description in a UI.
 
                                     One should use the standard Zulip rendered_markdown CSS when
                                     displaying this content so that emoji, LaTeX, and other syntax
@@ -1457,9 +1457,9 @@ paths:
                                   description: |
                                     Note: Only present if the changed property was `invite_only`.
 
-                                    Whether the history of the stream is public to its subscribers.
+                                    Whether the history of the channel is public to its subscribers.
 
-                                    Currently always true for public streams (i.e. `"invite_only": false` implies
+                                    Currently always true for public channels (i.e. `"invite_only": false` implies
                                     `"history_public_to_subscribers": true`), but clients should not make that
                                     assumption, as we may change that behavior in the future.
                                 is_web_public:
@@ -1467,7 +1467,7 @@ paths:
                                   description: |
                                     Note: Only present if the changed property was `invite_only`.
 
-                                    Whether the stream's history is now readable by web-public spectators.
+                                    Whether the channel's history is now readable by web-public spectators.
 
                                     **Changes**: New in Zulip 5.0 (feature level 71).
                               additionalProperties: false
@@ -1480,7 +1480,7 @@ paths:
                                   "history_public_to_subscribers": true,
                                   "is_web_public": false,
                                   "stream_id": 11,
-                                  "name": "test_stream",
+                                  "name": "test",
                                   "id": 0,
                                 }
                             - type: object
@@ -1925,9 +1925,9 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when an organization
-                                administrator changes the organization's configured default stream groups.
+                                administrator changes the organization's configured default channel groups.
 
-                                Default stream groups are an **experimental** feature that is not yet
+                                Default channel groups are an **experimental** feature that is not yet
                                 stabilized.
                               properties:
                                 id:
@@ -1941,7 +1941,7 @@ paths:
                                   type: array
                                   description: |
                                     An array of dictionaries where each dictionary
-                                    contains details about a single default stream group.
+                                    contains details about a single default channel group.
                                   items:
                                     $ref: "#/components/schemas/DefaultStreamGroup"
                               example:
@@ -2012,7 +2012,7 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to all users in a Zulip organization when the
-                                default streams in the organization are changed by an
+                                default channels in the organization are changed by an
                                 organization administrator.
                               properties:
                                 id:
@@ -2026,7 +2026,7 @@ paths:
                                   type: array
                                   description: |
                                     An array of dictionaries where each dictionary
-                                    contains details about a single default stream.
+                                    contains details about a single default channel.
                                   items:
                                     $ref: "#/components/schemas/DefaultStream"
                               example:
@@ -2060,15 +2060,15 @@ paths:
                                 Sent to all users who received the message.
 
                                 This event is also sent when the user loses access to a message,
-                                such as when it is [moved to a stream][message-move-stream] that
-                                the user does not [have permission to access][stream-access].
+                                such as when it is [moved to a channel][message-move-channel] that
+                                the user does not [have permission to access][channel-access].
 
                                 **Changes**: Before Zulip 5.0 (feature level 77), events
                                 for direct messages contained additional `sender_id` and
                                 `recipient_id` fields.
 
-                                [message-move-stream]: /help/move-content-to-another-channel
-                                [stream-access]: /help/channel-permissions
+                                [message-move-channel]: /help/move-content-to-another-channel
+                                [channel-access]: /help/channel-permissions
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2109,7 +2109,7 @@ paths:
                                   description: |
                                     Only present if `message_type` is `"stream"`.
 
-                                    The ID of the stream to which the message was sent.
+                                    The ID of the channel to which the message was sent.
                                 topic:
                                   type: string
                                   description: |
@@ -2140,7 +2140,7 @@ paths:
                                   deprecated: true
                                   description: |
                                     Array of tuples, where each tuple describes a muted topic.
-                                    The first element of the tuple is the stream name in which the topic
+                                    The first element of the tuple is the channel name in which the topic
                                     has to be muted, the second element is the topic name to be muted
                                     and the third element is an integer UNIX timestamp representing
                                     when the topic was muted.
@@ -2188,7 +2188,7 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The ID of the stream to which the topic belongs.
+                                    The ID of the channel to which the topic belongs.
                                 topic_name:
                                   type: string
                                   description: |
@@ -2336,7 +2336,7 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent when a message's content, topic and/or
-                                stream has been edited or when a message's content
+                                channel has been edited or when a message's content
                                 has a rendering update, such as for an
                                 [inline URL preview][inline-url-previews].
                                 Sent to all users who had received the original
@@ -2386,7 +2386,7 @@ paths:
                                     This field should be used to apply content edits to the client's
                                     cached message history, or to apply rendered content updates.
 
-                                    If the stream or topic was changed, the set of moved messages is
+                                    If the channel or topic was changed, the set of moved messages is
                                     encoded in the separate `message_ids` field, which is guaranteed
                                     to include `message_id`.
                                 message_ids:
@@ -2394,18 +2394,18 @@ paths:
                                   items:
                                     type: integer
                                   description: |
-                                    The list of IDs of messages to which any stream or topic changes
+                                    The list of IDs of messages to which any channel or topic changes
                                     encoded in this event should be applied.
 
                                     These messages are guaranteed to have all been previously sent
-                                    to stream `stream_id` with topic `orig_subject`, and have been
+                                    to channel `stream_id` with topic `orig_subject`, and have been
                                     moved to `new_stream_id` with topic `subject` (if those fields
                                     are present in the event).
 
                                     Clients processing these events should update all cached message
                                     history associated with the moved messages (including adjusting
                                     `unread_msgs` data structures, where the client may not have the
-                                    message itself in its history) to reflect the new stream and
+                                    message itself in its history) to reflect the new channel and
                                     topic.
 
                                     Content changes should be applied only to the single message
@@ -2445,37 +2445,37 @@ paths:
                                 stream_name:
                                   type: string
                                   description: |
-                                    Only present if the message was edited and originally sent to a stream.
+                                    Only present if the message was edited and originally sent to a channel.
 
-                                    The name of the stream that the message was sent to. Clients
+                                    The name of the channel that the message was sent to. Clients
                                     are recommended to use the `stream_id` field instead.
                                 stream_id:
                                   type: integer
                                   description: |
-                                    Only present if the message was edited and originally sent to a stream.
+                                    Only present if the message was edited and originally sent to a channel.
 
-                                    The pre-edit stream for all of the messages with IDs in
+                                    The pre-edit channel for all of the messages with IDs in
                                     `message_ids`.
 
                                     **Changes**: As of Zulip 5.0 (feature level 112), this field
-                                    is present for all edits to a stream message. Previously, it
-                                    was not present when only the content of the stream message was
+                                    is present for all edits to a channel message. Previously, it
+                                    was not present when only the content of the channel message was
                                     edited.
                                 new_stream_id:
                                   type: integer
                                   description: |
-                                    Only present if message(s) were moved to a different stream.
+                                    Only present if message(s) were moved to a different channel.
 
-                                    The post-edit stream for all of the messages with IDs in
+                                    The post-edit channel for all of the messages with IDs in
                                     `message_ids`.
                                 propagate_mode:
                                   type: string
                                   description: |
                                     Only present if this event moved messages to a different
-                                    topic and/or stream.
+                                    topic and/or channel.
 
                                     The choice the editing user made about which messages should be
-                                    affected by a stream/topic edit:
+                                    affected by a channel/topic edit:
 
                                     - `"change_one"`: Just change the one indicated in `message_id`.
                                     - `"change_later"`: Change messages in the same topic that had
@@ -2501,7 +2501,7 @@ paths:
                                   type: string
                                   description: |
                                     Only present if this event moved messages to a different
-                                    topic and/or stream.
+                                    topic and/or channel.
 
                                     The pre-edit topic for all of the messages with IDs in
                                     `message_ids`.
@@ -2632,14 +2632,14 @@ paths:
 
                                 Sent to all clients for users who would receive the
                                 message being typed, with the additional rule that typing
-                                notifications for stream messages are only sent to clients
+                                notifications for channel messages are only sent to clients
                                 that included `stream_typing_notifications` in their
                                 [client capabilities][client-capabilities] when registering
                                 the event queue.
 
                                 See [POST /typing](/api/set-typing-status) endpoint for more details.
 
-                                **Changes**: Typing notifications for stream messages are new in
+                                **Changes**: Typing notifications for channel messages are new in
                                 Zulip 4.0 (feature level 58).
 
                                 [client-capabilities]: /api/register-queue#parameter-client_capabilities
@@ -2710,7 +2710,7 @@ paths:
                                   description: |
                                     Only present if `message_type` is `"stream"`.
 
-                                    The unique ID of the stream to which message is being typed.
+                                    The unique ID of the channel to which message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     typing notifications were only for direct messages.
@@ -2719,7 +2719,7 @@ paths:
                                   description: |
                                     Only present if `message_type` is `"stream"`.
 
-                                    Topic within the stream where the message is being typed.
+                                    Topic within the channel where the message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     typing notifications were only for direct messages.
@@ -2753,14 +2753,14 @@ paths:
 
                                 Sent to all clients for users who would receive the message
                                 that was previously being typed, with the additional rule
-                                that typing notifications for stream messages are only sent to
+                                that typing notifications for channel messages are only sent to
                                 clients that included `stream_typing_notifications` in their
                                 [client capabilities][client-capabilities] when registering
                                 the event queue.
 
                                 See [POST /typing](/api/set-typing-status) endpoint for more details.
 
-                                **Changes**: Typing notifications for stream messages are new in
+                                **Changes**: Typing notifications for channel messages are new in
                                 Zulip 4.0 (feature level 58).
 
                                 [client-capabilities]: /api/register-queue#parameter-client_capabilities
@@ -2831,7 +2831,7 @@ paths:
                                   description: |
                                     Only present if `message_type` is `"stream"`.
 
-                                    The unique ID of the stream to which message is being typed.
+                                    The unique ID of the channel to which message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     typing notifications were only for direct messages.
@@ -2840,7 +2840,7 @@ paths:
                                   description: |
                                     Only present if `message_type` is `"stream"`.
 
-                                    Topic within the stream where the message is being typed.
+                                    Topic within the channel where the message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     typing notifications were only for direct messages.
@@ -2892,8 +2892,8 @@ paths:
                                   on a conversation.
                                 - The `"read"` flag is added when the user [mutes](/help/mute-a-user) a
                                   message's sender.
-                                - The `"read"` flag is added after the user unsubscribes from a stream,
-                                  or messages are moved to a not-subscribed stream, provided the user
+                                - The `"read"` flag is added after the user unsubscribes from a channel,
+                                  or messages are moved to a not-subscribed channel, provided the user
                                   can still access the messages at all. Note a
                                   [`delete_message`][message-delete] event is sent in the case where the
                                   user can no longer access the messages.
@@ -2901,7 +2901,7 @@ paths:
                                 In some cases, a change in message flags that's caused by another change
                                 may happen a short while after the original change, rather than
                                 simultaneously. For example, when messages that were unread are moved to
-                                a stream where the user is not subscribed, the resulting change in
+                                a channel where the user is not subscribed, the resulting change in
                                 message flags (and the corresponding `update_message_flags` event with
                                 flag `"read"`) may happen later than the message move itself. The delay
                                 in that example is typically at most a few hundred milliseconds and can
@@ -3039,7 +3039,7 @@ paths:
                                       type:
                                         type: string
                                         description: |
-                                          The type of this message.
+                                          The type of this message. Either `"stream"` or `"private"`.
                                         enum:
                                           - private
                                           - stream
@@ -3062,13 +3062,13 @@ paths:
                                       stream_id:
                                         type: integer
                                         description: |
-                                          Present only if `type` is `stream`.
+                                          Present only if `type` is `"stream"`.
 
-                                          The ID of the stream where the message was sent.
+                                          The ID of the channel where the message was sent.
                                       topic:
                                         type: string
                                         description: |
-                                          Present only if `type` is `stream`.
+                                          Present only if `type` is `"stream"`.
 
                                           Name of the topic where the message was sent.
                                       unmuted_stream_msg:
@@ -4223,23 +4223,23 @@ paths:
                                       type: integer
                                       description: |
                                         The [policy](/api/roles-and-permissions#permission-levels)
-                                        for which users can create public streams in this organization.
+                                        for which users can create public channels in this organization.
 
                                         **Changes**: Before Zulip 5.0 (feature level 102), permission to
-                                        create streams was controlled by the `create_stream_policy` setting.
+                                        create channels was controlled by the `create_stream_policy` setting.
                                     create_private_stream_policy:
                                       type: integer
                                       description: |
                                         The [policy](/api/roles-and-permissions#permission-levels)
-                                        for which users can create private streams in this organization.
+                                        for which users can create private channels in this organization.
 
                                         **Changes**: Before Zulip 5.0 (feature level 102), permission to
-                                        create streams was controlled by the `create_stream_policy` setting.
+                                        create channels was controlled by the `create_stream_policy` setting.
                                     create_web_public_stream_policy:
                                       type: integer
                                       description: |
                                         The [policy](/api/roles-and-permissions#permission-levels)
-                                        for which users can create web public streams in this organization.
+                                        for which users can create web public channels in this organization.
 
                                         **Changes**: New in Zulip 5.0 (feature level 103).
                                     default_code_block_language:
@@ -4311,7 +4311,7 @@ paths:
                                     enable_spectator_access:
                                       type: boolean
                                       description: |
-                                        Whether web-public streams are enabled in this organization.
+                                        Whether web-public channels are enabled in this organization.
 
                                         Can only be enabled if the `WEB_PUBLIC_STREAMS_ENABLED`
                                         [server setting][server-settings] is enabled on the Zulip
@@ -4366,7 +4366,7 @@ paths:
                                       type: integer
                                       description: |
                                         The [policy](/api/roles-and-permissions#permission-levels)
-                                        for which users can add other users to streams in this organization.
+                                        for which users can add other users to channels in this organization.
                                     logo_source:
                                       type: string
                                       description: |
@@ -4420,7 +4420,7 @@ paths:
                                       nullable: true
                                       description: |
                                         Messages sent more than this many seconds ago cannot be moved within a
-                                        stream to another topic by users who have permission to do so based on this
+                                        channel to another topic by users who have permission to do so based on this
                                         organization's [topic edit policy](/help/restrict-moving-messages). This
                                         setting does not affect moderators and administrators.
 
@@ -4435,7 +4435,7 @@ paths:
                                       nullable: true
                                       description: |
                                         Messages sent more than this many seconds ago cannot be moved between
-                                        streams by users who have permission to do so based on this organization's
+                                        channels by users who have permission to do so based on this organization's
                                         [message move policy](/help/restrict-moving-messages). This setting does
                                         not affect moderators and administrators.
 
@@ -4443,13 +4443,13 @@ paths:
                                         regardless of how long ago they were sent.
 
                                         **Changes**: New in Zulip 7.0 (feature level 162). Previously, there was
-                                        no time limit for moving messages between streams for users with permission
+                                        no time limit for moving messages between channels for users with permission
                                         to do so.
                                     move_messages_between_streams_policy:
                                       type: integer
                                       description: |
                                         The [policy][permission-level] for which users can move messages from
-                                        one stream to another.
+                                        one channel to another.
 
                                         - 1 = Members only
                                         - 2 = Administrators only
@@ -4493,17 +4493,17 @@ paths:
                                     new_stream_announcements_stream_id:
                                       type: integer
                                       description: |
-                                        The ID of the stream to which automated messages announcing the
-                                        [creation of new streams][new-stream-announce] are sent.
+                                        The ID of the channel to which automated messages announcing the
+                                        [creation of new channels][new-channel-announce] are sent.
 
                                         Will be `-1` if such automated messages are disabled.
 
                                         Since these automated messages are sent by the server, this field is
                                         primarily relevant to clients containing UI for changing it.
 
-                                        [new-stream-announce]: /help/configure-automated-notices#new-channel-announcements
+                                        [new-channel-announce]: /help/configure-automated-notices#new-channel-announcements
 
-                                        **Changes**: In Zulip 9.0 (feature level 241), renamed 'notifications_stream_id'
+                                        **Changes**: In Zulip 9.0 (feature level 241), renamed `notifications_stream_id`
                                         to `new_stream_announcements_stream_id`.
                                     org_type:
                                       type: integer
@@ -4570,7 +4570,7 @@ paths:
                                     signup_announcements_stream_id:
                                       type: integer
                                       description: |
-                                        The ID of the stream to which automated messages announcing
+                                        The ID of the channel to which automated messages announcing
                                         that [new users have joined the organization][new-user-announce] are sent.
 
                                         Will be `-1` if such automated messages are disabled.
@@ -4581,11 +4581,11 @@ paths:
                                         [new-user-announce]: /help/configure-automated-notices#new-user-announcements
 
                                         **Changes**: In Zulip 9.0 (feature level 241), renamed
-                                        'signup_notifications_stream_id' to `signup_announcements_stream_id`.
+                                        `signup_notifications_stream_id` to `signup_announcements_stream_id`.
                                     zulip_update_announcements_stream_id:
                                       type: integer
                                       description: |
-                                        The ID of the stream to which automated messages announcing
+                                        The ID of the channel to which automated messages announcing
                                         new features or other end-user updates about the Zulip software are sent.
 
                                         Will be `-1` if such automated messages are disabled.
@@ -4653,20 +4653,20 @@ paths:
                                       type: integer
                                       description: |
                                         The [policy][permission-level] for who can use wildcard mentions in
-                                        large streams.
+                                        large channels.
 
-                                        - 1 = Any user can use wildcard mentions in large streams.
-                                        - 2 = Only members can use wildcard mentions in large streams.
-                                        - 3 = Only [full members][calc-full-member] can use wildcard mentions in large streams.
-                                        - 5 = Only organization administrators can use wildcard mentions in large streams.
-                                        - 6 = Nobody can use wildcard mentions in large streams.
-                                        - 7 = Only organization administrators and moderators can use wildcard mentions in large streams.
+                                        - 1 = Any user can use wildcard mentions in large channels.
+                                        - 2 = Only members can use wildcard mentions in large channels.
+                                        - 3 = Only [full members][calc-full-member] can use wildcard mentions in large channels.
+                                        - 5 = Only organization administrators can use wildcard mentions in large channels.
+                                        - 6 = Nobody can use wildcard mentions in large channels.
+                                        - 7 = Only organization administrators and moderators can use wildcard mentions in large channels.
 
                                         All users will receive a warning/reminder when using
-                                        mentions in large streams, even when permitted to do so.
+                                        mentions in large channels, even when permitted to do so.
 
                                         **Changes**: New in Zulip 4.0 (feature level 33). Moderators option added in
-                                        Zulip 4.0 (feature level 62). Stream administrators option removed in
+                                        Zulip 4.0 (feature level 62). Channel administrators option removed in
                                         Zulip 6.0 (feature level 133).
 
                                         [permission-level]: /api/roles-and-permissions#permission-levels

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5096,7 +5096,7 @@ paths:
     get:
       operationId: get-stream-id
       summary: Get channel ID
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get the unique ID of a given channel.
       parameters:
@@ -5995,7 +5995,7 @@ paths:
   /default_streams:
     post:
       operationId: add-default-stream
-      tags: ["streams"]
+      tags: ["channels"]
       summary: Add a default channel
       x-requires-administrator: true
       description: |
@@ -6047,7 +6047,7 @@ paths:
     delete:
       operationId: remove-default-stream
       summary: Remove a default channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Remove a channel from the set of [default channels][default-channels]
         for new users joining the organization.
@@ -9076,7 +9076,7 @@ paths:
     get:
       operationId: get-stream-topics
       summary: Get topics in a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get all topics the user has access to in a specific channel.
 
@@ -9142,7 +9142,7 @@ paths:
     get:
       operationId: get-subscriptions
       summary: Get subscribed channels
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get all channels that the user is subscribed to.
       # operationId can be used to record which view function
@@ -9230,7 +9230,7 @@ paths:
     post:
       operationId: subscribe
       summary: Subscribe to a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Subscribe one or more users to one or more channels.
 
@@ -9476,7 +9476,7 @@ paths:
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Update which channels you are subscribed to.
       requestBody:
@@ -9595,7 +9595,7 @@ paths:
     delete:
       operationId: unsubscribe
       summary: Unsubscribe from a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Unsubscribe yourself or other users from one or more channels.
 
@@ -9721,7 +9721,7 @@ paths:
       deprecated: true
       operationId: mute-topic
       summary: Topic muting
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         [Mute or unmute a topic](/help/mute-a-topic) within a channel that
         the current user is subscribed to.
@@ -9846,7 +9846,7 @@ paths:
     post:
       operationId: update-user-topic
       summary: Update personal preferences for a topic
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         This endpoint is used to update the personal preferences for a topic,
         such as the topic's visibility policy, which is used to implement
@@ -10237,7 +10237,7 @@ paths:
     get:
       operationId: get-subscription-status
       summary: Get subscription status
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Check whether a user is subscribed to a channel.
 
@@ -11344,7 +11344,7 @@ paths:
     post:
       operationId: update-subscription-settings
       summary: Update subscription settings
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         This endpoint is used to update the user's personal settings for the
         channels they are subscribed to, including muting, color, pinning, and
@@ -17858,7 +17858,7 @@ paths:
     get:
       operationId: get-subscribers
       summary: Get the subscribers of a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get all users subscribed to a channel.
       parameters:
@@ -17899,7 +17899,7 @@ paths:
     get:
       operationId: get-streams
       summary: Get all channels
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get all channels that the user [has access to](/help/channel-permissions).
       x-curl-examples-parameters:
@@ -18111,7 +18111,7 @@ paths:
     get:
       operationId: get-stream-by-id
       summary: Get a channel by ID
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Fetch details for the channel with the ID `stream_id`.
 
@@ -18168,7 +18168,7 @@ paths:
     delete:
       operationId: archive-stream
       summary: Archive a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         [Archive the channel](/help/archive-a-channel) with the ID `stream_id`.
       x-requires-administrator: true
@@ -18189,7 +18189,7 @@ paths:
     patch:
       operationId: update-stream
       summary: Update a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Configure the channel with the ID `stream_id`. This endpoint supports
         an organization administrator editing any property of a channel,
@@ -18352,7 +18352,7 @@ paths:
     get:
       operationId: get-stream-email-address
       summary: Get the email address of a channel
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Get email address of a channel.
 
@@ -18396,7 +18396,7 @@ paths:
     post:
       operationId: delete-topic
       summary: Delete a topic
-      tags: ["streams"]
+      tags: ["channels"]
       description: |
         Delete all messages in a topic.
 
@@ -19368,7 +19368,7 @@ paths:
 
   /calls/bigbluebutton/create:
     get:
-      tags: ["streams"]
+      tags: ["channels"]
       operationId: create-big-blue-button-video-call
       summary: Create BigBlueButton video call
       description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5836,7 +5836,7 @@ paths:
                 type:
                   description: |
                     The type of scheduled message to be sent. `"direct"` for a direct
-                    message and `"stream"` or `"channel"` for a stream message.
+                    message and `"stream"` or `"channel"` for a channel message.
 
                     When updating the type of the scheduled message, the `to` parameter
                     is required. And, if updating the type of the scheduled message to
@@ -5848,7 +5848,7 @@ paths:
                     `"private"` may eventually be removed.
 
                     **Changes**: In Zulip 9.0 (feature level 248), `"channel"` was added as
-                    an additional value for this parameter to indicate the type of a stream
+                    an additional value for this parameter to indicate the type of a channel
                     message.
                   type: string
                   enum:
@@ -5861,7 +5861,7 @@ paths:
                   description: |
                     The scheduled message's tentative target audience.
 
-                    For stream messages, the integer ID of the stream.
+                    For channel messages, the integer ID of the channel.
                     For direct messages, a list containing integer user IDs.
 
                     Required when updating the `type` of the scheduled message.
@@ -5886,8 +5886,8 @@ paths:
                     The updated topic of the scheduled message.
 
                     Required when updating the `type` of the scheduled message to
-                    `"stream"`. Ignored when the existing or updated `type` of the
-                    scheduled message is `"direct"` (or `"private"`).
+                    `"stream"` or `"channel"`. Ignored when the existing or updated
+                    `type` of the scheduled message is `"direct"` (or `"private"`).
 
                     Clients should use the `max_topic_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
@@ -5923,8 +5923,8 @@ paths:
                   - allOf:
                       - $ref: "#/components/schemas/NonExistingChannelIdError"
                       - description: |
-                          A typical failed JSON response for when a stream message is scheduled
-                          to be sent to a stream that does not exist:
+                          A typical failed JSON response for when a channel message is scheduled
+                          to be sent to a channel that does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10933,7 +10933,7 @@ paths:
                   example: "google"
                 demote_inactive_streams:
                   description: |
-                    Whether to [demote inactive streams](/help/manage-inactive-channels) in the left sidebar.
+                    Whether to [demote inactive channels](/help/manage-inactive-channels) in the left sidebar.
 
                     - 1 - Automatic
                     - 2 - Always
@@ -10961,13 +10961,13 @@ paths:
                   example: 1
                 web_stream_unreads_count_display_policy:
                   description: |
-                    Configuration for which streams should be displayed with a numeric unread count in the left sidebar.
-                    Streams that do not have an unread count will have a simple dot indicator for whether there are any
+                    Configuration for which channels should be displayed with a numeric unread count in the left sidebar.
+                    Channels that do not have an unread count will have a simple dot indicator for whether there are any
                     unread messages.
 
-                    - 1 - All streams
-                    - 2 - Unmuted streams and topics
-                    - 3 - No streams
+                    - 1 - All channels
+                    - 2 - Unmuted channels and topics
+                    - 3 - No channels
 
                     **Changes**: New in Zulip 8.0 (feature level 210).
                   type: integer
@@ -10978,22 +10978,22 @@ paths:
                   example: 2
                 enable_stream_desktop_notifications:
                   description: |
-                    Enable visual desktop notifications for stream messages.
+                    Enable visual desktop notifications for channel messages.
                   type: boolean
                   example: true
                 enable_stream_email_notifications:
                   description: |
-                    Enable email notifications for stream messages.
+                    Enable email notifications for channel messages.
                   type: boolean
                   example: true
                 enable_stream_push_notifications:
                   description: |
-                    Enable mobile notifications for stream messages.
+                    Enable mobile notifications for channel messages.
                   type: boolean
                   example: true
                 enable_stream_audible_notifications:
                   description: |
-                    Enable audible desktop notifications for stream messages.
+                    Enable audible desktop notifications for channel messages.
                   type: boolean
                   example: true
                 notification_sound:
@@ -11148,7 +11148,7 @@ paths:
                   example: 1
                 automatically_unmute_topics_in_muted_streams_policy:
                   description: |
-                    Which [topics to unmute automatically in muted streams](/help/mute-a-topic).
+                    Which [topics to unmute automatically in muted channels](/help/mute-a-topic).
 
                     - 1 - Topics the user participates in
                     - 2 - Topics the user sends a message to
@@ -11202,7 +11202,7 @@ paths:
                 send_stream_typing_notifications:
                   description: |
                     Whether [typing notifications](/help/typing-notifications) be sent when composing
-                    stream messages.
+                    channel messages.
 
                     **Changes**: New in Zulip 5.0 (feature level 105).
                   type: boolean

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9075,17 +9075,17 @@ paths:
   /users/me/{stream_id}/topics:
     get:
       operationId: get-stream-topics
-      summary: Get topics in a stream
+      summary: Get topics in a channel
       tags: ["streams"]
       description: |
-        Get all topics the user has access to in a specific stream.
+        Get all topics the user has access to in a specific channel.
 
-        Note that for private streams with [protected
+        Note that for private channels with [protected
         history](/help/channel-permissions), the user will only have access to
         topics of messages sent after they [subscribed to](/api/subscribe) the
-        stream. Similarly, a user's [bot](/help/bots-overview#bot-type)
+        channel. Similarly, a user's [bot](/help/bots-overview#bot-type)
         will only have access to messages sent after the bot was subscribed to
-        the stream, instead of when the user subscribed.
+        the channel, instead of when the user subscribed.
       parameters:
         - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
@@ -9137,7 +9137,7 @@ paths:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the user is attempting to fetch the topics
-                      of a non-existing stream (or also a private stream they don't have access to):
+                      of a non-existing channel (or also a private channel they don't have access to):
   /users/me/subscriptions:
     get:
       operationId: get-subscriptions

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9478,7 +9478,7 @@ paths:
       summary: Update subscriptions
       tags: ["streams"]
       description: |
-        Update which streams you are subscribed to.
+        Update which channels you are subscribed to.
       requestBody:
         required: false
         content:
@@ -9488,16 +9488,16 @@ paths:
               properties:
                 delete:
                   description: |
-                    A list of stream names to unsubscribe from.
+                    A list of channel names to unsubscribe from.
                   type: array
                   items:
                     type: string
                   example: ["Verona", "Denmark"]
                 add:
                   description: |
-                    A list of objects describing which streams to subscribe to, optionally
+                    A list of objects describing which channels to subscribe to, optionally
                     including per-user subscription parameters (e.g. color) and if the
-                    stream is to be created, its description.
+                    channel is to be created, its description.
                   type: array
                   items:
                     type: object
@@ -9545,11 +9545,11 @@ paths:
                         description: |
                           A dictionary where the key is the Zulip API email
                           address of the user/bot and the value is a
-                          list of the names of the streams that were
+                          list of the names of the channels that were
                           subscribed to as a result of the query.
                         additionalProperties:
                           description: |
-                            `{email_id}`: A list of the names of streams that
+                            `{email_id}`: A list of the names of channels that
                             the user was subscribed to as a result of the query.
                           type: array
                           items:
@@ -9559,11 +9559,11 @@ paths:
                         description: |
                           A dictionary where the key is the Zulip API email
                           address of the user/bot and the value is a
-                          list of the names of the streams that the
+                          list of the names of the channels that the
                           user/bot is already subscribed to.
                         additionalProperties:
                           description: |
-                            `{email_id}`: A list of the names of streams that
+                            `{email_id}`: A list of the names of channels that
                             the user was already subscribed to.
                           type: array
                           items:
@@ -9573,7 +9573,7 @@ paths:
                         items:
                           type: string
                         description: |
-                          A list of the names of streams that the user
+                          A list of the names of channels that the user
                           is already unsubscribed from, and hence
                           doesn't need to be unsubscribed.
                       removed:
@@ -9581,7 +9581,7 @@ paths:
                         items:
                           type: string
                         description: |
-                          A list of the names of streams which were unsubscribed
+                          A list of the names of channels which were unsubscribed
                           from as a result of the query.
                     example:
                       {
@@ -9589,7 +9589,7 @@ paths:
                         "subscribed": {},
                         "already_subscribed": {"iago@zulip.com": ["Verona"]},
                         "not_removed": [],
-                        "removed": ["new stream"],
+                        "removed": ["testing-help"],
                         "result": "success",
                       }
     delete:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17365,7 +17365,7 @@ paths:
                   example: "google"
                 demote_inactive_streams:
                   description: |
-                    Whether to [demote inactive streams](/help/manage-inactive-channels) in the left sidebar.
+                    Whether to [demote inactive channels](/help/manage-inactive-channels) in the left sidebar.
 
                     - 1 - Automatic
                     - 2 - Always
@@ -17396,13 +17396,13 @@ paths:
                   example: 1
                 web_stream_unreads_count_display_policy:
                   description: |
-                    Configuration for which streams should be displayed with a numeric unread count in the left sidebar.
-                    Streams that do not have an unread count will have a simple dot indicator for whether there are any
+                    Configuration for which channels should be displayed with a numeric unread count in the left sidebar.
+                    Channels that do not have an unread count will have a simple dot indicator for whether there are any
                     unread messages.
 
-                    - 1 - All streams
-                    - 2 - Unmuted streams and topics
-                    - 3 - No streams
+                    - 1 - All channels
+                    - 2 - Unmuted channels and topics
+                    - 3 - No channels
 
                     **Changes**: New in Zulip 8.0 (feature level 210).
                   type: integer
@@ -17423,7 +17423,7 @@ paths:
                   example: "Asia/Kolkata"
                 enable_stream_desktop_notifications:
                   description: |
-                    Enable visual desktop notifications for stream messages.
+                    Enable visual desktop notifications for channel messages.
 
                     **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/notifications` endpoint.
@@ -17431,7 +17431,7 @@ paths:
                   example: true
                 enable_stream_email_notifications:
                   description: |
-                    Enable email notifications for stream messages.
+                    Enable email notifications for channel messages.
 
                     **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/notifications` endpoint.
@@ -17439,7 +17439,7 @@ paths:
                   example: true
                 enable_stream_push_notifications:
                   description: |
-                    Enable mobile notifications for stream messages.
+                    Enable mobile notifications for channel messages.
 
                     **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/notifications` endpoint.
@@ -17447,7 +17447,7 @@ paths:
                   example: true
                 enable_stream_audible_notifications:
                   description: |
-                    Enable audible desktop notifications for stream messages.
+                    Enable audible desktop notifications for channel messages.
 
                     **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/notifications` endpoint.
@@ -17661,7 +17661,7 @@ paths:
                   example: 1
                 automatically_unmute_topics_in_muted_streams_policy:
                   description: |
-                    Which [topics to unmute automatically in muted streams](/help/mute-a-topic).
+                    Which [topics to unmute automatically in muted channels](/help/mute-a-topic).
 
                     - 1 - Topics the user participates in
                     - 2 - Topics the user sends a message to
@@ -17712,7 +17712,7 @@ paths:
                 send_stream_typing_notifications:
                   description: |
                     Whether [typing notifications](/help/typing-notifications) be sent when composing
-                    stream messages.
+                    channel messages.
 
                     **Changes**: New in Zulip 5.0 (feature level 105).
                   type: boolean

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6465,7 +6465,7 @@ paths:
       summary: Send a message
       tags: ["messages"]
       description: |
-        Send a [stream message](/help/introduction-to-topics) or a
+        Send a [channel message](/help/introduction-to-topics) or a
         [direct message](/help/direct-messages).
       requestBody:
         required: true
@@ -6479,10 +6479,10 @@ paths:
                     The type of message to be sent.
 
                     `"direct"` for a direct message and `"stream"` or `"channel"` for a
-                    stream message.
+                    channel message.
 
                     **Changes**: In Zulip 9.0 (feature level 248), `"channel"` was added as
-                    an additional value for this parameter to request a stream message.
+                    an additional value for this parameter to request a channel message.
 
                     In Zulip 7.0 (feature level 174), `"direct"` was added as
                     the preferred way to request a direct message, deprecating the original
@@ -6499,11 +6499,11 @@ paths:
                   example: direct
                 to:
                   description: |
-                    For stream messages, either the name or integer ID of the stream. For
+                    For channel messages, either the name or integer ID of the channel. For
                     direct messages, either a list containing integer user IDs or a list
                     containing string Zulip API email addresses.
 
-                    **Changes**: Support for using user/stream IDs was added in Zulip 2.0.0.
+                    **Changes**: Support for using user/channel IDs was added in Zulip 2.0.0.
                   oneOf:
                     - type: string
                     - type: integer
@@ -6519,8 +6519,8 @@ paths:
                   $ref: "#/components/schemas/RequiredContent"
                 topic:
                   description: |
-                    The topic of the message. Only required for stream messages
-                    (`"type": "stream"`), ignored otherwise.
+                    The topic of the message. Only required for channel messages
+                    (`"type": "stream"` or `"type": "channel"`), ignored otherwise.
 
                     Clients should use the `max_topic_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
@@ -6611,7 +6611,7 @@ paths:
 
                           For example, the Zulip web application uses this field to decide whether
                           to display a warning or notice suggesting to unmute the topic after
-                          sending a message to a muted stream. Such a notice would be confusing in
+                          sending a message to a muted channel. Such a notice would be confusing in
                           the event that the act of sending the message had already resulted in the
                           user automatically unmuting or following the topic in question.
 
@@ -6632,7 +6632,7 @@ paths:
                   - allOf:
                       - $ref: "#/components/schemas/NonExistingChannelNameError"
                       - description: |
-                          A typical failed JSON response for when a stream message is sent to a stream
+                          A typical failed JSON response for when a channel message is sent to a channel
                           that does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
@@ -6656,7 +6656,7 @@ paths:
                         description: |
                           An example JSON error response for when the message was rejected because
                           of the organization's `wildcard_mention_policy` and large number of
-                          subscribers to the stream.
+                          subscribers to the channel.
 
                           **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
                           error returned the `"BAD_REQUEST"` code.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9229,17 +9229,17 @@ paths:
                       }
     post:
       operationId: subscribe
-      summary: Subscribe to a stream
+      summary: Subscribe to a channel
       tags: ["streams"]
       description: |
-        Subscribe one or more users to one or more streams.
+        Subscribe one or more users to one or more channels.
 
-        If any of the specified streams do not exist, they are automatically
-        created. The initial [stream settings](/api/update-stream) will be determined
+        If any of the specified channels do not exist, they are automatically
+        created. The initial [channel settings](/api/update-stream) will be determined
         by the optional parameters, like `invite_only`, detailed below.
 
         Note that the ability to subscribe oneself and/or other users to a specified
-        stream depends on the [stream's privacy settings](/help/channel-permissions).
+        channel depends on the [channel's privacy settings](/help/channel-permissions).
 
         **Changes**: Before Zulip 8.0 (feature level 208), if a user
         specified by the [`principals`][principals-param] parameter was
@@ -9258,7 +9258,7 @@ paths:
                 - subscriptions
           - type: include
             description: |
-              To subscribe another user to a stream, you may pass in
+              To subscribe another user to a channel, you may pass in
               the `principals` parameter, like so:
             parameters:
               enum:
@@ -9274,8 +9274,8 @@ paths:
                 subscriptions:
                   description: |
                     A list of dictionaries containing the key `name` and value
-                    specifying the name of the stream to subscribe. If the stream does not
-                    exist a new stream is created. The description of the stream created can
+                    specifying the name of the channel to subscribe. If the channel does not
+                    exist a new channel is created. The description of the channel created can
                     be specified by setting the dictionary key `description` with an
                     appropriate value.
                   type: array
@@ -9286,20 +9286,20 @@ paths:
                       name:
                         type: string
                         description: |
-                          The name of the stream.
+                          The name of the channel.
 
                           Clients should use the `max_stream_name_length` returned by the
                           [`POST /register`](/api/register-queue) endpoint to determine
-                          the maximum stream name length.
+                          the maximum channel name length.
                       description:
                         type: string
                         description: |
                           The [description](/help/change-the-channel-description)
-                          to use for a new stream being created, in text/markdown format.
+                          to use for a new channel being created, in text/markdown format.
 
                           Clients should use the `max_stream_description_length` returned
                           by the [`POST /register`](/api/register-queue) endpoint to
-                          determine the maximum stream description length.
+                          determine the maximum channel description length.
                     required:
                       - name
                     example:
@@ -9313,9 +9313,9 @@ paths:
                 authorization_errors_fatal:
                   description: |
                     A boolean specifying whether authorization errors (such as when the
-                    requesting user is not authorized to access a private stream) should be
+                    requesting user is not authorized to access a private channel) should be
                     considered fatal or not. When `true`, an authorization error is reported
-                    as such. When set to `false`, the response will be a 200 and any streams
+                    as such. When set to `false`, the response will be a 200 and any channels
                     where the request encountered an authorization error will be listed
                     in the `unauthorized` key.
                   type: boolean
@@ -9323,30 +9323,30 @@ paths:
                   example: false
                 announce:
                   description: |
-                    If one of the streams specified did not exist previously and is thus created
+                    If one of the channels specified did not exist previously and is thus created
                     by this call, this determines whether [notification bot](/help/configure-automated-notices)
-                    will send an announcement about the new stream's creation.
+                    will send an announcement about the new channel's creation.
                   type: boolean
                   default: false
                   example: true
                 invite_only:
                   description: |
-                    As described above, this endpoint will create a new stream if passed
-                    a stream name that doesn't already exist. This parameters and the ones
+                    As described above, this endpoint will create a new channel if passed
+                    a channel name that doesn't already exist. This parameters and the ones
                     that follow are used to request an initial configuration of a created
-                    stream; they are ignored for streams that already exist.
+                    channel; they are ignored for channels that already exist.
 
-                    This parameter determines whether any newly created streams will be
-                    private streams.
+                    This parameter determines whether any newly created channels will be
+                    private channels.
                   type: boolean
                   default: false
                   example: true
                 is_web_public:
                   description: |
-                    This parameter determines whether any newly created streams will be
-                    web-public streams.
+                    This parameter determines whether any newly created channels will be
+                    web-public channels.
 
-                    Note that creating web-public streams requires the
+                    Note that creating web-public channels requires the
                     `WEB_PUBLIC_STREAMS_ENABLED` [server setting][server-settings]
                     to be enabled on the Zulip server in question, the organization
                     to have enabled the `enable_spectator_access` realm setting, and
@@ -9361,13 +9361,13 @@ paths:
                   example: true
                 is_default_stream:
                   description: |
-                    This parameter determines whether any newly created streams will be
-                    added as [default streams][default-streams] for new users joining
+                    This parameter determines whether any newly created channels will be
+                    added as [default channels][default-channels] for new users joining
                     the organization.
 
-                    [default-streams]: /help/set-default-channels-for-new-users
+                    [default-channels]: /help/set-default-channels-for-new-users
 
-                    **Changes**: New in Zulip 8.0 (feature level 200). Previously, default stream status
+                    **Changes**: New in Zulip 8.0 (feature level 200). Previously, default channel status
                     could only be changed using the [dedicated API endpoint](/api/add-default-stream).
                   type: boolean
                   default: false
@@ -9420,11 +9420,11 @@ paths:
                         type: object
                         description: |
                           A dictionary where the key is the Zulip API email address of the user/bot
-                          and the value is a list of the names of the streams that were subscribed
+                          and the value is a list of the names of the channels that were subscribed
                           to as a result of the query.
                         additionalProperties:
                           description: |
-                            `{email_address}`: List of the names of the streams that were subscribed
+                            `{email_address}`: List of the names of the channels that were subscribed
                             to as a result of the query.
                           type: array
                           items:
@@ -9433,11 +9433,11 @@ paths:
                         type: object
                         description: |
                           A dictionary where the key is the Zulip API email address of the user/bot
-                          and the value is a list of the names of the streams that the user/bot is
+                          and the value is a list of the names of the channels that the user/bot is
                           already subscribed to.
                         additionalProperties:
                           description: |
-                            `{email_address}`: List of the names of the streams that the user is
+                            `{email_address}`: List of the names of the channels that the user is
                             already subscribed to.
                           type: array
                           items:
@@ -9447,15 +9447,15 @@ paths:
                         items:
                           type: string
                         description: |
-                          A list of names of streams that the requesting user/bot was not
+                          A list of names of channels that the requesting user/bot was not
                           authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
                     example:
                       {
                         "already_subscribed":
-                          {"iago@zulip.com": ["new stream"]},
+                          {"iago@zulip.com": ["testing-help"]},
                         "msg": "",
                         "result": "success",
-                        "subscribed": {"newbie@zulip.com": ["new stream"]},
+                        "subscribed": {"newbie@zulip.com": ["testing-help"]},
                       }
         "400":
           description: Bad request.
@@ -9472,7 +9472,7 @@ paths:
                       }
                     description: |
                       An example JSON response for when the requesting user does not have
-                      access to a private stream and `"authorization_errors_fatal": true`:
+                      access to a private channel and `"authorization_errors_fatal": true`:
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7748,7 +7748,7 @@ paths:
       summary: Edit a message
       tags: ["messages"]
       description: |
-        Edit/update the content, topic, or stream of a message.
+        Edit/update the content, topic, or channel of a message.
 
         `{msg_id}` in the above URL should be replaced with the ID of the
         message you wish you update.
@@ -7760,7 +7760,7 @@ paths:
         documentation on when users are allowed to edit message content and
         [restricting moving messages][restrict-move-messages] for detailed
         documentation on when users are allowed to change a message's topic
-        and/or stream.
+        and/or channel.
 
         The relevant realm settings in the API that are related to the above
         linked documentation on when users are allowed to update messages are:
@@ -7778,7 +7778,7 @@ paths:
         event in [`GET /events`](/api/get-events).
 
         **Changes**: Prior to Zulip 7.0 (feature level 172), anyone could add a
-        topic to stream messages without a topic, regardless of the organization's
+        topic to channel messages without a topic, regardless of the organization's
         [topic editing permissions](/help/restrict-moving-messages). As of this
         feature level, messages without topics have the same restrictions for
         topic edits as messages with topics.
@@ -7786,7 +7786,7 @@ paths:
         Before Zulip 7.0 (feature level 172), by using the `change_all` value for
         the `propagate_mode` parameter, users could move messages after the
         organization's configured time limits for changing a message's topic or
-        stream had passed. As of this feature level, the server will [return an
+        channel had passed. As of this feature level, the server will [return an
         error](/api/update-message#response) with `"code":
         "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"` if users, other than organization
         administrators or moderators, try to move messages after these time
@@ -7796,13 +7796,13 @@ paths:
         moderators could only edit topics if the target message was sent within the
         last 3 days. As of this feature level, that time limit is now controlled by
         the realm setting `move_messages_within_stream_limit_seconds`. Also at this
-        feature level, a similar time limit for moving messages between streams was
+        feature level, a similar time limit for moving messages between channels was
         added, controlled by the realm setting
         `move_messages_between_streams_limit_seconds`. Previously, all users who
-        had permission to move messages between streams did not have any time limit
+        had permission to move messages between channels did not have any time limit
         restrictions when doing so.
 
-        Before Zulip 7.0 (feature level 159), editing streams and topics of messages
+        Before Zulip 7.0 (feature level 159), editing channels and topics of messages
         was forbidden if the realm setting for `allow_message_editing` was `false`,
         regardless of an organization's configuration for the realm settings
         `edit_topic_policy` or `move_messages_between_streams_policy`.
@@ -7836,7 +7836,7 @@ paths:
                     the maximum topic length
 
                     Should only be sent when changing the topic, and will throw an error
-                    if the target message is not a stream message.
+                    if the target message is not a channel message.
 
                     **Changes**: New in Zulip 2.0.0. Previous Zulip releases encoded
                     this as `subject`, which is currently a deprecated alias.
@@ -7856,7 +7856,7 @@ paths:
                     This parameter determines both which messages get moved and also whether
                     clients that are currently narrowed to the topic containing the message
                     should navigate or adjust their compose box recipient to point to the
-                    post-edit stream/topic.
+                    post-edit channel/topic.
                   type: string
                   enum:
                     - change_one
@@ -7870,7 +7870,7 @@ paths:
                     notify users where the messages were moved to.
 
                     **Changes**: Before Zulip 6.0 (feature level 152), this parameter
-                    had a default of `true` and was ignored unless the stream was changed.
+                    had a default of `true` and was ignored unless the channel was changed.
 
                     New in Zulip 3.0 (feature level 9).
                   type: boolean
@@ -7885,7 +7885,7 @@ paths:
                     this parameter will not trigger an additional notification.
 
                     **Changes**: Before Zulip 6.0 (feature level 152), this parameter
-                    was ignored unless the stream was changed.
+                    was ignored unless the channel was changed.
 
                     New in Zulip 3.0 (feature level 9).
                   type: boolean
@@ -7895,13 +7895,13 @@ paths:
                   $ref: "#/components/schemas/OptionalContent"
                 stream_id:
                   description: |
-                    The stream ID to move the message(s) to, to request moving
-                    messages to another stream.
+                    The channel ID to move the message(s) to, to request moving
+                    messages to another channel.
 
-                    Should only be sent when changing the stream, and will throw an error
-                    if the target message is not a stream message.
+                    Should only be sent when changing the channel, and will throw an error
+                    if the target message is not a channel message.
 
-                    Note that a message's content and stream cannot be changed at the
+                    Note that a message's content and channel cannot be changed at the
                     same time, so sending both `content` and `stream_id` parameters will
                     throw an error.
 
@@ -7993,11 +7993,11 @@ paths:
                           a target message ID of `first_message_id_allowed_to_move`, if the user
                           desires to move only the portion of the topic that they can.
 
-                          Note that in a stream with [protected history](/help/channel-permissions),
+                          Note that in a channel with [protected history](/help/channel-permissions),
                           the Zulip security model requires that the above calculations only include
                           messages the acting user has access to. So in the rare case of a user
                           attempting to move a topic that started before the user joined a private
-                          stream with protected history, this API endpoint might move only the portion
+                          channel with protected history, this API endpoint might move only the portion
                           of a topic that they have access to, without this error or any confirmation
                           dialog.
 
@@ -8013,7 +8013,7 @@ paths:
                         description: |
                           An example JSON error response for when the message was rejected because
                           of the organization's `wildcard_mention_policy` and large number of
-                          subscribers to the stream.
+                          subscribers to the channel.
 
                           **Changes**: New in Zulip 8.0 (feature level 229). Previously, this
                           error returned the `"BAD_REQUEST"` code.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18188,21 +18188,21 @@ paths:
                       An example JSON response for when the supplied channel does not exist:
     patch:
       operationId: update-stream
-      summary: Update a stream
+      summary: Update a channel
       tags: ["streams"]
       description: |
-        Configure the stream with the ID `stream_id`. This endpoint supports
-        an organization administrator editing any property of a stream,
+        Configure the channel with the ID `stream_id`. This endpoint supports
+        an organization administrator editing any property of a channel,
         including:
 
-        - Stream [name](/help/rename-a-channel) and [description](/help/change-the-channel-description)
-        - Stream [permissions](/help/channel-permissions), including
+        - Channel [name](/help/rename-a-channel) and [description](/help/change-the-channel-description)
+        - Channel [permissions](/help/channel-permissions), including
           [privacy](/help/change-the-privacy-of-a-channel) and [who can
           send](/help/channel-posting-policy).
 
         Note that an organization administrator's ability to change a
-        [private stream's permissions](/help/channel-permissions#private-channels)
-        depends on them being subscribed to the stream.
+        [private channel's permissions](/help/channel-permissions#private-channels)
+        depends on them being subscribed to the channel.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -18223,11 +18223,11 @@ paths:
                 description:
                   description: |
                     The new [description](/help/change-the-channel-description) for
-                    the stream, in text/markdown format.
+                    the channel, in text/markdown format.
 
                     Clients should use the `max_stream_description_length` returned
                     by the [`POST /register`](/api/register-queue) endpoint to
-                    determine the maximum stream description length.
+                    determine the maximum channel description length.
 
                     **Changes**: Removed unnecessary JSON-encoding of this parameter in
                     Zulip 4.0 (feature level 64).
@@ -18235,11 +18235,11 @@ paths:
                   example: "Discuss Italian history and travel destinations."
                 new_name:
                   description: |
-                    The new name for the stream.
+                    The new name for the channel.
 
                     Clients should use the `max_stream_name_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
-                    the maximum stream name length.
+                    the maximum channel name length.
 
                     **Changes**: Removed unnecessary JSON-encoding of this parameter in
                     Zulip 4.0 (feature level 64).
@@ -18247,13 +18247,13 @@ paths:
                   example: Italy
                 is_private:
                   description: |
-                    Change whether the stream is a private stream.
+                    Change whether the channel is a private channel.
                   type: boolean
                   example: true
                 is_announcement_only:
                   deprecated: true
                   description: |
-                    Whether the stream is limited to announcements.
+                    Whether the channel is limited to announcements.
 
                     **Changes**: Deprecated in Zulip 3.0 (feature level 1). Clients
                     should use `stream_post_policy` instead.
@@ -18261,9 +18261,9 @@ paths:
                   example: true
                 is_web_public:
                   description: |
-                    Change whether the stream is a web-public stream.
+                    Change whether the channel is a web-public channel.
 
-                    Note that creating web-public streams requires the
+                    Note that creating web-public channels requires the
                     `WEB_PUBLIC_STREAMS_ENABLED` [server setting][server-settings]
                     to be enabled on the Zulip server in question, the organization
                     to have enabled the `enable_spectator_access` realm setting, and
@@ -18277,15 +18277,15 @@ paths:
                   example: true
                 history_public_to_subscribers:
                   description: |
-                    Whether the stream's message history should be available to
+                    Whether the channel's message history should be available to
                     newly subscribed members, or users can only access messages
-                    they actually received while subscribed to the stream.
+                    they actually received while subscribed to the channel.
 
                     Corresponds to the [shared history](/help/channel-permissions)
                     option in documentation.
 
                     It's an error for this parameter to be false for a public or
-                    web-public stream and when is_private is false.
+                    web-public channel and when is_private is false.
 
                     **Changes**: Before Zulip 6.0 (feature level 136), `history_public_to_subscribers`
                     was silently ignored unless the request also contained either `is_private` or
@@ -18294,12 +18294,12 @@ paths:
                   example: false
                 is_default_stream:
                   description: |
-                    Add or remove the stream as a [default stream][default-stream]
+                    Add or remove the channel as a [default channel][default-channel]
                     for new users joining the organization.
 
-                    [default-stream]: /help/set-default-channels-for-new-users
+                    [default-channel]: /help/set-default-channels-for-new-users
 
-                    **Changes**: New in Zulip 8.0 (feature level 200). Previously, default stream status
+                    **Changes**: New in Zulip 8.0 (feature level 200). Previously, default channel status
                     could only be changed using the [dedicated API endpoint](/api/add-default-stream).
                   type: boolean
                   example: false
@@ -18336,7 +18336,7 @@ paths:
                   - allOf:
                       - $ref: "#/components/schemas/InvalidChannelError"
                       - description: |
-                          An example JSON response for when the supplied stream does not exist:
+                          An example JSON response for when the supplied channel does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:
@@ -18346,7 +18346,7 @@ paths:
                             "result": "error",
                           }
                         description: |
-                          An example JSON response for when invalid combination of stream permission
+                          An example JSON response for when invalid combination of channel permission
                           parameters are passed:
   /streams/{stream_id}/email_address:
     get:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10323,7 +10323,7 @@ paths:
         organization administrators, who can deactivate any custom emoji.
 
         Note that deactivated emoji will still be visible in old messages, reactions,
-        user statuses and stream descriptions.
+        user statuses and channel descriptions.
 
         **Changes**: Before Zulip 8.0 (feature level 190), this endpoint returned an
         HTTP status code of 400 when the emoji did not exist, instead of 404.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5202,10 +5202,10 @@ paths:
     post:
       deprecated: true
       operationId: mark-stream-as-read
-      summary: Mark messages in a stream as read
+      summary: Mark messages in a channel as read
       tags: ["messages"]
       description: |
-        Mark all the unread messages in a stream as read.
+        Mark all the unread messages in a channel as read.
 
         **Changes**: Deprecated; clients should use the [update personal message
         flags for narrow](/api/update-message-flags-for-narrow) endpoint instead
@@ -5219,7 +5219,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the stream to access.
+                    The ID of the channel to access.
                   type: integer
                   example: 43
               required:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5251,7 +5251,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the stream to access.
+                    The ID of the channel to access.
                   type: integer
                   example: 43
                 topic_name:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12355,7 +12355,7 @@ paths:
 
                     **Changes**: New in Zulip 9.0 (feature level 261). Previous versions
                     of Zulip behaved as though this parameter was always `false`; clients
-                    needed to include the organization's default streams in the
+                    needed to include the organization's default channels in the
                     `stream_ids` parameter for a newly created user to be automatically
                     subscribed to them.
 
@@ -12419,9 +12419,9 @@ paths:
                             "result": "error",
                           }
                         description: |
-                          An example JSON error response for when any of the specified streams
+                          An example JSON error response for when any of the specified channels
                           does not exist or the user does not have permission to access one of
-                          the targeted streams.
+                          the targeted channels.
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:
@@ -12432,7 +12432,7 @@ paths:
                           }
                         description: |
                           An example JSON error response for when the user doesn't have permission
-                          to subscribe other users to streams and `stream_ids` is not empty.
+                          to subscribe other users to channels and `stream_ids` is not empty.
   /invites/{invite_id}:
     delete:
       operationId: revoke-email-invite

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18411,7 +18411,7 @@ paths:
         response will return `"complete": true`.
 
         **Changes**: Before Zulip 9.0 (feature level 256), the server never sent
-        events updating the `first_message_id` for a stream when the oldest
+        events updating the `first_message_id` for a channel when the oldest
         message that had been sent to it changed.
 
         Before Zulip 8.0 (feature level 211), if the server's

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18167,10 +18167,10 @@ paths:
                       An example JSON response for when the channel ID is not valid:
     delete:
       operationId: archive-stream
-      summary: Archive a stream
+      summary: Archive a channel
       tags: ["streams"]
       description: |
-        [Archive the stream](/help/archive-a-channel) with the ID `stream_id`.
+        [Archive the channel](/help/archive-a-channel) with the ID `stream_id`.
       x-requires-administrator: true
       parameters:
         - $ref: "#/components/parameters/ChannelIdInPath"
@@ -18185,7 +18185,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
-                      An example JSON response for when the supplied stream does not exist:
+                      An example JSON response for when the supplied channel does not exist:
     patch:
       operationId: update-stream
       summary: Update a stream

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12189,7 +12189,7 @@ paths:
 
                     **Changes**: New in Zulip 9.0 (feature level 261). Previous versions
                     of Zulip behaved as though this parameter was always `false`; clients
-                    needed to include the organization's default streams in the
+                    needed to include the organization's default channels in the
                     `stream_ids` parameter for a newly created user to be automatically
                     subscribed to them.
 
@@ -12278,9 +12278,9 @@ paths:
                             "result": "error",
                           }
                         description: |
-                          An example JSON error response for when any of the specified streams
+                          An example JSON error response for when any of the specified channels
                           does not exist or the user does not have permission to access one of
-                          the targeted streams.
+                          the targeted channels.
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:
@@ -12291,7 +12291,7 @@ paths:
                           }
                         description: |
                           An example JSON error response for when the user doesn't have permission
-                          to subscribe other users to streams and `stream_ids` is not empty.
+                          to subscribe other users to channels and `stream_ids` is not empty.
   /invites/multiuse:
     post:
       operationId: create-invite-link

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9723,7 +9723,7 @@ paths:
       summary: Topic muting
       tags: ["streams"]
       description: |
-        [Mute or unmute a topic](/help/mute-a-topic) within a stream that
+        [Mute or unmute a topic](/help/mute-a-topic) within a channel that
         the current user is subscribed to.
 
         **Changes**: Deprecated in Zulip 7.0 (feature level 170). Clients connecting
@@ -9748,7 +9748,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the stream to access.
+                    The ID of the channel to access.
 
                     Clients must provide either `stream` or `stream_id` as a parameter
                     to this endpoint, but not both.
@@ -9758,7 +9758,7 @@ paths:
                   example: 43
                 stream:
                   description: |
-                    The name of the stream to access.
+                    The name of the channel to access.
 
                     Clients must provide either `stream` or `stream_id` as a parameter
                     to this endpoint, but not both. Clients should use `stream_id`

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10239,7 +10239,7 @@ paths:
       summary: Get subscription status
       tags: ["streams"]
       description: |
-        Check whether a user is subscribed to a stream.
+        Check whether a user is subscribed to a channel.
 
         **Changes**: New in Zulip 3.0 (feature level 12).
       parameters:
@@ -10261,7 +10261,7 @@ paths:
                       is_subscribed:
                         type: boolean
                         description: |
-                          Whether the user is subscribed to the stream.
+                          Whether the user is subscribed to the channel.
                     example:
                       {"msg": "", "result": "success", "is_subscribed": false}
   /realm/emoji/{emoji_name}:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18110,10 +18110,10 @@ paths:
   /streams/{stream_id}:
     get:
       operationId: get-stream-by-id
-      summary: Get a stream by ID
+      summary: Get a channel by ID
       tags: ["streams"]
       description: |
-        Fetch details for the stream with the ID `stream_id`.
+        Fetch details for the channel with the ID `stream_id`.
 
         **Changes**: New in Zulip 6.0 (feature level 132).
       parameters:
@@ -18164,7 +18164,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
-                      An example JSON response for when the stream ID is not valid:
+                      An example JSON response for when the channel ID is not valid:
     delete:
       operationId: archive-stream
       summary: Archive a stream

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18533,12 +18533,12 @@ paths:
         for additional design details on Zulip's typing notifications protocol.
 
         **Changes**: Clients shouldn't care about the APIs prior to Zulip 8.0 (feature level 215)
-        for stream typing notifications, as no client actually implemented
+        for channel typing notifications, as no client actually implemented
         the previous API for those.
 
-        Support for displaying stream typing notifications was new
+        Support for displaying channel typing notifications was new
         in Zulip 4.0 (feature level 58). Clients should indicate they support
-        processing stream typing notifications via the `stream_typing_notifications`
+        processing channel typing notifications via the `stream_typing_notifications`
         value in the `client_capabilities` parameter of the
         [`POST /register`][client-capabilities] endpoint.
 
@@ -18566,7 +18566,7 @@ paths:
                     Type of the message being composed.
 
                     **Changes**: In Zulip 9.0 (feature level 248), `"channel"` was added as
-                    an additional value for this parameter to indicate a stream message is
+                    an additional value for this parameter to indicate a channel message is
                     being composed.
 
                     In Zulip 8.0 (feature level 215), stopped supporting
@@ -18597,15 +18597,18 @@ paths:
                 to:
                   description: |
                     User IDs of the recipients of the message being typed. Required for the
-                    `"direct"` type. Ignored in the case of `"stream"` type. Send a JSON-encoded
-                    list of user IDs. (Use a list even if there is only one recipient.)
+                    `"direct"` type. Ignored in the case of `"stream"` or `"channel"` type.
+
+                    Clients should send a JSON-encoded list of user IDs, even if there is only
+                    one recipient.
 
                     **Changes**: In Zulip 8.0 (feature level 215), stopped using this parameter
                     for the `"stream"` type. Previously, in the case of the `"stream"` type, it
-                    accepted a single-element list containing the ID of the stream. A new parameter,
-                    `stream_id`, is now used for this.
+                    accepted a single-element list containing the ID of the channel. A new parameter,
+                    `stream_id`, is now used for this. Note that the `"channel"` type did not
+                    exist at this feature level.
 
-                    Support for typing notifications for stream messages
+                    Support for typing notifications for channel' messages
                     is new in Zulip 4.0 (feature level 58). Previously, typing
                     notifications were only for direct messages.
 
@@ -18619,17 +18622,17 @@ paths:
                   example: [9, 10]
                 stream_id:
                   description: |
-                    ID of the stream in which the message is being typed. Required for the `"stream"`
-                    type. Ignored in the case of `"direct"` type.
+                    ID of the channel in which the message is being typed. Required for the `"stream"`
+                    or `"channel"` type. Ignored in the case of `"direct"` type.
 
                     **Changes**: New in Zulip 8.0 (feature level 215). Previously, a single-element
-                    list containing the ID of the stream was passed in `to` parameter.
+                    list containing the ID of the channel was passed in `to` parameter.
                   type: integer
                   example: 7
                 topic:
                   description: |
-                    Topic to which message is being typed. Required for the `"stream"` type.
-                    Ignored in the case of `"direct"` type.
+                    Topic to which message is being typed. Required for the `"stream"` or `"channel"`
+                    type. Ignored in the case of `"direct"` type.
 
                     **Changes**: New in Zulip 4.0 (feature level 58). Previously, typing
                     notifications were only for direct messages.
@@ -18659,7 +18662,7 @@ paths:
                         "result": "error",
                       }
                     description: |
-                      An example JSON error response when the user composes a stream message
+                      An example JSON error response when the user composes a channel message
                       and `stream_id` is not specified:
   /user_groups/create:
     post:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1312,7 +1312,7 @@ paths:
                                     Array of objects, each containing
                                     details about the newly added channel(s).
                                   items:
-                                    $ref: "#/components/schemas/BasicStream"
+                                    $ref: "#/components/schemas/BasicChannel"
                               additionalProperties: false
                               example:
                                 {
@@ -1370,7 +1370,7 @@ paths:
                                     Array of objects, each containing
                                     details about a channel that was deleted.
                                   items:
-                                    $ref: "#/components/schemas/BasicStream"
+                                    $ref: "#/components/schemas/BasicChannel"
                               additionalProperties: false
                               example:
                                 {
@@ -1943,7 +1943,7 @@ paths:
                                     An array of dictionaries where each dictionary
                                     contains details about a single default channel group.
                                   items:
-                                    $ref: "#/components/schemas/DefaultStreamGroup"
+                                    $ref: "#/components/schemas/DefaultChannelGroup"
                               example:
                                 {
                                   "type": "default_stream_groups",
@@ -2028,7 +2028,7 @@ paths:
                                     An array of dictionaries where each dictionary
                                     contains details about a single default channel.
                                   items:
-                                    $ref: "#/components/schemas/DefaultStream"
+                                    $ref: "#/components/schemas/DefaultChannel"
                               example:
                                 {
                                   "type": "default_streams",
@@ -5790,7 +5790,7 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/NonExistingStreamIdError"
+                      - $ref: "#/components/schemas/NonExistingChannelIdError"
                       - description: |
                           A typical failed JSON response for when a stream message is scheduled
                           to be sent to a stream that does not exist:
@@ -5921,7 +5921,7 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/NonExistingStreamIdError"
+                      - $ref: "#/components/schemas/NonExistingChannelIdError"
                       - description: |
                           A typical failed JSON response for when a stream message is scheduled
                           to be sent to a stream that does not exist:
@@ -6030,7 +6030,7 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/InvalidStreamError"
+                      - $ref: "#/components/schemas/InvalidChannelError"
                       - description: |
                           A typical failed JSON response for when an invalid stream ID is passed:
                   - allOf:
@@ -6080,7 +6080,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       A typical failed JSON response for when an invalid stream ID is passed:
   /messages:
@@ -6630,7 +6630,7 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/NonExistingStreamNameError"
+                      - $ref: "#/components/schemas/NonExistingChannelNameError"
                       - description: |
                           A typical failed JSON response for when a stream message is sent to a stream
                           that does not exist:
@@ -9087,7 +9087,7 @@ paths:
         will only have access to messages sent after the bot was subscribed to
         the stream, instead of when the user subscribed.
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           description: Success.
@@ -9134,7 +9134,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the user is attempting to fetch the topics
                       of a non-existing stream (or also a private stream they don't have access to):
@@ -9375,7 +9375,7 @@ paths:
                 history_public_to_subscribers:
                   $ref: "#/components/schemas/HistoryPublicToSubscribers"
                 stream_post_policy:
-                  $ref: "#/components/schemas/StreamPostPolicy"
+                  $ref: "#/components/schemas/ChannelPostPolicy"
                 message_retention_days:
                   $ref: "#/components/schemas/MessageRetentionDays"
                 can_remove_subscribers_group:
@@ -9713,7 +9713,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/NonExistingStreamNameError"
+                  - $ref: "#/components/schemas/NonExistingChannelNameError"
                   - description: |
                       A typical failed JSON response for when the target stream does not exist:
   /users/me/subscriptions/muted_topics:
@@ -10244,7 +10244,7 @@ paths:
         **Changes**: New in Zulip 3.0 (feature level 12).
       parameters:
         - $ref: "#/components/parameters/UserId"
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           description: Success
@@ -12661,7 +12661,7 @@ paths:
                 event_types:
                   $ref: "#/components/schemas/Event_types"
                 all_public_streams:
-                  $ref: "#/components/schemas/AllPublicStreams"
+                  $ref: "#/components/schemas/AllPublicChannels"
                 client_capabilities:
                   description: |
                     Dictionary containing details on features the client supports that are
@@ -13397,7 +13397,7 @@ paths:
                         type: array
                         items:
                           allOf:
-                            - $ref: "#/components/schemas/BasicStreamBase"
+                            - $ref: "#/components/schemas/BasicChannelBase"
                             - additionalProperties: false
                               properties:
                                 stream_id: {}
@@ -13596,7 +13596,7 @@ paths:
                       streams:
                         type: array
                         items:
-                          $ref: "#/components/schemas/BasicStream"
+                          $ref: "#/components/schemas/BasicChannel"
                         description: |
                           Present if `stream` is present in `fetch_event_types`.
 
@@ -13611,7 +13611,7 @@ paths:
                       realm_default_streams:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DefaultStream"
+                          $ref: "#/components/schemas/DefaultChannel"
                         description: |
                           Present if `default_streams` is present in `fetch_event_types`.
 
@@ -13621,7 +13621,7 @@ paths:
                       realm_default_stream_groups:
                         type: array
                         items:
-                          $ref: "#/components/schemas/DefaultStreamGroup"
+                          $ref: "#/components/schemas/DefaultChannelGroup"
                         description: |
                           Present if `default_stream_groups` is present in `fetch_event_types`.
 
@@ -17862,7 +17862,7 @@ paths:
       description: |
         Get all users subscribed to a stream.
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           description: Success.
@@ -17891,7 +17891,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the requested stream does not exist,
                       or where the user does not have permission to access the target stream:
@@ -17985,7 +17985,7 @@ paths:
                         type: array
                         items:
                           allOf:
-                            - $ref: "#/components/schemas/BasicStreamBase"
+                            - $ref: "#/components/schemas/BasicChannelBase"
                             - additionalProperties: false
                               properties:
                                 stream_id: {}
@@ -18117,7 +18117,7 @@ paths:
 
         **Changes**: New in Zulip 6.0 (feature level 132).
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           description: Success.
@@ -18132,7 +18132,7 @@ paths:
                       msg: {}
                       ignored_parameters_unsupported: {}
                       stream:
-                        $ref: "#/components/schemas/BasicStream"
+                        $ref: "#/components/schemas/BasicChannel"
                     example:
                       {
                         "msg": "",
@@ -18162,7 +18162,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the stream ID is not valid:
     delete:
@@ -18173,7 +18173,7 @@ paths:
         [Archive the stream](/help/archive-a-channel) with the ID `stream_id`.
       x-requires-administrator: true
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
@@ -18183,7 +18183,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the supplied stream does not exist:
     patch:
@@ -18212,7 +18212,7 @@ paths:
                 - description
                 - is_private
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       requestBody:
         required: false
         content:
@@ -18304,7 +18304,7 @@ paths:
                   type: boolean
                   example: false
                 stream_post_policy:
-                  $ref: "#/components/schemas/StreamPostPolicy"
+                  $ref: "#/components/schemas/ChannelPostPolicy"
                 message_retention_days:
                   $ref: "#/components/schemas/MessageRetentionDays"
                 can_remove_subscribers_group:
@@ -18334,7 +18334,7 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/InvalidStreamError"
+                      - $ref: "#/components/schemas/InvalidChannelError"
                       - description: |
                           An example JSON response for when the supplied stream does not exist:
                   - allOf:
@@ -18358,7 +18358,7 @@ paths:
 
         **Changes**: New in Zulip 8.0 (feature level 226).
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
         "200":
           description: Success.
@@ -18388,7 +18388,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
                       An example JSON response for when the requested stream does not exist,
                       or where the user does not have permission to access the target stream:
@@ -18434,7 +18434,7 @@ paths:
         returns an error.
       x-requires-administrator: true
       parameters:
-        - $ref: "#/components/parameters/StreamIdInPath"
+        - $ref: "#/components/parameters/ChannelIdInPath"
       requestBody:
         required: true
         content:
@@ -19201,7 +19201,7 @@ paths:
                 narrow:
                   $ref: "#/components/schemas/Narrow"
                 all_public_streams:
-                  $ref: "#/components/schemas/AllPublicStreams"
+                  $ref: "#/components/schemas/AllPublicChannels"
             encoding:
               event_types:
                 contentType: application/json
@@ -19500,9 +19500,9 @@ components:
                 description: |
                   The unique message ID. Messages should always be
                   displayed sorted by ID.
-    BasicStream:
+    BasicChannel:
       allOf:
-        - $ref: "#/components/schemas/BasicStreamBase"
+        - $ref: "#/components/schemas/BasicChannelBase"
         - additionalProperties: false
           properties:
             stream_id: {}
@@ -19553,9 +19553,9 @@ components:
             - is_announcement_only
             - can_remove_subscribers_group
             - stream_weekly_traffic
-    DefaultStream:
+    DefaultChannel:
       allOf:
-        - $ref: "#/components/schemas/BasicStreamBase"
+        - $ref: "#/components/schemas/BasicChannelBase"
         - additionalProperties: false
           properties:
             stream_id: {}
@@ -19590,7 +19590,7 @@ components:
             - first_message_id
             - is_announcement_only
             - can_remove_subscribers_group
-    BasicStreamBase:
+    BasicChannelBase:
       type: object
       description: |
         Object containing basic details about the channel.
@@ -20562,7 +20562,7 @@ components:
             was named `can_remove_subscribers_group_id`.
 
             New in Zulip 6.0 (feature level 142).
-    DefaultStreamGroup:
+    DefaultChannelGroup:
       type: object
       description: |
         Dictionary containing details of a default channel
@@ -20587,7 +20587,7 @@ components:
             Array containing details about the channels
             in the default channel group.
           items:
-            $ref: "#/components/schemas/DefaultStream"
+            $ref: "#/components/schemas/DefaultChannel"
     EmailAddressVisibility:
       type: integer
       description: |
@@ -21648,7 +21648,7 @@ components:
               "code": "BAD_REQUEST",
               "result": "error",
             }
-    InvalidStreamError:
+    InvalidChannelError:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
@@ -21662,7 +21662,7 @@ components:
               "code": "BAD_REQUEST",
               "result": "error",
             }
-    NonExistingStreamNameError:
+    NonExistingChannelNameError:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
@@ -21681,7 +21681,7 @@ components:
               "result": "error",
               "stream": "nonexistent",
             }
-    NonExistingStreamIdError:
+    NonExistingChannelIdError:
       allOf:
         - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
@@ -21977,7 +21977,7 @@ components:
           type: string
       default: []
       example: [["channel", "Denmark"]]
-    AllPublicStreams:
+    AllPublicChannels:
       description: |
         Whether you would like to request message events from all public
         channels. Useful for workflow bots that you'd like to see all new messages
@@ -22007,7 +22007,7 @@ components:
         throw an error.
       type: string
       example: Hello
-    StreamPostPolicy:
+    ChannelPostPolicy:
       description: |
         [Policy][permission-level] for which users can post messages to the channel.
 
@@ -22193,7 +22193,7 @@ components:
         type: string
       example: fb67bf8a-c031-47cc-84cf-ed80accacda8
       required: true
-    StreamIdInPath:
+    ChannelIdInPath:
       name: stream_id
       in: path
       description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19383,7 +19383,7 @@ paths:
           description: |
             Title to use for the BigBlueButton meeting.
 
-            A good choice is something like "{stream_name} meeting".
+            A good choice is something like "{channel_name} meeting".
       responses:
         "200":
           description: Success.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6887,10 +6887,10 @@ paths:
                         <td><code>stream_wildcard_mentioned</code></td>
                         <td>
                             Whether this message contained a
-                            <a href="/help/mention-a-user-or-group#mention-everyone-on-a-stream">stream wildcard mention</a>
+                            <a href="/help/mention-a-user-or-group#mention-everyone-on-a-channel">channel wildcard mention</a>
                             (like @**all**). Cannot be changed by the user directly, but
                             can change if the message is edited to add/remove
-                            a stream wildcard mention.
+                            a channel wildcard mention.
                             <br /><br />
                             <b>Changes</b>: New in Zulip 8.0 (feature level 224).
                         </td>
@@ -6922,8 +6922,8 @@ paths:
                             Is <code>true</code> for messages that the user did not receive
                             at the time they were sent but later was added to
                             the user's history (e.g. because they starred or
-                            reacted to a message sent to a public stream
-                            before they subscribed to that stream). Cannot be
+                            reacted to a message sent to a public channel
+                            before they subscribed to that channel). Cannot be
                             changed by the user directly.
                         </td>
                     </tr>
@@ -6931,11 +6931,11 @@ paths:
                         <td><code>wildcard_mentioned</code></td>
                         <td>
                             Whether this message contained either a
-                            <a href="/help/mention-a-user-or-group#mention-everyone-on-a-stream">stream wildcard mention</a>
+                            <a href="/help/mention-a-user-or-group#mention-everyone-on-a-channel">channel wildcard mention</a>
                             (like @**all**) or a
                             <a href="/help/mention-a-user-or-group#mention-all-topic-participants">topic wildcard mention</a>
                             (@**topic**). Cannot be changed by the user directly, but can change if
-                            the message is edited to add/remove a stream and/or topic wildcard
+                            the message is edited to add/remove a channel and/or topic wildcard
                             mention.
                             <br /><br />
                             <b>Changes</b>: Deprecated in Zulip 8.0 (feature level 224), in favor of
@@ -7080,7 +7080,7 @@ paths:
                     the server has a database index for unread messages.
 
                     **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
-                    for two new filters related to stream messages: `channel` and `channels`;
+                    for two new filters related to channel messages: `channel` and `channels`;
                     which are aliases for (and return the same results as) the `stream` and
                     `streams` filters respectively.
 
@@ -7118,7 +7118,7 @@ paths:
                         minItems: 2
                         maxItems: 2
                   default: []
-                  example: [{"operand": "Denmark", "operator": "stream"}]
+                  example: [{"operand": "Denmark", "operator": "channel"}]
                 op:
                   description: |
                     Whether to `add` the flag or `remove` it.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9594,24 +9594,24 @@ paths:
                       }
     delete:
       operationId: unsubscribe
-      summary: Unsubscribe from a stream
+      summary: Unsubscribe from a channel
       tags: ["streams"]
       description: |
-        Unsubscribe yourself or other users from one or more streams.
+        Unsubscribe yourself or other users from one or more channels.
 
         In addition to managing the current user's subscriptions, this
-        endpoint can be used to remove other users from streams. This
+        endpoint can be used to remove other users from channels. This
         is possible in 3 situations:
 
         - Organization administrators can remove any user from any
-          stream.
-        - Users can remove a bot that they own from any stream that
+          channel.
+        - Users can remove a bot that they own from any channel that
           the user [can access](/help/channel-permissions).
-        - Users can unsubscribe any user from a stream if they [have
-          access](/help/channel-permissions) to the stream and are a
+        - Users can unsubscribe any user from a channel if they [have
+          access](/help/channel-permissions) to the channel and are a
           member of the [user group](/api/get-user-groups) specified
           by the [`can_remove_subscribers_group`][can-remove-parameter]
-          for the stream.
+          for the channel.
 
         **Changes**: Before Zulip 8.0 (feature level 208), if a user
         specified by the [`principals`][principals-param] parameter was
@@ -9626,7 +9626,7 @@ paths:
         was named `can_remove_subscribers_group_id`.
 
         Before Zulip 7.0 (feature level 161), the
-        `can_remove_subscribers_group_id` for all streams was always
+        `can_remove_subscribers_group_id` for all channels was always
         the system group for organization administrators.
 
         Before Zulip 6.0 (feature level 145), users had no special
@@ -9638,7 +9638,7 @@ paths:
         oneOf:
           - type: include
             description: |
-              **Note**: Unsubscribing another user from a stream requires
+              **Note**: Unsubscribing another user from a channel requires
               administrative privileges.
             parameters:
               enum:
@@ -9658,7 +9658,7 @@ paths:
               properties:
                 subscriptions:
                   description: |
-                    A list of stream names to unsubscribe from. This parameter is called
+                    A list of channel names to unsubscribe from. This parameter is called
                     `streams` in our Python API.
                   type: array
                   items:
@@ -9691,20 +9691,20 @@ paths:
                         items:
                           type: string
                         description: |
-                          A list of the names of streams that the user is already unsubscribed
+                          A list of the names of channels that the user is already unsubscribed
                           from, and hence doesn't need to be unsubscribed.
                       removed:
                         type: array
                         items:
                           type: string
                         description: |
-                          A list of the names of streams which were unsubscribed from as a result
+                          A list of the names of channels which were unsubscribed from as a result
                           of the query.
                     example:
                       {
                         "msg": "",
                         "not_removed": [],
-                        "removed": ["new stream"],
+                        "removed": ["testing-help"],
                         "result": "success",
                       }
         "400":
@@ -9715,7 +9715,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/NonExistingChannelNameError"
                   - description: |
-                      A typical failed JSON response for when the target stream does not exist:
+                      A typical failed JSON response for when the target channel does not exist:
   /users/me/subscriptions/muted_topics:
     patch:
       deprecated: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5509,8 +5509,8 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/CodedError"
                   - description: |
-                      JSON response for when a draft targeted towards a stream does not specify
-                      exactly one stream ID:
+                      JSON response for when a draft targeted towards a channel does not specify
+                      exactly one channel ID:
                     example:
                       {
                         "code": "BAD_REQUEST",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6046,13 +6046,13 @@ paths:
                           to the default channels set:
     delete:
       operationId: remove-default-stream
-      summary: Remove a default stream
+      summary: Remove a default channel
       tags: ["streams"]
       description: |
-        Remove a stream from the set of [default streams][default-streams]
+        Remove a channel from the set of [default channels][default-channels]
         for new users joining the organization.
 
-        [default-streams]: /help/set-default-channels-for-new-users
+        [default-channels]: /help/set-default-channels-for-new-users
       x-requires-administrator: true
       requestBody:
         required: true
@@ -6063,7 +6063,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the target stream.
+                    The ID of the target channel.
                   type: integer
                   example: 10
               required:
@@ -6082,7 +6082,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/InvalidChannelError"
                   - description: |
-                      A typical failed JSON response for when an invalid stream ID is passed:
+                      A typical failed JSON response for when an invalid channel ID is passed:
   /messages:
     get:
       operationId: get-messages

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5996,13 +5996,13 @@ paths:
     post:
       operationId: add-default-stream
       tags: ["streams"]
-      summary: Add a default stream
+      summary: Add a default channel
       x-requires-administrator: true
       description: |
-        Add a stream to the set of [default streams][default-streams]
+        Add a channel to the set of [default channels][default-channels]
         for new users joining the organization.
 
-        [default-streams]: /help/set-default-channels-for-new-users
+        [default-channels]: /help/set-default-channels-for-new-users
       requestBody:
         required: true
         content:
@@ -6012,7 +6012,7 @@ paths:
               properties:
                 stream_id:
                   description: |
-                    The ID of the target stream.
+                    The ID of the target channel.
                   type: integer
                   example: 10
               required:
@@ -6032,7 +6032,7 @@ paths:
                   - allOf:
                       - $ref: "#/components/schemas/InvalidChannelError"
                       - description: |
-                          A typical failed JSON response for when an invalid stream ID is passed:
+                          A typical failed JSON response for when an invalid channel ID is passed:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:
@@ -6042,8 +6042,8 @@ paths:
                             "result": "error",
                           }
                         description: |
-                          A typical failed JSON response for when a user tries to add a private stream
-                          to the default streams set:
+                          A typical failed JSON response for when a user tries to add a private channel
+                          to the default channels set:
     delete:
       operationId: remove-default-stream
       summary: Remove a default stream

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6697,7 +6697,7 @@ paths:
         snapshot will be the only one present if the message has never been edited.
 
         Also note that each snapshot object will only contain additional data for the
-        modified fields for that particular edit (e.g. if only the topic or stream
+        modified fields for that particular edit (e.g. if only the topic or channel
         was edited, `prev_content`, `prev_rendered_content`, and
         `content_html_diff` will not appear).
       responses:
@@ -6734,18 +6734,18 @@ paths:
                             stream:
                               type: integer
                               description: |
-                                Only present if message's stream was edited.
+                                Only present if message's channel was edited.
 
-                                The ID of the stream containing the message
+                                The ID of the channel containing the message
                                 immediately after this edit event.
 
                                 **Changes**: New in Zulip 5.0 (feature level 118).
                             prev_stream:
                               type: integer
                               description: |
-                                Only present if message's stream was edited.
+                                Only present if message's channel was edited.
 
-                                The ID of the stream containing the message immediately
+                                The ID of the channel containing the message immediately
                                 prior to this edit event.
 
                                 **Changes**: New in Zulip 3.0 (feature level 1).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17898,10 +17898,10 @@ paths:
   /streams:
     get:
       operationId: get-streams
-      summary: Get all streams
+      summary: Get all channels
       tags: ["streams"]
       description: |
-        Get all streams that the user [has access to](/help/channel-permissions).
+        Get all channels that the user [has access to](/help/channel-permissions).
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -17919,7 +17919,7 @@ paths:
         - name: include_public
           in: query
           description: |
-            Include all public streams.
+            Include all public channels.
           schema:
             type: boolean
             default: true
@@ -17927,7 +17927,7 @@ paths:
         - name: include_web_public
           in: query
           description: |
-            Include all web-public streams.
+            Include all web-public channels.
           schema:
             type: boolean
             default: false
@@ -17935,7 +17935,7 @@ paths:
         - name: include_subscribed
           in: query
           description: |
-            Include all streams that the user is subscribed to.
+            Include all channels that the user is subscribed to.
           schema:
             type: boolean
             default: true
@@ -17943,7 +17943,7 @@ paths:
         - name: include_all_active
           in: query
           description: |
-            Include all active streams. The user must have administrative privileges
+            Include all active channels. The user must have administrative privileges
             to use this parameter.
           schema:
             type: boolean
@@ -17952,7 +17952,7 @@ paths:
         - name: include_default
           in: query
           description: |
-            Include all default streams for the user's realm.
+            Include all default channels for the user's realm.
           schema:
             type: boolean
             default: false
@@ -17960,7 +17960,7 @@ paths:
         - name: include_owner_subscribed
           in: query
           description: |
-            If the user is a bot, include all streams that the bot's owner is
+            If the user is a bot, include all channels that the bot's owner is
             subscribed to.
           schema:
             type: boolean
@@ -17981,7 +17981,7 @@ paths:
                       ignored_parameters_unsupported: {}
                       streams:
                         description: |
-                          A list of stream objects with details on the requested streams.
+                          A list of channel objects with details on the requested channels.
                         type: array
                         items:
                           allOf:
@@ -18009,11 +18009,11 @@ paths:
                                   type: integer
                                   nullable: true
                                   description: |
-                                    The average number of messages sent to the stream per week, as
+                                    The average number of messages sent to the channel per week, as
                                     estimated based on recent weeks, rounded to the nearest integer.
 
                                     If `null`, no information is provided on the average traffic.
-                                    This can be because the stream was recently created and there
+                                    This can be because the channel was recently created and there
                                     is insufficient data to make an estimate, or because the server
                                     wishes to omit this information for this client, this realm, or
                                     this endpoint or type of event.
@@ -18026,8 +18026,8 @@ paths:
                                     Only present when [`include_default`][include_default]
                                     parameter is `true`.
 
-                                    Whether the given stream is a
-                                    [default stream](/help/set-default-channels-for-new-users).
+                                    Whether the given channel is a
+                                    [default channel](/help/set-default-channels-for-new-users).
 
                                     [include_default]: /api/get-streams#parameter-include_default
                               required:
@@ -18056,7 +18056,7 @@ paths:
                               "can_remove_subscribers_group": 10,
                               "creator_id": null,
                               "date_created": 1691057093,
-                              "description": "A private stream",
+                              "description": "A private channel",
                               "first_message_id": 18,
                               "history_public_to_subscribers": false,
                               "invite_only": true,
@@ -18065,7 +18065,7 @@ paths:
                               "is_web_public": false,
                               "message_retention_days": null,
                               "name": "management",
-                              "rendered_description": "<p>A private stream</p>",
+                              "rendered_description": "<p>A private channel</p>",
                               "stream_id": 2,
                               "stream_post_policy": 1,
                               "stream_weekly_traffic": null,
@@ -18074,7 +18074,7 @@ paths:
                               "can_remove_subscribers_group": 9,
                               "creator_id": 12,
                               "date_created": 1691057093,
-                              "description": "A default public stream",
+                              "description": "A default public channel",
                               "first_message_id": 21,
                               "history_public_to_subscribers": true,
                               "invite_only": false,
@@ -18083,7 +18083,7 @@ paths:
                               "is_web_public": false,
                               "message_retention_days": null,
                               "name": "welcome",
-                              "rendered_description": "<p>A default public stream</p>",
+                              "rendered_description": "<p>A default public channel</p>",
                               "stream_id": 1,
                               "stream_post_policy": 1,
                               "stream_weekly_traffic": null,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11347,8 +11347,8 @@ paths:
       tags: ["streams"]
       description: |
         This endpoint is used to update the user's personal settings for the
-        streams they are subscribed to, including muting, color, pinning, and
-        per-stream notification settings.
+        channels they are subscribed to, including muting, color, pinning, and
+        per-channel notification settings.
 
         **Changes**: Prior to Zulip 5.0 (feature level 111), response
         object included the `subscription_data` in the the
@@ -11367,7 +11367,7 @@ paths:
                   description: |
                     A list of objects that describe the changes that should be applied in
                     each subscription. Each object represents a subscription, and must have
-                    a `stream_id` key that identifies the stream, as well as the `property`
+                    a `stream_id` key that identifies the channel, as well as the `property`
                     being modified and its new `value`.
                   type: array
                   items:
@@ -11377,7 +11377,7 @@ paths:
                       stream_id:
                         type: integer
                         description: |
-                          The unique ID of a stream.
+                          The unique ID of a channel.
                       property:
                         type: string
                         enum:
@@ -11391,11 +11391,11 @@ paths:
                           - email_notifications
                           - wildcard_mentions_notify
                         description: |
-                          One of the stream properties described below:
+                          One of the channel properties described below:
 
-                          - `"color"`: The hex value of the user's display color for the stream.
+                          - `"color"`: The hex value of the user's display color for the channel.
 
-                          - `"is_muted"`: Whether the stream is [muted](/help/mute-a-channel).<br>
+                          - `"is_muted"`: Whether the channel is [muted](/help/mute-a-channel).<br>
                             **Changes**: As of Zulip 6.0 (feature level 139), updating either
                             `"is_muted"` or `"in_home_view"` generates two [subscription update
                             events](/api/get-events#subscription-update), one for each property,
@@ -11407,22 +11407,22 @@ paths:
                             opposite value: `in_home_view=!is_muted`); for
                             backwards-compatibility, modern Zulip still accepts that property.
 
-                          - `"pin_to_top"`: Whether to pin the stream at the top of the stream list.
+                          - `"pin_to_top"`: Whether to pin the channel at the top of the channel list.
 
                           - `"desktop_notifications"`: Whether to show desktop notifications
-                            for all messages sent to the stream.
+                            for all messages sent to the channel.
 
                           - `"audible_notifications"`: Whether to play a sound
-                            notification for all messages sent to the stream.
+                            notification for all messages sent to the channel.
 
                           - `"push_notifications"`: Whether to trigger a mobile push
-                            notification for all messages sent to the stream.
+                            notification for all messages sent to the channel.
 
                           - `"email_notifications"`: Whether to trigger an email
-                            notification for all messages sent to the stream.
+                            notification for all messages sent to the channel.
 
                           - `"wildcard_mentions_notify"`: Whether wildcard mentions trigger
-                            notifications as though they were personal mentions in this stream.
+                            notifications as though they were personal mentions in this channel.
                       value:
                         oneOf:
                           - type: boolean
@@ -11432,7 +11432,7 @@ paths:
 
                           If the property is `"color"`, then `value` is a string
                           representing the hex value of the user's display
-                          color for the stream. For all other above properties,
+                          color for the channel. For all other above properties,
                           `value` is a boolean.
                     required:
                       - stream_id

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19526,11 +19526,11 @@ components:
               type: integer
               nullable: true
               description: |
-                The average number of messages sent to the stream per week, as
+                The average number of messages sent to the channel per week, as
                 estimated based on recent weeks, rounded to the nearest integer.
 
                 If `null`, no information is provided on the average traffic.
-                This can be because the stream was recently created and there
+                This can be because the channel was recently created and there
                 is insufficient data to make an estimate, or because the server
                 wishes to omit this information for this client, this realm, or
                 this endpoint or type of event.
@@ -19593,36 +19593,36 @@ components:
     BasicStreamBase:
       type: object
       description: |
-        Object containing basic details about the stream.
+        Object containing basic details about the channel.
       properties:
         stream_id:
           type: integer
           description: |
-            The unique ID of the stream.
+            The unique ID of the channel.
         name:
           type: string
           description: |
-            The name of the stream.
+            The name of the channel.
         description:
           type: string
           description: |
-            The short description of the stream in text/markdown format,
-            intended to be used to prepopulate UI for editing a stream's
+            The short description of the channel in text/markdown format,
+            intended to be used to prepopulate UI for editing a channel's
             description.
         date_created:
           type: integer
           description: |
-            The UNIX timestamp for when the stream was created, in UTC seconds.
+            The UNIX timestamp for when the channel was created, in UTC seconds.
 
             **Changes**: New in Zulip 4.0 (feature level 30).
         creator_id:
           type: integer
           nullable: true
           description: |
-            The ID of the user who created this stream.
+            The ID of the user who created this channel.
 
-            A `null` value means the stream has no recorded creator, which is often
-            because the stream is very old, or because it was created via a data
+            A `null` value means the channel has no recorded creator, which is often
+            because the channel is very old, or because it was created via a data
             import tool or [management command][management-commands].
 
             **Changes**: New in Zulip 9.0 (feature level 254).
@@ -19631,13 +19631,13 @@ components:
         invite_only:
           type: boolean
           description: |
-            Specifies whether the stream is private or not.
-            Only people who have been invited can access a private stream.
+            Specifies whether the channel is private or not.
+            Only people who have been invited can access a private channel.
         rendered_description:
           type: string
           description: |
-            The short description of the stream rendered as HTML, intended to
-            be used when displaying the stream description in a UI.
+            The short description of the channel rendered as HTML, intended to
+            be used when displaying the channel description in a UI.
 
             One should use the standard Zulip rendered_markdown CSS when
             displaying this content so that emoji, LaTeX, and other syntax
@@ -19647,14 +19647,14 @@ components:
         is_web_public:
           type: boolean
           description: |
-            Whether the stream has been configured to allow unauthenticated
+            Whether the channel has been configured to allow unauthenticated
             access to its message history from the web.
 
             **Changes**: New in Zulip 2.1.0.
         stream_post_policy:
           type: integer
           description: |
-            [Policy][permission-level] for which users can post messages to the stream.
+            [Policy][permission-level] for which users can post messages to the channel.
 
             - 1 = Any user can post.
             - 2 = Only administrators can post.
@@ -19670,41 +19670,41 @@ components:
           type: integer
           nullable: true
           description: |
-            Number of days that messages sent to this stream will be stored
+            Number of days that messages sent to this channel will be stored
             before being automatically deleted by the [message retention
             policy](/help/message-retention-policy). There are two special values:
 
-            - `null`, the default, means the stream will inherit the organization
+            - `null`, the default, means the channel will inherit the organization
               level setting.
-            - `-1` encodes retaining messages in this stream forever.
+            - `-1` encodes retaining messages in this channel forever.
 
             **Changes**: New in Zulip 3.0 (feature level 17).
         history_public_to_subscribers:
           type: boolean
           description: |
-            Whether the history of the stream is public to its subscribers.
+            Whether the history of the channel is public to its subscribers.
 
-            Currently always true for public streams (i.e. `"invite_only": false` implies
+            Currently always true for public channels (i.e. `"invite_only": false` implies
             `"history_public_to_subscribers": true`), but clients should not make that
             assumption, as we may change that behavior in the future.
         first_message_id:
           type: integer
           nullable: true
           description: |
-            The ID of the first message in the stream.
+            The ID of the first message in the channel.
 
             Intended to help clients determine whether they need to display
-            UI like the "more topics" widget that would suggest the stream
+            UI like the "more topics" widget that would suggest the channel
             has older history that can be accessed.
 
-            Is `null` for streams with no message history.
+            Is `null` for channels with no message history.
 
             **Changes**: New in Zulip 2.1.0.
         is_announcement_only:
           type: boolean
           deprecated: true
           description: |
-            Whether the given stream is announcement only or not.
+            Whether the given channel is announcement only or not.
 
             **Changes**: Deprecated in Zulip 3.0 (feature level 1). Clients
             should use `stream_post_policy` instead.
@@ -19712,7 +19712,7 @@ components:
           type: integer
           description: |
             ID of the user group whose members are allowed to unsubscribe others
-            from the stream.
+            from the channel.
 
             **Changes**: Before Zulip 8.0 (feature level 197),
             the `can_remove_subscribers_group` setting
@@ -19764,18 +19764,18 @@ components:
           type: string
           nullable: true
           description: |
-            The default sending stream of the bot. If `null`, the bot doesn't
-            have a default sending stream.
+            The default sending channel of the bot. If `null`, the bot doesn't
+            have a default sending channel.
         default_events_register_stream:
           type: string
           nullable: true
           description: |
-            The default stream for which the bot receives events/register data.
-            If `null`, the bot doesn't have such a default stream.
+            The default channel for which the bot receives events/register data.
+            If `null`, the bot doesn't have such a default channel.
         default_all_public_streams:
           type: boolean
           description: |
-            Whether the bot can send messages to all streams by default.
+            Whether the bot can send messages to all channels by default.
         avatar_url:
           type: string
           description: |
@@ -20340,24 +20340,24 @@ components:
         stream_id:
           type: integer
           description: |
-            The unique ID of a stream.
+            The unique ID of a channel.
         name:
           type: string
           description: |
-            The name of a stream.
+            The name of a channel.
         description:
           type: string
           description: |
-            The [description](/help/change-the-channel-description) of the stream in text/markdown format,
-            intended to be used to prepopulate UI for editing a stream's
+            The [description](/help/change-the-channel-description) of the channel in text/markdown format,
+            intended to be used to prepopulate UI for editing a channel's
             description.
 
             See also `rendered_description`.
         rendered_description:
           type: string
           description: |
-            The [description](/help/change-the-channel-description) of the stream rendered as HTML, intended to
-            be used when displaying the stream description in a UI.
+            The [description](/help/change-the-channel-description) of the channel rendered as HTML, intended to
+            be used when displaying the channel description in a UI.
 
             One should use the standard Zulip rendered_markdown CSS when
             displaying this content so that emoji, LaTeX, and other syntax
@@ -20369,17 +20369,17 @@ components:
         date_created:
           type: integer
           description: |
-            The UNIX timestamp for when the stream was created, in UTC seconds.
+            The UNIX timestamp for when the channel was created, in UTC seconds.
 
             **Changes**: New in Zulip 4.0 (feature level 30).
         creator_id:
           type: integer
           nullable: true
           description: |
-            The ID of the user who created this stream.
+            The ID of the user who created this channel.
 
-            A `null` value means the stream has no recorded creator, which is often
-            because the stream is very old, or because it was created via a data
+            A `null` value means the channel has no recorded creator, which is often
+            because the channel is very old, or because it was created via a data
             import tool or [management command][management-commands].
 
             **Changes**: New in Zulip 9.0 (feature level 254).
@@ -20388,8 +20388,8 @@ components:
         invite_only:
           type: boolean
           description: |
-            Specifies whether the stream is private or not.
-            Only people who have been invited can access a private stream.
+            Specifies whether the channel is private or not.
+            Only people who have been invited can access a private channel.
         # TODO: This subscribers item should probably be declared optional more
         # explicitly in the OpenAPI format?
         subscribers:
@@ -20398,72 +20398,72 @@ components:
             type: integer
           description: |
             A list of user IDs of users who are also subscribed
-            to a given stream. Included only if `include_subscribers` is `true`.
+            to a given channel. Included only if `include_subscribers` is `true`.
         desktop_notifications:
           type: boolean
           nullable: true
           description: |
             A boolean specifying whether desktop notifications
-            are enabled for the given stream.
+            are enabled for the given channel.
 
             A `null` value means the value of this setting
             should be inherited from the user-level default
-            setting, enable_stream_desktop_notifications, for
-            this stream.
+            setting, `enable_stream_desktop_notifications`, for
+            this channel.
         email_notifications:
           type: boolean
           nullable: true
           description: |
             A boolean specifying whether email notifications
-            are enabled for the given stream.
+            are enabled for the given channel.
 
             A `null` value means the value of this setting
             should be inherited from the user-level default
-            setting, enable_stream_email_notifications, for
-            this stream.
+            setting, `enable_stream_email_notifications`, for
+            this channel.
         wildcard_mentions_notify:
           type: boolean
           nullable: true
           description: |
             A boolean specifying whether wildcard mentions
             trigger notifications as though they were personal
-            mentions in this stream.
+            mentions in this channel.
 
             A `null` value means the value of this setting
             should be inherited from the user-level default
             setting, wildcard_mentions_notify, for
-            this stream.
+            this channel.
         push_notifications:
           type: boolean
           nullable: true
           description: |
             A boolean specifying whether push notifications
-            are enabled for the given stream.
+            are enabled for the given channel.
 
             A `null` value means the value of this setting
             should be inherited from the user-level default
-            setting, enable_stream_push_notifications, for
-            this stream.
+            setting, `enable_stream_push_notifications`, for
+            this channel.
         audible_notifications:
           type: boolean
           nullable: true
           description: |
             A boolean specifying whether audible notifications
-            are enabled for the given stream.
+            are enabled for the given channel.
 
             A `null` value means the value of this setting
             should be inherited from the user-level default
-            setting, enable_stream_audible_notifications, for
-            this stream.
+            setting, `enable_stream_audible_notifications`, for
+            this channel.
         pin_to_top:
           type: boolean
           description: |
-            A boolean specifying whether the given stream has been pinned
+            A boolean specifying whether the given channel has been pinned
             to the top.
         is_muted:
           type: boolean
           description: |
-            Whether the user has muted the stream. Muted streams do
+            Whether the user has muted the channel. Muted channels do
             not count towards your total unread count and do not show
             up in the `Combined feed` view (previously known as `All messages`).
 
@@ -20474,7 +20474,7 @@ components:
           type: boolean
           deprecated: true
           description: |
-            Legacy property for if the given stream is muted, with inverted meaning.
+            Legacy property for if the given channel is muted, with inverted meaning.
 
             **Changes**: Deprecated in Zulip 2.1.0. Clients should use `is_muted`
             where available.
@@ -20482,23 +20482,23 @@ components:
           type: boolean
           deprecated: true
           description: |
-            Whether only organization administrators can post to the stream.
+            Whether only organization administrators can post to the channel.
 
             **Changes**: Deprecated in Zulip 3.0 (feature level 1). Clients
             should use `stream_post_policy` instead.
         is_web_public:
           type: boolean
           description: |
-            Whether the stream has been configured to allow unauthenticated
+            Whether the channel has been configured to allow unauthenticated
             access to its message history from the web.
         color:
           type: string
           description: |
-            The user's personal color for the stream.
+            The user's personal color for the channel.
         stream_post_policy:
           type: integer
           description: |
-            [Policy][permission-level] for which users can post messages to the stream.
+            [Policy][permission-level] for which users can post messages to the channel.
 
             - 1 = Any user can post.
             - 2 = Only administrators can post.
@@ -20514,48 +20514,48 @@ components:
           type: integer
           nullable: true
           description: |
-            Number of days that messages sent to this stream will be stored
+            Number of days that messages sent to this channel will be stored
             before being automatically deleted by the [message retention
             policy](/help/message-retention-policy). There are two special values:
 
-            - `null`, the default, means the stream will inherit the organization
+            - `null`, the default, means the channel will inherit the organization
               level setting.
-            - `-1` encodes retaining messages in this stream forever.
+            - `-1` encodes retaining messages in this channel forever.
 
             **Changes**: New in Zulip 3.0 (feature level 17).
         history_public_to_subscribers:
           type: boolean
           description: |
-            Whether the history of the stream is public to its subscribers.
+            Whether the history of the channel is public to its subscribers.
 
-            Currently always true for public streams (i.e. `"invite_only": false` implies
+            Currently always true for public channels (i.e. `"invite_only": false` implies
             `"history_public_to_subscribers": true`), but clients should not make that
             assumption, as we may change that behavior in the future.
         first_message_id:
           type: integer
           nullable: true
           description: |
-            The ID of the first message in the stream.
+            The ID of the first message in the channel.
 
             Intended to help clients determine whether they need to display
-            UI like the "more topics" widget that would suggest the stream
+            UI like the "more topics" widget that would suggest the channel
             has older history that can be accessed.
 
-            Is `null` for streams with no message history.
+            Is `null` for channels with no message history.
         stream_weekly_traffic:
           type: integer
           nullable: true
           description: |
-            The average number of messages sent to the stream per week, as
+            The average number of messages sent to the channel per week, as
             estimated based on recent weeks, rounded to the nearest integer.
 
-            If `null`, the stream was recently created and there is
+            If `null`, the channel was recently created and there is
             insufficient data to estimate the average traffic.
         can_remove_subscribers_group:
           type: integer
           description: |
             ID of the user group whose members are allowed to unsubscribe others
-            from the stream.
+            from the channel.
 
             **Changes**: Before Zulip 8.0 (feature level 197),
             the `can_remove_subscribers_group` setting
@@ -20565,27 +20565,27 @@ components:
     DefaultStreamGroup:
       type: object
       description: |
-        Dictionary containing details of a default stream
+        Dictionary containing details of a default channel
         group.
       additionalProperties: false
       properties:
         name:
           type: string
           description: |
-            Name of the default stream group.
+            Name of the default channel group.
         description:
           type: string
           description: |
-            Description of the default stream group.
+            Description of the default channel group.
         id:
           type: integer
           description: |
-            The ID of the default stream group.
+            The ID of the default channel group.
         streams:
           type: array
           description: |
-            Array containing details about the streams
-            in the default stream group.
+            Array containing details about the channels
+            in the default channel group.
           items:
             $ref: "#/components/schemas/DefaultStream"
     EmailAddressVisibility:
@@ -20821,7 +20821,7 @@ components:
                       Whether the user is a mirror dummy.
           description: |
             Data on the recipient of the message;
-            either the name of a stream or a dictionary containing basic data on
+            either the name of a channel or a dictionary containing basic data on
             the users who received the message.
         edit_history:
           type: array
@@ -20852,9 +20852,9 @@ components:
               prev_stream:
                 type: integer
                 description: |
-                  Only present if message's stream was edited.
+                  Only present if message's channel was edited.
 
-                  The stream ID of the message immediately prior to this
+                  The channel ID of the message immediately prior to this
                   edit event.
 
                   **Changes**: New in Zulip 3.0 (feature level 1).
@@ -20874,9 +20874,9 @@ components:
               stream:
                 type: integer
                 description: |
-                  Only present if message's stream was edited.
+                  Only present if message's channel was edited.
 
-                  The ID of the stream containing the message
+                  The ID of the channel containing the message
                   immediately after this edit event.
 
                   **Changes**: New in Zulip 5.0 (feature level 118).
@@ -20919,7 +20919,7 @@ components:
             Every object will contain `user_id` and `timestamp`.
 
             The other fields are optional, and will be present or not
-            depending on whether the stream, topic, and/or message
+            depending on whether the channel, topic, and/or message
             content were modified in the edit event. For example, if
             only the topic was edited, only `prev_topic` and `topic`
             will be present in addition to `user_id` and `timestamp`.
@@ -20953,7 +20953,7 @@ components:
           type: integer
           description: |
             A unique ID for the set of users receiving the
-            message (either a stream or group of users). Useful primarily
+            message (either a channel or group of users). Useful primarily
             for hashing.
         sender_email:
           type: string
@@ -20977,7 +20977,7 @@ components:
         stream_id:
           type: integer
           description: |
-            Only present for stream messages; the ID of the stream.
+            Only present for channel messages; the ID of the channel.
         subject:
           type: string
           description: |
@@ -21049,7 +21049,7 @@ components:
         type:
           type: string
           description: |
-            The type of the message: `stream` or `private`.
+            The type of the message: `"stream"` or `"private"`.
     Presence:
       type: object
       description: |
@@ -21111,8 +21111,8 @@ components:
         type:
           type: string
           description: |
-            The type of the draft. Either unaddressed (empty string), "stream",
-            or "private" (for one-on-one and group direct messages).
+            The type of the draft. Either unaddressed (empty string), `"stream"`,
+            or `"private"` (for one-on-one and group direct messages).
           enum:
             - ""
             - stream
@@ -21120,9 +21120,9 @@ components:
         to:
           type: array
           description: |
-            An array of the tentative target audience IDs. For "stream"
+            An array of the tentative target audience IDs. For channel
             messages, this should contain exactly 1 ID, the ID of the
-            target stream. For direct messages, this should be an array
+            target channel. For direct messages, this should be an array
             of target user IDs. For unaddressed drafts, this is ignored,
             and clients should send an empty array.
           items:
@@ -21130,7 +21130,7 @@ components:
         topic:
           type: string
           description: |
-            For stream message drafts, the tentative topic name. For direct
+            For channel message drafts, the tentative topic name. For direct
             or unaddressed messages, this will be ignored and should ideally
             be the empty string. Should not contain null bytes.
         content:
@@ -21179,15 +21179,15 @@ components:
           description: |
             The scheduled message's tentative target audience.
 
-            For stream messages, it will be the unique ID of the target
-            stream. For direct messages, it will be an array with the
+            For channel messages, it will be the unique ID of the target
+            channel. For direct messages, it will be an array with the
             target users' IDs.
         topic:
           type: string
           description: |
             Only present if `type` is `"stream"`.
 
-            The topic for the stream message.
+            The topic for the channel message.
         content:
           type: string
           description: |
@@ -21673,7 +21673,7 @@ components:
             stream:
               type: string
               description: |
-                The name of the stream that could not be found.
+                The name of the channel that could not be found.
           example:
             {
               "code": "STREAM_DOES_NOT_EXIST",
@@ -21692,7 +21692,7 @@ components:
             stream_id:
               type: integer
               description: |
-                The stream ID that could not be found.
+                The channel ID that could not be found.
           example:
             {
               "code": "STREAM_DOES_NOT_EXIST",
@@ -21940,25 +21940,25 @@ components:
 
         Unlike the API for [fetching messages](/api/get-messages),
         this narrow parameter is simply a filter on messages that the
-        user receives through their stream subscriptions (or because
+        user receives through their channel subscriptions (or because
         they are a recipient of a direct message).
 
         This means that a client that requests a `narrow` filter of
-        `[["stream", "Denmark"]]` will receive events for new messages
-        sent to that stream while the user is subscribed to that
-        stream. The client will not receive any message events at all
+        `[["channel", "Denmark"]]` will receive events for new messages
+        sent to that channel while the user is subscribed to that
+        channel. The client will not receive any message events at all
         if the user is not subscribed to `"Denmark"`.
 
         Newly created bot users are not usually subscribed to any
-        streams, so bots using this API need to be
-        [subscribed](/api/subscribe) to any streams whose messages
+        channels, so bots using this API need to be
+        [subscribed](/api/subscribe) to any channels whose messages
         you'd like them to process using this endpoint.
 
         See the `all_public_streams` parameter for how to process all
-        public stream messages in an organization.
+        public channel messages in an organization.
 
         **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
-        for two new filters related to stream messages: `channel` and `channels`;
+        for two new filters related to channel messages: `channel` and `channels`;
         which are aliases for (and return the same results as) the `stream` and
         `streams` filters respectively.
 
@@ -21976,12 +21976,12 @@ components:
         items:
           type: string
       default: []
-      example: [["stream", "Denmark"]]
+      example: [["channel", "Denmark"]]
     AllPublicStreams:
       description: |
         Whether you would like to request message events from all public
-        streams. Useful for workflow bots that you'd like to see all new messages
-        sent to public streams. (You can also subscribe the user to private streams).
+        channels. Useful for workflow bots that you'd like to see all new messages
+        sent to public channels. (You can also subscribe the user to private channels).
       type: boolean
       default: false
       example: true
@@ -22002,14 +22002,14 @@ components:
         [`POST /register`](/api/register-queue) endpoint to determine
         the maximum message size.
 
-        Note that a message's content and stream cannot be changed at the
+        Note that a message's content and channel cannot be changed at the
         same time, so sending both `content` and `stream_id` parameters will
         throw an error.
       type: string
       example: Hello
     StreamPostPolicy:
       description: |
-        [Policy][permission-level] for which users can post messages to the stream.
+        [Policy][permission-level] for which users can post messages to the channel.
 
         - 1 = Any user can post.
         - 2 = Only administrators can post.
@@ -22026,9 +22026,9 @@ components:
       example: 2
     HistoryPublicToSubscribers:
       description: |
-        Whether the stream's message history should be available to
+        Whether the channel's message history should be available to
         newly subscribed members, or users can only access messages
-        they actually received while subscribed to the stream.
+        they actually received while subscribed to the channel.
 
         Corresponds to the [shared history](/help/channel-permissions)
         option in documentation.
@@ -22038,7 +22038,7 @@ components:
       description: |
         A list of user IDs (preferred) or Zulip API email
         addresses of the users to be subscribed to or unsubscribed
-        from the streams specified in the `subscriptions` parameter. If
+        from the channels specified in the `subscriptions` parameter. If
         not provided, then the requesting user/bot is subscribed.
 
         **Changes**: The integer format is new in Zulip 3.0 (feature level 9).
@@ -22096,7 +22096,7 @@ components:
       example: "1f419"
     MessageRetentionDays:
       description: |
-        Number of days that messages sent to this stream will be stored
+        Number of days that messages sent to this channel will be stored
         before being automatically deleted by the [message retention
         policy](/help/message-retention-policy). Two special string format
         values are supported:
@@ -22116,9 +22116,9 @@ components:
     CanRemoveSubscribersGroupId:
       description: |
         ID of the [user group](/api/get-user-groups) whose members are
-        allowed to unsubscribe others from the stream. Note that a user
+        allowed to unsubscribe others from the channel. Note that a user
         who is a member of the specified user group must also [have
-        access](/help/channel-permissions) to the stream in order to
+        access](/help/channel-permissions) to the channel in order to
         unsubscribe others.
 
         This setting can currently only be set to user groups that are
@@ -22197,7 +22197,7 @@ components:
       name: stream_id
       in: path
       description: |
-        The ID of the stream to access.
+        The ID of the channel to access.
       schema:
         type: integer
       example: 1
@@ -22255,11 +22255,11 @@ components:
       name: include_subscribers
       in: query
       description: |
-        Whether each returned stream object should include a `subscribers`
+        Whether each returned channel object should include a `subscribers`
         field containing a list of the user IDs of its subscribers.
 
         (This may be significantly slower in organizations with
-        thousands of users subscribed to many streams.)
+        thousands of users subscribed to many channels.)
 
         **Changes**: New in Zulip 2.1.0.
       schema:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6097,8 +6097,8 @@ paths:
         clients, backup scripts, etc.
 
         Note that a user's message history does not contain messages sent to
-        streams before they [subscribe](/api/subscribe), and newly created
-        bot users are not usually subscribed to any streams.
+        channels before they [subscribe](/api/subscribe), and newly created
+        bot users are not usually subscribed to any channels.
 
         By specifying a [narrow filter](/api/get-messages#parameter-narrow),
         you can use this endpoint to fetch the messages matching any search
@@ -6184,24 +6184,24 @@ paths:
             The narrow where you want to fetch the messages from. See how to
             [construct a narrow](/api/construct-narrow).
 
-            Note that many narrows, including all that lack a `stream`
-            or `streams` operator, search the user's personal message
+            Note that many narrows, including all that lack a `channel`, `channels`,
+            `stream`, or `streams` operator, search the user's personal message
             history. See [searching shared
             history](/help/search-for-messages#searching-shared-history)
             for details.
 
-            For example, if you would like to fetch messages from all public streams instead
+            For example, if you would like to fetch messages from all public channels instead
             of only the user's message history, then a specific narrow for
-            messages sent to all public streams can be used:
-            `{"operator": "streams", "operand": "public"}`.
+            messages sent to all public channels can be used:
+            `{"operator": "channels", "operand": "public"}`.
 
             Newly created bot users are not usually subscribed to any
-            streams, so bots using this API should either be
-            subscribed to appropriate streams or use a shared history
+            channels, so bots using this API should either be
+            subscribed to appropriate channels or use a shared history
             search narrow with this endpoint.
 
             **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
-            for two new filters related to stream messages: `channel` and `channels`;
+            for two new filters related to channel messages: `channel` and `channels`;
             which are aliases for (and return the same results as) the `stream` and
             `streams` filters respectively.
 
@@ -6214,8 +6214,8 @@ paths:
             `dm-including`; replacing and deprecating `is:private`, `pm-with` and
             `group-pm-with` respectively.
 
-            In Zulip 2.1.0, added support for using user/stream IDs when
-            constructing narrows for a message's sender, its stream and/or
+            In Zulip 2.1.0, added support for using user/channel IDs when
+            constructing narrows for a message's sender, its channel and/or
             its recipient(s).
           content:
             application/json:
@@ -6246,7 +6246,7 @@ paths:
                       minItems: 2
                       maxItems: 2
                 default: []
-              example: [{"operand": "Denmark", "operator": "stream"}]
+              example: [{"operand": "Denmark", "operator": "channel"}]
         - $ref: "#/components/parameters/ClientGravatar"
         - name: apply_markdown
           in: query

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17007,10 +17007,10 @@ paths:
                         type: boolean
                         description: |
                           Whether the organization has enabled the creation of
-                          [web-public streams](/help/public-access-option) and
-                          at least one web-public stream on the server currently
+                          [web-public channels](/help/public-access-option) and
+                          at least one web-public channel on the server currently
                           exists. Clients that support viewing content
-                          in web-public streams without an account can
+                          in web-public channels without an account can
                           use this to determine whether to offer that
                           feature on the login page for an organization.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7513,7 +7513,7 @@ paths:
             [construct a narrow](/api/construct-narrow).
 
             **Changes**: In Zulip 9.0 (feature level 250), narrows gained support
-            for two new filters related to stream messages: `channel` and `channels`;
+            for two new filters related to channel messages: `channel` and `channels`;
             which are aliases for (and return the same results as) the `stream` and
             `streams` filters respectively.
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -172,7 +172,7 @@ class DocPageTest(ZulipTestCase):
             "/api/delete-queue": "Delete a previously registered queue",
             "/api/get-events": "dont_block",
             "/api/get-own-user": "does not accept any parameters.",
-            "/api/get-stream-id": "The name of the stream to access.",
+            "/api/get-stream-id": "The name of the channel to access.",
             "/api/get-streams": "include_public",
             "/api/get-subscriptions": "Get all streams that the user is subscribed to.",
             "/api/get-users": "client_gravatar",

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -174,7 +174,7 @@ class DocPageTest(ZulipTestCase):
             "/api/get-own-user": "does not accept any parameters.",
             "/api/get-stream-id": "The name of the channel to access.",
             "/api/get-streams": "include_public",
-            "/api/get-subscriptions": "Get all streams that the user is subscribed to.",
+            "/api/get-subscriptions": "Get all channels that the user is subscribed to.",
             "/api/get-users": "client_gravatar",
             "/api/installation-instructions": "No download required!",
             "/api/register-queue": "apply_markdown",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -913,7 +913,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    --data-urlencode include_anchor=false \\",
             "    --data-urlencode num_before=4 \\",
             "    --data-urlencode num_after=8 \\",
-            '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "stream"}]\' \\',
+            '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "channel"}]\' \\',
             "    --data-urlencode client_gravatar=false \\",
             "    --data-urlencode apply_markdown=false \\",
             "    --data-urlencode use_first_unread_anchor=true",
@@ -988,7 +988,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    --data-urlencode include_anchor=false \\",
             "    --data-urlencode num_before=4 \\",
             "    --data-urlencode num_after=8 \\",
-            '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "stream"}]\' \\',
+            '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "channel"}]\' \\',
             "    --data-urlencode use_first_unread_anchor=true",
             "```",
         ]

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1010,7 +1010,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
             "server_and_organizations",
             "authentication",
             "real_time_events",
-            "streams",
+            "channels",
             "messages",
             "drafts",
             "webhooks",


### PR DESCRIPTION
Updates the API documentation to use "channel" in descriptive text, instead of "stream". This is in keeping with how we use "organization" instead of "realm" in descriptive text in our user-facing documentation.

See relevant CZO conversations:
- https://chat.zulip.org/#narrow/stream/438-release-management/topic/rename.20.22stream.22.20to.20.22channel.22.20project.2C.20.2328468/near/1799766
- https://chat.zulip.org/#narrow/stream/378-api-design/topic/renaming.20to.20.22channel.22.20across.20API/near/1796710

Before changes:
```console
$ git grep -i stream zerver/ | wc -l
14467
$ git grep -i stream zerver/openapi/ | wc -l
1328
$ git grep -i stream zerver/openapi/zulip.yaml | wc -l
1130
$ git grep -i stream api_docs/ | wc -l
255
```

After changes:
```console
$ git grep -i stream zerver/ | wc -l
13788
$ git grep -i stream zerver/openapi/ | wc -l
653
$ git grep -i stream zerver/openapi/zulip.yaml | wc -l
455
$ git grep -i stream api_docs/ | wc -l
205
```

**Notes**:
- Does not update the `operationID` of any of the endpoints documented in `zerver/openapi/zulip.yaml`. These are used for the API documentation URLs, so we'll need to create URL redirects for the existing ones when we do make those updates.
- Does not update existing API changelog entries, but does update **Changes** notes related to those entries in `zerver/openapi/zulip.yaml` since those are in the descriptions that are being updated here.

**Example screenshots:**

<details>
<summary>Get subscribed channels</summary>

[Current documentation](https://zulip.com/api/get-subscriptions)
![Screenshot from 2024-05-20 16-38-07](https://github.com/zulip/zulip/assets/63245456/0f09594b-f553-4510-8c07-dde2ddf5067f)
</details>
<details>
<summary>Get all channels</summary>

[Current documentation](https://zulip.com/api/get-streams)
![Screenshot from 2024-05-20 16-38-23](https://github.com/zulip/zulip/assets/63245456/4ebad83d-4a1f-4d0a-a484-540d9229e4b9)
</details>
<details>
<summary>Get channel ID</summary>

[Current documentation](https://zulip.com/api/get-stream-id)
![Screenshot from 2024-05-20 16-38-47](https://github.com/zulip/zulip/assets/63245456/16c74299-3475-4f6d-a12f-4a776b42efe8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
