### PR TITLE
support: Show annual revenue for active fixed price plans.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -191,17 +191,14 @@ def get_remote_activity_plan_data(
     elif remote_realm is not None:
         renewal_cents = RemoteRealmBillingSession(
             remote_realm=remote_realm
-        ).get_customer_plan_renewal_amount(plan, license_ledger)
+        ).get_annual_recurring_revenue_for_support_data(plan, license_ledger)
         current_rate = get_plan_rate_percentage(plan.discount)
     else:
         assert remote_server is not None
         renewal_cents = RemoteServerBillingSession(
             remote_server=remote_server
-        ).get_customer_plan_renewal_amount(plan, license_ledger)
+        ).get_annual_recurring_revenue_for_support_data(plan, license_ledger)
         current_rate = get_plan_rate_percentage(plan.discount)
-
-    if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
-        renewal_cents *= 12
 
     return RemoteActivityPlanData(
         current_status=plan.get_plan_status_as_text(),
@@ -238,9 +235,7 @@ def get_estimated_arr_and_rate_by_realm() -> Tuple[Dict[str, int], Dict[str, str
         assert latest_ledger_entry is not None
         renewal_cents = RealmBillingSession(
             realm=plan.customer.realm
-        ).get_customer_plan_renewal_amount(plan, latest_ledger_entry)
-        if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
-            renewal_cents *= 12
+        ).get_annual_recurring_revenue_for_support_data(plan, latest_ledger_entry)
         annual_revenue[plan.customer.realm.string_id] = renewal_cents
         plan_rate[plan.customer.realm.string_id] = get_plan_rate_percentage(plan.discount)
     return annual_revenue, plan_rate

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2305,6 +2305,19 @@ class BillingSession(ABC):
             ).first()
         return None
 
+    def get_annual_recurring_revenue_for_support_data(
+        self, plan: CustomerPlan, last_ledger_entry: LicenseLedger
+    ) -> int:
+        if plan.fixed_price is not None:
+            # For support and activity views, we want to show the annual
+            # revenue for the currently configured fixed price, which
+            # is the annual amount charged in cents.
+            return plan.fixed_price
+        revenue = self.get_customer_plan_renewal_amount(plan, last_ledger_entry)
+        if plan.billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
+            revenue *= 12
+        return revenue
+
     def get_customer_plan_renewal_amount(
         self,
         plan: CustomerPlan,

--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -186,7 +186,7 @@ def get_customer_sponsorship_data(customer: Customer) -> SponsorshipData:
 def get_annual_invoice_count(billing_schedule: int) -> int:
     if billing_schedule == CustomerPlan.BILLING_SCHEDULE_MONTHLY:
         return 12
-    else:
+    else:  # nocoverage
         return 1
 
 
@@ -283,13 +283,11 @@ def get_plan_data_for_support_view(
         plan_data.is_current_plan_billable = billing_session.check_plan_tier_is_billable(
             plan_tier=plan_data.current_plan.tier
         )
-        annual_invoice_count = get_annual_invoice_count(plan_data.current_plan.billing_schedule)
         if last_ledger_entry is not None:
             plan_data.annual_recurring_revenue = (
-                billing_session.get_customer_plan_renewal_amount(
+                billing_session.get_annual_recurring_revenue_for_support_data(
                     plan_data.current_plan, last_ledger_entry
                 )
-                * annual_invoice_count
             )
         else:
             plan_data.annual_recurring_revenue = 0  # nocoverage

--- a/corporate/tests/test_activity_views.py
+++ b/corporate/tests/test_activity_views.py
@@ -367,6 +367,6 @@ class ActivityTest(ZulipTestCase):
         add_audit_log_data(realm.server, remote_realm=realm, realm_id=None)
 
         self.login("iago")
-        with self.assert_database_query_count(12):
+        with self.assert_database_query_count(11):
             result = self.client_get("/activity/remote")
             self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
In the activity and support views, we want to see the annual revenue for fixed price plans. While on billing pages, we do not display this information as these plans are renegotiated annually.

Adds `get_annual_recurring_revenue_for_support_data` function to `BillingSession` class, so that we can get the fixed price plan data for these views without changing the logic for what is displayed on the billing pages.

**Screenshots and screen captures:**

<details>
<summary>Remote support view</summary>

| Before | After |
| --- | --- |
|![Screenshot from 2024-05-22 17-03-17](https://github.com/zulip/zulip/assets/63245456/a24df839-7d46-44bb-a260-f996a4dfd4e8) | ![Screenshot from 2024-05-22 17-03-38](https://github.com/zulip/zulip/assets/63245456/b2992986-84ca-4a4b-b846-b82e22142e7e)
</details>

<details>
<summary>Remote activity view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-05-22 17-06-23](https://github.com/zulip/zulip/assets/63245456/1b269eeb-7c92-45c8-bec8-eb81ba687140) | ![Screenshot from 2024-05-22 17-06-06](https://github.com/zulip/zulip/assets/63245456/99a93562-2694-438a-b031-93eda3bc8377)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
