### PR TITLE
Remove 'file://' and file_links in webhooks and tests

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -231,7 +231,6 @@ def get_web_link_regex() -> Pattern[str]:
         nested_paren_chunk = nested_paren_chunk % (paren_group,)
     nested_paren_chunk = nested_paren_chunk % (inner_paren_contents,)
 
-    file_links = r"| (?:file://(/[^/ ]*)+/?)" if settings.ENABLE_FILE_LINKS else r""
     REGEX = rf"""
         (?<![^\s'"\(,:<])    # Start after whitespace or specified chars
                              # (Double-negative lookbehind to allow start-of-string)
@@ -247,7 +246,7 @@ def get_web_link_regex() -> Pattern[str]:
                 {nested_paren_chunk}           # zero-to-6 sets of paired parens
             )?)              # Path is optional
             | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
-            {file_links}               # File path start with file:///, enable by setting ENABLE_FILE_LINKS=True
+            ""
             | (?:bitcoin:[13][a-km-zA-HJ-NP-Z1-9]{{25,34}})  # Bitcoin address pattern, see https://mokagio.github.io/tech-journal/2014/11/21/regex-bitcoin.html
         )
         (?=                            # URL must be followed by (not included in group)

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -573,11 +573,11 @@ class MarkdownTest(ZulipTestCase):
             self.assertEqual(match, converted)
 
     def test_inline_file(self) -> None:
-        msg = "Check out this file file:///Volumes/myserver/Users/Shared/pi.py"
+        msg = "Check out this file /Volumes/myserver/Users/Shared/pi.py"
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
-            '<p>Check out this file <a href="file:///Volumes/myserver/Users/Shared/pi.py">file:///Volumes/myserver/Users/Shared/pi.py</a></p>',
+            '<p>Check out this file <a href="/Volumes/myserver/Users/Shared/pi.py">/Volumes/myserver/Users/Shared/pi.py</a></p>',
         )
 
         clear_state_for_testing()
@@ -586,7 +586,7 @@ class MarkdownTest(ZulipTestCase):
             maybe_update_markdown_engines(realm.id, False)
             self.assertEqual(
                 markdown_convert(msg, message_realm=realm).rendered_content,
-                "<p>Check out this file file:///Volumes/myserver/Users/Shared/pi.py</p>",
+                "<p>Check out this file /Volumes/myserver/Users/Shared/pi.py</p>",
             )
 
     def test_inline_bitcoin(self) -> None:

--- a/zerver/webhooks/sentry/fixtures/event_for_exception_js.json
+++ b/zerver/webhooks/sentry/fixtures/event_for_exception_js.json
@@ -19,7 +19,7 @@
                 ["user", "ip:223.230.114.198"],
                 [
                     "url",
-                    "file:///mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/trigger-exception-with-external.html"
+                    "/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/trigger-exception-with-external.html"
                 ]
             ],
             "_metrics": {
@@ -41,7 +41,7 @@
             "culprit": "?(/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js)",
             "errors": [
                 {
-                    "url": "file:///mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js",
+                    "url": "/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js",
                     "type": "js_no_source"
                 }
             ],
@@ -51,7 +51,7 @@
                         "stacktrace": {
                             "frames": [
                                 {
-                                    "abs_path": "file:///mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js",
+                                    "abs_path": "/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js",
                                     "filename": "/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/external.js",
                                     "colno": 25,
                                     "data": {
@@ -93,7 +93,7 @@
             "received": 1592406695.060435,
             "request": {
                 "cookies": null,
-                "url": "file:///mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/trigger-exception-with-external.html",
+                "url": "/mnt/data/Documents/Stuff%20for%20Zulip/Repos/sentry/js/trigger-exception-with-external.html",
                 "headers": [
                     [
                         "User-Agent",

--- a/zerver/webhooks/sentry/fixtures/webhook_event_for_exception_javascript.json
+++ b/zerver/webhooks/sentry/fixtures/webhook_event_for_exception_javascript.json
@@ -96,7 +96,7 @@
       ],
       [
         "url",
-        "file:///tmp/raven-js-test.html"
+        "/tmp/raven-js-test.html"
       ]
     ],
     "user": {
@@ -162,7 +162,7 @@
       }
     },
     "request": {
-      "url": "file:///tmp/raven-js-test.html",
+      "url": "/tmp/raven-js-test.html",
       "headers": [
         [
           "User-Agent",

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -325,7 +325,6 @@ def linkified_id(object_id: str, lower: bool = False) -> str:
         "dp": ("Dispute", "disputes"),
         "du": ("Dispute", "disputes"),
         "file": ("File", "files"),
-        "link": ("File link", "file_links"),
         "pi": ("Payment intent", "payment_intents"),
         "po": ("Payout", "payouts"),
         "prod": ("Product", "products"),


### PR DESCRIPTION
This PR is meant to remove part of the references to 'file://' urls that are set to be completely removed due to browser depreciation.

Fixes part of: #19720


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
