### PR TITLE
sentry: More gracefully handle a value of 0.

### DIFF
--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -55,10 +55,10 @@ def traces_sampler(sampling_context: Dict[str, Any]) -> Union[float, bool]:
 
     queue = sampling_context.get("queue")
     if queue is not None and isinstance(queue, str):
-        if isinstance(settings.SENTRY_TRACE_WORKER_RATE, float):
-            return settings.SENTRY_TRACE_WORKER_RATE
-        else:
+        if isinstance(settings.SENTRY_TRACE_WORKER_RATE, dict):
             return settings.SENTRY_TRACE_WORKER_RATE.get(queue, 0.0)
+        else:
+            return settings.SENTRY_TRACE_WORKER_RATE
     else:
         return settings.SENTRY_TRACE_RATE
 


### PR DESCRIPTION
If the value at runtime is actually an int, not a float, we should not try to treat it as a dict.
