### PR TITLE
widgets: Fix bug where `process_submessages()` was run for empty rows.

### DIFF
--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -90,8 +90,9 @@ export function get_message_events(message: Message): SubmessageEvents | undefin
 
 export function process_widget_rows_in_list(list: MessageList | undefined): void {
     for (const message_id of widgetize.widget_event_handlers.keys()) {
-        if (list?.get(message_id) !== undefined) {
-            process_submessages({message_id, $row: list.get_row(message_id)});
+        const $row = list?.get_row(message_id);
+        if ($row && $row.length !== 0) {
+            process_submessages({message_id, $row});
         }
     }
 }


### PR DESCRIPTION
We now check if the row exists in the current view, and only then do we process the submessages in it, instead of letting `Error: Failed to do_process_submessages` happen.

Fixes: [CZO issue report](https://chat.zulip.org/#narrow/stream/9-issues/topic/Error.3A.20Failed.20to.20do_process_submessages/near/1805249)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
