### PR TITLE
Rename MessageList.narrow.

### DIFF
--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -83,7 +83,7 @@ function process_result(data, opts) {
     if (
         message_lists.current !== undefined &&
         opts.msg_list === message_lists.current &&
-        opts.msg_list.narrowed &&
+        !opts.msg_list.is_combined_feed_view &&
         opts.msg_list.visibly_empty()
     ) {
         // The view appears to be empty. However, because in stream
@@ -137,7 +137,11 @@ function get_messages_success(data, opts) {
         });
     }
 
-    if (opts.msg_list && opts.msg_list.narrowed && opts.msg_list !== message_lists.current) {
+    if (
+        opts.msg_list &&
+        !opts.msg_list.is_combined_feed_view &&
+        opts.msg_list !== message_lists.current
+    ) {
         // We unnarrowed before receiving new messages so
         // don't bother processing the newly arrived messages.
         return;
@@ -309,7 +313,7 @@ export function load_messages(opts, attempt = 1) {
             if (
                 opts.msg_list !== undefined &&
                 opts.msg_list !== message_lists.current &&
-                opts.msg_list.narrowed
+                !opts.msg_list.is_combined_feed_view
             ) {
                 // This fetch was for a narrow, and we unnarrowed
                 // before getting an error, so don't bother trying
@@ -330,7 +334,7 @@ export function load_messages(opts, attempt = 1) {
                 if (
                     message_lists.current !== undefined &&
                     opts.msg_list === message_lists.current &&
-                    opts.msg_list.narrowed &&
+                    !opts.msg_list.is_combined_feed_view &&
                     opts.msg_list.visibly_empty()
                 ) {
                     narrow_banner.show_empty_narrow_message();

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -57,8 +57,8 @@ export class MessageList {
         // DOM.
         this.view = new MessageListView(this, collapse_messages, opts.is_node_test);
 
-        // If this message list is not for the global feed.
-        this.narrowed = !this.data.filter.is_in_home();
+        // If this message list is for the combined feed view.
+        this.is_combined_feed_view = this.data.filter.is_in_home();
 
         // Keeps track of whether the user has done a UI interaction,
         // such as "Mark as unread", that should disable marking
@@ -81,7 +81,7 @@ export class MessageList {
         // This is intentionally not live-updated when web_home_view
         // changes, since it's easier to reason about if this
         // optimization is active or not for an entire session.
-        if (user_settings.web_home_view !== "all_messages" || this.narrowed) {
+        if (user_settings.web_home_view !== "all_messages" || !this.is_combined_feed_view) {
             return false;
         }
 
@@ -375,7 +375,7 @@ export class MessageList {
     // message list.
     update_trailing_bookend() {
         this.view.clear_trailing_bookend();
-        if (!this.narrowed) {
+        if (this.is_combined_feed_view) {
             return;
         }
         const stream_name = narrow_state.stream_name();
@@ -499,7 +499,7 @@ export class MessageList {
         this.view.clear_rendering_state(false);
         this.view.update_render_window(this.selected_idx(), false);
 
-        if (this.narrowed) {
+        if (!this.is_combined_feed_view) {
             if (
                 this.visibly_empty() &&
                 this.data.fetch_status.has_found_oldest() &&

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -239,9 +239,6 @@ export function activate(raw_terms, opts) {
         return;
     }
 
-    // Use to determine if user read any unread messages outside the combined feed.
-    const was_narrowed_already = message_lists.current?.narrowed;
-
     // Since narrow.activate is called directly from various
     // places in our code without passing through hashchange,
     // we need to check if the narrow is allowed for spectator here too.
@@ -276,7 +273,7 @@ export function activate(raw_terms, opts) {
     const span_data = {
         op: "function",
         description: "narrow",
-        data: {was_narrowed_already, raw_terms, trigger: opts.trigger},
+        data: {raw_terms, trigger: opts.trigger},
     };
     let span;
     if (!existing_span) {

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -320,7 +320,7 @@ run_test("bookend", ({override}) => {
     });
 
     list.view.clear_trailing_bookend = noop;
-    list.narrowed = true;
+    list.is_combined_feed_view = false;
 
     override(narrow_state, "stream_name", () => "IceCream");
 


### PR DESCRIPTION
Part of #23812

Next step is to rename the `narrow` library for which started discussion [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Renaming.20narrow.2Ejs.20library.2E).