### PR TITLE
kandra: Run rabbitmq cron jobs as root.

### DIFF
--- a/puppet/kandra/manifests/app_frontend_monitoring.pp
+++ b/puppet/kandra/manifests/app_frontend_monitoring.pp
@@ -12,10 +12,12 @@ class kandra::app_frontend_monitoring {
   }
   zulip::cron { 'check-rabbitmq-queue':
     minute  => '*',
+    user    => 'root',
     command => '/home/zulip/deployments/current/scripts/nagios/check-rabbitmq-queue',
   }
   zulip::cron { 'check-rabbitmq-consumers':
     minute  => '*',
+    user    => 'root',
     command => '/home/zulip/deployments/current/scripts/nagios/check-rabbitmq-consumers',
   }
 }


### PR DESCRIPTION
This is a regression introduced in
f246b82f67b62cd95e2c0eb02dd283ac569918d9.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
