### PR TITLE
right_sidebar: Rewrite users rows with CSS grid.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -351,6 +351,8 @@
         --color-left-sidebar-navigation-icon
     );
     --color-tab-picker-icon: hsl(200deg 100% 40%);
+    --color-user-circle-active: hsl(106deg 74% 44%);
+    --color-user-circle-idle: hsl(29deg 84% 51%);
 
     /* Reaction container colors */
     --color-message-reaction-border: hsl(0deg 0% 0% / 10%);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -60,6 +60,7 @@ $user_status_emoji_width: 24px;
     margin-bottom: 0;
     overflow-x: hidden;
     list-style-position: inside; /* Draw the bullets inside our box */
+    line-height: var(--line-height-sidebar-row);
 
     & li {
         overflow: hidden;
@@ -67,16 +68,10 @@ $user_status_emoji_width: 24px;
         text-overflow: ellipsis;
         list-style-type: none;
         border-radius: 4px;
-        padding-top: 1px;
-        padding-bottom: 2px;
+        padding: 0;
 
         .user-list-sidebar-menu-icon {
-            position: absolute;
-            top: 1px;
-            right: 0;
-            font-size: 1em;
             display: none;
-            text-align: center;
             padding: 0 6px;
 
             & i {
@@ -125,6 +120,10 @@ $user_status_emoji_width: 24px;
         height: 8px;
         margin: 0 5px;
         display: block;
+        /* This is a temporary adjustment until
+           the right-sidebar rows are rewritten
+           with CSS Grid. */
+        top: calc(var(--line-height-sidebar-row) / 4);
     }
 
     .empty-list-message {
@@ -265,7 +264,9 @@ $user_status_emoji_width: 24px;
     }
 
     & span.status-text:not(:empty) {
-        margin-top: -3px;
+        /* Cinch up the status text by one quarter of the
+           sidebar row's line-height. */
+        margin-top: calc((var(--line-height-sidebar-row) / 4) * -1);
     }
 
     .unread_count {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -117,14 +117,10 @@ $user_status_emoji_width: 24px;
     }
 
     .user_circle {
-        min-width: 8px;
+        width: 8px;
         height: 8px;
-        margin: 0 5px;
-        display: block;
-        /* This is a temporary adjustment until
-           the right-sidebar rows are rewritten
-           with CSS Grid. */
-        top: calc(var(--line-height-sidebar-row) / 4);
+        grid-area: starting-anchor-element;
+        place-self: center center;
     }
 
     .empty-list-message {
@@ -184,7 +180,6 @@ $user_status_emoji_width: 24px;
 
 .user-presence-link,
 .user_sidebar_entry .selectable_sidebar_block {
-    display: flex;
     overflow: hidden;
 
     .user-name {
@@ -195,21 +190,18 @@ $user_status_emoji_width: 24px;
 
 .user_sidebar_entry .selectable_sidebar_block {
     grid-area: row-content;
-    display: flex;
-    flex-direction: row;
-}
-
-.user-name-and-status-wrapper {
-    display: block;
-    width: 100%;
+    display: grid;
+    grid-template:
+        "starting-anchor-element row-content markers-and-controls" var(
+            --line-height-sidebar-row
+        )
+        ".                       row-content ." auto / 20px minmax(0, 1fr)
+        minmax(0, auto);
+    align-items: baseline;
 }
 
 .user-presence-link {
-    width: calc(100% - $user_status_emoji_width);
-
-    .status-emoji {
-        top: 9px;
-    }
+    grid-area: row-content;
 }
 
 .my_user_status {
@@ -266,7 +258,6 @@ $user_status_emoji_width: 24px;
 
     .status-text {
         display: block;
-        width: 170px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -281,8 +272,9 @@ $user_status_emoji_width: 24px;
     }
 
     .unread_count {
+        grid-area: markers-and-controls;
+        align-self: center;
         display: none;
-        margin-top: 2.5px;
     }
 
     .unread_count:not(.hide) {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -71,15 +71,16 @@ $user_status_emoji_width: 24px;
         padding: 0;
 
         .user-list-sidebar-menu-icon {
-            display: none;
-            padding: 0 6px;
+            visibility: hidden;
+            justify-self: center;
 
             & i {
-                padding-right: 0.35em;
-                display: inline-block;
-                width: 13px;
                 font-size: 17px;
-                vertical-align: middle;
+                /* Ensure the icon takes the same baseline
+                   as the rest of the row, for perfect
+                   vertical alignment with the username and
+                   status circle. */
+                line-height: inherit;
             }
 
             /*
@@ -90,7 +91,7 @@ $user_status_emoji_width: 24px;
             */
 
             @media (hover: none) {
-                display: inline;
+                visibility: visible;
                 /* Show dots on touchscreens in a less distracting,
                    lighter shade. */
                 color: var(--color-vdots-hint);
@@ -99,7 +100,7 @@ $user_status_emoji_width: 24px;
 
         &:hover {
             .user-list-sidebar-menu-icon {
-                display: inline;
+                visibility: visible;
                 cursor: pointer;
                 color: var(--color-vdots-visible);
 
@@ -193,7 +194,7 @@ $user_status_emoji_width: 24px;
 }
 
 .user_sidebar_entry .selectable_sidebar_block {
-    width: calc(100% - 26px);
+    grid-area: row-content;
     display: flex;
     flex-direction: row;
 }
@@ -245,9 +246,19 @@ $user_status_emoji_width: 24px;
 }
 
 .user_sidebar_entry {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    display: grid;
+    /* We establish a two-row, two-column outer grid so
+       that controls remain aligned with the username,
+       even when there is a status line shown below.
+
+       The 26px column for the vdots is less than the
+       30px allotted in the left sidebar, but it holds
+       the username area constant, so that no ellipsis
+       appears on the username on hover. */
+    grid-template:
+        "row-content ending-anchor-element" var(--line-height-sidebar-row)
+        "row-content ." auto / minmax(0, 1fr) 26px;
+    align-content: baseline;
 
     .user-name-and-status-emoji {
         display: flex;

--- a/web/styles/user_circles.css
+++ b/web/styles/user_circles.css
@@ -1,6 +1,3 @@
-$active_color: hsl(106deg 74% 44%);
-$idle_color: hsl(29deg 84% 51%);
-
 .user_circle_green,
 .user_circle_idle,
 .user_circle_empty,
@@ -13,16 +10,16 @@ $idle_color: hsl(29deg 84% 51%);
 }
 
 .user_circle_green {
-    background-color: $active_color;
-    border-color: $active_color;
+    background-color: var(--color-user-circle-active);
+    border-color: var(--color-user-circle-active);
 }
 
 .user_circle_idle {
-    border-color: $idle_color;
+    border-color: var(--color-user-circle-idle);
     background: linear-gradient(
         to bottom,
         hsl(0deg 0% 100% / 0%) 50%,
-        $idle_color 50%
+        var(--color-user-circle-idle) 50%
     );
 }
 

--- a/web/styles/user_circles.css
+++ b/web/styles/user_circles.css
@@ -4,9 +4,6 @@
 .user_circle_empty_line {
     border-radius: 50%;
     border: 1px solid;
-    float: left;
-    position: relative;
-    top: 5px;
 }
 
 .user_circle_green {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -836,6 +836,7 @@ strong {
                 height: 8px;
                 margin: 0 5px 0 -6px;
                 position: relative;
+                float: left;
                 top: 6px;
                 right: 8px;
                 display: inline-block;


### PR DESCRIPTION
This PR rewrites the user rows using CSS grid, improving alignment and making it so that long status messages, when shown, properly receive an ellipsis.

Only the user rows are touched by this PR; the "In this channel," "Others," and other rows require work (e.g., explicitly setting a font-size on `h5`, which currently just takes the browser default!) that would add too much churn to this PR.

Because these changes are much more like the left-sidebar row rewrites into grid from Fall 2023, and therefore prone to side-effects and possible conditions I might have overlooked, I've marked this for CZO review.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/indentation.20of.20user.20rows.3F/near/1811354)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![right-sidebar-before](https://github.com/zulip/zulip/assets/170719/7d82b617-fdd7-493a-8e7d-ee064f62c81b) | ![right-sidebar-after](https://github.com/zulip/zulip/assets/170719/f3de8a06-093c-45af-9e7e-a8254528bd00) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>