### PR TITLE
zilencer: Disambiguate no MX records from the domain not existing.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -5239,7 +5239,7 @@ class PushBouncerSignupTest(ZulipTestCase):
 
         request["contact_email"] = "admin@example.com"
         result = self.client_post("/api/v1/remotes/server/register", request)
-        self.assert_json_error(result, "Invalid address.")
+        self.assert_json_error(result, "Invalid email address.")
 
         # An example disposable domain.
         request["contact_email"] = "admin@mailnator.com"

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 from unittest import mock, skipUnless
 
 import aioapns
-import DNS
 import orjson
 import responses
 import time_machine
@@ -19,6 +18,7 @@ from django.http.response import ResponseHeaders
 from django.test import override_settings
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
+from dns.resolver import NoAnswer as DNSNoAnswer
 from requests.exceptions import ConnectionError
 from requests.models import PreparedRequest
 from typing_extensions import override
@@ -5247,17 +5247,24 @@ class PushBouncerSignupTest(ZulipTestCase):
         self.assert_json_error(result, "Please use your real email address.")
 
         request["contact_email"] = "admin@zulip.com"
-        with mock.patch("DNS.mxlookup", side_effect=DNS.Base.ServerError("test", 1)):
+        with mock.patch("zilencer.views.dns_resolver.Resolver") as resolver:
+            resolver.return_value.resolve.side_effect = DNSNoAnswer
+            resolver.return_value.resolve_name.return_value = ["whee"]
             result = self.client_post("/api/v1/remotes/server/register", request)
             self.assert_json_error(
-                result, "zulip.com does not exist or is not configured to accept email."
+                result, "zulip.com is invalid because it does not have any MX records"
             )
 
-        with mock.patch("DNS.mxlookup", return_value=[]):
+        with mock.patch("zilencer.views.dns_resolver.Resolver") as resolver:
+            resolver.return_value.resolve.side_effect = DNSNoAnswer
+            resolver.return_value.resolve_name.side_effect = DNSNoAnswer
             result = self.client_post("/api/v1/remotes/server/register", request)
-            self.assert_json_error(
-                result, "zulip.com does not exist or is not configured to accept email."
-            )
+            self.assert_json_error(result, "zulip.com does not exist")
+
+        with mock.patch("zilencer.views.dns_resolver.Resolver") as resolver:
+            resolver.return_value.resolve.return_value = ["whee"]
+            result = self.client_post("/api/v1/remotes/server/register", request)
+            self.assert_json_success(result)
 
 
 class TestUserPushIdentityCompat(ZulipTestCase):

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -5,7 +5,6 @@ from email.headerregistry import Address
 from typing import Any, Dict, List, Optional, Type, TypedDict, TypeVar, Union
 from uuid import UUID
 
-import DNS
 import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -18,6 +17,8 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext as err_
 from django.views.decorators.csrf import csrf_exempt
+from dns import resolver as dns_resolver
+from dns.exception import DNSException
 from pydantic import BaseModel, ConfigDict, Json, StringConstraints
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Annotated
@@ -170,19 +171,25 @@ def register_remote_server(
         raise JsonableError(_("Invalid email address."))
 
     # Check if the domain has an MX record
+    resolver = dns_resolver.Resolver()
+    resolver.timeout = 3
+    dns_mx_check_successful = False
     try:
-        records = DNS.mxlookup(contact_email_domain)
-        dns_mx_check_successful = True
-        if not records:
-            dns_mx_check_successful = False
-    except DNS.Base.ServerError:
-        dns_mx_check_successful = False
+        if resolver.resolve(contact_email_domain, "MX"):
+            dns_mx_check_successful = True
+    except DNSException:
+        pass
     if not dns_mx_check_successful:
-        raise JsonableError(
-            _("{domain} does not exist or is not configured to accept email.").format(
-                domain=contact_email_domain
+        # Check if the A/AAAA exist, for better error reporting
+        try:
+            resolver.resolve_name(contact_email_domain)
+            raise JsonableError(
+                _("{domain} is invalid because it does not have any MX records").format(
+                    domain=contact_email_domain
+                )
             )
-        )
+        except DNSException:
+            raise JsonableError(_("{domain} does not exist").format(domain=contact_email_domain))
 
     try:
         validate_uuid(zulip_org_id)

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -167,7 +167,7 @@ def register_remote_server(
 
     contact_email_domain = Address(addr_spec=contact_email).domain.lower()
     if contact_email_domain == "example.com":
-        raise JsonableError(_("Invalid address."))
+        raise JsonableError(_("Invalid email address."))
 
     # Check if the domain has an MX record
     try:

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -172,12 +172,12 @@ def register_remote_server(
     # Check if the domain has an MX record
     try:
         records = DNS.mxlookup(contact_email_domain)
-        dns_ms_check_successful = True
+        dns_mx_check_successful = True
         if not records:
-            dns_ms_check_successful = False
+            dns_mx_check_successful = False
     except DNS.Base.ServerError:
-        dns_ms_check_successful = False
-    if not dns_ms_check_successful:
+        dns_mx_check_successful = False
+    if not dns_mx_check_successful:
         raise JsonableError(
             _("{domain} does not exist or is not configured to accept email.").format(
                 domain=contact_email_domain


### PR DESCRIPTION
This switches to dnspython, since it offers the higher-level
`resolve_name` method to look up both A and AAAA records, and set
timeouts.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
