### PR TITLE
billing: Update help center links about license management.

### DIFF
--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -158,9 +158,15 @@
                 <div class="input-box billing-page-field no-validation input-box-number">
                     <label for="next-manual-license-count" class="inline-block label-title">
                         Number of licenses for next billing period
+                        {% if is_self_hosted_billing %}
+                        <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">
+                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                        </a>
+                        {% else %}
                         <a href="/help/zulip-cloud-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
+                        {% endif %}
                     </label>
                     <div class="number-input-with-label">
                         <form id="next-license-change-form">

--- a/templates/corporate/billing/upgrade.html
+++ b/templates/corporate/billing/upgrade.html
@@ -197,32 +197,31 @@
                     </div>
 
                     {% if page_params.free_trial_days %}
-                    {% elif not manual_license_management %}
-                    <div id="license-automatic-section" class="input-box upgrade-page-field license-management-section">
+                    {% else %}
+                    <div id="license-management-details" class="input-box upgrade-page-field license-management-section">
+                        {% if fixed_price_plan %}
                         <p class="not-editable-realm-field">
-                            {% if fixed_price_plan %}
-                            This is a fixed-price plan. You will be contacted by Zulip Sales a couple of months before the end of plan to discuss plan renewal.
-                            {% else %}
-                            Your subscription will renew automatically.
-                            Your bill will vary based on the number of active users in your organization. You can also
-                            <a href="{{ page_params.billing_base_url }}/upgrade/?manual_license_management=true&tier={{ page_params.tier }}">purchase a fixed number of licenses</a> instead. See
-                            <a target="_blank" href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
-                            {% endif %}
+                            This is a fixed-price plan. You will be contacted by Zulip Sales a couple of months before the plan ends to discuss plan renewal.
+                        </p>
+                        {% elif not manual_license_management %}
+                        <p class="not-editable-realm-field">
+                            Your subscription will renew automatically. Your bill will vary based on the number of active users in your organization.
+                            You can also <a href="{{ page_params.billing_base_url }}/upgrade/?manual_license_management=true&tier={{ page_params.tier }}">purchase a fixed number of licenses</a> instead.
+                            See <a target="_blank" href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
                         </p>
                         <input type="hidden" name="licenses" id="automatic_license_count" value="{{ seat_count }}" />
-                    </div>
-                    {% else %}
-                    <div id="license-manual-section" class="input-box upgrade-page-field license-management-section">
+                        {% else %}
                         <p class="not-editable-realm-field">
-                            Your subscription will renew automatically. You will be able to manage the number of licenses on
-                            your organization's billing page.
+                            Your subscription will renew automatically. You will be able to manage the number of licenses on your organization's billing page.
                             {% if not page_params.setup_payment_by_invoice %}
                             You can also <a href="{{ page_params.billing_base_url }}/upgrade/?tier={{ page_params.tier }}">choose automatic license management</a> instead.
                             {% endif %}
                             See <a href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
                         </p>
+                        {% endif %}
                     </div>
                     {% endif %}
+
                     {% if not is_demo_organization %}
                     <div {% if page_params.setup_payment_by_invoice %} id="update-invoice-billing-info" {% elif payment_method %} id="upgrade-payment-info"{% endif %}>
                         {% if page_params.setup_payment_by_invoice %}

--- a/templates/corporate/billing/upgrade.html
+++ b/templates/corporate/billing/upgrade.html
@@ -207,16 +207,30 @@
                         <p class="not-editable-realm-field">
                             Your subscription will renew automatically. Your bill will vary based on the number of active users in your organization.
                             You can also <a href="{{ page_params.billing_base_url }}/upgrade/?manual_license_management=true&tier={{ page_params.tier }}">purchase a fixed number of licenses</a> instead.
-                            See <a target="_blank" href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
+                            {% if is_self_hosting_management_page %}
+                                See <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                            {% else %}
+                                See <a href="/help/zulip-cloud-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                            {% endif %}
                         </p>
                         <input type="hidden" name="licenses" id="automatic_license_count" value="{{ seat_count }}" />
                         {% else %}
                         <p class="not-editable-realm-field">
                             Your subscription will renew automatically. You will be able to manage the number of licenses on your organization's billing page.
                             {% if not page_params.setup_payment_by_invoice %}
-                            You can also <a href="{{ page_params.billing_base_url }}/upgrade/?tier={{ page_params.tier }}">choose automatic license management</a> instead.
+                                You can also <a href="{{ page_params.billing_base_url }}/upgrade/?tier={{ page_params.tier }}">choose automatic license management</a> instead.
+                                {% if is_self_hosting_management_page %}
+                                    See <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                {% else %}
+                                    See <a href="/help/zulip-cloud-billing#how-does-automatic-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                {% endif %}
+                            {% else %}
+                                {% if is_self_hosting_management_page %}
+                                    See <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                {% else %}
+                                    See <a href="/help/zulip-cloud-billing#how-does-manual-billing-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                {% endif %}
                             {% endif %}
-                            See <a href="https://zulip.com/help/zulip-cloud-billing">here</a> for details.
                         </p>
                         {% endif %}
                     </div>

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -305,30 +305,6 @@ input[name="licenses"] {
     appearance: textfield;
 }
 
-#license-manual-section,
-#licensechange-input-section,
-#invoice-form {
-    & input {
-        padding: 4px 6px;
-        border-radius: 4px;
-        border: 1px solid hsl(0deg 0% 80%);
-        color: hsl(0deg 0% 33%);
-        margin-bottom: 10px;
-        transition:
-            border linear 0.2s,
-            box-shadow linear 0.2s;
-        box-shadow: inset 0 1px 1px hsla(0deg 0 0 / 7.5%);
-
-        &:focus {
-            border-color: hsl(206deg 80% 62% / 80%);
-            outline: 0;
-            box-shadow:
-                inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                0 0 8px hsl(206.494deg 80% 62% / 60%);
-        }
-    }
-}
-
 #confirm-licenses-modal .dialog_submit_button:active {
     /* This is needed to avoid button background changing
     when clicking on it due to "button:active" CSS in


### PR DESCRIPTION
**Updates**:
- Removes unused billing CSS rules for template IDs that have been removed as part of redesign of billing pages.
- For fixed price plans, always show the same text about license management. *Note that this does not address the current issues in the implementation of fixed price plan offers combined with the user selecting pay by invoice.*
- Updates both billing and upgrade pages to link to the appropriate help center links based on if it is self-hosted billing or Zulip Cloud billing.

Manually tested links to help center in dev environment when reviewing to make sure there were no visual changes in billing/upgrade pages due to the CSS changes, except for the fixed plan offer case.

**Notes on links**:
- Made sure that these all open a new tab/window, as this seemed nicer than navigating away from a billing/upgrade page.
- Zulip Cloud links are all relative as the current documentation for the organization will match what's on zulip.com help center pages.
- Self-hosted links are to zulip.com so that they are directed to the most up-to-date help center billing documentation.

---

**Screenshots and screen captures:**

<details>
<summary>Zulip Cloud - upgrade - no visual changes</summary>

### Automated license management:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-20-09](https://github.com/zulip/zulip/assets/63245456/f5d84d1a-9ee5-488f-8320-ca4aad5ad153) | ![Screenshot from 2024-06-04 15-19-38](https://github.com/zulip/zulip/assets/63245456/dd60bf81-7ac7-45ab-99f6-07c1d044d390)

### Manual license management:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-20-13](https://github.com/zulip/zulip/assets/63245456/df220d34-5504-464b-b163-5b5cd5f96f41) | ![Screenshot from 2024-06-04 15-19-44](https://github.com/zulip/zulip/assets/63245456/faba7486-38f7-44da-9951-c146c3e44b52)

### Pay by invoice selected:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-20-20](https://github.com/zulip/zulip/assets/63245456/0614d52e-367f-4b97-b4da-9b84a662a627) | ![Screenshot from 2024-06-04 15-19-50](https://github.com/zulip/zulip/assets/63245456/3b7a7a4a-34c4-4a5b-afb3-4020a25b120b)
</details>

<details>
<summary>Self-hosted billing - upgrade - no visual changes</summary>

### Automated license management:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-34-49](https://github.com/zulip/zulip/assets/63245456/7b689398-982b-4989-8c56-2a0277360d37) | ![Screenshot from 2024-06-04 15-33-37](https://github.com/zulip/zulip/assets/63245456/6945789d-6986-4d81-a693-bd4c6c8d6931)

### Manual license management:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-34-58](https://github.com/zulip/zulip/assets/63245456/a86fcbe2-f8ce-4105-aa6f-4d92211a6bd2) | ![Screenshot from 2024-06-04 15-33-55](https://github.com/zulip/zulip/assets/63245456/5d734429-ace5-401b-a383-5c1bee95aea7)

### Pay by invoice selected:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-35-02](https://github.com/zulip/zulip/assets/63245456/87eff3a5-7246-4532-bb69-e07d02e53003) | ![Screenshot from 2024-06-04 15-34-25](https://github.com/zulip/zulip/assets/63245456/cce4e2a4-867e-4e78-a8ba-a5a9ba324c03)
</details>

<details>
<summary>Self-hosted billing FIXED PRICE OFFER - upgrade</summary>

### Automated license management- NO CHANGES:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-41-27](https://github.com/zulip/zulip/assets/63245456/04d7220e-b152-4ae4-8453-04bd3236ee83) | ![Screenshot from 2024-06-04 15-41-10](https://github.com/zulip/zulip/assets/63245456/94efb73b-b7a0-4a79-8df6-6fb81aba7128)

### Pay by invoice selected - DESCRIPTIVE TEXT CHANGE:
*Note: We should still now show the selection for Number of licenses, but as that's a bit more involved of a change, thought this was a good check-point to merge in that direction.*
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 15-41-34](https://github.com/zulip/zulip/assets/63245456/4e2b92d0-535b-44af-a412-c1e3b096bbf7) | ![Screenshot from 2024-06-04 15-41-17](https://github.com/zulip/zulip/assets/63245456/33c5c08b-1c3c-4820-97e0-f6a4c5c9b2ee)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
