### PR TITLE
docs: Update section on Go to conversation button with new icon, etc.

### DIFF
--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -48,16 +48,17 @@ currently composing to.
 
 {start_tabs}
 
-{!start-composing.md!}
+1. [Open the compose box](/help/open-the-compose-box).
 
-1. If composing a channel message, click the **Go to conversation**
-   (<i class="zulip-icon zulip-icon-arrow-left-circle"></i>) button in the
-   compose box.
+1. Click the highlighted **Go to conversation** (<i class="zulip-icon
+   zulip-icon-chevron-right"></i>) button at the top of the compose box. It will
+   be clickable only if you're viewing a different conversation from the one you
+   are composing to.
 
 !!! keyboard_tip ""
 
-    For both channel and direct messages, use <kbd>Ctrl</kbd> + <kbd>.</kbd> to
-    go to the conversation you are composing to.
+    Use <kbd>Ctrl</kbd> + <kbd>.</kbd> to go to the conversation you're
+    composing to.
 
 {end_tabs}
 


### PR DESCRIPTION
Follow up to: #30027

This also fixes a small typo and removes the unnecessary distinction between channel and direct messages.

**Screenshots and screen captures:**
Before:
![image](https://github.com/zulip/zulip/assets/68962290/4fa34dae-3ede-41c9-9833-448c1786dcc2)
Now:
![image](https://github.com/zulip/zulip/assets/68962290/5afdaaf1-1d04-4deb-b6d9-221ad8e2d7a9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
