### PR TITLE
Take user to top / end of feed on home / end keypress.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -160,7 +160,7 @@ EXEMPT_FILES = make_set(
         "web/src/navbar_alerts.ts",
         "web/src/navbar_help_menu.ts",
         "web/src/navbar_menus.js",
-        "web/src/navigate.ts",
+        "web/src/navigate.js",
         "web/src/onboarding_steps.ts",
         "web/src/overlay_util.ts",
         "web/src/overlays.ts",

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -55,6 +55,16 @@ const consts = {
     recent_view_minimum_load_more_fetch_size: 50000,
 };
 
+export function load_messages_around_anchor(anchor, cont, msg_list_data) {
+    load_messages({
+        anchor,
+        num_before: consts.narrowed_view_backward_batch_size,
+        num_after: consts.narrowed_view_forward_batch_size,
+        msg_list_data,
+        cont,
+    });
+}
+
 function process_result(data, opts) {
     let messages = data.messages;
 

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -1,6 +1,7 @@
 import assert from "minimalistic-assert";
 
 import * as message_lists from "./message_lists";
+import * as message_view from "./message_view";
 import * as message_viewport from "./message_viewport";
 import * as unread_ops from "./unread_ops";
 
@@ -46,20 +47,11 @@ export function down(with_centering = false) {
 }
 
 export function to_home() {
-    assert(message_lists.current !== undefined);
-    message_viewport.set_last_movement_direction(-1);
-    const first_message = message_lists.current.first();
-    assert(first_message !== undefined);
-    message_lists.current.select_id(first_message.id, {then_scroll: true, from_scroll: true});
+    message_view.fast_track_current_msg_list_to_anchor("oldest");
 }
 
 export function to_end() {
-    assert(message_lists.current !== undefined);
-    const last_message = message_lists.current.last();
-    assert(last_message !== undefined);
-    message_viewport.set_last_movement_direction(1);
-    message_lists.current.select_id(last_message.id, {then_scroll: true, from_scroll: true});
-    unread_ops.process_visible();
+    message_view.fast_track_current_msg_list_to_anchor("newest");
 }
 
 function amount_to_paginate() {

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -4,12 +4,12 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as unread_ops from "./unread_ops";
 
-function go_to_row(msg_id: number): void {
+function go_to_row(msg_id) {
     assert(message_lists.current !== undefined);
     message_lists.current.select_id(msg_id, {then_scroll: true, from_scroll: true});
 }
 
-export function up(): void {
+export function up() {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(-1);
     const msg_id = message_lists.current.prev();
@@ -19,7 +19,7 @@ export function up(): void {
     go_to_row(msg_id);
 }
 
-export function down(with_centering = false): void {
+export function down(with_centering = false) {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(1);
 
@@ -45,7 +45,7 @@ export function down(with_centering = false): void {
     go_to_row(msg_id);
 }
 
-export function to_home(): void {
+export function to_home() {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(-1);
     const first_message = message_lists.current.first();
@@ -53,7 +53,7 @@ export function to_home(): void {
     message_lists.current.select_id(first_message.id, {then_scroll: true, from_scroll: true});
 }
 
-export function to_end(): void {
+export function to_end() {
     assert(message_lists.current !== undefined);
     const last_message = message_lists.current.last();
     assert(last_message !== undefined);
@@ -62,7 +62,7 @@ export function to_end(): void {
     unread_ops.process_visible();
 }
 
-function amount_to_paginate(): number {
+function amount_to_paginate() {
     // Some day we might have separate versions of this function
     // for Page Up vs. Page Down, but for now it's the same
     // strategy in either direction.
@@ -90,7 +90,7 @@ function amount_to_paginate(): number {
     return delta;
 }
 
-export function page_up_the_right_amount(): void {
+export function page_up_the_right_amount() {
     // This function's job is to scroll up the right amount,
     // after the user hits Page Up.  We do this ourselves
     // because we can't rely on the browser to account for certain
@@ -102,13 +102,13 @@ export function page_up_the_right_amount(): void {
     message_viewport.scrollTop(message_viewport.scrollTop() - delta);
 }
 
-export function page_down_the_right_amount(): void {
+export function page_down_the_right_amount() {
     // see also: page_up_the_right_amount
     const delta = amount_to_paginate();
     message_viewport.scrollTop(message_viewport.scrollTop() + delta);
 }
 
-export function page_up(): void {
+export function page_up() {
     assert(message_lists.current !== undefined);
     if (message_viewport.at_rendered_top() && !message_lists.current.visibly_empty()) {
         if (message_lists.current.view.is_fetched_start_rendered()) {
@@ -127,7 +127,7 @@ export function page_up(): void {
     }
 }
 
-export function page_down(): void {
+export function page_down() {
     assert(message_lists.current !== undefined);
     if (message_viewport.at_rendered_bottom() && !message_lists.current.visibly_empty()) {
         if (message_lists.current.view.is_fetched_end_rendered()) {


### PR DESCRIPTION
Fixes #14971

Instead of taking user to top / end of fetched history, we take
user to the first / last message of the narrow.

We simply check our cached history if we have the data for the
jump, if not, we ask server for the data.

Tested by simply pressing `fn + left / right arrow` on mac in
combined feed and topic narrows. Also, reduced message_fetch
constant values to be all single digital to check if the -
data not in cache -> fetch data -> select message logic works well.