### PR TITLE
i18n: Fix translated strings for delete profile field option.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -331,12 +331,14 @@ function show_modal_for_deleting_options(
         deleted_values,
     });
 
-    let modal_heading_text = "Delete this option?";
-    if (deleted_options_count !== 1) {
-        modal_heading_text = "Delete these options?";
-    }
     confirm_dialog.launch({
-        html_heading: $t_html({defaultMessage: "{modal_heading_text}"}, {modal_heading_text}),
+        html_heading: $t_html(
+            {
+                defaultMessage:
+                    "{N, plural, one {Delete this option?} other {Delete these options?}}",
+            },
+            {N: deleted_options_count},
+        ),
         html_body,
         on_click: update_profile_field,
     });


### PR DESCRIPTION
Fixes how the confirmation modal title is generated for translation for deleting an option or multiple options from a customer profile field that's a list of options.

Confirmed that running `makemessages` updates the strings in `translastion.json` for:
- Removing the untranslatable "{modal_heading_text}" key
- Adding new key with actual strings to translate "{N, plural, one {Delete this option?} other {Delete these options?}}":

### Deleting a single option - same modal title:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 17-50-31](https://github.com/zulip/zulip/assets/63245456/580a8584-d090-4e20-bc85-7442788676e4) | ![Screenshot from 2024-06-04 18-21-02](https://github.com/zulip/zulip/assets/63245456/ce11fdf8-3edc-4e1a-b078-96a31f116cd0)

### Deleting multiple options - same modal title:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-04 17-50-49](https://github.com/zulip/zulip/assets/63245456/3f3b5c19-adb6-40f1-8f30-40e35a6268bb) | ![Screenshot from 2024-06-04 18-21-16](https://github.com/zulip/zulip/assets/63245456/db52ef5c-5185-4882-b6aa-cab23f052e97)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
