### PR TITLE
compose: Correct layout of send controls in narrow viewports.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -284,6 +284,10 @@
        expands or contracts. */
     display: flex;
     flex-direction: column;
+    /* With a columnar flex, this ensures that
+       send controls occupy the same space as
+       the adjacent textbox. */
+    justify-content: space-between;
     /* We add 6px of margin to the grid-gap of
        6px, for 12px of space between the Send
        button and the textarea. */
@@ -298,13 +302,17 @@
     grid-area: message-formatting-controls-container;
 }
 
-#compose-limit-indicator {
+#compose-limit-indicator:not(:empty) {
     font-size: 12px;
     color: var(--color-limit-indicator);
     width: max-content;
 
     /* Keep the limit indicator just above
-       and aligned with the send button */
+       and aligned with the send button.
+       `:not(:empty)` prevents the padding
+       and margin-top from affecting layout
+       in the controls area when no indicator
+       is present. */
     margin-top: auto;
     padding: 3px 3px 3px 0;
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1291,6 +1291,14 @@ textarea.new_message_textarea,
     @media (width < $sm_min) {
         /* Drop to a square, rounded button. */
         width: 30px;
+        /* This reduces the vdots button so that
+           it and the send button fit within the
+           54px height the compose textarea occupies.
+           TODO: Should formatting buttons become part
+           of the textarea, the height here and its
+           participation in the columnar flexbox
+           should get a rewrite. */
+        height: 26px;
         margin-left: 0;
         border-radius: 4px;
     }
@@ -1299,6 +1307,12 @@ textarea.new_message_textarea,
         padding: 5px 0 5px 4px;
         font-size: 17px;
         flex-grow: 1;
+
+        @media (width < $sm_min) {
+            /* Keep vdots centered above the
+               Send button at smallest sizes. */
+            padding-left: 0;
+        }
     }
 }
 


### PR DESCRIPTION
This PR improves the layout of the send controls by using layout techniques, and not padding on the often-invisible `#compose-limit-indicator`, to keep the send controls in step with the compose box's text area at all sizes (normal, enlarged, maximized).

Additionally, this PR better centers the vdots when they appear above the send controls.

There is one change--setting a height of 26px on the send-later vdots--which should be revisited once #29953 or some similar PR gets close to being a candidate for merging. But as that work promises to take awhile, this PR corrects the immediate problem in the compose area with a workable interim solution.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Misalignment.20in.20compose.20send.20controls.20area.20at.20narrow.20widths/near/1802852)

**Screenshots and screen captures:**

| Before, narrow | After, narrow |
| --- | --- |
| ![narrow-send-area-before](https://github.com/zulip/zulip/assets/170719/eb6606fc-eab3-4080-bc3a-383b4687bc13) | ![narrow-send-area-after](https://github.com/zulip/zulip/assets/170719/7c7fb482-3e88-42fb-8ad9-f1873bb98726) | ![narrow-send-area-maximized-limit-after](https://github.com/zulip/zulip/assets/170719/2a5b577c-635f-4ef7-a600-646565a37525) |
| ![narrow-send-area-limit-before](https://github.com/zulip/zulip/assets/170719/ec669868-4756-4e43-b062-bbe9864e2f6e) | ![narrow-send-area-limit-after](https://github.com/zulip/zulip/assets/170719/48c165ec-ae2c-44ab-84fb-5575d1a51026) |
| ![narrow-send-area-maximized-limit-before](https://github.com/zulip/zulip/assets/170719/3e723863-4532-410f-a1ef-9dc4b6a7dbd0) | ![narrow-send-area-maximized-limit-after](https://github.com/zulip/zulip/assets/170719/8b470409-eb4e-4266-86b5-04bf801699c0) |
| ![narrow-send-area-maximized-before](https://github.com/zulip/zulip/assets/170719/53475419-571c-4317-9f6e-8848af950a06) | ![narrow-send-area-maximized-after](https://github.com/zulip/zulip/assets/170719/8a5ecbdc-6c61-4fe4-818a-57d99415e684) |









| Before, wide | After, wide (no changes) |
| --- | --- |
| ![wide-before](https://github.com/zulip/zulip/assets/170719/cce04994-1ddf-4e67-9fe3-5e0804243533) | ![wide-after](https://github.com/zulip/zulip/assets/170719/425142db-5265-491c-a230-a21ef9151481) |
| ![wide-counter-before](https://github.com/zulip/zulip/assets/170719/ef80e02a-bba9-44c6-ba61-725e6a0fb958) | ![wide-counter-after](https://github.com/zulip/zulip/assets/170719/931fa0fc-33f2-4fd5-a660-868a2835d117) |
| ![wide-maximized-before](https://github.com/zulip/zulip/assets/170719/fbb29048-2bfc-4dad-8fc1-3da58dc3de12) | ![wide-maximized-after](https://github.com/zulip/zulip/assets/170719/9f7fb6e6-d0f2-4fe6-86d5-6ed5838841d6) |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
