### PR TITLE
katex: Default the server on.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -193,15 +193,15 @@ Defaults to 14 days.
 
 #### `katex_server`
 
-Set to a true value to run a separate service for [rendering math with
-LaTeX](https://zulip.com/help/latex). This is not necessary except on servers
-with users who send several math blocks in a single message; it will address
-issues with such messages occasionally failing to send, at cost of a small
-amount of increased memory usage.
+Set to a false value to disable the separate service for [rendering math with
+LaTeX](https://zulip.com/help/latex). Disabling this service will save a small
+amount of memory, at the cost of making math blocks significantly slower to
+render, to the point that using dozens of them in a single message may cause
+the message to fail to send.
 
 #### `katex_server_port`
 
-Set to the port number for the KaTeX server, if enabled; defaults to port 9700.
+Set to the port number for the KaTeX server; defaults to port 9700.
 
 ### `[postfix]`
 

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -167,7 +167,7 @@ class zulip::app_frontend_base {
     include zulip::smokescreen
   }
 
-  $katex_server = zulipconf('application_server', 'katex_server', false)
+  $katex_server = zulipconf('application_server', 'katex_server', true)
   $katex_server_port = zulipconf('application_server', 'katex_server_port', '9700')
 
   if $proxy_host != '' and $proxy_port != '' {

--- a/puppet/zulip/templates/supervisor/zulip.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip.conf.template.erb
@@ -116,7 +116,7 @@ programs=zulip_events
 
 <% if @katex_server %>
 [program:zulip-katex]
-command=/usr/local/bin/secret-env-wrapper SHARED_SECRET=shared_secret /srv/zulip-node/bin/node /home/zulip/deployments/current/static/webpack-bundles/katex_server.js <%= @katex_server_port %>
+command=/usr/local/bin/secret-env-wrapper SHARED_SECRET=shared_secret /srv/zulip-node/bin/node /home/zulip/prod-static/webpack-bundles/katex_server.js <%= @katex_server_port %>
 environment=NODE_ENV=production
 priority=200                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -522,7 +522,7 @@ CAMO_KEY = get_secret("camo_key") if CAMO_URI != "" else None
 # KATEX SERVER SETTINGS
 ########################################################################
 
-KATEX_SERVER = get_config("application_server", "katex_server", False)
+KATEX_SERVER = get_config("application_server", "katex_server", True)
 KATEX_SERVER_PORT = get_config("application_server", "katex_server_port", "9700")
 
 

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -275,3 +275,5 @@ ALLOW_GROUP_VALUED_SETTINGS = True
 # This allows tests to not worry about the special behavior during the grace period.
 # Otherwise they would have to do lots of mocking of the timer to work around this.
 RESOLVE_TOPIC_UNDO_GRACE_PERIOD_SECONDS = 0
+
+KATEX_SERVER = False


### PR DESCRIPTION
The memory costs are low (~60MB), and likely worth the stability.
