### PR TITLE
Fix import of message edit history

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -327,8 +327,7 @@ def fix_message_rendered_content(
     realm: Realm, sender_map: Dict[int, Record], messages: List[Record]
 ) -> None:
     """
-    This function sets the rendered_content of all the messages
-    after the messages have been imported from a non-Zulip platform.
+    This function sets the rendered_content of the messages we're importing.
     """
     for message in messages:
         if message["rendered_content"] is not None:

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -324,13 +324,17 @@ def fix_customprofilefield(data: TableData) -> None:
 
 
 def fix_message_rendered_content(
-    realm: Realm, sender_map: Dict[int, Record], messages: List[Record]
+    realm: Realm,
+    sender_map: Dict[int, Record],
+    messages: List[Record],
+    content_key: str = "content",
+    rendered_content_key: str = "rendered_content",
 ) -> None:
     """
     This function sets the rendered_content of the messages we're importing.
     """
     for message in messages:
-        if message["rendered_content"] is not None:
+        if message[rendered_content_key] is not None:
             # For Zulip->Zulip imports, we use the original rendered
             # Markdown; this avoids issues where e.g. a mention can no
             # longer render properly because a user has changed their
@@ -339,7 +343,7 @@ def fix_message_rendered_content(
             # However, we still need to update the data-user-id and
             # similar values stored on mentions, stream mentions, and
             # similar syntax in the rendered HTML.
-            soup = BeautifulSoup(message["rendered_content"], "html.parser")
+            soup = BeautifulSoup(message[rendered_content_key], "html.parser")
 
             user_mentions = soup.findAll("span", {"class": "user-mention"})
             if len(user_mentions) != 0:
@@ -356,7 +360,7 @@ def fix_message_rendered_content(
                     old_user_id = int(mention["data-user-id"])
                     if old_user_id in user_id_map:
                         mention["data-user-id"] = str(user_id_map[old_user_id])
-                message["rendered_content"] = str(soup)
+                message[rendered_content_key] = str(soup)
 
             stream_mentions = soup.findAll("a", {"class": "stream"})
             if len(stream_mentions) != 0:
@@ -365,7 +369,7 @@ def fix_message_rendered_content(
                     old_stream_id = int(mention["data-stream-id"])
                     if old_stream_id in stream_id_map:
                         mention["data-stream-id"] = str(stream_id_map[old_stream_id])
-                message["rendered_content"] = str(soup)
+                message[rendered_content_key] = str(soup)
 
             user_group_mentions = soup.findAll("span", {"class": "user-group-mention"})
             if len(user_group_mentions) != 0:
@@ -374,11 +378,11 @@ def fix_message_rendered_content(
                     old_user_group_id = int(mention["data-user-group-id"])
                     if old_user_group_id in user_group_id_map:
                         mention["data-user-group-id"] = str(user_group_id_map[old_user_group_id])
-                message["rendered_content"] = str(soup)
+                message[rendered_content_key] = str(soup)
             continue
 
         try:
-            content = message["content"]
+            content = message[content_key]
 
             sender_id = message["sender_id"]
             sender = sender_map[sender_id]
@@ -398,7 +402,7 @@ def fix_message_rendered_content(
                 translate_emoticons=translate_emoticons,
             ).rendered_content
 
-            message["rendered_content"] = rendered_content
+            message[rendered_content_key] = rendered_content
             if "scheduled_timestamp" not in message:
                 # This logic runs also for ScheduledMessage, which doesn't use
                 # the rendered_content_version field.
@@ -412,6 +416,30 @@ def fix_message_rendered_content(
             logging.warning(
                 "Error in Markdown rendering for message ID %s; continuing", message["id"]
             )
+
+
+def fix_message_edit_history(
+    realm: Realm, sender_map: Dict[int, Record], messages: List[Record]
+) -> None:
+    user_id_map = ID_MAP["user_profile"]
+    for message in messages:
+        edit_history_json = message.get("edit_history")
+        if not edit_history_json:
+            continue
+
+        edit_history = orjson.loads(edit_history_json)
+        for edit_history_message_dict in edit_history:
+            edit_history_message_dict["user_id"] = user_id_map[edit_history_message_dict["user_id"]]
+
+        fix_message_rendered_content(
+            realm,
+            sender_map,
+            messages=edit_history,
+            content_key="prev_content",
+            rendered_content_key="prev_rendered_content",
+        )
+
+        message["edit_history"] = orjson.dumps(edit_history).decode()
 
 
 def current_table_ids(data: TableData, table: TableName) -> List[int]:
@@ -1682,6 +1710,9 @@ def import_message_data(realm: Realm, sender_map: Dict[int, Record], import_dir:
         )
         logging.info("Successfully rendered Markdown for message batch")
 
+        fix_message_edit_history(
+            realm=realm, sender_map=sender_map, messages=data["zerver_message"]
+        )
         # A LOT HAPPENS HERE.
         # This is where we actually import the message data.
         bulk_import_model(data, Message)


### PR DESCRIPTION
Fixes #26369.

After importing, edit history of imported messages is now displayed correctly:
![image](https://github.com/zulip/zulip/assets/45007152/da5f5372-0e3a-48e8-9fc3-d540ae16ec19)

Previously this would either be empty/throw a blueslip error due  to the `"user_id"` being the old value, so not present in the new, imported realm. Or if just `user_id` was fixed, mentions would be broken and show `@Unknown user`.