### PR TITLE
typeahead: Remove delay when opening / closing typeahead.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -344,6 +344,7 @@ export class Typeahead<ItemType extends string | object> {
             // Lets typeahead take the width needed to fit the content
             // and wraps it if it overflows the visible container.
             maxWidth: "none",
+            delay: [0, 0],
             theme: "popover-menu",
             placement: this.dropup ? "top-start" : "bottom-start",
             popperOptions: {


### PR DESCRIPTION
This default delay comes off as the typeahead being laggy to the user.


discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/typeahead.20slow.20to.20appear