### PR TITLE
postfix: Increase the max message size to 25MB.

### DIFF
--- a/puppet/zulip/templates/postfix/main.cf.erb
+++ b/puppet/zulip/templates/postfix/main.cf.erb
@@ -38,3 +38,6 @@ virtual_alias_maps = regexp:/etc/postfix/virtual
 allow_percent_hack = no
 allow_untrusted_routing = yes
 strict_rfc821_envelopes = no
+
+# Ingest messages up to 25MB
+message_size_limit = 26214400


### PR DESCRIPTION
The default is 10MB[^1]; increasing this to 25MB aligns it with the email mirror's internal limit.

[^1]: https://www.postfix.org/postconf.5.html#message_size_limit


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
