### PR TITLE
info_density: Set calculated font-size on body.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -169,7 +169,9 @@
         */
         padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
         color: var(--color-text-message-default);
-        font-size: var(--base-font-size-px);
+        /* We explicitly set line-height here so that
+           the message area is not beholden to the legacy
+           `max()` declaration on `body`. */
         line-height: var(--base-line-height-unitless);
         min-height: 17px;
         display: block;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -23,7 +23,7 @@ body {
     width: 100%;
     margin: 0;
     padding: 0;
-    font-size: 14px;
+    font-size: var(--base-font-size-px);
     /* The line-height used in most of the UI should be at least
        its legacy value, but should expand with larger base
        line-height values. */


### PR DESCRIPTION
It's time. This has no effect at legacy settings (`.more_dense_mode`), but this moves the `font-size` declaration to the `body` selector, paving the way for much easier testing and tweaking as the info-density project gets ready to make its debut.

Along those lines, I've created a new [`area: information density`](https://github.com/zulip/zulip/labels/area%3A%20information%20density) label to accompany this PR, as I suspect there will be more PRs like this one (not to mention issues) that will be about information density in general, and not necessarily tied to one part of the UI or another.

**Screenshots and screen captures:**

| Before | After (no changes) |
| --- | --- |
| ![body-font-size-before](https://github.com/zulip/zulip/assets/170719/c697e7c7-e73c-496d-a9dc-64c07af9be13) | ![body-font-size-after](https://github.com/zulip/zulip/assets/170719/97209cbb-aa6f-4885-bcd2-f3a715b63e6f) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>