### PR TITLE
emoji_popover: Fix white arrow color in dark theme.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -498,6 +498,8 @@
     --color-background-emoji-picker-emoji-reacted: hsl(195deg 50% 95%);
     --color-border-emoji-picker-emoji-reacted: hsl(195deg 52% 79%);
     --color-background-emoji-picker-emoji-reacted-focus: hsl(195deg 55% 88%);
+    /* Same color as background color of header / footer */
+    --color-border-emoji-picker-tippy-arrow: hsl(0deg 0% 93%);
 }
 
 %dark-theme {
@@ -800,6 +802,8 @@
     --color-border-emoji-picker-emoji-reacted: hsl(0deg 0% 0% / 90%);
     --color-background-emoji-picker-emoji-reacted-focus: hsl(0deg 0% 20% / 70%);
     --color-border-add-subscription-button-focus: hsl(0deg 0% 67%);
+    /* Same color as background color of header / footer */
+    --color-border-emoji-picker-tippy-arrow: hsl(211.58deg 33.33% 11.18%);
 }
 
 @media screen {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -873,11 +873,15 @@ ul {
     /* The emoji popover has a different background color for the
        header and footer, so we customize the arrow to match this color. */
     .tippy-box[data-placement="top"] .tippy-arrow::before {
-        border-top-color: hsl(0deg 0% 93%);
+        border-top-color: var(--color-border-emoji-picker-tippy-arrow);
     }
 
     .tippy-box[data-placement="bottom"] .tippy-arrow::before {
-        border-bottom-color: hsl(0deg 0% 93%);
+        border-bottom-color: var(--color-border-emoji-picker-tippy-arrow);
+    }
+
+    .tippy-box[data-placement="left"] .tippy-arrow::before {
+        border-left-color: var(--color-border-emoji-picker-tippy-arrow);
     }
 }
 


### PR DESCRIPTION
Tested left, top and bottom placement of emoji popover to check if arrow color is correctly displayed in both dark and light theme.

| before | after |
| --- | --- |
| <img width="456" alt="Screenshot 2024-05-31 at 1 02 59 PM" src="https://github.com/zulip/zulip/assets/25124304/34693d45-becd-4e21-a29f-777cbd75f91f"> | <img width="456" alt="Screenshot 2024-05-31 at 1 02 26 PM" src="https://github.com/zulip/zulip/assets/25124304/e0142de9-a546-4443-aa1b-f12ac4aadbd0"> |
