### PR TITLE
setup-recommended: Make user choose `osxfs` earlier to avoid failure.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -175,6 +175,7 @@ WSL 2 can be uninstalled by following [Microsoft's documentation][uninstall-wsl]
 
 1. Install [Vagrant][vagrant-dl] (latest).
 2. Install [Docker Desktop](https://docs.docker.com/desktop/mac/install/) (latest).
+3. Open the Docker desktop app's settings panel, and choose `osxfs (legacy)` under "Choose file sharing implementation for your containers."
    :::
 
 :::{tab-item} Ubuntu/Debian


### PR DESCRIPTION
Since the docker macOS setup doesn't work without this, it makes sense for it to be just part of the setup instead of a thing they fix after running into failure.

<img width="826" alt="Screenshot 2024-05-21 at 10 27 10 AM" src="https://github.com/zulip/zulip/assets/25124304/cd45050b-2282-47c1-9038-f9ba8e7a0e18">

Didn't remove the failure note since that seems useful for someone looking for that error.
