### PR TITLE
Fix code for generating audit log entries when changing `can_mention_group` setting.

### DIFF
--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -448,13 +448,13 @@ def do_change_user_group_permission_setting(
     setting_name: str,
     setting_value_group: UserGroup,
     *,
+    old_setting_api_value: Union[int, AnonymousSettingGroupDict],
     acting_user: Optional[UserProfile],
 ) -> None:
     old_value = getattr(user_group, setting_name)
     setattr(user_group, setting_name, setting_value_group)
     user_group.save()
 
-    old_setting_api_value = get_group_setting_value_for_api(old_value)
     new_setting_api_value = get_group_setting_value_for_api(setting_value_group)
 
     if not hasattr(old_value, "named_user_group") and hasattr(

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -107,6 +107,7 @@ from zerver.models import (
     Recipient,
     Stream,
     Subscription,
+    UserGroup,
     UserGroupMembership,
     UserMessage,
     UserProfile,
@@ -1976,6 +1977,23 @@ Output:
         do_change_realm_permission_group_setting(
             realm, "can_access_all_users_group", members_group, acting_user=None
         )
+
+    def create_or_update_anonymous_group_for_setting(
+        self,
+        direct_members: List[UserProfile],
+        direct_subgroups: List[NamedUserGroup],
+        existing_setting_group: Optional[UserGroup] = None,
+    ) -> UserGroup:
+        realm = get_realm("zulip")
+        if existing_setting_group is not None:
+            existing_setting_group.direct_members.set(direct_members)
+            existing_setting_group.direct_subgroups.set(direct_subgroups)
+            return existing_setting_group
+
+        user_group = UserGroup.objects.create(realm=realm)
+        user_group.direct_members.set(direct_members)
+        user_group.direct_subgroups.set(direct_subgroups)
+        return user_group
 
 
 class ZulipTestCase(ZulipTestCaseMixin, TestCase):

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -742,12 +742,10 @@ def are_both_group_setting_values_equal(
 
 
 def validate_group_setting_value_change(
-    current_value: UserGroup,
+    current_setting_api_value: Union[int, AnonymousSettingGroupDict],
     new_setting_value: Union[int, AnonymousSettingGroupDict],
     expected_current_setting_value: Optional[Union[int, AnonymousSettingGroupDict]],
 ) -> bool:
-    current_setting_api_value = get_group_setting_value_for_api(current_value)
-
     if expected_current_setting_value is not None and not are_both_group_setting_values_equal(
         expected_current_setting_value,
         current_setting_api_value,

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -81,7 +81,6 @@ from zerver.models import (
     RealmPlayground,
     Recipient,
     Subscription,
-    UserGroup,
     UserProfile,
 )
 from zerver.models.groups import SystemGroups
@@ -1347,9 +1346,7 @@ class TestRealmAuditLog(ZulipTestCase):
             name=SystemGroups.MODERATORS, realm=user_group.realm, is_system_group=True
         )
         old_group = user_group.can_mention_group
-        new_group = UserGroup.objects.create(realm=user_group.realm)
-        new_group.direct_members.set([hamlet.id])
-        new_group.direct_subgroups.set([moderators_group.id])
+        new_group = self.create_or_update_anonymous_group_for_setting([hamlet], [moderators_group])
 
         now = timezone_now()
         do_change_user_group_permission_setting(
@@ -1382,9 +1379,9 @@ class TestRealmAuditLog(ZulipTestCase):
         # Since the old setting value was a anonymous group, we just update the
         # members and subgroups of the already existing UserGroup instead of creating
         # a new UserGroup object to keep this consistent with the actual code.
-        new_group = user_group.can_mention_group
-        new_group.direct_members.set([othello.id])
-        new_group.direct_subgroups.set([moderators_group.id])
+        new_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [moderators_group], existing_setting_group=user_group.can_mention_group
+        )
 
         now = timezone_now()
         do_change_user_group_permission_setting(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -232,7 +232,6 @@ from zerver.models import (
     RealmUserDefault,
     Service,
     Stream,
-    UserGroup,
     UserMessage,
     UserPresence,
     UserProfile,
@@ -1776,9 +1775,9 @@ class NormalActionsTest(BaseAction):
         moderators_group = NamedUserGroup.objects.get(
             name=SystemGroups.MODERATORS, realm=self.user_profile.realm, is_system_group=True
         )
-        user_group = UserGroup.objects.create(realm=self.user_profile.realm)
-        user_group.direct_members.set([othello])
-        user_group.direct_subgroups.set([moderators_group])
+        user_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [moderators_group]
+        )
 
         with self.verify_action() as events:
             check_add_user_group(
@@ -1821,9 +1820,9 @@ class NormalActionsTest(BaseAction):
         check_user_group_update("events[0]", events[0], "can_mention_group")
         self.assertEqual(events[0]["data"]["can_mention_group"], moderators_group.id)
 
-        setting_group = UserGroup.objects.create(realm=self.user_profile.realm)
-        setting_group.direct_members.set([othello.id])
-        setting_group.direct_subgroups.set([moderators_group.id])
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [moderators_group]
+        )
         with self.verify_action() as events:
             do_change_user_group_permission_setting(
                 backend,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1812,7 +1812,11 @@ class NormalActionsTest(BaseAction):
         # Test can_mention_group setting update
         with self.verify_action() as events:
             do_change_user_group_permission_setting(
-                backend, "can_mention_group", moderators_group, acting_user=None
+                backend,
+                "can_mention_group",
+                moderators_group,
+                old_setting_api_value=everyone_group.id,
+                acting_user=None,
             )
         check_user_group_update("events[0]", events[0], "can_mention_group")
         self.assertEqual(events[0]["data"]["can_mention_group"], moderators_group.id)
@@ -1822,7 +1826,11 @@ class NormalActionsTest(BaseAction):
         setting_group.direct_subgroups.set([moderators_group.id])
         with self.verify_action() as events:
             do_change_user_group_permission_setting(
-                backend, "can_mention_group", setting_group, acting_user=None
+                backend,
+                "can_mention_group",
+                setting_group,
+                old_setting_api_value=moderators_group.id,
+                acting_user=None,
             )
         check_user_group_update("events[0]", events[0], "can_mention_group")
         self.assertEqual(

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -17,7 +17,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import queries_captured
 from zerver.lib.topic import TOPIC_NAME
 from zerver.lib.utils import assert_is_not_none
-from zerver.models import Message, NamedUserGroup, Realm, UserGroup, UserProfile, UserTopic
+from zerver.models import Message, NamedUserGroup, Realm, UserProfile, UserTopic
 from zerver.models.groups import SystemGroups
 from zerver.models.realms import EditTopicPolicyEnum, WildcardMentionPolicyEnum, get_realm
 from zerver.models.streams import get_stream
@@ -1599,9 +1599,9 @@ class EditMessageTest(ZulipTestCase):
 
         # Test all the cases when can_mention_group is not a named user group.
         content = "Test mentioning user group @*leadership*"
-        user_group = UserGroup.objects.create(realm=iago.realm)
-        user_group.direct_members.set([othello])
-        user_group.direct_subgroups.set([moderators_system_group])
+        user_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [moderators_system_group]
+        )
         leadership.can_mention_group = user_group
         leadership.save()
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -55,7 +55,6 @@ from zerver.models import (
     Recipient,
     Stream,
     Subscription,
-    UserGroup,
     UserMessage,
     UserProfile,
 )
@@ -2228,9 +2227,9 @@ class StreamMessagesTest(ZulipTestCase):
 
         # Test all the cases when can_mention_group is not a named user group.
         content = "Test mentioning user group @*leadership*"
-        user_group = UserGroup.objects.create(realm=iago.realm)
-        user_group.direct_members.set([othello])
-        user_group.direct_subgroups.set([moderators_system_group])
+        user_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [moderators_system_group]
+        )
         leadership.can_mention_group = user_group
         leadership.save()
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -105,10 +105,9 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[9]["can_mention_group"], everyone_group.id)
 
         othello = self.example_user("othello")
-        setting_group = UserGroup.objects.create(realm=realm)
-        setting_group.direct_members.set([othello])
-        setting_group.direct_subgroups.set([admins_system_group])
-
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [othello], [admins_system_group]
+        )
         new_user_group = check_add_user_group(
             realm,
             "newgroup2",

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -32,6 +32,7 @@ from zerver.lib.user_groups import (
     access_user_group_for_setting,
     check_user_group_name,
     get_direct_memberships_of_users,
+    get_group_setting_value_for_api,
     get_subgroup_ids,
     get_user_group_direct_member_ids,
     get_user_group_member_ids,
@@ -136,8 +137,9 @@ def edit_user_group(
             expected_current_setting_value = parse_group_setting_value(setting_value.old)
 
         current_value = getattr(user_group, setting_name)
+        current_setting_api_value = get_group_setting_value_for_api(current_value)
         if validate_group_setting_value_change(
-            current_value, new_setting_value, expected_current_setting_value
+            current_setting_api_value, new_setting_value, expected_current_setting_value
         ):
             setting_value_group = access_user_group_for_setting(
                 new_setting_value,
@@ -147,7 +149,11 @@ def edit_user_group(
                 current_setting_value=current_value,
             )
             do_change_user_group_permission_setting(
-                user_group, setting_name, setting_value_group, acting_user=user_profile
+                user_group,
+                setting_name,
+                setting_value_group,
+                old_setting_api_value=current_setting_api_value,
+                acting_user=user_profile,
             )
 
     return json_success(request)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix the code to generate correct audit log entries.
- Second commit is to add a helper function to be used in tests.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
