### PR TITLE
compose_banner: Don't show banner if message sent in a near view. 

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -125,8 +125,13 @@ export function is_local_mix(message: Message): boolean {
     }
 
     const current_filter = narrow_state.filter();
+    const is_conversation_view =
+        current_filter === undefined
+            ? false
+            : current_filter.is_conversation_view() ||
+              current_filter.is_conversation_view_with_near();
     const $row = message_lists.current.get_row(message.id);
-    if (current_filter && current_filter.is_conversation_view() && $row.length > 0) {
+    if (is_conversation_view && $row.length > 0) {
         // If our message is in the current conversation view, we do
         // not have a mix, so we are happy.
         return false;

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1261,6 +1261,17 @@ export class Filter {
         return false;
     }
 
+    is_conversation_view_with_near(): boolean {
+        const term_type = this.sorted_term_types();
+        if (
+            _.isEqual(term_type, ["channel", "topic", "near"]) ||
+            _.isEqual(term_type, ["dm", "near"])
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     excludes_muted_topics(): boolean {
         return (
             // not narrowed to a topic

--- a/web/src/scheduled_messages_feed_ui.ts
+++ b/web/src/scheduled_messages_feed_ui.ts
@@ -10,7 +10,10 @@ import * as util from "./util";
 function get_scheduled_messages_matching_narrow(): ScheduledMessage[] {
     const scheduled_messages_list = [...scheduled_messages.scheduled_messages_data.values()];
     const filter = narrow_state.filter();
-    const is_conversation_view = filter === undefined ? false : filter.is_conversation_view();
+    const is_conversation_view =
+        filter === undefined
+            ? false
+            : filter.is_conversation_view() || filter.is_conversation_view_with_near();
     const current_view_type = narrow_state.narrowed_to_pms() ? "private" : "stream";
 
     if (!is_conversation_view) {

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -181,6 +181,7 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel"));
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_conversation_view_with_near());
 
     // If our only channel operator is negated, then for all intents and purposes,
     // we don't consider ourselves to have a channel operator, because we don't
@@ -295,6 +296,22 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_conversation_view_with_near());
+
+    terms = [
+        {operator: "dm", operand: "joe@example.com"},
+        {operator: "near", operand: 17},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.is_non_huddle_pm());
+    assert.ok(filter.contains_only_private_messages());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_conversation_view_with_near());
 
     terms = [{operator: "dm", operand: "joe@example.com,jack@example.com"}];
     filter = new Filter(terms);
@@ -305,6 +322,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_conversation_view_with_near());
 
     // "pm-with" was renamed to "dm"
     terms = [{operator: "pm-with", operand: "joe@example.com"}];
@@ -376,6 +394,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_conversation_view_with_near());
 
     // "stream" was renamed to "channel"
     terms = [
@@ -393,6 +412,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_conversation_view_with_near());
 });
 
 function assert_not_mark_read_with_has_operands(additional_terms_to_test) {


### PR DESCRIPTION

Fixes two bugs:

When we are in `/near/` topic or dm view then,
1. scheduled message indicator is missing in the conversation.
2. On sending a message in the same topic, the 'jump to sent message' banner is incorrectly shown. Fixes #30341




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
