### PR TITLE
echo: Use newly created MessageWithBooleans in insert_local_message

### DIFF
--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -194,12 +194,12 @@ export function insert_local_message(message_request, local_id_float, insert_new
         message.topic_links = markdown.get_topic_links(message.topic);
     }
 
-    waiting_for_id.set(message.local_id, message);
-    waiting_for_ack.set(message.local_id, message);
-
     message.display_recipient = build_display_recipient(message);
 
-    insert_new_messages([message], true);
+    [message] = insert_new_messages([message], true);
+
+    waiting_for_id.set(message.local_id, message);
+    waiting_for_ack.set(message.local_id, message);
 
     return message;
 }

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -166,6 +166,8 @@ export function insert_new_messages(messages, sent_by_this_client) {
     message_notifications.received_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
+
+    return messages;
 }
 
 export function update_messages(events) {

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -254,9 +254,10 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
         override_rewire(echo, "try_deliver_locally", (message_request) => {
             const local_id_float = 123.04;
-            return echo.insert_local_message(message_request, local_id_float, (messages) =>
-                assert.equal(messages[0].timestamp, fake_now),
-            );
+            return echo.insert_local_message(message_request, local_id_float, (messages) => {
+                assert.equal(messages[0].timestamp, fake_now);
+                return messages;
+            });
         });
 
         override(transmit, "send_message", (payload, success) => {

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -240,6 +240,7 @@ run_test("insert_local_message streams", ({override}) => {
         assert.equal(message.sender_full_name, "Iago");
         assert.equal(message.sender_id, 123);
         insert_message_called = true;
+        return [message];
     };
 
     const message_request = {
@@ -280,6 +281,7 @@ run_test("insert_local_message direct message", ({override}) => {
     const insert_new_messages = ([message]) => {
         assert.equal(message.display_recipient.length, 3);
         insert_message_called = true;
+        return [message];
     };
 
     override(markdown, "render", () => {
@@ -311,7 +313,7 @@ run_test("test reify_message_id", ({override}) => {
         sender_id: 123,
         draft_id: 100,
     };
-    echo.insert_local_message(message_request, local_id_float, noop);
+    echo.insert_local_message(message_request, local_id_float, (messages) => messages);
 
     let message_store_reify_called = false;
     let notifications_reify_called = false;

--- a/web/tests/server_events.test.js
+++ b/web/tests/server_events.test.js
@@ -66,6 +66,7 @@ run_test("message_event", ({override}) => {
     override(message_events, "insert_new_messages", (messages) => {
         assert.equal(messages[0].content, event.message.content);
         inserted = true;
+        return messages;
     });
 
     server_events._get_events_success([event]);


### PR DESCRIPTION
Commit 50f5cf9ad818b2dfc8dc34f47d7d286a96250c37 (#30227) changed `message_helper.process_new_message` (called by
`message_events.insert_new_messages`) to return a newly created message object rather than mutating the object it was passed. So `echo.insert_local_message` needs to use this new object, fixing a regression where we’d fail to replace a locally echoed message when the server-rendered message came in.

[Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/bug.20.20in.20rendering.20code.20blocks/near/1811900).