### PR TITLE
Fix order of group direct message recipients.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -158,8 +158,8 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
     await pm.click();
     await page.waitForSelector("#compose-textarea", {visible: true});
     const recipient_internal_emails = [
-        await common.get_internal_email_from_name(page, common.fullname.othello),
         await common.get_internal_email_from_name(page, common.fullname.cordelia),
+        await common.get_internal_email_from_name(page, common.fullname.othello),
     ].join(",");
     await common.pm_recipient.expect(page, recipient_internal_emails);
 }

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -131,7 +131,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
             page,
             "#drafts_table .overlay-message-row .message_header_private_message .stream_label",
         ),
-        "You and King Hamlet, Cordelia, Lear's daughter",
+        "You and Cordelia, Lear's daughter, King Hamlet",
     );
     assert.strictEqual(
         await common.get_text_from_selector(

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -212,7 +212,7 @@ async function test_restore_private_message_draft_via_draft_overlay(page: Page):
         page,
         common.fullname.hamlet,
     );
-    await common.pm_recipient.expect(page, `${hamlet_internal_email},${cordelia_internal_email}`);
+    await common.pm_recipient.expect(page, `${cordelia_internal_email},${hamlet_internal_email}`);
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),
         "Cordelia, Lear's daughter, King Hamlet - Zulip Dev - Zulip",

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -354,9 +354,10 @@ export function restore_message(draft: LocalStorageDraft): ComposeArguments {
     const recipient_emails = draft.private_message_recipient
         .split(",")
         .filter((email) => people.is_valid_email_for_compose(email));
+    const sorted_recipient_emails = people.sort_emails_by_username(recipient_emails);
     return {
         type: "private",
-        private_message_recipient: recipient_emails.join(","),
+        private_message_recipient: sorted_recipient_emails.join(","),
         content: draft.content,
     };
 }

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1305,6 +1305,7 @@ export class Filter {
                 }
                 return person.full_name;
             });
+            names.sort(util.make_strcmp());
             return util.format_array_as_list(names, "long", "conjunction");
         }
         if (term_types.length === 1 && _.isEqual(term_types, ["sender"])) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -212,7 +212,7 @@ function get_users_for_recipient_row(message) {
     });
 
     function compare_by_name(a, b) {
-        return a.full_name < b.full_name ? -1 : a.full_name > b.full_name ? 1 : 0;
+        return util.strcmp(a.full_name, b.full_name);
     }
 
     return users.sort(compare_by_name);

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -5,6 +5,7 @@ import * as blueslip from "./blueslip";
 import * as people from "./people";
 import {topic_link_schema} from "./types";
 import type {UserStatusEmojiInfo} from "./user_status";
+import * as util from "./util";
 
 const stored_messages = new Map<number, Message>();
 
@@ -229,9 +230,10 @@ export function get_pm_emails(message: Message | MessageWithBooleans): string {
 
 export function get_pm_full_names(user_ids: number[]): string {
     user_ids = people.sorted_other_user_ids(user_ids);
-    const names = people.get_display_full_names(user_ids).sort();
+    const names = people.get_display_full_names(user_ids);
+    const sorted_names = names.sort(util.make_strcmp());
 
-    return names.join(", ");
+    return sorted_names.join(", ");
 }
 
 export function convert_raw_message_to_message_with_booleans(

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -1211,6 +1211,8 @@ export function narrow_by_recipient(target_id, opts) {
     opts = {then_select_id: target_id, ...opts};
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const message = message_store.get(target_id);
+    const emails = message.reply_to.split(",");
+    const reply_to = people.sort_emails_by_username(emails);
 
     switch (message.type) {
         case "private":
@@ -1224,7 +1226,7 @@ export function narrow_by_recipient(target_id, opts) {
                 // in the new view.
                 unread_ops.notify_server_message_read(message);
             }
-            show([{operator: "dm", operand: message.reply_to}], opts);
+            show([{operator: "dm", operand: reply_to.join(",")}], opts);
             break;
 
         case "stream":

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -432,8 +432,10 @@ export function get_recipients(user_ids_string: string): string {
         return my_full_name();
     }
 
-    const names = get_display_full_names(other_ids).sort();
-    return names.join(", ");
+    const names = get_display_full_names(other_ids);
+    const sorted_names = names.sort(util.make_strcmp());
+
+    return sorted_names.join(", ");
 }
 
 export function pm_reply_user_string(message: Message | MessageWithBooleans): string | undefined {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -324,16 +324,17 @@ export function reply_to_to_user_ids_string(emails_string: string): string | und
 }
 
 export function emails_to_full_names_string(emails: string[]): string {
-    return emails
-        .map((email) => {
-            email = email.trim();
-            const person = get_by_email(email);
-            if (person !== undefined) {
-                return person.full_name;
-            }
-            return INACCESSIBLE_USER_NAME;
-        })
-        .join(", ");
+    const names = emails.map((email) => {
+        email = email.trim();
+        const person = get_by_email(email);
+        if (person !== undefined) {
+            return person.full_name;
+        }
+        return INACCESSIBLE_USER_NAME;
+    });
+
+    const sorted_names = names.sort(util.make_strcmp());
+    return sorted_names.join(", ");
 }
 
 export function get_user_time(user_id: number): string | undefined {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -179,6 +179,24 @@ export function update_email(user_id: number, new_email: string): void {
     // still work correctly.
 }
 
+// A function that sorts Email according to the user's full name
+export function sort_emails_by_username(emails: string[]): (string | undefined)[] {
+    const user_ids = emails.map((email) => get_user_id(email));
+    const name_email_dict = user_ids.map((user_id, index) => ({
+        name:
+            user_id !== undefined && people_by_user_id_dict.has(user_id)
+                ? people_by_user_id_dict.get(user_id)?.full_name
+                : "?",
+        email: emails[index],
+    }));
+
+    const sorted_emails = name_email_dict
+        .sort((a, b) => util.strcmp(a.name!, b.name!))
+        .map(({email}) => email);
+
+    return sorted_emails;
+}
+
 export function get_visible_email(user: User): string {
     if (user.delivery_email) {
         return user.delivery_email;
@@ -268,9 +286,7 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
 
     emails = emails.map((email) => email.toLowerCase());
 
-    emails.sort();
-
-    return emails.join(",");
+    return sort_emails_by_username(emails).join(",");
 }
 
 export function user_ids_string_to_ids_array(user_ids_string: string): number[] {
@@ -465,9 +481,7 @@ export function pm_reply_to(message: Message): string | undefined {
         return person.email;
     });
 
-    emails.sort();
-
-    const reply_to = emails.join(",");
+    const reply_to = sort_emails_by_username(emails).join(",");
 
     return reply_to;
 }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2163,7 +2163,7 @@ test("navbar_helpers", () => {
             terms: dm_group_including_guest,
             is_common_narrow: true,
             zulip_icon: "user",
-            title: "translated: alice (guest) and joe",
+            title: "joe and translated: alice (guest)",
             redirect_url_with_search: "/#narrow/dm/" + joe.user_id + "," + alice.user_id + "-group",
         },
         {
@@ -2172,8 +2172,8 @@ test("navbar_helpers", () => {
             zulip_icon: "user",
             title: properly_separated_names([
                 joe.full_name,
-                steve.full_name,
                 "sally@doesnotexist.com",
+                steve.full_name,
             ]),
             redirect_url_with_search: "/#narrow/dm/undefined",
         },

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -920,7 +920,7 @@ test_people("message_methods", () => {
     };
     assert.equal(people.pm_with_url(message), "#narrow/dm/301,302-group");
     assert.equal(people.pm_perma_link(message), "#narrow/dm/30,301,302-group");
-    assert.equal(people.pm_reply_to(message), "Athens@example.com,charles@example.com");
+    assert.equal(people.pm_reply_to(message), "charles@example.com,Athens@example.com");
     assert.equal(people.small_avatar_url(message), "http://charles.com/foo.png");
 
     message = {

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -852,7 +852,7 @@ test_people("emails_to_full_names_string", () => {
             "unknown-email@example.com",
             maria.email,
         ]),
-        `${charles.full_name}, translated: Unknown user, ${maria.full_name}`,
+        `${charles.full_name}, ${maria.full_name}, translated: Unknown user`,
     );
 });
 

--- a/web/tests/people_errors.test.js
+++ b/web/tests/people_errors.test.js
@@ -48,7 +48,7 @@ run_test("blueslip", () => {
     blueslip.expect("error", "Unknown user_id");
     people.get_actual_name_from_user_id(9999);
 
-    blueslip.expect("error", "Unknown email for get_user_id");
+    blueslip.expect("error", "Unknown email for get_user_id", 2);
     people.get_user_id(unknown_email);
 
     blueslip.expect("warn", "No user_id provided");


### PR DESCRIPTION
This PR fixes the behaviour of inconsistent recipient name order for group direct message.

This PR fixes multiple sub issues:
- The message header for each narrowed group direct message.
- Recipient row having incorrect order.
- Recipient order in drafts for group direct message draft.
- Left sidebar recipient order.
- Recipient changing on `message_header` and `compose_to_target` narrow.
- Placeholder text on compose box.
- Order of pills in private message recipient in compose box.


All of the sub issues either uses `util.strcmp` or `sort_emails` function (which is also using `util.strcmp`) to sort the recipients to make it consistent.
<!-- Describe your pull request here.-->

Fixes: zulip#27375<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Before:

![Screenshot from 2024-05-22 16-29-25](https://github.com/zulip/zulip/assets/33497322/ebb07e63-b902-4c42-8663-687e4b8b7e71)

![Screenshot from 2024-05-22 16-29-38](https://github.com/zulip/zulip/assets/33497322/5ea96635-efe5-447d-a4e1-66ec37058f3a)

![Screenshot from 2024-05-22 17-18-16](https://github.com/zulip/zulip/assets/33497322/26c0c600-2a0d-4a3c-91fd-c4c2b1e6e734)

### After:

![Screenshot from 2024-05-22 03-37-00](https://github.com/zulip/zulip/assets/33497322/bf1e2366-8a5e-4242-b981-1a3ad70c028f)

![Screenshot from 2024-05-22 22-00-35](https://github.com/zulip/zulip/assets/33497322/d2a84c46-74c8-44cd-9901-a0f74d47ba57)

![Screenshot from 2024-05-22 22-00-44](https://github.com/zulip/zulip/assets/33497322/60b6d17e-5985-47a8-bf94-6baa25d27970)

[Screencast from 22-05-24 03:35:40 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/3ca6927f-1d96-4ba4-ab62-8a9afe027056)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
