### PR TITLE
right_sidebar: Uniformly group user name and status emoji.

### DIFF
--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -14,8 +14,10 @@
                     <span class="status-text">{{status_text}}</span>
                 </div>
             {{else}}
-                {{> user_full_name}}
-                {{> status_emoji status_emoji_info}}
+                <div class="user-name-and-status-emoji">
+                    {{> user_full_name}}
+                    {{> status_emoji status_emoji_info}}
+                </div>
             {{/if}}
         </a>
         <span class="unread_count {{#unless num_unread}}hide{{/unless}}">{{#if num_unread}}{{num_unread}}{{/if}}</span>


### PR DESCRIPTION
This fixes the presentation of emoji in the compact view, where the flexbox for properly aligning emoji was not set. That meant compact view status emoji were more distant and droopy than their show-status counterparts.

The discrepancy was introduced in be4d4085f2f691506f187a3138422293265c3706, but became much more noticeable after the grid rewrites in #30291.

**Screenshots and screen captures:**

| Compact, before | Compact, after |
| --- | --- |
| ![right-sidebar-compact-before](https://github.com/zulip/zulip/assets/170719/0963f9e1-4787-4a7d-a863-84826110edb2) | ![right-sidebar-compact-after](https://github.com/zulip/zulip/assets/170719/bb147308-836f-4e47-8a75-4f5307662d1a) |

| Show status, before | Show status, after (no change) |
| --- | --- |
| ![right-sidebar-status-before](https://github.com/zulip/zulip/assets/170719/3131fc97-261d-4714-9144-dc5b014b853c) | ![right-sidebar-status-after](https://github.com/zulip/zulip/assets/170719/ccdafbf0-8731-4891-b662-626313da18fe) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
