### PR TITLE
GcmPayload, RemoveGcmPayload and ApnsPayload for RemoteServerNotificationPayload

### DIFF
--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -509,16 +509,55 @@ class PushNotificationsDisallowedError(JsonableError):
         super().__init__(msg)
 
 
+class GcmPayload(TypedDict, total=False):
+    server: Optional[str]
+    realm_id: Optional[int]
+    realm_url: Optional[str]
+    realm_name: Optional[str]
+    user_id: Optional[int]
+    event: Optional[str]
+    zulip_message_id: Optional[int]
+    sender_id: Optional[int]
+    sender_email: Optional[str]
+    time: Optional[Union[int, float]]
+    mentioned_user_group_id: Optional[int]
+    mentioned_user_group_name: Optional[str]
+    recipient_type: Optional[str]
+    stream: Optional[str]
+    stream_id: Optional[int]
+    topic: Optional[str]
+    pm_users: Optional[str]
+    sender_avatar_url: Optional[str]
+    content: Optional[str]
+    content_truncated: Optional[bool]
+    sender_full_name: Optional[str]
+    zulip_message_ids: Optional[str]
+
+class RemoveGcmPayload(TypedDict, total=True):
+    event: str
+    zulip_message_ids: str
+
+class ApnsCustom(TypedDict):
+    zulip: Dict[str, Any]
+
+class ApnsPayload(TypedDict, total=False):
+    badge: int
+    custom: ApnsCustom
+    message_ids: List[int]
+    alert: Dict[str, str]
+    sound: str
+
 class RemoteServerNotificationPayload(BaseModel):
     user_id: Optional[int] = None
     user_uuid: Optional[str] = None
-    realm_uuid: Optional[str] = None
-    gcm_payload: Dict[str, Any] = {}
-    apns_payload: Dict[str, Any] = {}
+    realm_uuid: Optional[str] = None 
+    gcm_payload: Union[GcmPayload, RemoveGcmPayload] = {}
+    apns_payload: ApnsPayload = {}
     gcm_options: Dict[str, Any] = {}
 
     android_devices: List[str] = []
     apple_devices: List[str] = []
+
 
 
 @typed_endpoint


### PR DESCRIPTION
Before this pull request, `RemoteServerNotificationPayload`, which is used to validate `remote_server_notify_push` endpoint payload, had gcm_payload and apns_payload fields as Dict[str, Any]. In other to improve type validation for this endpoint, this pull request creates three classes that inherits from TypedDict, these are used as types for gcm_payload and apns_payload.

Fixes: #29469 

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
