### PR TITLE
settings: Unite user settings into a single panel.

### DIFF
--- a/help/change-a-users-name.md
+++ b/help/change-a-users-name.md
@@ -24,7 +24,7 @@ Organization administrators can always change any user's name.
 
 {tab|via-organization-settings}
 
-{settings_tab|user-list-admin}
+{settings_tab|users}
 
 1. Find the user you would like to manage. Click the **pencil**
    (<i class="fa fa-pencil"></i>) to the right of their name.

--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -48,7 +48,7 @@ When you deactivate a user:
 
 {tab|via-organization-settings}
 
-{settings_tab|user-list-admin}
+{settings_tab|users}
 
 1. In the **Actions** column, click the **deactivate** (<i class="fa
    fa-user-times"></i>) icon for the user you want to deactivate.

--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -80,7 +80,7 @@ bots will be deactivated until the user manually
 
 {tab|via-organization-settings}
 
-{settings_tab|deactivated-users-admin}
+{settings_tab|deactivated}
 
 1. Click the **Reactivate** button to the right of the user account that you
    want to reactivate.

--- a/help/gdpr-compliance.md
+++ b/help/gdpr-compliance.md
@@ -107,7 +107,7 @@ GDPR:
 
 * A Zulip user can change their profile information, delete their
   messages, uploaded files, etc., directly within the Zulip web app.
-* You can use the [organization users](/#organization/user-list-admin)
+* You can use the [organization users](/#organization/users)
   panel to deactivate users, edit or delete their account details,
   etc.
 * For complying with access requests, you'll want to start with that

--- a/help/include/change-a-users-role.md
+++ b/help/include/change-a-users-role.md
@@ -12,7 +12,7 @@
 
 {tab|via-organization-settings}
 
-{settings_tab|user-list-admin}
+{settings_tab|users}
 
 1. Find the user you would like to manage. Click the **pencil**
    (<i class="fa fa-pencil"></i>) to the right of their name.

--- a/help/include/invite-users.md
+++ b/help/include/invite-users.md
@@ -1,4 +1,6 @@
 1. Click on the **gear** (<i class="zulip-icon zulip-icon-gear"></i>) icon in the upper
    right corner of the web or desktop app.
 
-1. Select <i class="zulip-icon zulip-icon-user-plus"></i> **Invite users**.
+1. Select <i class="fa fa-user"></i> **Users**.
+
+1. Select the **Invitations** tab.

--- a/help/include/view-users-by-role.md
+++ b/help/include/view-users-by-role.md
@@ -1,6 +1,6 @@
 {start_tabs}
 
-{settings_tab|user-list-admin}
+{settings_tab|users}
 
 1. Select the desired role from the dropdown above the **Users** table.
 

--- a/help/invite-new-users.md
+++ b/help/invite-new-users.md
@@ -84,7 +84,7 @@ for invitations for the organization owners role.
 
 {start_tabs}
 
-{settings_tab|invites-list-admin}
+{settings_tab|invitations}
 
 1. From there, you can view pending invitations, **Revoke** email
    invitations and invitation links, or **Resend** email invitations.

--- a/help/manage-a-user.md
+++ b/help/manage-a-user.md
@@ -12,7 +12,7 @@
 
 {tab|via-organization-settings}
 
-{settings_tab|user-list-admin}
+{settings_tab|users}
 
 1. Find the user you would like to manage. Click the **pencil**
    (<i class="fa fa-pencil"></i>) to the right of their name.

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -15,6 +15,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
 
     await page.waitForSelector("#settings_overlay_container.show", {visible: true});
     await page.click("li[data-section='users']");
+    await page.waitForSelector("#admin-user-list.show", {visible: true});
 }
 
 async function user_row(page: Page, name: string): Promise<string> {
@@ -80,7 +81,8 @@ async function test_deactivated_users_section(page: Page): Promise<void> {
 
     // "Deactivated users" section doesn't render just deactivated users until reloaded.
     await page.reload();
-    const deactivated_users_section = "li[data-section='deactivated-users-admin']";
+    await page.waitForSelector("#admin-user-list.show", {visible: true});
+    const deactivated_users_section = ".tab-container .ind-tab[data-tab-key='deactivated']";
     await page.waitForSelector(deactivated_users_section, {visible: true});
     await page.click(deactivated_users_section);
 

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -14,7 +14,7 @@ async function navigate_to_user_list(page: Page): Promise<void> {
     await page.click(organization_settings);
 
     await page.waitForSelector("#settings_overlay_container.show", {visible: true});
-    await page.click("li[data-section='user-list-admin']");
+    await page.click("li[data-section='users']");
 }
 
 async function user_row(page: Page, name: string): Promise<string> {

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -280,6 +280,8 @@ export function launch(section) {
     settings_sections.reset_sections();
 
     settings.open_settings_overlay();
-    settings_panel_menu.org_settings.activate_section_or_default(section);
+    if (section !== "") {
+        settings_panel_menu.org_settings.set_current_tab(section);
+    }
     settings_toggle.highlight_toggle("organization");
 }

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -283,5 +283,5 @@ export function launch(section) {
     if (section !== "") {
         settings_panel_menu.org_settings.set_current_tab(section);
     }
-    settings_toggle.highlight_toggle("organization");
+    settings_toggle.goto("organization");
 }

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -80,11 +80,12 @@ function insert_tip_box() {
         is_admin: current_user.is_admin,
     });
     $(".organization-box")
-        .find(".settings-section")
+        .find(".settings-section, .user-settings-section")
         .not("#emoji-settings")
         .not("#organization-auth-settings")
         .not("#admin-bot-list")
         .not("#admin-invites-list")
+        .not("#admin-user-list")
         .prepend($(tip_box_html));
 }
 
@@ -276,12 +277,15 @@ export function build_page() {
     }
 }
 
-export function launch(section) {
+export function launch(section, user_settings_tab) {
     settings_sections.reset_sections();
 
     settings.open_settings_overlay();
     if (section !== "") {
         settings_panel_menu.org_settings.set_current_tab(section);
+    }
+    if (section === "users") {
+        settings_panel_menu.org_settings.set_user_settings_tab(user_settings_tab);
     }
     settings_toggle.goto("organization");
 }

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -23,6 +23,7 @@ export type Toggle = {
     value: () => string | undefined;
     get: () => JQuery;
     goto: (name: string) => void;
+    register_event_handlers: () => void;
 };
 
 export function toggle(opts: {
@@ -115,10 +116,14 @@ export function toggle(opts: {
         return false;
     }
 
-    meta.$ind_tab.on("click", function () {
-        const idx = Number($(this).attr("data-tab-id"));
-        select_tab(idx);
-    });
+    function register_event_handlers(): void {
+        meta.$ind_tab.off("click");
+        meta.$ind_tab.on("click", function () {
+            const idx = Number($(this).attr("data-tab-id"));
+            select_tab(idx);
+        });
+    }
+    register_event_handlers();
 
     keydown_util.handle({
         $elem: meta.$ind_tab,
@@ -186,6 +191,8 @@ export function toggle(opts: {
                 select_tab(idx);
             }
         },
+
+        register_event_handlers,
     };
 
     return prototype;

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -370,7 +370,7 @@ function do_hashchange_overlay(old_hash) {
         } else {
             settings_panel_menu.org_settings.set_current_tab(section);
         }
-        settings_toggle.highlight_toggle(base);
+        settings_toggle.goto(base);
         return;
     }
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -72,6 +72,24 @@ function is_somebody_else_profile_open() {
     );
 }
 
+function handle_invalid_users_section_url(user_settings_tab) {
+    const valid_user_settings_tab_values = new Set(["active", "deactivated", "invitations"]);
+    if (!valid_user_settings_tab_values.has(user_settings_tab)) {
+        const valid_users_section_url = "#organization/users/active";
+        browser_history.update(valid_users_section_url);
+        return "active";
+    }
+    return user_settings_tab;
+}
+
+function get_user_settings_tab(section) {
+    if (section === "users") {
+        const current_user_settings_tab = hash_parser.get_current_nth_hash_section(2);
+        return handle_invalid_users_section_url(current_user_settings_tab);
+    }
+    return undefined;
+}
+
 export function set_hash_to_home_view(triggered_by_escape_key = false) {
     const current_hash = window.location.hash;
     if (current_hash === "") {
@@ -352,7 +370,10 @@ function do_hashchange_overlay(old_hash) {
                 // hand-typed a hash.
                 blueslip.warn("missing section for organization");
             }
-            settings_panel_menu.org_settings.activate_section_or_default(section);
+            settings_panel_menu.org_settings.activate_section_or_default(
+                section,
+                get_user_settings_tab(section),
+            );
             return;
         }
 
@@ -373,6 +394,7 @@ function do_hashchange_overlay(old_hash) {
             settings_panel_menu.normal_settings.set_current_tab(section);
         } else {
             settings_panel_menu.org_settings.set_current_tab(section);
+            settings_panel_menu.org_settings.set_user_settings_tab(get_user_settings_tab(section));
         }
         settings_toggle.goto(base);
         return;
@@ -440,7 +462,7 @@ function do_hashchange_overlay(old_hash) {
     if (base === "organization") {
         settings.build_page();
         admin.build_page();
-        admin.launch(section);
+        admin.launch(section, get_user_settings_tab(section));
         return;
     }
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -276,6 +276,10 @@ function do_hashchange_overlay(old_hash) {
         // #settings/display-settings is being redirected to #settings/preferences.
         section = "preferences";
     }
+    if (section === "user-list-admin") {
+        // #settings/user-list-admin is being redirected to #settings/users after it was renamed.
+        section = "users";
+    }
     if ((base === "settings" || base === "organization") && !section) {
         let settings_panel_object = settings_panel_menu.normal_settings;
         if (base === "organization") {

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -284,7 +284,7 @@ function do_hashchange_overlay(old_hash) {
         window.history.replaceState(
             null,
             "",
-            browser_history.get_full_url(base + "/" + settings_panel_object.current_tab()),
+            browser_history.get_full_url(base + "/" + settings_panel_object.current_tab),
         );
     }
 
@@ -366,9 +366,9 @@ function do_hashchange_overlay(old_hash) {
         settings_hashes.has(base) && settings_hashes.has(old_base) && overlays.settings_open();
     if (is_hashchange_internal) {
         if (base === "settings") {
-            settings_panel_menu.normal_settings.activate_section_or_default(section);
+            settings_panel_menu.normal_settings.set_current_tab(section);
         } else {
-            settings_panel_menu.org_settings.activate_section_or_default(section);
+            settings_panel_menu.org_settings.set_current_tab(section);
         }
         settings_toggle.highlight_toggle(base);
         return;

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -175,6 +175,10 @@ export function initialize() {
         show_uploaded_files_section: realm.max_file_upload_size_mib > 0,
         show_emoji_settings_lock: !settings_data.user_can_add_custom_emoji(),
         can_create_new_bots: settings_bots.can_create_new_bots(),
+        can_edit_user_panel:
+            current_user.is_admin ||
+            settings_data.user_can_create_multiuse_invite() ||
+            settings_data.user_can_invite_users_by_email(),
     });
     $("#settings_overlay_container").append($(rendered_settings_overlay));
 

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -161,7 +161,9 @@ export function launch(section) {
     settings_sections.reset_sections();
 
     open_settings_overlay();
-    settings_panel_menu.normal_settings.activate_section_or_default(section);
+    if (section !== "") {
+        settings_panel_menu.normal_settings.set_current_tab(section);
+    }
     settings_toggle.highlight_toggle("settings");
 }
 

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -164,7 +164,7 @@ export function launch(section) {
     if (section !== "") {
         settings_panel_menu.normal_settings.set_current_tab(section);
     }
-    settings_toggle.highlight_toggle("settings");
+    settings_toggle.goto("settings");
 }
 
 export function initialize() {

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -8,6 +8,7 @@ import * as keydown_util from "./keydown_util";
 import * as popovers from "./popovers";
 import * as scroll_util from "./scroll_util";
 import * as settings_sections from "./settings_sections";
+import {redraw_active_users_list, redraw_deactivated_users_list} from "./settings_users";
 
 export let normal_settings;
 export let org_settings;
@@ -67,6 +68,11 @@ export class SettingsPanelMenu {
                 browser_history.update(`#organization/users/${key}`);
                 this.set_user_settings_tab(key);
                 $(".user-settings-section").hide();
+                if (key === "active") {
+                    redraw_active_users_list();
+                } else if (key === "deactivated") {
+                    redraw_deactivated_users_list();
+                }
                 $(`[data-user-settings-section="${CSS.escape(key)}"]`).show();
             },
         });

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -2,7 +2,8 @@ import $ from "jquery";
 
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
-import {$t_html} from "./i18n";
+import * as components from "./components";
+import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
 import * as popovers from "./popovers";
 import * as scroll_util from "./scroll_util";
@@ -50,12 +51,30 @@ export class SettingsPanelMenu {
         this.hash_prefix = opts.hash_prefix;
         this.$curr_li = this.$main_elem.children("li").eq(0);
         this.current_tab = this.$curr_li.data("section");
+        this.current_user_settings_tab = "active";
+        this.org_user_settings_toggler = components.toggle({
+            html_class: "org-user-settings-switcher",
+            child_wants_focus: true,
+            values: [
+                {label: $t({defaultMessage: "Users"}), key: "active"},
+                {
+                    label: $t({defaultMessage: "Deactivated users"}),
+                    key: "deactivated",
+                },
+                {label: $t({defaultMessage: "Invitations"}), key: "invitations"},
+            ],
+            callback: (_name, key) => {
+                browser_history.update(`#organization/users/${key}`);
+                this.set_user_settings_tab(key);
+                $(".user-settings-section").hide();
+                $(`[data-user-settings-section="${CSS.escape(key)}"]`).show();
+            },
+        });
 
         this.$main_elem.on("click", "li[data-section]", (e) => {
             const section = $(e.currentTarget).attr("data-section");
 
-            this.activate_section_or_default(section);
-
+            this.activate_section_or_default(section, this.current_user_settings_tab);
             // You generally want to add logic to activate_section,
             // not to this click handler.
 
@@ -66,11 +85,24 @@ export class SettingsPanelMenu {
     show() {
         this.$main_elem.show();
         const section = this.current_tab;
+        const user_settings_tab = this.current_user_settings_tab;
+
         if (two_column_mode()) {
             // In one column mode want to show the settings list, not the first settings section.
-            this.activate_section_or_default(section);
+            this.activate_section_or_default(section, user_settings_tab);
         }
         this.$curr_li.trigger("focus");
+    }
+
+    show_org_user_settings_toggler() {
+        if ($("#admin-user-list").find(".tab-switcher").length === 0) {
+            const toggler_html = this.org_user_settings_toggler.get();
+            $("#admin-user-list .tab-container").html(toggler_html);
+
+            // We need to re-register these handlers since they are
+            // destroyed once the settings modal closes.
+            this.org_user_settings_toggler.register_event_handlers();
+        }
     }
 
     hide() {
@@ -124,7 +156,11 @@ export class SettingsPanelMenu {
         this.current_tab = tab;
     }
 
-    activate_section_or_default(section) {
+    set_user_settings_tab(tab) {
+        this.current_user_settings_tab = tab;
+    }
+
+    activate_section_or_default(section, user_settings_tab) {
         popovers.hide_all();
         if (!section) {
             // No section is given so we display the default.
@@ -153,10 +189,16 @@ export class SettingsPanelMenu {
         this.$curr_li.addClass("active");
         this.set_current_tab(section);
 
-        const settings_section_hash = "#" + this.hash_prefix + section;
+        if (section !== "users") {
+            const settings_section_hash = "#" + this.hash_prefix + section;
 
-        // It could be that the hash has already been set.
-        browser_history.update_hash_internally_if_required(settings_section_hash);
+            // It could be that the hash has already been set.
+            browser_history.update_hash_internally_if_required(settings_section_hash);
+        }
+        if (section === "users" && this.org_user_settings_toggler !== undefined) {
+            this.show_org_user_settings_toggler();
+            this.org_user_settings_toggler.goto(user_settings_tab);
+        }
 
         $(".settings-section").removeClass("show");
 

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -49,6 +49,7 @@ export class SettingsPanelMenu {
         this.$main_elem = opts.$main_elem;
         this.hash_prefix = opts.hash_prefix;
         this.$curr_li = this.$main_elem.children("li").eq(0);
+        this.current_tab = this.$curr_li.data("section");
 
         this.$main_elem.on("click", "li[data-section]", (e) => {
             const section = $(e.currentTarget).attr("data-section");
@@ -64,7 +65,7 @@ export class SettingsPanelMenu {
 
     show() {
         this.$main_elem.show();
-        const section = this.current_tab();
+        const section = this.current_tab;
         if (two_column_mode()) {
             // In one column mode want to show the settings list, not the first settings section.
             this.activate_section_or_default(section);
@@ -74,10 +75,6 @@ export class SettingsPanelMenu {
 
     hide() {
         this.$main_elem.hide();
-    }
-
-    current_tab() {
-        return this.$curr_li.data("section");
     }
 
     li_for_section(section) {
@@ -123,6 +120,10 @@ export class SettingsPanelMenu {
         return true;
     }
 
+    set_current_tab(tab) {
+        this.current_tab = tab;
+    }
+
     activate_section_or_default(section) {
         popovers.hide_all();
         if (!section) {
@@ -130,7 +131,7 @@ export class SettingsPanelMenu {
 
             if (two_column_mode()) {
                 // In two column mode we resume to the last active section.
-                section = this.current_tab();
+                section = this.current_tab;
             } else {
                 // In single column mode we close the active section
                 // so that you always start at the settings list.
@@ -143,13 +144,14 @@ export class SettingsPanelMenu {
         if ($li_for_section.length === 0) {
             // This happens when there is no such section or the user does not have
             // permission to view that section.
-            section = this.current_tab();
+            section = this.current_tab;
         } else {
             this.$curr_li = $li_for_section;
         }
 
         this.$main_elem.children("li").removeClass("active");
         this.$curr_li.addClass("active");
+        this.set_current_tab(section);
 
         const settings_section_hash = "#" + this.hash_prefix + section;
 

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -108,6 +108,7 @@ export class SettingsPanelMenu {
             // We need to re-register these handlers since they are
             // destroyed once the settings modal closes.
             this.org_user_settings_toggler.register_event_handlers();
+            this.set_key_handlers(this.org_user_settings_toggler, $("#admin-user-list"));
         }
     }
 
@@ -120,10 +121,10 @@ export class SettingsPanelMenu {
         return $li;
     }
 
-    set_key_handlers(toggler) {
+    set_key_handlers(toggler, $elem = this.$main_elem) {
         const {vim_left, vim_right, vim_up, vim_down} = keydown_util;
         keydown_util.handle({
-            $elem: this.$main_elem,
+            $elem,
             handlers: {
                 ArrowLeft: toggler.maybe_go_left,
                 ArrowRight: toggler.maybe_go_right,

--- a/web/src/settings_sections.js
+++ b/web/src/settings_sections.js
@@ -35,7 +35,6 @@ export function get_group(section) {
             return "org_bots";
 
         case "users":
-        case "deactivated-users-admin":
             return "org_users";
 
         case "profile":
@@ -70,7 +69,6 @@ export function initialize() {
     load_func_dict.set("default-channels-list", settings_streams.set_up);
     load_func_dict.set("linkifier-settings", settings_linkifiers.set_up);
     load_func_dict.set("playground-settings", settings_playgrounds.set_up);
-    load_func_dict.set("invites-list-admin", settings_invites.set_up);
     load_func_dict.set("profile-field-settings", settings_profile_fields.set_up);
     load_func_dict.set("data-exports-admin", settings_exports.set_up);
     load_func_dict.set(

--- a/web/src/settings_sections.js
+++ b/web/src/settings_sections.js
@@ -34,7 +34,7 @@ export function get_group(section) {
         case "bot-list-admin":
             return "org_bots";
 
-        case "user-list-admin":
+        case "users":
         case "deactivated-users-admin":
             return "org_users";
 

--- a/web/src/settings_toggle.js
+++ b/web/src/settings_toggle.js
@@ -6,7 +6,7 @@ import * as settings_panel_menu from "./settings_panel_menu";
 
 let toggler;
 
-export function highlight_toggle(tab_name) {
+export function goto(tab_name) {
     if (toggler) {
         toggler.goto(tab_name);
     }

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -16,6 +16,7 @@ import * as scroll_util from "./scroll_util";
 import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
+import * as setting_invites from "./settings_invites";
 import {current_user} from "./state_data";
 import * as timerender from "./timerender";
 import * as user_deactivation_ui from "./user_deactivation_ui";
@@ -329,7 +330,7 @@ section.active.create_table = (active_users) => {
             },
             onupdate: reset_scrollbar($users_table),
         },
-        $parent_container: $("#admin-user-list").expectOne(),
+        $parent_container: $("#admin-active-users-list").expectOne(),
         init_sort: "full_name_alphabetic",
         sort_fields: {
             email: user_sort.sort_email,
@@ -338,7 +339,7 @@ section.active.create_table = (active_users) => {
             id: user_sort.sort_user_id,
             ...ListWidget.generic_sort_functions("alphabetic", ["full_name"]),
         },
-        $simplebar_container: $("#admin-user-list .progressive-table-wrapper"),
+        $simplebar_container: $("#admin-active-users-list .progressive-table-wrapper"),
     });
 
     loading.destroy_indicator($("#admin_page_users_loading_indicator"));
@@ -561,6 +562,7 @@ export function set_up_humans() {
     start_data_load();
     section.active.handle_events();
     section.deactivated.handle_events();
+    setting_invites.set_up();
 }
 
 export function set_up_bots() {

--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -176,6 +176,7 @@ export const update_person = function update(person) {
     if (Object.hasOwn(person, "is_active")) {
         if (person.is_active) {
             people.add_active_user(person_obj);
+            settings_users.update_view_on_reactivate(person.user_id);
         } else {
             people.deactivate(person_obj);
             stream_events.remove_deactivated_user_from_all_streams(person.user_id);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -385,7 +385,7 @@ select.settings_select {
     background-size: 14px;
 }
 
-#admin-user-list,
+#admin-active-users-list,
 #admin-bot-list {
     .table tr:first-of-type td {
         border-top: none;
@@ -1567,7 +1567,7 @@ $option_title_width: 180px;
     }
 }
 
-#admin-user-list .last_active {
+#admin-active-users-list .last_active {
     width: 100px;
 }
 
@@ -1997,4 +1997,12 @@ $option_title_width: 180px;
     #stream-not-specified-notice {
         margin-top: -10px;
     }
+}
+
+.tab-switcher.org-user-settings-switcher {
+    margin-bottom: 12px;
+}
+
+#admin-user-list .tab-switcher .ind-tab {
+    width: 110px;
 }

--- a/web/templates/buddy_list/view_all_users.hbs
+++ b/web/templates/buddy_list/view_all_users.hbs
@@ -1,1 +1,1 @@
-<a class="view-all-users-link" href="#organization/user-list-admin">{{t "View all users" }}</a>
+<a class="view-all-users-link" href="#organization/users">{{t "View all users" }}</a>

--- a/web/templates/invitation_failed_error.hbs
+++ b/web/templates/invitation_failed_error.hbs
@@ -16,7 +16,7 @@
     <p id="invitation_admin_message">
         {{#tr}}
             You can reactivate deactivated users from <z-link>organization settings</z-link>.
-            {{#*inline "z-link"}}<a href="#organization/deactivated-users-admin">{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-link"}}<a href="#organization/deactivated">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </p>
     {{else}}

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -1,0 +1,28 @@
+<div id="admin-active-users-list" class="user-settings-section" data-user-settings-section="active">
+
+    <div class="settings_panel_list_header">
+        <h3>{{t "Users"}}</h3>
+        <div class="alert-notification" id="user-field-status"></div>
+        <div class="user_filters">
+            {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+        </div>
+    </div>
+
+    <div class="progressive-table-wrapper" data-simplebar>
+        <table class="table table-striped wrapped-table">
+            <thead class="table-sticky-headers">
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                <th data-sort="email">{{t "Email" }}</th>
+                <th class="user_role" data-sort="role">{{t "Role" }}</th>
+                <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
+                {{#if is_admin}}
+                <th class="actions">{{t "Actions" }}</th>
+                {{/if}}
+            </thead>
+            <tbody id="admin_users_table" class="admin_user_table"
+              data-empty="{{t 'No users match your filters.' }}"></tbody>
+        </table>
+    </div>
+    <div id="admin_page_users_loading_indicator"></div>
+</div>

--- a/web/templates/settings/admin_tab.hbs
+++ b/web/templates/settings/admin_tab.hbs
@@ -15,8 +15,6 @@
 
 {{> user_list_admin }}
 
-{{> deactivated_users_admin }}
-
 {{> bot_list_admin }}
 
 {{> default_streams_list_admin }}
@@ -26,8 +24,6 @@
 {{> linkifier_settings_admin }}
 
 {{> playground_settings_admin }}
-
-{{> invites_list_admin }}
 
 {{> profile_field_settings_admin }}
 

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -1,4 +1,4 @@
-<div id="admin-deactivated-users-list" class="settings-section" data-name="deactivated-users-admin">
+<div id="admin-deactivated-users-list" class="user-settings-section" data-user-settings-section="deactivated">
     <div class="clear-float"></div>
 
     <div class="settings_panel_list_header">

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -6,9 +6,9 @@
     <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t "Invite users to organization" }}</a>
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Invites"}}</h3>
+        <h3>{{t "Invitations "}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invitations' }}" aria-label="{{t 'Filter invitations' }}"/>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
@@ -23,7 +23,7 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'There are no invites.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'There are no invitations.' }}" data-search-results-empty="{{t 'No invitations match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -1,4 +1,4 @@
-<div id="admin-invites-list" class="settings-section" data-name="invites-list-admin">
+<div id="admin-invites-list" class="user-settings-section" data-user-settings-section="invitations">
     <div class="tip invite-user-settings-tip"></div>
     {{#unless is_admin }}
     <div class="tip">{{t "You can only view or manage invitations that you sent." }}</div>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -1,30 +1,11 @@
 <div id="admin-user-list" class="settings-section" data-name="users">
 
-    <div class="clear-float"></div>
+    <div class="tab-container"></div>
 
-    <div class="settings_panel_list_header">
-        <h3>{{t "Users"}}</h3>
-        <div class="alert-notification" id="user-field-status"></div>
-        <div class="user_filters">
-            {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
-        </div>
-    </div>
+    {{>active_user_list_admin}}
 
-    <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-striped wrapped-table">
-            <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
-                <th class="user_role" data-sort="role">{{t "Role" }}</th>
-                <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
-                {{#if is_admin}}
-                <th class="actions">{{t "Actions" }}</th>
-                {{/if}}
-            </thead>
-            <tbody id="admin_users_table" class="admin_user_table"
-              data-empty="{{t 'No users match your filters.' }}"></tbody>
-        </table>
-    </div>
-    <div id="admin_page_users_loading_indicator"></div>
+    {{>deactivated_users_admin}}
+
+    {{>invites_list_admin}}
+
 </div>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -1,4 +1,4 @@
-<div id="admin-user-list" class="settings-section" data-name="user-list-admin">
+<div id="admin-user-list" class="settings-section" data-name="users">
 
     <div class="clear-float"></div>
 

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -86,7 +86,7 @@
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{#unless is_guest}}
-                    <li tabindex="0" data-section="user-list-admin">
+                    <li tabindex="0" data-section="users">
                         <i class="icon fa fa-user" aria-hidden="true"></i>
                         <div class="text">{{t "Users" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -89,14 +89,7 @@
                     <li tabindex="0" data-section="users">
                         <i class="icon fa fa-user" aria-hidden="true"></i>
                         <div class="text">{{t "Users" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#unless is_guest}}
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="deactivated-users-admin">
-                        <i class="icon fa fa-user-times" aria-hidden="true"></i>
-                        <div class="text">{{t "Deactivated users" }}</div>
-                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{/unless}}
                     {{#unless is_guest}}
@@ -104,12 +97,6 @@
                         <i class="icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_create_new_bots}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
-                    </li>
-                    {{/unless}}
-                    {{#unless is_guest}}
-                    <li tabindex="0" data-section="invites-list-admin">
-                        <i class="icon fa fa-user-plus" aria-hidden="true"></i>
-                        <div class="text">{{t "Invitations" }}</div>
                     </li>
                     {{/unless}}
                     {{#if is_admin}}

--- a/web/tests/components.test.js
+++ b/web/tests/components.test.js
@@ -73,6 +73,12 @@ const ind_tab = (function () {
         }
     };
 
+    $self.off = (name) => {
+        if (name === "click") {
+            env.click_f = undefined;
+        }
+    };
+
     $self.removeClass = (c) => {
         for (const $tab of env.tabs) {
             $tab.removeClass(c);

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -358,7 +358,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [settings, "launch"],
     ]);
 
-    window.location.hash = "#organization/users";
+    window.location.hash = "#organization/users/active";
 
     helper.clear_events();
     $window_stub.trigger("hashchange");
@@ -366,7 +366,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [overlays, "close_for_hash_change"],
         [settings, "build_page"],
         [admin, "build_page"],
-        [admin, "launch", ["users"]],
+        [admin, "launch", ["users", "active"]],
     ]);
 
     window.location.hash = "#organization/user-list-admin";
@@ -381,7 +381,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [overlays, "close_for_hash_change"],
         [settings, "build_page"],
         [admin, "build_page"],
-        [admin, "launch", ["users"]],
+        [admin, "launch", ["users", "active"]],
     ]);
 
     helper.clear_events();

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -358,7 +358,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [settings, "launch"],
     ]);
 
-    window.location.hash = "#organization/user-list-admin";
+    window.location.hash = "#organization/users";
 
     helper.clear_events();
     $window_stub.trigger("hashchange");
@@ -366,7 +366,22 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [overlays, "close_for_hash_change"],
         [settings, "build_page"],
         [admin, "build_page"],
-        [admin, "launch", ["user-list-admin"]],
+        [admin, "launch", ["users"]],
+    ]);
+
+    window.location.hash = "#organization/user-list-admin";
+
+    // Check whether `user-list-admin` is redirect to `users`, we
+    // cannot test the exact hashchange here, since the section url
+    // takes effect in `admin.launch` and that's why we're checking
+    // the arguments passed to `admin.launch`.
+    helper.clear_events();
+    $window_stub.trigger("hashchange");
+    helper.assert_events([
+        [overlays, "close_for_hash_change"],
+        [settings, "build_page"],
+        [admin, "build_page"],
+        [admin, "launch", ["users"]],
     ]);
 
     helper.clear_events();

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -169,7 +169,13 @@ function test_helper({override, override_rewire, change_tab}) {
         };
     }
 
-    stub(admin, "launch");
+    function stub_with_args(module, func_name) {
+        module[func_name] = (...args) => {
+            events.push([module, func_name, args]);
+        };
+    }
+
+    stub_with_args(admin, "launch");
     stub(admin, "build_page");
     stub(drafts_overlay_ui, "launch");
     stub(message_viewport, "stop_auto_scrolling");
@@ -360,7 +366,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [overlays, "close_for_hash_change"],
         [settings, "build_page"],
         [admin, "build_page"],
-        [admin, "launch"],
+        [admin, "launch", ["user-list-admin"]],
     ]);
 
     helper.clear_events();

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -19,6 +19,7 @@ const settings_account = mock_esm("../src/settings_account", {
 const settings_users = mock_esm("../src/settings_users", {
     update_user_data() {},
     update_view_on_deactivate() {},
+    update_view_on_reactivate() {},
 });
 mock_esm("../src/user_profile", {
     update_profile_modal_ui() {},

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -58,11 +58,15 @@ link_mapping = {
         "Authentication methods",
         "/#organization/auth-methods",
     ],
-    "users": ["Organization settings", "Users", "/#organization/users"],
-    "deactivated-users-admin": [
+    "users": [
+        "Organization settings",
+        "Users",
+        "/#organization/users/active",
+    ],
+    "deactivated": [
         "Organization settings",
         "Deactivated users",
-        "/#organization/deactivated-users-admin",
+        "/#organization/users/deactivated",
     ],
     "bot-list-admin": [
         "Organization settings",
@@ -89,10 +93,10 @@ link_mapping = {
         "Custom profile fields",
         "/#organization/profile-field-settings",
     ],
-    "invites-list-admin": [
+    "invitations": [
         "Organization settings",
         "Invitations",
-        "/#organization/invites-list-admin",
+        "/#organization/users/invitations",
     ],
     "data-exports-admin": [
         "Organization settings",

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -58,7 +58,7 @@ link_mapping = {
         "Authentication methods",
         "/#organization/auth-methods",
     ],
-    "user-list-admin": ["Organization settings", "Users", "/#organization/user-list-admin"],
+    "users": ["Organization settings", "Users", "/#organization/users"],
     "deactivated-users-admin": [
         "Organization settings",
         "Deactivated users",


### PR DESCRIPTION
Previously, there were three different sections for managing active users, deactivated users and invitations.

Fixes: #26949.

This PR builds upon #28359 and has @shashank-23002 as its co-author. Compared to the original PR, there is a bit of reorganisation of where each piece of code lives. I've also taken the liberty to not use the term `right_section` from the original PR since it was getting me confused with other `right_` components. I've renamed it to `user_settings_tab`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1298" alt="Screenshot 2024-05-31 at 12 53 10 PM" src="https://github.com/zulip/zulip/assets/13910561/49c90f03-a787-44c3-ac54-25d5805485ae">
<img width="1298" alt="Screenshot 2024-05-31 at 12 53 04 PM" src="https://github.com/zulip/zulip/assets/13910561/b54d7bfc-267a-4a16-bf9b-d4aa146456ca">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
