### PR TITLE
api-docs: Update feature level 256 changelog and changes notes.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -79,8 +79,10 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 256**
 
-* [`GET /events`](/api/get-events): Stream update events with a new
-  `first_message_id` may now be sent when messages are deleted.
+* [`POST /streams/{stream_id}/delete_topic`](/api/delete-topic),
+  [`GET /events`](/api/get-events): When messages are deleted, a
+  [`stream` op: `update`](/api/get-events#stream-update) event with
+  an updated value for `first_message_id` may now be sent to clients.
 
 **Feature level 255**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1401,7 +1401,14 @@ paths:
                             - type: object
                               description: |
                                 Event sent to all users who can see that a channel exists
-                                when a property of that channel changes.
+                                when a property of that channel changes. See
+                                [GET /streams](/api/get-streams#response) response
+                                for details on the various properties of a channel.
+
+                                **Changes**: Before Zulip 9.0 (feature level 256), this event
+                                was never sent when the `first_message_id` property of a channel
+                                was updated because the oldest message that had been sent to it
+                                changed.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -1426,8 +1433,8 @@ paths:
                                   type: string
                                   description: |
                                     The property of the channel which has changed. See
-                                    [GET /stream](/api/get-streams) for details on the various
-                                    properties of a channel.
+                                    [GET /streams](/api/get-streams#response) response for details
+                                    on the various properties of a channel.
 
                                     Clients should handle an "unknown" property received here without
                                     crashing, since that can happen when connecting to a server running a
@@ -18421,8 +18428,9 @@ paths:
         response will return `"complete": true`.
 
         **Changes**: Before Zulip 9.0 (feature level 256), the server never sent
-        events updating the `first_message_id` for a channel when the oldest
-        message that had been sent to it changed.
+        [`stream` op: `update`](/api/get-events#stream-update) events with an
+        updated `first_message_id` for a channel when the oldest message that
+        had been sent to it changed.
 
         Before Zulip 8.0 (feature level 211), if the server's
         processing was interrupted by a timeout, but some messages in the topic


### PR DESCRIPTION
The original feature level updates were made in commit de90d0acdf.

Relevant [CZO discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/Consistency.20when.20referring.20to.20events.20in.20API.20docs/near/1806105).

**Notes**:
- Added a link in the API changelog entry to the **Delete a topic** endpoint since there's a **Changes** note there.
- Updated the link in the event description to go to the response for **Get streams** since that's where the detailed information about channel properties is.
- Added a **Changes** note to the event description since it's linked to in the API changelog entry.

**Screenshots and screen captures:**

<details>
<summary>API changelog entry</summary>

[Current documentation](https://zulip.com/api/changelog)
![Screenshot from 2024-05-28 16-06-59](https://github.com/zulip/zulip/assets/63245456/4f4a2bfe-74e8-40cb-a32c-bc7799ed804b)
</details>
<details>
<summary>Delete a topic changes note</summary>

[Current documentation](https://zulip.com/api/delete-topic)
![Screenshot from 2024-05-28 14-14-41](https://github.com/zulip/zulip/assets/63245456/e9d1f621-15a8-4a08-a56e-bf4e101f8526)
</details>
<details>
<summary>stream op: update event</summary>

[Current documentation](https://zulip.com/api/get-events#stream-update)
![Screenshot from 2024-05-28 14-15-10](https://github.com/zulip/zulip/assets/63245456/b6a76e2c-d16d-4094-b858-5a9de1c8f5ad)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
