### PR TITLE
compose: Prevent lingering textarea typeahead after sending message.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -130,6 +130,7 @@ export function clear_compose_box() {
         compose_ui.make_compose_box_original_size();
     }
     $("textarea#compose-textarea").val("").trigger("focus");
+    compose_ui.compose_textarea_typeahead?.hide();
     compose_validate.check_overflow_text();
     compose_validate.clear_topic_resolved_warning();
     drafts.set_compose_draft_id(undefined);


### PR DESCRIPTION
Compose textarea typeaheads don't hide when `Send` button is clicked. If you type `@` and press send, mention typeahead is still visible. This happens since the textarea is still focused after sending the message while other input area trigger a `blur` event which hide the typeahead for them.

We always call `clear_compose_box` wherever textarea is cleared as a result of sending message. So, it is the right function to hide the typeahead in.
