### PR TITLE
left_sidebar: Normalize row sizes based on line-height.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -72,6 +72,9 @@
         var(--markdown-interelement-space-px) * 2
     );
 
+    /* Legacy values */
+    --legacy-body-line-height-unitless: calc(20 / 14);
+
     .more-dense-mode {
         /* The legacy values here are not altered by JavaScript */
         --base-font-size-px: 14px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -58,6 +58,13 @@
     --right-sidebar-width: 250px;
     --left-sidebar-header-icon-width: 15px;
 
+    /* We base sidebar row heights on their line heights.
+       Prominent rows include things like headers (e.g., VIEWS)
+       as well as navigation items. Everything else takes
+       the smaller line-height. */
+    --line-height-sidebar-row-prominent: 1.7142em; /* 24px / 14px em */
+    --line-height-sidebar-row: 1.5714em; /* 22px / 14px em */
+
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;
     --message-actions-popover-min-width: 230px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -108,7 +108,7 @@ li.show-more-topics {
             margin-left: 0;
 
             &.topic-list li {
-                padding: 2px 0;
+                padding: 0;
 
                 &.filter-topics {
                     padding-bottom: 0;
@@ -900,8 +900,6 @@ li.top_left_scheduled_messages {
 
 .topic-box,
 .searching-for-more-topics {
-    /* Padding from original .topic-box definition. */
-    padding-top: 1px;
     grid-template-columns:
         25px $topic_resolve_width minmax(0, 1fr) minmax(0, max-content)
         30px 0;
@@ -914,11 +912,7 @@ li.top_left_scheduled_messages {
 .sidebar-topic-name {
     cursor: pointer;
     grid-area: row-content;
-    padding: 1px $before_unread_count_padding 1px 0;
-
-    /* TODO: We should figure out how to remove this without changing the spacing */
-    line-height: 1.1;
-
+    padding: 0 $before_unread_count_padding 0 0;
     /* TODO: Consolidate these styles with conversation partners and stream name
         once grid rewrite is complete on all sidebar rows.
 
@@ -942,7 +936,6 @@ li.top_left_scheduled_messages {
 .sidebar-topic-check {
     grid-area: starting-anchor-element;
     font-size: 15px;
-    height: 20px;
 }
 
 .stream-markers-and-controls,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -264,6 +264,7 @@ li.show-more-topics {
         font-weight: 400;
         margin-left: 0;
         margin-bottom: 0;
+        line-height: var(--line-height-sidebar-row);
 
         & span.fa-group {
             font-size: 90%;
@@ -701,10 +702,6 @@ li.top_left_scheduled_messages {
 
 .conversation-partners {
     grid-area: row-content;
-    /* Set an 18px line-height to better vertically
-       center user circles and icons (both of which
-       have even heights). */
-    line-height: 18px;
     overflow: hidden;
     text-overflow: ellipsis;
     /* Use an inline grid to provide a modern layout
@@ -1086,8 +1083,6 @@ li.topic-list-item {
 
 .dm-box {
     grid-template-columns: 7px 22px minmax(0, 1fr) minmax(0, max-content) 30px 0;
-    /* This padding maintains a 22px height on DM rows. */
-    padding: 2px 0;
 
     .conversation-partners-icon {
         grid-area: starting-anchor-element;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -409,6 +409,7 @@ ul.filters {
     list-style-type: none;
     margin-left: 0;
     color: hsl(0deg 0% 20% / 100%);
+    line-height: var(--line-height-sidebar-row);
 
     & a {
         color: inherit;
@@ -975,7 +976,7 @@ li.top_left_scheduled_messages {
     overflow-x: hidden;
     overflow-x: clip;
     text-overflow: ellipsis;
-    padding: 1px $before_unread_count_padding 1px 0;
+    padding: 0 $before_unread_count_padding 0 0;
 }
 
 .conversation-partners-list {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -221,7 +221,7 @@ li.show-more-topics {
 
     #private_messages_section_header {
         grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
-        grid-template-rows: 24px;
+        grid-template-rows: var(--line-height-sidebar-row-prominent);
         /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
            value and the styles dependent on it so that this kind of
            1990s layout shenanigans is made unnecessary. */
@@ -787,8 +787,7 @@ li.top_left_scheduled_messages {
     grid-template-columns:
         0 15px minmax(0, 0.5fr) minmax(0, 1fr)
         30px 12px;
-    /* Base height on 24px icon-target area from Vlad's design. */
-    grid-template-rows: 24px;
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
     /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
        value and the styles dependent on it so that this kind of
        1990s layout shenanigans is made unnecessary. */
@@ -1161,7 +1160,7 @@ li.topic-list-item {
     top: 0;
     z-index: 2;
     grid-template-columns: 0 0 minmax(0, 1fr) max-content 0 42px;
-    grid-template-rows: 24px;
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
     padding-top: $sections_vertical_gutter;
     color: hsl(0deg 0% 43%);
     background-color: var(--color-background);
@@ -1188,7 +1187,7 @@ li.topic-list-item {
 #streams_header {
     grid-template-columns: 0 0 minmax(0, 1fr) minmax(17px, max-content) 30px 12px;
     /* Keep the stream-search area rows collapsed. */
-    grid-template-rows: 24px 0 0;
+    grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
     padding: $sections_vertical_gutter 0 3px calc($far_left_gutter_size + 2px);
     position: sticky;
@@ -1203,7 +1202,7 @@ li.topic-list-item {
         /* Open up the stream-search rows. The 10px
            row maintains space with the streams list
            below. */
-        grid-template-rows: 24px 28px 10px;
+        grid-template-rows: var(--line-height-sidebar-row-prominent) 28px 10px;
     }
 
     .left-sidebar-title {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -605,6 +605,7 @@ li.active-sub-filter {
        named grid area. */
     display: grid;
     grid-template-areas: "selected-home-view";
+    line-height: var(--line-height-sidebar-row-prominent);
 
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {
@@ -679,20 +680,6 @@ li.top_left_scheduled_messages {
        children. Same template areas, different
        column widths. */
     grid-template-columns: 0 22px minmax(0, 1fr) max-content 0 0;
-    /* This is a legacy value, from a former
-       1px of top padding on top_left_row plus
-       an inner 1px top margin on `<a>` elements.
-
-       These are added here, rather than on the label
-       container, to keep all hovered/highlighted areas
-       clickable.
-
-       This complicates true centering within a
-       row highlight. It might be better to make
-       these both 2px.
-    */
-    padding-top: 2px;
-    padding-bottom: 1px;
 
     .filter-icon {
         grid-area: starting-anchor-element;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1317,6 +1317,8 @@ li.topic-list-item {
 .streams_subheader {
     font-size: 0.8em;
     font-weight: normal;
+    /* 16px line-height at 0.8em (11.2px at 14px legacy em) */
+    line-height: 1.4286em;
     padding-left: $far_left_gutter_size;
     cursor: pointer;
     text-align: center;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -24,7 +24,13 @@ body {
     margin: 0;
     padding: 0;
     font-size: 14px;
-    line-height: calc(20 / 14);
+    /* The line-height used in most of the UI should be at least
+       its legacy value, but should expand with larger base
+       line-height values. */
+    line-height: max(
+        var(--legacy-body-line-height-unitless),
+        var(--base-line-height-unitless)
+    );
     font-family: "Source Sans 3 VF", sans-serif;
     color: var(--color-text-default);
     background-color: var(--color-background);


### PR DESCRIPTION
This PR accomplishes two primary goals:

1. It eliminates the use of small bits of padding and fiddly line-height adjustments to make left sidebar rows sized wholly based on their line-height, which will play extremely well with adjustable information density in ways that 1- or 2-pixel offsets would make a massive headache.
2. It consolidates the previous rather random-looking collection of row heights in the left sidebar into just two: 24px and 22px (which are here expressed in their `em` equivalents, thus preparing the left sidebar for adjustable information density).

A secondary goal of this PR is to make sure that there is 1:1 parity between the vertical areas of a row that show a highlight, and vertical areas that are clickable. There are no longer "dead zones" that show the hover effect but are not actually clickable. Additionally, there is [no longer any dead space](https://chat.zulip.org/#narrow/stream/101-design/topic/clickable.20filter.20areas/near/1666109) between row items.

Two preparatory commits here are useful for the overall information density project (and will be applied to parallel work on the right sidebar that is ongoing):

The first prep commit makes a variable out of the line-height previously set on `body` (which currently differs from the database-stored value targeted to the message area), and sets that value as the _minimum_ line-height for the UI. As line-heights expand, the sidebar rows can, under this logic, expand along with them.

The second prep commit expresses the line-height of sidebar rows as `em` values, based on the legacy 14px em. That is essential to the goals of this PR, which again is to have line-heights responsible for the height of sidebar rows. Tying that height to line-height is a necessary pre-condition to extending information density to the sidebars.

CZO discussion (TBD)

**Screenshots and screen captures:**

_Note in the After screenshot the pleasing uniformity of space between unread counts up and down the entire left sidebar, including especially in the expanded topic area._

| Before | After |
| --- | --- |
| ![left-sidebar-rows-before](https://github.com/zulip/zulip/assets/170719/3e42729e-8996-4ba8-bdf3-1b885a67b6cf) | ![left-sidebar-rows-after](https://github.com/zulip/zulip/assets/170719/3b769170-c097-4f5c-be1e-d85340e07ab8) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>