### PR TITLE
Prerequisite PR for #28478 (Management of names of archived streams)

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 296**
+
+* [POST /register](/api/register-queue),
+  [`GET /streams/{stream_id}`](/api/get-stream-by-id),
+  [`GET /events`](/api/get-events),
+  [GET /users/me/subscriptions](/api/get-subscriptions):
+  The `is_archived` property has been added to the streams
+  and subscriptions to indicate their active status.
+
 **Feature level 295**
 
 * [`GET /export/realm/consents`](/api/get-realm-export-consents): Added

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 295  # Last bumped for `/export/realm/consents` endpoint.
+API_FEATURE_LEVEL = 296  # Last bumped for `is_archived`
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -569,6 +569,10 @@ export function validate_stream_message_mentions(opts: StreamWildcardOptions): b
 }
 
 export function validate_stream_message_address_info(sub: StreamSubscription): boolean {
+    if (sub.is_archived) {
+        compose_banner.show_stream_does_not_exist_error(sub.name);
+        return false;
+    }
     if (sub.subscribed) {
         return true;
     }

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -463,7 +463,6 @@ export function show(raw_terms, opts) {
                     );
 
                     if (adjusted_terms === null) {
-                        blueslip.error("adjusted_terms impossibly null");
                         return;
                     }
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -573,6 +573,10 @@ export function can_unsubscribe_others(sub: StreamSubscription): boolean {
 }
 
 export function can_post_messages_in_stream(stream: StreamSubscription): boolean {
+    if (stream.is_archived) {
+        return false;
+    }
+
     if (page_params.is_spectator) {
         return false;
     }

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -16,6 +16,7 @@ export const stream_schema = z.object({
     history_public_to_subscribers: z.boolean(),
     invite_only: z.boolean(),
     is_announcement_only: z.boolean(),
+    is_archived: z.boolean(),
     is_web_public: z.boolean(),
     message_retention_days: z.number().nullable(),
     name: z.string(),

--- a/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -1,6 +1,13 @@
 <p>
+    {{#tr}}Archiving channel <z-stream></z-stream> will:{{/tr}}
+    <ul>
+        <li>{{#tr}}Remove it from the left sidebar for all users.{{/tr}}</li>
+        <li>{{#tr}}Prevent new messages from being sent to this channel.{{/tr}}</li>
+        <li>{{#tr}}Prevent messages in this channel from being edited, deleted, or moved.{{/tr}}</li>
+    </ul>
     {{#tr}}
-        Archiving channel <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
+        Users can still search for messages in archived channels.<br/>
+        This action cannot be undone.
         {{#*inline "z-stream"}}<strong>{{{stream_name_with_privacy_symbol_html}}}</strong>{{/inline}}
     {{/tr}}
 </p>

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -40,6 +40,7 @@ const fake_now = 1596713966;
 
 exports.test_streams = {
     devel: {
+        is_archived: false,
         name: "devel",
         description: ":devel fun:",
         rendered_description: "<b>devel fun</b>",
@@ -56,6 +57,7 @@ exports.test_streams = {
         can_remove_subscribers_group: 2,
     },
     test: {
+        is_archived: false,
         name: "test",
         description: "test desc",
         rendered_description: "test desc",

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -1091,6 +1091,9 @@ test("can_post_messages_in_stream", () => {
 
     page_params.is_spectator = true;
     assert.equal(stream_data.can_post_messages_in_stream(social), false);
+
+    social.is_archived = true;
+    assert.equal(stream_data.can_post_messages_in_stream(social), false);
 });
 
 test("can_unsubscribe_others", () => {

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -72,44 +72,6 @@ from zerver.models.users import active_non_guest_user_ids, active_user_ids, get_
 from zerver.tornado.django_api import send_event_on_commit
 
 
-def send_user_remove_events_on_stream_deactivation(
-    stream: Stream, subscribed_users: list[UserProfile]
-) -> None:
-    guest_subscribed_users = [user for user in subscribed_users if user.is_guest]
-
-    if len(guest_subscribed_users) == 0:  # nocoverage
-        # Save a few database queries in the case that the stream
-        # didn't contain any guest users.
-        return
-
-    other_subscriptions_of_subscribed_users = get_subscribers_of_target_user_subscriptions(
-        guest_subscribed_users
-    )
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users(
-        guest_subscribed_users, stream.realm
-    )
-
-    subscriber_ids = {user.id for user in subscribed_users}
-    inaccessible_user_dict: dict[int, set[int]] = defaultdict(set)
-    for guest_user in guest_subscribed_users:
-        users_accessible_by_guest = (
-            {guest_user.id}
-            | other_subscriptions_of_subscribed_users[guest_user.id]
-            | users_involved_in_dms_dict[guest_user.id]
-        )
-        users_inaccessible_to_guest = subscriber_ids - users_accessible_by_guest
-        for user_id in users_inaccessible_to_guest:
-            inaccessible_user_dict[user_id].add(guest_user.id)
-
-    for user_id, notify_user_ids in inaccessible_user_dict.items():
-        event_remove_user = dict(
-            type="realm_user",
-            op="remove",
-            person=dict(user_id=user_id, full_name=str(UserProfile.INACCESSIBLE_USER_NAME)),
-        )
-        send_event_on_commit(stream.realm, event_remove_user, list(notify_user_ids))
-
-
 @transaction.atomic(savepoint=False)
 def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> None:
     # If the stream is already deactivated, this is a no-op
@@ -130,13 +92,6 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
     # Get the affected user ids *before* we deactivate everybody.
     affected_user_ids = can_access_stream_user_ids(stream)
 
-    stream_subscribers = get_active_subscriptions_for_stream_id(
-        stream.id, include_deactivated_users=True
-    ).select_related("user_profile")
-    subscribed_users = [sub.user_profile for sub in stream_subscribers]
-    stream_subscribers.update(active=False)
-
-    was_invite_only = stream.invite_only
     was_public = stream.is_public()
     was_web_public = stream.is_web_public
 
@@ -145,7 +100,6 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
     # changing stream privacy. And due to this we also need to duplicate
     # the code to unset is_web_public field on attachments below.
     stream.deactivated = True
-    stream.invite_only = True
     # Preserve as much as possible the original stream name while giving it a
     # special prefix that both indicates that the stream is deactivated and
     # frees up the original name for reuse.
@@ -159,13 +113,13 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
     new_name = (hashed_stream_id + "!DEACTIVATED:" + old_name)[: Stream.MAX_NAME_LENGTH]
 
     stream.name = new_name[: Stream.MAX_NAME_LENGTH]
-    stream.save(update_fields=["name", "deactivated", "invite_only"])
+    stream.save(update_fields=["name", "deactivated"])
 
     assert stream.recipient_id is not None
     if was_web_public:
         assert was_public
         # Unset the is_web_public and is_realm_public cache on attachments,
-        # since the stream is now private.
+        # since the stream is now archived.
         Attachment.objects.filter(messages__recipient_id=stream.recipient_id).update(
             is_web_public=None, is_realm_public=None
         )
@@ -173,7 +127,7 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
             is_web_public=None, is_realm_public=None
         )
     elif was_public:
-        # Unset the is_realm_public cache on attachments, since the stream is now private.
+        # Unset the is_realm_public cache on attachments, since the stream is now archived.
         Attachment.objects.filter(messages__recipient_id=stream.recipient_id).update(
             is_realm_public=None
         )
@@ -191,12 +145,9 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
         do_remove_streams_from_default_stream_group(stream.realm, group, [stream])
 
     stream_dict = stream_to_dict(stream)
-    stream_dict.update(dict(name=old_name, invite_only=was_invite_only))
+    stream_dict.update(dict(name=old_name))
     event = dict(type="stream", op="delete", streams=[stream_dict])
     send_event_on_commit(stream.realm, event, affected_user_ids)
-
-    if stream.realm.can_access_all_users_group.named_user_group.name != SystemGroups.EVERYONE:
-        send_user_remove_events_on_stream_deactivation(stream, subscribed_users)
 
     event_time = timezone_now()
     RealmAuditLog.objects.create(
@@ -235,32 +186,27 @@ def deactivated_streams_by_old_name(realm: Realm, stream_name: str) -> QuerySet[
 @transaction.atomic(savepoint=False)
 def do_unarchive_stream(stream: Stream, new_name: str, *, acting_user: UserProfile | None) -> None:
     realm = stream.realm
+    stream_subscribers = get_active_subscriptions_for_stream_id(
+        stream.id, include_deactivated_users=True
+    ).select_related("user_profile")
+
     if not stream.deactivated:
         raise JsonableError(_("Channel is not currently deactivated"))
     if Stream.objects.filter(realm=realm, name=new_name).exists():
         raise JsonableError(
             _("Channel named {channel_name} already exists").format(channel_name=new_name)
         )
+    if stream.invite_only and not stream_subscribers:
+        raise JsonableError(_("Channel is private and have no subscribers"))
     assert stream.recipient_id is not None
 
     stream.deactivated = False
     stream.name = new_name
 
-    # We only set invite_only=True during deactivation, which can lead
-    # to the invalid state of to invite-only but also web-public
-    # streams.  Explicitly reset the access; we do not use
-    # do_change_stream_permission because no users need be notified,
-    # and it cannot handle the broken state that may currently exist.
-    stream.is_web_public = False
-    stream.invite_only = True
-    stream.history_public_to_subscribers = True
     stream.save(
         update_fields=[
             "name",
             "deactivated",
-            "is_web_public",
-            "invite_only",
-            "history_public_to_subscribers",
         ]
     )
 
@@ -292,17 +238,12 @@ def do_unarchive_stream(stream: Stream, new_name: str, *, acting_user: UserProfi
 
     recent_traffic = get_streams_traffic({stream.id}, realm)
 
-    # All admins always get to know about private streams' existence,
-    # but we only subscribe the realm owners.
-    send_stream_creation_event(
-        realm, stream, [user.id for user in realm.get_admin_users_and_bots()], recent_traffic
-    )
-    bulk_add_subscriptions(
-        realm=realm,
-        streams=[stream],
-        users=realm.get_human_owner_users(),
-        acting_user=acting_user,
-    )
+    subscribed_users = {sub.user_profile for sub in stream_subscribers}
+    admin_users_and_bots = set(realm.get_admin_users_and_bots())
+
+    notify_users = admin_users_and_bots | subscribed_users
+
+    send_stream_creation_event(realm, stream, [user.id for user in notify_users], recent_traffic)
 
     sender = get_system_bot(settings.NOTIFICATION_BOT, stream.realm_id)
     with override_language(stream.realm.default_language):

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -394,6 +394,7 @@ def send_subscription_add_events(
                 description=stream_dict["description"],
                 first_message_id=stream_dict["first_message_id"],
                 history_public_to_subscribers=stream_dict["history_public_to_subscribers"],
+                is_archived=stream_dict["is_archived"],
                 invite_only=stream_dict["invite_only"],
                 is_web_public=stream_dict["is_web_public"],
                 message_retention_days=stream_dict["message_retention_days"],

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -58,6 +58,7 @@ default_stream_fields = [
     ("history_public_to_subscribers", bool),
     ("invite_only", bool),
     ("is_announcement_only", bool),
+    ("is_archived", bool),
     ("is_web_public", bool),
     ("message_retention_days", OptionalType(int)),
     ("name", str),

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -385,6 +385,10 @@ def has_message_access(
         # You can't access public stream messages in other realms
         return False
 
+    if stream.deactivated:
+        # You can't access messages in deactivated streams
+        return False
+
     def is_subscribed_helper() -> bool:
         if is_subscribed is not None:
             return is_subscribed

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -872,6 +872,7 @@ def stream_to_dict(stream: Stream, recent_traffic: dict[int, int] | None = None)
         stream_weekly_traffic = None
 
     return APIStreamDict(
+        is_archived=stream.deactivated,
         can_remove_subscribers_group=stream.can_remove_subscribers_group_id,
         creator_id=stream.creator_id,
         date_created=datetime_to_timestamp(stream.date_created),

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -287,6 +287,12 @@ def access_stream_for_send_message(
         else:
             raise JsonableError(_("User not authorized for this query"))
 
+    # Deactivated streams are not accessible.
+    if stream.deactivated:
+        raise JsonableError(
+            _("Not authorized to send to channel '{channel_name}'").format(channel_name=stream.name)
+        )
+
     if is_cross_realm_bot_email(sender.delivery_email):
         return
 
@@ -425,7 +431,9 @@ def access_stream_common(
     except Subscription.DoesNotExist:
         sub = None
 
-    if check_basic_stream_access(user_profile, stream, sub, allow_realm_admin=allow_realm_admin):
+    if not stream.deactivated and check_basic_stream_access(
+        user_profile, stream, sub, allow_realm_admin=allow_realm_admin
+    ):
         return sub
 
     # Otherwise it is a private stream and you're not on it, so throw
@@ -661,6 +669,11 @@ def filter_stream_authorization(
 
     unauthorized_streams: list[Stream] = []
     for stream in streams:
+        # Deactivated streams are not accessible
+        if stream.deactivated:
+            unauthorized_streams.append(stream)
+            continue
+
         # The user is authorized for their own streams
         if stream.recipient_id in subscribed_recipient_ids:
             continue

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -42,6 +42,7 @@ def get_web_public_subs(realm: Realm) -> SubscriptionInfo:
     subscribed = []
     for stream in get_web_public_streams_queryset(realm):
         # Add Stream fields.
+        is_archived = stream.deactivated
         can_remove_subscribers_group_id = stream.can_remove_subscribers_group_id
         creator_id = stream.creator_id
         date_created = datetime_to_timestamp(stream.date_created)
@@ -73,6 +74,7 @@ def get_web_public_subs(realm: Realm) -> SubscriptionInfo:
         wildcard_mentions_notify = True
 
         sub = SubscriptionStreamDict(
+            is_archived=is_archived,
             audible_notifications=audible_notifications,
             can_remove_subscribers_group=can_remove_subscribers_group_id,
             color=color,
@@ -115,6 +117,7 @@ def build_unsubscribed_sub_from_stream_dict(
         can_remove_subscribers_group_id=stream_dict["can_remove_subscribers_group"],
         creator_id=stream_dict["creator_id"],
         date_created=timestamp_to_datetime(stream_dict["date_created"]),
+        deactivated=stream_dict["is_archived"],
         description=stream_dict["description"],
         first_message_id=stream_dict["first_message_id"],
         history_public_to_subscribers=stream_dict["history_public_to_subscribers"],
@@ -144,6 +147,7 @@ def build_stream_dict_for_sub(
     recent_traffic: dict[int, int] | None,
 ) -> SubscriptionStreamDict:
     # Handle Stream.API_FIELDS
+    is_archived = raw_stream_dict["deactivated"]
     can_remove_subscribers_group_id = raw_stream_dict["can_remove_subscribers_group_id"]
     creator_id = raw_stream_dict["creator_id"]
     date_created = datetime_to_timestamp(raw_stream_dict["date_created"])
@@ -187,6 +191,7 @@ def build_stream_dict_for_sub(
 
     # Our caller may add a subscribers field.
     return SubscriptionStreamDict(
+        is_archived=is_archived,
         audible_notifications=audible_notifications,
         can_remove_subscribers_group=can_remove_subscribers_group_id,
         color=color,
@@ -218,6 +223,7 @@ def build_stream_dict_for_never_sub(
     raw_stream_dict: RawStreamDict,
     recent_traffic: dict[int, int] | None,
 ) -> NeverSubscribedStreamDict:
+    is_archived = raw_stream_dict["deactivated"]
     can_remove_subscribers_group_id = raw_stream_dict["can_remove_subscribers_group_id"]
     creator_id = raw_stream_dict["creator_id"]
     date_created = datetime_to_timestamp(raw_stream_dict["date_created"])
@@ -244,6 +250,7 @@ def build_stream_dict_for_never_sub(
 
     # Our caller may add a subscribers field.
     return NeverSubscribedStreamDict(
+        is_archived=is_archived,
         can_remove_subscribers_group=can_remove_subscribers_group_id,
         creator_id=creator_id,
         date_created=date_created,

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -143,6 +143,7 @@ class RawStreamDict(TypedDict):
     can_remove_subscribers_group_id: int
     creator_id: int | None
     date_created: datetime
+    deactivated: bool
     description: str
     first_message_id: int | None
     history_public_to_subscribers: bool
@@ -192,6 +193,7 @@ class SubscriptionStreamDict(TypedDict):
     in_home_view: bool
     invite_only: bool
     is_announcement_only: bool
+    is_archived: bool
     is_muted: bool
     is_web_public: bool
     message_retention_days: int | None
@@ -207,6 +209,7 @@ class SubscriptionStreamDict(TypedDict):
 
 
 class NeverSubscribedStreamDict(TypedDict):
+    is_archived: bool
     can_remove_subscribers_group: int
     creator_id: int | None
     date_created: int
@@ -231,6 +234,7 @@ class DefaultStreamDict(TypedDict):
     with few exceptions and possible additional fields.
     """
 
+    is_archived: bool
     can_remove_subscribers_group: int
     creator_id: int | None
     date_created: int

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -177,11 +177,12 @@ class Stream(models.Model):
     # * "id" is represented as "stream_id" in most API interfaces.
     # * "email_token" is not realm-public and thus is not included here.
     # * is_in_zephyr_realm is a backend-only optimization.
-    # * "deactivated" streams are filtered from the API entirely.
+    # * "deactivated" is represented as "is_archived" in API interfaces.
     # * "realm" and "recipient" are not exposed to clients via the API.
     API_FIELDS = [
         "creator_id",
         "date_created",
+        "deactivated",
         "description",
         "first_message_id",
         "history_public_to_subscribers",
@@ -197,6 +198,7 @@ class Stream(models.Model):
 
     def to_dict(self) -> DefaultStreamDict:
         return DefaultStreamDict(
+            is_archived=self.deactivated,
             can_remove_subscribers_group=self.can_remove_subscribers_group_id,
             creator_id=self.creator_id,
             date_created=datetime_to_timestamp(self.date_created),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -680,6 +680,7 @@ paths:
                                       {
                                         "name": "test",
                                         "stream_id": 9,
+                                        "is_archived": false,
                                         "creator_id": null,
                                         "description": "",
                                         "rendered_description": "",
@@ -1323,6 +1324,7 @@ paths:
                                       {
                                         "name": "private",
                                         "stream_id": 12,
+                                        "is_archived": false,
                                         "description": "",
                                         "rendered_description": "",
                                         "date_created": 1691057093,
@@ -1381,6 +1383,7 @@ paths:
                                       {
                                         "name": "private",
                                         "stream_id": 12,
+                                        "is_archived": false,
                                         "description": "",
                                         "rendered_description": "",
                                         "date_created": 1691057093,
@@ -1972,6 +1975,7 @@ paths:
                                             {
                                               "name": "Scotland",
                                               "stream_id": 3,
+                                              "is_archived": false,
                                               "description": "Located in the United Kingdom",
                                               "rendered_description": "<p>Located in the United Kingdom</p>",
                                               "date_created": 1691057093,
@@ -1988,6 +1992,7 @@ paths:
                                             {
                                               "name": "Denmark",
                                               "stream_id": 1,
+                                              "is_archived": false,
                                               "description": "A Scandinavian country",
                                               "rendered_description": "<p>A Scandinavian country</p>",
                                               "date_created": 1691057093,
@@ -2004,6 +2009,7 @@ paths:
                                             {
                                               "name": "Verona",
                                               "stream_id": 5,
+                                              "is_archived": false,
                                               "description": "A city in Italy",
                                               "rendered_description": "<p>A city in Italy</p>",
                                               "date_created": 1691057093,
@@ -2051,6 +2057,7 @@ paths:
                                       {
                                         "name": "Scotland",
                                         "stream_id": 3,
+                                        "is_archived": false,
                                         "description": "Located in the United Kingdom",
                                         "rendered_description": "<p>Located in the United Kingdom</p>",
                                         "date_created": 1691057093,
@@ -9744,6 +9751,7 @@ paths:
                               "pin_to_top": false,
                               "push_notifications": false,
                               "stream_id": 1,
+                              "is_archived": false,
                               "subscribers": [7, 10, 11, 12, 14],
                             },
                             {
@@ -9758,6 +9766,7 @@ paths:
                               "pin_to_top": false,
                               "push_notifications": false,
                               "stream_id": 3,
+                              "is_archived": false,
                               "subscribers": [7, 11, 12, 14],
                             },
                           ],
@@ -14252,6 +14261,7 @@ paths:
                             - additionalProperties: false
                               properties:
                                 stream_id: {}
+                                is_archived: {}
                                 name: {}
                                 description: {}
                                 date_created: {}
@@ -19053,6 +19063,7 @@ paths:
                             - additionalProperties: false
                               properties:
                                 stream_id: {}
+                                is_archived: {}
                                 name: {}
                                 description: {}
                                 date_created: {}
@@ -19096,6 +19107,7 @@ paths:
                                     [include_default]: /api/get-streams#parameter-include_default
                               required:
                                 - stream_id
+                                - is_archived
                                 - name
                                 - description
                                 - date_created
@@ -19131,6 +19143,7 @@ paths:
                               "name": "management",
                               "rendered_description": "<p>A private channel</p>",
                               "stream_id": 2,
+                              "is_archived": false,
                               "stream_post_policy": 1,
                               "stream_weekly_traffic": null,
                             },
@@ -19149,6 +19162,7 @@ paths:
                               "name": "welcome",
                               "rendered_description": "<p>A default public channel</p>",
                               "stream_id": 1,
+                              "is_archived": false,
                               "stream_post_policy": 1,
                               "stream_weekly_traffic": null,
                             },
@@ -19215,6 +19229,7 @@ paths:
                             "name": "Denmark",
                             "rendered_description": "<p>A Scandinavian country</p>",
                             "stream_id": 7,
+                            "is_archived": false,
                             "stream_post_policy": 1,
                             "can_remove_subscribers_group": 2,
                             "stream_weekly_traffic": null,
@@ -20719,6 +20734,7 @@ components:
         - additionalProperties: false
           properties:
             stream_id: {}
+            is_archived: {}
             name: {}
             description: {}
             date_created: {}
@@ -20752,6 +20768,7 @@ components:
                 statistic was available only in subscription objects.
           required:
             - stream_id
+            - is_archived
             - name
             - description
             - date_created
@@ -20772,6 +20789,7 @@ components:
         - additionalProperties: false
           properties:
             stream_id: {}
+            is_archived: {}
             name: {}
             description: {}
             date_created: {}
@@ -20790,6 +20808,7 @@ components:
             can_remove_subscribers_group: {}
           required:
             - stream_id
+            - is_archived
             - name
             - description
             - date_created
@@ -20816,6 +20835,13 @@ components:
           type: string
           description: |
             The name of the channel.
+        is_archived:
+          type: boolean
+          description: |
+            A boolean indicating whether a stream is archived.
+
+            **Changes**: New in Zulip 10.0 (feature level 296).
+            Previously, this endpoint never returned archived streams.
         description:
           type: string
           description: |
@@ -21852,6 +21878,13 @@ components:
             was named `can_remove_subscribers_group_id`.
 
             New in Zulip 6.0 (feature level 142).
+        is_archived:
+          type: boolean
+          description: |
+            A boolean indicating whether the stream is archived.
+
+            **Changes**: New in Zulip 10.0 (feature level 296).
+            Previously, subscriptions only included active streams.
     DefaultChannelGroup:
       type: object
       description: |

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3149,11 +3149,9 @@ class NormalActionsTest(BaseAction):
             self.users_subscribed_to_stream(stream.name, realm), [hamlet, polonius]
         )
 
-        with self.verify_action(num_events=2) as events:
+        with self.verify_action(num_events=1) as events:
             do_deactivate_stream(stream, acting_user=None)
         check_stream_delete("events[0]", events[0])
-        check_realm_user_remove("events[1]", events[1])
-        self.assertEqual(events[1]["person"]["user_id"], hamlet.id)
 
         # Test that if the subscribers of deactivated stream are involved in
         # DMs with guest, then the guest does not get "remove" event for them.
@@ -3165,11 +3163,9 @@ class NormalActionsTest(BaseAction):
             self.users_subscribed_to_stream(stream.name, realm), [iago, polonius, shiva]
         )
 
-        with self.verify_action(num_events=2) as events:
+        with self.verify_action(num_events=1) as events:
             do_deactivate_stream(stream, acting_user=None)
         check_stream_delete("events[0]", events[0])
-        check_realm_user_remove("events[1]", events[1])
-        self.assertEqual(events[1]["person"]["user_id"], iago.id)
 
     def test_subscribe_other_user_never_subscribed(self) -> None:
         for i, include_streams in enumerate([True, False]):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -238,8 +238,8 @@ class TestMiscStuff(ZulipTestCase):
         """Verify that all the fields from `Stream.API_FIELDS` and `Subscription.API_FIELDS` present
         in `APIStreamDict` and `APISubscriptionDict`, respectively.
         """
-        expected_fields = set(Stream.API_FIELDS) | {"stream_id"}
-        expected_fields -= {"id", "can_remove_subscribers_group_id"}
+        expected_fields = set(Stream.API_FIELDS) | {"stream_id", "is_archived"}
+        expected_fields -= {"id", "can_remove_subscribers_group_id", "deactivated"}
         expected_fields |= {"can_remove_subscribers_group"}
 
         stream_dict_fields = set(APIStreamDict.__annotations__.keys())
@@ -5941,10 +5941,11 @@ class GetSubscribersTest(ZulipTestCase):
             "stream_id",
             "stream_weekly_traffic",
             "subscribers",
+            "is_archived",
         }
 
         expected_fields = set(Stream.API_FIELDS) | set(Subscription.API_FIELDS) | other_fields
-        expected_fields -= {"id", "can_remove_subscribers_group_id"}
+        expected_fields -= {"id", "can_remove_subscribers_group_id", "deactivated"}
         expected_fields |= {"can_remove_subscribers_group"}
 
         for lst in [sub_data.subscriptions, sub_data.unsubscribed]:
@@ -5956,10 +5957,11 @@ class GetSubscribersTest(ZulipTestCase):
             "stream_id",
             "stream_weekly_traffic",
             "subscribers",
+            "is_archived",
         }
 
         expected_fields = set(Stream.API_FIELDS) | other_fields
-        expected_fields -= {"id", "can_remove_subscribers_group_id"}
+        expected_fields -= {"id", "can_remove_subscribers_group_id", "deactivated"}
         expected_fields |= {"can_remove_subscribers_group"}
 
         for never_sub in sub_data.never_subscribed:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1424,7 +1424,7 @@ class StreamAdminTest(ZulipTestCase):
             )
             .exists()
         )
-        self.assertFalse(subscription_exists)
+        self.assertTrue(subscription_exists)
 
     def test_deactivate_stream_removes_default_stream(self) -> None:
         stream = self.make_stream("new_stream")
@@ -1512,6 +1512,12 @@ class StreamAdminTest(ZulipTestCase):
         with self.assertRaisesRegex(JsonableError, "Channel named existing already exists"):
             do_unarchive_stream(stream, new_name="existing", acting_user=None)
 
+    def test_unarchive_stream_private_with_no_subscribers(self) -> None:
+        stream = self.make_stream("private", invite_only=True)
+        do_deactivate_stream(stream, acting_user=None)
+        with self.assertRaisesRegex(JsonableError, "Channel is private and have no subscribers"):
+            do_unarchive_stream(stream, new_name="private", acting_user=None)
+
     def test_unarchive_stream(self) -> None:
         desdemona = self.example_user("desdemona")
         iago = self.example_user("iago")
@@ -1519,49 +1525,30 @@ class StreamAdminTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
 
         stream = self.make_stream("new_stream", is_web_public=True)
+        was_invite_only = stream.invite_only
+        was_web_public = stream.is_web_public
+        was_history_public = stream.history_public_to_subscribers
+
         self.subscribe(hamlet, stream.name)
         self.subscribe(cordelia, stream.name)
         do_deactivate_stream(stream, acting_user=None)
-        with self.capture_send_event_calls(expected_num_events=4) as events:
+        with self.capture_send_event_calls(expected_num_events=2) as events:
             do_unarchive_stream(stream, new_name="new_stream", acting_user=None)
 
-        # Tell all admins and owners that the stream exists
+        # Tell all subscribers and admins and owners that the stream exists
         self.assertEqual(events[0]["event"]["op"], "create")
         self.assertEqual(events[0]["event"]["streams"][0]["name"], "new_stream")
         self.assertEqual(events[0]["event"]["streams"][0]["stream_id"], stream.id)
-        self.assertEqual(set(events[0]["users"]), {iago.id, desdemona.id})
-
-        # Tell the owners that they're subscribed to it
-        self.assertEqual(events[1]["event"]["op"], "add")
-        self.assertEqual(events[1]["event"]["subscriptions"][0]["name"], "new_stream")
-        self.assertEqual(events[1]["event"]["subscriptions"][0]["stream_id"], stream.id)
-        self.assertEqual(events[1]["users"], [desdemona.id])
-
-        # iago (as an admin) gets to know that desdemona (the owner) is now subscribed.
-        self.assertEqual(
-            events[2],
-            {
-                "event": {
-                    "op": "peer_add",
-                    "stream_ids": [stream.id],
-                    "type": "subscription",
-                    "user_ids": [desdemona.id],
-                },
-                "users": [iago.id],
-            },
-        )
-
-        # Send a message there logging the reactivation
-        self.assertEqual(events[3]["event"]["type"], "message")
+        self.assertEqual(set(events[0]["users"]), {hamlet.id, cordelia.id, iago.id, desdemona.id})
 
         stream = Stream.objects.get(id=stream.id)
         self.assertFalse(stream.deactivated)
-        self.assertTrue(stream.invite_only)
-        self.assertFalse(stream.is_web_public)
-        self.assertTrue(stream.history_public_to_subscribers)
+        self.assertEqual(stream.invite_only, was_invite_only)
+        self.assertEqual(stream.is_web_public, was_web_public)
+        self.assertEqual(stream.history_public_to_subscribers, was_history_public)
 
         self.assertEqual(
-            [desdemona.id],
+            [hamlet.id, cordelia.id],
             [
                 sub.user_profile_id
                 for sub in get_active_subscriptions_for_stream_id(
@@ -2507,10 +2494,7 @@ class StreamAdminTest(ZulipTestCase):
         deactivated_stream_name = hashed_stream_id + "!DEACTIVATED:" + active_name
         deactivated_stream = get_stream(deactivated_stream_name, realm)
         self.assertTrue(deactivated_stream.deactivated)
-        self.assertTrue(deactivated_stream.invite_only)
         self.assertEqual(deactivated_stream.name, deactivated_stream_name)
-        subscribers = self.users_subscribed_to_stream(deactivated_stream_name, realm)
-        self.assertEqual(subscribers, [])
 
         # It doesn't show up in the list of public streams anymore.
         result = self.client_get("/json/streams", {"include_subscribed": "false"})


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This pull request is a prerequisite for PR #28478. It addresses issues with the deactivation logic of streams and ensures that archived streams are properly restricted.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
