### PR TITLE
Show unread @-mention indicator for DMs.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -51,6 +51,7 @@ type DirectMessageContext = {
     is_collapsed: boolean;
     latest_msg_id: number;
     column_indexes: typeof COLUMNS;
+    has_unread_mention: boolean;
 };
 
 const direct_message_context_properties: (keyof DirectMessageContext)[] = [
@@ -300,6 +301,7 @@ function format_dm(
         is_bot = people.get_by_user_id(recipient_ids[0]).is_bot;
         user_circle_class = is_bot ? false : buddy_data.get_user_circle_class(recipient_ids[0]);
     }
+    const has_unread_mention = unread.num_unread_mentions_for_user_ids_strings(user_ids_string) > 0;
 
     const context = {
         conversation_key: user_ids_string,
@@ -315,6 +317,7 @@ function format_dm(
         is_collapsed: collapsed_containers.has("inbox-dm-header"),
         latest_msg_id,
         column_indexes: COLUMNS,
+        has_unread_mention,
     };
 
     return context;
@@ -588,6 +591,7 @@ function reset_data(): {
     is_dms_collapsed: boolean;
     has_dms_post_filter: boolean;
     has_visible_unreads: boolean;
+    has_unread_mention: boolean;
 } {
     dms_dict = new Map();
     topics_dict = new Map();
@@ -596,6 +600,7 @@ function reset_data(): {
     const unread_dms = unread.get_unread_pm();
     const unread_dms_count = unread_dms.total_count;
     const unread_dms_dict = unread_dms.pm_dict;
+    const has_unread_mention = unread.num_unread_mentions_in_dms() > 0;
 
     const unread_stream_message = unread.get_unread_topics();
     const unread_stream_msg_count = unread_stream_message.stream_unread_messages;
@@ -637,6 +642,7 @@ function reset_data(): {
     const is_dms_collapsed = collapsed_containers.has("inbox-dm-header");
 
     return {
+        has_unread_mention,
         unread_dms_count,
         is_dms_collapsed,
         has_dms_post_filter,
@@ -1236,6 +1242,7 @@ export function update(): void {
     const unread_dms = unread.get_unread_pm();
     const unread_dms_count = unread_dms.total_count;
     const unread_dms_dict = unread_dms.pm_dict;
+    const has_unread_mention = unread.num_unread_mentions_in_dms() > 0;
 
     const unread_stream_message = unread.get_unread_topics();
     const unread_streams_dict = unread_stream_message.topic_counts;
@@ -1269,6 +1276,7 @@ export function update(): void {
     } else {
         $inbox_dm_header.removeClass("hidden_by_filters");
         $inbox_dm_header.find(".unread_count").text(unread_dms_count);
+        $inbox_dm_header.find(".unread_mention_info").toggleClass("hidden", !has_unread_mention);
     }
 
     let has_topics_post_filter = false;

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -782,7 +782,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 new_stream_id: post_edit_stream_id,
                 new_topic: post_edit_topic,
             });
-            unread.clear_and_populate_unread_mention_topics();
+            unread.clear_and_populate_unread_mentions();
             recent_view_ui.process_topic_edit(
                 old_stream_id,
                 pre_edit_topic,

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -46,6 +46,7 @@ type DisplayObject = {
     user_circle_class: string | undefined;
     is_group: boolean;
     is_bot: boolean;
+    has_unread_mention: boolean;
 };
 
 export function get_conversations(search_string = ""): DisplayObject[] {
@@ -81,6 +82,8 @@ export function get_conversations(search_string = ""): DisplayObject[] {
         const recipients_string = people.get_recipients(user_ids_string);
 
         const num_unread = unread.num_unread_for_user_ids_string(user_ids_string);
+        const has_unread_mention =
+            unread.num_unread_mentions_for_user_ids_strings(user_ids_string) > 0;
         const is_group = user_ids_string.includes(",");
         const is_active = user_ids_string === active_user_ids_string;
 
@@ -112,6 +115,7 @@ export function get_conversations(search_string = ""): DisplayObject[] {
             user_circle_class,
             is_group,
             is_bot,
+            has_unread_mention,
         };
         display_objects.push(display_object);
     }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -606,6 +606,7 @@ type ConversationContext = {
           is_group: boolean;
           is_bot: boolean;
           user_circle_class: string | undefined;
+          has_unread_mention: boolean;
       }
     | {
           is_private: false;
@@ -710,6 +711,8 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         const recipient_id = last_msg.recipient_id;
         const pm_url = last_msg.pm_with_url;
         const is_group = last_msg.display_recipient.length > 2;
+        const has_unread_mention =
+            unread.num_unread_mentions_for_user_ids_strings(user_ids_string) > 0;
 
         let is_bot = false;
         let user_circle_class;
@@ -742,6 +745,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
             is_group,
             is_bot,
             user_circle_class,
+            has_unread_mention,
         };
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1270,6 +1270,7 @@ li.top_left_scheduled_messages {
     margin-right: 1px;
 }
 
+.dm-markers-and-unreads,
 .stream-markers-and-unreads,
 .topic-markers-and-unreads {
     grid-area: markers-and-unreads;
@@ -1497,24 +1498,11 @@ li.topic-list-item {
 
     .unread_count {
         grid-area: markers-and-unreads;
-        /* TODO: This is an alternative method
-           for presenting a 16px-tall unread
-           counter, regardless of context. This
-           method could be used app-wide once
-           all of the layout methods for presenting
-           unreads have been modernized.
-
-           Set the line-height to match the
-           font-size, so that the numerals sit in
-           a 12px box. */
-        line-height: 12px;
         /* Use flexbox to vertically center
            the 12px-high text node within the
            16px-high unread box. */
         display: flex;
         align-items: center;
-        /* Extra margin for unreads. */
-        margin-right: var(--left-sidebar-unread-offset);
 
         &:empty {
             margin-right: 0;

--- a/web/templates/inbox_view/inbox_list.hbs
+++ b/web/templates/inbox_view/inbox_list.hbs
@@ -9,6 +9,9 @@
                         <a tabindex="-1" role="button" href="/#narrow/is/private">{{t 'Direct messages'}}</a>
                     </div>
                 </div>
+                <span class="unread_mention_info tippy-zulip-tooltip
+                  {{#unless has_unread_mention}}hidden{{/unless}}"
+                  data-tippy-content="{{t 'You have unread mentions' }}">@</span>
                 <div class="unread-count-focus-outline" tabindex="0">
                     <span class="unread_count tippy-zulip-tooltip on_hover_all_dms_read"
                       data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -19,6 +19,9 @@
                                 <span class="recipients_name">{{{rendered_dm_with}}}</span>
                             </span>
                         </a>
+                        <span class="unread_mention_info tippy-zulip-tooltip
+                          {{#unless has_unread_mention}}hidden{{/unless}}"
+                          data-tippy-content="{{t 'You have unread mentions' }}">@</span>
                         <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_dm_read"
                               data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -32,7 +32,7 @@
                         </div>
                         <span class="unread_mention_info tippy-zulip-tooltip
                           {{#unless mention_in_unread}}hidden{{/unless}}"
-                          data-tippy-content="{{t 'You have mentions'}}">@</span>
+                          data-tippy-content="{{t 'You have unread mentions'}}">@</span>
                         <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                               data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -18,7 +18,7 @@
                 </div>
                 <span class="unread_mention_info tippy-zulip-tooltip
                   {{#unless mention_in_unread}}hidden{{/unless}}"
-                  data-tippy-content="{{t 'You have mentions'}}">@</span>
+                  data-tippy-content="{{t 'You have unread mentions'}}">@</span>
                 <div class="unread-count-focus-outline" tabindex="0">
                     <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                       data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -14,8 +14,15 @@
                 <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
         </a>
-        <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
-            {{unread}}
-        </span>
+        <div class="dm-markers-and-unreads">
+            {{#if has_unread_mention}}
+                <span class="unread_mention_info">
+                    @
+                </span>
+            {{/if}}
+            <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
+                {{unread}}
+            </span>
+        </div>
     </div>
 </li>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -39,6 +39,8 @@
             </div>
             <div class="right_part">
                 {{#if is_private}}
+                <span class="unread_mention_info tippy-zulip-tooltip {{#unless has_unread_mention}}unread_hidden{{/unless}}"
+                  data-tippy-content="{{t 'You have unread mentions' }}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable" data-col-index="{{ column_indexes.read }}">
                         <span class="unread_count unread_count_pm recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -52,7 +52,7 @@
                 </div>
                 {{else}}
                 <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread}}unread_hidden{{/unless}}"
-                  data-tippy-content="{{t 'You have mentions'}}">@</span>
+                  data-tippy-content="{{t 'You have unread mentions'}}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable hidden-for-spectators" data-col-index="{{ column_indexes.read }}">
                         <span class="unread_count recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>

--- a/web/tests/pm_list_data.test.cjs
+++ b/web/tests/pm_list_data.test.cjs
@@ -6,7 +6,14 @@ const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
-const unread = mock_esm("../src/unread");
+const unread = mock_esm("../src/unread", {
+    num_unread_mentions_for_user_ids_strings(user_ids_string) {
+        if (user_ids_string === "103") {
+            return true;
+        }
+        return false;
+    },
+});
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -123,6 +130,7 @@ test("get_conversations", ({override}) => {
             status_emoji_info: {
                 emoji_code: "20",
             },
+            has_unread_mention: true,
         },
         {
             recipients: "Alice, Bob",
@@ -135,6 +143,7 @@ test("get_conversations", ({override}) => {
             is_group: true,
             is_bot: false,
             status_emoji_info: undefined,
+            has_unread_mention: false,
         },
     ];
 
@@ -164,6 +173,7 @@ test("get_conversations", ({override}) => {
         user_circle_class: "user-circle-offline",
         is_group: false,
         is_bot: false,
+        has_unread_mention: false,
     });
     set_pm_with_filter("iago@zulip.com");
     pm_data = pm_list_data.get_conversations();
@@ -203,6 +213,7 @@ test("get_conversations bot", ({override}) => {
             user_circle_class: "user-circle-offline",
             is_group: false,
             is_bot: true,
+            has_unread_mention: false,
         },
         {
             recipients: "Alice, Bob",
@@ -215,6 +226,7 @@ test("get_conversations bot", ({override}) => {
             status_emoji_info: undefined,
             is_group: true,
             is_bot: false,
+            has_unread_mention: false,
         },
     ];
 

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -185,6 +185,12 @@ mock_esm("../src/unread", {
         return 0;
     },
     topic_has_any_unread_mentions: () => false,
+    num_unread_mentions_for_user_ids_strings(user_ids_string) {
+        if (user_ids_string === "2,3") {
+            return false;
+        }
+        return true;
+    },
 });
 mock_esm("../src/resize", {
     update_recent_view: noop,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR introduces unread @-mention indicators for DMs in inbox, recent conversations and left sidebar.

Uses `unread.get_counts()` to maintain a `mention_dict` mapping `user_ids_strings` of DMs to a `boolean` if unread dm message contains any mentions.

Fixes: zulip#28849<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-05-25 02-56-11](https://github.com/zulip/zulip/assets/33497322/e90a730a-77a3-457c-8ffa-da83de3be26f)

![Screenshot from 2024-05-25 02-56-20](https://github.com/zulip/zulip/assets/33497322/d60c5ca3-f687-447d-b428-a9c4b4042488)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
