### PR TITLE
filter: Fix combined feed navigating to muted unread message.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -123,9 +123,15 @@ function message_in_home(message: Message): boolean {
         return true;
     }
 
+    if (user_topics.is_topic_muted(message.stream_id, message.topic)) {
+        // If topic is muted, we don't show the message.
+        return false;
+    }
+
     return (
+        // If stream is muted, we show the message if topic is unmuted or followed.
         !stream_data.is_muted(message.stream_id) ||
-        user_topics.is_topic_unmuted(message.stream_id, message.topic)
+        user_topics.is_topic_unmuted_or_followed(message.stream_id, message.topic)
     );
 }
 


### PR DESCRIPTION
Some we didn't have a check for if topic is muted here which resulted in combined feed trying to navigate user to muted unread message if it was the first unread in the narrow.

Reproducer:
* Mark a message as unread which is not the last message.
* mute the topic
* Navigating to combined feed takes you a random message. (which is actually the message nearest to that unread message if the topic was not muted).
