### PR TITLE
streams: Move enforcement of stripped-stream-names lower

### DIFF
--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -1719,7 +1719,7 @@ msgstr "به روز رسانی"
 #: templates/zerver/portico-header.html:8
 #: templates/zerver/portico-header.html:12
 msgid "Zulip"
-msgstr "زولیپ "
+msgstr "زولیپ"
 
 #: templates/zerver/digest_base.html:5
 msgid "Digest"

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -149,6 +149,8 @@ def create_stream_if_needed(
             name=SystemGroups.ADMINISTRATORS, is_system_group=True, realm=realm
         )
 
+    stream_name = stream_name.strip()
+
     assert can_remove_subscribers_group is not None
     (stream, created) = Stream.objects.get_or_create(
         realm=realm,


### PR DESCRIPTION
This catches things like trailing spaces in internationalized default-stream names.

---

The Persian translation was also fixed in Transifex.