### PR TITLE
settings: Refactor code to handle authentication methods.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -164,6 +164,10 @@ export function get_property_value(
         return "no_restriction";
     }
 
+    if (property_name === "realm_authentication_methods") {
+        return JSON.stringify(realm_authentication_methods_to_boolean_dict());
+    }
+
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return realm[property_name as keyof RealmSetting] as valueof<RealmSetting>;
 }
@@ -728,6 +732,8 @@ export function get_input_element_value(
             return get_field_data_input_value($input_elem);
         case "language-setting":
             return $input_elem.find(".language_selection_button span").attr("data-language-code");
+        case "auth-methods":
+            return JSON.stringify(get_auth_method_list_data());
         default:
             return undefined;
     }
@@ -834,7 +840,7 @@ export function check_property_changed(
         $elem,
         for_realm_default_settings,
     ) as setting_property_type;
-    let current_val = get_property_value(
+    const current_val = get_property_value(
         property_name,
         for_realm_default_settings,
         sub,
@@ -846,9 +852,7 @@ export function check_property_changed(
 
     switch (property_name) {
         case "realm_authentication_methods":
-            current_val = JSON.stringify(realm_authentication_methods_to_boolean_dict());
-            proposed_val = get_auth_method_list_data();
-            proposed_val = JSON.stringify(proposed_val);
+            proposed_val = get_input_element_value(elem, "auth-methods");
             break;
         case "realm_new_stream_announcements_stream_id":
         case "realm_signup_announcements_stream_id":

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -876,43 +876,16 @@ export function register_save_discard_widget_handlers(
         settings_components.change_save_button_state($save_btn_controls, "discarded");
     });
 
-    function get_complete_data_for_subsection(subsection) {
-        let data = {};
-
-        switch (subsection) {
-            case "auth_settings":
-                data = {};
-                data.authentication_methods = JSON.stringify(
-                    settings_components.get_auth_method_list_data(),
-                );
-                break;
-        }
-        return data;
-    }
-
     $container.on("click", ".subsection-header .subsection-changes-save button", (e) => {
         e.preventDefault();
         e.stopPropagation();
         const $save_button = $(e.currentTarget);
         const $subsection_elem = $save_button.closest(".settings-subsection-parent");
-        let extra_data = {};
 
-        if (!for_realm_default_settings) {
-            // The organization settings system has some coupled
-            // fields that must be submitted together, which is
-            // managed by the get_complete_data_for_subsection function.
-            const [, subsection_id] = /^org-(.*)$/.exec($subsection_elem.attr("id"));
-            const subsection = subsection_id.replaceAll("-", "_");
-            extra_data = get_complete_data_for_subsection(subsection);
-        }
-
-        const data = {
-            ...settings_components.populate_data_for_request(
-                $subsection_elem,
-                for_realm_default_settings,
-            ),
-            ...extra_data,
-        };
+        const data = settings_components.populate_data_for_request(
+            $subsection_elem,
+            for_realm_default_settings,
+        );
         save_organization_settings(data, $save_button, patch_url);
     });
 }

--- a/web/templates/popovers/send_later_popover.hbs
+++ b/web/templates/popovers/send_later_popover.hbs
@@ -2,7 +2,7 @@
     <li>
         <div class="enter_sends_choices grey-box">
             <label class="enter_sends_choice">
-                <input type="radio" name="enter_sends_choice" class="prop-element" value="true"{{#if enter_sends_true }} checked{{/if}} />
+                <input type="radio" name="enter_sends_choice" value="true"{{#if enter_sends_true }} checked{{/if}} />
                 <div class="enter_sends_choice_text">
                     <span>
                         {{#tr}}
@@ -19,7 +19,7 @@
                 </div>
             </label>
             <label class="enter_sends_choice">
-                <input type="radio" name="enter_sends_choice" class="prop-element" value="false"{{#unless enter_sends_true }} checked{{/unless}} />
+                <input type="radio" name="enter_sends_choice" value="false"{{#unless enter_sends_true }} checked{{/unless}} />
                 <div class="enter_sends_choice_text">
                     <span>
                         {{#tr}}

--- a/web/templates/settings/admin_auth_methods_list.hbs
+++ b/web/templates/settings/admin_auth_methods_list.hbs
@@ -5,5 +5,6 @@
       is_checked=enabled
       label=method
       is_disabled=disable_configure_auth_method
-      tooltip_text=unavailable_reason}}
+      tooltip_text=unavailable_reason
+      skip_prop_element=true}}
 </div>

--- a/web/templates/settings/auth_methods_settings_admin.hbs
+++ b/web/templates/settings/auth_methods_settings_admin.hbs
@@ -19,7 +19,7 @@
 
             <div>
                 <p>{{t "Configure the authentication methods for your organization."}}</p>
-                <div id="id_realm_authentication_methods">
+                <div id="id_realm_authentication_methods" class="prop-element" data-setting-widget-type="auth-methods">
                     {{! Empty div is intentional, it will get populated by a dedicated template }}
                 </div>
             </div>

--- a/web/templates/settings/settings_checkbox.hbs
+++ b/web/templates/settings/settings_checkbox.hbs
@@ -1,7 +1,7 @@
 {{#unless (eq render_only false)}}
 <div class="input-group {{#if is_disabled}}control-label-disabled{{/if}}">
     <label class="checkbox">
-        <input type="checkbox" class="{{setting_name}} inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="boolean"
+        <input type="checkbox" class="{{setting_name}} inline-block setting-widget {{#unless skip_prop_element}}prop-element{{/unless}}" name="{{setting_name}}" data-setting-widget-type="boolean"
           id="{{#if prefix}}{{prefix}}{{/if}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} {{#if is_disabled}}disabled{{/if}} />
         <span></span>
     </label>

--- a/web/templates/user_topic_ui_row.hbs
+++ b/web/templates/user_topic_ui_row.hbs
@@ -3,7 +3,7 @@
     <td>{{stream}}</td>
     <td>{{topic}}</td>
     <td>
-        <select class="settings_user_topic_visibility_policy prop-element list_select bootstrap-focus-style" data-setting-widget-type="number">
+        <select class="settings_user_topic_visibility_policy list_select bootstrap-focus-style" data-setting-widget-type="number">
             {{#each ../user_topic_visibility_policy_values}}
                 <option value='{{this.code}}' {{#if (eq this.code ../visibility_policy)}}selected{{/if}}>{{this.description}}</option>
             {{/each}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to refactor authentication settings code.
- Second commit is to cleanup unnecessary use of `prop-element` class.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
