### PR TITLE
navbar: Express font and icon sizes in ems.

### DIFF
--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -14,10 +14,16 @@
         display: none;
     }
 
+    /* TODO: Remove the `.navbar_title` span from the `message_view_header.hbs`
+       template. That span predates the use of flexbox, and makes it so that
+       elements like the `.narrow_description` have different line-height and
+       sizing contexts depending on whether it's a view or a narrow being shown. */
+
     .message-header-stream-settings-button,
     .navbar_title {
         font-weight: 600;
-        font-size: 16px;
+        /* 16px at 14px em */
+        font-size: 1.1429em;
         padding: 0 2px 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -32,14 +38,16 @@
         align-items: baseline;
 
         .zulip-icon {
-            font-size: 14px;
+            /* 14px at 16px em, inherited from .navbar_title */
+            font-size: 0.875em;
             /* Pull the icon out of baseline alignment,
                and center with stream name. */
             align-self: center;
         }
 
         .zulip-icon-inbox {
-            font-size: 16px;
+            /* 16px at 16px em, inherited from .navbar_title */
+            font-size: 1em;
         }
 
         .fa-envelope {
@@ -61,9 +69,15 @@
 
         .fa {
             .fa-envelope {
-                font-size: 14px;
+                /* 14px at 16px em, inherited from .navbar_title */
+                font-size: 0.875em;
                 margin: 0 5px;
             }
+        }
+
+        .narrow_description {
+            /* 14px at 16px em, inherited from .navbar_title */
+            font-size: 0.875em;
         }
     }
 
@@ -83,7 +97,8 @@
            before the stream name must begin to shrink */
         flex-shrink: 100;
         background: none;
-        font-size: 14px;
+        /* 14px at 14px em */
+        font-size: 1em;
         color: inherit;
         font-weight: 400;
         padding-left: 10px;

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -64,11 +64,6 @@
                 font-size: 14px;
                 margin: 0 5px;
             }
-
-            .fa-hashtag {
-                font-size: 1.2rem;
-                margin: 0 2px 0 5px;
-            }
         }
     }
 


### PR DESCRIPTION
This PR does a bit of cleanup and then proceeds to express navbar font and icon sizes in ems. There are still pixel values in the area, specifically the `line-height` value tied to the 40px `--header-height` variable. But even within that value, there is a respectable amount of room for font-size and line-height values to grow in that area beyond 16/140.

As a comment in `message_view_header.css` explains, removing `.navbar_title` from the templates will make it easier to consistently work in this area (how long have we dealt with icon alignment issues that differ in narrows but not in other views?), but that's just a bit beyond the scope of the information density project at this point.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![stream-navbar-before](https://github.com/zulip/zulip/assets/170719/523e812e-be5a-4068-bd23-c362906741b2) | ![stream-navbar-after](https://github.com/zulip/zulip/assets/170719/f1fc6c41-b66b-4c76-9cbd-8671658aae3b) |
| ![combined-navbar-before](https://github.com/zulip/zulip/assets/170719/7e602fca-fee2-41ca-b0c0-35de4685ebd7) | ![combined-navbar-after](https://github.com/zulip/zulip/assets/170719/7b397292-3c34-4c8f-842e-f297f14c3ab5) |
| ![starred-navbar-before](https://github.com/zulip/zulip/assets/170719/de3d0f79-fa87-444b-8889-764e4b6f2892) | ![starred-navbar-after](https://github.com/zulip/zulip/assets/170719/094a7945-1ac2-4c97-802c-c98fa7d392c3) |

_With 16px/140% density in effect (not possible on this PR alone)_
![stream-navbar-after-16-140](https://github.com/zulip/zulip/assets/170719/3d7e04b2-d2a2-4711-af17-8daf49fba1c3)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
