### PR TITLE
popovers: Flatten nested lists for better accessibility.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -128,12 +128,14 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
     const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;
+    const is_spectator = page_params.is_spectator;
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
         stream_muted: sub.is_muted,
         topic_name,
         topic_unmuted,
+        is_spectator,
         can_move_topic,
         can_rename_topic,
         is_realm_admin: current_user.is_admin,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1420,6 +1420,17 @@ ul {
     }
 }
 
+ul.popover-menu-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+
+    li.popover-menu-separator {
+        margin: 4px 0;
+        border-bottom: solid 1px var(--color-border-popover-menu-separator);
+    }
+}
+
 ul.popover-menu-outer-list {
     list-style: none;
     margin: 0;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1343,10 +1343,11 @@ ul {
 }
 
 #gear-menu-dropdown {
-    .org-info {
+    .org-info-container {
         padding: 9px 0 5px;
+        border-bottom: solid 1px var(--color-border-popover-menu-separator);
 
-        & li {
+        .org-info {
             display: flex;
             justify-content: flex-start;
             font-size: 15px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1432,26 +1432,6 @@ ul.popover-menu-list {
     }
 }
 
-ul.popover-menu-outer-list {
-    list-style: none;
-    margin: 0;
-
-    li.popover-menu-outer-list-item {
-        border-bottom: solid 1px var(--color-border-popover-menu-separator);
-
-        &:last-child {
-            border-bottom: none;
-        }
-
-        ul.popover-menu-inner-list {
-            margin: 0;
-            padding: 4px 0;
-            list-style: none;
-            background: none !important;
-        }
-    }
-}
-
 .spectator-view {
     #gear-menu-dropdown .gear-menu-select-dark-theme {
         display: block;

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -1,76 +1,68 @@
-{{! Contents of the "stream actions" popup }}
 <div class="popover-menu" id="stream-actions-menu-popover" data-simplebar>
-    <ul class="popover-menu-outer-list">
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="popover-stream-header text-item popover-menu-inner-list-item">
-                    <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
-                        {{> ../../stream_privacy
-                          invite_only=stream.invite_only
-                          is_web_public=stream.is_web_public }}
-                    </span>
-                    <span class="popover-stream-name">{{stream.name}}</span>
-                </li>
-            </ul>
+    <ul role="menu" class="popover-menu-list" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
+        <li role="none" class="popover-stream-header text-item popover-menu-inner-list-item">
+            <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
+                {{> ../../stream_privacy
+                  invite_only=stream.invite_only
+                  is_web_public=stream.is_web_public }}
+            </span>
+            <span class="popover-stream-name">{{stream.name}}</span>
         </li>
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="open_stream_settings popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Channel settings" }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="pin_to_top popover-menu-link" tabindex="0">
-                        {{#if stream.pin_to_top}}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-unpin" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Unpin channel from top"}}</span>
-                        {{else}}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-pin" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Pin channel to top"}}</span>
-                        {{/if}}
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="mark_stream_as_read popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="toggle_stream_muted popover-menu-link" tabindex="0">
-                        {{#if stream.is_muted}}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Unmute channel"}}</span>
-                        {{else}}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mute channel"}}</span>
-                        {{/if}}
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="popover_new_topic_button popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "New topic"}}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="popover_sub_unsub_button popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-circle-x" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Unsubscribe"}}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
-                    <span class="colorpicker-container">
-                        <input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" />
-                    </span>
-                    <a class="choose_stream_color popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-pipette" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Change color"}}</span>
-                    </a>
-                </li>
-            </ul>
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="link-item popover-menu-inner-list-item">
+            <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Channel settings" }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="pin_to_top popover-menu-link" tabindex="0">
+                {{#if stream.pin_to_top}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-unpin" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Unpin channel from top"}}</span>
+                {{else}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-pin" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Pin channel to top"}}</span>
+                {{/if}}
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="toggle_stream_muted popover-menu-link" tabindex="0">
+                {{#if stream.is_muted}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Unmute channel"}}</span>
+                {{else}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mute channel"}}</span>
+                {{/if}}
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="popover_new_topic_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "New topic"}}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="popover_sub_unsub_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-circle-x" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Unsubscribe"}}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
+            <span class="colorpicker-container">
+                <input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" />
+            </span>
+            <a role="menuitem" class="choose_stream_color popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-pipette" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Change color"}}</span>
+            </a>
         </li>
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -9,18 +9,18 @@
         <li role="none" class="popover-menu-list-item hidden-for-spectators">
             <div role="group" class="tabs-container" aria-label="{{t 'Topic visibility' }}">
                 <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
-                    <i class="zulip-icon zulip-icon-mute-new"></i>
+                    <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
                 </div>
                 <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.INHERIT}}" data-tippy-content="{{t 'Default' }}" aria-label="{{t 'Default' }}">
-                    <i class="zulip-icon zulip-icon-inherit"></i>
+                    <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
                 </div>
                 {{#if (or stream_muted topic_unmuted)}}
                     <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" data-tippy-content="{{t 'Unmute' }}" aria-label="{{t 'Unmute' }}">
-                        <i class="zulip-icon zulip-icon-unmute-new"></i>
+                        <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
                     </div>
                 {{/if}}
                 <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" data-tippy-content="{{t 'Follow' }}" aria-label="{{t 'Follow' }}">
-                    <i class="zulip-icon zulip-icon-follow"></i>
+                    <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
                 </div>
             </div>
         </li>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -1,110 +1,99 @@
-{{! Contents of the "topic actions" popup }}
 <div class="popover-menu" id="topic-actions-menu-popover" data-simplebar>
-    <ul class="popover-menu-outer-list">
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="popover-topic-header text-item popover-menu-inner-list-item">
-                    <span class="popover-topic-name">{{topic_name}}</span>
-                </li>
-            </ul>
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="popover-topic-header text-item popover-menu-list-item">
+            <span class="popover-topic-name">{{topic_name}}</span>
         </li>
-        <li class="popover-menu-outer-list-item hidden-for-spectators">
-            <ul class="popover-menu-inner-list">
-                <li class="popover-menu-inner-list-item">
-                    <div class="tabs-container">
-                        <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
-                            <i class="zulip-icon zulip-icon-mute-new"></i>
-                        </div>
-                        <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.INHERIT}}" data-tippy-content="{{t 'Default' }}" aria-label="{{t 'Default' }}">
-                            <i class="zulip-icon zulip-icon-inherit"></i>
-                        </div>
-                        {{#if (or stream_muted topic_unmuted)}}
-                            <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" data-tippy-content="{{t 'Unmute' }}" aria-label="{{t 'Unmute' }}">
-                                <i class="zulip-icon zulip-icon-unmute-new"></i>
-                            </div>
-                        {{/if}}
-                        <div class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" data-tippy-content="{{t 'Follow' }}" aria-label="{{t 'Follow' }}">
-                            <i class="zulip-icon zulip-icon-follow"></i>
-                        </div>
+        {{!-- Group 1 --}}
+        {{#unless is_spectator}}
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="popover-menu-list-item hidden-for-spectators">
+            <div role="group" class="tabs-container" aria-label="{{t 'Topic visibility' }}">
+                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.MUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.MUTED}}" data-tippy-content="{{t 'Mute' }}" aria-label="{{t 'Mute' }}">
+                    <i class="zulip-icon zulip-icon-mute-new"></i>
+                </div>
+                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.INHERIT}}" data-tippy-content="{{t 'Default' }}" aria-label="{{t 'Default' }}">
+                    <i class="zulip-icon zulip-icon-inherit"></i>
+                </div>
+                {{#if (or stream_muted topic_unmuted)}}
+                    <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" data-tippy-content="{{t 'Unmute' }}" aria-label="{{t 'Unmute' }}">
+                        <i class="zulip-icon zulip-icon-unmute-new"></i>
                     </div>
-                </li>
-            </ul>
-        </li>
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if has_starred_messages}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="sidebar-popover-unstar-all-in-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Unstar all messages in topic" }}</span>
-                    </a>
-                </li>
                 {{/if}}
-
-                {{#if has_unread_messages}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="sidebar-popover-mark-topic-read popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
-                    </a>
-                </li>
-                {{else}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a class="sidebar-popover-mark-topic-unread popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark all messages as unread" }}</span>
-                    </a>
-                </li>
-                {{/if}}
-
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="sidebar-popover-copy-link-to-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
-                    </a>
-                </li>
-            </ul>
+                <div role="menuitemradio" class="tab-option tippy-zulip-tooltip {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}selected-tab{{/if}}" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" data-tippy-content="{{t 'Follow' }}" aria-label="{{t 'Follow' }}">
+                    <i class="zulip-icon zulip-icon-follow"></i>
+                </div>
+            </div>
         </li>
+        {{/unless}}
+        {{!-- Group 2 --}}
+        <li role="separator" class="popover-menu-separator"></li>
+        {{#if has_starred_messages}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" class="sidebar-popover-unstar-all-in-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Unstar all messages in topic" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if has_unread_messages}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+            </a>
+        </li>
+        {{else}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" class="sidebar-popover-mark-topic-unread popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as unread" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
+            </a>
+        </li>
+        {{!-- Group 3 --}}
         {{#if (or can_move_topic can_rename_topic is_realm_admin)}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if can_move_topic}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="sidebar-popover-move-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Move topic" }}</span>
-                    </a>
-                </li>
-                {{else if can_rename_topic}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="sidebar-popover-rename-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-rename" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Rename topic" }}</span>
-                    </a>
-                </li>
+        <li role="separator" class="popover-menu-separator"></li>
+        {{/if}}
+        {{#if can_move_topic}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="sidebar-popover-move-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Move topic" }}</span>
+            </a>
+        </li>
+        {{else if can_rename_topic}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="sidebar-popover-rename-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-rename" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Rename topic" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if can_rename_topic}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                {{# if topic_is_resolved }}
+                <i class="popover-menu-icon zulip-icon zulip-icon-check-x" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark as unresolved"}}</span>
+                {{else}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-check" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark as resolved"}}</span>
                 {{/if}}
-                {{#if can_rename_topic}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="sidebar-popover-toggle-resolved popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        {{# if topic_is_resolved }}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-check-x" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark as unresolved"}}</span>
-                        {{else}}
-                        <i class="popover-menu-icon zulip-icon zulip-icon-check" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark as resolved"}}</span>
-                        {{/if}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if is_realm_admin}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="sidebar-popover-delete-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Delete topic"}}</span>
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
+            </a>
+        </li>
+        {{/if}}
+        {{#if is_realm_admin}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Delete topic"}}</span>
+            </a>
         </li>
         {{/if}}
     </ul>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -29,7 +29,7 @@
         <li role="separator" class="popover-menu-separator"></li>
         {{#if has_starred_messages}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-unstar-all-in-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-unstar-all-in-topic popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Unstar all messages in topic" }}</span>
             </a>
@@ -37,21 +37,21 @@
         {{/if}}
         {{#if has_unread_messages}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
             </a>
         </li>
         {{else}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-mark-topic-unread popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-mark-topic-unread popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Mark all messages as unread" }}</span>
             </a>
         </li>
         {{/if}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
             </a>
@@ -62,14 +62,14 @@
         {{/if}}
         {{#if can_move_topic}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-move-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-move-topic-messages popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Move topic" }}</span>
             </a>
         </li>
         {{else if can_rename_topic}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-rename-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-rename-topic-messages popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-rename" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Rename topic" }}</span>
             </a>
@@ -77,7 +77,7 @@
         {{/if}}
         {{#if can_rename_topic}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" tabindex="0">
                 {{# if topic_is_resolved }}
                 <i class="popover-menu-icon zulip-icon zulip-icon-check-x" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Mark as unresolved"}}</span>
@@ -90,7 +90,7 @@
         {{/if}}
         {{#if is_realm_admin}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Delete topic"}}</span>
             </a>

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -1,132 +1,120 @@
-{{! Contents of the "message actions" popup }}
 <div class="popover-menu" id="message-actions-menu-dropdown" data-simplebar>
-    <ul class="popover-menu-outer-list">
+    <ul role="menu" class="popover-menu-list">
+        {{!-- Group 1 --}}
         {{#if should_display_quote_and_reply}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="respond_button popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-quote-and-reply" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Quote and reply" }}</span>
-                        {{popover_hotkey_hints ">"}}
-                    </a>
-                </li>
-            </ul>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="respond_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-quote-and-reply" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Quote and reply" }}</span>
+                {{popover_hotkey_hints ">"}}
+            </a>
         </li>
         {{/if}}
+        {{!-- Group 2 --}}
         {{#if (or editability_menu_item move_message_menu_item should_display_delete_option)}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if editability_menu_item}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="popover_edit_message popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{editability_menu_item}}</span>
-                        {{popover_hotkey_hints "E"}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if move_message_menu_item}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="popover_move_message popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{move_message_menu_item}}</span>
-                        {{popover_hotkey_hints "M"}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if should_display_delete_option}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="delete_message popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Delete message" }}</span>
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
+        <li role="separator" class="popover-menu-separator"></li>
+        {{/if}}
+        {{#if editability_menu_item}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="popover_edit_message popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{editability_menu_item}}</span>
+                {{popover_hotkey_hints "E"}}
+            </a>
         </li>
         {{/if}}
+        {{#if move_message_menu_item}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="popover_move_message popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{move_message_menu_item}}</span>
+                {{popover_hotkey_hints "M"}}
+            </a>
+        </li>
+        {{/if}}
+        {{#if should_display_delete_option}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="delete_message popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Delete message" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{!-- Group 3 --}}
         {{#if should_display_add_reaction_option}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="reaction_button popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-smile" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Add emoji reaction" }}</span>
-                        {{popover_hotkey_hints ":"}}
-                    </a>
-                </li>
-            </ul>
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="reaction_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-smile" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Add emoji reaction" }}</span>
+                {{popover_hotkey_hints ":"}}
+            </a>
         </li>
         {{/if}}
-        {{#if (or should_display_mark_as_unread should_display_reminder_option should_display_hide_option should_display_collapse should_display_uncollapse)}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if should_display_mark_as_unread}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="mark_as_unread popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Mark as unread from here" }}</span>
-                        {{popover_hotkey_hints "Shift" "U"}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if should_display_hide_option}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="rehide_muted_user_message popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-hide" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Hide muted message again" }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                {{#if should_display_collapse}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="popover_toggle_collapse popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Collapse message" }}</span>
-                        {{popover_hotkey_hints "-"}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if should_display_uncollapse}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="popover_toggle_collapse popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-expand" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Expand message" }}</span>
-                        {{popover_hotkey_hints "-"}}
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
+        {{!-- Group 4 --}}
+        {{#if (or should_display_mark_as_unread should_display_hide_option should_display_collapse should_display_uncollapse)}}
+        <li role="separator" class="popover-menu-separator"></li>
+        {{/if}}
+        {{#if should_display_mark_as_unread}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="mark_as_unread popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark as unread from here" }}</span>
+                {{popover_hotkey_hints "Shift" "U"}}
+            </a>
         </li>
         {{/if}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if view_source_menu_item}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="popover_view_source popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-source" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{view_source_menu_item}}</span>
-                        {{popover_hotkey_hints "E"}}
-                    </a>
-                </li>
-                {{/if}}
-                {{#if should_display_read_receipts_option}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a data-message-id="{{message_id}}" class="view_read_receipts popover-menu-link" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-readreceipts" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "View read receipts" }}</span>
-                        {{popover_hotkey_hints "Shift" "V"}}
-                    </a>
-                </li>
-                {{/if}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a class="copy_link navigate-link-on-enter popover-menu-link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_url }}" tabindex="0">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t "Copy link to message" }}</span>
-                    </a>
-                </li>
-            </ul>
+        {{#if should_display_hide_option}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="rehide_muted_user_message popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-hide" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Hide muted message again" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if should_display_collapse}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="popover_toggle_collapse popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Collapse message" }}</span>
+                {{popover_hotkey_hints "-"}}
+            </a>
+        </li>
+        {{/if}}
+        {{#if should_display_uncollapse}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="popover_toggle_collapse popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-expand" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Expand message" }}</span>
+                {{popover_hotkey_hints "-"}}
+            </a>
+        </li>
+        {{/if}}
+        {{!-- Group 5 --}}
+        <li role="separator" class="popover-menu-separator"></li>
+        {{#if view_source_menu_item}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="popover_view_source popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-source" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{view_source_menu_item}}</span>
+                {{popover_hotkey_hints "E"}}
+            </a>
+        </li>
+        {{/if}}
+        {{#if should_display_read_receipts_option}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" data-message-id="{{message_id}}" class="view_read_receipts popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-readreceipts" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "View read receipts" }}</span>
+                {{popover_hotkey_hints "Shift" "V"}}
+            </a>
+        </li>
+        {{/if}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="copy_link navigate-link-on-enter popover-menu-link" data-message-id="{{message_id}}" data-clipboard-text="{{ conversation_time_url }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Copy link to message" }}</span>
+            </a>
         </li>
     </ul>
 </div>

--- a/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
@@ -1,195 +1,186 @@
 <div class="popover-menu" id="gear-menu-dropdown" aria-labelledby="settings-dropdown" data-simplebar>
-    <ul class="popover-menu-outer-list">
-        <li class="org-info popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="org-name popover-menu-inner-list-item">{{realm_name}}</li>
-                <li class="org-url popover-menu-inner-list-item">{{realm_url}}</li>
-                {{#if is_self_hosted }}
-                    <li class="org-version popover-menu-inner-list-item">
-                        <a href="#about-zulip" class="navigate-link-on-enter popover-menu-link">{{version_display_string}}</a>
-                    </li>
-                    {{#if server_needs_upgrade }}
-                    <li class="org-upgrade popover-menu-inner-list-item">
-                        <a href="https://zulip.readthedocs.io/en/stable/production/upgrade.html" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Upgrade to the latest release' }}</a>
-                    </li>
-                    {{/if}}
-                {{else}}
-                    <li class="org-plan popover-menu-inner-list-item hidden-for-spectators">
-                        {{#if is_plan_limited }}
-                            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Free</a>
-                        {{else if is_plan_standard}}
-                            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Standard</a>
-                        {{else if is_plan_standard_sponsored_for_free}}
-                            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Standard (sponsored)</a>
-                        {{else if is_plan_plus}}
-                            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Plus</a>
-                        {{/if}}
-                    </li>
-                {{/if}}
-                {{#if (and (not is_self_hosted) user_has_billing_access (not is_plan_standard_sponsored_for_free)) }}
-                    {{#if sponsorship_pending }}
-                    <li class="org-upgrade popover-menu-inner-list-item">
-                        <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Sponsorship request pending" }}</a>
-                    </li>
-                    {{else}}
-                    {{#if is_plan_limited }}
-                    <li class="org-upgrade popover-menu-inner-list-item">
-                        <a href="/upgrade/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Upgrade to {standard_plan_name}" }}</a>
-                    </li>
-                    {{/if}}
-                    {{#unless is_org_on_paid_plan}}
-                        {{#if is_education_org }}
-                        <li class="org-upgrade popover-menu-inner-list-item">
-                            <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Request education pricing' }}</a>
-                        </li>
-                        {{else if (not is_business_org) }}
-                        <li class="org-upgrade popover-menu-inner-list-item">
-                            <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Request sponsorship' }}</a>
-                        </li>
-                        {{/if}}
-                    {{/unless}}
-                    {{/if}}
-                {{/if}}
-            </ul>
+    <div class="org-info-container">
+        <div class="org-info org-name">{{realm_name}}</div>
+        <div class="org-info org-url">{{realm_url}}</div>
+        {{#if is_self_hosted }}
+        <div class="org-info org-version">
+            <a href="#about-zulip" class="navigate-link-on-enter popover-menu-link">{{version_display_string}}</a>
+        </div>
+        {{#if server_needs_upgrade }}
+        <div class="org-info org-upgrade">
+            <a href="https://zulip.readthedocs.io/en/stable/production/upgrade.html" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Upgrade to the latest release' }}</a>
+        </div>
+        {{/if}}
+        {{else}}
+        <div class="org-info org-plan hidden-for-spectators">
+            {{#if is_plan_limited }}
+            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Free</a>
+            {{else if is_plan_standard}}
+            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Standard</a>
+            {{else if is_plan_standard_sponsored_for_free}}
+            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Standard (sponsored)</a>
+            {{else if is_plan_plus}}
+            <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">Zulip Cloud Plus</a>
+            {{/if}}
+        </div>
+        {{/if}}
+        {{#if (and (not is_self_hosted) user_has_billing_access (not is_plan_standard_sponsored_for_free)) }}
+        {{#if sponsorship_pending }}
+        <div class="org-info org-upgrade">
+            <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Sponsorship request pending" }}</a>
+        </div>
+        {{else}}
+        {{#if is_plan_limited }}
+        <div class="org-info org-upgrade">
+            <a href="/upgrade/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t "Upgrade to {standard_plan_name}" }}</a>
+        </div>
+        {{/if}}
+        {{#unless is_org_on_paid_plan}}
+        {{#if is_education_org }}
+        <div class="org-info org-upgrade">
+            <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Request education pricing' }}</a>
+        </div>
+        {{else if (not is_business_org) }}
+        <div class="org-info org-upgrade">
+            <a href="/sponsorship/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">{{t 'Request sponsorship' }}</a>
+        </div>
+        {{/if}}
+        {{/unless}}
+        {{/if}}
+        {{/if}}
+    </div>
+    <ul role="menu" class="popover-menu-list">
+        {{!-- Group 1 --}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" href="#channels/subscribed" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Channel settings' }}</span>
+            </a>
         </li>
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a href="#channels/subscribed" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-hash" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Channel settings' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item admin-menu-item hidden-for-spectators">
-                    <a href="#organization" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-building" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Organization settings' }}</span>
-                    </a>
-                </li>
-                {{#unless is_guest}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a href="#groups/your" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-user-cog" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Group settings' }}</span>
-                    </a>
-                </li>
-                {{/unless}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a href="#settings" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-tool" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Personal settings' }}</span>
-                    </a>
-                </li>
-                {{#unless is_guest}}
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a href="/stats" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-bar-chart" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Usage statistics' }}</span>
-                    </a>
-                </li>
-                {{/unless}}
-                <li class="link-item popover-menu-inner-list-item only-visible-for-spectators">
-                    <a tabindex="0" class="change-language-spectator popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-f-globe" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Select language' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item gear-menu-select-dark-theme only-visible-for-spectators">
-                    <a tabindex="0" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-moon" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Switch to dark theme' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item gear-menu-select-light-theme only-visible-for-spectators">
-                    <a tabindex="0" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-sun" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Switch to light theme' }}</span>
-                    </a>
-                </li>
-            </ul>
+        <li role="none" class="link-item popover-menu-list-item admin-menu-item hidden-for-spectators">
+            <a role="menuitem" href="#organization" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-building" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Organization settings' }}</span>
+            </a>
         </li>
-        <li class="hidden-for-spectators popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="{{ apps_page_url }}" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-monitor" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Desktop & mobile apps' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/integrations/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-git-pull-request" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Integrations' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/api/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-file-text" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'API documentation' }}</span>
-                    </a>
-                </li>
-                {{#if show_billing}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/billing/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-credit-card" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Billing' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                {{#if promote_sponsoring_zulip}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="https://zulip.com/help/support-zulip-project" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-heart" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Support Zulip' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                {{#if show_remote_billing }}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/self-hosted-billing/" id="open-self-hosted-billing" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-rocket" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Plan management' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                {{#if show_plans}}
-                {{!-- This will be hidden for self hosted realms since they will have corporate disabled. --}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-rocket" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Plans and pricing' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
+        {{#unless is_guest}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" href="#groups/your" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-user-cog" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Group settings' }}</span>
+            </a>
         </li>
-        {{#if (or can_invite_users_by_email can_create_multiuse_invite is_spectator show_webathena)}}
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                {{#if (or can_invite_users_by_email can_create_multiuse_invite)}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a tabindex="0" class="invite-user-link popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Invite users' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                {{#if show_webathena}}
-                <li class="link-item popover-menu-inner-list-item" title="{{t 'Grant Zulip the Kerberos tickets needed to run your Zephyr mirror via Webathena' }}" id="webathena_login_menu">
-                    <a href="#webathena" class="webathena_login popover-menu-link">
-                        <i class="popover-menu-icon fa fa-bolt" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Link with Webathena' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-                <li class="link-item popover-menu-inner-list-item only-visible-for-spectators">
-                    <a href="{{login_link}}" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-log-in" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Log in' }}</span>
-                    </a>
-                </li>
-            </ul>
+        {{/unless}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" href="#settings" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-tool" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Personal settings' }}</span>
+            </a>
+        </li>
+        {{#unless is_guest}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" href="/stats" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-bar-chart" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Usage statistics' }}</span>
+            </a>
+        </li>
+        {{/unless}}
+        <li role="none" class="link-item popover-menu-list-item only-visible-for-spectators">
+            <a role="menuitem" tabindex="0" class="change-language-spectator popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-f-globe" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Select language' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item gear-menu-select-dark-theme only-visible-for-spectators">
+            <a role="menuitem" tabindex="0" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-moon" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Switch to dark theme' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item gear-menu-select-light-theme only-visible-for-spectators">
+            <a role="menuitem" tabindex="0" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-sun" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Switch to light theme' }}</span>
+            </a>
+        </li>
+        {{!-- Group 2 --}}
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="{{ apps_page_url }}" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-monitor" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Desktop & mobile apps' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/integrations/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-git-pull-request" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Integrations' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/api/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-file-text" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'API documentation' }}</span>
+            </a>
+        </li>
+        {{#if show_billing}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/billing/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-credit-card" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Billing' }}</span>
+            </a>
         </li>
         {{/if}}
+        {{#if promote_sponsoring_zulip}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="https://zulip.com/help/support-zulip-project" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-heart" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Support Zulip' }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if show_remote_billing }}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/self-hosted-billing/" id="open-self-hosted-billing" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-rocket" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Plan management' }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if show_plans}}
+        {{!-- This will be hidden for self hosted realms since they will have corporate disabled. --}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/plans/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-rocket" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Plans and pricing' }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{!-- Group 3 --}}
+        {{#if (or can_invite_users_by_email can_create_multiuse_invite is_spectator show_webathena)}}
+        <li role="separator" class="popover-menu-separator"></li>
+        {{/if}}
+        {{#if (or can_invite_users_by_email can_create_multiuse_invite)}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" tabindex="0" class="invite-user-link popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Invite users' }}</span>
+            </a>
+        </li>
+        {{/if}}
+        {{#if show_webathena}}
+        <li role="none" class="link-item popover-menu-list-item" title="{{t 'Grant Zulip the Kerberos tickets needed to run your Zephyr mirror via Webathena' }}" id="webathena_login_menu">
+            <a role="menuitem" href="#webathena" class="webathena_login popover-menu-link">
+                <i class="popover-menu-icon fa fa-bolt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Link with Webathena' }}</span>
+            </a>
+        </li>
+        {{/if}}
+        <li role="none" class="link-item popover-menu-list-item only-visible-for-spectators">
+            <a role="menuitem" href="{{login_link}}" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-log-in" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Log in' }}</span>
+            </a>
+        </li>
     </ul>
 </div>

--- a/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
@@ -1,47 +1,43 @@
 <div class="popover-menu" id="help-menu-dropdown" aria-labelledby="help-menu" data-simplebar>
-    <ul class="popover-menu-outer-list">
-        <li class="popover-menu-outer-list-item">
-            <ul class="popover-menu-inner-list">
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/help/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-help" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Help center' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item">
-                    <a tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="keyboard-shortcuts">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Keyboard shortcuts' }}</span>
-                        {{popover_hotkey_hints "?"}}
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item hidden-for-spectators">
-                    <a tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="message-formatting">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Message formatting' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item">
-                    <a tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="search-operators">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-manage-search" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Search filters' }}</span>
-                    </a>
-                </li>
-                <li class="link-item popover-menu-inner-list-item" id="gear_menu_about_zulip">
-                    <a href="#about-zulip" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-info"></i>
-                        <span class="popover-menu-label">{{t "About Zulip" }}</span>
-                    </a>
-                </li>
-                {{#if corporate_enabled}}
-                <li class="link-item popover-menu-inner-list-item">
-                    <a href="/help/contact-support" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-life-buoy" aria-hidden="true"></i>
-                        <span class="popover-menu-label">{{t 'Contact support' }}</span>
-                    </a>
-                </li>
-                {{/if}}
-            </ul>
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/help/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-help" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Help center' }}</span>
+            </a>
         </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="keyboard-shortcuts">
+                <i class="popover-menu-icon zulip-icon zulip-icon-keyboard" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Keyboard shortcuts' }}</span>
+                {{popover_hotkey_hints "?"}}
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="message-formatting">
+                <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Message formatting' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" tabindex="0" class="navigate-link-on-enter popover-menu-link" data-overlay-trigger="search-operators">
+                <i class="popover-menu-icon zulip-icon zulip-icon-manage-search" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Search filters' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item" id="gear_menu_about_zulip">
+            <a role="menuitem" href="#about-zulip" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-info"></i>
+                <span class="popover-menu-label">{{t "About Zulip" }}</span>
+            </a>
+        </li>
+        {{#if corporate_enabled}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/help/contact-support" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">
+                <i class="popover-menu-icon zulip-icon zulip-icon-life-buoy" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Contact support' }}</span>
+            </a>
+        </li>
+        {{/if}}
     </ul>
 </div>

--- a/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
@@ -27,7 +27,7 @@
         </li>
         <li role="none" class="link-item popover-menu-list-item" id="gear_menu_about_zulip">
             <a role="menuitem" href="#about-zulip" class="navigate-link-on-enter popover-menu-link">
-                <i class="popover-menu-icon zulip-icon zulip-icon-info"></i>
+                <i class="popover-menu-icon zulip-icon zulip-icon-info" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "About Zulip" }}</span>
             </a>
         </li>

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -15,137 +15,122 @@
             </div>
         </header>
         <section class="dropdown-menu-list-section personal-menu-actions" data-user-id="{{user_id}}">
-            <ul class="popover-menu-outer-list">
+            <ul role="menu" class="popover-menu-list">
                 {{#if user_time}}
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="text-item hidden-for-spectators popover-menu-inner-list-item">
-                            <i class="popover-menu-icon zulip-icon zulip-icon-clock"></i>
-                            {{#tr}}{user_time} local time{{/tr}}
-                        </li>
-                    </ul>
+                <li role="none" class="text-item hidden-for-spectators popover-menu-list-item">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-clock"></i>
+                    {{#tr}}{user_time} local time{{/tr}}
+                </li>
+                <li role="separator" class="popover-menu-separator"></li>
+                {{/if}}
+                {{#if status_content_available}}
+                <li role="none" class="text-item popover-menu-list-item">
+                    <span class="personal-menu-status-wrapper">
+                        {{#if status_emoji_info}}
+                            {{#if status_emoji_info.emoji_alt_code}}
+                            <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
+                            {{else if status_emoji_info.url}}
+                            <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
+                            {{else}}
+                            <span class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></span>
+                            {{/if}}
+                        {{/if}}
+                        <span class="status_text personal-menu-status-text">
+                            {{#if show_placeholder_for_status_text}}
+                                <i class="personal-menu-no-status-text">{{t "No status text"}}</i>
+                            {{else}}
+                                {{status_text}}
+                            {{/if}}
+                        </span>
+                    </span>
+                    <a role="menuitem" tabindex="0" class="personal-menu-clear-status popover-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
+                        <i class="personal-menu-clear-status-icon popover-menu-icon zulip-icon zulip-icon-x-circle"></i>
+                    </a>
+                </li>
+                {{!-- Group 1 --}}
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
+                        <span class="popover-menu-label">{{t 'Edit status' }}</span>
+                    </a>
+                </li>
+                {{else}}
+                <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
+                        <span class="popover-menu-label">{{t 'Set status' }}</span>
+                    </a>
                 </li>
                 {{/if}}
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        {{#if status_content_available}}
-                        <li class="text-item popover-menu-inner-list-item">
-                            <span class="personal-menu-status-wrapper">
-                                {{#if status_emoji_info}}
-                                    {{#if status_emoji_info.emoji_alt_code}}
-                                    <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
-                                    {{else if status_emoji_info.url}}
-                                    <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
-                                    {{else}}
-                                    <span class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></span>
-                                    {{/if}}
-                                {{/if}}
-                                <span class="status_text personal-menu-status-text">
-                                    {{#if show_placeholder_for_status_text}}
-                                        <i class="personal-menu-no-status-text">{{t "No status text"}}</i>
-                                    {{else}}
-                                        {{status_text}}
-                                    {{/if}}
-                                </span>
-                            </span>
-                            <a tabindex="0" class="personal-menu-clear-status popover-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
-                                <i class="personal-menu-clear-status-icon popover-menu-icon zulip-icon zulip-icon-x-circle"></i>
-                            </a>
-                        </li>
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a tabindex="0" class="update_status_text popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
-                                <span class="popover-menu-label">{{t 'Edit status' }}</span>
-                            </a>
-                        </li>
-                        {{else}}
-                        <li class="link-item hidden-for-spectators popover-menu-inner-list-item">
-                            <a tabindex="0" class="update_status_text popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
-                                <span class="popover-menu-label">{{t 'Set status' }}</span>
-                            </a>
-                        </li>
-                        {{/if}}
-
-                        {{#if invisible_mode}}
-                        <li class="link-item hidden-for-spectators popover-menu-inner-list-item">
-                            <a tabindex="0" class="invisible_mode_turn_off popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-play-circle"></i>
-                                <span class="popover-menu-label">{{t 'Turn off invisible mode' }}</span>
-                            </a>
-                        </li>
-                        {{else}}
-                        <li class="link-item hidden-for-spectators popover-menu-inner-list-item">
-                            <a tabindex="0" class="invisible_mode_turn_on popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-stop-circle"></i>
-                                <span class="popover-menu-label">{{t 'Go invisible' }}</span>
-                            </a>
-                        </li>
-                        {{/if}}
-                    </ul>
+                {{#if invisible_mode}}
+                <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="invisible_mode_turn_off popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-play-circle"></i>
+                        <span class="popover-menu-label">{{t 'Turn off invisible mode' }}</span>
+                    </a>
                 </li>
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="popover-menu-inner-list-item">
-                            <div id="theme-switcher" class="tab-picker">
-                                <input type="radio" id="select-automatic-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.automatic.code}}" {{#if (eq user_color_scheme color_scheme_values.automatic.code)}}checked{{/if}} />
-                                <label class="tab-option-content tippy-zulip-delayed-tooltip" for="select-automatic-theme" aria-label="{{t 'Select automatic theme' }}" data-tooltip-template-id="automatic-theme-template" tabindex="0">
-                                    <i class="zulip-icon zulip-icon-monitor" aria-hidden="true"></i>
-                                </label>
-                                <input type="radio" id="select-light-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.day.code}}" {{#if (eq user_color_scheme color_scheme_values.day.code)}}checked{{/if}} />
-                                <label class="tab-option-content tippy-zulip-delayed-tooltip" for="select-light-theme" aria-label="{{t 'Select light theme' }}" data-tippy-content="{{t 'Light theme' }}" tabindex="0">
-                                    <i class="zulip-icon zulip-icon-sun" aria-hidden="true"></i>
-                                </label>
-                                <input type="radio" id="select-dark-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.night.code}}" {{#if (eq user_color_scheme color_scheme_values.night.code)}}checked{{/if}} />
-                                <label class="tab-option-content tippy-zulip-delayed-tooltip" for="select-dark-theme" aria-label="{{t 'Select dark theme' }}" data-tippy-content="{{t 'Dark theme' }}" tabindex="0">
-                                    <i class="zulip-icon zulip-icon-moon" aria-hidden="true"></i>
-                                </label>
-                                <span class="slider"></span>
-                            </div>
-                        </li>
-                    </ul>
+                {{else}}
+                <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="invisible_mode_turn_on popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-stop-circle"></i>
+                        <span class="popover-menu-label">{{t 'Go invisible' }}</span>
+                    </a>
                 </li>
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a href="#user/{{user_id}}" tabindex="0" class="view_full_user_profile popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-account"></i>
-                                <span class="popover-menu-label">{{t 'View your profile' }}</span>
-                            </a>
-                        </li>
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a tabindex="0" class="narrow-self-direct-message popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-users"></i>
-                                <span class="popover-menu-label">{{t 'View messages with yourself' }}</span>
-                            </a>
-                        </li>
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a tabindex="0" class="narrow-messages-sent popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-message-square"></i>
-                                <span class="popover-menu-label">{{t 'View messages sent' }}</span>
-                            </a>
-                        </li>
-                    </ul>
+                {{/if}}
+                {{!-- Group 2 --}}
+                <li role="separator" class="popover-menu-separator"></li>
+                <li role="none" class="popover-menu-list-item">
+                    <div role="group" id="theme-switcher" class="tab-picker" aria-label="{{t 'App theme' }}">
+                        <input type="radio" id="select-automatic-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.automatic.code}}" {{#if (eq user_color_scheme color_scheme_values.automatic.code)}}checked{{/if}} />
+                        <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="select-automatic-theme" aria-label="{{t 'Select automatic theme' }}" data-tooltip-template-id="automatic-theme-template" tabindex="0">
+                            <i class="zulip-icon zulip-icon-monitor" aria-hidden="true"></i>
+                        </label>
+                        <input type="radio" id="select-light-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.day.code}}" {{#if (eq user_color_scheme color_scheme_values.day.code)}}checked{{/if}} />
+                        <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="select-light-theme" aria-label="{{t 'Select light theme' }}" data-tippy-content="{{t 'Light theme' }}" tabindex="0">
+                            <i class="zulip-icon zulip-icon-sun" aria-hidden="true"></i>
+                        </label>
+                        <input type="radio" id="select-dark-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.night.code}}" {{#if (eq user_color_scheme color_scheme_values.night.code)}}checked{{/if}} />
+                        <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="select-dark-theme" aria-label="{{t 'Select dark theme' }}" data-tippy-content="{{t 'Dark theme' }}" tabindex="0">
+                            <i class="zulip-icon zulip-icon-moon" aria-hidden="true"></i>
+                        </label>
+                        <span class="slider"></span>
+                    </div>
                 </li>
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a href="#settings/profile" class="open-profile-settings popover-menu-link">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-tool"></i>
-                                <span class="popover-menu-label">{{t 'Settings' }}</span>
-                            </a>
-                        </li>
-                    </ul>
+                {{!-- Group 3 --}}
+                <li role="separator" class="popover-menu-separator"></li>
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" href="#user/{{user_id}}" tabindex="0" class="view_full_user_profile popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-account"></i>
+                        <span class="popover-menu-label">{{t 'View your profile' }}</span>
+                    </a>
                 </li>
-                <li class="popover-menu-outer-list-item">
-                    <ul class="popover-menu-inner-list">
-                        <li class="link-item popover-menu-inner-list-item">
-                            <a class="logout_button hidden-for-spectators popover-menu-link" tabindex="0">
-                                <i class="popover-menu-icon zulip-icon zulip-icon-log-out" aria-hidden="true"></i>
-                                <span class="popover-menu-label">{{t 'Log out' }}</span>
-                            </a>
-                        </li>
-                    </ul>
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="narrow-self-direct-message popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-users"></i>
+                        <span class="popover-menu-label">{{t 'View messages with yourself' }}</span>
+                    </a>
+                </li>
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" tabindex="0" class="narrow-messages-sent popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-message-square"></i>
+                        <span class="popover-menu-label">{{t 'View messages sent' }}</span>
+                    </a>
+                </li>
+                {{!-- Group 4 --}}
+                <li role="separator" class="popover-menu-separator"></li>
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" href="#settings/profile" class="open-profile-settings popover-menu-link">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-tool"></i>
+                        <span class="popover-menu-label">{{t 'Settings' }}</span>
+                    </a>
+                </li>
+                {{!-- Group 5 --}}
+                <li role="separator" class="popover-menu-separator"></li>
+                <li role="none" class="link-item popover-menu-list-item">
+                    <a role="menuitem" class="logout_button hidden-for-spectators popover-menu-link" tabindex="0">
+                        <i class="popover-menu-icon zulip-icon zulip-icon-log-out" aria-hidden="true"></i>
+                        <span class="popover-menu-label">{{t 'Log out' }}</span>
+                    </a>
                 </li>
             </ul>
         </section>

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -18,7 +18,7 @@
             <ul role="menu" class="popover-menu-list">
                 {{#if user_time}}
                 <li role="none" class="text-item hidden-for-spectators popover-menu-list-item">
-                    <i class="popover-menu-icon zulip-icon zulip-icon-clock"></i>
+                    <i class="popover-menu-icon zulip-icon zulip-icon-clock" aria-hidden="true"></i>
                     {{#tr}}{user_time} local time{{/tr}}
                 </li>
                 <li role="separator" class="popover-menu-separator"></li>
@@ -44,20 +44,20 @@
                         </span>
                     </span>
                     <a role="menuitem" tabindex="0" class="personal-menu-clear-status popover-menu-link" aria-label="{{t 'Clear status'}}" data-tippy-content="{{t 'Clear your status' }}">
-                        <i class="personal-menu-clear-status-icon popover-menu-icon zulip-icon zulip-icon-x-circle"></i>
+                        <i class="personal-menu-clear-status-icon popover-menu-icon zulip-icon zulip-icon-x-circle" aria-hidden="true"></i>
                     </a>
                 </li>
                 {{!-- Group 1 --}}
                 <li role="none" class="link-item popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Edit status' }}</span>
                     </a>
                 </li>
                 {{else}}
                 <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="update_status_text popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-smile-smaller" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Set status' }}</span>
                     </a>
                 </li>
@@ -65,14 +65,14 @@
                 {{#if invisible_mode}}
                 <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="invisible_mode_turn_off popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-play-circle"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-play-circle" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Turn off invisible mode' }}</span>
                     </a>
                 </li>
                 {{else}}
                 <li role="none" class="link-item hidden-for-spectators popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="invisible_mode_turn_on popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-stop-circle"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-stop-circle" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Go invisible' }}</span>
                     </a>
                 </li>
@@ -100,19 +100,19 @@
                 <li role="separator" class="popover-menu-separator"></li>
                 <li role="none" class="link-item popover-menu-list-item">
                     <a role="menuitem" href="#user/{{user_id}}" tabindex="0" class="view_full_user_profile popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-account"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-account" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'View your profile' }}</span>
                     </a>
                 </li>
                 <li role="none" class="link-item popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="narrow-self-direct-message popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-users"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-users" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'View messages with yourself' }}</span>
                     </a>
                 </li>
                 <li role="none" class="link-item popover-menu-list-item">
                     <a role="menuitem" tabindex="0" class="narrow-messages-sent popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-message-square"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-message-square" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'View messages sent' }}</span>
                     </a>
                 </li>
@@ -120,7 +120,7 @@
                 <li role="separator" class="popover-menu-separator"></li>
                 <li role="none" class="link-item popover-menu-list-item">
                     <a role="menuitem" href="#settings/profile" class="open-profile-settings popover-menu-link">
-                        <i class="popover-menu-icon zulip-icon zulip-icon-tool"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-tool" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t 'Settings' }}</span>
                     </a>
                 </li>


### PR DESCRIPTION
This refactors popover list structure to use a flattened `ul > li` structure along with aria-related additions, enabling screen reader accessibility and announcing menu length and position (`# of n`).

Added ARIA roles:
- `role="menu"` to the parent `<ul>` element, indicating it is a widget offering a list of choices.
- `role="menuitem"`, `role="menuitemcheckbox"`, or`role="menuitemradio"` to child elements based on their function.
- `role="group"` to the theme switcher and topic visibility switcher, identifying them as containers for related menu items.
- `role="none"` to `<li>` elements, removing the implied `listitem` role that conflicts with the parent menu structure.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/nested.20HTML.20lists/near/1799749)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## NVDA Speech Viewer Output:

<table><thead>
  <tr>
    <th></th>
    <th>Focus Mode</th>
    <th>Browse Mode</th>
  </tr></thead>
<tbody>
  <tr>
    <td>Message Actions</td>
    <td>scrollable content  tool tip<br>scrollable content  region<br>Quote and reply > 1 of 8<br>Message actions   <br>Messages<br>Move messages M  2 of 8<br>Delete message  3 of 8<br>Mark as unread from here ⇧ U  4 of 8<br>Collapse message -  5 of 8<br>View original message E  6 of 8<br>View read receipts ⇧ V  7 of 8<br>Copy link to message  8 of 8</td>
    <td>clickable  scrollable content  region    menu    menu item    Quote and reply &gt;<br>separator  <br>menu item    Edit message E<br>menu item    Move messages M<br>menu item    Delete message<br>separator  <br>menu item    Add emoji reaction :<br>separator  <br>menu item    Mark as unread from here⇧U<br>menu item    Collapse message -<br>separator  <br>menu item    View read receipts⇧V<br>menu item    Copy link to message</td>
  </tr>
  <tr>
    <td>Gear Menu</td>
    <td>tool tip<br>scrollable content  region<br>Zulip Server dev environment  link<br>Channel settings  1 of 10<br>Organization settings  2 of 10<br>Group settings  3 of 10<br>Personal settings  4 of 10<br>Usage statistics  5 of 10<br>Desktop &amp;amp; mobile apps  6 of 10<br>Integrations  7 of 10<br>API documentation  8 of 10<br>Support Zulip  9 of 10<br>Invite users  10 of 10</td>
    <td>clickable  scrollable content  region    Zulip Devlocalhost<br>link    Zulip Server dev environment<br>menu    menu item    Channel settings<br>menu item    Organization settings<br>menu item    Group settings<br>menu item    Personal settings<br>menu item    Usage statistics<br>separator  <br>menu item    Desktop &amp; mobile apps<br>menu item    Integrations<br>menu item    API documentation<br>menu item    Support Zulip<br>separator  <br>menu item    Invite users</td>
  </tr>
  <tr>
    <td>Help Menu</td>
    <td>tool tip<br>scrollable content  region<br>Help center  1 of 6<br>Keyboard shortcuts ?  2 of 6<br>Message formatting  3 of 6<br>Search filters  4 of 6<br>About Zulip  5 of 6<br>Contact support  6 of 6</td>
    <td>clickable  scrollable content  region    menu    menu item    Help center<br>menu item    Keyboard shortcuts ?<br>menu item    Message formatting<br>menu item    Search filters<br>menu item    About Zulip<br>menu item    Contact support</td>
  </tr>
  <tr>
    <td>Personal Menu</td>
    <td>scrollable content  tool tip<br>scrollable content  region<br>navigation landmark<br>Set status  1 of 10<br>Go invisible  2 of 10<br>App theme  grouping<br>Select automatic theme  radio menu item  not checked  3 of 10<br>Select light theme  radio menu item  not checked  4 of 10<br>Select dark theme  radio menu item  not checked  5 of 10<br>View your profile  6 of 10<br>View messages with yourself  7 of 10<br>View messages sent  8 of 10<br>Settings  9 of 10<br>Log out  10 of 10<br></td>
    <td>clickable  scrollable content  region    navigation landmark    Desdemona<br>Owner<br>menu    8:44 AM local time<br>separator  <br>menu item    Set status<br>menu item    Go invisible<br>separator  <br>App theme  grouping    Select automatic theme  radio menu item  not checked  <br>Select light theme  radio menu item  not checked  <br>Select dark theme  radio menu item  not checked  <br>out of grouping  separator  <br>menu item    View your profile<br>menu item    View messages with yourself<br>menu item    View messages sent<br>separator  <br>menu item    Settings<br>separator  <br>menu item    Log out<br></td>
  </tr>
  <tr>
    <td>Topics Popover</td>
    <td>scrollable content  tool tip<br>scrollable content  region<br>Mark all messages as unread  4 of 8<br>Copy link to topic  5 of 8<br>Move topic  6 of 8<br>Mark as resolved  7 of 8<br>Delete topic  8 of 8</td>
    <td>clickable  scrollable content  region    menu    blue nas wasn't loading quickly<br>separator  <br>separator  <br>menu item    Mark all messages as unread<br>menu item    Copy link to topic<br>separator  <br>menu item    Move topic<br>menu item    Mark as resolved<br>menu item    Delete topic</td>
  </tr>
  <tr>
    <td>Streams popover</td>
    <td>scrollable content  tool tip<br>scrollable content  region<br>Channel settings  1 of 7<br>Pin channel to top  2 of 7<br>Mark all messages as read  3 of 7<br>Mute channel  4 of 7<br>New topic  5 of 7<br>Unsubscribe  6 of 7<br>Change color  7 of 7</td>
    <td>clickable  scrollable content  region    menu    Rome<br>separator  <br>menu item    Channel settings<br>menu item    Pin channel to top<br>menu item    Mark all messages as read<br>menu item    Mute channel<br>menu item    New topic<br>menu item    Unsubscribe<br>menu item    Change color</td>
  </tr>
</tbody></table>

## Screenshots and screen captures

| Popover Name | Before | After |
|--------|--------|--------|
| Help Menu | ![before_help-menu](https://github.com/zulip/zulip/assets/82862779/8524d161-78b3-4f30-9fcb-17cda631a260) | ![after_help-menu](https://github.com/zulip/zulip/assets/82862779/f387c22e-ef13-4cd8-a581-b1743d713474) |
| Gear Menu | ![before_gear-menu](https://github.com/zulip/zulip/assets/82862779/c56c430d-f830-4eb3-8a51-8abd26ab203c) | ![after_gear-menu](https://github.com/zulip/zulip/assets/82862779/bfaf15a5-b846-4eae-9007-2f434c2aad83) |
| Personal Menu | ![before_personal-menu](https://github.com/zulip/zulip/assets/82862779/4aa91362-97aa-4632-80cd-9ffd2bac3c66) | ![after_personal-menu](https://github.com/zulip/zulip/assets/82862779/76f931fb-0675-43b9-bb4d-8d4f3497abba) |
| Message Actions Menu | ![before_msg-actions](https://github.com/zulip/zulip/assets/82862779/b39e46b2-64aa-4b85-a6c2-2c2875226734) | ![after_msg-actions](https://github.com/zulip/zulip/assets/82862779/ef7478ad-c5ca-449a-89c5-5773fab2b6e9) |
| Stream Actions Menu | ![before_streams-menu](https://github.com/zulip/zulip/assets/82862779/68c7193c-85ea-4201-a329-c01a97b63d74) | ![image](https://github.com/zulip/zulip/assets/82862779/052fffaa-d8a3-4125-83b1-1e98017eddf2) |
| Topic Actions Menu | ![before_topics-menu](https://github.com/zulip/zulip/assets/82862779/caf8a644-a55b-4b6d-98db-3321c3511f57) | ![after_topics-menu](https://github.com/zulip/zulip/assets/82862779/7de333f9-b6d7-46bf-8742-204e57a05f2d) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
