### PR TITLE
nginx: Strip off request headers which might affect S3's behaviour.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
@@ -16,6 +16,20 @@ location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
     # have been signed over, leading to signature mismatches.
     proxy_set_header x-amz-cf-id "";
 
+    # Strip off any auth request headers which the Zulip client might
+    # have sent, as they will not work for S3, and will report an error due
+    # to the signed auth header we also provide.
+    proxy_set_header Authorization "";
+    proxy_set_header x-amz-security-token "";
+
+    # These headers are only valid if there is a body, but better to
+    # strip them to be safe.
+    proxy_set_header Content-Length "";
+    proxy_set_header Content-Type "";
+    proxy_set_header Content-MD5 "";
+    proxy_set_header x-amz-content-sha256 "";
+    proxy_set_header Expect "";
+
     # Ensure that we only get _one_ of these response headers: the one
     # that Django added, not the one from S3.
     proxy_hide_header Cache-Control;


### PR DESCRIPTION
Clients making requests to Zulip with a `Authorization: Basic ...` for an upload in S3 pass along all of their request headers to the S3 backend -- causing errors of the form:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>InvalidArgument</Code>
  <Message>Only one auth mechanism allowed; only the X-Amz-Algorithm
  query parameter, Signature query string parameter or the
  Authorization header should be specified</Message>
  <ArgumentName>Authorization</ArgumentName>
  <ArgumentValue>Basic ...</ArgumentValue>
  <RequestId>...</RequestId>
  <HostId>...</HostId>
</Error>
```

Strip off all request headers which AWS reports that S3 may read[^1].

Fixes: #30180.

[^1]: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
