### PR TITLE
remove_single_newlines: Fix regex to parse list syntax correctly.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1435,4 +1435,4 @@ def set_visibility_policy_possible(user_profile: UserProfile, message: Message) 
 
 def remove_single_newlines(content: str) -> str:
     content = content.strip("\n")
-    return re.sub(r"(?<!\n)\n(?![\n0-9*-])", " ", content)
+    return re.sub(r"(?<!\n)\n(?!\n|[-*] |[0-9]+\. )", " ", content)

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -312,6 +312,25 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
         expected_output = "- This is a bullet.\n- This is another bullet.\n\n1. This is a list\n1. This is more list."
         self.assertEqual(remove_single_newlines(input_text), expected_output)
 
+        # Asterisks after newline for bold.
+        input_text = "* This is a bullet.\n**word in bold** on the same line.\n* Another bullet."
+        expected_output = (
+            "* This is a bullet. **word in bold** on the same line.\n* Another bullet."
+        )
+        self.assertEqual(remove_single_newlines(input_text), expected_output)
+
+        # Digit after newline.
+        input_text = "1. This is a numbered list.\n2. Second list element.\n3.5 is a decimal.\n3. Third list element."
+        expected_output = "1. This is a numbered list.\n2. Second list element. 3.5 is a decimal.\n3. Third list element."
+        self.assertEqual(remove_single_newlines(input_text), expected_output)
+
+        # Hyphen after newline.
+        input_text = "- This is a list.\n-C-C- organic molecule structure.\n- Another list element."
+        expected_output = (
+            "- This is a list. -C-C- organic molecule structure.\n- Another list element."
+        )
+        self.assertEqual(remove_single_newlines(input_text), expected_output)
+
     def test_zulip_updates_for_realm_imported_from_other_product(self) -> None:
         with mock.patch(
             "zerver.lib.zulip_update_announcements.zulip_update_announcements",


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/438-release-management/topic/zulip_updates.20items.20of.20note/near/1804031)


I have tested it manually with the case in https://github.com/zulip/zulip/commit/330439a83b7c9d01bfc608a7e82b427f53bae164 and few other cases (with hyphen, digit etc)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
