### PR TITLE
Send SNI for proxied S3 requests in uploads-internal.conf

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
@@ -11,6 +11,8 @@ location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
     # (see associated commit message for more details)
     set $download_url https://$s3_hostname/$s3_path;
     proxy_set_header Host $s3_hostname;
+    proxy_ssl_name $s3_hostname;
+    proxy_ssl_server_name on;
 
     # Strip off X-amz-cf-id header, which otherwise the request has to
     # have been signed over, leading to signature mismatches.


### PR DESCRIPTION
This makes sure that requests sent to the S3 backend by the `/internal/s3` route (used by `/user_uploads`, among others) send the hostname via SNI.

Fixes: Some S3 backends (e.g. garage or minio behind caddy) are unable to respond to TLS requests that only have the `Host` header set. This makes sure those configurations are supported going forward.