### PR TITLE
left_sidebar: Adjust navbar, topic row-heights.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -409,6 +409,7 @@ ul.filters {
     list-style-type: none;
     margin-left: 0;
     color: hsl(0deg 0% 20% / 100%);
+    /* Streams take a standard row height. */
     line-height: var(--line-height-sidebar-row);
 
     & a {
@@ -1066,6 +1067,7 @@ li.top_left_scheduled_messages {
 }
 
 ul.topic-list {
+    line-height: var(--line-height-sidebar-row-prominent);
     list-style-type: none;
     font-weight: normal;
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -608,7 +608,7 @@ li.active-sub-filter {
        named grid area. */
     display: grid;
     grid-template-areas: "selected-home-view";
-    line-height: var(--line-height-sidebar-row-prominent);
+    line-height: var(--line-height-sidebar-row);
 
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {


### PR DESCRIPTION
This PR condenses the height of the navigation rows, and expands the height of topic rows.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/consolidating.20heights.20of.20left-sidebar.20rows/near/1811602)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![left-sidebar-row-adjustments-before](https://github.com/zulip/zulip/assets/170719/00e97e90-58d2-41cd-96f9-737ff4e9edd7) | ![left-sidebar-row-adjustments-after](https://github.com/zulip/zulip/assets/170719/2c066e8f-68b2-416e-9617-79d5293f87b5) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>