### PR TITLE
Enable TypeScript `noUncheckedIndexedAccess`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
         "noImplicitOverride": true,
+        "noUncheckedIndexedAccess": true,
 
         /* Additional checks */
         "noUnusedLocals": true,

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -78,7 +78,7 @@ async function test_reply_by_click_prepopulates_private_message_recipient(
     assert.ok(private_message !== null);
     await private_message.click();
     await page.waitForSelector("#private_message_recipient", {visible: true});
-    const email = await common.get_internal_email_from_name(page, "cordelia");
+    const email = await common.get_internal_email_from_name(page, common.fullname.cordelia);
     assert(email !== undefined);
     await common.pm_recipient.expect(page, email);
     await close_compose_box(page);
@@ -151,8 +151,8 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
     await pm.click();
     await page.waitForSelector("#compose-textarea", {visible: true});
     const recipient_internal_emails = [
-        await common.get_internal_email_from_name(page, "othello"),
-        await common.get_internal_email_from_name(page, "cordelia"),
+        await common.get_internal_email_from_name(page, common.fullname.othello),
+        await common.get_internal_email_from_name(page, common.fullname.cordelia),
     ].join(",");
     await common.pm_recipient.expect(page, recipient_internal_emails);
 }

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -203,8 +203,14 @@ async function test_restore_private_message_draft_via_draft_overlay(page: Page):
     await common.check_compose_state(page, {
         content: "Test direct message.",
     });
-    const cordelia_internal_email = await common.get_internal_email_from_name(page, "cordelia");
-    const hamlet_internal_email = await common.get_internal_email_from_name(page, "hamlet");
+    const cordelia_internal_email = await common.get_internal_email_from_name(
+        page,
+        common.fullname.cordelia,
+    );
+    const hamlet_internal_email = await common.get_internal_email_from_name(
+        page,
+        common.fullname.hamlet,
+    );
     await common.pm_recipient.expect(page, `${hamlet_internal_email},${cordelia_internal_email}`);
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -139,8 +139,7 @@ export async function fill_form(
     async function is_dropdown(page: Page, name: string): Promise<boolean> {
         return (await page.$(`select[name="${CSS.escape(name)}"]`)) !== null;
     }
-    for (const name of Object.keys(params)) {
-        const value = params[name];
+    for (const [name, value] of Object.entries(params)) {
         if (typeof value === "boolean") {
             await page.$eval(
                 `${form_selector} input[name="${CSS.escape(name)}"]`,

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -49,7 +49,7 @@ export const pm_recipient = {
     },
 };
 
-export const fullname: Record<string, string> = {
+export const fullname = {
     cordelia: "Cordelia, Lear's daughter",
     othello: "Othello, the Moor of Venice",
     hamlet: "King Hamlet",
@@ -237,9 +237,6 @@ export async function get_stream_id(page: Page, stream_name: string): Promise<nu
 }
 
 export async function get_user_id_from_name(page: Page, name: string): Promise<number | undefined> {
-    if (fullname[name] !== undefined) {
-        name = fullname[name];
-    }
     return await page.evaluate((name: string) => zulip_test.get_user_id_from_name(name), name);
 }
 
@@ -247,9 +244,6 @@ export async function get_internal_email_from_name(
     page: Page,
     name: string,
 ): Promise<string | undefined> {
-    if (fullname[name] !== undefined) {
-        name = fullname[name];
-    }
     return await page.evaluate((fullname: string) => {
         const user_id = zulip_test.get_user_id_from_name(fullname);
         return user_id === undefined ? undefined : zulip_test.get_person_by_user_id(user_id).email;

--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -52,8 +52,8 @@ async function test_user_filter_ui(page: Page): Promise<void> {
     // Desdemona should be there by default
     await await_user_visible(page, "desdemona");
 
-    await add_user_to_stream(page, "cordelia");
-    await add_user_to_stream(page, "othello");
+    await add_user_to_stream(page, common.fullname.cordelia);
+    await add_user_to_stream(page, common.fullname.othello);
 
     await page.type(`form#stream_creation_form [name="user_list_filter"]`, "ot", {delay: 100});
     await page.waitForSelector("#create_stream_subscribers", {visible: true});
@@ -64,16 +64,16 @@ async function test_user_filter_ui(page: Page): Promise<void> {
                 .length === 1,
     );
 
-    await await_user_hidden(page, "cordelia");
+    await await_user_hidden(page, common.fullname.cordelia);
     await await_user_hidden(page, "desdemona");
-    await await_user_visible(page, "othello");
+    await await_user_visible(page, common.fullname.othello);
 
     // Clear the filter.
     await clear_ot_filter_with_backspace(page);
 
-    await await_user_visible(page, "cordelia");
+    await await_user_visible(page, common.fullname.cordelia);
     await await_user_visible(page, "desdemona");
-    await await_user_visible(page, "othello");
+    await await_user_visible(page, common.fullname.othello);
 }
 
 async function create_stream(page: Page): Promise<void> {

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -41,7 +41,7 @@ async function test_reactivation_confirmation_modal(page: Page, fullname: string
 }
 
 async function test_deactivate_user(page: Page): Promise<void> {
-    const cordelia_user_row = await user_row(page, "cordelia");
+    const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row, {visible: true});
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
     await page.click(cordelia_user_row + " .deactivate");
@@ -62,7 +62,7 @@ async function test_deactivate_user(page: Page): Promise<void> {
 }
 
 async function test_reactivate_user(page: Page): Promise<void> {
-    let cordelia_user_row = await user_row(page, "cordelia");
+    let cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row + ".deactivated_user");
     await page.waitForSelector(cordelia_user_row + " .fa-user-plus");
     await page.click(cordelia_user_row + " .reactivate");
@@ -70,12 +70,12 @@ async function test_reactivate_user(page: Page): Promise<void> {
     await test_reactivation_confirmation_modal(page, common.fullname.cordelia);
 
     await page.waitForSelector(cordelia_user_row + ":not(.deactivated_user)", {visible: true});
-    cordelia_user_row = await user_row(page, "cordelia");
+    cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
 }
 
 async function test_deactivated_users_section(page: Page): Promise<void> {
-    const cordelia_user_row = await user_row(page, "cordelia");
+    const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await test_deactivate_user(page);
 
     // "Deactivated users" section doesn't render just deactivated users until reloaded.

--- a/web/shared/src/fenced_code.ts
+++ b/web/shared/src/fenced_code.ts
@@ -215,9 +215,9 @@ export function process_fenced_code(content: string): string {
     consume_line = function consume_line(output_lines: string[], line: string) {
         const match = fence_re.exec(line);
         if (match) {
-            const fence = match[1];
-            const lang = match[3];
-            const header = match[5];
+            const fence = match[1]!;
+            const lang = match[3]!;
+            const header = match[5]!;
             const handler = handler_for_fence(output_lines, fence, lang, header);
             handler_stack.push(handler);
         } else {
@@ -255,7 +255,7 @@ export function get_unused_fence(content: string): string {
     let match;
     fence_length_re.lastIndex = 0;
     while ((match = fence_length_re.exec(content)) !== null) {
-        length = Math.max(length, match[1].length + 1);
+        length = Math.max(length, match[1]!.length + 1);
     }
     return "`".repeat(length);
 }

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -68,12 +68,12 @@ export function last_prefix_match(prefix: string, words: string[]): number | nul
     let found = false;
     while (left < right) {
         const mid = Math.floor((left + right) / 2);
-        if (words[mid].startsWith(prefix)) {
+        if (words[mid]!.startsWith(prefix)) {
             // Note that left can never be 0 if `found` is true,
             // since it is incremented at least once here.
             left = mid + 1;
             found = true;
-        } else if (words[mid] < prefix) {
+        } else if (words[mid]! < prefix) {
             left = mid + 1;
         } else {
             right = mid;

--- a/web/src/about_zulip.ts
+++ b/web/src/about_zulip.ts
@@ -19,12 +19,12 @@ export function launch(): void {
 
     const zulip_version_clipboard = new ClipboardJS("#about-zulip .fa-copy.zulip-version");
     zulip_version_clipboard.on("success", () => {
-        show_copied_confirmation($("#about-zulip .fa-copy.zulip-version")[0]);
+        show_copied_confirmation($("#about-zulip .fa-copy.zulip-version")[0]!);
     });
 
     const zulip_merge_base_clipboard = new ClipboardJS("#about-zulip .fa-copy.zulip-merge-base");
     zulip_merge_base_clipboard.on("success", () => {
-        show_copied_confirmation($("#about-zulip .fa-copy.zulip-merge-base")[0]);
+        show_copied_confirmation($("#about-zulip .fa-copy.zulip-merge-base")[0]!);
     });
 }
 

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -167,12 +167,12 @@ function render_attachments_ui(): void {
     scroll_util.reset_scrollbar($uploaded_files_table.closest(".progressive-table-wrapper"));
 }
 
-function format_attachment_data(new_attachments: ServerAttachment[]): Attachment[] {
-    return new_attachments.map((attachment) => ({
+function format_attachment_data(attachment: ServerAttachment): Attachment {
+    return {
         ...attachment,
         create_time_str: timerender.render_now(new Date(attachment.create_time)).time_str,
         size_str: bytes_to_size(attachment.size),
-    }));
+    };
 }
 
 export function update_attachments(event: AttachmentEvent): void {
@@ -184,7 +184,7 @@ export function update_attachments(event: AttachmentEvent): void {
         attachments = attachments.filter((a) => a.id !== event.attachment.id);
     }
     if (event.op === "add" || event.op === "update") {
-        attachments.push(format_attachment_data([event.attachment])[0]);
+        attachments.push(format_attachment_data(event.attachment));
     }
     upload_space_used = event.upload_space_used;
     // TODO: This is inefficient and we should be able to do some sort
@@ -213,7 +213,9 @@ export function set_up_attachments(): void {
         success(data) {
             const clean_data = attachment_api_response_schema.parse(data);
             loading.destroy_indicator($("#attachments_loading_indicator"));
-            attachments = format_attachment_data(clean_data.attachments);
+            attachments = clean_data.attachments.map((attachment) =>
+                format_attachment_data(attachment),
+            );
             upload_space_used = clean_data.upload_space_used;
             render_attachments_ui();
         },

--- a/web/src/audible_notifications.ts
+++ b/web/src/audible_notifications.ts
@@ -22,6 +22,6 @@ export function update_notification_sound_source(
     if (notification_sound !== "none") {
         // Load it so that it is ready to be played; without this the old sound
         // is played.
-        $container_elem[0].load();
+        $container_elem[0]!.load();
     }
 }

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -158,7 +158,7 @@ export function update_discount_details(
 }
 
 export function is_valid_input($elem: JQuery<HTMLFormElement>): boolean {
-    return $elem[0].checkValidity();
+    return $elem[0]!.checkValidity();
 }
 
 export function redirect_to_billing_with_successful_upgrade(billing_base_url: string): void {

--- a/web/src/billing/remote_billing_auth.ts
+++ b/web/src/billing/remote_billing_auth.ts
@@ -55,13 +55,10 @@ export function initialize(): void {
         },
         showErrors(error_map) {
             $("*[class$='-error']").hide();
-            for (const key in error_map) {
-                if (Object.prototype.hasOwnProperty.call(error_map, key)) {
-                    const error = error_map[key];
-                    const $error_element = $(`.${CSS.escape(key)}-error`);
-                    $error_element.text(error);
-                    $error_element.show();
-                }
+            for (const [key, error] of Object.entries(error_map)) {
+                const $error_element = $(`.${CSS.escape(key)}-error`);
+                $error_element.text(error);
+                $error_element.show();
             }
         },
     });

--- a/web/src/billing/sponsorship.ts
+++ b/web/src/billing/sponsorship.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 import {z} from "zod";
 
 import * as helpers from "./helpers";
@@ -19,18 +20,21 @@ function hide_submit_loading_indicator(): void {
 
 function validate_data(data: helpers.FormDataObject): boolean {
     let found_error = false;
+    assert(data.description !== undefined);
     if (data.description.trim() === "") {
         $("#sponsorship-description-error").text("Organization description cannot be blank.");
         hide_submit_loading_indicator();
         found_error = true;
     }
 
+    assert(data.paid_users_count !== undefined);
     if (data.paid_users_count.trim() === "") {
         $("#sponsorship-paid-users-count-error").text("Number of paid staff cannot be blank.");
         hide_submit_loading_indicator();
         found_error = true;
     }
 
+    assert(data.expected_total_users !== undefined);
     if (data.expected_total_users.trim() === "") {
         $("#sponsorship-expected-total-users-error").text(
             "Expected number of users cannot be blank.",

--- a/web/src/blueslip_stacktrace.ts
+++ b/web/src/blueslip_stacktrace.ts
@@ -90,7 +90,7 @@ async function get_context(location: StackFrame): Promise<NumberedLine[] | undef
     if (fileName === undefined || lineNumber === undefined) {
         return undefined;
     }
-    let sourceContent: string;
+    let sourceContent: string | undefined;
     try {
         sourceContent = await sourceCache[fileName];
     } catch {

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -471,7 +471,7 @@ export class Typeahead<ItemType extends string | object> {
         let $next = $active.next();
 
         if (!$next.length) {
-            $next = $(this.$menu.find("li")[0]);
+            $next = this.$menu.find("li").first();
         }
 
         $next.addClass("active");

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -279,7 +279,7 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     select(e?: JQuery.ClickEvent | JQuery.KeyUpEvent | JQuery.KeyDownEvent): this {
-        const val = this.values.get(this.$menu.find(".active")[0]);
+        const val = this.values.get(this.$menu.find(".active")[0]!);
         assert(val !== undefined);
         if (this.input_element.type === "contenteditable") {
             this.input_element.$element
@@ -295,8 +295,8 @@ export class Typeahead<ItemType extends string | object> {
             const [from, to_before, to_after] = get_string_diff(element_val, after_text);
             const replacement = after_text.slice(from, to_after);
             // select / highlight the minimal text to be replaced
-            this.input_element.$element[0].setSelectionRange(from, to_before);
-            insertTextIntoField(this.input_element.$element[0], replacement);
+            this.input_element.$element[0]!.setSelectionRange(from, to_before);
+            insertTextIntoField(this.input_element.$element[0]!, replacement);
             this.input_element.$element.trigger("change");
         }
 
@@ -304,7 +304,7 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     set_value(): void {
-        const val = this.values.get(this.$menu.find(".active")[0]);
+        const val = this.values.get(this.$menu.find(".active")[0]!);
         assert(typeof val === "string");
         if (this.input_element.type === "contenteditable") {
             this.input_element.$element.text(val);
@@ -340,7 +340,7 @@ export class Typeahead<ItemType extends string | object> {
             // We don't need tippy to position typeaheads which already know where they should be.
             return this;
         }
-        this.instance = tippy.default(this.input_element.$element[0], {
+        this.instance = tippy.default(this.input_element.$element[0]!, {
             // Lets typeahead take the width needed to fit the content
             // and wraps it if it overflows the visible container.
             maxWidth: "none",
@@ -371,7 +371,7 @@ export class Typeahead<ItemType extends string | object> {
             interactive: true,
             appendTo: () => document.body,
             showOnCreate: true,
-            content: this.$container[0],
+            content: this.$container[0]!,
             // We expect the typeahead creator to handle when to hide / show the typeahead.
             trigger: "manual",
             arrow: false,
@@ -449,7 +449,7 @@ export class Typeahead<ItemType extends string | object> {
     render(final_items: ItemType[], matching_items: ItemType[]): this {
         const $items: JQuery[] = final_items.map((item) => {
             const $i = $(ITEM_HTML);
-            this.values.set($i[0], item);
+            this.values.set($i[0]!, item);
             const item_html = this.highlighter_html(item, this.query) ?? "";
             const $item_html = $i.find("a").html(item_html);
 
@@ -461,7 +461,7 @@ export class Typeahead<ItemType extends string | object> {
             return $i;
         });
 
-        $items[0].addClass("active");
+        $items[0]!.addClass("active");
         this.$menu.empty().append($items);
         return this;
     }
@@ -621,12 +621,12 @@ export class Typeahead<ItemType extends string | object> {
 
                 this.select(e);
 
-                if (this.input_element.$element[0].id === "stream_message_recipient_topic") {
+                if (this.input_element.$element[0]!.id === "stream_message_recipient_topic") {
                     assert(this.input_element.type === "input");
                     // Move the cursor to the end of the topic
                     const topic_length = this.input_element.$element.val()!.length;
-                    this.input_element.$element[0].selectionStart = topic_length;
-                    this.input_element.$element[0].selectionEnd = topic_length;
+                    this.input_element.$element[0]!.selectionStart = topic_length;
+                    this.input_element.$element[0]!.selectionEnd = topic_length;
                 }
 
                 break;
@@ -653,7 +653,7 @@ export class Typeahead<ItemType extends string | object> {
                 // when shift (keycode 16) + tabbing to the topic field
                 if (
                     pseudo_keycode === 16 &&
-                    this.input_element.$element[0].id === "stream_message_recipient_topic"
+                    this.input_element.$element[0]!.id === "stream_message_recipient_topic"
                 ) {
                     return;
                 }

--- a/web/src/bot_data.ts
+++ b/web/src/bot_data.ts
@@ -78,7 +78,11 @@ export function update(bot_id: number, bot_update: ServerUpdateBotData): void {
 
     // We currently only support one service per bot.
     const service = services.get(bot_id)![0];
-    if (bot_update.services !== undefined && bot_update.services.length > 0) {
+    if (
+        service !== undefined &&
+        bot_update.services !== undefined &&
+        bot_update.services.length > 0
+    ) {
         Object.assign(service, services_schema.parse(bot_update.services)[0]);
     }
 }

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -46,7 +46,11 @@ function total_subscriber_count(
         const pm_ids_list = [...pm_ids_set];
         // Plus one for the "me" user, who isn't in the recipients list (except
         // for when it's a private message conversation with only "me" in it).
-        if (pm_ids_list.length === 1 && people.is_my_user_id(pm_ids_list[0])) {
+        if (
+            pm_ids_list.length === 1 &&
+            pm_ids_list[0] !== undefined &&
+            people.is_my_user_id(pm_ids_list[0])
+        ) {
             return 1;
         }
         return pm_ids_list.length + 1;
@@ -610,22 +614,16 @@ export class BuddyList extends BuddyListConf {
 
     find_position(opts: {user_id: number; user_id_list: number[]}): number {
         const user_id = opts.user_id;
-        let i;
-
         const user_id_list = opts.user_id_list;
 
         const current_sub = narrow_state.stream_sub();
         const pm_ids_set = narrow_state.pm_ids_set();
 
-        for (i = 0; i < user_id_list.length; i += 1) {
-            const list_user_id = user_id_list[i];
-
-            if (this.compare_function(user_id, list_user_id, current_sub, pm_ids_set) < 0) {
-                return i;
-            }
-        }
-
-        return user_id_list.length;
+        const i = user_id_list.findIndex(
+            (list_user_id) =>
+                this.compare_function(user_id, list_user_id, current_sub, pm_ids_set) < 0,
+        );
+        return i === -1 ? user_id_list.length : i;
     }
 
     force_render(opts: {pos: number}): void {

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -170,7 +170,7 @@ export class BuddyList extends BuddyListConf {
                     // This will default to "bottom" placement for this tooltip.
                     placement = "auto";
                 }
-                tippy.default($elem[0], {
+                tippy.default($elem[0]!, {
                     // Because the buddy list subheadings are potential click targets
                     // for purposes having nothing to do with the subscriber count
                     // (collapsing/expanding), we delay showing the tooltip until the
@@ -765,7 +765,7 @@ export class BuddyList extends BuddyListConf {
 
         const elem = scroll_util
             .get_scroll_element($(this.scroll_container_selector))
-            .expectOne()[0];
+            .expectOne()[0]!;
 
         // Add a fudge factor.
         height += 10;

--- a/web/src/color_data.ts
+++ b/web/src/color_data.ts
@@ -62,7 +62,7 @@ export function claim_colors(subs: {color: string}[]): void {
 }
 
 export function pick_color(): string {
-    const color = unused_colors[0];
+    const color = unused_colors[0]!;
 
     claim_color(color);
 

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -108,7 +108,7 @@ function set_password_toggle_label(
 ): void {
     $(password_selector).attr("aria-label", label);
     if (tippy_tooltips) {
-        const element: tippy.ReferenceElement = $(password_selector)[0];
+        const element: tippy.ReferenceElement = $(password_selector)[0]!;
         const tippy_instance = element._tippy ?? tippy.default(element);
         tippy_instance.setContent(label);
     } else {

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -7,21 +7,7 @@ export const status_classes = "alert-error alert-success alert-info alert-warnin
 
 export function phrase_match(query: string, phrase: string): boolean {
     // match "tes" to "test" and "stream test" but not "hostess"
-    let i;
-    query = query.toLowerCase();
-
-    phrase = phrase.toLowerCase();
-    if (phrase.startsWith(query)) {
-        return true;
-    }
-
-    const parts = phrase.split(" ");
-    for (i = 0; i < parts.length; i += 1) {
-        if (parts[i].startsWith(query)) {
-            return true;
-        }
-    }
-    return false;
+    return (" " + phrase.toLowerCase()).includes(" " + query.toLowerCase());
 }
 
 const keys_map = new Map([

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -82,7 +82,7 @@ export function toggle(opts: {
 
         meta.idx = idx;
         if (opts.callback) {
-            opts.callback(opts.values[idx].label, opts.values[idx].key);
+            opts.callback(opts.values[idx]!.label, opts.values[idx]!.key);
         }
 
         if (!opts.child_wants_focus) {
@@ -162,7 +162,7 @@ export function toggle(opts: {
 
         value() {
             if (meta.idx >= 0) {
-                return opts.values[meta.idx].label;
+                return opts.values[meta.idx]!.label;
             }
             /* istanbul ignore next */
             return undefined;

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -269,6 +269,7 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
     const subbed_streams = stream_data.subscribed_subs();
     if (
         subbed_streams.length === 1 &&
+        subbed_streams[0] !== undefined &&
         (is_clear_topic_button_triggered ||
             (opts.trigger === "compose_hotkey" && opts.message_type === "stream"))
     ) {
@@ -516,7 +517,11 @@ export function on_narrow(opts: NarrowActivateOpts): void {
             opts.private_message_recipient
         ) {
             const emails = opts.private_message_recipient.split(",");
-            if (emails.length !== 1 || !people.get_by_email(emails[0])!.is_bot) {
+            if (
+                emails.length !== 1 ||
+                emails[0] === undefined ||
+                !people.get_by_email(emails[0])!.is_bot
+            ) {
                 // If we are navigating between direct message conversations,
                 // we want the compose box to close for non-bot users.
                 if (compose_state.composing()) {

--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -213,7 +213,7 @@ export function update_rendered_message_groups(
     // the other code takes advantage of blocks beneath recipient bars.
     for (const message_group of message_groups) {
         const $elt = get_element(message_group);
-        const first_message = message_group.message_containers[0].msg;
+        const first_message = message_group.message_containers[0]!.msg;
         const should_fade = compose_fade_helper.should_fade_message(first_message);
         change_fade_state($elt, should_fade);
     }

--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -129,22 +129,16 @@ function fade_messages(): void {
         return;
     }
 
-    let i;
-    let first_message;
-    let $first_row;
-    let should_fade_group = false;
-    const visible_groups = message_viewport.visible_groups(false);
-
     normal_display = false;
 
     // Update the visible messages first, before the compose box opens
-    for (i = 0; i < visible_groups.length; i += 1) {
-        $first_row = rows.first_message_in_group($(visible_groups[i]));
-        first_message = message_lists.current.get(rows.id($first_row));
+    for (const group_elt of message_viewport.visible_groups(false)) {
+        const $first_row = rows.first_message_in_group($(group_elt));
+        const first_message = message_lists.current.get(rows.id($first_row));
         assert(first_message !== undefined);
-        should_fade_group = compose_fade_helper.should_fade_message(first_message);
+        const should_fade_group = compose_fade_helper.should_fade_message(first_message);
 
-        change_fade_state($(visible_groups[i]), should_fade_group);
+        change_fade_state($(group_elt), should_fade_group);
     }
 
     // Defer updating all message groups so that the compose box can open sooner
@@ -158,13 +152,12 @@ function fade_messages(): void {
                 return;
             }
 
-            should_fade_group = false;
             const $all_groups = message_lists.current.view.$list.find(".recipient_row");
             // Note: The below algorithm relies on the fact that all_elts is
             // sorted as it would be displayed in the message view
-            for (i = 0; i < $all_groups.length; i += 1) {
-                const $group_elt = $($all_groups[i]);
-                should_fade_group = compose_fade_helper.should_fade_message(
+            for (const group_elt of $all_groups) {
+                const $group_elt = $(group_elt);
+                const should_fade_group = compose_fade_helper.should_fade_message(
                     rows.recipient_from_group($group_elt)!,
                 );
                 change_fade_state($group_elt, should_fade_group);

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -314,7 +314,7 @@ function on_hidden_callback(): void {
         // Always move focus to the topic input even if it's not empty,
         // since it's likely the user will want to update the topic
         // after updating the stream.
-        ui_util.place_caret_at_end($("input#stream_message_recipient_topic")[0]);
+        ui_util.place_caret_at_end($("input#stream_message_recipient_topic")[0]!);
     } else {
         if (compose_state.private_message_recipient().length === 0) {
             $("#private_message_recipient").trigger("focus").trigger("select");

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -82,6 +82,7 @@ export function respond_to_message(opts: {
             const current_filter = narrow_state.filter();
             assert(current_filter !== undefined);
             const first_term = current_filter.terms()[0];
+            assert(first_term !== undefined);
             const first_operator = first_term.operator;
             const first_operand = first_term.operand;
 

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -98,9 +98,9 @@ export function insert_and_scroll_into_view(
     replace_all = false,
 ): void {
     if (replace_all) {
-        setFieldText($textarea[0], content);
+        setFieldText($textarea[0]!, content);
     } else {
-        insertTextIntoField($textarea[0], content);
+        insertTextIntoField($textarea[0]!, content);
     }
     // Blurring and refocusing ensures the cursor / selection is in view
     // in chromium browsers.
@@ -275,7 +275,7 @@ export function replace_syntax(
     // for details.
 
     const old_text = $textarea.val();
-    replaceFieldText($textarea[0], old_syntax, () => new_syntax, "after-replacement");
+    replaceFieldText($textarea[0]!, old_syntax, () => new_syntax, "after-replacement");
     const new_text = $textarea.val();
 
     // When replacing content in a textarea, we need to move the cursor

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -144,7 +144,7 @@ export function set_focus(opts: ComposeTriggeredOptions): void {
 }
 
 export function smart_insert_inline($textarea: JQuery<HTMLTextAreaElement>, syntax: string): void {
-    function is_space(c: string): boolean {
+    function is_space(c: string | undefined): boolean {
         return c === " " || c === "\t" || c === "\n";
     }
 
@@ -333,7 +333,7 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
         });
         const recipient_names = util.format_array_as_list(recipient_parts, "long", "conjunction");
 
-        if (users.length === 1) {
+        if (users.length === 1 && users[0] !== undefined) {
             // If it's a single user, display status text if available
             const user = users[0];
             const status = user_status.get_status_text(user.user_id);
@@ -896,8 +896,9 @@ export function format_text(
             text.slice(range.start + 1, range.end - 1).includes("](");
 
         if (is_selection_link()) {
-            const description = selected_text.split("](")[0].slice(1);
-            let url = selected_text.split("](")[1].slice(0, -1);
+            const i = selected_text.indexOf("](", 1);
+            const description = selected_text.slice(1, i);
+            let url = selected_text.slice(i + "](".length, -1);
             url = url_to_retain(url);
             text =
                 text.slice(0, range.start) +

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -250,7 +250,7 @@ function handle_bulleting_or_numbering(
         if (bulleted_numbered_list_util.strip_bullet(previous_line) === "") {
             // below we select and replace the last 2 characters in the textarea before
             // the cursor - the bullet syntax - with an empty string
-            $textarea[0].setSelectionRange($textarea.caret() - 2, $textarea.caret());
+            $textarea[0]!.setSelectionRange($textarea.caret() - 2, $textarea.caret());
             compose_ui.insert_and_scroll_into_view("", $textarea);
             e.preventDefault();
             return;
@@ -264,7 +264,7 @@ function handle_bulleting_or_numbering(
         if (bulleted_numbered_list_util.strip_numbering(previous_line) === "") {
             // below we select then replaces the last few characters in the textarea before
             // the cursor - the numbering syntax - with an empty string
-            $textarea[0].setSelectionRange(
+            $textarea[0]!.setSelectionRange(
                 $textarea.caret() - previous_number_string.length - 2,
                 $textarea.caret(),
             );
@@ -297,7 +297,7 @@ export function handle_enter($textarea: JQuery<HTMLTextAreaElement>, e: JQuery.K
 
     // If the selectionStart and selectionEnd are not the same, that
     // means that some text was selected.
-    if ($textarea[0].selectionStart !== $textarea[0].selectionEnd) {
+    if ($textarea[0]!.selectionStart !== $textarea[0]!.selectionEnd) {
         // Replace it with the newline, remembering to resize the
         // textarea if needed.
         compose_ui.insert_and_scroll_into_view("\n", $textarea);
@@ -431,7 +431,7 @@ export function tokenize_compose_str(s: string): string {
             case "_":
                 if (i === 0) {
                     return s;
-                } else if (/[\s"'(/<[{]/.test(s[i - 1])) {
+                } else if (/[\s"'(/<[{]/.test(s[i - 1]!)) {
                     return s.slice(i);
                 }
                 break;
@@ -775,7 +775,7 @@ export function get_candidates(
 
     // We will likely want to extend this list to be more i18n-friendly.
     const terminal_symbols = ",.;?!()[]> \"'\n\t";
-    if (rest !== "" && !terminal_symbols.includes(rest[0])) {
+    if (rest !== "" && !terminal_symbols.includes(rest[0]!)) {
         return [];
     }
 
@@ -1158,7 +1158,7 @@ export function content_typeahead_selected(
                 $textbox.caret(beginning.length);
                 compose_ui.autosize_textarea($textbox);
             };
-            flatpickr.show_flatpickr(input_element.$element[0], on_timestamp_selection, timestamp);
+            flatpickr.show_flatpickr(input_element.$element[0]!, on_timestamp_selection, timestamp);
             return beginning + rest;
         }
     }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -933,7 +933,7 @@ export function get_candidates(
             assert(tokens !== null);
             if (tokens[1]) {
                 const stream_name = tokens[1];
-                token = tokens[2] || "";
+                token = tokens[2] ?? "";
 
                 // Don't autocomplete if there is a space following '>'
                 if (token.startsWith(" ")) {

--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -151,7 +151,7 @@ function get_message_height(elem: HTMLElement): number {
     // This needs to be very fast. This function runs hundreds of times
     // when displaying a message feed view that has hundreds of message
     // history, which ideally should render in <100ms.
-    return $(elem).find(".message_content")[0].scrollHeight;
+    return $(elem).find(".message_content")[0]!.scrollHeight;
 }
 
 export function hide_message_expander($row: JQuery): void {

--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -132,7 +132,7 @@ function select_div($div: JQuery, selection: Selection): void {
         background: "#FFF",
     }).attr("id", "copytempdiv");
     $("body").append($div);
-    selection.selectAllChildren($div[0]);
+    selection.selectAllChildren($div[0]!);
 }
 
 function remove_div(_div: JQuery, ranges: Range[]): void {
@@ -591,7 +591,7 @@ function is_safe_url_paste_target($textarea: JQuery<HTMLTextAreaElement>): boole
     // Look at the two characters before the start of the original
     // range in search of the tell-tale `](` from existing Markdown
     // link syntax
-    const possible_markdown_link_markers = $textarea[0].value.slice(range.start - 2, range.start);
+    const possible_markdown_link_markers = $textarea[0]!.value.slice(range.start - 2, range.start);
 
     if (possible_markdown_link_markers === "](") {
         return false;

--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -84,6 +84,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
     const copy_rows = rows.visible_range(start_id, end_id);
 
     const $start_row = copy_rows[0];
+    assert($start_row !== undefined);
     const $start_recipient_row = rows.get_message_recipient_row($start_row);
     const start_recipient_row_id = rows.id_for_recipient_row($start_recipient_row);
     let should_include_start_recipient_header = false;
@@ -503,7 +504,7 @@ export function paste_handler_converter(paste_html: string): string {
                 (text_children = [...node.childNodes].filter(
                     (child) => child.textContent !== null && child.textContent.trim() !== "",
                 )).length === 1 &&
-                text_children[0].nodeName === "CODE"
+                text_children[0]?.nodeName === "CODE"
             );
         },
 

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -367,7 +367,7 @@ function draft_notify(): void {
         content: $t({defaultMessage: "Saved as draft"}),
         arrow: true,
         placement: "right",
-    })[0];
+    })[0]!;
     instance.show();
     function remove_instance(): void {
         instance.destroy();

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -154,7 +154,7 @@ export const draft_model = (function () {
     }
 
     function getDraft(id: string): LocalStorageDraft | false {
-        return get()[id] || false;
+        return get()[id] ?? false;
     }
 
     function getDraftCount(): number {
@@ -191,8 +191,9 @@ export const draft_model = (function () {
             return _.isEqual(_.omit(draft_a, ["updatedAt"]), _.omit(draft_b, ["updatedAt"]));
         }
 
-        if (drafts[id]) {
-            changed = !check_if_equal(drafts[id], draft);
+        const old_draft = drafts[id];
+        if (old_draft !== undefined) {
+            changed = !check_if_equal(old_draft, draft);
             drafts[id] = draft;
             save(drafts);
         }
@@ -264,9 +265,7 @@ export function rename_stream_recipient(
     new_stream_id: number,
     new_topic: string,
 ): void {
-    const current_drafts = draft_model.get();
-    for (const draft_id of Object.keys(current_drafts)) {
-        const draft = current_drafts[draft_id];
+    for (const [draft_id, draft] of Object.entries(draft_model.get())) {
         if (draft.type !== "stream" || draft.stream_id === undefined) {
             continue;
         }
@@ -655,9 +654,7 @@ export function initialize(): void {
     // refreshed in the middle of sending a message. We
     // reset the field on page reload to ensure that drafts
     // don't get stuck in that state.
-    const current_drafts = draft_model.get();
-    for (const draft_id of Object.keys(current_drafts)) {
-        const draft = current_drafts[draft_id];
+    for (const [draft_id, draft] of Object.entries(draft_model.get())) {
         if (draft.is_sending_saving) {
             draft.is_sending_saving = false;
             draft_model.editDraft(draft_id, draft);

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -243,6 +243,7 @@ export class DropdownWidget {
 
                     function first_item(): JQuery {
                         const first_item = list_items[0];
+                        assert(first_item !== undefined);
                         return $popper.find(`.list-item[data-unique-id="${first_item.unique_id}"]`);
                     }
 

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -581,7 +581,7 @@ export class Filter {
             return parts;
         }
 
-        if (terms.length >= 2) {
+        if (terms[0] !== undefined && terms[1] !== undefined) {
             const is = (term: NarrowTerm, expected: string): boolean =>
                 Filter.canonicalize_operator(term.operator) === expected && !term.negated;
 
@@ -1151,6 +1151,7 @@ export class Filter {
 
     filter_with_new_params(params: NarrowTerm): Filter {
         const new_params = this.fix_terms([params])[0];
+        assert(new_params !== undefined);
         const terms = this._terms.map((term) => {
             const new_term = {...term};
             if (new_term.operator === new_params.operator && !new_term.negated) {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -86,7 +86,7 @@ function zephyr_topic_name_match(message: Message & {type: "stream"}, operand: s
     const m = /^(.*?)(?:\.d)*$/i.exec(operand);
     // m should never be null because any string matches that regex.
     assert(m !== null);
-    const base_topic = m[1];
+    const base_topic = m[1]!;
     let related_regexp;
 
     // Additionally, Zephyr users expect the empty instance and
@@ -257,7 +257,7 @@ export class Filter {
     constructor(terms: NarrowTerm[]) {
         this._terms = this.fix_terms(terms);
         if (this.has_operator("channel")) {
-            this._sub = stream_data.get_sub_by_name(this.operands("channel")[0]);
+            this._sub = stream_data.get_sub_by_name(this.operands("channel")[0]!);
         }
     }
 
@@ -724,7 +724,7 @@ export class Filter {
     }
 
     is_non_huddle_pm(): boolean {
-        return this.has_operator("dm") && this.operands("dm")[0].split(",").length === 1;
+        return this.has_operator("dm") && this.operands("dm")[0]!.split(",").length === 1;
     }
 
     supports_collapsing_recipients(): boolean {
@@ -872,7 +872,7 @@ export class Filter {
                 "/#narrow/" +
                 CHANNEL_SYNONYM +
                 "/" +
-                stream_data.name_to_slug(this.operands("channel")[0]) +
+                stream_data.name_to_slug(this.operands("channel")[0]!) +
                 "/topic/" +
                 this.operands("topic")[0]
             );
@@ -894,7 +894,7 @@ export class Filter {
                         "/#narrow/" +
                         CHANNEL_SYNONYM +
                         "/" +
-                        stream_data.name_to_slug(this.operands("channel")[0])
+                        stream_data.name_to_slug(this.operands("channel")[0]!)
                     );
                 case "is-dm":
                     return "/#narrow/is/dm";
@@ -911,7 +911,7 @@ export class Filter {
                 // TODO: It is ambiguous how we want to handle the 'sender' case,
                 // we may remove it in the future based on design decisions
                 case "sender":
-                    return "/#narrow/sender/" + people.emails_to_slug(this.operands("sender")[0]);
+                    return "/#narrow/sender/" + people.emails_to_slug(this.operands("sender")[0]!);
             }
         }
 
@@ -991,7 +991,7 @@ export class Filter {
             (term_types.length === 2 && _.isEqual(term_types, ["dm", "near"])) ||
             (term_types.length === 1 && _.isEqual(term_types, ["dm"]))
         ) {
-            const emails = this.operands("dm")[0].split(",");
+            const emails = this.operands("dm")[0]!.split(",");
             const names = emails.map((email) => {
                 const person = people.get_by_email(email);
                 if (!person) {
@@ -1006,7 +1006,7 @@ export class Filter {
             return util.format_array_as_list(names, "long", "conjunction");
         }
         if (term_types.length === 1 && _.isEqual(term_types, ["sender"])) {
-            const email = this.operands("sender")[0];
+            const email = this.operands("sender")[0]!;
             const user = people.get_by_email(email);
             let sender = email;
             if (user) {

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -25,7 +25,7 @@ export function show_flatpickr(
 ): flatpickr.Instance {
     const $flatpickr_input = $<HTMLInputElement>("<input>").attr("id", "#timestamp_flatpickr");
 
-    flatpickr_instance = flatpickr($flatpickr_input[0], {
+    flatpickr_instance = flatpickr($flatpickr_input[0]!, {
         mode: "single",
         enableTime: true,
         clickOpens: false,

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -1,6 +1,6 @@
 export function get_hash_category(hash?: string): string {
     // given "#channels/subscribed", returns "channels"
-    return hash ? hash.replace(/^#/, "").split(/\//)[0] : "";
+    return hash ? hash.replace(/^#/, "").split(/\//)[0]! : "";
 }
 
 export function get_hash_section(hash?: string): string {
@@ -88,7 +88,7 @@ export function is_editing_stream(desired_stream_id: number): boolean {
 
     // if the string casted to a number is valid, and another component
     // after exists then it's a stream name/id pair.
-    const stream_id = Number.parseFloat(hash_components[1]);
+    const stream_id = Number.parseFloat(hash_components[1]!);
 
     return stream_id === desired_stream_id;
 }

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -12,7 +12,7 @@ export function get_hash_section(hash?: string): string {
 
     const parts = hash.replace(/\/$/, "").split(/\//);
 
-    return parts[1] || "";
+    return parts[1] ?? "";
 }
 
 function get_nth_hash_section(hash: string, n: number): string {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -218,7 +218,7 @@ export function validate_channels_settings_hash(hash: string): string {
         return channels_settings_section_url();
     }
 
-    if (/\d+/.test(section)) {
+    if (section !== undefined && /\d+/.test(section)) {
         const stream_id = Number.parseInt(section, 10);
         const sub = sub_store.get(stream_id);
         // There are a few situations where we can't display stream settings:
@@ -235,7 +235,7 @@ export function validate_channels_settings_hash(hash: string): string {
 
         let right_side_tab = hash_components[3];
         const valid_right_side_tab_values = new Set(["general", "personal", "subscribers"]);
-        if (!valid_right_side_tab_values.has(right_side_tab)) {
+        if (right_side_tab === undefined || !valid_right_side_tab_values.has(right_side_tab)) {
             right_side_tab = "general";
         }
         return channels_settings_edit_url(sub, right_side_tab);
@@ -253,7 +253,7 @@ export function validate_group_settings_hash(hash: string): string {
         return "#groups/your";
     }
 
-    if (/\d+/.test(section)) {
+    if (section !== undefined && /\d+/.test(section)) {
         const group_id = Number.parseInt(section, 10);
         const group = user_groups.maybe_get_user_group_from_id(group_id);
         if (!group) {
@@ -265,17 +265,21 @@ export function validate_group_settings_hash(hash: string): string {
         const group_name = hash_components[2];
         let right_side_tab = hash_components[3];
         const valid_right_side_tab_values = new Set(["general", "members"]);
-        if (group.name === group_name && valid_right_side_tab_values.has(right_side_tab)) {
+        if (
+            group.name === group_name &&
+            right_side_tab !== undefined &&
+            valid_right_side_tab_values.has(right_side_tab)
+        ) {
             return hash;
         }
-        if (!valid_right_side_tab_values.has(right_side_tab)) {
+        if (right_side_tab === undefined || !valid_right_side_tab_values.has(right_side_tab)) {
             right_side_tab = "general";
         }
         return group_edit_url(group, right_side_tab);
     }
 
     const valid_section_values = ["new", "your", "all"];
-    if (!valid_section_values.includes(section)) {
+    if (section === undefined || !valid_section_values.includes(section)) {
         blueslip.info("invalid section for groups: " + section);
         return "#groups/your";
     }

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -164,7 +164,7 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
     for (i = 1; i < hash.length; i += 2) {
         // We don't construct URLs with an odd number of components,
         // but the user might write one.
-        let operator = internal_url.decodeHashComponent(hash[i]);
+        let operator = internal_url.decodeHashComponent(hash[i]!);
         // Do not parse further if empty operator encountered.
         if (operator === "") {
             break;

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -5,6 +5,7 @@ import type {MessageDescriptor} from "@formatjs/intl";
 import {DEFAULT_INTL_CONFIG, IntlErrorCode, createIntl, createIntlCache} from "@formatjs/intl";
 import type {FormatXMLElementFn, PrimitiveType} from "intl-messageformat";
 import _ from "lodash";
+import assert from "minimalistic-assert";
 
 import {page_params} from "./base_page_params";
 
@@ -53,13 +54,9 @@ export function $t_html(
 export let language_list: (typeof page_params & {page_type: "home"})["language_list"];
 
 export function get_language_name(language_code: string): string {
-    const language_list_map: Record<string, string> = {};
-
-    // One-to-one mapping from code to name for all languages
-    for (const language of language_list) {
-        language_list_map[language.code] = language.name;
-    }
-    return language_list_map[language_code];
+    const language = language_list.find((language) => language.code === language_code);
+    assert(language !== undefined);
+    return language.name;
 }
 
 export function initialize(language_params: {language_list: typeof language_list}): void {

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -324,7 +324,7 @@ function insert_dms(keys_to_insert: string[]): void {
         }
 
         if (keys_to_insert.includes(key)) {
-            const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]);
+            const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]!);
             $previous_row.after($(render_inbox_row(dms_dict.get(key))));
         }
     }
@@ -462,7 +462,7 @@ function insert_stream(
     if (stream_index === 0) {
         $("#inbox-streams-container").prepend($(rendered_stream));
     } else {
-        const previous_stream_key = sorted_stream_keys[stream_index - 1];
+        const previous_stream_key = sorted_stream_keys[stream_index - 1]!;
         $(rendered_stream).insertAfter(get_stream_container(previous_stream_key));
     }
     return !streams_dict.get(stream_key)!.is_hidden;
@@ -486,7 +486,7 @@ function insert_topics(keys: string[], stream_key: string): void {
         }
 
         if (keys.includes(key)) {
-            const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]);
+            const $previous_row = get_row_from_conversation_key(sorted_keys[i - 1]!);
             $previous_row.after($(render_inbox_row(stream_topics_data.get(key))));
         }
     }
@@ -1393,7 +1393,7 @@ function move_focus_to_visible_area(): void {
     }
 
     const INBOX_ROW_HEIGHT = 30;
-    const position = $("#inbox-filters")[0].getBoundingClientRect();
+    const position = $("#inbox-filters")[0]!.getBoundingClientRect();
     const inbox_center_x = (position.left + position.right) / 2;
     // We are aiming to get the first row if it is completely visible or the second row.
     const inbox_row_below_filters = position.bottom + INBOX_ROW_HEIGHT;

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -286,7 +286,7 @@ function format_dm(
 
     let user_circle_class: string | false | undefined;
     let is_bot = false;
-    if (recipient_ids.length === 1) {
+    if (recipient_ids.length === 1 && recipient_ids[0] !== undefined) {
         is_bot = people.get_by_user_id(recipient_ids[0]).is_bot;
         user_circle_class = is_bot ? false : buddy_data.get_user_circle_class(recipient_ids[0]);
     }
@@ -312,7 +312,7 @@ function format_dm(
 function insert_dms(keys_to_insert: string[]): void {
     const sorted_keys = [...dms_dict.keys()];
     // If we need to insert at the top, we do it separately to avoid edge case in loop below.
-    if (keys_to_insert.includes(sorted_keys[0])) {
+    if (sorted_keys[0] !== undefined && keys_to_insert.includes(sorted_keys[0])) {
         $("#inbox-direct-messages-container").prepend(
             $(render_inbox_row(dms_dict.get(sorted_keys[0]))),
         );
@@ -473,7 +473,7 @@ function insert_topics(keys: string[], stream_key: string): void {
     assert(stream_topics_data !== undefined);
     const sorted_keys = [...stream_topics_data.keys()];
     // If we need to insert at the top, we do it separately to avoid edge case in loop below.
-    if (keys.includes(sorted_keys[0])) {
+    if (sorted_keys[0] !== undefined && keys.includes(sorted_keys[0])) {
         const $stream = get_stream_container(stream_key);
         $stream
             .find(".inbox-topic-container")
@@ -1017,7 +1017,9 @@ function set_list_focus(input_key?: string): void {
         }
     }
 
-    $($cols_to_focus[col_focus]).trigger("focus");
+    const col_to_focus = $cols_to_focus[col_focus];
+    assert(col_to_focus !== undefined);
+    $(col_to_focus).trigger("focus");
 }
 
 function focus_filters_dropdown(): void {
@@ -1350,7 +1352,7 @@ function center_focus_if_offscreen(): void {
     // Move focused to row to visible area so to avoid
     // it being under compose box or inbox filters.
     const $elt = $(".inbox-row:focus, .inbox-header:focus");
-    if ($elt.length === 0) {
+    if ($elt[0] === undefined) {
         return;
     }
 
@@ -1377,12 +1379,15 @@ function move_focus_to_visible_area(): void {
         return;
     }
 
-    if (row_focus >= $all_rows.length) {
+    let row = $all_rows[row_focus];
+    if (row === undefined) {
         row_focus = $all_rows.length - 1;
+        row = $all_rows[row_focus];
+        assert(row !== undefined);
         revive_current_focus();
     }
 
-    const elt_pos = $all_rows[row_focus].getBoundingClientRect();
+    const elt_pos = row.getBoundingClientRect();
     if (is_element_visible(elt_pos)) {
         return;
     }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -225,10 +225,10 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             const idx = store.pills.findIndex((pill) => pill.$element[0] === element);
 
             if (idx !== -1) {
-                store.pills[idx].$element.remove();
+                store.pills[idx]!.$element.remove();
                 const pill = store.pills.splice(idx, 1);
                 if (store.onPillRemove !== undefined) {
-                    store.onPillRemove(pill[0]);
+                    store.onPillRemove(pill[0]!);
                 }
 
                 // This is needed to run the "change" event handler registered in
@@ -264,7 +264,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 this.removeLastPill(quiet);
             }
 
-            this.clear(store.$input[0]);
+            this.clear(store.$input[0]!);
         },
 
         insertManyPills(pills: string | string[]) {
@@ -285,7 +285,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             // when using the `text` insertion feature with jQuery the caret is
             // placed at the beginning of the input field, so this moves it to
             // the end.
-            ui_util.place_caret_at_end(store.$input[0]);
+            ui_util.place_caret_at_end(store.$input[0]!);
 
             // this sends a flag if the operation wasn't completely successful,
             // which in this case is defined as some of the pills not autofilling
@@ -370,7 +370,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 // if the pill is successful, it will create the pill and clear
                 // the input.
                 if (funcs.appendPill(store.$input.text().trim())) {
-                    funcs.clear(store.$input[0]);
+                    funcs.clear(store.$input[0]!);
                 }
                 e.preventDefault();
 
@@ -399,7 +399,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                     break;
                 case "Backspace": {
                     const $next = $pill.next();
-                    funcs.removePill($pill[0]);
+                    funcs.removePill($pill[0]!);
                     $next.trigger("focus");
                     // the "Backspace" key in Firefox will go back a page if you do
                     // not prevent it.
@@ -439,7 +439,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             const $pill = $(this).closest(".pill");
             const $next = $pill.next();
 
-            funcs.removePill($pill[0]);
+            funcs.removePill($pill[0]!);
             $next.trigger("focus");
         });
 

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -52,7 +52,9 @@ export function show_generate_integration_url_modal(api_key: string): void {
             },
         });
         clipboard.on("success", () => {
-            show_copied_confirmation($("#generate-integration-url-modal .dialog_submit_button")[0]);
+            show_copied_confirmation(
+                $("#generate-integration-url-modal .dialog_submit_button")[0]!,
+            );
         });
 
         $override_topic.on("change", function () {

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -206,7 +206,7 @@ function submit_invitation_form(): void {
             $("#invite-user-modal .dialog_submit_button").text($t({defaultMessage: "Invite"}));
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
-            $invite_status[0].scrollIntoView();
+            $invite_status[0]!.scrollIntoView();
         },
     });
 }
@@ -226,7 +226,7 @@ function generate_multiuse_invite(): void {
             clipboard.on("success", () => {
                 const tippy_timeout_in_ms = 800;
                 show_copied_confirmation(
-                    $("#copy_generated_invite_link")[0],
+                    $("#copy_generated_invite_link")[0]!,
                     () => {
                         // Do nothing on hide
                     },
@@ -243,7 +243,7 @@ function generate_multiuse_invite(): void {
             );
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
-            $invite_status[0].scrollIntoView();
+            $invite_status[0]!.scrollIntoView();
         },
     });
 }
@@ -308,7 +308,7 @@ function set_streams_to_join_list_visibility(): void {
     const realm_has_default_streams = stream_data.get_default_stream_ids().length !== 0;
     const hide_streams_list =
         realm_has_default_streams &&
-        $<HTMLInputElement>("input#invite_select_default_streams")[0].checked;
+        $<HTMLInputElement>("input#invite_select_default_streams")[0]!.checked;
     if (hide_streams_list) {
         $("#streams_to_add .invite-stream-controls").hide();
         $("#invite-stream-checkboxes").hide();

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -97,14 +97,14 @@ export function handle_narrow_activated(filter: Filter): void {
 
     // TODO: handle confused filters like "in:all stream:foo"
     ops = filter.operands("in");
-    if (ops.length >= 1) {
+    if (ops[0] !== undefined) {
         filter_name = ops[0];
         if (filter_name === "home") {
             highlight_all_messages_view();
         }
     }
     ops = filter.operands("is");
-    if (ops.length >= 1) {
+    if (ops[0] !== undefined) {
         filter_name = ops[0];
         if (filter_name === "starred") {
             $filter_li = $(".top_left_starred_messages");

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -114,12 +114,12 @@ export class PanZoomControl {
         // See https://github.com/anvaka/panzoom/issues/112 for upstream discussion.
 
         const {scale, x, y} = e.getTransform();
-        const image_width = $(".zoom-element > img")[0].clientWidth * scale;
-        const image_height = $(".zoom-element > img")[0].clientHeight * scale;
-        const zoom_element_width = $(".zoom-element")[0].clientWidth * scale;
-        const zoom_element_height = $(".zoom-element")[0].clientHeight * scale;
-        const max_translate_x = $(".image-preview")[0].clientWidth;
-        const max_translate_y = $(".image-preview")[0].clientHeight;
+        const image_width = $(".zoom-element > img")[0]!.clientWidth * scale;
+        const image_height = $(".zoom-element > img")[0]!.clientHeight * scale;
+        const zoom_element_width = $(".zoom-element")[0]!.clientWidth * scale;
+        const zoom_element_height = $(".zoom-element")[0]!.clientHeight * scale;
+        const max_translate_x = $(".image-preview")[0]!.clientWidth;
+        const max_translate_y = $(".image-preview")[0]!.clientHeight;
 
         // When the image is dragged out of the image-preview container
         // (max_translate) it will be "snapped" back so that the number
@@ -377,7 +377,7 @@ export function build_open_media_function(
                 payload = asset_map.get($preview_src);
             }
             if (payload === undefined) {
-                payload = parse_media_data($media[0]);
+                payload = parse_media_data($media[0]!);
             }
         }
 
@@ -562,7 +562,7 @@ export function initialize(): void {
 
     // Bind the pan/zoom control the newly created element.
     const pan_zoom_control = new PanZoomControl(
-        $("#lightbox_overlay .image-preview > .zoom-element")[0],
+        $("#lightbox_overlay .image-preview > .zoom-element")[0]!,
     );
 
     const reset_lightbox_state = function (): void {

--- a/web/src/linkifiers.ts
+++ b/web/src/linkifiers.ts
@@ -29,7 +29,7 @@ function python_to_js_linkifier(
     let current_group = 1;
     const group_number_to_name: Record<number, string> = {};
     while (match) {
-        const name = match[1];
+        const name = match[1]!;
         // Replace named group with regular matching group
         pattern = pattern.replace("(?P<" + name + ">", "(");
         // Map numbered reference to named reference for template expansion
@@ -49,7 +49,7 @@ function python_to_js_linkifier(
     // JS regexes only support i (case insensitivity) and m (multiline)
     // flags, so keep those and ignore the rest
     if (match) {
-        const py_flags = match[1];
+        const py_flags = match[1]!;
 
         for (const flag of py_flags) {
             if ("im".includes(flag)) {

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -518,10 +518,10 @@ export function create<Key, Item = Key>(
                 }
                 const rendered_row = opts.modifier_html(item, meta.filter_value);
                 if (insert_index === meta.filtered_list.length - 1) {
-                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]);
+                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
                     $target_row.after($(rendered_row));
                 } else {
-                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]);
+                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]!);
                     $target_row.before($(rendered_row));
                 }
                 widget.increase_rendered_offset();

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -250,7 +250,7 @@ function parse_with_options(
                     misfeature).
                 */
                 full_name = match[1];
-                user_id = Number.parseInt(match[2], 10);
+                user_id = Number.parseInt(match[2]!, 10);
 
                 if (full_name === undefined) {
                     // For @**|id** syntax
@@ -420,7 +420,7 @@ export function get_topic_links(topic: string): TopicLink[] {
             const template_context = Object.fromEntries(
                 match
                     .slice(1)
-                    .map((matched_group, i) => [group_number_to_name[i + 1], matched_group]),
+                    .map((matched_group, i) => [group_number_to_name[i + 1]!, matched_group]),
             );
             const link_url = url_template.expand(template_context);
             // We store the starting index as well, to sort the order of occurrence of the links
@@ -563,7 +563,7 @@ function handleLinkifier({
     assert(item !== undefined);
     const {url_template, group_number_to_name} = item;
     const template_context = Object.fromEntries(
-        matches.map((match, i) => [group_number_to_name[i + 1], match]),
+        matches.map((match, i) => [group_number_to_name[i + 1]!, match]),
     );
     return url_template.expand(template_context);
 }

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -240,7 +240,7 @@ export function fetch_and_render_message_history(message: Message): void {
                 .each(function () {
                     rendered_markdown.update_elements($(this));
                 });
-            const first_element_id = content_edit_history[0].timestamp;
+            const first_element_id = content_edit_history[0]!.timestamp;
             messages_overlay_ui.set_initial_element(
                 String(first_element_id),
                 keyboard_handling_context,

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -233,7 +233,7 @@ export class MessageListData {
                 return true;
             }
 
-            const recipient_id = Number.parseInt(recipients[0], 10);
+            const recipient_id = Number.parseInt(recipients[0]!, 10);
             return (
                 !muted_users.is_user_muted(recipient_id) &&
                 !muted_users.is_user_muted(message.sender_id)
@@ -487,7 +487,7 @@ export class MessageListData {
 
         let idx = this.selected_idx() + 1;
         while (idx < this._items.length) {
-            const msg_id = this._items[idx].id;
+            const msg_id = this._items[idx]!.id;
             if (!id_set.has(msg_id)) {
                 break;
             }

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -92,7 +92,7 @@ export function at_rendered_bottom(): boolean {
 // further to see the rest of that message.
 export function bottom_rendered_message_visible(): boolean {
     const $last_row = rows.last_visible();
-    if ($last_row.length) {
+    if ($last_row[0] !== undefined) {
         const message_bottom = $last_row[0].getBoundingClientRect().bottom;
         const bottom_of_feed = $("#compose")[0].getBoundingClientRect().top;
         return bottom_of_feed > message_bottom;

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -78,7 +78,7 @@ export function message_viewport_info(): MessageViewportInfo {
 export function at_rendered_bottom(): boolean {
     const bottom = scrollTop() + height();
     // This also includes bottom whitespace.
-    const full_height = $scroll_container[0].scrollHeight;
+    const full_height = $scroll_container[0]!.scrollHeight;
 
     // We only know within a pixel or two if we're
     // exactly at the bottom, due to browser quirkiness,
@@ -94,7 +94,7 @@ export function bottom_rendered_message_visible(): boolean {
     const $last_row = rows.last_visible();
     if ($last_row[0] !== undefined) {
         const message_bottom = $last_row[0].getBoundingClientRect().bottom;
-        const bottom_of_feed = $("#compose")[0].getBoundingClientRect().top;
+        const bottom_of_feed = $("#compose")[0]!.getBoundingClientRect().top;
         return bottom_of_feed > message_bottom;
     }
     return false;
@@ -214,7 +214,7 @@ const top_of_feed = new util.CachedValue({
 
 const bottom_of_feed = new util.CachedValue({
     compute_value() {
-        return $("#compose")[0].getBoundingClientRect().top;
+        return $("#compose")[0]!.getBoundingClientRect().top;
     },
 });
 

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -13,8 +13,8 @@ export type Context = {
 };
 
 export function row_with_focus(context: Context): JQuery {
-    const focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`)[0];
-    return $(focused_item).parent(`.${CSS.escape(context.row_item_selector)}`);
+    const $focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`);
+    return $focused_item.parent(`.${CSS.escape(context.row_item_selector)}`);
 }
 
 export function activate_element(elem: HTMLElement, context: Context): void {
@@ -41,7 +41,7 @@ export function focus_on_sibling_element(context: Context): void {
     }
 
     const $new_focus_element = get_element_by_id(elem_to_be_focused_id ?? "", context);
-    if ($new_focus_element.length > 0) {
+    if ($new_focus_element[0] !== undefined) {
         assert($new_focus_element[0].children[0] instanceof HTMLElement);
         activate_element($new_focus_element[0].children[0], context);
     }
@@ -125,39 +125,23 @@ function initialize_focus(event_name: string, context: Context): void {
     }
 
     const modal_items_ids = context.get_items_ids();
-    if (modal_items_ids.length === 0) {
+    const id = modal_items_ids.at(event_name === "up_arrow" ? -1 : 0);
+    if (id === undefined) {
         // modal is empty
         return;
     }
 
-    let $element: JQuery;
-
-    function get_last_element(): JQuery {
-        const last_id = modal_items_ids.at(-1) ?? "";
-        return get_element_by_id(last_id, context);
-    }
-
-    function get_first_element(): JQuery {
-        const first_id = modal_items_ids[0];
-        return get_element_by_id(first_id, context);
-    }
-
-    if (event_name === "up_arrow") {
-        $element = get_last_element();
-    } else {
-        $element = get_first_element();
-    }
-
+    const $element = get_element_by_id(id, context);
     const focus_element = $element[0].children[0];
     assert(focus_element instanceof HTMLElement);
     activate_element(focus_element, context);
 }
 
 function scroll_to_element($element: JQuery, context: Context): void {
-    if ($element.length === 0) {
+    if ($element[0] === undefined) {
         return;
     }
-    if ($element.children.length === 0) {
+    if ($element[0].children[0] === undefined) {
         return;
     }
     assert($element[0].children[0] instanceof HTMLElement);

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -74,10 +74,10 @@ export function modals_handle_events(event_key: string, context: Context): void 
 export function set_initial_element(element_id: string, context: Context): void {
     if (element_id) {
         const $current_element = get_element_by_id(element_id, context);
-        const focus_element = $current_element[0].children[0];
+        const focus_element = $current_element[0]!.children[0];
         assert(focus_element instanceof HTMLElement);
         activate_element(focus_element, context);
-        $(`.${CSS.escape(context.items_list_selector)}`)[0].scrollTop = 0;
+        $(`.${CSS.escape(context.items_list_selector)}`)[0]!.scrollTop = 0;
     }
 }
 
@@ -132,7 +132,7 @@ function initialize_focus(event_name: string, context: Context): void {
     }
 
     const $element = get_element_by_id(id, context);
-    const focus_element = $element[0].children[0];
+    const focus_element = $element[0]!.children[0];
     assert(focus_element instanceof HTMLElement);
     activate_element(focus_element, context);
 }
@@ -152,28 +152,28 @@ function scroll_to_element($element: JQuery, context: Context): void {
     const $box_item = $(`.${CSS.escape(context.box_item_selector)}`);
 
     // If focused element is first, scroll to the top.
-    if ($box_item.first()[0].parentElement === $element[0]) {
-        $items_list[0].scrollTop = 0;
+    if ($box_item.first()[0]!.parentElement === $element[0]) {
+        $items_list[0]!.scrollTop = 0;
     }
 
     // If focused element is last, scroll to the bottom.
-    if ($box_item.last()[0].parentElement === $element[0]) {
-        $items_list[0].scrollTop = $items_list[0].scrollHeight - ($items_list.height() ?? 0);
+    if ($box_item.last()[0]!.parentElement === $element[0]) {
+        $items_list[0]!.scrollTop = $items_list[0]!.scrollHeight - ($items_list.height() ?? 0);
     }
 
     // If focused element is cut off from the top, scroll up halfway in modal.
     if ($element.position().top < 55) {
         // 55 is the minimum distance from the top that will require extra scrolling.
-        $items_list[0].scrollTop -= $items_list[0].clientHeight / 2;
+        $items_list[0]!.scrollTop -= $items_list[0]!.clientHeight / 2;
     }
 
     // If focused element is cut off from the bottom, scroll down halfway in modal.
     const dist_from_top = $element.position().top;
     const total_dist = dist_from_top + $element[0].clientHeight;
-    const dist_from_bottom = $items_container[0].clientHeight - total_dist;
+    const dist_from_bottom = $items_container[0]!.clientHeight - total_dist;
     if (dist_from_bottom < -4) {
         // -4 is the min dist from the bottom that will require extra scrolling.
-        $items_list[0].scrollTop += $items_list[0].clientHeight / 2;
+        $items_list[0]!.scrollTop += $items_list[0]!.clientHeight / 2;
     }
 }
 

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -292,7 +292,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                 };
             }
             const user_ids = people.emails_strings_to_user_ids_array(first_operand);
-            assert(user_ids !== undefined);
+            assert(user_ids?.[0] !== undefined);
             if (
                 realm.realm_private_message_policy ===
                     settings_config.private_message_policy_values.disabled.code &&

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -32,7 +32,7 @@ function retrieve_search_query_data(): SearchData {
     const current_filter = narrow_state.filter();
     assert(current_filter !== undefined);
     const search_query = current_filter.operands("search")[0];
-    const query_words = search_query.split(" ");
+    const query_words = search_query!.split(" ");
 
     const search_string_result: SearchData = {
         query_words: [],
@@ -96,7 +96,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
         return default_banner;
     }
 
-    const first_term = current_filter.terms()[0];
+    const first_term = current_filter.terms()[0]!;
     const first_operator = first_term.operator;
     const first_operand = first_term.operand;
     const num_terms = current_filter.terms().length;

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -121,7 +121,7 @@ export function stream_name(current_filter: Filter | undefined = filter()): stri
         return undefined;
     }
     const stream_operands = current_filter.operands("channel");
-    if (stream_operands.length === 1) {
+    if (stream_operands.length === 1 && stream_operands[0] !== undefined) {
         const name = stream_operands[0];
 
         // Use get_name() to get the most current stream
@@ -139,7 +139,7 @@ export function stream_sub(
     }
     const stream_operands = current_filter.operands("channel");
 
-    if (stream_operands.length !== 1) {
+    if (stream_operands.length !== 1 || stream_operands[0] === undefined) {
         return undefined;
     }
 

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -47,7 +47,7 @@ export function compute_narrow_title(filter?: Filter): string {
     }
 
     if (filter.has_operator("dm")) {
-        const emails = filter.operands("dm")[0];
+        const emails = filter.operands("dm")[0]!;
         const user_ids = people.emails_strings_to_user_ids_string(emails);
 
         if (user_ids !== undefined) {
@@ -60,7 +60,7 @@ export function compute_narrow_title(filter?: Filter): string {
     }
 
     if (filter.has_operator("sender")) {
-        const user = people.get_by_email(filter.operands("sender")[0]);
+        const user = people.get_by_email(filter.operands("sender")[0]!);
         if (user) {
             if (people.is_my_user_id(user.user_id)) {
                 return $t({defaultMessage: "Messages sent by you"});

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -621,7 +621,7 @@ export function pm_perma_link(message: Message): string | undefined {
 export function pm_with_url(message: Message | MessageWithBooleans): string | undefined {
     const user_ids = pm_with_user_ids(message);
 
-    if (!user_ids) {
+    if (user_ids?.[0] === undefined) {
         return undefined;
     }
 
@@ -710,7 +710,7 @@ export function emails_to_slug(emails_string: string): string | undefined {
 
     const emails = emails_string.split(",");
 
-    if (emails.length === 1) {
+    if (emails.length === 1 && emails[0] !== undefined) {
         const person = get_by_email(emails[0]);
         assert(person !== undefined, "Unknown person in emails_to_slug");
         const name = person.full_name;
@@ -807,6 +807,7 @@ export function user_can_direct_message(recipient_ids_string: string): boolean {
     const recipient_ids = user_ids_string_to_ids_array(recipient_ids_string);
     if (
         recipient_ids.length === 1 &&
+        recipient_ids[0] !== undefined &&
         (is_valid_bot_user(recipient_ids[0]) || is_my_user_id(recipient_ids[0]))
     ) {
         return true;

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -737,7 +737,7 @@ export function slug_to_emails(slug: string): string | undefined {
     */
     const m = /^([\d,]+)(-.*)?/.exec(slug);
     if (m) {
-        let user_ids_string = m[1];
+        let user_ids_string = m[1]!;
         user_ids_string = exclude_me_from_string(user_ids_string);
         return user_ids_string_to_emails_string(user_ids_string);
     }

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -111,7 +111,7 @@ function register_click_handlers(): void {
             // the language has multiple playground links configured, a popover
             // is shown.
             const extracted_code = $codehilite_div.find("code").text();
-            if (playground_info.length === 1) {
+            if (playground_info.length === 1 && playground_info[0] !== undefined) {
                 const url_template = url_template_lib.parse(playground_info[0].url_template);
                 $view_in_playground_button.attr(
                     "href",

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -126,7 +126,7 @@ function register_click_handlers(): void {
                 }
                 const popover_target = $view_in_playground_button.find(
                     ".playground-links-popover-container",
-                )[0];
+                )[0]!;
                 toggle_playground_links_popover(popover_target, playground_store);
             }
         },

--- a/web/src/poll_modal.ts
+++ b/web/src/poll_modal.ts
@@ -46,7 +46,7 @@ export function poll_options_setup(): void {
 
     // setTimeout is needed to here to give time for simplebar to initialise
     setTimeout(() => {
-        SortableJS.create($("#add-poll-form .poll-options-list .simplebar-content")[0], {
+        SortableJS.create($("#add-poll-form .poll-options-list .simplebar-content")[0]!, {
             onUpdate() {
                 // Do nothing on drag; the order is only processed on submission.
             },

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -192,7 +192,7 @@ export const default_popover_props: Partial<tippy.Props> = {
                     // $tippy_box[0].hasAttribute("data-reference-hidden"); is the real check
                     // but linter wants us to write it like this.
                     const is_reference_outside_window = Object.hasOwn(
-                        $tippy_box[0].dataset,
+                        $tippy_box[0]!.dataset,
                         "referenceHidden",
                     );
                     if (is_reference_outside_window) {
@@ -215,7 +215,7 @@ export const default_popover_props: Partial<tippy.Props> = {
                         return;
                     }
 
-                    const reference_rect = $reference[0].getBoundingClientRect();
+                    const reference_rect = $reference[0]!.getBoundingClientRect();
                     // This is the logic we want but since it is too expensive to run
                     // on every scroll, we run a cheaper version of this to just check if
                     // compose, sticky header or navbar are not obscuring the reference

--- a/web/src/portico/hello.ts
+++ b/web/src/portico/hello.ts
@@ -1,12 +1,13 @@
-// Mark this as a module for ESLint and Webpack.
-export {};
+import assert from "minimalistic-assert";
 
 function get_new_rand(old_random_int: number, max: number): number {
+    assert(max >= 2);
     const random_int = Math.floor(Math.random() * max);
     return random_int === old_random_int ? get_new_rand(random_int, max) : random_int;
 }
 
 function get_random_item_from_array<T>(array: T[]): T {
+    assert(array.length >= 1);
     return array[Math.floor(Math.random() * array.length)];
 }
 

--- a/web/src/portico/hello.ts
+++ b/web/src/portico/hello.ts
@@ -8,7 +8,7 @@ function get_new_rand(old_random_int: number, max: number): number {
 
 function get_random_item_from_array<T>(array: T[]): T {
     assert(array.length >= 1);
-    return array[Math.floor(Math.random() * array.length)];
+    return array[Math.floor(Math.random() * array.length)]!;
 }
 
 const current_client_logo_class_names = new Set([
@@ -40,7 +40,7 @@ function update_client_logo(): void {
         current_client_logo_class_names_index,
         client_logos.length,
     );
-    const client_logo_elt = client_logos[current_client_logo_class_names_index];
+    const client_logo_elt = client_logos[current_client_logo_class_names_index]!;
 
     const current_logo_class = client_logo_elt.className;
     current_client_logo_class_names.delete(current_logo_class);

--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -58,7 +58,7 @@ export function activate_correct_tab($tabbed_section: JQuery): void {
     const $active_list_items = $li.filter(".active");
     if (!$active_list_items.length) {
         $li.first().addClass("active");
-        const tab_key = $li.first()[0].dataset.tabKey;
+        const tab_key = $li.first()[0]!.dataset.tabKey;
         if (tab_key) {
             $blocks.filter("[data-tab-key=" + tab_key + "]").addClass("active");
         } else {

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -89,7 +89,7 @@ export function show_user_list(message_id: number): void {
                             $("#read_receipts_modal .read_receipts_list").html(
                                 render_read_receipts(context),
                             );
-                            new SimpleBar($("#read_receipts_modal .modal__content")[0]);
+                            new SimpleBar($("#read_receipts_modal .modal__content")[0]!);
                         }
                     },
                     error(xhr) {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -340,7 +340,7 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
     if (using_keyboard) {
         const scroll_element = $(
             "#recent_view_table .table_fix_head .simplebar-content-wrapper",
-        )[0];
+        )[0]!;
         const half_height_of_visible_area = scroll_element.offsetHeight / 2;
         const topic_offset = topic_offset_to_visible_area($topic_row);
 
@@ -1093,14 +1093,14 @@ function topic_offset_to_visible_area($topic_row: JQuery): string | undefined {
     }
     const $scroll_container = $("#recent_view_table .table_fix_head");
     const thead_height = $scroll_container.find("thead").outerHeight(true)!;
-    const scroll_container_props = $scroll_container[0].getBoundingClientRect();
+    const scroll_container_props = $scroll_container[0]!.getBoundingClientRect();
 
     // Since user cannot see row under thead, exclude it as part of the scroll container.
     const scroll_container_top = scroll_container_props.top + thead_height;
     const compose_height = $("#compose").outerHeight(true)!;
     const scroll_container_bottom = scroll_container_props.bottom - compose_height;
 
-    const topic_props = $topic_row[0].getBoundingClientRect();
+    const topic_props = $topic_row[0]!.getBoundingClientRect();
 
     // Topic is above the visible scroll region.
     if (topic_props.top < scroll_container_top) {
@@ -1119,7 +1119,7 @@ function recenter_focus_if_off_screen(): void {
         return;
     }
 
-    const table_wrapper_element = $("#recent_view_table .table_fix_head")[0];
+    const table_wrapper_element = $("#recent_view_table .table_fix_head")[0]!;
     const $topic_rows = $("#recent_view_table table tbody tr");
 
     if (row_focus >= $topic_rows.length) {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -289,6 +289,7 @@ function get_row_type(row: number): string {
 
     const current_list = topics_widget.get_current_list();
     const current_row = current_list[row];
+    assert(current_row !== undefined);
     return current_row.type;
 }
 
@@ -1318,7 +1319,9 @@ function is_focus_at_last_table_row(): boolean {
 
 function has_unread(row: number): boolean {
     assert(topics_widget !== undefined);
-    const last_msg_id = topics_widget.get_current_list()[row].last_msg_id;
+    const current_row = topics_widget.get_current_list()[row];
+    assert(current_row !== undefined);
+    const last_msg_id = current_row.last_msg_id;
     const last_msg = message_store.get(last_msg_id);
     assert(last_msg !== undefined);
     if (last_msg.type === "stream") {

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -312,7 +312,7 @@ export const update_elements = ($content: JQuery): void => {
             $view_in_playground_button.attr("aria-label", title);
         }
         const $copy_button = $buttonContainer.find(".copy_codeblock");
-        const clipboard = new ClipboardJS($copy_button[0], {
+        const clipboard = new ClipboardJS($copy_button[0]!, {
             text(copy_element) {
                 const $code = $(copy_element).parent().siblings("code");
                 return $code.text();
@@ -320,7 +320,7 @@ export const update_elements = ($content: JQuery): void => {
         });
 
         clipboard.on("success", () => {
-            show_copied_confirmation($copy_button[0]);
+            show_copied_confirmation($copy_button[0]!);
         });
         $codehilite.addClass("zulip-code-block");
     });

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -296,7 +296,11 @@ export const update_elements = ($content: JQuery): void => {
             // popover listing the options.
             let title = $t({defaultMessage: "View in playground"});
             const $view_in_playground_button = $buttonContainer.find(".code_external_link");
-            if (playground_info && playground_info.length === 1) {
+            if (
+                playground_info &&
+                playground_info.length === 1 &&
+                playground_info[0] !== undefined
+            ) {
                 title = $t(
                     {defaultMessage: "View in {playground_name}"},
                     {playground_name: playground_info[0].name},
@@ -327,7 +331,7 @@ export const update_elements = ($content: JQuery): void => {
         $content
             .find(".emoji")
             .text(function () {
-                const text = $(this).attr("title");
+                const text = $(this).attr("title") ?? "";
                 return ":" + text + ":";
             })
             .contents()

--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -5,7 +5,7 @@ import SimpleBar from "simplebar";
 type JQueryOrZJQuery = {__zjquery?: true} & JQuery;
 
 export function get_content_element($element: JQuery): JQuery {
-    const element = $element.expectOne()[0];
+    const element = $element.expectOne()[0]!;
     const sb = SimpleBar.instances.get(element);
     if (sb) {
         return $(sb.getContentElement()!);
@@ -19,7 +19,7 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
         return $element;
     }
 
-    const element = $element.expectOne()[0];
+    const element = $element.expectOne()[0]!;
     const sb = SimpleBar.instances.get(element);
     if (sb) {
         return $(sb.getScrollElement()!);
@@ -32,7 +32,7 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
 }
 
 export function reset_scrollbar($element: JQuery): void {
-    const element = $element.expectOne()[0];
+    const element = $element.expectOne()[0]!;
     const sb = SimpleBar.instances.get(element);
     if (sb) {
         sb.getScrollElement()!.scrollTop = 0;

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -34,15 +34,12 @@ type SettingOptionValueWithKey = SettingOptionValue & {key: string};
 export function get_sorted_options_list(
     option_values_object: Record<string, SettingOptionValue>,
 ): SettingOptionValueWithKey[] {
-    const options_list: SettingOptionValueWithKey[] = Object.keys(option_values_object).map(
-        (key: string) => ({
-            ...option_values_object[key],
-            key,
-        }),
+    const options_list: SettingOptionValueWithKey[] = Object.entries(option_values_object).map(
+        ([key, value]) => ({...value, key}),
     );
     let comparator: (x: SettingOptionValueWithKey, y: SettingOptionValueWithKey) => number;
 
-    if (!options_list[0].order) {
+    if (options_list[0] !== undefined && !options_list[0].order) {
         comparator = (x, y) => {
             const key_x = x.key.toUpperCase();
             const key_y = y.key.toUpperCase();
@@ -172,14 +169,14 @@ export function get_property_value(
 }
 
 export function realm_authentication_methods_to_boolean_dict(): Record<string, boolean> {
-    const auth_method_to_bool: Record<string, boolean> = {};
-    for (const [auth_method_name, auth_method_info] of Object.entries(
-        realm.realm_authentication_methods,
-    )) {
-        auth_method_to_bool[auth_method_name] = auth_method_info.enabled;
-    }
-
-    return sort_object_by_key(auth_method_to_bool);
+    return Object.fromEntries(
+        Object.entries(realm.realm_authentication_methods)
+            .sort()
+            .map(([auth_method_name, auth_method_info]) => [
+                auth_method_name,
+                auth_method_info.enabled,
+            ]),
+    );
 }
 
 export function extract_property_name($elem: JQuery, for_realm_default_settings?: boolean): string {
@@ -474,17 +471,6 @@ function get_field_data_input_value($input_elem: JQuery): string | undefined {
         JSON.parse(field.field_data),
     );
     return JSON.stringify(proposed_value);
-}
-
-export function sort_object_by_key(obj: Record<string, boolean>): Record<string, boolean> {
-    const keys = Object.keys(obj).sort();
-    const new_obj: Record<string, boolean> = {};
-
-    for (const key of keys) {
-        new_obj[key] = obj[key];
-    }
-
-    return new_obj;
 }
 
 export let default_code_language_widget: DropdownWidget | null = null;

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -187,7 +187,7 @@ export function extract_property_name($elem: JQuery, for_realm_default_settings?
         // "realm_{settings_name}}" because both user and realm default
         // settings use the same template and each element should have
         // unique id.
-        return /^realm_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1];
+        return /^realm_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1]!;
     }
 
     if (elem_id.startsWith("id_authmethod")) {
@@ -197,14 +197,14 @@ export function extract_property_name($elem: JQuery, for_realm_default_settings?
         // The [\da-z]+ part of the regexp covers the auth method name itself.
         // We assume it's not an empty string and can contain only digits and lowercase ASCII letters,
         // this is ensured by a respective allowlist-based filter in populate_auth_methods().
-        return /^id_authmethod[\da-z]+_(.*)$/.exec(elem_id)![1];
+        return /^id_authmethod[\da-z]+_(.*)$/.exec(elem_id)![1]!;
     }
 
     if (elem_id.startsWith("id-custom-profile-field")) {
-        return /^id_custom_profile_field_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1];
+        return /^id_custom_profile_field_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1]!;
     }
 
-    return /^id_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1];
+    return /^id_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1]!;
 }
 
 export function get_subsection_property_elements($subsection: JQuery): HTMLElement[] {
@@ -397,7 +397,7 @@ function read_select_field_data_from_form(
         }
     }
     $profile_field_form.find("div.choice-row").each(function (this: HTMLElement) {
-        const text = $(this).find("input")[0].value;
+        const text = $(this).find("input")[0]!.value;
         if (text) {
             let value = old_option_value_map.get(text);
             if (value !== undefined) {
@@ -753,7 +753,7 @@ export function get_auth_method_list_data(): Record<string, boolean> {
     for (const method_row of $auth_method_rows) {
         const method = $(method_row).attr("data-method");
         assert(method !== undefined);
-        new_auth_methods[method] = $(method_row).find<HTMLInputElement>("input")[0].checked;
+        new_auth_methods[method] = $(method_row).find<HTMLInputElement>("input")[0]!.checked;
     }
 
     return new_auth_methods;
@@ -957,11 +957,11 @@ export function populate_data_for_request(
                         $input_elem.attr("id")!,
                     );
                     assert(match_array !== null);
-                    property_name = match_array[1];
+                    property_name = match_array[1]!;
                 } else {
                     const match_array = /^id_realm_(.*)$/.exec($input_elem.attr("id")!);
                     assert(match_array !== null);
-                    property_name = match_array[1];
+                    property_name = match_array[1]!;
                 }
 
                 if (property_name === "stream_privacy") {
@@ -1146,7 +1146,7 @@ function enable_or_disable_save_button($subsection_elem: JQuery): void {
         const $button_wrapper = $subsection_elem.find<tippy.PopperElement>(
             ".subsection-changes-save",
         );
-        const tippy_instance = $button_wrapper[0]._tippy;
+        const tippy_instance = $button_wrapper[0]!._tippy;
         if (disable_save_btn) {
             // avoid duplication of tippy
             if (!tippy_instance) {
@@ -1184,5 +1184,5 @@ export function initialize_disable_btn_hint_popover(
     if (hint_text !== undefined) {
         tippy_opts.content = hint_text;
     }
-    tippy.default($btn_wrapper[0], tippy_opts);
+    tippy.default($btn_wrapper[0]!, tippy_opts);
 }

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -221,6 +221,7 @@ function show_modal(): void {
         const emoji: Record<string, string> = {};
 
         function submit_custom_emoji_request(formData: FormData): void {
+            assert(emoji.name !== undefined);
             void channel.post({
                 url: "/json/realm/emoji/" + encodeURIComponent(emoji.name),
                 data: formData,
@@ -241,6 +242,7 @@ function show_modal(): void {
         for (const obj of $("#add-custom-emoji-form").serializeArray()) {
             emoji[obj.name] = obj.value;
         }
+        assert(emoji.name !== undefined);
 
         if (emoji.name.trim() === "") {
             ui_report.client_error(

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -265,7 +265,7 @@ function show_modal(): void {
         }
 
         const formData = new FormData();
-        const files = $<HTMLInputElement>("input#emoji_file_input")[0].files;
+        const files = $<HTMLInputElement>("input#emoji_file_input")[0]!.files;
         assert(files !== null);
         for (const [i, file] of [...files].entries()) {
             formData.append("file-" + i, file);

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -194,7 +194,7 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
     });
 
     if (current_user.is_admin) {
-        new SortableJS($linkifiers_table[0], {
+        new SortableJS($linkifiers_table[0]!, {
             onUpdate: update_linkifiers_order,
             handle: ".move-handle",
             filter: "input",

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -421,7 +421,7 @@ function set_up_select_field_edit_form(
 
     // Add blank choice at last
     create_choice_row($choice_list);
-    SortableJS.create($choice_list[0], {
+    SortableJS.create($choice_list[0]!, {
         onUpdate() {
             // Do nothing on drag. We process the order on submission
         },
@@ -706,7 +706,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
     display_in_profile_summary_fields_limit_reached = display_in_profile_summary_fields_count >= 2;
 
     if (current_user.is_admin) {
-        const field_list = $("#admin_profile_fields_table")[0];
+        const field_list = $("#admin_profile_fields_table")[0]!;
         SortableJS.create(field_list, {
             onUpdate: update_field_order,
             filter: "input",
@@ -724,7 +724,7 @@ function set_up_select_field(): void {
     create_choice_row($("#profile_field_choices"));
 
     if (current_user.is_admin) {
-        const choice_list = $("#profile_field_choices")[0];
+        const choice_list = $("#profile_field_choices")[0]!;
         SortableJS.create(choice_list, {
             onUpdate() {
                 // Do nothing on drag. We process the order on submission

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -183,8 +183,10 @@ function set_up_create_field_form(): void {
             $field_url_pattern_elem.show();
         } else {
             $field_url_pattern_elem.hide();
-            const profile_field_name =
-                realm.realm_default_external_accounts[profile_field_external_account_type].name;
+            const external_account =
+                realm.realm_default_external_accounts[profile_field_external_account_type];
+            assert(external_account !== undefined);
+            const profile_field_name = external_account.name;
             $("#profile_field_name").val(profile_field_name).prop("disabled", true);
             $("#profile_field_hint").val("").prop("disabled", true);
         }
@@ -776,7 +778,9 @@ export function get_external_account_link(field: UserExternalAccountData): strin
         assert(field.field_data.url_pattern !== undefined);
         field_url_pattern = field.field_data.url_pattern;
     } else {
-        field_url_pattern = realm.realm_default_external_accounts[field_subtype].url_pattern;
+        const external_account = realm.realm_default_external_accounts[field_subtype];
+        assert(external_account !== undefined);
+        field_url_pattern = external_account.url_pattern;
     }
     return field_url_pattern.replace("%(username)s", () => field.value);
 }

--- a/web/src/settings_realm_domains.ts
+++ b/web/src/settings_realm_domains.ts
@@ -114,7 +114,7 @@ export function setup_realm_domains_modal_handlers(): void {
         const domain = $widget.find(".new-realm-domain").val();
         const allow_subdomains = $widget.find<HTMLInputElement>(
             "input.new-realm-domain-allow-subdomains",
-        )[0].checked;
+        )[0]!.checked;
         const data = {
             domain,
             allow_subdomains: JSON.stringify(allow_subdomains),

--- a/web/src/setup.ts
+++ b/web/src/setup.ts
@@ -25,7 +25,7 @@ $(() => {
     }
 
     $.fn.get_offset_to_window = function () {
-        return this[0].getBoundingClientRect();
+        return this[0]!.getBoundingClientRect();
     };
 
     $.fn.expectOne = function () {

--- a/web/src/spoilers.ts
+++ b/web/src/spoilers.ts
@@ -21,7 +21,7 @@ function expand_spoiler($spoiler: JQuery): void {
     // of the content). CSS animations do not work with properties set to
     // `auto`, so we get the actual height of the content here and temporarily
     // put it explicitly on the element styling to allow the transition to work.
-    const spoiler_height = $spoiler[0].scrollHeight;
+    const spoiler_height = $spoiler[0]!.scrollHeight;
     $spoiler.height(`${spoiler_height}px`);
     // The `spoiler-content-open` class has CSS animations defined on it which
     // will trigger on the frame after this class change.

--- a/web/src/stats/stats.ts
+++ b/web/src/stats/stats.ts
@@ -419,7 +419,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
             .on("plotly_hover", (data) => {
                 $("#hoverinfo").show();
                 document.querySelector("#hover_date")!.textContent =
-                    data.points[0].data.text[data.points[0].pointNumber];
+                    data.points[0]!.data.text[data.points[0]!.pointNumber]!;
                 const values: Plotly.Datum[] = [null, null, null];
                 for (const trace of data.points) {
                     values[trace.curveNumber] = trace.y;
@@ -432,16 +432,16 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
                 ];
                 for (const [i, value] of values.entries()) {
                     if (value !== null) {
-                        document.querySelector<HTMLElement>(hover_text_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_text_ids[i]!)!.style.display =
                             "inline";
-                        document.querySelector<HTMLElement>(hover_value_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_value_ids[i]!)!.style.display =
                             "inline";
-                        document.querySelector<HTMLElement>(hover_value_ids[i])!.textContent =
+                        document.querySelector<HTMLElement>(hover_value_ids[i]!)!.textContent =
                             value.toString();
                     } else {
-                        document.querySelector<HTMLElement>(hover_text_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_text_ids[i]!)!.style.display =
                             "none";
-                        document.querySelector<HTMLElement>(hover_value_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_value_ids[i]!)!.style.display =
                             "none";
                     }
                 }
@@ -461,13 +461,13 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
         let start;
         let is_boundary;
         if (aggregation === "day") {
-            start = floor_to_local_day(start_dates[0]);
+            start = floor_to_local_day(start_dates[0]!);
             is_boundary = function (date: Date) {
                 return date.getHours() === 0;
             };
         } else {
             assert(aggregation === "week");
-            start = floor_to_local_week(start_dates[0]);
+            start = floor_to_local_week(start_dates[0]!);
             is_boundary = function (date: Date) {
                 return date.getHours() === 0 && date.getDay() === 0;
             };
@@ -476,25 +476,25 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
         const values: DataByUserType<number[]> = {human: [], bot: [], me: []};
         let current: DataByUserType<number> = {human: 0, bot: 0, me: 0};
         let i_init = 0;
-        if (is_boundary(start_dates[0])) {
+        if (is_boundary(start_dates[0]!)) {
             current = {
-                human: data.everyone.human[0],
-                bot: data.everyone.bot[0],
-                me: data.user.human[0],
+                human: data.everyone.human[0]!,
+                bot: data.everyone.bot[0]!,
+                me: data.user.human[0]!,
             };
             i_init = 1;
         }
         for (let i = i_init; i < start_dates.length; i += 1) {
-            if (is_boundary(start_dates[i])) {
-                dates.push(start_dates[i]);
+            if (is_boundary(start_dates[i]!)) {
+                dates.push(start_dates[i]!);
                 values.human.push(current.human);
                 values.bot.push(current.bot);
                 values.me.push(current.me);
                 current = {human: 0, bot: 0, me: 0};
             }
-            current.human += data.everyone.human[i];
-            current.bot += data.everyone.bot[i];
-            current.me += data.user.human[i];
+            current.human += data.everyone.human[i]!;
+            current.bot += data.everyone.bot[i]!;
+            current.me += data.user.human[i]!;
         }
         values.human.push(current.human);
         values.bot.push(current.bot);
@@ -563,9 +563,9 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
             const plotDiv = document.querySelector<Plotly.PlotlyHTMLElement>(
                 "#id_messages_sent_over_time",
             )!;
-            assert("visible" in plotDiv.data[0]);
-            assert("visible" in plotDiv.data[1]);
-            assert("visible" in plotDiv.data[2]);
+            assert("visible" in plotDiv.data[0]!);
+            assert("visible" in plotDiv.data[1]!);
+            assert("visible" in plotDiv.data[2]!);
             traces.me.visible = plotDiv.data[0].visible;
             traces.human.visible = plotDiv.data[1].visible;
             traces.bot.visible = plotDiv.data[2].visible;
@@ -730,8 +730,8 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
     const label_values: {label: string; value: number}[] = [];
     for (let i = 0; i < everyone_month.values.length; i += 1) {
         label_values.push({
-            label: everyone_month.labels[i],
-            value: everyone_month.labels[i] === "Other" ? -1 : everyone_month.values[i],
+            label: everyone_month.labels[i]!,
+            value: everyone_month.labels[i] === "Other" ? -1 : everyone_month.values[i]!,
         });
     }
     label_values.sort((a, b) => b.value - a.value);
@@ -754,9 +754,9 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
             text: [],
         };
         for (let i = 0; i < plot_data.values.length; i += 1) {
-            if (plot_data.values[i] > 0) {
-                annotations.values.push(plot_data.values[i]);
-                annotations.labels.push(plot_data.labels[i]);
+            if (plot_data.values[i]! > 0) {
+                annotations.values.push(plot_data.values[i]!);
+                annotations.labels.push(plot_data.labels[i]!);
                 annotations.text.push(
                     "   " + plot_data.labels[i] + " (" + plot_data.percentages[i] + ")",
                 );
@@ -1044,7 +1044,7 @@ function populate_number_of_users(raw_data: unknown): void {
             .on("plotly_hover", (data) => {
                 $("#users_hover_info").show();
                 document.querySelector("#users_hover_date")!.textContent =
-                    data.points[0].data.text[data.points[0].pointNumber];
+                    data.points[0]!.data.text[data.points[0]!.pointNumber]!;
                 const values: Plotly.Datum[] = [null, null, null];
                 for (const trace of data.points) {
                     values[trace.curveNumber] = trace.y;
@@ -1056,11 +1056,11 @@ function populate_number_of_users(raw_data: unknown): void {
                 ];
                 for (const [i, value] of values.entries()) {
                     if (value !== null) {
-                        document.querySelector<HTMLElement>(hover_value_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_value_ids[i]!)!.style.display =
                             "inline";
-                        document.querySelector(hover_value_ids[i])!.textContent = value.toString();
+                        document.querySelector(hover_value_ids[i]!)!.textContent = value.toString();
                     } else {
-                        document.querySelector<HTMLElement>(hover_value_ids[i])!.style.display =
+                        document.querySelector<HTMLElement>(hover_value_ids[i]!)!.style.display =
                             "none";
                     }
                 }
@@ -1185,7 +1185,7 @@ function populate_messages_read_over_time(raw_data: unknown): void {
             .on("plotly_hover", (data) => {
                 $("#read_hover_info").show();
                 document.querySelector("#read_hover_date")!.textContent =
-                    data.points[0].data.text[data.points[0].pointNumber];
+                    data.points[0]!.data.text[data.points[0]!.pointNumber]!;
                 const values: Plotly.Datum[] = [null, null];
                 for (const trace of data.points) {
                     values[trace.curveNumber] = trace.y;
@@ -1194,18 +1194,20 @@ function populate_messages_read_over_time(raw_data: unknown): void {
                 const read_hover_value_ids = ["#read_hover_me_value", "#read_hover_everyone_value"];
                 for (const [i, value] of values.entries()) {
                     if (value !== null) {
-                        document.querySelector<HTMLElement>(read_hover_text_ids[i])!.style.display =
-                            "inline";
                         document.querySelector<HTMLElement>(
-                            read_hover_value_ids[i],
+                            read_hover_text_ids[i]!,
                         )!.style.display = "inline";
-                        document.querySelector<HTMLElement>(read_hover_value_ids[i])!.textContent =
+                        document.querySelector<HTMLElement>(
+                            read_hover_value_ids[i]!,
+                        )!.style.display = "inline";
+                        document.querySelector<HTMLElement>(read_hover_value_ids[i]!)!.textContent =
                             value.toString();
                     } else {
-                        document.querySelector<HTMLElement>(read_hover_text_ids[i])!.style.display =
-                            "none";
                         document.querySelector<HTMLElement>(
-                            read_hover_value_ids[i],
+                            read_hover_text_ids[i]!,
+                        )!.style.display = "none";
+                        document.querySelector<HTMLElement>(
+                            read_hover_value_ids[i]!,
                         )!.style.display = "none";
                     }
                 }
@@ -1225,13 +1227,13 @@ function populate_messages_read_over_time(raw_data: unknown): void {
         let start;
         let is_boundary;
         if (aggregation === "day") {
-            start = floor_to_local_day(start_dates[0]);
+            start = floor_to_local_day(start_dates[0]!);
             is_boundary = function (date: Date) {
                 return date.getHours() === 0;
             };
         } else {
             assert(aggregation === "week");
-            start = floor_to_local_week(start_dates[0]);
+            start = floor_to_local_week(start_dates[0]!);
             is_boundary = function (date: Date) {
                 return date.getHours() === 0 && date.getDay() === 0;
             };
@@ -1240,19 +1242,19 @@ function populate_messages_read_over_time(raw_data: unknown): void {
         const values: DataByEveryoneMe<number[]> = {everyone: [], me: []};
         let current: DataByEveryoneMe<number> = {everyone: 0, me: 0};
         let i_init = 0;
-        if (is_boundary(start_dates[0])) {
-            current = {everyone: data.everyone.read[0], me: data.user.read[0]};
+        if (is_boundary(start_dates[0]!)) {
+            current = {everyone: data.everyone.read[0]!, me: data.user.read[0]!};
             i_init = 1;
         }
         for (let i = i_init; i < start_dates.length; i += 1) {
-            if (is_boundary(start_dates[i])) {
-                dates.push(start_dates[i]);
+            if (is_boundary(start_dates[i]!)) {
+                dates.push(start_dates[i]!);
                 values.everyone.push(current.everyone);
                 values.me.push(current.me);
                 current = {everyone: 0, me: 0};
             }
-            current.everyone += data.everyone.read[i];
-            current.me += data.user.read[i];
+            current.everyone += data.everyone.read[i]!;
+            current.me += data.user.read[i]!;
         }
         values.everyone.push(current.everyone);
         values.me.push(current.me);
@@ -1315,8 +1317,8 @@ function populate_messages_read_over_time(raw_data: unknown): void {
             const plotDiv = document.querySelector<Plotly.PlotlyHTMLElement>(
                 "#id_messages_read_over_time",
             )!;
-            assert("visible" in plotDiv.data[0]);
-            assert("visible" in plotDiv.data[1]);
+            assert("visible" in plotDiv.data[0]!);
+            assert("visible" in plotDiv.data[1]!);
             traces.me.visible = plotDiv.data[0].visible;
             traces.everyone.visible = plotDiv.data[1].visible;
         }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -270,7 +270,7 @@ export function slug_to_name(slug: string): string {
     */
     const m = /^(\d+)(-.*)?$/.exec(slug);
     if (m) {
-        const stream_id = Number.parseInt(m[1], 10);
+        const stream_id = Number.parseInt(m[1]!, 10);
         const sub = sub_store.get(stream_id);
         if (sub) {
             return sub.name;

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -677,7 +677,7 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
     };
 
     const op_stream = filter.operands("channel");
-    if (op_stream.length === 0) {
+    if (op_stream[0] === undefined) {
         return result;
     }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -285,7 +285,7 @@ export function initialize(): void {
                 const second_line = $t({defaultMessage: "File name: {filename}"}, {filename});
                 $markup.append($("<br>"), $("<span>").text(second_line));
             }
-            instance.setContent($markup[0]);
+            instance.setContent($markup[0]!);
             return undefined;
         },
         onHidden(instance) {

--- a/web/src/topic_generator.ts
+++ b/web/src/topic_generator.ts
@@ -19,19 +19,19 @@ export function next_topic(
     const curr_stream_index = streams.indexOf(curr_stream); // -1 if not found
 
     if (curr_stream_index >= 0) {
-        const stream = streams[curr_stream_index];
+        const stream = streams[curr_stream_index]!;
         const topics = get_topics(stream);
         const curr_topic_index = topics.indexOf(curr_topic); // -1 if not found
 
         for (let i = curr_topic_index + 1; i < topics.length; i += 1) {
-            const topic = topics[i];
+            const topic = topics[i]!;
             if (has_unread_messages(stream, topic)) {
                 return {stream, topic};
             }
         }
 
         for (let i = 0; i < curr_topic_index; i += 1) {
-            const topic = topics[i];
+            const topic = topics[i]!;
             if (has_unread_messages(stream, topic)) {
                 return {stream, topic};
             }
@@ -39,7 +39,7 @@ export function next_topic(
     }
 
     for (let i = curr_stream_index + 1; i < streams.length; i += 1) {
-        const stream = streams[i];
+        const stream = streams[i]!;
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
                 return {stream, topic};
@@ -48,7 +48,7 @@ export function next_topic(
     }
 
     for (let i = 0; i < curr_stream_index; i += 1) {
-        const stream = streams[i];
+        const stream = streams[i]!;
         for (const topic of get_topics(stream)) {
             if (has_unread_messages(stream, topic)) {
                 return {stream, topic};
@@ -150,13 +150,13 @@ export function get_next_unread_pm_string(curr_pm: string): string | undefined {
     const curr_pm_index = my_pm_strings.indexOf(curr_pm); // -1 if not found
 
     for (let i = curr_pm_index + 1; i < my_pm_strings.length; i += 1) {
-        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]) > 0) {
+        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]!) > 0) {
             return my_pm_strings[i];
         }
     }
 
     for (let i = 0; i < curr_pm_index; i += 1) {
-        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]) > 0) {
+        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]!) > 0) {
             return my_pm_strings[i];
         }
     }

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -54,7 +54,7 @@ export function zoom_out(): void {
 
     const stream_ids = [...active_widgets.keys()];
 
-    if (stream_ids.length !== 1) {
+    if (stream_ids.length !== 1 || stream_ids[0] === undefined) {
         blueslip.error("Unexpected number of topic lists to zoom out.");
         return;
     }
@@ -237,6 +237,7 @@ export function clear_topic_search(e: JQuery.Event): void {
         const stream_ids = [...active_widgets.keys()];
 
         const stream_id = stream_ids[0];
+        assert(stream_id !== undefined);
         const widget = active_widgets.get(stream_id);
         assert(widget !== undefined);
         const parent_widget = widget.get_parent();
@@ -258,7 +259,7 @@ export function active_stream_id(): number | undefined {
 export function get_stream_li(): JQuery | undefined {
     const widgets = [...active_widgets.values()];
 
-    if (widgets.length !== 1) {
+    if (widgets.length !== 1 || widgets[0] === undefined) {
         return undefined;
     }
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -58,8 +58,7 @@ export function highlight_with_escaping_and_regex(regex: RegExp, item: string): 
     const pieces = item.split(regex).filter(Boolean);
     let result = "";
 
-    for (let i = 0; i < pieces.length; i += 1) {
-        const piece = pieces[i];
+    for (const [i, piece] of pieces.entries()) {
         if (regex.test(piece) && (i === 0 || pieces[i - 1].endsWith(" "))) {
             // only highlight if the matching part is a word prefix, ie
             // if it is the 1st piece or if there was a space before it

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -59,7 +59,7 @@ export function highlight_with_escaping_and_regex(regex: RegExp, item: string): 
     let result = "";
 
     for (const [i, piece] of pieces.entries()) {
-        if (regex.test(piece) && (i === 0 || pieces[i - 1].endsWith(" "))) {
+        if (regex.test(piece) && (i === 0 || pieces[i - 1]!.endsWith(" "))) {
             // only highlight if the matching part is a word prefix, ie
             // if it is the 1st piece or if there was a space before it
             result += "<strong>" + Handlebars.Utils.escapeExpression(piece) + "</strong>";

--- a/web/src/typing_events.ts
+++ b/web/src/typing_events.ts
@@ -64,7 +64,7 @@ function get_users_typing_for_narrow(): number[] {
     }
 
     const terms = narrow_state.search_terms();
-    if (terms.length === 0) {
+    if (terms[0] === undefined) {
         return [];
     }
 

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -472,6 +472,7 @@ export function process_unread_messages_event({
     for (const message_id of message_ids) {
         const message = message_store.get(message_id);
         const message_info = message_details[message_id];
+        assert(message_info !== undefined);
         let mentioned_me_directly;
 
         if (message) {

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -534,7 +534,7 @@ export function initialize(): void {
         if (compose_state.composing()) {
             // Compose box is open; drop there.
             upload_files(compose_upload_object, compose_config, files);
-        } else if ($last_drag_drop_edit_container.length !== 0) {
+        } else if ($last_drag_drop_edit_container[0] !== undefined) {
             // A message edit box is open; drop there.
             const row_id = rows.get_message_id($last_drag_drop_edit_container[0]);
             const $drag_drop_container = edit_config(row_id).drag_drop_container();

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -79,9 +79,9 @@ export function build_widget(
 
     get_file_input().attr("accept", supported_types.toString());
     get_file_input().on("change", (e) => {
-        if (e.target.files?.length === 0) {
+        if (e.target.files?.[0] === undefined) {
             $input_error.hide();
-        } else if (e.target.files?.length === 1) {
+        } else if (e.target.files.length === 1) {
             const file = e.target.files[0];
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 $input_error.text(
@@ -167,9 +167,9 @@ export function build_direct_upload_widget(
 
     get_file_input().attr("accept", supported_types.toString());
     get_file_input().on("change", (e) => {
-        if (e.target.files?.length === 0) {
+        if (e.target.files?.[0] === undefined) {
             $input_error.hide();
-        } else if (e.target.files?.length === 1) {
+        } else if (e.target.files.length === 1) {
             const file = e.target.files[0];
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 $input_error.text(

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -72,7 +72,7 @@ export function build_widget(
         if (files === null || files === undefined || files.length === 0) {
             return false;
         }
-        get_file_input()[0].files = files;
+        get_file_input()[0]!.files = files;
         e.preventDefault();
         return false;
     });
@@ -160,7 +160,7 @@ export function build_direct_upload_widget(
         if (files === null || files === undefined || files.length === 0) {
             return false;
         }
-        get_file_input()[0].files = files;
+        get_file_input()[0]!.files = files;
         e.preventDefault();
         return false;
     });

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -35,7 +35,7 @@ export function lower_bound<T1, T2>(
     while (len > 0) {
         step = Math.floor(len / 2);
         middle = first + step;
-        if (less(array[middle], value, middle)) {
+        if (less(array[middle]!, value, middle)) {
             first = middle;
             first += 1;
             len = len - step - 1;
@@ -204,7 +204,7 @@ export function find_stream_wildcard_mentions(message_content: string): string |
     if (mention === null) {
         return null;
     }
-    return mention[2];
+    return mention[2]!;
 }
 
 export const move_array_elements_to_front = function util_move_array_elements_to_front<T>(

--- a/web/src/vdom.ts
+++ b/web/src/vdom.ts
@@ -38,7 +38,7 @@ export function eq_array<T>(
         return false;
     }
 
-    return a.every((item, i) => eq(item, b[i]));
+    return a.every((item, i) => eq(item, b[i]!));
 }
 
 export function ul<T>(opts: Options<T>): Tag<T> {
@@ -198,7 +198,7 @@ export function update<T>(
     const $child_elems = find().children();
 
     for (const [i, new_node] of new_opts.keyed_nodes.entries()) {
-        const old_node = old_opts.keyed_nodes[i];
+        const old_node = old_opts.keyed_nodes[i]!;
         if (new_node.eq(old_node)) {
             continue;
         }

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -754,7 +754,7 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
         dropped_row_id = config.row;
         upload_files_called = true;
     });
-    $(".message_edit_form form").last = () => ({length: 1});
+    $(".message_edit_form form").last = () => ({length: 1, [0]: "stub"});
     override(rows, "get_message_id", () => 40);
 
     // Edit box which registered the event handler no longer exists.
@@ -776,7 +776,7 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
 
     override(rows, "get_message_id", () => 40);
     // Edit box open
-    $(".message_edit_form form").last = () => ({length: 1});
+    $(".message_edit_form form").last = () => ({length: 1, [0]: "stub"});
     drop_handler(drop_event);
     assert.equal(upload_files_called, true);
     assert.equal(dropped_row_id, 40);


### PR DESCRIPTION
[`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) prevents `undefined` from slipping through the type system via out-of-range `array[index]` and missing `record[key]`. This has caught several type safety issues:

- #30188
- #30189
- #30190
- #30193
- #30205
- #30206
- #30250
- #30251
- #30259

(It also caused me to notice #30191, #30192.)

The last commit adds a bunch of unchecked non-null assertions `!` with no other changes, so it has no runtime effect. I’ve split all other changes by file for easier review and bisection.