### PR TITLE
popovers: Fix selected message being changed on scroll inside popover.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -222,6 +222,7 @@ export function initialize_kitchen_sink_stuff() {
     message_viewport.$scroll_container.on("wheel", (e) => {
         const delta = e.originalEvent.deltaY;
         if (
+            !popovers.any_active() &&
             !overlays.any_active() &&
             !modals.any_active() &&
             narrow_state.is_message_feed_visible()


### PR DESCRIPTION
Since scroll event is always fired at root level, we don't have control over capturing the event and containing it to the popover if scroll happened inside the popover.

This can lead to unintentional moving of selected message since we try to move the selected message to rendered top / bottom if we receive a scroll event when top / bottom ends are rendered.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/scrolling.20emoji.20picker.2C.20changes.20focused.20message

I tested by narrowing to a topic with 2 messages and opening emoji popover. We correctly don't move the selected message.

When the end of the message list is rendered and last message is not selected; if you open emoji popover and scroll, we don't move the selected message now, I don't see this as a regression but not sure we can do better.