### PR TITLE
MessageDelete : Bug fix 

### DIFF
--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -180,9 +180,11 @@ def delete_message_backend(
     # concurrently are serialized properly with deleting the message; this prevents a deadlock
     # that would otherwise happen because of the other transaction holding a lock on the `Message`
     # row.
-    message = access_message(user_profile, message_id, lock_message=True)
-    validate_can_delete_message(user_profile, message)
     try:
+        message = access_message(user_profile, message_id, lock_message=True)
+        if message is None:
+            raise Message.DoesNotExist
+        validate_can_delete_message(user_profile, message)
         do_delete_messages(user_profile.realm, [message])
     except (Message.DoesNotExist, IntegrityError):
         raise JsonableError(_("Message already deleted"))


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In This PR I have fixed the bug which is coming When a user(admin or moderator) tries to delete message in stream they are not subscribed in, the message stays there and upon trying to delete again it shows an error saying Error deleting message: Invalid message(s).

Fixes:https://github.com/zulip/zulip/issues/29826

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


https://github.com/zulip/zulip/assets/96649866/503e13a7-ac19-488b-9b5d-9ff7164ec428



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
