### PR TITLE
bootstrap_typeahead: Fix AssertionError due to `onHidden` not called.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -379,11 +379,6 @@ export class Typeahead<ItemType extends string | object> {
             // We have event handlers to hide the typeahead, so we
             // don't want tippy to hide it for us.
             hideOnClick: false,
-            onHidden: () => {
-                assert(this.instance !== undefined);
-                this.instance.destroy();
-                this.instance = undefined;
-            },
         });
 
         return this;
@@ -394,7 +389,8 @@ export class Typeahead<ItemType extends string | object> {
         if (this.parentElement) {
             this.$container.hide();
         } else {
-            this.instance?.hide();
+            this.instance?.destroy();
+            this.instance = undefined;
         }
 
         if (this.closeInputFieldOnHide !== undefined) {


### PR DESCRIPTION
Since `onHidden` is only called once tippy is fully hidden, tippy can fail to call `onHidden` if `onShow` is called before tippy is fully hidden. This hurts us as we want to call `destroy` to remove this tippy instance from DOM.

To avoid this, we `destroy` the tippy instance outside of tippy callbacks which is more reliable since our event handlers call `hide` without fail.

