### PR TITLE
integrations: Prevent duplicate PR review messages

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -479,6 +479,16 @@ A temporary team so that I can get some webhook fixtures!
             payload = orjson.dumps(data).decode()
             self.verify_post_is_ignored(payload, "pull_request")
 
+    def test_ignored_pull_request_review_actions(self) -> None:
+        ignored_actions = [
+            "edited",
+        ]
+        for action in ignored_actions:
+            # empty changes to simulate a submitted pr review that should not send a message
+            data = dict(action=action, changes=dict())
+            payload = orjson.dumps(data).decode()
+            self.verify_post_is_ignored(payload, "pull_request_review")
+
     def test_ignored_team_actions(self) -> None:
         ignored_actions = [
             "added_to_repository",

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -970,6 +970,13 @@ def get_zulip_event_name(
             return "pull_request_auto_merge"
         if action in IGNORED_PULL_REQUEST_ACTIONS:
             return None
+    elif header_event == "pull_request_review":
+        action = payload["action"].tame(check_string)
+        changes = payload.get("changes", {})
+        if action == "edited" and len(changes) == 0:
+            # to prevent double "$person submitted PR review for …" messages
+            return None
+        return "pull_request_review"
     elif header_event == "push":
         if is_merge_queue_push_event(payload):
             return None


### PR DESCRIPTION
Add condition in view to check if the edited pull
request review has any changes, so it does not send a message when it does not.
Add test that verify that the condition works.

Fixes #26145

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
