### PR TITLE
message_list: Remove ids_greater_or_equal_than

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -210,10 +210,6 @@ export class MessageList {
         return this.data.last();
     }
 
-    ids_greater_or_equal_than(id) {
-        return this.data.ids_greater_or_equal_than(id);
-    }
-
     prev() {
         return this.data.prev();
     }

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -108,21 +108,6 @@ export class MessageListData {
         return this.first()!.id <= msg_id && msg_id <= this.last()!.id;
     }
 
-    ids_greater_or_equal_than(my_id: number): number[] {
-        const result = [];
-
-        for (let i = this._items.length - 1; i >= 0; i -= 1) {
-            const message_id = this._items[i].id;
-            if (message_id >= my_id) {
-                result.push(message_id);
-            } else {
-                continue;
-            }
-        }
-
-        return result;
-    }
-
     select_idx(): number | undefined {
         if (this._selected_id === -1) {
             return undefined;


### PR DESCRIPTION
It’s unused since commit c876e12b86e9e2cb22240d0d38921010da7a1765 (#23579).