### PR TITLE
widgets: Refactor and improve existing Markdown widgets.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -91,7 +91,7 @@
     }
 
     & ul {
-        margin: 5px 0;
+        margin: 0 0 5px;
         padding: 0;
     }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -24,8 +24,12 @@
 
 .todo-widget {
     .todo-task-list-title-bar {
+        flex: 1 1 auto;
         display: flex;
+        /* Ensure controls remain visible on narrower screens. */
+        flex-flow: row wrap;
         gap: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
     }
 
     .add-task-bar {
@@ -233,12 +237,8 @@ input {
     &.poll-option,
     &.poll-question,
     &.todo-task-list-title {
-        flex: 1 1 auto;
+        flex: 1 0 auto;
         padding: 4px 6px;
-    }
-
-    &.todo-task-list-title {
-        flex: 0 0 auto;
     }
 }
 
@@ -251,8 +251,11 @@ input {
 .poll-question-remove,
 .todo-task-list-title-check,
 .todo-task-list-title-remove {
-    width: 28px !important;
-    height: 28px;
+    align-self: stretch;
+    /* TODO: Re-express the 30.5px value here
+       as part of information density work. */
+    flex: 0 0 30.5px;
+    min-height: 30.5px;
     border-radius: 3px;
     border: 1px solid hsl(0deg 0% 80%);
     background-color: hsl(0deg 0% 100%);
@@ -265,17 +268,26 @@ input {
 .poll-edit-question,
 .todo-edit-task-list-title {
     opacity: 0.4;
-    display: inline-block;
-    margin-left: 5px;
 
     &:hover {
         opacity: 1;
     }
 }
 
-.poll-question-header,
-.todo-task-list-title-header {
-    display: inline;
+.poll-question-bar {
+    flex: 1 1 auto;
+    display: flex;
+    /* Ensure controls remain visible on narrower screens. */
+    flex-flow: row wrap;
+    gap: 5px;
+    margin-bottom: var(--markdown-interelement-space-px);
+}
+
+.poll-widget-header-area,
+.todo-widget-header-area {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
 }
 
 .current-user-vote {

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -33,11 +33,18 @@
 
     & label.checkbox {
         display: flex; /* Arrange that a multi-line description line wraps properly. */
-        position: relative;
-        vertical-align: top;
+        /* Keep checkboxes vertically aligned, including with multi-line tasks. */
+        align-items: baseline;
+        /* Reset things from .new-style */
+        gap: 5px;
+        position: static;
+        min-height: 0;
 
         & input[type="checkbox"] {
             ~ .custom-checkbox {
+                position: static;
+                margin-right: 0;
+
                 height: 12px;
                 width: 12px;
                 border: 2px solid hsl(156deg 28% 70%);

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -23,12 +23,23 @@
 }
 
 .todo-widget {
+    .todo-task-list-title-bar {
+        display: flex;
+        gap: 5px;
+    }
+
+    .add-task-bar {
+        display: flex;
+        /* Ensure controls remain visible on narrower screens. */
+        flex-flow: row wrap;
+        gap: 5px;
+    }
+
     /* For the box-shadow to be visible on the left */
     .add-task,
     .add-desc {
         font-size: 14px;
         font-weight: 400;
-        margin-right: 4px;
     }
 
     & label.checkbox {
@@ -102,16 +113,10 @@
         padding: 0;
     }
 
-    & input {
-        &.poll-question,
-        &.poll-option,
-        &.add-task,
-        &.add-desc {
-            width: 206px;
-        }
-    }
-
     & input[type="text"] {
+        /* Reset from zulip.css */
+        height: unset;
+
         border: 1px solid hsl(0deg 0% 80%);
         box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
         transition:
@@ -130,13 +135,15 @@
 }
 
 .poll-widget {
-    .poll-option {
-        font-weight: 400;
+    .poll-option-bar {
+        display: flex;
+        /* Ensure controls remain visible on narrower screens. */
+        flex-flow: row wrap;
+        gap: 5px;
     }
 
-    /* For the box-shadow to be visible on the left */
-    & input.poll-option {
-        margin-right: 4px;
+    .poll-option {
+        font-weight: 400;
     }
 
     & span.poll-option {
@@ -189,7 +196,8 @@ button {
     &.poll-option {
         color: hsl(156deg 41% 40%);
         border: 1px solid hsl(156deg 28% 70%);
-        width: 100px;
+        width: max-content;
+        flex: 0 0 auto;
         border-radius: 3px;
         background-color: hsl(0deg 0% 100%);
         padding: 4px;
@@ -211,15 +219,18 @@ button {
     }
 }
 
-input,
-button {
+input {
     &.add-task,
     &.add-desc,
     &.poll-option,
     &.poll-question,
     &.todo-task-list-title {
+        flex: 1 1 auto;
         padding: 4px 6px;
-        margin: 2px 0;
+    }
+
+    &.todo-task-list-title {
+        flex: 0 0 auto;
     }
 }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -104,8 +104,11 @@
     }
 
     & li {
+        display: flex;
+        gap: 5px;
+        align-items: baseline;
         list-style: none;
-        margin: 0 2px 6px 0;
+        margin: 0 0 5px;
     }
 
     & ul {
@@ -148,6 +151,9 @@
 
     & span.poll-option {
         font-weight: 600;
+        /* Start with max-content, but allow options
+           to shrink, so that voting names wrap comfortably. */
+        flex: 0 1 max-content;
     }
 
     .poll-vote {
@@ -156,7 +162,6 @@
         border-style: solid;
         font-weight: 600;
         border-radius: 3px;
-        margin-right: 4px;
         min-width: 25px;
         height: 25px;
         font-size: 13px;
@@ -174,7 +179,10 @@
 
     .poll-names {
         color: hsl(0deg 0% 45%);
-        padding-left: 4px;
+        /* Aim for 50% of the flexbox for voting names,
+           but also shrink modestly (.5) adjacent a long
+           option. */
+        flex: 1 0.5 50%;
     }
 }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -37,7 +37,7 @@
         vertical-align: top;
 
         & input[type="checkbox"] {
-            ~ span {
+            ~ .custom-checkbox {
                 height: 12px;
                 width: 12px;
                 border: 2px solid hsl(156deg 28% 70%);
@@ -48,7 +48,7 @@
                 cursor: pointer;
             }
 
-            &:checked ~ span {
+            &:checked ~ .custom-checkbox {
                 background-image: url("../images/checkbox-white.svg");
                 background-size: 75%;
                 background-position: 50% 50%;
@@ -57,16 +57,16 @@
                 border: 2px solid hsl(156deg 41% 40%);
             }
 
-            &:disabled ~ span {
+            &:disabled ~ .custom-checkbox {
                 opacity: 0.5;
                 cursor: not-allowed;
             }
 
-            &:hover ~ span {
+            &:hover ~ .custom-checkbox {
                 border-color: hsl(156deg 30% 50%);
             }
 
-            &:focus ~ span {
+            &:focus ~ .custom-checkbox {
                 outline-color: hsl(0deg 0% 100% / 0%);
             }
         }

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -87,7 +87,7 @@
 
     & li {
         list-style: none;
-        margin: 2px 2px 6px 0;
+        margin: 0 2px 6px 0;
     }
 
     & ul {
@@ -125,7 +125,6 @@
 .poll-widget {
     .poll-option {
         font-weight: 400;
-        font-size: 14px;
     }
 
     /* For the box-shadow to be visible on the left */
@@ -135,23 +134,15 @@
 
     & span.poll-option {
         font-weight: 600;
-        padding-top: 28px;
     }
 
     .poll-vote {
-        /* This is to ensure that even when the list of poll-names overflows,
-        the voting button remains clickable and on top of all other containers. */
-        position: relative;
-        z-index: 1;
-
         color: hsl(156deg 41% 40%);
         border-color: hsl(156deg 28% 70%);
         border-style: solid;
         font-weight: 600;
         border-radius: 3px;
         margin-right: 4px;
-        padding-left: 2px; /* padding for Chromium browsers */
-        padding-right: 2px;
         min-width: 25px;
         height: 25px;
         font-size: 13px;
@@ -170,8 +161,6 @@
     .poll-names {
         color: hsl(0deg 0% 45%);
         padding-left: 4px;
-        padding-top: 28px;
-        font-size: 14px;
     }
 }
 

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -1,13 +1,15 @@
 <div class="poll-widget">
-    <h4 class="poll-question-header"></h4>
+    <div class="poll-widget-header-area">
+        <h4 class="poll-question-header"></h4>
+        <i class="fa fa-pencil poll-edit-question"></i>
+        <div class="poll-question-bar">
+            <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
+            <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
+            <button class="poll-question-check"><i class="fa fa-check"></i></button>
+        </div>
+    </div>
     <div class="poll-please-wait">
         {{t 'We are about to have a poll.  Please wait for the question.'}}
-    </div>
-    <i class="fa fa-pencil poll-edit-question"></i>
-    <div class="poll-question-bar">
-        <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
-        <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
-        <button class="poll-question-check"><i class="fa fa-check"></i></button>
     </div>
     <div class="poll-author-help">
         {{t 'Tip: You can also send "/poll Some question"'}}

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,10 +1,12 @@
 <div class="todo-widget">
-    <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
-    <i class="fa fa-pencil todo-edit-task-list-title"></i>
-    <div class="todo-task-list-title-bar">
-        <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
-        <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
-        <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+    <div class="todo-widget-header-area">
+        <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
+        <i class="fa fa-pencil todo-edit-task-list-title"></i>
+        <div class="todo-task-list-title-bar">
+            <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
+            <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
+            <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+        </div>
     </div>
     <ul class="todo-widget new-style">
     </ul>

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -1,11 +1,11 @@
 {{#each all_tasks}}
     <li>
         <label class="checkbox">
-            <div>
+            <div class="todo-checkbox">
                 <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>
-                <span></span>
+                <span class="custom-checkbox"></span>
             </div>
-            <div>
+            <div class="todo-task">
                 {{#if completed}}
                 <strike><strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}</strike>
                 {{else}}


### PR DESCRIPTION
This PR modernizes the layout and presentation of the poll and todo widgets. While this area is in need of a design pass at some point in the future, for now, this corrects a number of sore points on widgets, maximizes the space available for inputs and buttons, and also gets the spacing of these widgets in line with the overall spacing strategy in the rendered markdown area. It also radically improves buttons for internationalization.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/button.2Epoll-option.20width/near/1804563) (button widths)

Note that a follow-up pass will be required on widgets as part of information density (especially the 30.5px height on the header-edit form). That would add too much churn to this already quite large PR.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![widgets-display-before](https://github.com/zulip/zulip/assets/170719/193eb6a7-8814-4551-9121-76275a1c18ee) | ![widgets-display-after](https://github.com/zulip/zulip/assets/170719/df01b0f0-2be6-40f6-8493-1f09418f9559) |
| ![widgets-german-before](https://github.com/zulip/zulip/assets/170719/e8715a9c-2734-4dba-9dfd-402e2e263d30) | ![widgets-german-after](https://github.com/zulip/zulip/assets/170719/3f677584-0b1b-4787-863c-58f4970d3078) |
| ![widgets-edit-before](https://github.com/zulip/zulip/assets/170719/09f88b4a-c4dd-4e4a-99e5-1d790a520322) | ![widgets-edit-after](https://github.com/zulip/zulip/assets/170719/d990f540-618e-4c6e-8c00-12b27ed718a4) |






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>