### PR TITLE
push_notifications: Support test notifications from old servers.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1449,7 +1449,8 @@ def send_test_push_notification_directly_to_devices(
     apple_payload = copy.deepcopy(payload)
     android_payload = copy.deepcopy(payload)
 
-    realm_url = base_payload["realm_url"]
+    # TODO/compatibility: Backwards-compatibility name for realm_url.
+    realm_url = base_payload.get("realm_url", base_payload["realm_uri"])
     realm_name = base_payload["realm_name"]
     apns_data = {
         "alert": {


### PR DESCRIPTION
4430ab9cbee8 changed this, assuming that all servers would send `realm_url` -- however, only servers running that commit do.  Update to accept either `realm_url` or `realm_uri` payload properties.

---

Regression in #29959.