### PR TITLE
invite_user_modal: Fix background color of input field.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -222,6 +222,7 @@
     --color-masked-unread-marker: hsl(0deg 0% 80%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
     --color-background-modal: hsl(0deg 0% 98%);
+    --color-background-invitee-emails-pill-container: hsl(0deg 0% 100%);
     --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
     --color-outline-focus: hsl(215deg 47% 50%);
     --color-background-search: hsl(0deg 0% 100%);
@@ -558,6 +559,7 @@
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
     --color-background-modal: hsl(212deg 28% 18%);
+    --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);
     --color-background-search: hsl(0deg 0% 20%);

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -143,6 +143,8 @@
 
 #invitee_emails_container .pill-container {
     width: 100%;
+    box-sizing: border-box;
+    background-color: var(--color-background-invitee-emails-pill-container);
 }
 
 .deactivated-pill {


### PR DESCRIPTION
Fixed the missing background color which made the input field look disabled.

**Screenshots and screen captures:**
Before: 
![image](https://github.com/zulip/zulip/assets/78212328/20801edf-c570-4df1-966d-02a9dd44849a)

After:
![image](https://github.com/zulip/zulip/assets/78212328/a665a623-0228-4bfa-9a81-b5f4c0597d7a)

The difference is not quite clear from the screenshots, but becomes clear when seen in a browser.

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/invite.20email.20field)