### PR TITLE
todo: Add option for modal to create to-do lists.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -248,6 +248,7 @@ EXEMPT_FILES = make_set(
         "web/src/subscriber_api.ts",
         "web/src/timerender.ts",
         "web/src/tippyjs.ts",
+        "web/src/todo_modal.ts",
         "web/src/todo_widget.js",
         "web/src/topic_list.ts",
         "web/src/topic_popover.js",

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -140,6 +140,7 @@ export function clear_compose_box() {
     compose_ui.hide_compose_spinner();
     scheduled_messages.reset_selected_schedule_timestamp();
     $(".compose_control_button_container:has(.add-poll)").removeClass("disabled-on-hover");
+    $(".compose_control_button_container:has(.add-todo)").removeClass("disabled-on-hover");
 }
 
 export function send_message_success(request, data) {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import {unresolve_name} from "../shared/src/resolved_topic";
 import render_add_poll_modal from "../templates/add_poll_modal.hbs";
+import render_add_todo_modal from "../templates/add_todo_modal.hbs";
 
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
@@ -30,6 +31,7 @@ import * as stream_settings_components from "./stream_settings_components";
 import * as sub_store from "./sub_store";
 import * as subscriber_api from "./subscriber_api";
 import {get_timestamp_for_flatpickr} from "./timerender";
+import * as todo_modal from "./todo_modal";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as user_topics from "./user_topics";
@@ -83,11 +85,13 @@ export function initialize() {
             $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
         }
 
-        // The poll widget requires an empty compose box.
+        // The poll & todo widget require an empty compose box.
         if (compose_text_length > 0) {
             $(".add-poll").parent().addClass("disabled-on-hover");
+            $(".add-todo").parent().addClass("disabled-on-hover");
         } else {
             $(".add-poll").parent().removeClass("disabled-on-hover");
+            $(".add-todo").parent().removeClass("disabled-on-hover");
         }
     });
 
@@ -403,6 +407,29 @@ export function initialize() {
             id: "add-poll-modal",
             post_render: poll_modal.poll_options_setup,
             help_link: "https://zulip.com/help/create-a-poll",
+        });
+    });
+
+    $("body").on("click", ".compose_control_button_container:not(.disabled) .add-todo", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        dialog_widget.launch({
+            html_heading: $t_html({defaultMessage: "Create a collaborative to-do list"}),
+            html_body: render_add_todo_modal(),
+            html_submit_button: $t_html({defaultMessage: "Add to-do list"}),
+            close_on_submit: true,
+            on_click(e) {
+                // frame a message using data input in modal, then populate the compose textarea with it
+                e.preventDefault();
+                e.stopPropagation();
+                const todo_message_content = todo_modal.frame_todo_message_content();
+                compose_ui.insert_syntax_and_focus(todo_message_content);
+            },
+            form_id: "add-todo-form",
+            id: "add-todo-modal",
+            post_render: todo_modal.todo_options_setup,
+            help_link: "https://zulip.com/help/collaborative-to-do-lists",
         });
     });
 

--- a/web/src/todo_modal.ts
+++ b/web/src/todo_modal.ts
@@ -1,0 +1,76 @@
+import $ from "jquery";
+import SortableJS from "sortablejs";
+
+import render_todo_modal_option from "../templates/todo_modal_option.hbs";
+
+function create_option_row($last_option_row_input: JQuery): void {
+    const row_html = render_todo_modal_option();
+    const $row_container = $last_option_row_input.closest(".simplebar-content");
+    $row_container.append($(row_html));
+}
+
+function add_option_row(this: HTMLElement): void {
+    // if the option triggering the input event e is not the last,
+    // that is, its next sibling has the class `option-row`, we
+    // do not add a new option row and return from this function
+    // This handles a case when the next empty input row is already
+    // added and user is updating the above row(s).
+    if ($(this).closest(".option-row").next().hasClass("option-row")) {
+        return;
+    }
+    create_option_row($(this));
+}
+
+function delete_option_row(this: HTMLElement): void {
+    const $row = $(this).closest(".option-row");
+    $row.remove();
+}
+
+export function todo_options_setup(): void {
+    const $todo_options_list = $("#add-todo-form .todo-options-list");
+
+    $todo_options_list.on("input", "input.todo-option-input", add_option_row);
+    $todo_options_list.on("input", "input.todo-option-description", add_option_row);
+    $todo_options_list.on("click", "button.delete-option", delete_option_row);
+
+    // setTimeout is needed to here to give time for simplebar to initialise
+    setTimeout(() => {
+        SortableJS.create($("#add-todo-form .todo-options-list .simplebar-content")[0], {
+            onUpdate() {
+                // Do nothing on drag; the order is only processed on submission.
+            },
+            // We don't want the last (empty) row to be draggable, as a new row
+            // is added on input event of the last row.
+            filter: "input, .option-row:last-child",
+            preventOnFilter: false,
+        });
+    }, 0);
+}
+
+export function frame_todo_message_content(): string {
+    const title = $<HTMLInputElement>("input#todo-title-input").val()!.trim();
+
+    const options = $<HTMLInputElement>("input.todo-option-input")
+        .map(function () {
+            return $(this).val()!.trim();
+        })
+        .toArray();
+
+    const descriptions = $<HTMLInputElement>("input.todo-option-description")
+        .map(function () {
+            return $(this).val()!.trim();
+        })
+        .toArray();
+
+    const task = options
+        .map((option, index) => {
+            const description = ": " + descriptions[index];
+            if (option.trim() !== "") {
+                return `${option}${description}`;
+            }
+            return "";
+        })
+        .filter(Boolean);
+
+    return "/todo " + title + "\n" + task.join("\n");
+}

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -472,6 +472,88 @@
     }
 }
 
+#add-todo-modal {
+    /* this height allows 3-4 option rows
+    to fit in without need for scrolling */
+    height: 450px;
+    overflow: hidden;
+
+    .modal__content {
+        flex-grow: 1;
+
+        .simplebar-content {
+            box-sizing: border-box;
+            height: 100%;
+        }
+    }
+
+    #add-todo-form {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        height: 100%;
+
+        .todo-label {
+            font-weight: bold;
+            margin: 5px 0;
+        }
+
+        .todo-title-input-container {
+            display: flex;
+            margin-bottom: 10px;
+
+            #todo-title-input {
+                flex-grow: 1;
+            }
+        }
+
+        .todo-options-list {
+            margin: 0;
+            height: 0;
+            overflow: auto;
+            flex-grow: 1;
+
+            .option-row {
+                list-style-type: none;
+                cursor: move;
+                margin-top: 10px;
+                padding: 0;
+                display: flex;
+                align-items: center;
+                gap: 10px;
+
+                .drag-icon {
+                    color: hsl(0deg 0% 75%);
+                }
+
+                .todo-option-input {
+                    flex-grow: 1;
+                }
+
+                .todo-option-description {
+                    flex-grow: 1;
+                }
+            }
+
+            .option-row:first-child {
+                margin-top: 0;
+            }
+
+            .option-row:last-child {
+                cursor: default;
+
+                .delete-option {
+                    visibility: hidden;
+                }
+
+                .drag-icon {
+                    visibility: hidden;
+                }
+            }
+        }
+    }
+}
+
 #introduce-zulip-view-modal {
     i {
         vertical-align: middle;

--- a/web/templates/add_todo_modal.hbs
+++ b/web/templates/add_todo_modal.hbs
@@ -1,0 +1,13 @@
+<form id="add-todo-form" class="new-style">
+    <label class="todo-label">{{t "Task list title"}}</label>
+    <div class="todo-title-input-container">
+        <input type="text" id="todo-title-input" class="modal_text_input" placeholder="{{t 'Your task list title'}}" />
+    </div>
+    <label class="todo-label">{{t "Tasks"}}</label>
+    <p>{{t "Anyone can add more options after the to-do list is posted."}}</p>
+    <ul class="todo-options-list" data-simplebar>
+        {{> todo_modal_option }}
+        {{> todo_modal_option }}
+        {{> todo_modal_option }}
+    </ul>
+</form>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -28,6 +28,9 @@
     <div class="compose_control_button_container preview_mode_disabled" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-poll add-poll" aria-label="{{t 'Add poll' }}" tabindex=0></a>
     </div>
+    <div class="compose_control_button_container preview_mode_disabled" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
+        <a role="button" class="compose_control_button zulip-icon zulip-icon-check add-todo" aria-label="{{t 'Add to-do list' }}" tabindex=0></a>
+    </div>
     {{/unless}}
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}} preview_mode_disabled" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>

--- a/web/templates/todo_modal_option.hbs
+++ b/web/templates/todo_modal_option.hbs
@@ -1,0 +1,8 @@
+<li class="option-row">
+    <i class="zulip-icon zulip-icon-grip-vertical drag-icon"></i>
+    <input type="text" class="todo-option-input modal_text_input" placeholder="{{t 'New task' }}" />
+    <input type="text" class="todo-option-description modal_text_input" placeholder="{{t 'Description'}}" />
+    <button type="button" class="button rounded small btn-secondary delete-option" title="{{t 'Delete' }}">
+        <i class="fa fa-trash-o" aria-hidden="true"></i>
+    </button>
+</li>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -69,6 +69,12 @@
         <span class="tooltip-inner-content italic">{{t "A poll must be an entire message." }}</span>
     </div>
 </template>
+<template id="add-todo-tooltip">
+    <div>
+        <span>{{t "Add to-do list" }}</span><br/>
+        <span class="tooltip-inner-content italic">{{t "A to-do list must be an entire message." }}</span>
+    </div>
+</template>
 <template id="link-tooltip">
     {{t 'Link' }}
     {{tooltip_hotkey_hints "Ctrl" "Shift" "L"}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
New Feature
Earlier the /todo slash command was the only way to create to-do lists. To increase user friendliness with a GUI, a button to launch a modal to create a to-do list, has been added to the compose box. This button is enabled only when the compose box is empty, to avoid complexities with losing / having to save as draft any message already being composed.

The modal has a form which on submission frames a message using the /todo syntax and the data input in the form, and sets the content of the compose box to that message, which the user can then send.

i followed the code of the already implemented poll button from #26783 .
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![imagem](https://github.com/zulip/zulip/assets/107312709/716e9977-f723-4652-85b2-0b242621002a)
![imagem](https://github.com/zulip/zulip/assets/107312709/d25e7882-a8a7-48e2-b31a-8b5be15ef2f2)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
