### PR TITLE
message_list: Remove nth_most_recent_id

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -226,10 +226,6 @@ export class MessageList {
         return this.data.is_at_end();
     }
 
-    nth_most_recent_id(n) {
-        return this.data.nth_most_recent_id(n);
-    }
-
     is_keyword_search() {
         return this.data.is_keyword_search();
     }

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -180,14 +180,6 @@ export class MessageListData {
         return last_msg.id === this._selected_id;
     }
 
-    nth_most_recent_id(n: number): number {
-        const i = this._items.length - n;
-        if (i < 0) {
-            return -1;
-        }
-        return this._items[i].id;
-    }
-
     clear(): void {
         this._all_items = [];
         this._items = [];

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -192,17 +192,6 @@ run_test("message_range", () => {
     assert.deepEqual(list.message_range(-1, 40), [{id: 30}, {id: 40}]);
 });
 
-run_test("nth_most_recent_id", () => {
-    const list = new MessageList({
-        filter: new Filter([]),
-    });
-    list.append([{id: 10}, {id: 20}, {id: 30}]);
-    assert.equal(list.nth_most_recent_id(1), 30);
-    assert.equal(list.nth_most_recent_id(2), 20);
-    assert.equal(list.nth_most_recent_id(3), 10);
-    assert.equal(list.nth_most_recent_id(4), -1);
-});
-
 run_test("change_message_id", () => {
     const list = new MessageList({
         filter: new Filter([]),


### PR DESCRIPTION
It’s unused since commit 748e5b6da6e1e55799add8db76eaa5e512927d3a.