### PR TITLE
message_fetch: Convert to typed_endpoint.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -150,7 +150,7 @@ class NarrowParameter(BaseModel):
         return self
 
 
-def is_spectator_compatible(narrow: Iterable[Dict[str, Any]]) -> bool:
+def is_spectator_compatible(narrow: Iterable[NarrowParameter]) -> bool:
     # This implementation should agree with is_spectator_compatible in hash_parser.ts.
     supported_operators = [
         *channel_operators,
@@ -163,15 +163,13 @@ def is_spectator_compatible(narrow: Iterable[Dict[str, Any]]) -> bool:
         "id",
     ]
     for element in narrow:
-        operator = element["operator"]
-        if "operand" not in element:
-            return False
+        operator = element.operator
         if operator not in supported_operators:
             return False
     return True
 
 
-def is_web_public_narrow(narrow: Optional[Iterable[Dict[str, Any]]]) -> bool:
+def is_web_public_narrow(narrow: Optional[Iterable[NarrowParameter]]) -> bool:
     if narrow is None:
         return False
 
@@ -179,9 +177,9 @@ def is_web_public_narrow(narrow: Optional[Iterable[Dict[str, Any]]]) -> bool:
         # Web-public queries are only allowed for limited types of narrows.
         # term == {'operator': 'channels', 'operand': 'web-public', 'negated': False}
         # or term == {'operator': 'streams', 'operand': 'web-public', 'negated': False}
-        term["operator"] in channels_operators
-        and term["operand"] == "web-public"
-        and term["negated"] is False
+        term.operator in channels_operators
+        and term.operand == "web-public"
+        and term.negated is False
         for term in narrow
     )
 
@@ -203,8 +201,6 @@ class BadNarrowOperatorError(JsonableError):
 
 
 ConditionTransform: TypeAlias = Callable[[ClauseElement], ClauseElement]
-
-OptionalNarrowListT: TypeAlias = Optional[List[Dict[str, Any]]]
 
 # These delimiters will not appear in rendered messages or HTML-escaped topics.
 TS_START = "<ts-match>"
@@ -307,7 +303,7 @@ class NarrowBuilder:
                 "No message can be both a channel message and direct message"
             )
 
-    def add_term(self, query: Select, term: Dict[str, Any]) -> Select:
+    def add_term(self, query: Select, term: NarrowParameter) -> Select:
         """
         Extend the given query to one narrowed by the given term, and return the result.
 
@@ -320,10 +316,10 @@ class NarrowBuilder:
         # methods to the same criterion.  See the class's block comment
         # for details.
 
-        operator = term["operator"]
-        operand = term["operand"]
+        operator = term.operator
+        operand = term.operand
 
-        negated = term.get("negated", False)
+        negated = term.negated
 
         if operator in self.by_method_map:
             method = self.by_method_map[operator]
@@ -804,7 +800,9 @@ class NarrowBuilder:
 
 
 def ok_to_include_history(
-    narrow: OptionalNarrowListT, user_profile: Optional[UserProfile], is_web_public_query: bool
+    narrow: Optional[List[NarrowParameter]],
+    user_profile: Optional[UserProfile],
+    is_web_public_query: bool,
 ) -> bool:
     # There are occasions where we need to find Message rows that
     # have no corresponding UserMessage row, because the user is
@@ -830,16 +828,16 @@ def ok_to_include_history(
     include_history = False
     if narrow is not None:
         for term in narrow:
-            if term["operator"] in channel_operators and not term.get("negated", False):
-                operand: Union[str, int] = term["operand"]
+            if term.operator in channel_operators and not term.negated:
+                operand: Union[str, int] = term.operand
                 if isinstance(operand, str):
                     include_history = can_access_stream_history_by_name(user_profile, operand)
                 else:
                     include_history = can_access_stream_history_by_id(user_profile, operand)
             elif (
-                term["operator"] in channels_operators
-                and term["operand"] == "public"
-                and not term.get("negated", False)
+                term.operator in channels_operators
+                and term.operand == "public"
+                and not term.negated
                 and user_profile.can_access_public_streams()
             ):
                 include_history = True
@@ -847,24 +845,24 @@ def ok_to_include_history(
         # that's a property on the UserMessage table.  There cannot be
         # historical messages in these cases anyway.
         for term in narrow:
-            if term["operator"] == "is" and term["operand"] not in {"resolved", "followed"}:
+            if term.operator == "is" and term.operand not in {"resolved", "followed"}:
                 include_history = False
 
     return include_history
 
 
 def get_channel_from_narrow_access_unchecked(
-    narrow: OptionalNarrowListT, realm: Realm
+    narrow: Optional[List[NarrowParameter]], realm: Realm
 ) -> Optional[Stream]:
     if narrow is not None:
         for term in narrow:
-            if term["operator"] in channel_operators:
-                return get_stream_by_narrow_operand_access_unchecked(term["operand"], realm)
+            if term.operator in channel_operators:
+                return get_stream_by_narrow_operand_access_unchecked(term.operand, realm)
     return None
 
 
 def exclude_muting_conditions(
-    user_profile: UserProfile, narrow: OptionalNarrowListT
+    user_profile: UserProfile, narrow: Optional[List[NarrowParameter]]
 ) -> List[ClauseElement]:
     conditions: List[ClauseElement] = []
     channel_id = None
@@ -957,7 +955,7 @@ def add_narrow_conditions(
     user_profile: Optional[UserProfile],
     inner_msg_id_col: ColumnElement[Integer],
     query: Select,
-    narrow: OptionalNarrowListT,
+    narrow: Optional[List[NarrowParameter]],
     is_web_public_query: bool,
     realm: Realm,
 ) -> Tuple[Select, bool]:
@@ -974,15 +972,15 @@ def add_narrow_conditions(
     # our query, but we need to collect the search operands and handle
     # them after the loop.
     for term in narrow:
-        if term["operator"] == "search":
-            search_operands.append(term["operand"])
+        if term.operator == "search":
+            search_operands.append(term.operand)
         else:
             query = builder.add_term(query, term)
 
     if search_operands:
         is_search = True
         query = query.add_columns(topic_column_sa(), column("rendered_content", Text))
-        search_term = dict(
+        search_term = NarrowParameter(
             operator="search",
             operand=" ".join(search_operands),
         )
@@ -992,7 +990,9 @@ def add_narrow_conditions(
 
 
 def find_first_unread_anchor(
-    sa_conn: Connection, user_profile: Optional[UserProfile], narrow: OptionalNarrowListT
+    sa_conn: Connection,
+    user_profile: Optional[UserProfile],
+    narrow: Optional[List[NarrowParameter]],
 ) -> int:
     # For anonymous web users, all messages are treated as read, and so
     # always return LARGER_THAN_MAX_MESSAGE_ID.
@@ -1253,7 +1253,7 @@ class FetchedMessages(LimitedMessages[Row]):
 
 def fetch_messages(
     *,
-    narrow: OptionalNarrowListT,
+    narrow: Optional[List[NarrowParameter]],
     user_profile: Optional[UserProfile],
     realm: Realm,
     is_web_public_query: bool,

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -15,7 +15,6 @@ from typing import (
     Union,
 )
 
-import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connection
@@ -67,7 +66,6 @@ from zerver.lib.types import Validator
 from zerver.lib.user_topics import exclude_topic_mutes
 from zerver.lib.validator import (
     check_bool,
-    check_dict,
     check_required_string,
     check_string,
     check_string_or_int,
@@ -803,73 +801,6 @@ class NarrowBuilder:
 
         cond = column("search_tsvector", postgresql.TSVECTOR).op("@@")(tsquery)
         return query.where(maybe_negate(cond))
-
-
-def narrow_parameter(var_name: str, json: str) -> OptionalNarrowListT:
-    data = orjson.loads(json)
-    if not isinstance(data, list):
-        raise ValueError("argument is not a list")
-    if len(data) == 0:
-        # The "empty narrow" should be None, and not []
-        return None
-
-    def convert_term(elem: Union[Dict[str, Any], List[str]]) -> Dict[str, Any]:
-        # We have to support a legacy tuple format.
-        if isinstance(elem, list):
-            if len(elem) != 2 or any(not isinstance(x, str) for x in elem):
-                raise ValueError("element is not a string pair")
-            return dict(operator=elem[0], operand=elem[1])
-
-        if isinstance(elem, dict):
-            # Make sure to sync this list to frontend also when adding a new operator that
-            # supports integer IDs. Relevant code is located in web/src/message_fetch.js
-            # in handle_operators_supporting_id_based_api function where you will need to
-            # update operators_supporting_id, or operators_supporting_ids array.
-            operators_supporting_id = [
-                *channel_operators,
-                "id",
-                "sender",
-                "group-pm-with",
-                "dm-including",
-            ]
-            operators_supporting_ids = ["pm-with", "dm"]
-            operators_non_empty_operand = {"search"}
-
-            operator = elem.get("operator", "")
-            if operator in operators_supporting_id:
-                operand_validator: Validator[object] = check_string_or_int
-            elif operator in operators_supporting_ids:
-                operand_validator = check_string_or_int_list
-            elif operator in operators_non_empty_operand:
-                operand_validator = check_required_string
-            else:
-                operand_validator = check_string
-
-            validator = check_dict(
-                required_keys=[
-                    ("operator", check_string),
-                    ("operand", operand_validator),
-                ],
-                optional_keys=[
-                    ("negated", check_bool),
-                ],
-            )
-
-            try:
-                validator("elem", elem)
-            except ValidationError as error:
-                raise JsonableError(error.message)
-
-            # whitelist the fields we care about for now
-            return dict(
-                operator=elem["operator"],
-                operand=elem["operand"],
-                negated=elem.get("negated", False),
-            )
-
-        raise ValueError("element is not a dictionary")
-
-    return list(map(convert_term, data))
 
 
 def ok_to_include_history(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -3655,13 +3655,16 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         self.assertEqual(final_dict["content"], "<p>test content</p>")
 
-    def common_check_get_messages_query(
-        self, query_params: Dict[str, object], expected: str
-    ) -> None:
+    def common_check_get_messages_query(self, query_params: Dict[str, Any], expected: str) -> None:
         user_profile = self.example_user("hamlet")
         request = HostRequestMock(query_params, user_profile)
         with queries_captured() as queries:
-            get_messages_backend(request, user_profile)
+            get_messages_backend(
+                request,
+                user_profile,
+                num_before=query_params["num_before"],
+                num_after=query_params["num_after"],
+            )
 
         for query in queries:
             sql = str(query.sql)
@@ -3721,7 +3724,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], first_message_id)
         self.assertEqual(result["found_newest"], True)
@@ -3758,7 +3766,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], first_message_id)
 
@@ -3771,7 +3784,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], 0)
 
@@ -3785,7 +3803,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], LARGER_THAN_MAX_MESSAGE_ID)
 
@@ -3799,7 +3822,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], 0)
 
@@ -3813,7 +3841,12 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         request = HostRequestMock(query_params, user_profile)
 
-        payload = get_messages_backend(request, user_profile)
+        payload = get_messages_backend(
+            request,
+            user_profile,
+            num_before=10,
+            num_after=10,
+        )
         result = orjson.loads(payload.content)
         self.assertEqual(result["anchor"], LARGER_THAN_MAX_MESSAGE_ID)
 
@@ -3842,7 +3875,12 @@ class GetOldMessagesTest(ZulipTestCase):
         request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
-            get_messages_backend(request, user_profile)
+            get_messages_backend(
+                request,
+                user_profile,
+                num_before=10,
+                num_after=10,
+            )
 
         # Verify the query for old messages looks correct.
         queries = [q for q in all_queries if "/* get_messages */" in q.sql]
@@ -3889,7 +3927,12 @@ class GetOldMessagesTest(ZulipTestCase):
         first_visible_message_id = first_unread_message_id + 2
         with first_visible_id_as(first_visible_message_id):
             with queries_captured() as all_queries:
-                get_messages_backend(request, user_profile)
+                get_messages_backend(
+                    request,
+                    user_profile,
+                    num_before=10,
+                    num_after=10,
+                )
 
         queries = [q for q in all_queries if "/* get_messages */" in q.sql]
         self.assert_length(queries, 1)
@@ -3913,7 +3956,12 @@ class GetOldMessagesTest(ZulipTestCase):
         request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
-            get_messages_backend(request, user_profile)
+            get_messages_backend(
+                request,
+                user_profile,
+                num_before=10,
+                num_after=10,
+            )
 
         queries = [q for q in all_queries if "/* get_messages */" in q.sql]
         self.assert_length(queries, 1)
@@ -3927,7 +3975,12 @@ class GetOldMessagesTest(ZulipTestCase):
         first_visible_message_id = 5
         with first_visible_id_as(first_visible_message_id):
             with queries_captured() as all_queries:
-                get_messages_backend(request, user_profile)
+                get_messages_backend(
+                    request,
+                    user_profile,
+                    num_before=10,
+                    num_after=10,
+                )
             queries = [q for q in all_queries if "/* get_messages */" in q.sql]
             sql = queries[0].sql
             self.assertNotIn("AND message_id <=", sql)
@@ -3966,7 +4019,12 @@ class GetOldMessagesTest(ZulipTestCase):
         request = HostRequestMock(query_params, user_profile)
 
         with queries_captured() as all_queries:
-            get_messages_backend(request, user_profile)
+            get_messages_backend(
+                request,
+                user_profile,
+                num_before=0,
+                num_after=0,
+            )
 
         # Do some tests on the main query, to verify the muting logic
         # runs on this code path.

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -92,13 +92,8 @@ def update_message_flags_for_narrow(
     )
     num_after = min(num_after, MAX_MESSAGES_PER_UPDATE - num_before)
 
-    if narrow is not None and len(narrow) > 0:
-        narrow_dict = [x.model_dump() for x in narrow]
-    else:
-        narrow_dict = None
-
     query_info = fetch_messages(
-        narrow=narrow_dict,
+        narrow=narrow,
         user_profile=user_profile,
         realm=user_profile.realm,
         is_web_public_query=False,

--- a/zilencer/management/commands/profile_request.py
+++ b/zilencer/management/commands/profile_request.py
@@ -21,9 +21,16 @@ class MockSession(SessionBase):
         self.modified = False
 
 
-def profile_request(request: HttpRequest) -> HttpResponseBase:
+def profile_request(request: HttpRequest, num_before: int, num_after: int) -> HttpResponseBase:
     def get_response(request: HttpRequest) -> HttpResponseBase:
-        return prof.runcall(get_messages_backend, request, request.user, apply_markdown=True)
+        return prof.runcall(
+            get_messages_backend,
+            request,
+            request.user,
+            num_before=num_before,
+            num_after=num_after,
+            apply_markdown=True,
+        )
 
     prof = cProfile.Profile()
     with tempfile.NamedTemporaryFile(prefix="profile.data.", delete=False) as stats_file:
@@ -58,4 +65,4 @@ class Command(ZulipBaseCommand):
         mock_request.session = MockSession()
         RequestNotes.get_notes(mock_request).log_data = None
 
-        profile_request(mock_request)
+        profile_request(mock_request, num_before=1200, num_after=200)


### PR DESCRIPTION
Migrated `message_fetch` to `typed_endpoint`.

Removed the old `narrow_parameter` as we have shifted to the new `NarrowParameter` Pydantic Object.

This new object provides better error messages for data validation, hence changed the error messages in `test_message_fetch`. 

`num_before` and `num_after` are required parameters, added them to all the calls of `get_messages_backend`.


### narrow: Use NarrowParameter instead of dictionary.
Earlier we were using the type `OptionalNarrowListT` for all functions
that required "narrow" as a parameter.
This commit changes all the functions accepting a "narrow"
to use a list of the new `NarrowParameter`
instead of `OptionalNarrowListT` which is a list of dicts.

