### PR TITLE
zilencer: Do not error on old stats which we no longer have.

### DIFF
--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -759,9 +759,17 @@ def validate_incoming_table_data(
 ) -> None:
     last_id = get_last_id_from_server(server, model)
     for row in rows:
-        if is_count_stat and (
-            row["property"] not in COUNT_STATS
-            or row["property"] in BOUNCER_ONLY_REMOTE_COUNT_STAT_PROPERTIES
+        # We are silent about stats not in COUNT_STATS which are
+        # in LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER --
+        # these are stats we stopped recording, but old versions
+        # may still have and report.
+        if (
+            is_count_stat
+            and (
+                row["property"] not in COUNT_STATS
+                or row["property"] in BOUNCER_ONLY_REMOTE_COUNT_STAT_PROPERTIES
+            )
+            and row["property"] not in LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER
         ):
             raise JsonableError(_("Invalid property {property}").format(property=row["property"]))
 


### PR DESCRIPTION
This should ideally get a test, but I think writing it is hard because we need the _client_ of the upload to have different `LOGGING_COUNT_STAT_PROPERTIES_NOT_SENT_TO_BOUNCER` from the _server_.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
