### PR TITLE
settings_streams: Fix error thrown when adding default channels.

### DIFF
--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -28,8 +28,11 @@ function add_choice_row($widget) {
 function get_chosen_default_streams() {
     // Return the set of stream id's of streams chosen in the default stream modal.
     return new Set(
-        $("#default-stream-choices .choice-row .dropdown_widget_value")
-            .map((_i, elem) => Number($(elem).attr("data-stream-id")).toString())
+        // Note: We selectively map through the dropdown elements that contain the
+        // `data-stream-id` attribute to avoid adding an element with undefined value
+        //  into the returned `Set`.
+        $("#default-stream-choices .choice-row .dropdown_widget_value[data-stream-id]")
+            .map((_i, elem) => Number($(elem).attr("data-stream-id")))
             .get(),
     );
 }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -296,12 +296,12 @@ export function delete_sub(stream_id: number): void {
     stream_info.delete(stream_id);
 }
 
-export function get_non_default_stream_names(): {name: string; unique_id: string}[] {
+export function get_non_default_stream_names(): {name: string; unique_id: number}[] {
     let subs = [...stream_info.values()];
     subs = subs.filter((sub) => !is_default_stream_id(sub.stream_id) && !sub.invite_only);
     const names = subs.map((sub) => ({
         name: sub.name,
-        unique_id: sub.stream_id.toString(),
+        unique_id: sub.stream_id,
     }));
     return names;
 }

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -491,7 +491,7 @@ test("default_stream_names", () => {
     stream_data.add_sub(general);
 
     const names = stream_data.get_non_default_stream_names();
-    assert.deepEqual(names.sort(), [{name: "public", unique_id: "102"}]);
+    assert.deepEqual(names.sort(), [{name: "public", unique_id: 102}]);
 
     const default_stream_ids = stream_data.get_default_stream_ids();
     assert.deepEqual(default_stream_ids.sort(), [announce.stream_id, general.stream_id]);


### PR DESCRIPTION
The 'Select channel' dropdown in 'Add default channels' modal is
the LAST dropdown element on the modal and it does not contain
`data-stream-id` attribute.

.attr('data-stream-id') would return undefined for this element
and as a result the returned `Set` would have its last element a
`NaN` --- passing a `NaN` inside 'data' field of 'channel.post' threw
an error.

We tweaked the selector string to selectively map over the elements with
'data-stream-id' attribute.
Also we removed '.toString()' converting stream-id to a string (stream-id is a
'number' type).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:

https://github.com/zulip/zulip/assets/123243429/8ebb4f4b-58dd-4da5-967f-8139f7787a4e

After:

https://github.com/zulip/zulip/assets/123243429/80435418-7c5e-4f61-8333-44c8ed463bf1


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
