### PR TITLE
5xx: Fix development server preview of 500 error page

### DIFF
--- a/templates/zerver/development/dev_tools.html
+++ b/templates/zerver/development/dev_tools.html
@@ -56,7 +56,7 @@
                 </tr>
                 <tr>
                     <td><a href="/webpack/5xx.html">/webpack/5xx.html</a></td>
-                    <td><code>./manage.py collectstatic --noinput</code></td>
+                    <td>None needed</td>
                     <td>Error 5xx page served by nginx (used when Django is totally broken)</td>
                 </tr>
                 <tr>

--- a/web/html/5xx.html
+++ b/web/html/5xx.html
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8" />
         <title>500 internal server error | Zulip</title>
-        <base href="/static/webpack-bundles/" />
         <meta http-equiv="refresh" content="60;URL='/'" />
         <!-- We use `error-styles` webpack assets to styles this page. -->
 

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -215,6 +215,7 @@ const config = (
                 filename: "5xx.html",
                 template: "html/5xx.html",
                 chunks: ["error-styles"],
+                publicPath: production ? "/static/webpack-bundles/" : "/webpack/",
             }),
         ],
         devServer: {


### PR DESCRIPTION
This can be viewed at http://localhost:9991/webpack/5xx.html on the development server.