### PR TITLE
spoilers: Style headers in Markdown-neutral way.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -247,11 +247,11 @@
             padding: 8px 5px;
             font-weight: bold;
 
-            > p {
+            > :not(.spoiler-button) {
                 /* Disallow margin from ordinary rendered-markdown
-                   paragraphs. The header's vertical space is handled
+                   elements. The header's vertical space is handled
                    independently by padding on .spoiler-header. */
-                margin: 0;
+                margin-bottom: 0;
                 /* Message grows to push the arrow to the right,
                    but shrinks so as to allow long multi-line
                    spoiler messages to wrap. */


### PR DESCRIPTION
This PR corrects for some over-zealous CSS introduced in #29715:

1) It no longer assumes a paragraph for the spoiler header, which assumption lead to a misplaced spoiler arrow previously.
2) It no longer touches possible margin-left or -right values, such as may be used to style list items.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/spoilers.3A.20collapse.20icon.20misplaced.20when.20header.20is.20a.20list.20item/near/1806485)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![spoiler-headers-before](https://github.com/zulip/zulip/assets/170719/7e17b33a-3987-40e0-8034-15504649e2a7) | ![spoiler-headers-after](https://github.com/zulip/zulip/assets/170719/aa28b015-d72b-4e87-aea2-939b1250cc2d) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>