### PR TITLE
search-suggestions: Remove is:dm suggestion from get_operator_suggestions

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -615,7 +615,17 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             ],
         },
     ];
-    return get_special_filter_suggestions(last, terms, suggestions);
+    const special_filtered_suggestions = get_special_filter_suggestions(last, terms, suggestions);
+    // Suggest "is:dm" to anyone with "is:private" in their muscle memory
+    const other_suggestions = [];
+    if (last.operator === "is" && common.phrase_match(last.operand, "private")) {
+        const is_dm = format_as_suggestion([
+            {operator: last.operator, operand: "dm", negated: last.negated},
+        ]);
+        other_suggestions.push(is_dm);
+    }
+    const all_suggestions = [...special_filtered_suggestions, ...other_suggestions];
+    return all_suggestions;
 }
 
 function get_has_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
@@ -676,14 +686,6 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
 }
 
 function get_operator_suggestions(last: NarrowTerm): Suggestion[] {
-    // Suggest "is:dm" to anyone with "is:private" in their muscle memory
-    if (last.operator === "is" && common.phrase_match(last.operand, "private")) {
-        const is_dm = format_as_suggestion([
-            {operator: last.operator, operand: "dm", negated: last.negated},
-        ]);
-        return [is_dm];
-    }
-
     if (!(last.operator === "search")) {
         return [];
     }

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -23,6 +23,7 @@ run_test("phrase_match", () => {
     assert.ok(common.phrase_match("Tes", "test"));
     assert.ok(common.phrase_match("Tes", "Test"));
     assert.ok(common.phrase_match("tes", "Stream Test"));
+    assert.ok(common.phrase_match("", "test"));
 
     assert.ok(!common.phrase_match("tests", "test"));
     assert.ok(!common.phrase_match("tes", "hostess"));

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -99,6 +99,16 @@ test("basic_get_suggestions_for_spectator", () => {
     page_params.is_spectator = false;
 });
 
+test("get_is_suggestions_for_spectator", () => {
+    page_params.is_spectator = true;
+
+    const query = "is:";
+    const suggestions = get_suggestions(query);
+    // The list of suggestions should be empty for a spectator
+    assert.deepEqual(suggestions.strings, []);
+    page_params.is_spectator = false;
+});
+
 test("subset_suggestions", ({mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/30320

Currently, there are 2 lists of filterers
* one for non-spectators ([here](https://github.com/zulip/zulip/pull/30330/files#diff-426bbd5e4a5470f26a21e1b64d96f3d668b91dc2602cb51c77786126162374f2R842))
* one for spectators ([here](https://github.com/zulip/zulip/pull/30330/files#diff-426bbd5e4a5470f26a21e1b64d96f3d668b91dc2602cb51c77786126162374f2R858))

When you type `is:` in the search bar as a spectator, it currently suggests "Direct messages" (Issue 30320) because [get_operator_suggestions](https://github.com/zulip/zulip/pull/30330/files#diff-426bbd5e4a5470f26a21e1b64d96f3d668b91dc2602cb51c77786126162374f2L857) is adding the suggestion.

This PR
* Removes the `is:dm` suggestion from `get_operator_suggestions` 
   * And since `get_is_operator_suggestions` doesn't apply to spectators, we no longer suggest "Direct messages" when the user searches "is:" (see screenshot)
   * For non-spectators, the `is:dm` suggestion will be populated from `get_is_filter_suggestions`

Alternatives considered
* You can add something like `visible_to_spectators` on the `Suggestion` object. This would fix the core problem that suggestions that spectators can't access still appear to them.
  * Why I didn't implement this: In some cases, you might want the suggestion to appear still, I wasn't sure. In any case, when the user clicks the suggestion, they'll see the modal prompting them to login to access more features.  

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="786" alt="Screenshot 2024-06-06 at 12 50 46 AM" src="https://github.com/zulip/zulip/assets/7107181/c3629d9f-3c41-4956-92de-8f95d69ffe9b">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
