### PR TITLE
ui_init: Don't store onboarding_steps state_data as current_user_param.

### DIFF
--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -1,7 +1,21 @@
+import {z} from "zod";
+
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
-import {current_user} from "./state_data";
-import type {OnboardingStep} from "./state_data";
+
+const one_time_notice_schema = z.object({
+    name: z.string(),
+    type: z.literal("one_time_notice"),
+});
+
+/* We may introduce onboarding step of types other than 'one time notice'
+in future. Earlier, we had 'hotspot' and 'one time notice' as the two
+types. We can simply do:
+const onboarding_step_schema = z.union([one_time_notice_schema, other_type_schema]);
+to avoid major refactoring when new type is introduced in the future. */
+const onboarding_step_schema = one_time_notice_schema;
+
+export type OnboardingStep = z.output<typeof onboarding_step_schema>;
 
 export const ONE_TIME_NOTICES_TO_DISPLAY = new Set<string>();
 
@@ -31,6 +45,6 @@ export function update_onboarding_steps_to_display(onboarding_steps: OnboardingS
     }
 }
 
-export function initialize(): void {
-    update_onboarding_steps_to_display(current_user.onboarding_steps);
+export function initialize(params: {onboarding_steps: OnboardingStep[]}): void {
+    update_onboarding_steps_to_display(params.onboarding_steps);
 }

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -21,7 +21,7 @@ export function post_onboarding_step_as_read(onboarding_step_name: string): void
     });
 }
 
-export function update_notice_to_display(onboarding_steps: OnboardingStep[]): void {
+export function update_onboarding_steps_to_display(onboarding_steps: OnboardingStep[]): void {
     ONE_TIME_NOTICES_TO_DISPLAY.clear();
 
     for (const onboarding_step of onboarding_steps) {
@@ -32,5 +32,5 @@ export function update_notice_to_display(onboarding_steps: OnboardingStep[]): vo
 }
 
 export function initialize(): void {
-    update_notice_to_display(current_user.onboarding_steps);
+    update_onboarding_steps_to_display(current_user.onboarding_steps);
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -146,7 +146,7 @@ export function dispatch_normal_event(event) {
             break;
 
         case "onboarding_steps":
-            onboarding_steps.update_notice_to_display(event.onboarding_steps);
+            onboarding_steps.update_onboarding_steps_to_display(event.onboarding_steps);
             current_user.onboarding_steps = current_user.onboarding_steps
                 ? [...current_user.onboarding_steps, ...event.onboarding_steps]
                 : event.onboarding_steps;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -147,9 +147,6 @@ export function dispatch_normal_event(event) {
 
         case "onboarding_steps":
             onboarding_steps.update_onboarding_steps_to_display(event.onboarding_steps);
-            current_user.onboarding_steps = current_user.onboarding_steps
-                ? [...current_user.onboarding_steps, ...event.onboarding_steps]
-                : event.onboarding_steps;
             break;
 
         case "invites_changed":

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -21,20 +21,6 @@ export const narrow_term_schema = z.object({
 export type NarrowTerm = z.output<typeof narrow_term_schema>;
 // Sync this with zerver.lib.events.do_events_register.
 
-const one_time_notice_schema = z.object({
-    name: z.string(),
-    type: z.literal("one_time_notice"),
-});
-
-/* We may introduce onboarding step of types other than 'one time notice'
-in future. Earlier, we had 'hotspot' and 'one time notice' as the two
-types. We can simply do:
-const onboarding_step_schema = z.union([one_time_notice_schema, other_type_schema]);
-to avoid major refactoring when new type is introduced in the future. */
-const onboarding_step_schema = one_time_notice_schema;
-
-export type OnboardingStep = z.output<typeof onboarding_step_schema>;
-
 export const custom_profile_field_schema = z.object({
     display_in_profile_summary: z.optional(z.boolean()),
     field_data: z.string(),
@@ -57,7 +43,6 @@ export const current_user_schema = z.object({
     is_guest: z.boolean(),
     is_moderator: z.boolean(),
     is_owner: z.boolean(),
-    onboarding_steps: z.array(onboarding_step_schema),
     user_id: z.number(),
 });
 // Sync this with zerver.lib.events.do_events_register.

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -510,6 +510,8 @@ export function initialize_everything(state_data) {
     );
     const local_message_params = pop_fields("max_message_id");
 
+    const onboarding_steps_params = pop_fields("onboarding_steps");
+
     const current_user_params = pop_fields(
         "avatar_source",
         "avatar_url",
@@ -529,7 +531,6 @@ export function initialize_everything(state_data) {
         "is_guest",
         "is_moderator",
         "is_owner",
-        "onboarding_steps",
         "user_id",
     );
 
@@ -880,7 +881,7 @@ export function initialize_everything(state_data) {
     });
     drafts.initialize_ui();
     drafts_overlay_ui.initialize();
-    onboarding_steps.initialize();
+    onboarding_steps.initialize(onboarding_steps_params);
     typing.initialize();
     starred_messages_ui.initialize();
     user_status_ui.initialize();

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -126,6 +126,7 @@ const emoji = zrequire("emoji");
 const message_store = zrequire("message_store");
 const people = zrequire("people");
 const user_status = zrequire("user_status");
+const onboarding_steps = zrequire("onboarding_steps");
 
 const server_events_dispatch = zrequire("server_events_dispatch");
 
@@ -321,10 +322,14 @@ run_test("default_streams", ({override}) => {
 });
 
 run_test("onboarding_steps", () => {
-    current_user.onboarding_steps = [];
+    onboarding_steps.initialize({onboarding_steps: []});
     const event = event_fixtures.onboarding_steps;
+    const one_time_notices = new Set();
+    for (const onboarding_step of event.onboarding_steps) {
+        one_time_notices.add(onboarding_step.name);
+    }
     dispatch(event);
-    assert_same(current_user.onboarding_steps, event.onboarding_steps);
+    assert_same(onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY, one_time_notices);
 });
 
 run_test("invites_changed", ({override}) => {


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/.60onboarding_steps.60.20-.20.60state_data.60.20field/near/1810939)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
