### PR TITLE
i18n: Allow `get_language_name` to return `undefined` again

### DIFF
--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -5,7 +5,6 @@ import type {MessageDescriptor} from "@formatjs/intl";
 import {DEFAULT_INTL_CONFIG, IntlErrorCode, createIntl, createIntlCache} from "@formatjs/intl";
 import type {FormatXMLElementFn, PrimitiveType} from "intl-messageformat";
 import _ from "lodash";
-import assert from "minimalistic-assert";
 
 import {page_params} from "./base_page_params";
 
@@ -53,10 +52,8 @@ export function $t_html(
 
 export let language_list: (typeof page_params & {page_type: "home"})["language_list"];
 
-export function get_language_name(language_code: string): string {
-    const language = language_list.find((language) => language.code === language_code);
-    assert(language !== undefined);
-    return language.name;
+export function get_language_name(language_code: string): string | undefined {
+    return language_list.find((language) => language.code === language_code)?.name;
 }
 
 export function initialize(language_params: {language_list: typeof language_list}): void {

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -35,9 +35,9 @@ const meta = {
 
 export let user_settings_panel: SettingsPanel;
 
-export let user_default_language_name: string;
+export let user_default_language_name: string | undefined;
 
-export function set_default_language_name(name: string): void {
+export function set_default_language_name(name: string | undefined): void {
     user_default_language_name = name;
 }
 
@@ -345,7 +345,7 @@ export function update_page(property: UserSettingsProperty): void {
     // The default_language button text updates to the language
     // name and not the value of the user_settings property.
     if (property === "default_language") {
-        $container.find(".default_language_name").text(user_default_language_name);
+        $container.find(".default_language_name").text(user_default_language_name ?? "");
         return;
     }
 


### PR DESCRIPTION
This can happen when the user’s configured language is less than 5% translated.  Fixes an assertion failure introduced by commit 6a429603ad8dc1bcdda591d0a12c77dc7f7f97ee (#30261).