### PR TITLE
message_edit: Update do_update_message codepath to send event on commit.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -81,7 +81,7 @@ from zerver.models import (
 )
 from zerver.models.streams import get_stream_by_id_in_realm
 from zerver.models.users import get_system_bot
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event, send_event_on_commit
 
 
 def subscriber_info(user_id: int) -> Dict[str, Any]:
@@ -363,7 +363,7 @@ def do_update_embedded_data(
             "flags": um.flags_list(),
         }
 
-    send_event(user_profile.realm, event, list(map(user_info, ums)))
+    send_event_on_commit(user_profile.realm, event, list(map(user_info, ums)))
 
 
 def get_visibility_policy_after_merge(

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -81,7 +81,7 @@ from zerver.models import (
 )
 from zerver.models.streams import get_stream_by_id_in_realm
 from zerver.models.users import get_system_bot
-from zerver.tornado.django_api import send_event, send_event_on_commit
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def subscriber_info(user_id: int) -> Dict[str, Any]:
@@ -730,7 +730,9 @@ def do_update_message(
             "stream_id": stream_being_edited.id,
             "topic": orig_topic_name,
         }
-        send_event(user_profile.realm, delete_event, [user.id for user in users_losing_access])
+        send_event_on_commit(
+            user_profile.realm, delete_event, [user.id for user in users_losing_access]
+        )
 
         # Reset the Attachment.is_*_public caches for all messages
         # moved to another stream with different access permissions.
@@ -1003,7 +1005,7 @@ def do_update_message(
                     visibility_policy=new_visibility_policy,
                 )
 
-    send_event(user_profile.realm, event, users_to_be_notified)
+    send_event_on_commit(user_profile.realm, event, users_to_be_notified)
 
     resolved_topic_message_id = None
     if topic_name is not None and content is None:

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1127,7 +1127,7 @@ class EditMessageTest(ZulipTestCase):
         do_edit_message_assert_success(id_, "G", "cordelia")
         do_edit_message_assert_success(id_, "H", "hamlet")
 
-    @mock.patch("zerver.actions.message_edit.send_event")
+    @mock.patch("zerver.actions.message_edit.send_event_on_commit")
     def test_topic_wildcard_mention_in_followed_topic(
         self, mock_send_event: mock.MagicMock
     ) -> None:
@@ -1185,7 +1185,7 @@ class EditMessageTest(ZulipTestCase):
                 called = True
         self.assertTrue(called)
 
-    @mock.patch("zerver.actions.message_edit.send_event")
+    @mock.patch("zerver.actions.message_edit.send_event_on_commit")
     def test_stream_wildcard_mention_in_followed_topic(
         self, mock_send_event: mock.MagicMock
     ) -> None:
@@ -1243,7 +1243,7 @@ class EditMessageTest(ZulipTestCase):
                 called = True
         self.assertTrue(called)
 
-    @mock.patch("zerver.actions.message_edit.send_event")
+    @mock.patch("zerver.actions.message_edit.send_event_on_commit")
     def test_topic_wildcard_mention(self, mock_send_event: mock.MagicMock) -> None:
         stream_name = "Macbeth"
         hamlet = self.example_user("hamlet")
@@ -1349,7 +1349,7 @@ class EditMessageTest(ZulipTestCase):
             )
         self.assert_json_success(result)
 
-    @mock.patch("zerver.actions.message_edit.send_event")
+    @mock.patch("zerver.actions.message_edit.send_event_on_commit")
     def test_stream_wildcard_mention(self, mock_send_event: mock.MagicMock) -> None:
         stream_name = "Macbeth"
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -100,7 +100,8 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         )
 
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m:
-            result = self.client_patch(url, request)
+            with self.captureOnCommitCallbacks(execute=True):
+                result = self.client_patch(url, request)
 
         cordelia = self.example_user("cordelia")
         cordelia_calls = [

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -111,7 +111,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid character in topic, at position 8!")
 
-    @mock.patch("zerver.actions.message_edit.send_event")
+    @mock.patch("zerver.actions.message_edit.send_event_on_commit")
     def test_edit_topic_public_history_stream(self, mock_send_event: mock.MagicMock) -> None:
         stream_name = "Macbeth"
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -333,12 +333,13 @@ class MutedUsersTests(ZulipTestCase):
 
         self.login("cordelia")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m:
-            result = self.client_patch(
-                "/json/messages/" + str(message_id),
-                dict(
-                    content="@**King Hamlet**",
-                ),
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                result = self.client_patch(
+                    "/json/messages/" + str(message_id),
+                    dict(
+                        content="@**King Hamlet**",
+                    ),
+                )
             self.assert_json_success(result)
             m.assert_called_once()
             # `maybe_enqueue_notifications` was called for Hamlet after message edit mentioned him.


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/messages.20appear.20missing.20after.20move/near/1806156): Update `do_update_message` codepath to send event on commit.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
