### PR TITLE
puppet: Silence "needrestart" nags about kernel upgrades.

### DIFF
--- a/puppet/kandra/files/needrestart/zulip.conf
+++ b/puppet/kandra/files/needrestart/zulip.conf
@@ -11,3 +11,7 @@ my @ignore = (
 );
 
 $nrconf{override_rc}{$_} = 0 for @ignore;
+
+# ksplice keeps the kernel updated in a way that needrestart does not
+# understand; silence these hints
+$nrconf{kernelhints} = -1


### PR DESCRIPTION
Ksplice keeps the kernel updated without restarts.
