### PR TITLE
redesign: Topic visibility policy popover

### DIFF
--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -10,6 +10,7 @@ import * as util from "./util";
 
 export function initialize() {
     popover_menus.register_popover_menu(".change_visibility_policy", {
+        theme: "popover-menu",
         placement: "bottom",
         popperOptions: {
             modifiers: [

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1067,8 +1067,10 @@ ul {
     }
 }
 
-.visibility_policy_popover {
-    padding: 0 4px;
+.visibility-policy-popover {
+    .popover-menu-list {
+        padding: 2px;
+    }
 }
 
 .recipient-bar-topic-visibility-switcher {
@@ -1240,6 +1242,15 @@ ul {
             &:active {
                 background: var(--color-background-active-popover-menu);
             }
+        }
+    }
+
+    .tab-picker {
+        .tab-option-content:focus-visible {
+            border-radius: 4px;
+            /* Override the default focus style */
+            outline: 1px solid var(--color-outline-focus) !important;
+            outline-offset: -1px;
         }
     }
 
@@ -1431,11 +1442,4 @@ ul.popover-menu-list {
 #theme-switcher,
 .sidebar-topic-visibility-switcher {
     margin: 2px 10px;
-
-    .tab-option-content:focus-visible {
-        border-radius: 4px;
-        /* Override the default focus style */
-        outline: 1px solid var(--color-outline-focus) !important;
-        outline-offset: -1px;
-    }
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1246,6 +1246,10 @@ ul {
     }
 
     .tab-picker {
+        &.popover-menu-tab-group {
+            margin: 2px 10px;
+        }
+
         .tab-option-content:focus-visible {
             border-radius: 4px;
             /* Override the default focus style */
@@ -1437,9 +1441,4 @@ ul.popover-menu-list {
         border-radius: 3px;
         border: 1px solid var(--color-border-popover-hotkey-hint);
     }
-}
-
-#theme-switcher,
-.sidebar-topic-visibility-switcher {
-    margin: 2px 10px;
 }

--- a/web/templates/popovers/change_visibility_policy_popover.hbs
+++ b/web/templates/popovers/change_visibility_policy_popover.hbs
@@ -1,27 +1,31 @@
-<ul class="nav nav-list visibility_policy_popover hidden-for-spectators">
-    <div class="recipient-bar-topic-visibility-switcher tab-picker tab-picker-vertical">
-        <input type="radio" id="select-muted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
-        <label class="tab-option-content" for="select-muted-policy" tabindex="0">
-            <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-            {{t "Mute"}}
-        </label>
-        <input type="radio" id="select-inherit-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
-        <label class="tab-option-content" for="select-inherit-policy" tabindex="0">
-            <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
-            {{t "Default"}}
-        </label>
-        {{#if (or stream_muted topic_unmuted)}}
-        <input type="radio" id="select-unmuted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
-        <label class="tab-option-content" for="select-unmuted-policy" tabindex="0">
-            <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-            {{t "Unmute"}}
-        </label>
-        {{/if}}
-        <input type="radio" id="select-followed-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
-        <label class="tab-option-content" for="select-followed-policy" tabindex="0">
-            <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
-            {{t "Follow"}}
-        </label>
-        <span class="slider"></span>
-    </div>
-</ul>
+<div class="popover-menu visibility-policy-popover" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="popover-menu-list-item">
+            <div role="group" class="recipient-bar-topic-visibility-switcher tab-picker tab-picker-vertical" aria-label="{{t 'Topic visibility' }}">
+                <input type="radio" id="select-muted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content" for="select-muted-policy" tabindex="0">
+                    <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
+                    {{t "Mute"}}
+                </label>
+                <input type="radio" id="select-inherit-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content" for="select-inherit-policy" tabindex="0">
+                    <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
+                    {{t "Default"}}
+                </label>
+                {{#if (or stream_muted topic_unmuted)}}
+                <input type="radio" id="select-unmuted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content" for="select-unmuted-policy" tabindex="0">
+                    <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
+                    {{t "Unmute"}}
+                </label>
+                {{/if}}
+                <input type="radio" id="select-followed-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
+                <label role="menuitemradio" class="tab-option-content" for="select-followed-policy" tabindex="0">
+                    <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
+                    {{t "Follow"}}
+                </label>
+                <span class="slider"></span>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -7,7 +7,7 @@
         {{#unless is_spectator}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item">
-            <div role="group" class="sidebar-topic-visibility-switcher tab-picker" aria-label="{{t 'Topic visibility' }}">
+            <div role="group" class="tab-picker popover-menu-tab-group" aria-label="{{t 'Topic visibility' }}">
                 <input type="radio" id="sidebar-topic-muted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
                 <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-muted-policy" aria-label="{{t 'Mute' }}" data-tippy-content="{{t 'Mute' }}" tabindex="0">
                     <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -106,7 +106,7 @@
                     </a>
                 </li>
                 <li role="none" class="popover-menu-list-item">
-                    <div role="group" id="theme-switcher" class="tab-picker" aria-label="{{t 'App theme' }}">
+                    <div role="group" class="tab-picker popover-menu-tab-group" aria-label="{{t 'App theme' }}">
                         <input type="radio" id="select-automatic-theme" class="tab-option" name="theme-select" data-theme-code="{{color_scheme_values.automatic.code}}" {{#if (eq user_color_scheme color_scheme_values.automatic.code)}}checked{{/if}} />
                         <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="select-automatic-theme" aria-label="{{t 'Select automatic theme' }}" data-tooltip-template-id="automatic-theme-template" tabindex="0">
                             <i class="zulip-icon zulip-icon-monitor" aria-hidden="true"></i>


### PR DESCRIPTION
As part of the popover menu redesign, this updates the topic visibility popover to use the new "popover-menu" popover theme and improves accessibility by using appropriate ARIA attributes.

Fixes part of #28699.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/82862779/d951aa1e-070c-46a4-8fd9-76a14f5e9246) | ![image](https://github.com/zulip/zulip/assets/82862779/ea661f05-bff1-4c89-bddd-253fe3bd5b37) |
| ![image](https://github.com/zulip/zulip/assets/82862779/0e726348-051b-4e5f-88d2-09e2eec7c03d) | ![image](https://github.com/zulip/zulip/assets/82862779/538c4c45-5297-49b1-8b1d-235d7119450c) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
