### PR TITLE
message: Respect first_visible_message_id when computing unreads.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -579,10 +579,11 @@ def get_raw_unread_data(
     user_profile: UserProfile, message_ids: Optional[List[int]] = None
 ) -> RawUnreadMessagesResult:
     excluded_recipient_ids = get_inactive_recipient_ids(user_profile)
-
+    first_visible_message_id = get_first_visible_message_id(user_profile.realm)
     user_msgs = (
         UserMessage.objects.filter(
             user_profile=user_profile,
+            message_id__gte=first_visible_message_id,
         )
         .exclude(
             message__recipient_id__in=excluded_recipient_ids,


### PR DESCRIPTION
This prevents unread counts for messages which the web UI does not display, and does not let you mark as unread via "mark all as read."
