### PR TITLE
import: Check off old, redundant TODO about huddle import.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1204,7 +1204,8 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         # We don't import Huddle yet, since we don't have the data to
         # compute huddle hashes until we've imported some of the
         # tables below.
-        # TODO: double-check this.
+        # We can't get huddle hashes without processing subscriptions
+        # first, during which get_huddles_from_subscription is called.
 
     re_map_foreign_keys(
         data,


### PR DESCRIPTION
This was added long ago in
38dd9e49de99040969563e4ba47a04de3c001af1

Double-checked that this is right and added a brief mention of what exactly the dependency here is.
