### PR TITLE
Add "Alphabetize choices" button for "List of options" type custom profile fields.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -288,13 +288,16 @@ function open_custom_profile_field_form_modal(): void {
 }
 
 function add_choice_row(this: HTMLElement, e: JQuery.TriggeredEvent): void {
-    const $curr_choice_row = $(this).parent();
-    if ($curr_choice_row.next().hasClass("choice-row")) {
+    const $delete_choice_button = $(this).parent().find("button.delete-choice");
+
+    // We use delete button to determine if this was a new empty choice.
+    if ($delete_choice_button.is(":visible")) {
         return;
     }
     // Display delete buttons for all existing choices before creating the new row,
     // which will not have the delete button so that there is at least one option present.
-    $curr_choice_row.find("button.delete-choice").show();
+    $delete_choice_button.show();
+
     assert(e.delegateTarget instanceof HTMLElement);
     const choices_div = e.delegateTarget;
     create_choice_row($(choices_div));

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -504,15 +504,18 @@ function open_edit_form_modal(this: HTMLElement): void {
         // Set initial value in edit form
         $profile_field_form.find("input[name=name]").val(field.name);
         $profile_field_form.find("input[name=hint]").val(field.hint);
+        const $edit_profile_field_choices_container = $profile_field_form.find(
+            ".edit_profile_field_choices_container",
+        );
 
-        $profile_field_form
-            .find(".edit_profile_field_choices_container")
-            .on("input", ".choice-row input", add_choice_row);
-        $profile_field_form
-            .find(".edit_profile_field_choices_container")
-            .on("click", "button.delete-choice", function (this: HTMLElement) {
+        $edit_profile_field_choices_container.on("input", ".choice-row input", add_choice_row);
+        $edit_profile_field_choices_container.on(
+            "click",
+            "button.delete-choice",
+            function (this: HTMLElement) {
                 delete_choice_row_for_edit(this, $profile_field_form, field);
-            });
+            },
+        );
 
         $("#edit-custom-profile-field-form-modal .dialog_submit_button").prop("disabled", true);
         // Setup onInput event listeners to disable/enable submit button,
@@ -726,11 +729,12 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
 
 function set_up_select_field(): void {
     const field_types = realm.custom_profile_field_types;
+    const $profile_field_choices = $("#profile_field_choices");
 
-    create_choice_row($("#profile_field_choices"));
+    create_choice_row($profile_field_choices);
 
     if (current_user.is_admin) {
-        const choice_list = $("#profile_field_choices")[0]!;
+        const choice_list = $profile_field_choices[0]!;
         SortableJS.create(choice_list, {
             onUpdate() {
                 // Do nothing on drag. We process the order on submission
@@ -759,8 +763,8 @@ function set_up_select_field(): void {
         },
     );
 
-    $("#profile_field_choices").on("input", ".choice-row input", add_choice_row);
-    $("#profile_field_choices").on("click", "button.delete-choice", function (this: HTMLElement) {
+    $profile_field_choices.on("input", ".choice-row input", add_choice_row);
+    $profile_field_choices.on("click", "button.delete-choice", function (this: HTMLElement) {
         delete_choice_row(this);
     });
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1733,6 +1733,11 @@ $option_title_width: 180px;
     }
 }
 
+.profile-field-choices-wrapper > .alphabetize-choices-button {
+    display: block;
+    margin: 12px 0 0;
+}
+
 .custom_user_field,
 .bot_owner_user_field {
     .pill-container {

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -26,11 +26,12 @@
             <input type="text" id="profile_field_hint" class="modal_text_input" name="hint" autocomplete="off" maxlength="80" />
             <div class="alert" id="admin-profile-field-hint-status"></div>
         </div>
-        <div class="input-group" id="profile_field_choices_row">
+        <div class="input-group profile-field-choices-wrapper" id="profile_field_choices_row">
             <label for="profile_field_choices" class="modal-field-label">{{t "Field choices" }}</label>
             <table class="profile_field_choices_table">
                 <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
             </table>
+            <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">
             <label for="custom_field_url_pattern" class="modal-field-label">{{t "URL pattern" }}</label>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -9,7 +9,7 @@
         <input type="text" name="hint" id="id-custom-profile-field-hint" class="modal_text_input prop-element" value="{{ hint }}" maxlength="80" data-setting-widget-type="string" />
     </div>
     {{#if is_select_field }}
-    <div class="input-group prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
+    <div class="input-group prop-element profile-field-choices-wrapper" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
         <label for="profile_field_choices_edit" class="modal-field-label">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
             <div class="edit_profile_field_choices_container">
@@ -18,6 +18,7 @@
                 {{/each}}
             </div>
         </div>
+        <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
     </div>
     {{else if is_external_account_field}}
     <div class="prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

**Commit 1** Fixes a bug reported in [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Bad.20state.20when.20editing.20options.20for.20custom.20profile.20field.2E/near/1808130).

**Commit 2** Fixes: #28607 
[CZO #design](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Favorite.20editor/near/1836053)

**Changes from previous PR #28867** 
- We disable the button instead of hiding it, this was decided in [CZO thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Favorite.20editor/near/1721247) linked in the issue.
- I do not fully understand the approach used in that PR and I think it's better to build this feature around `SortableJS.sort()`, so I started from scratch in this PR.

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/8b85ff8a-e35f-47b4-81a9-4d97d1417459) | ![image](https://github.com/zulip/zulip/assets/133781250/3447b98a-2296-47a6-8f9a-9b565558a522) |
| ![image](https://github.com/zulip/zulip/assets/133781250/1bc8b2d6-9e62-4802-b1a5-04ea0a7482b8) | ![image](https://github.com/zulip/zulip/assets/133781250/0ce25d7f-5c05-4f7e-bde8-42bb58cce2d6) | 

| Enabled | Disabled |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/a52522a6-7a5c-44db-a87b-4020a8c29af5) | ![image](https://github.com/zulip/zulip/assets/133781250/2d908231-2f31-44a9-a0be-a1e1bdb4844d) | 
| ![image](https://github.com/zulip/zulip/assets/133781250/e3d0cae6-a4fc-4de4-9707-0ba72557f765) | ![image](https://github.com/zulip/zulip/assets/133781250/37e9bc31-e4cc-4408-8a7c-1623c1243997) |

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
