### PR TITLE
recent_view: Reduce constant flashing of recent view on initial load.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -81,7 +81,7 @@ export type ListWidget<Key, Item = Key> = BaseListWidget & {
         get_insert_index: (list: Item[], item: Item) => number,
     ) => void;
     sort: (sorting_function: string, prop?: string) => void;
-    replace_list_data: (list: Key[]) => void;
+    replace_list_data: (list: Key[], should_redraw?: boolean) => void;
 };
 
 const DEFAULTS = {
@@ -534,14 +534,16 @@ export function create<Key, Item = Key>(
             widget.hard_redraw();
         },
 
-        replace_list_data(list) {
+        replace_list_data(list, should_redraw = true) {
             /*
                 We mostly use this widget for lists where you are
                 not adding or removing rows, so when you do modify
                 the list, we have a brute force solution.
             */
             meta.list = list;
-            widget.hard_redraw();
+            if (should_redraw) {
+                widget.hard_redraw();
+            }
         },
     };
 

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -587,8 +587,8 @@ export function initialize(finished_initial_fetch) {
     // Since `all_messages_data` contains continuous message history
     // which always contains the latest message, it makes sense for
     // Recent view to display the same data and be in sync.
-    all_messages_data.set_add_messages_callback((messages) => {
-        recent_view_ui.process_messages(messages, all_messages_data);
+    all_messages_data.set_add_messages_callback((messages, rows_order_changed) => {
+        recent_view_ui.process_messages(messages, rows_order_changed, all_messages_data);
     });
 
     // TODO: Ideally we'd have loading indicators for Recent Conversations

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -42,7 +42,7 @@ export class MessageListData {
     _selected_id: number;
     predicate?: (message: Message) => boolean;
     // This is a callback that is called when messages are added to the message list.
-    add_messages_callback?: (messages: Message[]) => void;
+    add_messages_callback?: (messages: Message[], recipient_order_changed: boolean) => void;
 
     // MessageListData is a core data structure for keeping track of a
     // contiguous block of messages matching a given narrow that can
@@ -332,7 +332,14 @@ export class MessageListData {
         }
 
         if (this.add_messages_callback) {
-            this.add_messages_callback(messages);
+            // If we only added old messages, last message for any of the existing recipients didn't change.
+            // Although, it maybe have resulted in new recipients being added which should be handled by the caller.
+            const recipient_order_changed = !(
+                top_messages.length > 0 &&
+                bottom_messages.length === 0 &&
+                interior_messages.length === 0
+            );
+            this.add_messages_callback(messages, recipient_order_changed);
         }
 
         const info = {


### PR DESCRIPTION
We completely rerender recent view when we receive a new message, which is not ideal since it is flashes recent view frequently during the initial fetch.

Since later parts of initial fetch which trigger the flash, only load old messages, they cannot change the latest message of rendered rows in recent view. That means we can just inplace rerender the rendered rows which got updated and don't have to worry about order of rows being changed.

I had a 5k messages populated db which did flash first row with focused underline even after this change due to `inplace_rerender` but after I sent a message in a new topic, I didn't notice any flashing on reload since the first row didn't update in the subsequent fetches.

<img width="921" alt="Screenshot 2024-05-30 at 9 57 28 AM" src="https://github.com/zulip/zulip/assets/25124304/3a521bd6-1d03-43fb-a108-757812b765eb">


discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/recent.20view.20flashing.20on.20initial.20load
