### PR TITLE
eslint: Fix and enable prefer-arrow-functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
         "warnOnUnsupportedTypeScriptVersion": false,
         "sourceType": "unambiguous"
     },
-    "plugins": ["formatjs", "no-jquery"],
+    "plugins": ["formatjs", "no-jquery", "prefer-arrow-functions"],
     "settings": {
         "formatjs": {
             "additionalFunctionNames": ["$t", "$t_html"]
@@ -103,9 +103,10 @@
         "no-useless-concat": "error",
         "no-useless-constructor": "error",
         "no-var": "error",
-        "object-shorthand": ["error", "always", {"avoidExplicitReturnArrows": true}],
+        "object-shorthand": ["error", "always"],
         "one-var": ["error", "never"],
         "prefer-arrow-callback": "error",
+        "prefer-arrow-functions/prefer-arrow-functions": "error",
         "prefer-const": ["error", {"ignoreReadBeforeAssign": true}],
         "radix": "error",
         "sort-imports": ["error", {"ignoreDeclarationSort": true}],

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "eslint-plugin-formatjs": "^4.0.2",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-no-jquery": "^2.7.0",
+    "eslint-plugin-prefer-arrow-functions": "^3.3.2",
     "eslint-plugin-unicorn": "^53.0.0",
     "jsdom": "^24.0.0",
     "minimist": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       eslint-plugin-no-jquery:
         specifier: ^2.7.0
         version: 2.7.0(patch_hash=3o6vd4atcpz6wln5ovpbrt3cea)(eslint@8.57.0)
+      eslint-plugin-prefer-arrow-functions:
+        specifier: ^3.3.2
+        version: 3.3.2(eslint@8.57.0)
       eslint-plugin-unicorn:
         specifier: ^53.0.0
         version: 53.0.0(eslint@8.57.0)
@@ -3602,6 +3605,11 @@ packages:
     resolution: {integrity: sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==}
     peerDependencies:
       eslint: '>=2.3.0'
+
+  eslint-plugin-prefer-arrow-functions@3.3.2:
+    resolution: {integrity: sha512-XRGsga9cK6pZ48IA2PM2PABBlWshRYhkofkQxcWzCM0YlDnal2hrQKsuz0FqtBHimJpgEXGgHUko3KrOayxlOQ==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-unicorn@53.0.0:
     resolution: {integrity: sha512-kuTcNo9IwwUCfyHGwQFOK/HjJAYzbODHN3wP0PgqbW+jbXqpNWxNVpVhj2tO9SixBwuAdmal8rVcWKBxwFnGuw==}
@@ -11170,6 +11178,10 @@ snapshots:
       - supports-color
 
   eslint-plugin-no-jquery@2.7.0(patch_hash=3o6vd4atcpz6wln5ovpbrt3cea)(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
+
+  eslint-plugin-prefer-arrow-functions@3.3.2(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
 

--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -19,7 +19,7 @@ const argv = yargs(hideBin(process.argv))
     })
     .parse();
 
-async function checkFile(file) {
+const checkFile = async (file) => {
     const yaml = await fs.promises.readFile(file, "utf8");
     const lineCounter = new LineCounter();
     const tokens = [...new Parser(lineCounter.addNewLine).parse(yaml)];
@@ -46,7 +46,7 @@ async function checkFile(file) {
     const promises = [];
 
     visit(doc, {
-        Map(_key, node) {
+        Map: (_key, node) => {
             if (node.has("$ref") && node.items.length !== 1) {
                 const {line, col} = lineCounter.linePos(node.range[0]);
                 console.error("%s:%d:%d: Siblings of $ref have no effect", file, line, col);
@@ -54,7 +54,7 @@ async function checkFile(file) {
             }
         },
 
-        Pair(_key, node) {
+        Pair: (_key, node) => {
             if (
                 node.key instanceof Scalar &&
                 node.key.value === "allOf" &&
@@ -155,7 +155,7 @@ async function checkFile(file) {
         }
         process.exitCode = 1;
     }
-}
+};
 
 (async () => {
     for (const file of argv._) {

--- a/tools/screenshots/message-screenshot.js
+++ b/tools/screenshots/message-screenshot.js
@@ -27,7 +27,7 @@ if (options.messageId === undefined) {
 }
 
 // TODO: Refactor to share code with web/e2e-tests/realm-creation.test.ts
-async function run() {
+const run = async () => {
     const browser = await puppeteer.launch({
         args: [
             "--window-size=1400,1024",
@@ -84,6 +84,6 @@ async function run() {
     } finally {
         await browser.close();
     }
-}
+};
 
 run();

--- a/tools/screenshots/thread-screenshot.js
+++ b/tools/screenshots/thread-screenshot.js
@@ -29,7 +29,7 @@ if (options.imagePath === undefined) {
 }
 
 // TODO: Refactor to share code with web/e2e-tests/realm-creation.test.ts
-async function run() {
+const run = async () => {
     const browser = await puppeteer.launch({
         args: [
             "--window-size=1400,1024",
@@ -85,6 +85,6 @@ async function run() {
     } finally {
         await browser.close();
     }
-}
+};
 
 run();

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 263
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (280, 1)  # last bumped 2024-06-03 for adding @types/js-cookie
+PROVISION_VERSION = (280, 2)  # bumped 2024-06-07 for adding eslint-plugin-prefer-arrow-functions

--- a/web/debug-require.js
+++ b/web/debug-require.js
@@ -2,7 +2,7 @@
 
 /* global __webpack_require__ */
 
-function debugRequire(request) {
+const debugRequire = (request) => {
     if (!Object.prototype.hasOwnProperty.call(debugRequire.ids, request)) {
         throw new Error("Cannot find module '" + request + "'");
     }
@@ -11,7 +11,7 @@ function debugRequire(request) {
         throw new Error("Module '" + request + "' has not been loaded yet");
     }
     return __webpack_require__(moduleId);
-}
+};
 
 debugRequire.r = __webpack_require__;
 debugRequire.ids = __webpack_require__.debugRequireIds;

--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function submit_announcements_stream_settings(page: Page): Promise<void> {
+const submit_announcements_stream_settings = async (page: Page): Promise<void> => {
     await page.waitForSelector('#org-notifications .save-button[data-status="unsaved"]', {
         visible: true,
     });
@@ -27,9 +27,9 @@ async function submit_announcements_stream_settings(page: Page): Promise<void> {
     );
 
     await page.waitForSelector("#org-notifications .save-button", {hidden: true});
-}
+};
 
-async function test_change_new_stream_announcements_stream(page: Page): Promise<void> {
+const test_change_new_stream_announcements_stream = async (page: Page): Promise<void> => {
     await page.click("#realm_new_stream_announcements_stream_id_widget.dropdown-widget-button");
     await page.waitForSelector(".dropdown-list-container", {
         visible: true,
@@ -45,9 +45,9 @@ async function test_change_new_stream_announcements_stream(page: Page): Promise<
     await rome_in_dropdown.click();
 
     await submit_announcements_stream_settings(page);
-}
+};
 
-async function test_change_signup_announcements_stream(page: Page): Promise<void> {
+const test_change_signup_announcements_stream = async (page: Page): Promise<void> => {
     console.log('Changing signup notifications stream to Verona by filtering with "verona"');
 
     await page.click("#realm_signup_announcements_stream_id_widget");
@@ -58,9 +58,9 @@ async function test_change_signup_announcements_stream(page: Page): Promise<void
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("Enter");
     await submit_announcements_stream_settings(page);
-}
+};
 
-async function test_change_zulip_update_announcements_stream(page: Page): Promise<void> {
+const test_change_zulip_update_announcements_stream = async (page: Page): Promise<void> => {
     await page.click("#realm_zulip_update_announcements_stream_id_widget.dropdown-widget-button");
     await page.waitForSelector(".dropdown-list-container", {
         visible: true,
@@ -76,17 +76,17 @@ async function test_change_zulip_update_announcements_stream(page: Page): Promis
     await rome_in_dropdown.click();
 
     await submit_announcements_stream_settings(page);
-}
+};
 
-async function test_permissions_change_save_worked(page: Page): Promise<void> {
+const test_permissions_change_save_worked = async (page: Page): Promise<void> => {
     const saved_status = '#org-stream-permissions .save-button[data-status="saved"]';
     await page.waitForSelector(saved_status, {
         visible: true,
     });
     await page.waitForSelector(saved_status, {hidden: true});
-}
+};
 
-async function submit_stream_permissions_change(page: Page): Promise<void> {
+const submit_stream_permissions_change = async (page: Page): Promise<void> => {
     const save_button = "#org-stream-permissions .save-button";
     await page.waitForSelector(save_button, {visible: true});
     assert.strictEqual(
@@ -97,11 +97,11 @@ async function submit_stream_permissions_change(page: Page): Promise<void> {
     await page.click(save_button);
 
     await test_permissions_change_save_worked(page);
-}
+};
 
-async function test_changing_create_streams_and_invite_to_stream_policies(
+const test_changing_create_streams_and_invite_to_stream_policies = async (
     page: Page,
-): Promise<void> {
+): Promise<void> => {
     const policies = {
         "create private stream": "#id_realm_create_private_stream_policy",
         "create public stream": "#id_realm_create_public_stream_policy",
@@ -121,17 +121,17 @@ async function test_changing_create_streams_and_invite_to_stream_policies(
             await submit_stream_permissions_change(page);
         }
     }
-}
+};
 
-async function test_save_joining_organization_change_worked(page: Page): Promise<void> {
+const test_save_joining_organization_change_worked = async (page: Page): Promise<void> => {
     const saved_status = '#org-join-settings .save-button[data-status="saved"]';
     await page.waitForSelector(saved_status, {
         visible: true,
     });
     await page.waitForSelector(saved_status, {hidden: true});
-}
+};
 
-async function submit_joining_organization_change(page: Page): Promise<void> {
+const submit_joining_organization_change = async (page: Page): Promise<void> => {
     const save_button = "#org-join-settings .save-button";
     await page.waitForSelector(save_button, {visible: true});
     assert.strictEqual(
@@ -143,16 +143,16 @@ async function submit_joining_organization_change(page: Page): Promise<void> {
     await page.click(save_button);
 
     await test_save_joining_organization_change_worked(page);
-}
+};
 
-async function test_set_new_user_threshold_to_three_days(page: Page): Promise<void> {
+const test_set_new_user_threshold_to_three_days = async (page: Page): Promise<void> => {
     console.log("Test setting new user threshold to three days.");
     await page.waitForSelector("#id_realm_waiting_period_threshold", {visible: true});
     await page.select("#id_realm_waiting_period_threshold", "3");
     await submit_joining_organization_change(page);
-}
+};
 
-async function test_set_new_user_threshold_to_N_days(page: Page): Promise<void> {
+const test_set_new_user_threshold_to_N_days = async (page: Page): Promise<void> => {
     console.log("Test setting new user threshold to N days.");
     await page.waitForSelector("#id_realm_waiting_period_threshold", {visible: true});
     await page.select("#id_realm_waiting_period_threshold", "custom_period");
@@ -160,9 +160,9 @@ async function test_set_new_user_threshold_to_N_days(page: Page): Promise<void> 
     const N = "10";
     await common.clear_and_type(page, "#id_realm_waiting_period_threshold_custom_input", N);
     await submit_joining_organization_change(page);
-}
+};
 
-async function test_organization_permissions(page: Page): Promise<void> {
+const test_organization_permissions = async (page: Page): Promise<void> => {
     await page.click("li[data-section='organization-permissions']");
 
     // Test temporarily disabled 2024-02-07 due to nondeterminsitic failures.
@@ -173,9 +173,9 @@ async function test_organization_permissions(page: Page): Promise<void> {
     // See https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1743361
     console.log("Skipping", test_set_new_user_threshold_to_three_days);
     console.log("Skipping", test_set_new_user_threshold_to_N_days);
-}
+};
 
-async function test_add_emoji(page: Page): Promise<void> {
+const test_add_emoji = async (page: Page): Promise<void> => {
     await common.fill_form(page, "#add-custom-emoji-form", {name: "zulip logo"});
 
     const emoji_upload_handle = await page.$("input#emoji_file_input");
@@ -191,9 +191,9 @@ async function test_add_emoji(page: Page): Promise<void> {
         "Emoji name incorrectly saved.",
     );
     await page.waitForSelector("tr#emoji_zulip_logo img", {visible: true});
-}
+};
 
-async function test_delete_emoji(page: Page): Promise<void> {
+const test_delete_emoji = async (page: Page): Promise<void> => {
     await page.click("tr#emoji_zulip_logo button.delete");
 
     await common.wait_for_micromodal_to_open(page);
@@ -202,18 +202,18 @@ async function test_delete_emoji(page: Page): Promise<void> {
 
     // assert the emoji is deleted.
     await page.waitForSelector("tr#emoji_zulip_logo", {hidden: true});
-}
+};
 
-async function test_custom_realm_emoji(page: Page): Promise<void> {
+const test_custom_realm_emoji = async (page: Page): Promise<void> => {
     await page.click("li[data-section='emoji-settings']");
     await page.click("#add-custom-emoji-button");
     await common.wait_for_micromodal_to_open(page);
 
     await test_add_emoji(page);
     await test_delete_emoji(page);
-}
+};
 
-async function test_upload_realm_icon_image(page: Page): Promise<void> {
+const test_upload_realm_icon_image = async (page: Page): Promise<void> => {
     const upload_handle = await page.$("#realm-icon-upload-widget input.image_file_input");
     assert.ok(upload_handle);
     await upload_handle.uploadFile("static/images/logo/zulip-icon-128x128.png");
@@ -228,16 +228,16 @@ async function test_upload_realm_icon_image(page: Page): Promise<void> {
         '#realm-icon-upload-widget .image-block[src^="/user_avatars/2/realm/icon.png?version=2"]',
         {visible: true},
     );
-}
+};
 
-async function delete_realm_icon(page: Page): Promise<void> {
+const delete_realm_icon = async (page: Page): Promise<void> => {
     await page.click("li[data-section='organization-profile']");
     await page.click("#realm-icon-upload-widget .image-delete-button");
 
     await page.waitForSelector("#realm-icon-upload-widget .image-delete-button", {hidden: true});
-}
+};
 
-async function test_organization_profile(page: Page): Promise<void> {
+const test_organization_profile = async (page: Page): Promise<void> => {
     await page.click("li[data-section='organization-profile']");
     const gravatar_selctor =
         '#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]';
@@ -250,9 +250,9 @@ async function test_organization_profile(page: Page): Promise<void> {
     await delete_realm_icon(page);
     await page.waitForSelector("#realm-icon-upload-widget .image-delete-button", {hidden: true});
     await page.waitForSelector(gravatar_selctor, {visible: true});
-}
+};
 
-async function test_authentication_methods(page: Page): Promise<void> {
+const test_authentication_methods = async (page: Page): Promise<void> => {
     await page.click("li[data-section='auth-methods']");
     await page.waitForSelector(".method_row[data-method='Google'] input[type='checkbox'] + span", {
         visible: true,
@@ -277,9 +277,9 @@ async function test_authentication_methods(page: Page): Promise<void> {
     await page.waitForSelector(
         ".method_row[data-method='Google'] input[type='checkbox']:not(:checked)",
     );
-}
+};
 
-async function admin_test(page: Page): Promise<void> {
+const admin_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
 
     await common.manage_organization(page);
@@ -297,6 +297,6 @@ async function admin_test(page: Page): Promise<void> {
         await test_organization_profile(page);
     }
     await test_authentication_methods(page);
-}
+};
 
 common.run_test(admin_test);

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -4,15 +4,15 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function check_compose_form_empty(page: Page): Promise<void> {
+const check_compose_form_empty = async (page: Page): Promise<void> => {
     await common.check_compose_state(page, {
         stream_name: "",
         topic: "",
         content: "",
     });
-}
+};
 
-async function close_compose_box(page: Page): Promise<void> {
+const close_compose_box = async (page: Page): Promise<void> => {
     const recipient_dropdown_visible = (await page.$(".dropdown-list-container")) !== null;
 
     if (recipient_dropdown_visible) {
@@ -21,13 +21,11 @@ async function close_compose_box(page: Page): Promise<void> {
     }
     await page.keyboard.press("Escape");
     await page.waitForSelector("#compose-textarea", {hidden: true});
-}
+};
 
-function get_message_selector(text: string): string {
-    return `xpath/(//p[text()='${text}'])[last()]`;
-}
+const get_message_selector = (text: string): string => `xpath/(//p[text()='${text}'])[last()]`;
 
-async function test_send_messages(page: Page): Promise<void> {
+const test_send_messages = async (page: Page): Promise<void> => {
     const initial_msgs_count = (await page.$$(".message-list .message_row")).length;
 
     await common.send_multiple_messages(page, [
@@ -37,28 +35,28 @@ async function test_send_messages(page: Page): Promise<void> {
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     assert.equal((await page.$$(".message-list .message_row")).length, initial_msgs_count + 2);
-}
+};
 
-async function test_stream_compose_keyboard_shortcut(page: Page): Promise<void> {
+const test_stream_compose_keyboard_shortcut = async (page: Page): Promise<void> => {
     await page.keyboard.press("KeyC");
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
     await check_compose_form_empty(page);
     await close_compose_box(page);
-}
+};
 
-async function test_private_message_compose_shortcut(page: Page): Promise<void> {
+const test_private_message_compose_shortcut = async (page: Page): Promise<void> => {
     await page.keyboard.press("KeyX");
     await page.waitForSelector("#private_message_recipient", {visible: true});
     await common.pm_recipient.expect(page, "");
     await close_compose_box(page);
-}
+};
 
-async function test_keyboard_shortcuts(page: Page): Promise<void> {
+const test_keyboard_shortcuts = async (page: Page): Promise<void> => {
     await test_stream_compose_keyboard_shortcut(page);
     await test_private_message_compose_shortcut(page);
-}
+};
 
-async function test_reply_by_click_prepopulates_stream_topic_names(page: Page): Promise<void> {
+const test_reply_by_click_prepopulates_stream_topic_names = async (page: Page): Promise<void> => {
     const stream_message_selector = get_message_selector("Compose stream reply test");
     const stream_message = await page.waitForSelector(stream_message_selector, {visible: true});
     assert.ok(stream_message !== null);
@@ -70,11 +68,11 @@ async function test_reply_by_click_prepopulates_stream_topic_names(page: Page): 
         content: "",
     });
     await close_compose_box(page);
-}
+};
 
-async function test_reply_by_click_prepopulates_private_message_recipient(
+const test_reply_by_click_prepopulates_private_message_recipient = async (
     page: Page,
-): Promise<void> {
+): Promise<void> => {
     const private_message = await page.$(get_message_selector("Compose direct message reply test"));
     assert.ok(private_message !== null);
     await private_message.click();
@@ -83,9 +81,9 @@ async function test_reply_by_click_prepopulates_private_message_recipient(
     assert(email !== undefined);
     await common.pm_recipient.expect(page, email);
     await close_compose_box(page);
-}
+};
 
-async function test_reply_with_r_shortcut(page: Page): Promise<void> {
+const test_reply_with_r_shortcut = async (page: Page): Promise<void> => {
     // The last message(private) in the narrow is currently selected as a result of previous tests.
     // Now we go up and open compose box with r key.
     await page.keyboard.press("KeyK");
@@ -95,9 +93,9 @@ async function test_reply_with_r_shortcut(page: Page): Promise<void> {
         topic: "Reply test",
         content: "",
     });
-}
+};
 
-async function test_open_close_compose_box(page: Page): Promise<void> {
+const test_open_close_compose_box = async (page: Page): Promise<void> => {
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
     await close_compose_box(page);
     await page.waitForSelector("#stream_message_recipient_topic", {hidden: true});
@@ -106,9 +104,9 @@ async function test_open_close_compose_box(page: Page): Promise<void> {
     await page.waitForSelector("#compose-direct-recipient", {visible: true});
     await close_compose_box(page);
     await page.waitForSelector("#compose-direct-recipient", {hidden: true});
-}
+};
 
-async function test_narrow_to_private_messages_with_cordelia(page: Page): Promise<void> {
+const test_narrow_to_private_messages_with_cordelia = async (page: Page): Promise<void> => {
     const you_and_cordelia_selector =
         '*[data-tippy-content="Go to direct messages with Cordelia, Lear\'s daughter"]';
     // For some unknown reason page.click() isn't working here.
@@ -124,9 +122,9 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
     await page.waitForSelector("#compose", {visible: true});
     await page.waitForSelector(`.dropdown-list-container .list-item`, {visible: true});
     await close_compose_box(page);
-}
+};
 
-async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): Promise<void> {
+const test_send_multirecipient_pm_from_cordelia_pm_narrow = async (page: Page): Promise<void> => {
     const recipients = ["cordelia@zulip.com", "othello@zulip.com"];
     const multiple_recipients_pm = "A huddle to check spaces";
     await common.send_message(page, "private", {
@@ -156,12 +154,12 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
         await common.get_internal_email_from_name(page, common.fullname.cordelia),
     ].join(",");
     await common.pm_recipient.expect(page, recipient_internal_emails);
-}
+};
 
 const markdown_preview_button = "#compose .markdown_preview";
 const markdown_preview_hide_button = "#compose .undo_markdown_preview";
 
-async function test_markdown_preview_buttons_visibility(page: Page): Promise<void> {
+const test_markdown_preview_buttons_visibility = async (page: Page): Promise<void> => {
     await page.waitForSelector(markdown_preview_button, {visible: true});
     await page.waitForSelector(markdown_preview_hide_button, {hidden: true});
 
@@ -174,9 +172,9 @@ async function test_markdown_preview_buttons_visibility(page: Page): Promise<voi
     await page.click(markdown_preview_hide_button);
     await page.waitForSelector(markdown_preview_button, {visible: true});
     await page.waitForSelector(markdown_preview_hide_button, {hidden: true});
-}
+};
 
-async function test_markdown_preview_without_any_content(page: Page): Promise<void> {
+const test_markdown_preview_without_any_content = async (page: Page): Promise<void> => {
     await page.click("#compose .markdown_preview");
     await page.waitForSelector("#compose .undo_markdown_preview", {visible: true});
     const markdown_preview_element = await page.$("#compose .preview_content");
@@ -186,9 +184,9 @@ async function test_markdown_preview_without_any_content(page: Page): Promise<vo
         "Nothing to preview",
     );
     await page.click("#compose .undo_markdown_preview");
-}
+};
 
-async function test_markdown_rendering(page: Page): Promise<void> {
+const test_markdown_rendering = async (page: Page): Promise<void> => {
     await page.waitForSelector("#compose .markdown_preview", {visible: true});
     assert.equal(await common.get_text_from_selector(page, "#compose .preview_content"), "");
     await common.fill_form(page, 'form[action^="/json/messages"]', {
@@ -208,15 +206,15 @@ async function test_markdown_rendering(page: Page): Promise<void> {
         await (await preview_content.getProperty("innerHTML")).jsonValue(),
         expected_markdown_html,
     );
-}
+};
 
-async function test_markdown_preview(page: Page): Promise<void> {
+const test_markdown_preview = async (page: Page): Promise<void> => {
     await test_markdown_preview_buttons_visibility(page);
     await test_markdown_preview_without_any_content(page);
     await test_markdown_rendering(page);
-}
+};
 
-async function compose_tests(page: Page): Promise<void> {
+const compose_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -229,6 +227,6 @@ async function compose_tests(page: Page): Promise<void> {
     await test_narrow_to_private_messages_with_cordelia(page);
     await test_send_multirecipient_pm_from_cordelia_pm_narrow(page);
     await test_markdown_preview(page);
-}
+};
 
 common.run_test(compose_tests);

--- a/web/e2e-tests/copy-and-paste.test.ts
+++ b/web/e2e-tests/copy-and-paste.test.ts
@@ -4,18 +4,17 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function copy_messages(
+const copy_messages = async (
     page: Page,
     start_message: string,
     end_message: string,
-): Promise<string[]> {
-    return await page.evaluate(
+): Promise<string[]> =>
+    await page.evaluate(
         (start_message: string, end_message: string) => {
-            function get_message_node(message: string): Element {
-                return [...document.querySelectorAll(".message-list .message_content")].find(
+            const get_message_node = (message: string): Element =>
+                [...document.querySelectorAll(".message-list .message_content")].find(
                     (node) => node.textContent?.trim() === message,
                 )!;
-            }
 
             // select messages from start_message to end_message
             const selectedRange = document.createRange();
@@ -46,27 +45,26 @@ async function copy_messages(
         start_message,
         end_message,
     );
-}
 
-async function test_copying_first_message_from_topic(page: Page): Promise<void> {
+const test_copying_first_message_from_topic = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test C");
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_last_message_from_topic(page: Page): Promise<void> {
+const test_copying_last_message_from_topic = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test E", "copy paste test E");
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_first_two_messages_from_topic(page: Page): Promise<void> {
+const test_copying_first_two_messages_from_topic = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test D");
     const expected_copied_lines = ["Desdemona: copy paste test C", "Desdemona: copy paste test D"];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
+const test_copying_all_messages_from_topic = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test E");
     const expected_copied_lines = [
         "Desdemona: copy paste test C",
@@ -74,9 +72,9 @@ async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
         "Desdemona: copy paste test E",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_last_from_prev_first_from_next(page: Page): Promise<void> {
+const test_copying_last_from_prev_first_from_next = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test C");
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
@@ -85,9 +83,9 @@ async function test_copying_last_from_prev_first_from_next(page: Page): Promise<
         "Desdemona: copy paste test C",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_last_from_prev_all_from_next(page: Page): Promise<void> {
+const test_copying_last_from_prev_all_from_next = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test E");
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
@@ -98,9 +96,9 @@ async function test_copying_last_from_prev_all_from_next(page: Page): Promise<vo
         "Desdemona: copy paste test E",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_all_from_prev_first_from_next(page: Page): Promise<void> {
+const test_copying_all_from_prev_first_from_next = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test A", "copy paste test C");
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
@@ -110,9 +108,9 @@ async function test_copying_all_from_prev_first_from_next(page: Page): Promise<v
         "Desdemona: copy paste test C",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function test_copying_messages_from_several_topics(page: Page): Promise<void> {
+const test_copying_messages_from_several_topics = async (page: Page): Promise<void> => {
     const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test F");
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
@@ -125,9 +123,9 @@ async function test_copying_messages_from_several_topics(page: Page): Promise<vo
         "Desdemona: copy paste test F",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
-}
+};
 
-async function copy_paste_test(page: Page): Promise<void> {
+const copy_paste_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -170,6 +168,6 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_last_from_prev_all_from_next(page);
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
-}
+};
 
 common.run_test(copy_paste_test);

--- a/web/e2e-tests/custom-profile.test.ts
+++ b/web/e2e-tests/custom-profile.test.ts
@@ -7,7 +7,7 @@ import * as common from "./lib/common";
 // This will be the row of the custom profile field we add.
 const profile_field_row = "#admin_profile_fields_table tr:nth-last-child(1)";
 
-async function test_add_new_profile_field(page: Page): Promise<void> {
+const test_add_new_profile_field = async (page: Page): Promise<void> => {
     await page.click("#add-custom-profile-field-btn");
     await common.wait_for_micromodal_to_open(page);
     assert.strictEqual(
@@ -33,9 +33,9 @@ async function test_add_new_profile_field(page: Page): Promise<void> {
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
         "Text (short)",
     );
-}
+};
 
-async function test_edit_profile_field(page: Page): Promise<void> {
+const test_edit_profile_field = async (page: Page): Promise<void> => {
     await page.click(`${profile_field_row} button.open-edit-form-modal`);
     await common.wait_for_micromodal_to_open(page);
     assert.strictEqual(
@@ -59,9 +59,9 @@ async function test_edit_profile_field(page: Page): Promise<void> {
         await common.get_text_from_selector(page, `${profile_field_row} span.profile_field_type`),
         "Text (short)",
     );
-}
+};
 
-async function test_delete_custom_profile_field(page: Page): Promise<void> {
+const test_delete_custom_profile_field = async (page: Page): Promise<void> => {
     await page.click(`${profile_field_row} button.delete`);
     await common.wait_for_micromodal_to_open(page);
     assert.strictEqual(
@@ -80,9 +80,9 @@ async function test_delete_custom_profile_field(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "div#admin-profile-field-status"),
         "Saved",
     );
-}
+};
 
-async function test_custom_profile(page: Page): Promise<void> {
+const test_custom_profile = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await common.manage_organization(page);
 
@@ -92,6 +92,6 @@ async function test_custom_profile(page: Page): Promise<void> {
     await test_add_new_profile_field(page);
     await test_edit_profile_field(page);
     await test_delete_custom_profile_field(page);
-}
+};
 
 common.run_test(test_custom_profile);

--- a/web/e2e-tests/delete-message.test.ts
+++ b/web/e2e-tests/delete-message.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function click_delete_and_return_last_msg_id(page: Page): Promise<string> {
+const click_delete_and_return_last_msg_id = async (page: Page): Promise<string> => {
     const msg = (await page.$$(".message-list .message_row")).at(-1);
     assert.ok(msg !== undefined);
     const id = await (await msg.getProperty("id")).jsonValue();
@@ -18,9 +18,9 @@ async function click_delete_and_return_last_msg_id(page: Page): Promise<string> 
     await page.waitForSelector(".delete_message", {visible: true});
     await page.click(".delete_message");
     return id;
-}
+};
 
-async function delete_message_test(page: Page): Promise<void> {
+const delete_message_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     const message_list_id = await common.get_current_msg_list_id(page, true);
@@ -41,6 +41,6 @@ async function delete_message_test(page: Page): Promise<void> {
 
     await page.waitForSelector(`#${CSS.escape(last_message_id)}`, {hidden: true});
     assert.equal((await page.$$(".message-list .message_row")).length, messages_quantity - 1);
-}
+};
 
 common.run_test(delete_message_test);

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -4,22 +4,21 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function wait_for_drafts_to_disappear(page: Page): Promise<void> {
+const wait_for_drafts_to_disappear = async (page: Page): Promise<void> => {
     await page.waitForSelector("#draft_overlay.show", {hidden: true});
-}
+};
 
-async function wait_for_drafts_to_appear(page: Page): Promise<void> {
+const wait_for_drafts_to_appear = async (page: Page): Promise<void> => {
     await page.waitForSelector("#draft_overlay.show");
-}
+};
 
-async function get_drafts_count(page: Page): Promise<number> {
-    return await page.$$eval("#drafts_table .overlay-message-row", (drafts) => drafts.length);
-}
+const get_drafts_count = async (page: Page): Promise<number> =>
+    await page.$$eval("#drafts_table .overlay-message-row", (drafts) => drafts.length);
 
 const drafts_button = ".top_left_drafts";
 const drafts_overlay = "#draft_overlay";
 
-async function test_empty_drafts(page: Page): Promise<void> {
+const test_empty_drafts = async (page: Page): Promise<void> => {
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
 
@@ -29,9 +28,9 @@ async function test_empty_drafts(page: Page): Promise<void> {
 
     await page.click(`${drafts_overlay} .exit`);
     await wait_for_drafts_to_disappear(page);
-}
+};
 
-async function create_stream_message_draft(page: Page): Promise<void> {
+const create_stream_message_draft = async (page: Page): Promise<void> => {
     console.log("Creating stream message draft");
     await page.keyboard.press("KeyC");
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
@@ -41,9 +40,11 @@ async function create_stream_message_draft(page: Page): Promise<void> {
     });
     await page.type("#stream_message_recipient_topic", "tests", {delay: 100});
     await page.click("#compose_close");
-}
+};
 
-async function test_restore_stream_message_draft_by_opening_compose_box(page: Page): Promise<void> {
+const test_restore_stream_message_draft_by_opening_compose_box = async (
+    page: Page,
+): Promise<void> => {
     await page.click(".search_icon");
     await page.waitForSelector("#search_query", {visible: true});
     await common.clear_and_type(page, "#search_query", "stream:Denmark topic:tests");
@@ -62,18 +63,20 @@ async function test_restore_stream_message_draft_by_opening_compose_box(page: Pa
     });
     await page.click("#compose_close");
     await page.waitForSelector("#send_message_form", {visible: false});
-}
+};
 
-async function create_private_message_draft(page: Page): Promise<void> {
+const create_private_message_draft = async (page: Page): Promise<void> => {
     console.log("Creating direct message draft");
     await page.keyboard.press("KeyX");
     await page.waitForSelector("#private_message_recipient", {visible: true});
     await common.fill_form(page, "form#send_message_form", {content: "Test direct message."});
     await common.pm_recipient.set(page, "cordelia@zulip.com");
     await common.pm_recipient.set(page, "hamlet@zulip.com");
-}
+};
 
-async function test_restore_private_message_draft_by_opening_composebox(page: Page): Promise<void> {
+const test_restore_private_message_draft_by_opening_composebox = async (
+    page: Page,
+): Promise<void> => {
     await page.click("#left_bar_compose_reply_button_big");
     await page.waitForSelector("#private_message_recipient", {visible: true});
 
@@ -82,9 +85,9 @@ async function test_restore_private_message_draft_by_opening_composebox(page: Pa
     });
     await page.click("#compose_close");
     await page.waitForSelector("#private_message_recipient", {visible: false});
-}
+};
 
-async function open_compose_markdown_preview(page: Page): Promise<void> {
+const open_compose_markdown_preview = async (page: Page): Promise<void> => {
     const new_conversation_button = "#new_conversation_button";
     await page.waitForSelector(new_conversation_button, {visible: true});
     await page.click(new_conversation_button);
@@ -92,16 +95,16 @@ async function open_compose_markdown_preview(page: Page): Promise<void> {
     const markdown_preview_button = "#compose .markdown_preview"; // eye icon.
     await page.waitForSelector(markdown_preview_button, {visible: true});
     await page.click(markdown_preview_button);
-}
+};
 
-async function open_drafts_after_markdown_preview(page: Page): Promise<void> {
+const open_drafts_after_markdown_preview = async (page: Page): Promise<void> => {
     await open_compose_markdown_preview(page);
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
     await wait_for_drafts_to_appear(page);
-}
+};
 
-async function test_previously_created_drafts_rendered(page: Page): Promise<void> {
+const test_previously_created_drafts_rendered = async (page: Page): Promise<void> => {
     const drafts_count = await get_drafts_count(page);
     assert.strictEqual(drafts_count, 2, "Drafts improperly loaded.");
     assert.strictEqual(
@@ -139,9 +142,9 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
         ),
         "Test stream message.",
     );
-}
+};
 
-async function test_restore_message_draft_via_draft_overlay(page: Page): Promise<void> {
+const test_restore_message_draft_via_draft_overlay = async (page: Page): Promise<void> => {
     console.log("Restoring stream message draft");
     await page.click("#drafts_table .message_row:not(.private-message) .restore-overlay-message");
     await wait_for_drafts_to_disappear(page);
@@ -157,17 +160,17 @@ async function test_restore_message_draft_via_draft_overlay(page: Page): Promise
         "#Denmark > tests - Zulip Dev - Zulip",
         "Didn't narrow to the right topic.",
     );
-}
+};
 
-async function edit_stream_message_draft(page: Page): Promise<void> {
+const edit_stream_message_draft = async (page: Page): Promise<void> => {
     await common.select_stream_in_compose_via_dropdown(page, "Denmark");
     await common.fill_form(page, "form#send_message_form", {
         content: "Updated stream message",
     });
     await page.click("#compose_close");
-}
+};
 
-async function test_edited_draft_message(page: Page): Promise<void> {
+const test_edited_draft_message = async (page: Page): Promise<void> => {
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
 
@@ -193,9 +196,9 @@ async function test_edited_draft_message(page: Page): Promise<void> {
         ),
         "Updated stream message",
     );
-}
+};
 
-async function test_restore_private_message_draft_via_draft_overlay(page: Page): Promise<void> {
+const test_restore_private_message_draft_via_draft_overlay = async (page: Page): Promise<void> => {
     console.log("Restoring direct message draft.");
     await page.click(".message_row.private-message .restore-overlay-message");
     await wait_for_drafts_to_disappear(page);
@@ -218,9 +221,9 @@ async function test_restore_private_message_draft_via_draft_overlay(page: Page):
         "Didn't narrow to the direct messages with cordelia and hamlet",
     );
     await page.click("#compose_close");
-}
+};
 
-async function test_delete_draft(page: Page): Promise<void> {
+const test_delete_draft = async (page: Page): Promise<void> => {
     console.log("Deleting draft");
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
@@ -232,9 +235,9 @@ async function test_delete_draft(page: Page): Promise<void> {
     await page.click(`${drafts_overlay} .exit`);
     await wait_for_drafts_to_disappear(page);
     await page.click("body");
-}
+};
 
-async function test_save_draft_by_reloading(page: Page): Promise<void> {
+const test_save_draft_by_reloading = async (page: Page): Promise<void> => {
     console.log("Saving draft by reloading.");
     await page.keyboard.press("KeyX");
     await page.waitForSelector("#compose-direct-recipient", {visible: true});
@@ -270,9 +273,9 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
         ),
         "Test direct message draft.",
     );
-}
+};
 
-async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
+const test_delete_draft_on_clearing_text = async (page: Page): Promise<void> => {
     console.log("Deleting draft by clearing compose box textarea.");
     await page.click("#drafts_table .message_row:not(.private-message) .restore-overlay-message");
     await wait_for_drafts_to_disappear(page);
@@ -284,9 +287,9 @@ async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
     await wait_for_drafts_to_appear(page);
     const drafts_count = await get_drafts_count(page);
     assert.strictEqual(drafts_count, 1, "Draft not deleted.");
-}
+};
 
-async function drafts_test(page: Page): Promise<void> {
+const drafts_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -321,6 +324,6 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_clearing_text(page);
-}
+};
 
 common.run_test(drafts_test);

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function trigger_edit_last_message(page: Page): Promise<void> {
+const trigger_edit_last_message = async (page: Page): Promise<void> => {
     const msg = (await page.$$(".message-list .message_row")).at(-1);
     assert.ok(msg !== undefined);
     const id = await (await msg.getProperty("id")).jsonValue();
@@ -18,18 +18,18 @@ async function trigger_edit_last_message(page: Page): Promise<void> {
     await page.waitForSelector(".popover_edit_message", {visible: true});
     await page.click(".popover_edit_message");
     await page.waitForSelector(".message_edit_content", {visible: true});
-}
+};
 
-async function edit_stream_message(page: Page, content: string): Promise<void> {
+const edit_stream_message = async (page: Page, content: string): Promise<void> => {
     await trigger_edit_last_message(page);
 
     await common.clear_and_type(page, ".message_edit_content", content);
     await page.click(".message_edit_save");
 
     await common.wait_for_fully_processed_message(page, content);
-}
+};
 
-async function test_stream_message_edit(page: Page): Promise<void> {
+const test_stream_message_edit = async (page: Page): Promise<void> => {
     await common.send_message(page, "stream", {
         stream_name: "Verona",
         topic: "edits",
@@ -40,9 +40,9 @@ async function test_stream_message_edit(page: Page): Promise<void> {
 
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [["Verona > edits", ["test edited"]]]);
-}
+};
 
-async function test_edit_message_with_slash_me(page: Page): Promise<void> {
+const test_edit_message_with_slash_me = async (page: Page): Promise<void> => {
     const last_message_xpath = `(//*[${common.has_class_x("message-list")}]//*[${common.has_class_x(
         "messagebox",
     )}])[last()]`;
@@ -75,9 +75,9 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
             "sender_name",
         )} and normalize-space()="Desdemona"]`,
     );
-}
+};
 
-async function test_edit_private_message(page: Page): Promise<void> {
+const test_edit_private_message = async (page: Page): Promise<void> => {
     await common.send_message(page, "private", {
         recipient: "cordelia@zulip.com",
         content: "test editing pm",
@@ -92,9 +92,9 @@ async function test_edit_private_message(page: Page): Promise<void> {
     await common.check_messages_sent(page, message_list_id, [
         ["You and Cordelia, Lear's daughter", ["test edited pm"]],
     ]);
-}
+};
 
-async function edit_tests(page: Page): Promise<void> {
+const edit_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -102,6 +102,6 @@ async function edit_tests(page: Page): Promise<void> {
     await test_stream_message_edit(page);
     await test_edit_message_with_slash_me(page);
     await test_edit_private_message(page);
-}
+};
 
 common.run_test(edit_tests);

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -29,7 +29,7 @@ const gps = new StackTraceGPS({ajax: async (url) => (await fetch(url)).text()});
 let last_current_msg_list_id: number | undefined;
 
 export const pm_recipient = {
-    async set(page: Page, recipient: string): Promise<void> {
+    set: async (page: Page, recipient: string): Promise<void> => {
         // Without using the delay option here there seems to be
         // a flake where the typeahead doesn't show up.
         await page.type("#private_message_recipient", recipient, {delay: 100});
@@ -43,7 +43,7 @@ export const pm_recipient = {
         await entry!.click();
     },
 
-    async expect(page: Page, expected: string): Promise<void> {
+    expect: async (page: Page, expected: string): Promise<void> => {
         const actual_recipients = await page.evaluate(() => zulip_test.private_message_recipient());
         assert.equal(actual_recipients, expected);
     },
@@ -60,7 +60,7 @@ export const window_size = {
     height: 1024,
 };
 
-export async function ensure_browser(): Promise<Browser> {
+export const ensure_browser = async (): Promise<Browser> => {
     if (browser === null) {
         browser = await puppeteer.launch({
             args: [
@@ -75,15 +75,15 @@ export async function ensure_browser(): Promise<Browser> {
         });
     }
     return browser;
-}
+};
 
-export async function get_page(): Promise<Page> {
+export const get_page = async (): Promise<Page> => {
     const browser = await ensure_browser();
     const page = await browser.newPage();
     return page;
-}
+};
 
-export async function screenshot(page: Page, name: string | null = null): Promise<void> {
+export const screenshot = async (page: Page, name: string | null = null): Promise<void> => {
     if (name === null) {
         name = `${screenshot_id}`;
         screenshot_id += 1;
@@ -93,26 +93,19 @@ export async function screenshot(page: Page, name: string | null = null): Promis
     await page.screenshot({
         path: screenshot_path,
     });
-}
+};
 
-export async function page_url_with_fragment(page: Page): Promise<string> {
-    // `page.url()` does not include the url fragment when running
-    // Puppeteer with Firefox: https://github.com/puppeteer/puppeteer/issues/6787.
-    //
-    // This function hacks around that issue; once it's fixed in
-    // puppeteer upstream, we can delete this function and return
-    // its callers to using `page.url()`
-    return await page.evaluate(() => window.location.href);
-}
+export const page_url_with_fragment = async (page: Page): Promise<string> =>
+    await page.evaluate(() => window.location.href);
 
 // This function will clear the existing value of the element and
 // replace it with the text.
-export async function clear_and_type(page: Page, selector: string, text: string): Promise<void> {
+export const clear_and_type = async (page: Page, selector: string, text: string): Promise<void> => {
     // Select all text currently in the element.
     await page.click(selector, {clickCount: 3});
     await page.keyboard.press("Delete");
     await page.type(selector, text);
-}
+};
 
 /**
  * This function takes a params object whose fields
@@ -131,14 +124,13 @@ export async function clear_and_type(page: Page, selector: string, text: string)
  *     terms: true
  * });
  */
-export async function fill_form(
+export const fill_form = async (
     page: Page,
     form_selector: string,
     params: Record<string, boolean | string>,
-): Promise<void> {
-    async function is_dropdown(page: Page, name: string): Promise<boolean> {
-        return (await page.$(`select[name="${CSS.escape(name)}"]`)) !== null;
-    }
+): Promise<void> => {
+    const is_dropdown = async (page: Page, name: string): Promise<boolean> =>
+        (await page.$(`select[name="${CSS.escape(name)}"]`)) !== null;
     for (const [name, value] of Object.entries(params)) {
         if (typeof value === "boolean") {
             await page.$eval(
@@ -159,13 +151,13 @@ export async function fill_form(
             await clear_and_type(page, `${form_selector} [name="${CSS.escape(name)}"]`, value);
         }
     }
-}
+};
 
-export async function check_form_contents(
+export const check_form_contents = async (
     page: Page,
     form_selector: string,
     params: Record<string, boolean | string>,
-): Promise<void> {
+): Promise<void> => {
     for (const name of Object.keys(params)) {
         const expected_value = params[name];
         if (typeof expected_value === "boolean") {
@@ -190,24 +182,24 @@ export async function check_form_contents(
             );
         }
     }
-}
+};
 
-export async function get_element_text(element: ElementHandle): Promise<string> {
+export const get_element_text = async (element: ElementHandle): Promise<string> => {
     const text = await (await element.getProperty("innerText")).jsonValue();
     assert.ok(typeof text === "string");
     return text;
-}
+};
 
-export async function get_text_from_selector(page: Page, selector: string): Promise<string> {
+export const get_text_from_selector = async (page: Page, selector: string): Promise<string> => {
     const elements = await page.$$(selector);
     const texts = await Promise.all(elements.map(async (element) => get_element_text(element)));
     return texts.join("").trim();
-}
+};
 
-export async function check_compose_state(
+export const check_compose_state = async (
     page: Page,
     params: {stream_name?: string; topic?: string; content: string},
-): Promise<void> {
+): Promise<void> => {
     const form_params: Record<string, string> = {content: params.content};
     if (params.stream_name) {
         assert.equal(
@@ -222,37 +214,36 @@ export async function check_compose_state(
         form_params.stream_message_recipient_topic = params.topic;
     }
     await check_form_contents(page, "form#send_message_form", form_params);
-}
+};
 
-export function has_class_x(class_name: string): string {
-    return `contains(concat(" ", @class, " "), " ${class_name} ")`;
-}
+export const has_class_x = (class_name: string): string =>
+    `contains(concat(" ", @class, " "), " ${class_name} ")`;
 
-export async function get_stream_id(page: Page, stream_name: string): Promise<number | undefined> {
-    return await page.evaluate(
+export const get_stream_id = async (page: Page, stream_name: string): Promise<number | undefined> =>
+    await page.evaluate(
         (stream_name: string) => zulip_test.get_stream_id(stream_name),
         stream_name,
     );
-}
 
-export async function get_user_id_from_name(page: Page, name: string): Promise<number | undefined> {
-    return await page.evaluate((name: string) => zulip_test.get_user_id_from_name(name), name);
-}
-
-export async function get_internal_email_from_name(
+export const get_user_id_from_name = async (
     page: Page,
     name: string,
-): Promise<string | undefined> {
-    return await page.evaluate((fullname: string) => {
+): Promise<number | undefined> =>
+    await page.evaluate((name: string) => zulip_test.get_user_id_from_name(name), name);
+
+export const get_internal_email_from_name = async (
+    page: Page,
+    name: string,
+): Promise<string | undefined> =>
+    await page.evaluate((fullname: string) => {
         const user_id = zulip_test.get_user_id_from_name(fullname);
         return user_id === undefined ? undefined : zulip_test.get_person_by_user_id(user_id).email;
     }, name);
-}
 
-export async function log_in(
+export const log_in = async (
     page: Page,
     credentials: {username: string; password: string} | null = null,
-): Promise<void> {
+): Promise<void> => {
     console.log("Logging in");
     await page.goto(realm_url + "login/");
     assert.equal(realm_url + "login/", page.url());
@@ -270,9 +261,9 @@ export async function log_in(
     });
 
     await page.waitForSelector("#inbox-main", {visible: true});
-}
+};
 
-export async function log_out(page: Page): Promise<void> {
+export const log_out = async (page: Page): Promise<void> => {
     await page.goto(realm_url);
     const menu_selector = "#personal-menu";
     const logout_selector = ".personal-menu-actions a.logout_button";
@@ -286,13 +277,13 @@ export async function log_out(page: Page): Promise<void> {
     // page is loaded. Then check that we are at the login url.
     await page.waitForSelector('input[name="username"]');
     assert.ok(page.url().includes("/login/"));
-}
+};
 
-export function set_realm_url(new_realm_url: string): void {
+export const set_realm_url = (new_realm_url: string): void => {
     realm_url = new_realm_url;
-}
+};
 
-export async function ensure_enter_does_not_send(page: Page): Promise<void> {
+export const ensure_enter_does_not_send = async (page: Page): Promise<void> => {
     // NOTE: Caller should ensure that the compose box is already open.
     await page.click("#send_later");
     await page.waitForSelector("#send_later_popover");
@@ -306,12 +297,12 @@ export async function ensure_enter_does_not_send(page: Page): Promise<void> {
         await page.waitForSelector(enter_sends_false_selector);
         await page.click(enter_sends_false_selector);
     }
-}
+};
 
-export async function assert_compose_box_content(
+export const assert_compose_box_content = async (
     page: Page,
     expected_value: string,
-): Promise<void> {
+): Promise<void> => {
     const compose_box_element = await page.waitForSelector("textarea#compose-textarea");
     assert(compose_box_element !== null);
     const compose_box_content = await page.evaluate(
@@ -323,9 +314,12 @@ export async function assert_compose_box_content(
         expected_value,
         `Compose box content did not match with the expected value '{${expected_value}}'`,
     );
-}
+};
 
-export async function wait_for_fully_processed_message(page: Page, content: string): Promise<void> {
+export const wait_for_fully_processed_message = async (
+    page: Page,
+    content: string,
+): Promise<void> => {
     // Wait in parallel for the message list scroll animation, which
     // interferes with Puppeteer accurately clicking on messages.
     const scroll_delay = timersPromises.setTimeout(400);
@@ -385,12 +379,12 @@ export async function wait_for_fully_processed_message(page: Page, content: stri
     );
 
     await scroll_delay;
-}
+};
 
-export async function select_stream_in_compose_via_dropdown(
+export const select_stream_in_compose_via_dropdown = async (
     page: Page,
     stream_name: string,
-): Promise<void> {
+): Promise<void> => {
     console.log(`Clicking on 'compose_select_recipient_widget' to select ${stream_name}`);
     const menu_visible = (await page.$(".dropdown-list-container")) !== null;
     if (!menu_visible) {
@@ -404,14 +398,14 @@ export async function select_stream_in_compose_via_dropdown(
     await page.waitForSelector(stream_to_select, {visible: true});
     await page.click(stream_to_select);
     assert((await page.$(".dropdown-list-container")) === null);
-}
+};
 
 // Wait for any previous send to finish, then send a message.
-export async function send_message(
+export const send_message = async (
     page: Page,
     type: "stream" | "private",
     params: Message,
-): Promise<void> {
+): Promise<void> => {
     // If a message is outside the view, we do not need
     // to wait for it to be processed later.
     const outside_view = params.outside_view;
@@ -462,13 +456,13 @@ export async function send_message(
     });
     // Make sure the compose box is closed.
     await page.waitForSelector("#compose-textarea", {hidden: true});
-}
+};
 
-export async function send_multiple_messages(page: Page, msgs: Message[]): Promise<void> {
+export const send_multiple_messages = async (page: Page, msgs: Message[]): Promise<void> => {
     for (const msg of msgs) {
         await send_message(page, msg.stream_name !== undefined ? "stream" : "private", msg);
     }
-}
+};
 
 /**
  * This method returns a array, which is formatted as:
@@ -479,10 +473,10 @@ export async function send_multiple_messages(page: Page, msgs: Message[]): Promi
  *
  * The messages are sorted chronologically.
  */
-export async function get_rendered_messages(
+export const get_rendered_messages = async (
     page: Page,
     message_list_id: number,
-): Promise<[string, string[]][]> {
+): Promise<[string, string[]][]> => {
     const recipient_rows = await page.$$(
         `.message-list[data-message-list-id='${message_list_id}'] .recipient_row`,
     );
@@ -510,18 +504,18 @@ export async function get_rendered_messages(
             return [key, messages];
         }),
     );
-}
+};
 
 // This method takes in page, table to fetch the messages
 // from, and expected messages. The format of expected
 // message is { "stream > topic": [messages] }.
 // The method will only check that all the messages in the
 // messages array passed exist in the order they are passed.
-export async function check_messages_sent(
+export const check_messages_sent = async (
     page: Page,
     message_list_id: number,
     messages: [string, string[]][],
-): Promise<void> {
+): Promise<void> => {
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
     });
@@ -531,9 +525,9 @@ export async function check_messages_sent(
     // the test with --interactive there will be duplicates.
     const last_n_messages = rendered_messages.slice(-messages.length);
     assert.deepStrictEqual(last_n_messages, messages);
-}
+};
 
-export async function open_streams_modal(page: Page): Promise<void> {
+export const open_streams_modal = async (page: Page): Promise<void> => {
     const all_streams_selector = "#subscribe-to-more-streams";
     await page.waitForSelector(all_streams_selector, {visible: true});
     await page.click(all_streams_selector);
@@ -541,15 +535,15 @@ export async function open_streams_modal(page: Page): Promise<void> {
     await page.waitForSelector("#subscription_overlay.new-style", {visible: true});
     const url = await page_url_with_fragment(page);
     assert.ok(url.includes("#channels/notsubscribed"));
-}
+};
 
-export async function open_personal_menu(page: Page): Promise<void> {
+export const open_personal_menu = async (page: Page): Promise<void> => {
     const menu_selector = "#personal-menu";
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
-}
+};
 
-export async function manage_organization(page: Page): Promise<void> {
+export const manage_organization = async (page: Page): Promise<void> => {
     const menu_selector = "#settings-dropdown";
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
@@ -564,14 +558,14 @@ export async function manage_organization(page: Page): Promise<void> {
 
     const organization_settings_data_section = "li[data-section='organization-settings']";
     await page.click(organization_settings_data_section);
-}
+};
 
-export async function select_item_via_typeahead(
+export const select_item_via_typeahead = async (
     page: Page,
     field_selector: string,
     str: string,
     item: string,
-): Promise<void> {
+): Promise<void> => {
     console.log(`Looking in ${field_selector} to select ${str}, ${item}`);
     await clear_and_type(page, field_selector, str);
     const entry = await page.waitForSelector(
@@ -586,26 +580,28 @@ export async function select_item_via_typeahead(
         }
         entry.click();
     }, entry);
-}
+};
 
-export async function wait_for_modal_to_close(page: Page): Promise<void> {
+export const wait_for_modal_to_close = async (page: Page): Promise<void> => {
     // This function will ensure that the mouse events are enabled for the background for further tests.
     await page.waitForFunction(
         () => document.querySelector(".overlay.show")?.getAttribute("style") === null,
     );
-}
+};
 
-export async function wait_for_micromodal_to_open(page: Page): Promise<void> {
+export const wait_for_micromodal_to_open = async (page: Page): Promise<void> => {
     // We manually add the `modal--open` class to the modal after the modal animation completes.
     await page.waitForFunction(() => document.querySelector(".modal--open") !== null);
-}
+};
 
-export async function wait_for_micromodal_to_close(page: Page): Promise<void> {
+export const wait_for_micromodal_to_close = async (page: Page): Promise<void> => {
     // This function will ensure that the mouse events are enabled for the background for further tests.
     await page.waitForFunction(() => document.querySelector(".modal--open") === null);
-}
+};
 
-export async function run_test_async(test_function: (page: Page) => Promise<void>): Promise<void> {
+export const run_test_async = async (
+    test_function: (page: Page) => Promise<void>,
+): Promise<void> => {
     // Pass a page instance to test so we can take
     // a screenshot of it when the test fails.
     const browser = await ensure_browser();
@@ -706,19 +702,19 @@ export async function run_test_async(test_function: (page: Page) => Promise<void
         await console_ready;
         await browser.close();
     }
-}
+};
 
-export function run_test(test_function: (page: Page) => Promise<void>): void {
+export const run_test = (test_function: (page: Page) => Promise<void>): void => {
     run_test_async(test_function).catch((error: unknown) => {
         console.error(error);
         process.exit(1);
     });
-}
+};
 
-export async function get_current_msg_list_id(
+export const get_current_msg_list_id = async (
     page: Page,
     wait_for_change = false,
-): Promise<number> {
+): Promise<number> => {
     if (wait_for_change) {
         // Wait for the current_msg_list to change if the in the middle of switching narrows.
         // Also works as a way to verify that the current message list did change.
@@ -739,4 +735,4 @@ export async function get_current_msg_list_id(
     last_current_msg_list_id = await page.evaluate(() => zulip_test.current_msg_list?.id);
     assert(last_current_msg_list_id !== undefined);
     return last_current_msg_list_id;
-}
+};

--- a/web/e2e-tests/mention.test.ts
+++ b/web/e2e-tests/mention.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function test_mention(page: Page): Promise<void> {
+const test_mention = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -37,6 +37,6 @@ async function test_mention(page: Page): Promise<void> {
     await common.check_messages_sent(page, message_list_id, [
         ["Verona > Test mention all", ["@all"]],
     ]);
-}
+};
 
 common.run_test(test_mention);

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -4,13 +4,13 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function get_stream_li(page: Page, stream_name: string): Promise<string> {
+const get_stream_li = async (page: Page, stream_name: string): Promise<string> => {
     const stream_id = await common.get_stream_id(page, stream_name);
     assert(stream_id !== undefined);
     return `#stream_filters [data-stream-id="${CSS.escape(stream_id.toString())}"]`;
-}
+};
 
-async function expect_home(page: Page): Promise<void> {
+const expect_home = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -31,9 +31,9 @@ async function expect_home(page: Page): Promise<void> {
         ["You and Cordelia, Lear's daughter, King Hamlet", ["group direct message d"]],
         ["You and Cordelia, Lear's daughter", ["direct message e"]],
     ]);
-}
+};
 
-async function expect_verona_stream(page: Page): Promise<void> {
+const expect_verona_stream = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -44,9 +44,9 @@ async function expect_verona_stream(page: Page): Promise<void> {
         ["Verona > test", ["verona test d"]],
     ]);
     assert.strictEqual(await page.title(), "#Verona - Zulip Dev - Zulip");
-}
+};
 
-async function expect_verona_stream_test_topic(page: Page): Promise<void> {
+const expect_verona_stream_test_topic = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -58,9 +58,9 @@ async function expect_verona_stream_test_topic(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "#new_conversation_button"),
         "Start new conversation",
     );
-}
+};
 
-async function expect_verona_other_topic(page: Page): Promise<void> {
+const expect_verona_other_topic = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -68,9 +68,9 @@ async function expect_verona_other_topic(page: Page): Promise<void> {
     await common.check_messages_sent(page, message_list_id, [
         ["Verona > other topic", ["verona other topic c"]],
     ]);
-}
+};
 
-async function expect_test_topic(page: Page): Promise<void> {
+const expect_test_topic = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -80,9 +80,9 @@ async function expect_test_topic(page: Page): Promise<void> {
         ["Denmark > test", ["denmark message"]],
         ["Verona > test", ["verona test d"]],
     ]);
-}
+};
 
-async function expect_group_direct_messages(page: Page): Promise<void> {
+const expect_group_direct_messages = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -97,9 +97,9 @@ async function expect_group_direct_messages(page: Page): Promise<void> {
         await page.title(),
         "Cordelia, Lear's daughter, King Hamlet - Zulip Dev - Zulip",
     );
-}
+};
 
-async function expect_cordelia_direct_messages(page: Page): Promise<void> {
+const expect_cordelia_direct_messages = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -107,25 +107,25 @@ async function expect_cordelia_direct_messages(page: Page): Promise<void> {
     await common.check_messages_sent(page, message_list_id, [
         ["You and Cordelia, Lear's daughter", ["direct message c", "direct message e"]],
     ]);
-}
+};
 
-async function un_narrow(page: Page): Promise<void> {
+const un_narrow = async (page: Page): Promise<void> => {
     if ((await (await page.$(".message_comp"))!.boundingBox())?.height) {
         await page.keyboard.press("Escape");
     }
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-}
+};
 
-async function un_narrow_by_clicking_org_icon(page: Page): Promise<void> {
+const un_narrow_by_clicking_org_icon = async (page: Page): Promise<void> => {
     await page.click(".brand");
-}
+};
 
-async function expect_recent_view(page: Page): Promise<void> {
+const expect_recent_view = async (page: Page): Promise<void> => {
     await page.waitForSelector("#recent_view_table", {visible: true});
     assert.strictEqual(await page.title(), "Recent conversations - Zulip Dev - Zulip");
-}
+};
 
-async function test_navigations_from_home(page: Page): Promise<void> {
+const test_navigations_from_home = async (page: Page): Promise<void> => {
     return; // No idea why this is broken.
     console.log("Narrowing by clicking stream");
     await page.click(`.focused-message-list [title='Narrow to stream "Verona"']`);
@@ -157,15 +157,15 @@ async function test_navigations_from_home(page: Page): Promise<void> {
     );
     await un_narrow_by_clicking_org_icon(page);
     await expect_recent_view(page);
-}
+};
 
-async function search_and_check(
+const search_and_check = async (
     page: Page,
     search_str: string,
     item_to_select: string,
     check: (page: Page) => Promise<void>,
     expected_narrow_title: string,
-): Promise<void> {
+): Promise<void> => {
     await page.click(".search_icon");
     await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", search_str, item_to_select);
@@ -173,9 +173,9 @@ async function search_and_check(
     assert.strictEqual(await page.title(), expected_narrow_title);
     await un_narrow(page);
     await expect_home(page);
-}
+};
 
-async function search_silent_user(page: Page, str: string, item: string): Promise<void> {
+const search_silent_user = async (page: Page, str: string, item: string): Promise<void> => {
     await page.click(".search_icon");
     await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
@@ -188,9 +188,9 @@ async function search_silent_user(page: Page, str: string, item: string): Promis
     await common.get_current_msg_list_id(page, true);
     await un_narrow(page);
     await expect_home(page);
-}
+};
 
-async function expect_non_existing_user(page: Page): Promise<void> {
+const expect_non_existing_user = async (page: Page): Promise<void> => {
     await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(".empty_feed_notice", {visible: true});
     const expected_message = "This user does not exist!";
@@ -198,9 +198,9 @@ async function expect_non_existing_user(page: Page): Promise<void> {
         await common.get_text_from_selector(page, ".empty_feed_notice"),
         expected_message,
     );
-}
+};
 
-async function expect_non_existing_users(page: Page): Promise<void> {
+const expect_non_existing_users = async (page: Page): Promise<void> => {
     await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(".empty_feed_notice", {visible: true});
     const expected_message = "One or more of these users do not exist!";
@@ -208,18 +208,18 @@ async function expect_non_existing_users(page: Page): Promise<void> {
         await common.get_text_from_selector(page, ".empty_feed_notice"),
         expected_message,
     );
-}
+};
 
-async function search_non_existing_user(page: Page, str: string, item: string): Promise<void> {
+const search_non_existing_user = async (page: Page, str: string, item: string): Promise<void> => {
     await page.click(".search_icon");
     await page.waitForSelector(".navbar-search.expanded", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await expect_non_existing_user(page);
     await un_narrow(page);
     await expect_home(page);
-}
+};
 
-async function search_tests(page: Page): Promise<void> {
+const search_tests = async (page: Page): Promise<void> => {
     await search_and_check(
         page,
         "Verona",
@@ -287,9 +287,9 @@ async function search_tests(page: Page): Promise<void> {
         expect_non_existing_users,
         "Invalid users - Zulip Dev - Zulip",
     );
-}
+};
 
-async function expect_all_direct_messages(page: Page): Promise<void> {
+const expect_all_direct_messages = async (page: Page): Promise<void> => {
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(`.message-list[data-message-list-id='${message_list_id}']`, {
         visible: true,
@@ -308,9 +308,9 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
         "Start new conversation",
     );
     assert.strictEqual(await page.title(), "Direct message feed - Zulip Dev - Zulip");
-}
+};
 
-async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {
+const test_narrow_by_clicking_the_left_sidebar = async (page: Page): Promise<void> => {
     console.log("Narrowing with left sidebar");
 
     await page.click((await get_stream_li(page, "Verona")) + " a");
@@ -326,13 +326,13 @@ async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<voi
 
     await un_narrow(page);
     await expect_home(page);
-}
+};
 
-async function arrow(page: Page, direction: "Up" | "Down"): Promise<void> {
+const arrow = async (page: Page, direction: "Up" | "Down"): Promise<void> => {
     await page.keyboard.press(({Up: "ArrowUp", Down: "ArrowDown"} as const)[direction]);
-}
+};
 
-async function test_search_venice(page: Page): Promise<void> {
+const test_search_venice = async (page: Page): Promise<void> => {
     await common.clear_and_type(page, ".stream-list-filter", "vEnI"); // Must be case insensitive.
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {hidden: true});
@@ -348,9 +348,9 @@ async function test_search_venice(page: Page): Promise<void> {
 
     await page.click("#streams_header .left-sidebar-title");
     await page.waitForSelector(".input-append.notdisplayed");
-}
+};
 
-async function test_stream_search_filters_stream_list(page: Page): Promise<void> {
+const test_stream_search_filters_stream_list = async (page: Page): Promise<void> => {
     console.log("Filter streams using left side bar");
 
     await page.waitForSelector(".input-append.notdisplayed"); // Stream filter box invisible initially
@@ -431,29 +431,29 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
         "Clicking on stream didn't clear search",
     );
     await un_narrow(page);
-}
+};
 
-async function test_users_search(page: Page): Promise<void> {
+const test_users_search = async (page: Page): Promise<void> => {
     console.log("Search users using right sidebar");
-    async function assert_in_list(page: Page, name: string): Promise<void> {
+    const assert_in_list = async (page: Page, name: string): Promise<void> => {
         await page.waitForSelector(`#buddy-list-other-users li [data-name="${CSS.escape(name)}"]`, {
             visible: true,
         });
-    }
+    };
 
-    async function assert_selected(page: Page, name: string): Promise<void> {
+    const assert_selected = async (page: Page, name: string): Promise<void> => {
         await page.waitForSelector(
             `#buddy-list-other-users li.highlighted_user [data-name="${CSS.escape(name)}"]`,
             {visible: true},
         );
-    }
+    };
 
-    async function assert_not_selected(page: Page, name: string): Promise<void> {
+    const assert_not_selected = async (page: Page, name: string): Promise<void> => {
         await page.waitForSelector(
             `#buddy-list-other-users li.highlighted_user [data-name="${CSS.escape(name)}"]`,
             {hidden: true},
         );
-    }
+    };
 
     await assert_in_list(page, "Desdemona");
     await assert_in_list(page, "Cordelia, Lear's daughter");
@@ -495,9 +495,9 @@ async function test_users_search(page: Page): Promise<void> {
     await arrow(page, "Up");
     await page.keyboard.press("Enter");
     await expect_cordelia_direct_messages(page);
-}
+};
 
-async function test_narrow_public_streams(page: Page): Promise<void> {
+const test_narrow_public_streams = async (page: Page): Promise<void> => {
     const stream_id = await common.get_stream_id(page, "Denmark");
     await page.goto(`http://zulip.zulipdev.com:9981/#channels/${stream_id}/Denmark`);
     await page.waitForSelector("button.sub_unsub_button", {visible: true});
@@ -530,9 +530,9 @@ async function test_narrow_public_streams(page: Page): Promise<void> {
             `.message-list[data-message-list-id='${message_list_id}'] .stream-status`,
         )) === null,
     );
-}
+};
 
-async function message_basic_tests(page: Page): Promise<void> {
+const message_basic_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     await page.waitForSelector(".message-list .message_row", {visible: true});
@@ -562,6 +562,6 @@ async function message_basic_tests(page: Page): Promise<void> {
     await test_stream_search_filters_stream_list(page);
     await test_users_search(page);
     await test_narrow_public_streams(page);
-}
+};
 
 common.run_test(message_basic_tests);

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -4,19 +4,19 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function navigate_using_left_sidebar(page: Page, click_target: string): Promise<void> {
+const navigate_using_left_sidebar = async (page: Page, click_target: string): Promise<void> => {
     console.log("Visiting #" + click_target);
     await page.click(`#left-sidebar a[href='#${CSS.escape(click_target)}']`);
     await page.waitForSelector(`#message_feed_container`, {visible: true});
-}
+};
 
-async function open_menu(page: Page): Promise<void> {
+const open_menu = async (page: Page): Promise<void> => {
     const menu_selector = "#settings-dropdown";
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
-}
+};
 
-async function navigate_to_settings(page: Page): Promise<void> {
+const navigate_to_settings = async (page: Page): Promise<void> => {
     console.log("Navigating to settings");
 
     await common.open_personal_menu(page);
@@ -35,9 +35,9 @@ async function navigate_to_settings(page: Page): Promise<void> {
     await page.click("#settings_page .content-wrapper .exit");
     // Wait until the overlay is completely closed.
     await page.waitForSelector("#settings_overlay_container", {hidden: true});
-}
+};
 
-async function navigate_to_subscriptions(page: Page): Promise<void> {
+const navigate_to_subscriptions = async (page: Page): Promise<void> => {
     console.log("Navigate to subscriptions");
 
     await open_menu(page);
@@ -51,9 +51,9 @@ async function navigate_to_subscriptions(page: Page): Promise<void> {
     await page.click("#subscription_overlay .exit");
     // Wait until the overlay is completely closed.
     await page.waitForSelector("#subscription_overlay", {hidden: true});
-}
+};
 
-async function navigate_to_private_messages(page: Page): Promise<void> {
+const navigate_to_private_messages = async (page: Page): Promise<void> => {
     console.log("Navigate to direct messages");
 
     const all_private_messages_icon = "#show_all_private_messages";
@@ -61,9 +61,9 @@ async function navigate_to_private_messages(page: Page): Promise<void> {
     await page.click(all_private_messages_icon);
 
     await page.waitForSelector("#message_view_header .fa-envelope", {visible: true});
-}
+};
 
-async function test_reload_hash(page: Page): Promise<void> {
+const test_reload_hash = async (page: Page): Promise<void> => {
     const initial_page_load_time = await page.evaluate(() => zulip_test.page_load_time);
     assert(initial_page_load_time !== undefined);
     console.log(`initial load time: ${initial_page_load_time}`);
@@ -85,9 +85,9 @@ async function test_reload_hash(page: Page): Promise<void> {
 
     const hash = await page.evaluate(() => window.location.hash);
     assert.strictEqual(hash, initial_hash, "Hash not preserved.");
-}
+};
 
-async function navigation_tests(page: Page): Promise<void> {
+const navigation_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
 
     await navigate_to_settings(page);
@@ -118,6 +118,6 @@ async function navigation_tests(page: Page): Promise<void> {
             "message-header-stream-settings-button",
         )} and normalize-space()="Verona"]`,
     );
-}
+};
 
 common.run_test(navigation_tests);

--- a/web/e2e-tests/realm-creation.test.ts
+++ b/web/e2e-tests/realm-creation.test.ts
@@ -9,7 +9,7 @@ const email = "alice@test.example.com";
 const organization_name = "Awesome Organization";
 const host = "zulipdev.com:9981";
 
-async function realm_creation_tests(page: Page): Promise<void> {
+const realm_creation_tests = async (page: Page): Promise<void> => {
     await page.goto("http://" + host + "/new/");
 
     // submit the email for realm creation.
@@ -79,6 +79,6 @@ async function realm_creation_tests(page: Page): Promise<void> {
 
     // Updating common.realm_url because we are redirecting to it when logging out.
     common.set_realm_url(page.url());
-}
+};
 
 common.run_test(realm_creation_tests);

--- a/web/e2e-tests/realm-linkifier.test.ts
+++ b/web/e2e-tests/realm-linkifier.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function test_add_linkifier(page: Page): Promise<void> {
+const test_add_linkifier = async (page: Page): Promise<void> => {
     await page.waitForSelector(".admin-linkifier-form", {visible: true});
     await common.fill_form(page, "form.admin-linkifier-form", {
         pattern: "#(?P<id>[0-9]+)",
@@ -35,18 +35,18 @@ async function test_add_linkifier(page: Page): Promise<void> {
         ),
         "https://trac.example.com/ticket/{id}",
     );
-}
+};
 
-async function test_delete_linkifier(page: Page): Promise<void> {
+const test_delete_linkifier = async (page: Page): Promise<void> => {
     await page.waitForFunction(() => document.querySelectorAll(".linkifier_row").length === 4);
     await page.click(".linkifier_row:nth-last-child(1) .delete");
     await common.wait_for_micromodal_to_open(page);
     await page.click("#confirm_delete_linkifiers_modal .dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);
     await page.waitForFunction(() => document.querySelectorAll(".linkifier_row").length === 3);
-}
+};
 
-async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
+const test_add_invalid_linkifier_pattern = async (page: Page): Promise<void> => {
     await page.waitForSelector(".admin-linkifier-form", {visible: true});
     await common.fill_form(page, "form.admin-linkifier-form", {
         pattern: "(foo",
@@ -59,9 +59,9 @@ async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "div#admin-linkifier-status"),
         "Failed: Bad regular expression: missing ): (foo",
     );
-}
+};
 
-async function test_edit_linkifier(page: Page): Promise<void> {
+const test_edit_linkifier = async (page: Page): Promise<void> => {
     await page.click(".linkifier_row:nth-last-child(1) .edit");
     await common.wait_for_micromodal_to_open(page);
     await common.fill_form(page, "form.linkifier-edit-form", {
@@ -86,9 +86,9 @@ async function test_edit_linkifier(page: Page): Promise<void> {
         ),
         "https://trac.example.com/commit/{num}",
     );
-}
+};
 
-async function test_edit_invalid_linkifier(page: Page): Promise<void> {
+const test_edit_invalid_linkifier = async (page: Page): Promise<void> => {
     await page.click(".linkifier_row:nth-last-child(1) .edit");
     await common.wait_for_micromodal_to_open(page);
     await common.fill_form(page, "form.linkifier-edit-form", {
@@ -134,9 +134,9 @@ async function test_edit_invalid_linkifier(page: Page): Promise<void> {
         ),
         "https://trac.example.com/commit/{num}",
     );
-}
+};
 
-async function linkifier_test(page: Page): Promise<void> {
+const linkifier_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await common.manage_organization(page);
     await page.click("li[data-section='linkifier-settings']");
@@ -146,6 +146,6 @@ async function linkifier_test(page: Page): Promise<void> {
     await test_edit_invalid_linkifier(page);
     await test_add_invalid_linkifier_pattern(page);
     await test_delete_linkifier(page);
-}
+};
 
 common.run_test(linkifier_test);

--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -10,7 +10,10 @@ type Playground = {
     url_template: string;
 };
 
-async function _add_playground_and_return_status(page: Page, payload: Playground): Promise<string> {
+const _add_playground_and_return_status = async (
+    page: Page,
+    payload: Playground,
+): Promise<string> => {
     await page.waitForSelector(".admin-playground-form", {visible: true});
     // Let's first ensure that the success/failure status from an earlier step has disappeared.
     const admin_playground_status_selector = "div#admin-playground-status";
@@ -41,9 +44,9 @@ async function _add_playground_and_return_status(page: Page, payload: Playground
         admin_playground_status_selector,
     );
     return admin_playground_status;
-}
+};
 
-async function test_successful_playground_creation(page: Page): Promise<void> {
+const test_successful_playground_creation = async (page: Page): Promise<void> => {
     const payload = {
         pygments_language: "Python",
         playground_name: "Python3 playground",
@@ -67,9 +70,9 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
         await common.get_text_from_selector(page, ".playground_row span.playground_url_template"),
         "https://python.example.com?code={code}",
     );
-}
+};
 
-async function test_invalid_playground_parameters(page: Page): Promise<void> {
+const test_invalid_playground_parameters = async (page: Page): Promise<void> => {
     const payload = {
         pygments_language: "Python",
         playground_name: "Python3 playground",
@@ -82,9 +85,9 @@ async function test_invalid_playground_parameters(page: Page): Promise<void> {
     payload.pygments_language = "py!@%&";
     status = await _add_playground_and_return_status(page, payload);
     assert.strictEqual(status, "Failed: Invalid characters in pygments language");
-}
+};
 
-async function test_successful_playground_deletion(page: Page): Promise<void> {
+const test_successful_playground_deletion = async (page: Page): Promise<void> => {
     await page.click(".playground_row button.delete");
 
     await common.wait_for_micromodal_to_open(page);
@@ -92,9 +95,9 @@ async function test_successful_playground_deletion(page: Page): Promise<void> {
     await common.wait_for_micromodal_to_close(page);
 
     await page.waitForSelector(".playground_row", {hidden: true});
-}
+};
 
-async function playground_test(page: Page): Promise<void> {
+const playground_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await common.manage_organization(page);
     await page.click("li[data-section='playground-settings']");
@@ -102,6 +105,6 @@ async function playground_test(page: Page): Promise<void> {
     await test_successful_playground_creation(page);
     await test_invalid_playground_parameters(page);
     await test_successful_playground_deletion(page);
-}
+};
 
 common.run_test(playground_test);

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -12,12 +12,12 @@ const GENERIC_BOT_TYPE = "1";
 const zuliprc_regex =
     /^data:application\/octet-stream;charset=utf-8,\[api]\nemail=.+\nkey=.+\nsite=.+\n$/;
 
-async function get_decoded_url_in_selector(page: Page, selector: string): Promise<string> {
+const get_decoded_url_in_selector = async (page: Page, selector: string): Promise<string> => {
     const a = await page.$(`a:is(${selector})`);
     return decodeURIComponent(await (await a!.getProperty("href")).jsonValue());
-}
+};
 
-async function open_settings(page: Page): Promise<void> {
+const open_settings = async (page: Page): Promise<void> => {
     await common.open_personal_menu(page);
 
     const settings_selector = "#personal-menu-dropdown a[href^='#settings']";
@@ -30,9 +30,9 @@ async function open_settings(page: Page): Promise<void> {
         page_url.includes("/#settings/"),
         `Page url: ${page_url} does not contain /#settings/`,
     );
-}
+};
 
-async function close_settings_and_date_picker(page: Page): Promise<void> {
+const close_settings_and_date_picker = async (page: Page): Promise<void> => {
     const date_picker_selector = ".custom_user_field_value.datepicker.form-control";
     await page.click(date_picker_selector);
 
@@ -40,9 +40,9 @@ async function close_settings_and_date_picker(page: Page): Promise<void> {
 
     await page.keyboard.press("Escape");
     await page.waitForSelector(".flatpickr-calendar", {hidden: true});
-}
+};
 
-async function test_change_full_name(page: Page): Promise<void> {
+const test_change_full_name = async (page: Page): Promise<void> => {
     await page.click("#full_name");
 
     const full_name_input_selector = 'input[name="full_name"]';
@@ -53,9 +53,9 @@ async function test_change_full_name(page: Page): Promise<void> {
     await page.waitForFunction(
         () => document.querySelector<HTMLInputElement>("#full_name")?.value === "New name",
     );
-}
+};
 
-async function test_change_password(page: Page): Promise<void> {
+const test_change_password = async (page: Page): Promise<void> => {
     await page.click("#change_password");
 
     const change_password_button_selector = "#change_password_modal .dialog_submit_button";
@@ -69,9 +69,9 @@ async function test_change_password(page: Page): Promise<void> {
 
     // On success the change password modal gets closed.
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function test_get_api_key(page: Page): Promise<void> {
+const test_get_api_key = async (page: Page): Promise<void> => {
     await page.click('[data-section="account-and-privacy"]');
     const show_change_api_key_selector = "#api_key_button";
     await page.click(show_change_api_key_selector);
@@ -100,9 +100,9 @@ async function test_get_api_key(page: Page): Promise<void> {
     assert.match(zuliprc_decoded_url, zuliprc_regex, "Incorrect zuliprc file");
     await page.click("#api_key_modal .modal__close");
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function test_webhook_bot_creation(page: Page): Promise<void> {
+const test_webhook_bot_creation = async (page: Page): Promise<void> => {
     await page.click("#bot-settings .add-a-new-bot");
     await common.wait_for_micromodal_to_open(page);
     assert.strictEqual(
@@ -140,9 +140,9 @@ async function test_webhook_bot_creation(page: Page): Promise<void> {
         outgoing_webhook_zuliprc_regex,
         "Incorrect outgoing webhook bot zuliprc format",
     );
-}
+};
 
-async function test_normal_bot_creation(page: Page): Promise<void> {
+const test_normal_bot_creation = async (page: Page): Promise<void> => {
     await page.click("#bot-settings .add-a-new-bot");
     await common.wait_for_micromodal_to_open(page);
     assert.strictEqual(
@@ -172,9 +172,9 @@ async function test_normal_bot_creation(page: Page): Promise<void> {
     await page.click(download_zuliprc_selector);
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
     assert.match(zuliprc_decoded_url, zuliprc_regex, "Incorrect zuliprc format for bot.");
-}
+};
 
-async function test_botserverrc(page: Page): Promise<void> {
+const test_botserverrc = async (page: Page): Promise<void> => {
     await page.click("#download_botserverrc");
     await page.waitForSelector('#download_botserverrc[href^="data:application"]', {visible: true});
     const botserverrc_decoded_url = await get_decoded_url_in_selector(
@@ -184,13 +184,13 @@ async function test_botserverrc(page: Page): Promise<void> {
     const botserverrc_regex =
         /^data:application\/octet-stream;charset=utf-8,\[]\nemail=.+\nkey=.+\nsite=.+\ntoken=.+\n$/;
     assert.match(botserverrc_decoded_url, botserverrc_regex, "Incorrect botserverrc format.");
-}
+};
 
 // Disabled the below test due to non-deterministic failures.
 // The test often fails to close the modal, as does the
 // test_invalid_edit_bot_form above.
 // TODO: Debug this and re-enable with a fix.
-async function test_edit_bot_form(page: Page): Promise<void> {
+const test_edit_bot_form = async (page: Page): Promise<void> => {
     return;
     const bot1_email = "1-bot@zulip.testserver";
     const bot1_edit_btn = `.open_edit_bot_form[data-email="${CSS.escape(bot1_email)}"]`;
@@ -219,12 +219,12 @@ async function test_edit_bot_form(page: Page): Promise<void> {
     );
 
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
 // Disabled the below test due to non-deterministic failures.
 // The test often fails to close the modal.
 // TODO: Debug this and re-enable with a fix.
-async function test_invalid_edit_bot_form(page: Page): Promise<void> {
+const test_invalid_edit_bot_form = async (page: Page): Promise<void> => {
     return;
     const bot1_email = "1-bot@zulip.testserver";
     const bot1_edit_btn = `.open_edit_bot_form[data-email="${CSS.escape(bot1_email)}"]`;
@@ -266,20 +266,20 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
     );
 
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function test_your_bots_section(page: Page): Promise<void> {
+const test_your_bots_section = async (page: Page): Promise<void> => {
     await page.click('[data-section="your-bots"]');
     await test_webhook_bot_creation(page);
     await test_normal_bot_creation(page);
     await test_botserverrc(page);
     await test_edit_bot_form(page);
     await test_invalid_edit_bot_form(page);
-}
+};
 
 const alert_word_status_selector = "#alert_word_status";
 
-async function add_alert_word(page: Page, word: string): Promise<void> {
+const add_alert_word = async (page: Page, word: string): Promise<void> => {
     await page.click("#open-add-alert-word-modal");
     await common.wait_for_micromodal_to_open(page);
 
@@ -287,29 +287,29 @@ async function add_alert_word(page: Page, word: string): Promise<void> {
     await page.click("#add-alert-word .dialog_submit_button");
 
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function check_alert_word_added(page: Page, word: string): Promise<void> {
+const check_alert_word_added = async (page: Page, word: string): Promise<void> => {
     const added_alert_word_selector = `.alert-word-item[data-word='${CSS.escape(word)}']`;
     await page.waitForSelector(added_alert_word_selector, {visible: true});
-}
+};
 
-async function get_alert_words_status_text(page: Page): Promise<string> {
+const get_alert_words_status_text = async (page: Page): Promise<string> => {
     await page.waitForSelector(alert_word_status_selector, {visible: true});
     const status_text = await common.get_text_from_selector(page, ".alert_word_status_text");
     return status_text;
-}
+};
 
-async function close_alert_words_status(page: Page): Promise<void> {
+const close_alert_words_status = async (page: Page): Promise<void> => {
     const status_close_btn = ".close-alert-word-status";
     await page.click(status_close_btn);
     await page.waitForSelector(alert_word_status_selector, {hidden: true});
-}
+};
 
-async function test_duplicate_alert_words_cannot_be_added(
+const test_duplicate_alert_words_cannot_be_added = async (
     page: Page,
     duplicate_word: string,
-): Promise<void> {
+): Promise<void> => {
     await page.click("#open-add-alert-word-modal");
     await common.wait_for_micromodal_to_open(page);
 
@@ -323,31 +323,31 @@ async function test_duplicate_alert_words_cannot_be_added(
 
     await page.click("#add-alert-word .dialog_exit_button");
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function delete_alert_word(page: Page, word: string): Promise<void> {
+const delete_alert_word = async (page: Page, word: string): Promise<void> => {
     const delete_btn_selector = `.remove-alert-word[data-word="${CSS.escape(word)}"]`;
     await page.click(delete_btn_selector);
     await page.waitForSelector(delete_btn_selector, {hidden: true});
-}
+};
 
-async function test_alert_word_deletion(page: Page, word: string): Promise<void> {
+const test_alert_word_deletion = async (page: Page, word: string): Promise<void> => {
     await delete_alert_word(page, word);
     const status_text = await get_alert_words_status_text(page);
     assert.strictEqual(status_text, `Alert word "${word}" removed successfully!`);
     await close_alert_words_status(page);
-}
+};
 
-async function test_alert_words_section(page: Page): Promise<void> {
+const test_alert_words_section = async (page: Page): Promise<void> => {
     await page.click('[data-section="alert-words"]');
     const word = "puppeteer";
     await add_alert_word(page, word);
     await check_alert_word_added(page, word);
     await test_duplicate_alert_words_cannot_be_added(page, word);
     await test_alert_word_deletion(page, word);
-}
+};
 
-async function change_language(page: Page, language_data_code: string): Promise<void> {
+const change_language = async (page: Page, language_data_code: string): Promise<void> => {
     await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
@@ -355,15 +355,15 @@ async function change_language(page: Page, language_data_code: string): Promise<
     await common.wait_for_micromodal_to_open(page);
     const language_selector = `a[data-code="${CSS.escape(language_data_code)}"]`;
     await page.click(language_selector);
-}
+};
 
-async function check_language_setting_status(page: Page): Promise<void> {
+const check_language_setting_status = async (page: Page): Promise<void> => {
     await page.waitForSelector("#user-preferences .general-settings-status .reload_link", {
         visible: true,
     });
-}
+};
 
-async function assert_language_changed_to_chinese(page: Page): Promise<void> {
+const assert_language_changed_to_chinese = async (page: Page): Promise<void> => {
     await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
@@ -376,17 +376,17 @@ async function assert_language_changed_to_chinese(page: Page): Promise<void> {
         "简体中文",
         "Default language has not been changed to Chinese.",
     );
-}
+};
 
-async function test_i18n_language_precedence(page: Page): Promise<void> {
+const test_i18n_language_precedence = async (page: Page): Promise<void> => {
     const settings_url_for_german = "http://zulip.zulipdev.com:9981/de/#settings";
     await page.goto(settings_url_for_german);
     await page.waitForSelector("#settings-change-box", {visible: true});
     const page_language_code = await page.evaluate(() => document.documentElement.lang);
     assert.strictEqual(page_language_code, "de");
-}
+};
 
-async function test_default_language_setting(page: Page): Promise<void> {
+const test_default_language_setting = async (page: Page): Promise<void> => {
     const preferences_section = '[data-section="preferences"]';
     await page.click(preferences_section);
 
@@ -417,9 +417,9 @@ async function test_default_language_setting(page: Page): Promise<void> {
     await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
-}
+};
 
-async function test_notifications_section(page: Page): Promise<void> {
+const test_notifications_section = async (page: Page): Promise<void> => {
     await page.click('[data-section="notifications"]');
     // At the beginning, "DMs, mentions, and alerts"(checkbox name=enable_sounds) audio will be on
     // and "Streams"(checkbox name=enable_stream_audible_notifications) audio will be off by default.
@@ -445,9 +445,9 @@ async function test_notifications_section(page: Page): Promise<void> {
     const notification_sound_disabled = ".setting_notification_sound:disabled";
     await page.waitForSelector(notification_sound_disabled);
     */
-}
+};
 
-async function settings_tests(page: Page): Promise<void> {
+const settings_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await open_settings(page);
     await close_settings_and_date_picker(page);
@@ -463,6 +463,6 @@ async function settings_tests(page: Page): Promise<void> {
     // replaces your session, which can lead to some nondeterministic
     // failures in test code after it, involving `GET /events`
     // returning a 401. (We reset the test database after each file).
-}
+};
 
 common.run_test(settings_tests);

--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -6,11 +6,10 @@ import * as common from "./lib/common";
 
 const message = "test star";
 
-async function stars_count(page: Page): Promise<number> {
-    return (await page.$$(".message-list .zulip-icon-star-filled:not(.empty-star)")).length;
-}
+const stars_count = async (page: Page): Promise<number> =>
+    (await page.$$(".message-list .zulip-icon-star-filled:not(.empty-star)")).length;
 
-async function toggle_test_star_message(page: Page): Promise<void> {
+const toggle_test_star_message = async (page: Page): Promise<void> => {
     const messagebox = await page.waitForSelector(
         `xpath/(//*[${common.has_class_x("message-list")}]//*[${common.has_class_x(
             "message_content",
@@ -25,9 +24,9 @@ async function toggle_test_star_message(page: Page): Promise<void> {
     const star_icon = await messagebox.waitForSelector(".star", {visible: true});
     assert.ok(star_icon !== null);
     await star_icon.click();
-}
+};
 
-async function test_narrow_to_starred_messages(page: Page): Promise<void> {
+const test_narrow_to_starred_messages = async (page: Page): Promise<void> => {
     await page.click('#left-sidebar-navigation-list a[href^="#narrow/is/starred"]');
     const message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [["Verona > stars", [message]]]);
@@ -39,9 +38,9 @@ async function test_narrow_to_starred_messages(page: Page): Promise<void> {
         `.message-list[data-message-list-id='${combined_feed_id}'] .message_row`,
         {visible: true},
     );
-}
+};
 
-async function stars_test(page: Page): Promise<void> {
+const stars_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
     let message_list_id = await common.get_current_msg_list_id(page, true);
@@ -81,6 +80,6 @@ async function stars_test(page: Page): Promise<void> {
 
     await toggle_test_star_message(page);
     assert.strictEqual(await stars_count(page), 0, "Message was not unstarred correctly.");
-}
+};
 
 common.run_test(stars_test);

--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -4,50 +4,50 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function user_row_selector(page: Page, name: string): Promise<string> {
+const user_row_selector = async (page: Page, name: string): Promise<string> => {
     const user_id = await common.get_user_id_from_name(page, name);
     const selector = `.remove_potential_subscriber[data-user-id="${user_id}"]`;
     return selector;
-}
+};
 
-async function await_user_visible(page: Page, name: string): Promise<void> {
+const await_user_visible = async (page: Page, name: string): Promise<void> => {
     const selector = await user_row_selector(page, name);
     await page.waitForSelector(selector, {visible: true});
-}
+};
 
-async function await_user_hidden(page: Page, name: string): Promise<void> {
+const await_user_hidden = async (page: Page, name: string): Promise<void> => {
     const selector = await user_row_selector(page, name);
     await page.waitForSelector(selector, {hidden: true});
-}
+};
 
-async function add_user_to_stream(page: Page, name: string): Promise<void> {
+const add_user_to_stream = async (page: Page, name: string): Promise<void> => {
     const user_id = await common.get_user_id_from_name(page, name);
     await page.evaluate((user_id) => {
         zulip_test.add_user_id_to_new_stream(user_id);
     }, user_id);
     await await_user_visible(page, name);
-}
+};
 
-async function stream_name_error(page: Page): Promise<string> {
+const stream_name_error = async (page: Page): Promise<string> => {
     await page.waitForSelector("#stream_name_error", {visible: true});
     return await common.get_text_from_selector(page, "#stream_name_error");
-}
+};
 
-async function click_create_new_stream(page: Page): Promise<void> {
+const click_create_new_stream = async (page: Page): Promise<void> => {
     await page.click("#add_new_subscription .create_stream_button");
     await page.waitForSelector(".finalize_create_stream", {visible: true});
 
     // sanity check that desdemona is the initial subsscriber
     await await_user_visible(page, "desdemona");
-}
+};
 
-async function clear_ot_filter_with_backspace(page: Page): Promise<void> {
+const clear_ot_filter_with_backspace = async (page: Page): Promise<void> => {
     await page.click(".add-user-list-filter");
     await page.keyboard.press("Backspace");
     await page.keyboard.press("Backspace");
-}
+};
 
-async function test_user_filter_ui(page: Page): Promise<void> {
+const test_user_filter_ui = async (page: Page): Promise<void> => {
     await page.waitForSelector("form#stream_creation_form", {visible: true});
     // Desdemona should be there by default
     await await_user_visible(page, "desdemona");
@@ -74,9 +74,9 @@ async function test_user_filter_ui(page: Page): Promise<void> {
     await await_user_visible(page, common.fullname.cordelia);
     await await_user_visible(page, "desdemona");
     await await_user_visible(page, common.fullname.othello);
-}
+};
 
-async function create_stream(page: Page): Promise<void> {
+const create_stream = async (page: Page): Promise<void> => {
     await page.waitForSelector('xpath///*[text()="Create channel"]', {visible: true});
     await common.fill_form(page, "form#stream_creation_form", {
         stream_name: "Puppeteer",
@@ -110,34 +110,34 @@ async function create_stream(page: Page): Promise<void> {
             "subscriber-count",
         )} and normalize-space()="3"]`,
     );
-}
+};
 
-async function test_streams_with_empty_names_cannot_be_created(page: Page): Promise<void> {
+const test_streams_with_empty_names_cannot_be_created = async (page: Page): Promise<void> => {
     await page.click("#add_new_subscription .create_stream_button");
     await page.waitForSelector("form#stream_creation_form", {visible: true});
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "  "});
     await page.click("form#stream_creation_form button.finalize_create_stream");
     assert.strictEqual(await stream_name_error(page), "Choose a name for the new channel.");
-}
+};
 
-async function test_streams_with_duplicate_names_cannot_be_created(page: Page): Promise<void> {
+const test_streams_with_duplicate_names_cannot_be_created = async (page: Page): Promise<void> => {
     await common.fill_form(page, "form#stream_creation_form", {stream_name: "Puppeteer"});
     await page.click("form#stream_creation_form button.finalize_create_stream");
     assert.strictEqual(await stream_name_error(page), "A channel with this name already exists.");
 
     const cancel_button_selector = "form#stream_creation_form button.button.white";
     await page.click(cancel_button_selector);
-}
+};
 
-async function test_stream_creation(page: Page): Promise<void> {
+const test_stream_creation = async (page: Page): Promise<void> => {
     await click_create_new_stream(page);
     await test_user_filter_ui(page);
     await create_stream(page);
     await test_streams_with_empty_names_cannot_be_created(page);
     await test_streams_with_duplicate_names_cannot_be_created(page);
-}
+};
 
-async function test_streams_search_feature(page: Page): Promise<void> {
+const test_streams_search_feature = async (page: Page): Promise<void> => {
     assert.strictEqual(await common.get_text_from_selector(page, "#search_stream_name"), "");
     const hidden_streams_selector = ".stream-row.notdisplayed .stream-name";
     assert.strictEqual(
@@ -166,13 +166,13 @@ async function test_streams_search_feature(page: Page): Promise<void> {
         !(await common.get_text_from_selector(page, hidden_streams_selector)).includes("Puppeteer"),
         "Puppeteer is hidden after searching.",
     );
-}
+};
 
-async function subscriptions_tests(page: Page): Promise<void> {
+const subscriptions_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await common.open_streams_modal(page);
     await test_stream_creation(page);
     await test_streams_search_feature(page);
-}
+};
 
 common.run_test(subscriptions_tests);

--- a/web/e2e-tests/subscribe_toggle.test.ts
+++ b/web/e2e-tests/subscribe_toggle.test.ts
@@ -2,7 +2,7 @@ import type {ElementHandle, Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function test_subscription_button(page: Page): Promise<void> {
+const test_subscription_button = async (page: Page): Promise<void> => {
     const all_stream_selector = "[data-tab-key='all-streams']";
     await page.waitForSelector(all_stream_selector, {visible: true});
     await page.click(all_stream_selector);
@@ -11,23 +11,23 @@ async function test_subscription_button(page: Page): Promise<void> {
     const subscribed_selector = `${button_selector}.checked`;
     const unsubscribed_selector = `${button_selector}:not(.checked)`;
 
-    async function subscribed(): Promise<ElementHandle | null> {
+    const subscribed = async (): Promise<ElementHandle | null> => {
         await page.waitForSelector(
             `xpath///*[${common.has_class_x("stream_settings_header")}]//*[${common.has_class_x(
                 "sub_unsub_button",
             )} and normalize-space()="Unsubscribe"]`,
         );
         return await page.waitForSelector(subscribed_selector, {visible: true});
-    }
+    };
 
-    async function unsubscribed(): Promise<ElementHandle | null> {
+    const unsubscribed = async (): Promise<ElementHandle | null> => {
         await page.waitForSelector(
             `xpath///*[${common.has_class_x("stream_settings_header")}]//*[${common.has_class_x(
                 "sub_unsub_button",
             )} and normalize-space()="Subscribe"]`,
         );
         return await page.waitForSelector(unsubscribed_selector, {visible: true});
-    }
+    };
 
     // Make sure that Venice is even in our list of streams.
     await page.waitForSelector(stream_selector, {visible: true});
@@ -44,12 +44,12 @@ async function test_subscription_button(page: Page): Promise<void> {
     await (await subscribed())!.click();
     await (await unsubscribed())!.click();
     await subscribed();
-}
+};
 
-async function subscriptions_tests(page: Page): Promise<void> {
+const subscriptions_tests = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await common.open_streams_modal(page);
     await test_subscription_button(page);
-}
+};
 
 common.run_test(subscriptions_tests);

--- a/web/e2e-tests/user-deactivation.test.ts
+++ b/web/e2e-tests/user-deactivation.test.ts
@@ -4,7 +4,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function navigate_to_user_list(page: Page): Promise<void> {
+const navigate_to_user_list = async (page: Page): Promise<void> => {
     const menu_selector = "#settings-dropdown";
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
@@ -15,15 +15,18 @@ async function navigate_to_user_list(page: Page): Promise<void> {
 
     await page.waitForSelector("#settings_overlay_container.show", {visible: true});
     await page.click("li[data-section='user-list-admin']");
-}
+};
 
-async function user_row(page: Page, name: string): Promise<string> {
+const user_row = async (page: Page, name: string): Promise<string> => {
     const user_id = await common.get_user_id_from_name(page, name);
     assert(user_id !== undefined);
     return `.user_row[data-user-id="${CSS.escape(user_id.toString())}"]`;
-}
+};
 
-async function test_reactivation_confirmation_modal(page: Page, fullname: string): Promise<void> {
+const test_reactivation_confirmation_modal = async (
+    page: Page,
+    fullname: string,
+): Promise<void> => {
     await common.wait_for_micromodal_to_open(page);
 
     assert.strictEqual(
@@ -38,9 +41,9 @@ async function test_reactivation_confirmation_modal(page: Page, fullname: string
     );
     await page.click(".micromodal .dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function test_deactivate_user(page: Page): Promise<void> {
+const test_deactivate_user = async (page: Page): Promise<void> => {
     const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row, {visible: true});
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
@@ -59,9 +62,9 @@ async function test_deactivate_user(page: Page): Promise<void> {
     );
     await page.click(".micromodal .dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);
-}
+};
 
-async function test_reactivate_user(page: Page): Promise<void> {
+const test_reactivate_user = async (page: Page): Promise<void> => {
     let cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row + ".deactivated_user");
     await page.waitForSelector(cordelia_user_row + " .fa-user-plus");
@@ -72,9 +75,9 @@ async function test_reactivate_user(page: Page): Promise<void> {
     await page.waitForSelector(cordelia_user_row + ":not(.deactivated_user)", {visible: true});
     cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await page.waitForSelector(cordelia_user_row + " .fa-user-times");
-}
+};
 
-async function test_deactivated_users_section(page: Page): Promise<void> {
+const test_deactivated_users_section = async (page: Page): Promise<void> => {
     const cordelia_user_row = await user_row(page, common.fullname.cordelia);
     await test_deactivate_user(page);
 
@@ -100,9 +103,9 @@ async function test_deactivated_users_section(page: Page): Promise<void> {
         "#admin_deactivated_users_table " + cordelia_user_row + " button:not(.reactivate)",
         {visible: true},
     );
-}
+};
 
-async function test_bot_deactivation_and_reactivation(page: Page): Promise<void> {
+const test_bot_deactivation_and_reactivation = async (page: Page): Promise<void> => {
     await page.click("li[data-section='bot-list-admin']");
 
     const default_bot_user_row = await user_row(page, "Zulip Default Bot");
@@ -130,15 +133,15 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
     await test_reactivation_confirmation_modal(page, "Zulip Default Bot");
     await page.waitForSelector(default_bot_user_row + ":not(.deactivated_user)", {visible: true});
     await page.waitForSelector(default_bot_user_row + " .fa-user-times");
-}
+};
 
-async function user_deactivation_test(page: Page): Promise<void> {
+const user_deactivation_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await navigate_to_user_list(page);
     await test_deactivate_user(page);
     await test_reactivate_user(page);
     await test_deactivated_users_section(page);
     await test_bot_deactivation_and_reactivation(page);
-}
+};
 
 common.run_test(user_deactivation_test);

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -2,7 +2,7 @@ import type {Page} from "puppeteer";
 
 import * as common from "./lib/common";
 
-async function open_set_user_status_modal(page: Page): Promise<void> {
+const open_set_user_status_modal = async (page: Page): Promise<void> => {
     // We are clicking on the menu icon with the help of `waitForFunction` because the list
     // re-renders many times and can cause the element to become stale.
     await page.waitForFunction((): boolean => {
@@ -23,9 +23,9 @@ async function open_set_user_status_modal(page: Page): Promise<void> {
 
     // Wait for the modal to completely open.
     await common.wait_for_micromodal_to_open(page);
-}
+};
 
-async function test_user_status(page: Page): Promise<void> {
+const test_user_status = async (page: Page): Promise<void> => {
     await open_set_user_status_modal(page);
     // Check by clicking on common statues.
     await page.click(".user-status-value:nth-child(2)");
@@ -58,11 +58,11 @@ async function test_user_status(page: Page): Promise<void> {
 
     // Check if the emoji is added in user presence list.
     await page.waitForSelector(`.user-presence-link .status-emoji${tada_emoji_selector}`);
-}
+};
 
-async function user_status_test(page: Page): Promise<void> {
+const user_status_test = async (page: Page): Promise<void> => {
     await common.log_in(page);
     await test_user_status(page);
-}
+};
 
 common.run_test(user_status_test);

--- a/web/shared/src/fenced_code.ts
+++ b/web/shared/src/fenced_code.ts
@@ -41,18 +41,16 @@ const fencestr =
 const fence_re = new RegExp(fencestr);
 
 // Default stashing function does nothing
-let stash_func = function (text: string): string {
-    return text;
-};
+let stash_func = (text: string): string => text;
 
 // We fill up the actual values when initializing.
 let pygments_data: PygmentsData["langs"] = {};
 
-export function initialize(generated_pygments_data: PygmentsData): void {
+export const initialize = (generated_pygments_data: PygmentsData): void => {
     pygments_data = generated_pygments_data.langs;
-}
+};
 
-export function wrap_code(code: string, lang?: string): string {
+export const wrap_code = (code: string, lang?: string): string => {
     let header = '<div class="codehilite"><pre><span></span><code>';
     // Mimics the backend logic of adding a data-attribute (data-code-language)
     // to know what Pygments language was used to highlight this code block.
@@ -69,9 +67,9 @@ export function wrap_code(code: string, lang?: string): string {
     // Trim trailing \n until there's just one left
     // This mirrors how pygments handles code input
     return header + _.escape(code.replace(/^\n+|\n+$/g, "")) + "\n</code></pre></div>";
-}
+};
 
-function wrap_quote(text: string): string {
+const wrap_quote = (text: string): string => {
     const paragraphs = text.split("\n");
     const quoted_paragraphs = [];
 
@@ -83,17 +81,21 @@ function wrap_quote(text: string): string {
     }
 
     return quoted_paragraphs.join("\n");
-}
+};
 
-function wrap_tex(tex: string): string {
+const wrap_tex = (tex: string): string => {
     try {
         return "<p>" + katex.renderToString(tex, {displayMode: true}) + "</p>";
     } catch {
         return '<p><span class="tex-error">' + _.escape(tex) + "</span></p>";
     }
-}
+};
 
-function wrap_spoiler(header: string, text: string, stash_func: (text: string) => string): string {
+const wrap_spoiler = (
+    header: string,
+    text: string,
+    stash_func: (text: string) => string,
+): string => {
     const header_div_open_html = '<div class="spoiler-block"><div class="spoiler-header">';
     const end_header_start_content_html = '</div><div class="spoiler-content" aria-hidden="true">';
     const footer_html = "</div></div>";
@@ -106,11 +108,11 @@ function wrap_spoiler(header: string, text: string, stash_func: (text: string) =
         stash_func(footer_html),
     ];
     return output.join("\n\n");
-}
+};
 
-export function set_stash_func(stash_handler: (text: string) => string): void {
+export const set_stash_func = (stash_handler: (text: string) => string): void => {
     stash_func = stash_handler;
-}
+};
 
 export function process_fenced_code(content: string): string {
     const input = content.split("\n");
@@ -137,7 +139,7 @@ export function process_fenced_code(content: string): string {
                     }
                 },
 
-                done() {
+                done: () => {
                     const text = wrap_quote(lines.join("\n"));
                     output_lines.push("", text, "");
                     handler_stack.pop();
@@ -155,7 +157,7 @@ export function process_fenced_code(content: string): string {
                     }
                 },
 
-                done() {
+                done: () => {
                     const text = wrap_tex(lines.join("\n"));
                     const placeholder = stash_func(text);
                     output_lines.push("", placeholder, "");
@@ -174,7 +176,7 @@ export function process_fenced_code(content: string): string {
                     }
                 },
 
-                done() {
+                done: () => {
                     const text = wrap_spoiler(header, lines.join("\n"), stash_func);
                     output_lines.push("", text, "");
                     handler_stack.pop();
@@ -191,7 +193,7 @@ export function process_fenced_code(content: string): string {
                 }
             },
 
-            done() {
+            done: () => {
                 const text = wrap_code(lines.join("\n"), lang);
                 // insert safe HTML that is passed through the parsing
                 const placeholder = stash_func(text);
@@ -201,18 +203,16 @@ export function process_fenced_code(content: string): string {
         };
     }
 
-    function default_handler(): Handler {
-        return {
-            handle_line(line) {
-                consume_line(output, line);
-            },
-            done() {
-                handler_stack.pop();
-            },
-        };
-    }
+    const default_handler = (): Handler => ({
+        handle_line: (line) => {
+            consume_line(output, line);
+        },
+        done: () => {
+            handler_stack.pop();
+        },
+    });
 
-    consume_line = function consume_line(output_lines: string[], line: string) {
+    consume_line = (output_lines: string[], line: string) => {
         const match = fence_re.exec(line);
         if (match) {
             const fence = match[1]!;
@@ -249,7 +249,7 @@ export function process_fenced_code(content: string): string {
 }
 
 const fence_length_re = /^ {0,3}(`{3,})/gm;
-export function get_unused_fence(content: string): string {
+export const get_unused_fence = (content: string): string => {
     // we only return ``` fences, not ~~~.
     let length = 3;
     let match;
@@ -258,4 +258,4 @@ export function get_unused_fence(content: string): string {
         length = Math.max(length, match[1]!.length + 1);
     }
     return "`".repeat(length);
-}
+};

--- a/web/shared/src/internal_url.ts
+++ b/web/shared/src/internal_url.ts
@@ -10,23 +10,16 @@ const hashReplacements = new Map([
 // Some browsers zealously URI-decode the contents of
 // window.location.hash.  So we hide our URI-encoding
 // by replacing % with . (like MediaWiki).
-export function encodeHashComponent(str: string): string {
-    return encodeURIComponent(str).replace(/[%().]/g, (matched) => hashReplacements.get(matched)!);
-}
+export const encodeHashComponent = (str: string): string =>
+    encodeURIComponent(str).replace(/[%().]/g, (matched) => hashReplacements.get(matched)!);
 
-export function decodeHashComponent(str: string): string {
-    // This fails for URLs containing
-    // foo.foo or foo%foo due to our fault in special handling
-    // of such characters when encoding. This can also,
-    // fail independent of our fault.
-    // Here we let the calling code handle the exception.
-    return decodeURIComponent(str.replace(/\./g, "%"));
-}
+export const decodeHashComponent = (str: string): string =>
+    decodeURIComponent(str.replace(/\./g, "%"));
 
-export function stream_id_to_slug(
+export const stream_id_to_slug = (
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
-): string {
+): string => {
     let name = maybe_get_stream_name(stream_id) ?? "unknown";
 
     // The name part of the URL doesn't really matter, so we try to
@@ -37,33 +30,30 @@ export function stream_id_to_slug(
     name = name.replace(/ /g, "-");
 
     return `${stream_id}-${name}`;
-}
+};
 
-export function encode_stream_id(
+export const encode_stream_id = (
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
-): string {
+): string => {
     // stream_id_to_slug appends the stream name, but it does not do the
     // URI encoding piece.
     const slug = stream_id_to_slug(stream_id, maybe_get_stream_name);
 
     return encodeHashComponent(slug);
-}
+};
 
-export function by_stream_url(
+export const by_stream_url = (
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
-): string {
-    return `#narrow/stream/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
-}
+): string => `#narrow/stream/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
 
-export function by_stream_topic_url(
+export const by_stream_topic_url = (
     stream_id: number,
     topic: string,
     maybe_get_stream_name: MaybeGetStreamName,
-): string {
-    return `#narrow/stream/${encode_stream_id(
+): string =>
+    `#narrow/stream/${encode_stream_id(
         stream_id,
         maybe_get_stream_name,
     )}/topic/${encodeHashComponent(topic)}`;
-}

--- a/web/shared/src/resolved_topic.ts
+++ b/web/shared/src/resolved_topic.ts
@@ -11,22 +11,18 @@ export const RESOLVED_TOPIC_PREFIX = "✔ ";
 // Compare maybe_send_resolve_topic_notifications in zerver/actions/message_edit.py.
 const RESOLVED_TOPIC_PREFIX_RE = /^✔ [ ✔]*/;
 
-export function is_resolved(topic_name: string): boolean {
-    return topic_name.startsWith(RESOLVED_TOPIC_PREFIX);
-}
+export const is_resolved = (topic_name: string): boolean =>
+    topic_name.startsWith(RESOLVED_TOPIC_PREFIX);
 
-export function resolve_name(topic_name: string): string {
-    return RESOLVED_TOPIC_PREFIX + topic_name;
-}
+export const resolve_name = (topic_name: string): string => RESOLVED_TOPIC_PREFIX + topic_name;
 
 /**
  * The un-resolved form of this topic name.
  *
  * If the topic is already not a resolved topic, this is the identity.
  */
-export function unresolve_name(topic_name: string): string {
-    return topic_name.replace(RESOLVED_TOPIC_PREFIX_RE, "");
-}
+export const unresolve_name = (topic_name: string): string =>
+    topic_name.replace(RESOLVED_TOPIC_PREFIX_RE, "");
 
 /**
  * Split the topic name for display, into a "resolved" prefix and remainder.
@@ -38,8 +34,7 @@ export function unresolve_name(topic_name: string): string {
  * property we want when listing topics in the UI, so that we don't end up
  * showing what look like several identical topics.
  */
-export function display_parts(topic_name: string): [string, string] {
-    return is_resolved(topic_name)
+export const display_parts = (topic_name: string): [string, string] =>
+    is_resolved(topic_name)
         ? [RESOLVED_TOPIC_PREFIX, topic_name.slice(RESOLVED_TOPIC_PREFIX.length)]
         : ["", topic_name];
-}

--- a/web/src/about_zulip.ts
+++ b/web/src/about_zulip.ts
@@ -8,11 +8,11 @@ import {show_copied_confirmation} from "./copied_tooltip";
 import * as overlays from "./overlays";
 import {realm} from "./state_data";
 
-export function launch(): void {
+export const launch = (): void => {
     overlays.open_overlay({
         name: "about-zulip",
         $overlay: $("#about-zulip"),
-        on_close() {
+        on_close: () => {
             browser_history.exit_overlay();
         },
     });
@@ -26,13 +26,13 @@ export function launch(): void {
     zulip_merge_base_clipboard.on("success", () => {
         show_copied_confirmation($("#about-zulip .fa-copy.zulip-merge-base")[0]!);
     });
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     const rendered_about_zulip = render_about_zulip({
         zulip_version: realm.zulip_version,
         zulip_merge_base: realm.zulip_merge_base,
         is_fork: realm.zulip_merge_base && realm.zulip_merge_base !== realm.zulip_version,
     });
     $("#about-zulip-modal-container").append($(rendered_about_zulip));
-}
+};

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -57,22 +57,22 @@ export let client_is_active = document.hasFocus();
 // server-initiated reload as user activity.
 export let new_user_input = true;
 
-export function set_new_user_input(value: boolean): void {
+export const set_new_user_input = (value: boolean): void => {
     new_user_input = value;
-}
+};
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     client_is_active = false;
-}
+};
 
-export function mark_client_idle(): void {
+export const mark_client_idle = (): void => {
     // When we become idle, we don't immediately send anything to the
     // server; instead, we wait for our next periodic update, since
     // this data is fundamentally not timely.
     client_is_active = false;
-}
+};
 
-export function compute_active_status(): ActivityState {
+export const compute_active_status = (): ActivityState => {
     // The overall algorithm intent for the `status` field is to send
     // `ACTIVE` (aka green circle) if we know the user is at their
     // computer, and IDLE (aka orange circle) if the user might not
@@ -95,9 +95,9 @@ export function compute_active_status(): ActivityState {
         return ActivityState.ACTIVE;
     }
     return ActivityState.IDLE;
-}
+};
 
-export function send_presence_to_server(redraw?: () => void): void {
+export const send_presence_to_server = (redraw?: () => void): void => {
     // Zulip has 2 data feeds coming from the server to the client:
     // The server_events data, and this presence feed.  Data from
     // server_events is nicely serialized, but if we've been offline
@@ -128,7 +128,7 @@ export function send_presence_to_server(redraw?: () => void): void {
             new_user_input,
             last_update_id: presence.presence_last_update_id,
         },
-        success(response) {
+        success: (response) => {
             const data = post_presence_response_schema.parse(response);
 
             // Update Zephyr mirror activity warning
@@ -163,17 +163,17 @@ export function send_presence_to_server(redraw?: () => void): void {
             }
         },
     });
-}
+};
 
-export function mark_client_active(): void {
+export const mark_client_active = (): void => {
     // exported for testing
     if (!client_is_active) {
         client_is_active = true;
         send_presence_to_server();
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("html").on("mousemove", () => {
         new_user_input = true;
     });
@@ -185,4 +185,4 @@ export function initialize(): void {
         onActive: mark_client_active,
         keepTracking: true,
     });
-}
+};

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -28,20 +28,19 @@ export let user_filter: UserSearch | undefined;
 // Function initialized from `ui_init` to avoid importing narrow.js and causing circular imports.
 let narrow_by_email: (email: string) => void;
 
-function get_pm_list_item(user_id: string): JQuery | undefined {
-    return buddy_list.find_li({
+const get_pm_list_item = (user_id: string): JQuery | undefined =>
+    buddy_list.find_li({
         key: Number.parseInt(user_id, 10),
     });
-}
 
-function set_pm_count(user_ids_string: string, count: number): void {
+const set_pm_count = (user_ids_string: string, count: number): void => {
     const $pm_li = get_pm_list_item(user_ids_string);
     if ($pm_li !== undefined) {
         ui_util.update_unread_count_in_dom($pm_li, count);
     }
-}
+};
 
-export function update_dom_with_unread_counts(counts: FullUnreadCountsData): void {
+export const update_dom_with_unread_counts = (counts: FullUnreadCountsData): void => {
     // counts is just a data object that gets calculated elsewhere
     // Our job is to update some DOM elements.
 
@@ -52,14 +51,14 @@ export function update_dom_with_unread_counts(counts: FullUnreadCountsData): voi
             set_pm_count(user_ids_string, count);
         }
     }
-}
+};
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     user_cursor = undefined;
     user_filter = undefined;
-}
+};
 
-export function redraw_user(user_id: number): void {
+export const redraw_user = (user_id: number): void => {
     if (realm.realm_presence_disabled) {
         return;
     }
@@ -76,9 +75,9 @@ export function redraw_user(user_id: number): void {
         user_id,
         item: info,
     });
-}
+};
 
-export function check_should_redraw_new_user(user_id: number): boolean {
+export const check_should_redraw_new_user = (user_id: number): boolean => {
     if (realm.realm_presence_disabled) {
         return false;
     }
@@ -86,13 +85,11 @@ export function check_should_redraw_new_user(user_id: number): boolean {
     const user_is_in_presence_info = presence.presence_info.has(user_id);
     const user_not_yet_known = people.maybe_get_user_by_id(user_id, true) === undefined;
     return user_is_in_presence_info && user_not_yet_known;
-}
+};
 
-export function searching(): boolean {
-    return user_filter?.searching() ?? false;
-}
+export const searching = (): boolean => user_filter?.searching() ?? false;
 
-export function render_empty_user_list_message_if_needed($container: JQuery): void {
+export const render_empty_user_list_message_if_needed = ($container: JQuery): void => {
     const empty_list_message = $container.attr("data-search-results-empty");
 
     if (!empty_list_message || $container.children().length) {
@@ -101,9 +98,9 @@ export function render_empty_user_list_message_if_needed($container: JQuery): vo
 
     const empty_list_widget_html = render_empty_list_widget_for_list({empty_list_message});
     $container.append($(empty_list_widget_html));
-}
+};
 
-export function build_user_sidebar(): number[] | undefined {
+export const build_user_sidebar = (): number[] | undefined => {
     if (realm.realm_presence_disabled) {
         return undefined;
     }
@@ -119,20 +116,20 @@ export function build_user_sidebar(): number[] | undefined {
     render_empty_user_list_message_if_needed(buddy_list.$other_users_container);
 
     return all_user_ids; // for testing
-}
+};
 
-function do_update_users_for_search(): void {
+const do_update_users_for_search = (): void => {
     // Hide all the popovers but not userlist sidebar
     // when the user is searching.
     popovers.hide_all();
     build_user_sidebar();
     assert(user_cursor !== undefined);
     user_cursor.reset();
-}
+};
 
 const update_users_for_search = _.throttle(do_update_users_for_search, 50);
 
-export function initialize(opts: {narrow_by_email: (email: string) => void}): void {
+export const initialize = (opts: {narrow_by_email: (email: string) => void}): void => {
     narrow_by_email = opts.narrow_by_email;
 
     set_cursor_and_filter();
@@ -141,9 +138,9 @@ export function initialize(opts: {narrow_by_email: (email: string) => void}): vo
 
     buddy_list.start_scroll_handler();
 
-    function get_full_presence_list_update(): void {
+    const get_full_presence_list_update = (): void => {
         activity.send_presence_to_server(redraw);
-    }
+    };
 
     /* Time between keep-alive pings */
     const active_ping_interval_ms = realm.server_presence_ping_interval_seconds * 1000;
@@ -152,13 +149,13 @@ export function initialize(opts: {narrow_by_email: (email: string) => void}): vo
     // Let the server know we're here, but do not pass
     // redraw, since we just got all this info in page_params.
     activity.send_presence_to_server();
-}
+};
 
-export function update_presence_info(
+export const update_presence_info = (
     user_id: number,
     info: PresenceInfoFromEvent,
     server_time: number,
-): void {
+): void => {
     // There can be some case where the presence event
     // was set for an inaccessible user if
     // CAN_ACCESS_ALL_USERS_GROUP_LIMITS_PRESENCE is
@@ -171,28 +168,28 @@ export function update_presence_info(
     presence.update_info_from_event(user_id, info, server_time);
     redraw_user(user_id);
     pm_list.update_private_messages();
-}
+};
 
-export function redraw(): void {
+export const redraw = (): void => {
     build_user_sidebar();
     assert(user_cursor !== undefined);
     user_cursor.redraw();
     pm_list.update_private_messages();
-}
+};
 
-export function reset_users(): void {
+export const reset_users = (): void => {
     // Call this when we're leaving the search widget.
     build_user_sidebar();
     assert(user_cursor !== undefined);
     user_cursor.clear();
-}
+};
 
-export function narrow_for_user(opts: {$li: JQuery}): void {
+export const narrow_for_user = (opts: {$li: JQuery}): void => {
     const user_id = buddy_list.get_user_id_from_li({$li: opts.$li});
     narrow_for_user_id({user_id});
-}
+};
 
-export function narrow_for_user_id(opts: {user_id: number}): void {
+export const narrow_for_user_id = (opts: {user_id: number}): void => {
     const person = people.get_by_user_id(opts.user_id);
     const email = person.email;
 
@@ -200,9 +197,9 @@ export function narrow_for_user_id(opts: {user_id: number}): void {
     narrow_by_email(email);
     assert(user_filter !== undefined);
     user_filter.clear_and_hide_search();
-}
+};
 
-function keydown_enter_key(): void {
+const keydown_enter_key = (): void => {
     assert(user_cursor !== undefined);
     const user_id = user_cursor.get_key();
     if (user_id === undefined) {
@@ -212,9 +209,9 @@ function keydown_enter_key(): void {
     narrow_for_user_id({user_id});
     sidebar_ui.hide_all();
     popovers.hide_all();
-}
+};
 
-export function set_cursor_and_filter(): void {
+export const set_cursor_and_filter = (): void => {
     user_cursor = new ListCursor({
         list: buddy_list,
         highlight_class: "highlighted_user",
@@ -223,7 +220,7 @@ export function set_cursor_and_filter(): void {
     user_filter = new UserSearch({
         update_list: update_users_for_search,
         reset_items: reset_users,
-        on_focus() {
+        on_focus: () => {
             user_cursor!.reset();
         },
     });
@@ -237,37 +234,37 @@ export function set_cursor_and_filter(): void {
     keydown_util.handle({
         $elem: $input,
         handlers: {
-            Enter() {
+            Enter: () => {
                 keydown_enter_key();
                 return true;
             },
-            ArrowUp() {
+            ArrowUp: () => {
                 user_cursor!.prev();
                 return true;
             },
-            ArrowDown() {
+            ArrowDown: () => {
                 user_cursor!.next();
                 return true;
             },
         },
     });
-}
+};
 
-export function initiate_search(): void {
+export const initiate_search = (): void => {
     if (user_filter) {
         $("body").removeClass("hide-right-sidebar");
         popovers.hide_all();
         user_filter.initiate_search();
     }
-}
+};
 
-export function escape_search(): void {
+export const escape_search = (): void => {
     if (user_filter) {
         user_filter.clear_and_hide_search();
     }
-}
+};
 
-export function get_filter_text(): string {
+export const get_filter_text = (): string => {
     if (!user_filter) {
         // This may be overly defensive, but there may be
         // situations where get called before everything is
@@ -278,4 +275,4 @@ export function get_filter_text(): string {
     }
 
     return user_filter.text();
-}
+};

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -8,9 +8,9 @@ import * as popover_menus from "./popover_menus";
 import * as settings_data from "./settings_data";
 import {parse_html} from "./ui_util";
 
-export function initialize(): void {
+export const initialize = (): void => {
     popover_menus.register_popover_menu("#streams_inline_icon", {
-        onShow(instance) {
+        onShow: (instance) => {
             const can_create_streams =
                 settings_data.user_can_create_private_streams() ||
                 settings_data.user_can_create_public_streams() ||
@@ -51,7 +51,7 @@ export function initialize(): void {
 
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.stream_settings = null;
             //  After the popover menu is closed, we want the
@@ -74,4 +74,4 @@ export function initialize(): void {
             });
         },
     });
-}
+};

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -7,10 +7,10 @@ import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import * as user_pill from "./user_pill";
 
-function create_item_from_text(
+const create_item_from_text = (
     text: string,
     current_items: CombinedPillItem[],
-): CombinedPillItem | undefined {
+): CombinedPillItem | undefined => {
     const funcs = [
         stream_pill.create_item_from_stream_name,
         user_group_pill.create_item_from_group_name,
@@ -23,9 +23,9 @@ function create_item_from_text(
         }
     }
     return undefined;
-}
+};
 
-function get_text_from_item(item: CombinedPillItem): string {
+const get_text_from_item = (item: CombinedPillItem): string => {
     let text: string;
     switch (item.type) {
         case "stream":
@@ -39,9 +39,9 @@ function get_text_from_item(item: CombinedPillItem): string {
             break;
     }
     return text;
-}
+};
 
-function set_up_pill_typeahead({
+const set_up_pill_typeahead = ({
     pill_widget,
     $pill_container,
     get_users,
@@ -49,7 +49,7 @@ function set_up_pill_typeahead({
     pill_widget: CombinedPillContainer;
     $pill_container: JQuery;
     get_users: () => User[];
-}): void {
+}): void => {
     const opts = {
         user_source: get_users,
         stream: true,
@@ -57,24 +57,24 @@ function set_up_pill_typeahead({
         user: true,
     };
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
-}
+};
 
-export function create({
+export const create = ({
     $pill_container,
     get_potential_subscribers,
 }: {
     $pill_container: JQuery;
     get_potential_subscribers: () => User[];
-}): input_pill.InputPillContainer<CombinedPillItem> {
+}): input_pill.InputPillContainer<CombinedPillItem> => {
     const pill_widget = input_pill.create<CombinedPillItem>({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
     });
-    function get_users(): User[] {
+    const get_users = (): User[] => {
         const potential_subscribers = get_potential_subscribers();
         return user_pill.filter_taken_users(potential_subscribers, pill_widget);
-    }
+    };
 
     set_up_pill_typeahead({pill_widget, $pill_container, get_users});
 
@@ -97,16 +97,16 @@ export function create({
     );
 
     return pill_widget;
-}
+};
 
-function get_pill_user_ids(pill_widget: CombinedPillContainer): number[] {
+const get_pill_user_ids = (pill_widget: CombinedPillContainer): number[] => {
     const user_ids = user_pill.get_user_ids(pill_widget);
     const stream_user_ids = stream_pill.get_user_ids(pill_widget);
     const group_user_ids = user_group_pill.get_user_ids(pill_widget);
     return [...user_ids, ...stream_user_ids, ...group_user_ids];
-}
+};
 
-export function set_up_handlers({
+export const set_up_handlers = ({
     get_pill_widget,
     $parent_container,
     pill_selector,
@@ -118,7 +118,7 @@ export function set_up_handlers({
     pill_selector: string;
     button_selector: string;
     action: ({pill_user_ids}: {pill_user_ids: number[]}) => void;
-}): void {
+}): void => {
     /*
         This function handles events for any UI that looks like
         this:
@@ -146,11 +146,11 @@ export function set_up_handlers({
             * user group
             * stream (i.e. subscribed users for the stream)
     */
-    function callback(): void {
+    const callback = (): void => {
         const pill_widget = get_pill_widget();
         const pill_user_ids = get_pill_user_ids(pill_widget);
         action({pill_user_ids});
-    }
+    };
 
     $parent_container.on("keyup", pill_selector, (e) => {
         if (keydown_util.is_enter_event(e)) {
@@ -163,4 +163,4 @@ export function set_up_handlers({
         e.preventDefault();
         callback();
     });
-}
+};

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -72,7 +72,7 @@ const admin_settings_label = {
     }),
 };
 
-function insert_tip_box() {
+const insert_tip_box = () => {
     if (current_user.is_admin) {
         return;
     }
@@ -86,9 +86,9 @@ function insert_tip_box() {
         .not("#admin-bot-list")
         .not("#admin-invites-list")
         .prepend($(tip_box_html));
-}
+};
 
-function get_realm_level_notification_settings(options) {
+const get_realm_level_notification_settings = (options) => {
     const all_notifications_settings = settings_config.all_notifications(
         realm_user_settings_defaults,
     );
@@ -102,9 +102,9 @@ function get_realm_level_notification_settings(options) {
     options.notification_settings = all_notifications_settings.settings;
     options.show_push_notifications_tooltip =
         all_notifications_settings.show_push_notifications_tooltip;
-}
+};
 
-export function build_page() {
+export const build_page = () => {
     const options = {
         custom_profile_field_types: realm.custom_profile_field_types,
         full_name: current_user.full_name,
@@ -274,12 +274,12 @@ export function build_page() {
 
         tippy.default($("#realm_can_access_all_users_group_widget_container")[0], opts);
     }
-}
+};
 
-export function launch(section) {
+export const launch = (section) => {
     settings_sections.reset_sections();
 
     settings.open_settings_overlay();
     settings_panel_menu.org_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle("organization");
-}
+};

--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -7,16 +7,16 @@ import * as people from "./people";
 // data, since that matches what the server sends us.
 let my_alert_words: string[] = [];
 
-export function set_words(words: string[]): void {
+export const set_words = (words: string[]): void => {
     // This module's highlighting algorithm of greedily created
     // highlight spans cannot correctly handle overlapping alert word
     // clauses, but processing in order from longest-to-shortest
     // reduces some symptoms of this. See #28415 for details.
     my_alert_words = words;
     my_alert_words.sort((a, b) => b.length - a.length);
-}
+};
 
-export function get_word_list(): {word: string}[] {
+export const get_word_list = (): {word: string}[] => {
     // Returns a array of objects
     // (with each alert_word as value and 'word' as key to the object.)
     const words = [];
@@ -24,11 +24,9 @@ export function get_word_list(): {word: string}[] {
         words.push({word});
     }
     return words;
-}
+};
 
-export function has_alert_word(word: string): boolean {
-    return my_alert_words.includes(word);
-}
+export const has_alert_word = (word: string): boolean => my_alert_words.includes(word);
 
 const alert_regex_replacements = new Map<string, string>([
     ["&", "&amp;"],
@@ -39,7 +37,7 @@ const alert_regex_replacements = new Map<string, string>([
     ["'", "(?:'|&#39;)"],
 ]);
 
-export function process_message(message: Message): void {
+export const process_message = (message: Message): void => {
     // Parsing for alert words is expensive, so we rely on the host
     // to tell us there any alert words to even look for.
     if (!message.alerted) {
@@ -81,15 +79,10 @@ export function process_message(message: Message): void {
             },
         );
     }
-}
+};
 
-export function notifies(message: Message): boolean {
-    // We exclude ourselves from notifications when we type one of our own
-    // alert words into a message, just because that can be annoying for
-    // certain types of workflows where everybody on your team, including
-    // yourself, sets up an alert word to effectively mention the team.
-    return !people.is_current_user(message.sender_email) && message.alerted;
-}
+export const notifies = (message: Message): boolean =>
+    !people.is_current_user(message.sender_email) && message.alerted;
 
 export const initialize = (params: {alert_words: string[]}): void => {
     set_words(params.alert_words);

--- a/web/src/alert_words_ui.ts
+++ b/web/src/alert_words_ui.ts
@@ -12,7 +12,7 @@ import * as ui_report from "./ui_report";
 
 export let loaded = false;
 
-export function rerender_alert_words_ui(): void {
+export const rerender_alert_words_ui = (): void => {
     if (!loaded) {
         return;
     }
@@ -24,18 +24,16 @@ export function rerender_alert_words_ui(): void {
     ListWidget.create($word_list, words, {
         name: "alert-words-list",
         get_item: ListWidget.default_get_item,
-        modifier_html(alert_word) {
-            return render_alert_word_settings_item({alert_word});
-        },
+        modifier_html: (alert_word) => render_alert_word_settings_item({alert_word}),
         $parent_container: $("#alert-word-settings"),
         $simplebar_container: $("#alert-word-settings .progressive-table-wrapper"),
         sort_fields: {
             ...ListWidget.generic_sort_functions("alphabetic", ["word"]),
         },
     });
-}
+};
 
-function update_alert_word_status(status_text: string, is_error: boolean): void {
+const update_alert_word_status = (status_text: string, is_error: boolean): void => {
     const $alert_word_status = $("#alert_word_status");
     if (is_error) {
         $alert_word_status.removeClass("alert-success").addClass("alert-danger");
@@ -44,9 +42,9 @@ function update_alert_word_status(status_text: string, is_error: boolean): void 
     }
     $alert_word_status.find(".alert_word_status_text").text(status_text);
     $alert_word_status.show();
-}
+};
 
-function add_alert_word(): void {
+const add_alert_word = (): void => {
     const alert_word = $<HTMLInputElement>("input#add-alert-word-name").val()!.trim();
 
     if (alert_words.has_alert_word(alert_word)) {
@@ -62,14 +60,14 @@ function add_alert_word(): void {
 
     const data = {alert_words: JSON.stringify(words_to_be_added)};
     dialog_widget.submit_api_request(channel.post, "/json/users/me/alert_words", data);
-}
+};
 
-function remove_alert_word(alert_word: string): void {
+const remove_alert_word = (alert_word: string): void => {
     const words_to_be_removed = [alert_word];
     void channel.del({
         url: "/json/users/me/alert_words",
         data: {alert_words: JSON.stringify(words_to_be_removed)},
-        success() {
+        success: () => {
             update_alert_word_status(
                 $t(
                     {defaultMessage: `Alert word "{alert_word}" removed successfully!`},
@@ -78,16 +76,16 @@ function remove_alert_word(alert_word: string): void {
                 false,
             );
         },
-        error() {
+        error: () => {
             update_alert_word_status($t({defaultMessage: "Error removing alert word!"}), true);
         },
     });
-}
+};
 
-export function show_add_alert_word_modal(): void {
+export const show_add_alert_word_modal = (): void => {
     const html_body = render_add_alert_word();
 
-    function add_alert_word_post_render(): void {
+    const add_alert_word_post_render = (): void => {
         const $add_user_group_input_element = $<HTMLInputElement>("input#add-alert-word-name");
         const $add_user_group_submit_button = $("#add-alert-word .dialog_submit_button");
         $add_user_group_submit_button.prop("disabled", true);
@@ -98,7 +96,7 @@ export function show_add_alert_word_modal(): void {
                 $add_user_group_input_element.val()!.trim() === "",
             );
         });
-    }
+    };
 
     dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Add a new alert word"}),
@@ -112,9 +110,9 @@ export function show_add_alert_word_modal(): void {
         on_shown: () => $("#add-alert-word-name").trigger("focus"),
         post_render: add_alert_word_post_render,
     });
-}
+};
 
-export function set_up_alert_words(): void {
+export const set_up_alert_words = (): void => {
     // The settings page must be rendered before this function gets called.
     loaded = true;
     rerender_alert_words_ui();
@@ -133,8 +131,8 @@ export function set_up_alert_words(): void {
         const $alert = $(event.currentTarget).parents(".alert");
         $alert.hide();
     });
-}
+};
 
-export function reset(): void {
+export const reset = (): void => {
     loaded = false;
-}
+};

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -56,7 +56,7 @@ const attachment_api_response_schema = z.object({
 let attachments: Attachment[];
 let upload_space_used: z.infer<typeof attachment_api_response_schema>["upload_space_used"];
 
-export function bytes_to_size(bytes: number, kb_with_1024_bytes = false): string {
+export const bytes_to_size = (bytes: number, kb_with_1024_bytes = false): string => {
     const kb_size = kb_with_1024_bytes ? 1024 : 1000;
     const sizes = ["B", "KB", "MB", "GB", "TB"];
     if (bytes === 0) {
@@ -68,20 +68,18 @@ export function bytes_to_size(bytes: number, kb_with_1024_bytes = false): string
         size = Math.round((bytes / Math.pow(kb_size, i)) * 10) / 10;
     }
     return size + " " + sizes[i];
-}
+};
 
-export function mib_to_bytes(mib: number): number {
-    return mib * 1024 * 1024;
-}
+export const mib_to_bytes = (mib: number): number => mib * 1024 * 1024;
 
-export function percentage_used_space(uploads_size: number): string | null {
+export const percentage_used_space = (uploads_size: number): string | null => {
     if (realm.realm_upload_quota_mib === null) {
         return null;
     }
     return ((100 * uploads_size) / mib_to_bytes(realm.realm_upload_quota_mib)).toFixed(1);
-}
+};
 
-function set_upload_space_stats(): void {
+const set_upload_space_stats = (): void => {
     if (realm.realm_upload_quota_mib === null) {
         return;
     }
@@ -92,9 +90,9 @@ function set_upload_space_stats(): void {
     };
     const rendered_upload_stats_html = render_settings_upload_space_stats(args);
     $("#attachment-stats-holder").html(rendered_upload_stats_html);
-}
+};
 
-function delete_attachments(attachment: string, file_name: string): void {
+const delete_attachments = (attachment: string, file_name: string): void => {
     const html_body = render_confirm_delete_attachment({file_name});
 
     dialog_widget.launch({
@@ -103,14 +101,14 @@ function delete_attachments(attachment: string, file_name: string): void {
         html_submit_button: $t_html({defaultMessage: "Delete"}),
         id: "confirm_delete_file_modal",
         focus_submit_on_open: true,
-        on_click() {
+        on_click: () => {
             dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment, {});
         },
         loading_spinner: true,
     });
-}
+};
 
-function sort_mentioned_in(a: Attachment, b: Attachment): number {
+const sort_mentioned_in = (a: Attachment, b: Attachment): number => {
     const a_m = a.messages[0];
     const b_m = b.messages[0];
 
@@ -128,9 +126,9 @@ function sort_mentioned_in(a: Attachment, b: Attachment): number {
     }
 
     return -1;
-}
+};
 
-function render_attachments_ui(): void {
+const render_attachments_ui = (): void => {
     set_upload_space_stats();
 
     const $uploaded_files_table = $("#uploaded_files_table").expectOne();
@@ -139,15 +137,11 @@ function render_attachments_ui(): void {
     ListWidget.create<Attachment>($uploaded_files_table, attachments, {
         name: "uploaded-files-list",
         get_item: ListWidget.default_get_item,
-        modifier_html(attachment) {
-            return render_uploaded_files_list({attachment});
-        },
+        modifier_html: (attachment) => render_uploaded_files_list({attachment}),
         filter: {
             $element: $search_input,
-            predicate(item, value) {
-                return item.name.toLocaleLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) => item.name.toLocaleLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar(
                     $uploaded_files_table.closest(".progressive-table-wrapper"),
                 );
@@ -165,17 +159,15 @@ function render_attachments_ui(): void {
     });
 
     scroll_util.reset_scrollbar($uploaded_files_table.closest(".progressive-table-wrapper"));
-}
+};
 
-function format_attachment_data(attachment: ServerAttachment): Attachment {
-    return {
-        ...attachment,
-        create_time_str: timerender.render_now(new Date(attachment.create_time)).time_str,
-        size_str: bytes_to_size(attachment.size),
-    };
-}
+const format_attachment_data = (attachment: ServerAttachment): Attachment => ({
+    ...attachment,
+    create_time_str: timerender.render_now(new Date(attachment.create_time)).time_str,
+    size_str: bytes_to_size(attachment.size),
+});
 
-export function update_attachments(event: AttachmentEvent): void {
+export const update_attachments = (event: AttachmentEvent): void => {
     if (attachments === undefined) {
         // If we haven't fetched attachment data yet, there's nothing to do.
         return;
@@ -190,9 +182,9 @@ export function update_attachments(event: AttachmentEvent): void {
     // TODO: This is inefficient and we should be able to do some sort
     // of incremental ListWidget update instead.
     render_attachments_ui();
-}
+};
 
-export function set_up_attachments(): void {
+export const set_up_attachments = (): void => {
     // The settings page must be rendered before this function gets called.
 
     const $status = $("#delete-upload-status");
@@ -210,7 +202,7 @@ export function set_up_attachments(): void {
 
     void channel.get({
         url: "/json/attachments",
-        success(data) {
+        success: (data) => {
             const clean_data = attachment_api_response_schema.parse(data);
             loading.destroy_indicator($("#attachments_loading_indicator"));
             attachments = clean_data.attachments.map((attachment) =>
@@ -219,9 +211,9 @@ export function set_up_attachments(): void {
             upload_space_used = clean_data.upload_space_used;
             render_attachments_ui();
         },
-        error(xhr) {
+        error: (xhr) => {
             loading.destroy_indicator($("#attachments_loading_indicator"));
             ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $status);
         },
     });
-}
+};

--- a/web/src/audible_notifications.ts
+++ b/web/src/audible_notifications.ts
@@ -2,14 +2,14 @@ import $ from "jquery";
 
 import {user_settings} from "./user_settings";
 
-export function initialize(): void {
+export const initialize = (): void => {
     update_notification_sound_source($("audio#user-notification-sound-audio"), user_settings);
-}
+};
 
-export function update_notification_sound_source(
+export const update_notification_sound_source = (
     $container_elem: JQuery<HTMLAudioElement>,
     settings_object: {notification_sound: string},
-): void {
+): void => {
     const notification_sound = settings_object.notification_sound;
     const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
     $container_elem
@@ -24,4 +24,4 @@ export function update_notification_sound_source(
         // is played.
         $container_elem[0]!.load();
     }
-}
+};

--- a/web/src/avatar.ts
+++ b/web/src/avatar.ts
@@ -10,13 +10,11 @@ import {current_user, realm} from "./state_data";
 import * as upload_widget from "./upload_widget";
 import type {UploadFunction, UploadWidget} from "./upload_widget";
 
-export function build_bot_create_widget(): UploadWidget {
+export const build_bot_create_widget = (): UploadWidget => {
     // We have to do strange gyrations with the file input to clear it,
     // where we replace it wholesale, so we generalize the file input with
     // a callback function.
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $("#bot_avatar_file_input");
-    };
+    const get_file_input = (): JQuery<HTMLInputElement> => $("#bot_avatar_file_input");
 
     const $file_name_field = $("#bot_avatar_file");
     const $input_error = $("#bot_avatar_file_input_error");
@@ -33,12 +31,11 @@ export function build_bot_create_widget(): UploadWidget {
         $preview_text,
         $preview_image,
     );
-}
+};
 
-export function build_bot_edit_widget($target: JQuery): UploadWidget {
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $target.find<HTMLInputElement>(".edit_bot_avatar_file_input");
-    };
+export const build_bot_edit_widget = ($target: JQuery): UploadWidget => {
+    const get_file_input = (): JQuery<HTMLInputElement> =>
+        $target.find<HTMLInputElement>(".edit_bot_avatar_file_input");
 
     const $file_name_field = $target.find(".edit_bot_avatar_file");
     const $input_error = $target.find(".edit_bot_avatar_error");
@@ -56,24 +53,23 @@ export function build_bot_edit_widget($target: JQuery): UploadWidget {
         $preview_text,
         $preview_image,
     );
-}
+};
 
-function display_avatar_delete_complete(): void {
+const display_avatar_delete_complete = (): void => {
     $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
     $("#user-avatar-upload-widget .image-upload-text").show();
     $("#user-avatar-source").show();
-}
+};
 
-function display_avatar_delete_started(): void {
+const display_avatar_delete_started = (): void => {
     $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "visible"});
     $("#user-avatar-upload-widget .image-upload-text").hide();
     $("#user-avatar-upload-widget .image-delete-button").hide();
-}
+};
 
-export function build_user_avatar_widget(upload_function: UploadFunction): void {
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $<HTMLInputElement>("#user-avatar-upload-widget input.image_file_input").expectOne();
-    };
+export const build_user_avatar_widget = (upload_function: UploadFunction): void => {
+    const get_file_input = (): JQuery<HTMLInputElement> =>
+        $<HTMLInputElement>("#user-avatar-upload-widget input.image_file_input").expectOne();
 
     if (current_user.avatar_source === "G") {
         $("#user-avatar-upload-widget .image-delete-button").hide();
@@ -89,11 +85,11 @@ export function build_user_avatar_widget(upload_function: UploadFunction): void 
     $("#user-avatar-upload-widget .image-delete-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        function delete_user_avatar(): void {
+        const delete_user_avatar = (): void => {
             display_avatar_delete_started();
             void channel.del({
                 url: "/json/users/me/avatar",
-                success() {
+                success: () => {
                     display_avatar_delete_complete();
 
                     // Need to clear input because of a small edge case
@@ -101,12 +97,12 @@ export function build_user_avatar_widget(upload_function: UploadFunction): void 
                     get_file_input().val("");
                     // Rest of the work is done via the user_events -> avatar_url event we will get
                 },
-                error() {
+                error: () => {
                     display_avatar_delete_complete();
                     $("#user-avatar-upload-widget .image-delete-button").show();
                 },
             });
-        }
+        };
         const html_body = render_confirm_delete_user_avatar({});
 
         confirm_dialog.launch({
@@ -123,4 +119,4 @@ export function build_user_avatar_widget(upload_function: UploadFunction): void 
         upload_function,
         realm.max_avatar_file_size_mib,
     );
-}
+};

--- a/web/src/billing/billing.ts
+++ b/web/src/billing/billing.ts
@@ -22,7 +22,7 @@ enum CustomerPlanStatus {
     SWITCH_TO_MONTHLY_AT_END_OF_CYCLE = 6,
 }
 
-export function create_update_current_cycle_license_request(): void {
+export const create_update_current_cycle_license_request = (): void => {
     $("#current-manual-license-count-update-button .billing-button-text").text("");
     $("#current-manual-license-count-update-button .loader").show();
     helpers.create_ajax_request(
@@ -45,9 +45,9 @@ export function create_update_current_cycle_license_request(): void {
             $("#current-manual-license-count-update-button .billing-button-text").text("Update");
         },
     );
-}
+};
 
-export function create_update_next_cycle_license_request(): void {
+export const create_update_next_cycle_license_request = (): void => {
     $("#next-manual-license-count-update-button .loader").show();
     $("#next-manual-license-count-update-button .billing-button-text").text("");
     helpers.create_ajax_request(
@@ -68,7 +68,7 @@ export function create_update_next_cycle_license_request(): void {
             $("#next-manual-license-count-update-button .billing-button-text").text("Update");
         },
     );
-}
+};
 
 export function initialize(): void {
     $("#update-card-button").on("click", (e) => {
@@ -91,10 +91,10 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    function get_old_and_new_license_count_for_current_cycle(): {
+    const get_old_and_new_license_count_for_current_cycle = (): {
         new_current_manual_license_count: number;
         old_current_manual_license_count: number;
-    } {
+    } => {
         const new_current_manual_license_count: number = Number.parseInt(
             $<HTMLInputElement>("input#current-manual-license-count").val()!,
             10,
@@ -107,12 +107,12 @@ export function initialize(): void {
             new_current_manual_license_count,
             old_current_manual_license_count,
         };
-    }
+    };
 
-    function get_old_and_new_license_count_for_next_cycle(): {
+    const get_old_and_new_license_count_for_next_cycle = (): {
         new_next_manual_license_count: number;
         old_next_manual_license_count: number;
-    } {
+    } => {
         const new_next_manual_license_count: number = Number.parseInt(
             $<HTMLInputElement>("input#next-manual-license-count").val()!,
             10,
@@ -125,7 +125,7 @@ export function initialize(): void {
             new_next_manual_license_count,
             old_next_manual_license_count,
         };
-    }
+    };
 
     $("#current-license-change-form, #next-license-change-form").on("submit", (e) => {
         // We don't want user to accidentally update the license count on pressing enter.
@@ -376,13 +376,13 @@ export function initialize(): void {
             type: "PATCH",
             url: `/json${billing_base_url}/billing/plan`,
             data,
-            success() {
+            success: () => {
                 window.location.replace(
                     `${billing_base_url}/billing/?success_message=` +
                         encodeURIComponent("Billing frequency has been updated."),
                 );
             },
-            error(xhr) {
+            error: (xhr) => {
                 const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
                 if (parsed.success) {
                     $("#org-billing-frequency-change-error").text(parsed.data.msg);

--- a/web/src/billing/deactivate_server.ts
+++ b/web/src/billing/deactivate_server.ts
@@ -1,15 +1,15 @@
 import $ from "jquery";
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("#server-deactivate-form").validate({
-        submitHandler(form) {
+        submitHandler: (form) => {
             $("#server-deactivate-form").find(".loader").css("display", "inline-block");
             $("#server-deactivate-button .server-deactivate-button-text").hide();
 
             form.submit();
         },
     });
-}
+};
 
 $(() => {
     initialize();

--- a/web/src/billing/event_status.ts
+++ b/web/src/billing/event_status.ts
@@ -28,17 +28,17 @@ const stripe_response_schema = z.object({
 
 type StripeSession = z.infer<typeof stripe_response_schema>["session"];
 
-function update_status_and_redirect(redirect_to: string): void {
+const update_status_and_redirect = (redirect_to: string): void => {
     window.location.replace(redirect_to);
-}
+};
 
-function show_error_message(message: string): void {
+const show_error_message = (message: string): void => {
     $("#webhook-loading").hide();
     $("#webhook-error").show();
     $("#webhook-error").text(message);
-}
+};
 
-function handle_session_complete_event(session: StripeSession): void {
+const handle_session_complete_event = (session: StripeSession): void => {
     let redirect_to = "";
     switch (session.type) {
         case "card_update_from_billing_page":
@@ -53,9 +53,11 @@ function handle_session_complete_event(session: StripeSession): void {
             break;
     }
     update_status_and_redirect(redirect_to);
-}
+};
 
-async function stripe_checkout_session_status_check(stripe_session_id: string): Promise<boolean> {
+const stripe_checkout_session_status_check = async (
+    stripe_session_id: string,
+): Promise<boolean> => {
     const response: unknown = await $.get(`/json${billing_base_url}/billing/event/status`, {
         stripe_session_id,
     });
@@ -77,9 +79,9 @@ async function stripe_checkout_session_status_check(stripe_session_id: string): 
     }
 
     return false;
-}
+};
 
-export async function stripe_invoice_status_check(stripe_invoice_id: string): Promise<boolean> {
+export const stripe_invoice_status_check = async (stripe_invoice_id: string): Promise<boolean> => {
     const response: unknown = await $.get(`/json${billing_base_url}/billing/event/status`, {
         stripe_invoice_id,
     });
@@ -111,18 +113,18 @@ export async function stripe_invoice_status_check(stripe_invoice_id: string): Pr
         default:
             return false;
     }
-}
+};
 
-export async function check_status(): Promise<boolean> {
+export const check_status = async (): Promise<boolean> => {
     if ($("#data").attr("data-stripe-session-id")) {
         return await stripe_checkout_session_status_check(
             $("#data").attr("data-stripe-session-id")!,
         );
     }
     return await stripe_invoice_status_check($("#data").attr("data-stripe-invoice-id")!);
-}
+};
 
-async function start_status_polling(): Promise<void> {
+const start_status_polling = async (): Promise<void> => {
     let completed = false;
     try {
         completed = await check_status();
@@ -133,9 +135,9 @@ async function start_status_polling(): Promise<void> {
     if (!completed) {
         setTimeout(() => void start_status_polling(), 5000);
     }
-}
+};
 
-async function initialize(): Promise<void> {
+const initialize = async (): Promise<void> => {
     const form_loading = "#webhook-loading";
     const form_loading_indicator = "#webhook_loading_indicator";
 
@@ -145,7 +147,7 @@ async function initialize(): Promise<void> {
     });
     $(form_loading).show();
     await start_status_polling();
-}
+};
 
 $(() => {
     void initialize();

--- a/web/src/billing/helpers.ts
+++ b/web/src/billing/helpers.ts
@@ -44,7 +44,7 @@ const remote_discount_details: DiscountDetails = {
         "The Community plan is free for education non-profits with up to 100 users. For larger organizations, paid plans are discounted by 90% with online purchase.",
 };
 
-export function create_ajax_request(
+export const create_ajax_request = (
     url: string,
     form_name: string,
     ignored_inputs: string[] = [],
@@ -53,7 +53,7 @@ export function create_ajax_request(
     error_callback: (xhr: JQuery.jqXHR) => void = () => {
         // Ignore errors by default
     },
-): void {
+): void => {
     const $form = $(`#${CSS.escape(form_name)}-form`);
     const form_loading_indicator = `#${CSS.escape(form_name)}_loading_indicator`;
     const form_input_section = `#${CSS.escape(form_name)}-input-section`;
@@ -82,7 +82,7 @@ export function create_ajax_request(
         type,
         url,
         data,
-        success(response: unknown) {
+        success: (response: unknown) => {
             $(form_loading).hide();
             $(form_error).hide();
             $(form_success).show();
@@ -95,7 +95,7 @@ export function create_ajax_request(
             }
             success_callback(response);
         },
-        error(xhr) {
+        error: (xhr) => {
             $(form_loading).hide();
             const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
             if (parsed.success) {
@@ -113,10 +113,10 @@ export function create_ajax_request(
             }
         },
     });
-}
+};
 
 // This function imitates the behavior of the format_money in views/billing_page.py
-export function format_money(cents: number): string {
+export const format_money = (cents: number): string => {
     // allow for small floating point errors
     cents = Math.ceil(cents - 0.001);
     let precision;
@@ -129,12 +129,12 @@ export function format_money(cents: number): string {
         minimumFractionDigits: precision,
         maximumFractionDigits: precision,
     }).format(Number.parseFloat((cents / 100).toFixed(precision)));
-}
+};
 
-export function update_discount_details(
+export const update_discount_details = (
     organization_type: string,
     is_remotely_hosted: boolean,
-): void {
+): void => {
     let discount_notice = is_remotely_hosted
         ? "Your organization may be eligible for a free Community plan, or a discounted Business plan."
         : "Your organization may be eligible for a discount on Zulip Cloud Standard. Organizations whose members are not employees are generally eligible.";
@@ -155,25 +155,24 @@ export function update_discount_details(
     }
 
     $("#sponsorship-discount-details").text(discount_notice);
-}
+};
 
-export function is_valid_input($elem: JQuery<HTMLFormElement>): boolean {
-    return $elem[0]!.checkValidity();
-}
+export const is_valid_input = ($elem: JQuery<HTMLFormElement>): boolean =>
+    $elem[0]!.checkValidity();
 
-export function redirect_to_billing_with_successful_upgrade(billing_base_url: string): void {
+export const redirect_to_billing_with_successful_upgrade = (billing_base_url: string): void => {
     window.location.replace(
         billing_base_url +
             "/billing/?success_message=" +
             encodeURIComponent("Your organization has been upgraded to PLAN_NAME."),
     );
-}
+};
 
-export function get_upgrade_page_url(
+export const get_upgrade_page_url = (
     is_manual_license_management_upgrade_session: boolean | undefined,
     tier: number,
     billing_base_url: string,
-): string {
+): string => {
     const base_url = billing_base_url + "/upgrade/";
     let params = `tier=${String(tier)}`;
     if (is_manual_license_management_upgrade_session !== undefined) {
@@ -182,4 +181,4 @@ export function get_upgrade_page_url(
         )}`;
     }
     return base_url + "?" + params;
-}
+};

--- a/web/src/billing/remote_billing_auth.ts
+++ b/web/src/billing/remote_billing_auth.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-function handle_submit_for_server_login_form(form: HTMLFormElement): void {
+const handle_submit_for_server_login_form = (form: HTMLFormElement): void => {
     // Get value of zulip_org_id.
     const zulip_org_id = $<HTMLInputElement>("input#zulip-org-id").val();
     const $error_field = $(".zulip_org_id-error");
@@ -25,7 +25,7 @@ function handle_submit_for_server_login_form(form: HTMLFormElement): void {
     $("#server-login-form").find(".loader").css("display", "inline-block");
     $("#server-login-button .server-login-button-text").hide();
     form.submit();
-}
+};
 
 export function initialize(): void {
     $(
@@ -33,7 +33,7 @@ export function initialize(): void {
     ).validate({
         errorClass: "text-error",
         wrapper: "div",
-        submitHandler(form) {
+        submitHandler: (form) => {
             if (form.id === "server-login-form") {
                 handle_submit_for_server_login_form(form);
                 return;
@@ -50,10 +50,10 @@ export function initialize(): void {
 
             form.submit();
         },
-        invalidHandler() {
+        invalidHandler: () => {
             $("*[class$='-error']").hide();
         },
-        showErrors(error_map) {
+        showErrors: (error_map) => {
             $("*[class$='-error']").hide();
             for (const [key, error] of Object.entries(error_map)) {
                 const $error_element = $(`.${CSS.escape(key)}-error`);

--- a/web/src/billing/sponsorship.ts
+++ b/web/src/billing/sponsorship.ts
@@ -6,19 +6,19 @@ import * as helpers from "./helpers";
 
 const is_remotely_hosted = $("#sponsorship-form").attr("data-is-remotely-hosted") === "True";
 
-function show_submit_loading_indicator(): void {
+const show_submit_loading_indicator = (): void => {
     $("#sponsorship-button .sponsorship-button-loader").css("display", "inline-block");
     $("#sponsorship-button").prop("disabled", true);
     $("#sponsorship-button .sponsorship-button-text").hide();
-}
+};
 
-function hide_submit_loading_indicator(): void {
+const hide_submit_loading_indicator = (): void => {
     $("#sponsorship-button .sponsorship-button-loader").css("display", "none");
     $("#sponsorship-button").prop("disabled", false);
     $("#sponsorship-button .sponsorship-button-text").show();
-}
+};
 
-function validate_data(data: helpers.FormDataObject): boolean {
+const validate_data = (data: helpers.FormDataObject): boolean => {
     let found_error = false;
     assert(data.description !== undefined);
     if (data.description.trim() === "") {
@@ -43,9 +43,9 @@ function validate_data(data: helpers.FormDataObject): boolean {
         found_error = true;
     }
     return !found_error;
-}
+};
 
-function create_ajax_request(): void {
+const create_ajax_request = (): void => {
     show_submit_loading_indicator();
     const $form = $("#sponsorship-form");
     const data: helpers.FormDataObject = {};
@@ -65,10 +65,10 @@ function create_ajax_request(): void {
         type: "post",
         url: `/json${billing_base_url}/billing/sponsorship`,
         data,
-        success() {
+        success: () => {
             window.location.reload();
         },
-        error(xhr) {
+        error: (xhr) => {
             hide_submit_loading_indicator();
             const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
             if (parsed.success) {
@@ -80,9 +80,9 @@ function create_ajax_request(): void {
             }
         },
     });
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("#sponsorship-button").on("click", (e) => {
         if (!helpers.is_valid_input($("#sponsorship-form"))) {
             return;
@@ -91,19 +91,19 @@ export function initialize(): void {
         create_ajax_request();
     });
 
-    function update_discount_details(): void {
+    const update_discount_details = (): void => {
         const selected_org_type =
             $<HTMLSelectElement>("select#organization-type")
                 .find(":selected")
                 .attr("data-string-value") ?? "";
         helpers.update_discount_details(selected_org_type, is_remotely_hosted);
-    }
+    };
 
     update_discount_details();
     $<HTMLSelectElement>("select#organization-type").on("change", () => {
         update_discount_details();
     });
-}
+};
 
 $(() => {
     // Don't preserve scroll position on reload. This allows us to

--- a/web/src/billing/upgrade.ts
+++ b/web/src/billing/upgrade.ts
@@ -44,7 +44,7 @@ const upgrade_response_schema = z.object({
     organization_upgrade_successful: z.boolean().optional(),
 });
 
-function update_due_today(schedule: string): void {
+const update_due_today = (schedule: string): void => {
     let num_months = 12;
     if (schedule === "monthly") {
         num_months = 1;
@@ -81,9 +81,9 @@ function update_due_today(schedule: string): void {
         $(".billing-page-selected-schedule-discount").text(page_params.percent_off_monthly_price);
         $(".billing-page-discount").show();
     }
-}
+};
 
-function update_due_today_for_remote_server(start_date: string): void {
+const update_due_today_for_remote_server = (start_date: string): void => {
     const $due_today_for_future_update_wrapper = $("#due-today-for-future-update-wrapper");
     if ($due_today_for_future_update_wrapper.length === 0) {
         // Only present legacy remote server page.
@@ -102,9 +102,9 @@ function update_due_today_for_remote_server(start_date: string): void {
         $("#org-future-upgrade-button-text-remote-server").hide();
         $("#org-today-upgrade-button-text").show();
     }
-}
+};
 
-function update_license_count(license_count: number): void {
+const update_license_count = (license_count: number): void => {
     $("#upgrade-licenses-change-error").text("");
     if (!license_count || license_count < page_params.seat_count) {
         $("#upgrade-licenses-change-error").text(
@@ -123,9 +123,9 @@ function update_license_count(license_count: number): void {
     current_license_count = license_count;
     ls.set("manual_license_count", license_count);
     update_due_today(selected_schedule);
-}
+};
 
-function restore_manual_license_count(): void {
+const restore_manual_license_count = (): void => {
     const $manual_license_count_input = $("#manual_license_count");
     // Only present on the manual license management page.
     if ($manual_license_count_input.length) {
@@ -135,7 +135,7 @@ function restore_manual_license_count(): void {
             update_license_count(ls_manual_license_count);
         }
     }
-}
+};
 
 export const initialize = (): void => {
     restore_manual_license_count();

--- a/web/src/blueslip.ts
+++ b/web/src/blueslip.ts
@@ -51,42 +51,44 @@ class Logger {
 
 const logger = new Logger();
 
-export function get_log(): string[] {
-    return logger.get_log();
-}
+export const get_log = (): string[] => logger.get_log();
 
-function build_arg_list(msg: string, more_info?: unknown): [string, string?, unknown?] {
+const build_arg_list = (msg: string, more_info?: unknown): [string, string?, unknown?] => {
     const args: [string, string?, unknown?] = [msg];
     if (more_info !== undefined) {
         args.push("\nAdditional information: ", more_info);
     }
     return args;
-}
+};
 
-export function debug(msg: string, more_info?: unknown): void {
+export const debug = (msg: string, more_info?: unknown): void => {
     const args = build_arg_list(msg, more_info);
     logger.debug(...args);
-}
+};
 
-export function log(msg: string, more_info?: unknown): void {
+export const log = (msg: string, more_info?: unknown): void => {
     const args = build_arg_list(msg, more_info);
     logger.log(...args);
-}
+};
 
-export function info(msg: string, more_info?: unknown): void {
+export const info = (msg: string, more_info?: unknown): void => {
     const args = build_arg_list(msg, more_info);
     logger.info(...args);
-}
+};
 
-export function warn(msg: string, more_info?: unknown): void {
+export const warn = (msg: string, more_info?: unknown): void => {
     const args = build_arg_list(msg, more_info);
     logger.warn(...args);
     if (page_params.development_environment) {
         console.trace();
     }
-}
+};
 
-export function error(msg: string, more_info?: object | undefined, original_error?: unknown): void {
+export const error = (
+    msg: string,
+    more_info?: object | undefined,
+    original_error?: unknown,
+): void => {
     // Log the Sentry error before the console warning, so we don't
     // end up with a doubled message in the Sentry logs.
     Sentry.setContext("more_info", more_info ?? null);
@@ -105,7 +107,7 @@ export function error(msg: string, more_info?: object | undefined, original_erro
     }
     // This function returns to its caller in production!  To raise a
     // fatal error even in production, use throw new Error(…) instead.
-}
+};
 
 // Install a window-wide onerror handler in development to display the stacktraces, to make them
 // hard to miss

--- a/web/src/blueslip_stacktrace.ts
+++ b/web/src/blueslip_stacktrace.ts
@@ -35,13 +35,13 @@ type CleanStackFrame = {
     context: NumberedLine[] | undefined;
 };
 
-export function exception_msg(
+export const exception_msg = (
     ex: Error & {
         // Unsupported properties available on some browsers
         fileName?: string;
         lineNumber?: number;
     },
-): string {
+): string => {
     let message = ex.message;
     if (ex.fileName !== undefined) {
         message += " at " + ex.fileName;
@@ -50,9 +50,9 @@ export function exception_msg(
         }
     }
     return message;
-}
+};
 
-export function clean_path(full_path?: string): string | undefined {
+export const clean_path = (full_path?: string): string | undefined => {
     // If the file is local, just show the filename.
     // Otherwise, show the full path starting from node_modules.
     if (full_path === undefined) {
@@ -66,11 +66,11 @@ export function clean_path(full_path?: string): string | undefined {
         return full_path.slice("webpack://".length);
     }
     return full_path;
-}
+};
 
-export function clean_function_name(
+export const clean_function_name = (
     function_name: string | undefined,
-): {scope: string; name: string} | undefined {
+): {scope: string; name: string} | undefined => {
     if (function_name === undefined) {
         return undefined;
     }
@@ -79,13 +79,13 @@ export function clean_function_name(
         scope: function_name.slice(0, idx + 1),
         name: function_name.slice(idx + 1),
     };
-}
+};
 
 const sourceCache: Record<string, string | Promise<string>> = {};
 
 const stack_trace_gps = new StackTraceGPS({sourceCache});
 
-async function get_context(location: StackFrame): Promise<NumberedLine[] | undefined> {
+const get_context = async (location: StackFrame): Promise<NumberedLine[] | undefined> => {
     const {fileName, lineNumber} = location;
     if (fileName === undefined || lineNumber === undefined) {
         return undefined;
@@ -107,9 +107,9 @@ async function get_context(location: StackFrame): Promise<NumberedLine[] | undef
         line,
         focus: lo_line_num + i + 1 === lineNumber,
     }));
-}
+};
 
-export async function display_stacktrace(ex: Error): Promise<void> {
+export const display_stacktrace = async (ex: Error): Promise<void> => {
     const errors = [];
     while (true) {
         const stackframes: CleanStackFrame[] = await Promise.all(
@@ -148,4 +148,4 @@ export async function display_stacktrace(ex: Error): Promise<void> {
     const $alert = $("<div>").addClass("stacktrace").html(render_blueslip_stacktrace({errors}));
     $(".alert-box").append($alert);
     $alert.addClass("show");
-}
+};

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -142,18 +142,18 @@ import * as tippy from "tippy.js";
 
 import {get_string_diff} from "./util";
 
-function get_pseudo_keycode(
+const get_pseudo_keycode = (
     event: JQuery.KeyDownEvent | JQuery.KeyUpEvent | JQuery.KeyPressEvent,
-): number {
+): number => {
     const isComposing = event.originalEvent?.isComposing ?? false;
     /* We treat IME compose enter keypresses as a separate -13 key. */
     if (event.keyCode === 13 && isComposing) {
         return -13;
     }
     return event.keyCode;
-}
+};
 
-export function defaultSorter(items: string[], query: string): string[] {
+export const defaultSorter = (items: string[], query: string): string[] => {
     const beginswith = [];
     const caseSensitive = [];
     const caseInsensitive = [];
@@ -170,7 +170,7 @@ export function defaultSorter(items: string[], query: string): string[] {
     }
 
     return [...beginswith, ...caseSensitive, ...caseInsensitive];
-}
+};
 
 /* TYPEAHEAD PUBLIC CLASS DEFINITION
  * ================================= */

--- a/web/src/bot_data.ts
+++ b/web/src/bot_data.ts
@@ -56,23 +56,21 @@ const server_add_bot_schema = server_update_bot_schema.extend({
     is_active: z.boolean(),
 });
 
-export function all_user_ids(): number[] {
-    return [...bots.keys()];
-}
+export const all_user_ids = (): number[] => [...bots.keys()];
 
-export function add(bot_data: ServerAddBotData): void {
+export const add = (bot_data: ServerAddBotData): void => {
     const {services: bot_services, ...clean_bot} = server_add_bot_schema.parse(bot_data);
     bots.set(clean_bot.user_id, clean_bot);
 
     services.set(clean_bot.user_id, bot_services);
-}
+};
 
-export function del(bot_id: number): void {
+export const del = (bot_id: number): void => {
     bots.delete(bot_id);
     services.delete(bot_id);
-}
+};
 
-export function update(bot_id: number, bot_update: ServerUpdateBotData): void {
+export const update = (bot_id: number, bot_update: ServerUpdateBotData): void => {
     const bot = bots.get(bot_id)!;
     Object.assign(bot, server_update_bot_schema.deepPartial().parse(bot_update));
 
@@ -85,9 +83,9 @@ export function update(bot_id: number, bot_update: ServerUpdateBotData): void {
     ) {
         Object.assign(service, services_schema.parse(bot_update.services)[0]);
     }
-}
+};
 
-export function get_all_bots_for_current_user(): Bot[] {
+export const get_all_bots_for_current_user = (): Bot[] => {
     const ret = [];
     for (const bot of bots.values()) {
         if (bot.owner_id !== null && people.is_my_user_id(bot.owner_id)) {
@@ -95,9 +93,9 @@ export function get_all_bots_for_current_user(): Bot[] {
         }
     }
     return ret;
-}
+};
 
-export function get_editable(): Bot[] {
+export const get_editable = (): Bot[] => {
     const ret = [];
     for (const bot of bots.values()) {
         if (bot.is_active && bot.owner_id !== null && people.is_my_user_id(bot.owner_id)) {
@@ -105,9 +103,9 @@ export function get_editable(): Bot[] {
         }
     }
     return ret;
-}
+};
 
-export function get_all_bots_owned_by_user(user_id: number): Bot[] {
+export const get_all_bots_owned_by_user = (user_id: number): Bot[] => {
     const ret = [];
     for (const bot of bots.values()) {
         if (bot.owner_id === user_id && bot.is_active) {
@@ -115,19 +113,15 @@ export function get_all_bots_owned_by_user(user_id: number): Bot[] {
         }
     }
     return ret;
-}
+};
 
-export function get(bot_id: number): Bot | undefined {
-    return bots.get(bot_id);
-}
+export const get = (bot_id: number): Bot | undefined => bots.get(bot_id);
 
-export function get_services(bot_id: number): Services | undefined {
-    return services.get(bot_id);
-}
+export const get_services = (bot_id: number): Services | undefined => services.get(bot_id);
 
-export function initialize(params: BotDataParams): void {
+export const initialize = (params: BotDataParams): void => {
     bots.clear();
     for (const bot of params.realm_bots) {
         add(bot);
     }
-}
+};

--- a/web/src/browser_history.ts
+++ b/web/src/browser_history.ts
@@ -25,39 +25,37 @@ export const state: {
         : null,
 };
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     state.is_internal_change = false;
     state.hash_before_overlay = null;
     state.old_hash = "#";
-}
+};
 
-export function old_hash(): string {
-    return state.old_hash;
-}
+export const old_hash = (): string => state.old_hash;
 
-export function set_hash_before_overlay(hash: string): void {
+export const set_hash_before_overlay = (hash: string): void => {
     state.hash_before_overlay = hash;
-}
+};
 
-export function update_web_public_hash(hash: string): boolean {
+export const update_web_public_hash = (hash: string): boolean => {
     // Returns true if hash is web-public compatible.
     if (hash_parser.is_spectator_compatible(hash)) {
         state.spectator_old_hash = hash;
         return true;
     }
     return false;
-}
+};
 
-export function save_old_hash(): boolean {
+export const save_old_hash = (): boolean => {
     state.old_hash = window.location.hash;
 
     const was_internal_change = state.is_internal_change;
     state.is_internal_change = false;
 
     return was_internal_change;
-}
+};
 
-export function update(new_hash: string): void {
+export const update = (new_hash: string): void => {
     const old_hash = window.location.hash;
 
     if (!new_hash.startsWith("#")) {
@@ -77,34 +75,34 @@ export function update(new_hash: string): void {
     state.old_hash = old_hash;
     state.is_internal_change = true;
     window.location.hash = new_hash;
-}
+};
 
-export function exit_overlay(): void {
+export const exit_overlay = (): void => {
     if (hash_parser.is_overlay_hash(window.location.hash) && !state.changing_hash) {
         ui_util.blur_active_element();
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const new_hash = state.hash_before_overlay || `#${user_settings.web_home_view}`;
         update(new_hash);
     }
-}
+};
 
-export function go_to_location(hash: string): void {
+export const go_to_location = (hash: string): void => {
     // Call this function when you WANT the hashchanged
     // function to run.
     window.location.hash = hash;
-}
+};
 
-export function update_hash_internally_if_required(hash: string): void {
+export const update_hash_internally_if_required = (hash: string): void => {
     if (window.location.hash !== hash) {
         update(hash);
     }
-}
+};
 
-export function return_to_web_public_hash(): void {
+export const return_to_web_public_hash = (): void => {
     window.location.hash = state.spectator_old_hash ?? `#${user_settings.web_home_view}`;
-}
+};
 
-export function get_full_url(hash: string): string {
+export const get_full_url = (hash: string): string => {
     const location = window.location;
 
     if (!hash.startsWith("#") && hash !== "") {
@@ -122,9 +120,9 @@ export function get_full_url(hash: string): string {
     // Build a full URL to not have same origin problems
     const url = location.protocol + "//" + location.host + pathname + hash;
     return url;
-}
+};
 
-export function set_hash(hash: string): void {
+export const set_hash = (hash: string): void => {
     if (hash === window.location.hash) {
         // Avoid adding duplicate entries in browser history.
         return;
@@ -153,7 +151,7 @@ export function set_hash(hash: string): void {
         blueslip.error("browser does not support pushState");
         window.location.hash = hash;
     }
-}
+};
 
 type StateData = {
     narrow_pointer?: number;
@@ -161,7 +159,7 @@ type StateData = {
     show_more_topics?: boolean;
 };
 
-export function update_current_history_state_data(new_data: StateData): void {
+export const update_current_history_state_data = (new_data: StateData): void => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const current_state = history.state as StateData | null;
     const current_state_data = {
@@ -171,4 +169,4 @@ export function update_current_history_state_data(new_data: StateData): void {
     };
     const state_data = {...current_state_data, ...new_data};
     history.replaceState(state_data, "", window.location.href);
-}
+};

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -26,15 +26,13 @@ export const max_size_before_shrinking = 600;
 
 let is_searching_users = false;
 
-export function get_is_searching_users(): boolean {
-    return is_searching_users;
-}
+export const get_is_searching_users = (): boolean => is_searching_users;
 
-export function set_is_searching_users(val: boolean): void {
+export const set_is_searching_users = (val: boolean): void => {
     is_searching_users = val;
-}
+};
 
-export function get_user_circle_class(user_id: number): string {
+export const get_user_circle_class = (user_id: number): string => {
     const status = presence.get_status(user_id);
 
     switch (status) {
@@ -45,9 +43,9 @@ export function get_user_circle_class(user_id: number): string {
         default:
             return "user_circle_empty";
     }
-}
+};
 
-export function level(user_id: number): number {
+export const level = (user_id: number): number => {
     // Put current user at the top, unless we're in a user search view.
     if (people.is_my_user_id(user_id) && !is_searching_users) {
         return 0;
@@ -63,13 +61,13 @@ export function level(user_id: number): number {
         default:
             return 3;
     }
-}
+};
 
-export function user_matches_narrow(
+export const user_matches_narrow = (
     user_id: number,
     pm_ids: Set<number>,
     stream_id?: number | null,
-): boolean {
+): boolean => {
     if (stream_id) {
         return stream_data.is_user_subscribed(stream_id, user_id);
     }
@@ -77,14 +75,14 @@ export function user_matches_narrow(
         return pm_ids.has(user_id) || people.is_my_user_id(user_id);
     }
     return false;
-}
+};
 
-export function compare_function(
+export const compare_function = (
     a: number,
     b: number,
     current_sub: StreamSubscription | undefined,
     pm_ids: Set<number>,
-): number {
+): number => {
     const a_would_receive_message = user_matches_narrow(a, pm_ids, current_sub?.stream_id);
     const b_would_receive_message = user_matches_narrow(b, pm_ids, current_sub?.stream_id);
     if (a_would_receive_message && !b_would_receive_message) {
@@ -109,21 +107,20 @@ export function compare_function(
     const full_name_b = person_b ? person_b.full_name : "";
 
     return util.strcmp(full_name_a, full_name_b);
-}
+};
 
-export function sort_users(user_ids: number[]): number[] {
+export const sort_users = (user_ids: number[]): number[] => {
     // TODO sort by unread count first, once we support that
     const current_sub = narrow_state.stream_sub();
     const pm_ids_set = narrow_state.pm_ids_set();
     user_ids.sort((a, b) => compare_function(a, b, current_sub, pm_ids_set));
     return user_ids;
-}
+};
 
-function get_num_unread(user_id: number): number {
-    return unread.num_unread_for_user_ids_string(user_id.toString());
-}
+const get_num_unread = (user_id: number): number =>
+    unread.num_unread_for_user_ids_string(user_id.toString());
 
-export function user_last_seen_time_status(user_id: number): string {
+export const user_last_seen_time_status = (user_id: number): string => {
     const status = presence.get_status(user_id);
     if (status === "active") {
         return $t({defaultMessage: "Active now"});
@@ -151,7 +148,7 @@ export function user_last_seen_time_status(user_id: number): string {
         return $t({defaultMessage: "Active more than 2 weeks ago"});
     }
     return timerender.last_seen_status_from_date(last_active_date);
-}
+};
 
 export type BuddyUserInfo = {
     href: string;
@@ -171,7 +168,7 @@ export type BuddyUserInfo = {
     faded?: boolean;
 };
 
-export function info_for(user_id: number): BuddyUserInfo {
+export const info_for = (user_id: number): BuddyUserInfo => {
     const user_circle_class = get_user_circle_class(user_id);
     const person = people.get_by_user_id(user_id);
 
@@ -196,9 +193,9 @@ export function info_for(user_id: number): BuddyUserInfo {
         user_list_style,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(user_id),
     };
-}
+};
 
-export function get_title_data(
+export const get_title_data = (
     user_ids_string: string,
     is_group: boolean,
 ): {
@@ -206,7 +203,7 @@ export function get_title_data(
     second_line: string | undefined;
     third_line: string;
     show_you?: boolean;
-} {
+} => {
     if (is_group) {
         // For groups, just return a string with recipient names.
         return {
@@ -266,24 +263,21 @@ export function get_title_data(
         third_line: "",
         show_you: is_my_user,
     };
-}
+};
 
-export function get_item(user_id: number): BuddyUserInfo {
+export const get_item = (user_id: number): BuddyUserInfo => {
     const info = info_for(user_id);
     return info;
-}
+};
 
-export function get_items_for_users(user_ids: number[]): BuddyUserInfo[] {
+export const get_items_for_users = (user_ids: number[]): BuddyUserInfo[] => {
     const user_info = user_ids.map((user_id) => info_for(user_id));
     return user_info;
-}
+};
 
-function user_is_recently_active(user_id: number): boolean {
-    // return true if the user has a green/orange circle
-    return level(user_id) <= 2;
-}
+const user_is_recently_active = (user_id: number): boolean => level(user_id) <= 2;
 
-function maybe_shrink_list(user_ids: number[], user_filter_text: string): number[] {
+const maybe_shrink_list = (user_ids: number[], user_filter_text: string): number[] => {
     if (user_ids.length <= max_size_before_shrinking) {
         return user_ids;
     }
@@ -305,9 +299,9 @@ function maybe_shrink_list(user_ids: number[], user_filter_text: string): number
     );
 
     return user_ids;
-}
+};
 
-function filter_user_ids(user_filter_text: string, user_ids: number[]): number[] {
+const filter_user_ids = (user_filter_text: string, user_ids: number[]): number[] => {
     // This first filter is for whether the user is eligible to be
     // displayed in the right sidebar at all.
     user_ids = user_ids.filter((user_id) => {
@@ -341,9 +335,9 @@ function filter_user_ids(user_filter_text: string, user_ids: number[]): number[]
     // If a query is present in "Search people", we return matches.
     const persons = user_ids.map((user_id) => people.get_by_user_id(user_id));
     return [...people.filter_people_by_search_terms(persons, user_filter_text)];
-}
+};
 
-function get_filtered_user_id_list(user_filter_text: string): number[] {
+const get_filtered_user_id_list = (user_filter_text: string): number[] => {
     let base_user_id_list;
 
     if (user_filter_text) {
@@ -372,17 +366,14 @@ function get_filtered_user_id_list(user_filter_text: string): number[] {
 
     const user_ids = filter_user_ids(user_filter_text, base_user_id_list);
     return user_ids;
-}
+};
 
-export function get_filtered_and_sorted_user_ids(user_filter_text: string): number[] {
+export const get_filtered_and_sorted_user_ids = (user_filter_text: string): number[] => {
     let user_ids;
     user_ids = get_filtered_user_id_list(user_filter_text);
     user_ids = maybe_shrink_list(user_ids, user_filter_text);
     return sort_users(user_ids);
-}
+};
 
-export function matches_filter(user_filter_text: string, user_id: number): boolean {
-    // This is a roundabout way of checking a user if you look
-    // too hard at it, but it should be fine for now.
-    return filter_user_ids(user_filter_text, [user_id]).length === 1;
-}
+export const matches_filter = (user_filter_text: string, user_id: number): boolean =>
+    filter_user_ids(user_filter_text, [user_id]).length === 1;

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -26,19 +26,19 @@ import type {StreamSubscription} from "./sub_store";
 import {INTERACTIVE_HOVER_DELAY} from "./tippyjs";
 import {user_settings} from "./user_settings";
 
-function get_formatted_sub_count(sub_count: number): string {
+const get_formatted_sub_count = (sub_count: number): string => {
     if (sub_count < 1000) {
         return sub_count.toString();
     }
     return new Intl.NumberFormat(user_settings.default_language, {notation: "compact"}).format(
         sub_count,
     );
-}
+};
 
-function total_subscriber_count(
+const total_subscriber_count = (
     current_sub: StreamSubscription | undefined,
     pm_ids_set: Set<number>,
-): number {
+): number => {
     // Includes inactive users who might not show up in the buddy list.
     if (current_sub) {
         return peer_data.get_subscriber_count(current_sub.stream_id, false);
@@ -56,17 +56,12 @@ function total_subscriber_count(
         return pm_ids_list.length + 1;
     }
     return 0;
-}
+};
 
-function should_hide_headers(
+const should_hide_headers = (
     current_sub: StreamSubscription | undefined,
     pm_ids_set: Set<number>,
-): boolean {
-    // If we aren't in a stream/DM view, then there's never "other"
-    // users, so we don't show section headers and only show one
-    // untitled section.
-    return !current_sub && !pm_ids_set.size;
-}
+): boolean => !current_sub && !pm_ids_set.size;
 
 type BuddyListRenderData = {
     current_sub: StreamSubscription | undefined;
@@ -77,7 +72,7 @@ type BuddyListRenderData = {
     hide_headers: boolean;
 };
 
-function get_render_data(): BuddyListRenderData {
+const get_render_data = (): BuddyListRenderData => {
     const current_sub = narrow_state.stream_sub();
     const pm_ids_set = narrow_state.pm_ids_set();
 
@@ -94,7 +89,7 @@ function get_render_data(): BuddyListRenderData {
         total_user_count,
         hide_headers,
     };
-}
+};
 
 class BuddyListConf {
     matching_view_list_selector = "#buddy-list-users-matching-view";

--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -33,14 +33,14 @@ export type AjaxRequestHandler = typeof call | typeof patch;
 let password_change_in_progress = false;
 export let password_changes = 0;
 
-export function set_password_change_in_progress(value: boolean): void {
+export const set_password_change_in_progress = (value: boolean): void => {
     password_change_in_progress = value;
     if (!value) {
         password_changes += 1;
     }
-}
+};
 
-function call(args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
+const call = (args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined => {
     if (reload_state.is_in_progress() && !args.ignore_reload) {
         // If we're in the process of reloading, most HTTP requests
         // are useless, with exceptions like cleaning up our event
@@ -83,7 +83,7 @@ function call(args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefine
         (() => {
             // Ignore errors by default
         });
-    args.error = function wrapped_error(xhr, error_type, xhn) {
+    args.error = (xhr, error_type, xhn) => {
         if (span !== undefined) {
             span.setHttpStatus(xhr.status);
             span.finish();
@@ -148,7 +148,7 @@ function call(args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefine
         (() => {
             // Do nothing by default
         });
-    args.success = function wrapped_success(data, textStatus, jqXHR) {
+    args.success = (data, textStatus, jqXHR) => {
         if (span !== undefined) {
             span.setHttpStatus(jqXHR.status);
             span.finish();
@@ -174,32 +174,32 @@ function call(args: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefine
     } finally {
         Sentry.getCurrentHub().popScope();
     }
-}
+};
 
-export function get(options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
+export const get = (options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined => {
     const args = {type: "GET", dataType: "json", ...options};
     return call(args);
-}
+};
 
-export function post(options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
+export const post = (options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined => {
     const args = {type: "POST", dataType: "json", ...options};
     return call(args);
-}
+};
 
-export function put(options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
+export const put = (options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined => {
     const args = {type: "PUT", dataType: "json", ...options};
     return call(args);
-}
+};
 
 // Not called exports.delete because delete is a reserved word in JS
-export function del(options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined {
+export const del = (options: AjaxRequestHandlerOptions): JQuery.jqXHR<unknown> | undefined => {
     const args = {type: "DELETE", dataType: "json", ...options};
     return call(args);
-}
+};
 
-export function patch(
+export const patch = (
     options: Omit<AjaxRequestHandlerOptions, "data"> & PatchRequestData,
-): JQuery.jqXHR<unknown> | undefined {
+): JQuery.jqXHR<unknown> | undefined => {
     // Send a PATCH as a POST in order to work around QtWebkit
     // (Linux/Windows desktop app) not supporting PATCH body.
     if (options.processData === false) {
@@ -210,9 +210,9 @@ export function patch(
         options.data = {...options.data, method: "PATCH"};
     }
     return post(options);
-}
+};
 
-export function xhr_error_message(message: string, xhr: JQuery.jqXHR<unknown>): string {
+export const xhr_error_message = (message: string, xhr: JQuery.jqXHR<unknown>): string => {
     let parsed;
     if (
         xhr.status >= 400 &&
@@ -230,4 +230,4 @@ export function xhr_error_message(message: string, xhr: JQuery.jqXHR<unknown>): 
     }
 
     return message;
-}
+};

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -98,7 +98,7 @@ export function initialize() {
         initialize_long_tap();
     }
 
-    function is_clickable_message_element($target) {
+    const is_clickable_message_element = ($target) => {
         // This function defines all the elements within a message
         // body that have UI behavior other than starting a reply.
 
@@ -158,7 +158,7 @@ export function initialize() {
         }
 
         return false;
-    }
+    };
 
     const select_message_function = function (e) {
         if (is_clickable_message_element($(e.target))) {
@@ -455,7 +455,7 @@ export function initialize() {
 
     // RECIPIENT BARS
 
-    function get_row_id_for_narrowing(narrow_link_elem) {
+    const get_row_id_for_narrowing = (narrow_link_elem) => {
         const $group = rows.get_closest_group(narrow_link_elem);
         const msg_id = rows.id_for_recipient_row($group);
 
@@ -466,7 +466,7 @@ export function initialize() {
             return selected.id;
         }
         return nearest.id;
-    }
+    };
 
     $("#message_feed_container").on("click", ".narrows_by_recipient", function (e) {
         if (e.metaKey || e.ctrlKey || e.shiftKey) {
@@ -503,7 +503,7 @@ export function initialize() {
     });
 
     // Doesn't show tooltip on touch devices.
-    function do_render_buddy_list_tooltip(
+    const do_render_buddy_list_tooltip = (
         $elem,
         title_data,
         get_target_node,
@@ -511,7 +511,7 @@ export function initialize() {
         subtree = false,
         parent_element_to_append = null,
         is_custom_observer_needed = true,
-    ) {
+    ) => {
         let placement = "left";
         let observer;
         if (window.innerWidth < media_breakpoints_num.md) {
@@ -533,13 +533,13 @@ export function initialize() {
             arrow: true,
             placement,
             showOnCreate: true,
-            onHidden(instance) {
+            onHidden: (instance) => {
                 instance.destroy();
                 if (is_custom_observer_needed) {
                     observer.disconnect();
                 }
             },
-            onShow(instance) {
+            onShow: (instance) => {
                 if (!is_custom_observer_needed) {
                     return;
                 }
@@ -548,7 +548,7 @@ export function initialize() {
                 const target_node = get_target_node(instance);
                 // We only need to know if any of the `li` elements were removed.
                 const config = {attributes: false, childList: true, subtree};
-                const callback = function (mutationsList) {
+                const callback = (mutationsList) => {
                     for (const mutation of mutationsList) {
                         // Hide instance if reference is in the removed node list.
                         if (check_reference_removed(mutation, instance)) {
@@ -561,7 +561,7 @@ export function initialize() {
             },
             appendTo: () => parent_element_to_append || document.body,
         });
-    }
+    };
 
     // BUDDY LIST TOOLTIPS (not displayed on touch devices)
     $(".buddy-list-section").on("mouseenter", ".selectable_sidebar_block", (e) => {
@@ -571,16 +571,10 @@ export function initialize() {
         const title_data = buddy_data.get_title_data(user_id_string, false);
 
         // `target_node` is the `ul` element since it stays in DOM even after updates.
-        function get_target_node() {
-            return $(e.target).parents(".buddy-list-section")[0];
-        }
+        const get_target_node = () => $(e.target).parents(".buddy-list-section")[0];
 
-        function check_reference_removed(mutation, instance) {
-            return Array.prototype.includes.call(
-                mutation.removedNodes,
-                instance.reference.parentElement,
-            );
-        }
+        const check_reference_removed = (mutation, instance) =>
+            Array.prototype.includes.call(mutation.removedNodes, instance.reference.parentElement);
 
         do_render_buddy_list_tooltip(
             $elem.parent(),
@@ -622,17 +616,14 @@ export function initialize() {
         const title_data = buddy_data.get_title_data(user_ids_string, is_group);
 
         // Since anything inside `#left_sidebar_scroll_container` can be replaced, it is our target node here.
-        function get_target_node() {
-            return document.querySelector("#left_sidebar_scroll_container");
-        }
+        const get_target_node = () => document.querySelector("#left_sidebar_scroll_container");
 
         // Whole list is just replaced, so we need to check for that.
-        function check_reference_removed(mutation, instance) {
-            return Array.prototype.includes.call(
+        const check_reference_removed = (mutation, instance) =>
+            Array.prototype.includes.call(
                 mutation.removedNodes,
                 $(instance.reference).parents(".dm-list")[0],
             );
-        }
 
         const check_subtree = true;
         do_render_buddy_list_tooltip(
@@ -731,7 +722,7 @@ export function initialize() {
         browser_history.go_to_location(target);
     });
 
-    function handle_compose_click(e) {
+    const handle_compose_click = (e) => {
         const $target = $(e.target);
         // Emoji clicks should be handled by their own click handler in emoji_picker.js
         if ($target.is(".emoji_map, img.emoji, .drag, .compose_gif_icon, .compose_control_menu")) {
@@ -756,7 +747,7 @@ export function initialize() {
         if ($target.is(".compose_mobile_button, .compose_mobile_button *")) {
             return;
         }
-    }
+    };
 
     $("body").on("click", "#compose-content", handle_compose_click);
 

--- a/web/src/color_data.ts
+++ b/web/src/color_data.ts
@@ -34,13 +34,13 @@ const stream_colors = [
 // bias toward "early" colors.
 export const colors = _.shuffle(stream_colors);
 
-export function reset(): void {
+export const reset = (): void => {
     unused_colors = [...colors];
-}
+};
 
 reset();
 
-export function claim_color(color: string): void {
+export const claim_color = (color: string): void => {
     const i = unused_colors.indexOf(color);
 
     if (i < 0) {
@@ -52,19 +52,19 @@ export function claim_color(color: string): void {
     if (unused_colors.length === 0) {
         reset();
     }
-}
+};
 
-export function claim_colors(subs: {color: string}[]): void {
+export const claim_colors = (subs: {color: string}[]): void => {
     const colors = new Set(subs.map((sub) => sub.color));
     for (const color of colors) {
         claim_color(color);
     }
-}
+};
 
-export function pick_color(): string {
+export const pick_color = (): string => {
     const color = unused_colors[0]!;
 
     claim_color(color);
 
     return color;
-}
+};

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -5,10 +5,8 @@ import {$t} from "./i18n";
 
 export const status_classes = "alert-error alert-success alert-info alert-warning alert-loading";
 
-export function phrase_match(query: string, phrase: string): boolean {
-    // match "tes" to "test" and "stream test" but not "hostess"
-    return (" " + phrase.toLowerCase()).includes(" " + query.toLowerCase());
-}
+export const phrase_match = (query: string, phrase: string): boolean =>
+    (" " + phrase.toLowerCase()).includes(" " + query.toLowerCase());
 
 const keys_map = new Map([
     ["Backspace", "Delete"],
@@ -23,9 +21,7 @@ const keys_map = new Map([
 
 const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
 
-export function has_mac_keyboard(): boolean {
-    return /mac/i.test(navigator.platform);
-}
+export const has_mac_keyboard = (): boolean => /mac/i.test(navigator.platform);
 
 // We convert the <kbd> tags used for keyboard shortcuts to mac equivalent
 // key combinations, when we detect that the user is using a mac-style keyboard.
@@ -68,7 +64,7 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
 
 // We convert the hotkey hints used in the tooltips to mac equivalent
 // key combinations, when we detect that the user is using a mac-style keyboard.
-export function adjust_mac_hotkey_hints(hotkeys: string[]): void {
+export const adjust_mac_hotkey_hints = (hotkeys: string[]): void => {
     if (!has_mac_keyboard()) {
         return;
     }
@@ -84,12 +80,12 @@ export function adjust_mac_hotkey_hints(hotkeys: string[]): void {
             hotkeys.unshift("Fn");
         }
     }
-}
+};
 
 // We convert the Shift key with ⇧ (Level 2 Select Symbol) in the
 // popover menu hotkey hints. This helps us reduce the width of
 // the popover menus.
-export function adjust_shift_hotkey(hotkeys: string[]): boolean {
+export const adjust_shift_hotkey = (hotkeys: string[]): boolean => {
     for (const [index, hotkey] of hotkeys.entries()) {
         if (hotkey === "Shift") {
             hotkeys[index] = "⇧";
@@ -97,15 +93,15 @@ export function adjust_shift_hotkey(hotkeys: string[]): boolean {
         }
     }
     return false;
-}
+};
 
 // See https://zulip.readthedocs.io/en/latest/development/authentication.html#password-form-implementation
 // for design details on this feature.
-function set_password_toggle_label(
+const set_password_toggle_label = (
     password_selector: string,
     label: string,
     tippy_tooltips: boolean,
-): void {
+): void => {
     $(password_selector).attr("aria-label", label);
     if (tippy_tooltips) {
         const element: tippy.ReferenceElement = $(password_selector)[0]!;
@@ -114,13 +110,13 @@ function set_password_toggle_label(
     } else {
         $(password_selector).attr("title", label);
     }
-}
+};
 
-function toggle_password_visibility(
+const toggle_password_visibility = (
     password_field_id: string,
     password_selector: string,
     tippy_tooltips: boolean,
-): void {
+): void => {
     let label;
     const $password_field = $(password_field_id);
 
@@ -134,23 +130,23 @@ function toggle_password_visibility(
         label = $t({defaultMessage: "Show password"});
     }
     set_password_toggle_label(password_selector, label, tippy_tooltips);
-}
+};
 
-export function reset_password_toggle_icons(
+export const reset_password_toggle_icons = (
     password_field: string,
     password_selector: string,
-): void {
+): void => {
     $(password_field).attr("type", "password");
     $(password_selector).removeClass("fa-eye").addClass("fa-eye-slash");
     const label = $t({defaultMessage: "Show password"});
     set_password_toggle_label(password_selector, label, true);
-}
+};
 
-export function setup_password_visibility_toggle(
+export const setup_password_visibility_toggle = (
     password_field_id: string,
     password_selector: string,
     {tippy_tooltips = false} = {},
-): void {
+): void => {
     const label = $t({defaultMessage: "Show password"});
     set_password_toggle_label(password_selector, label, tippy_tooltips);
     $(password_selector).on("click", (e) => {
@@ -165,4 +161,4 @@ export function setup_password_visibility_toggle(
             toggle_password_visibility(password_field_id, password_selector, tippy_tooltips);
         }
     });
-}
+};

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -71,7 +71,7 @@ export function toggle(opts: {
     };
 
     // Returns false if the requested tab is disabled.
-    function select_tab(idx: number): boolean {
+    const select_tab = (idx: number): boolean => {
         const $elem = meta.$ind_tab.eq(idx);
         if ($elem.hasClass("disabled")) {
             return false;
@@ -89,9 +89,9 @@ export function toggle(opts: {
             $elem.trigger("focus");
         }
         return true;
-    }
+    };
 
-    function maybe_go_left(): boolean {
+    const maybe_go_left = (): boolean => {
         // Select the first non-disabled tab to the left, if any.
         let i = 1;
         while (meta.idx - i >= 0) {
@@ -101,9 +101,9 @@ export function toggle(opts: {
             i += 1;
         }
         return false;
-    }
+    };
 
-    function maybe_go_right(): boolean {
+    const maybe_go_right = (): boolean => {
         // Select the first non-disabled tab to the right, if any.
         let i = 1;
         while (meta.idx + i <= opts.values.length - 1) {
@@ -113,7 +113,7 @@ export function toggle(opts: {
             i += 1;
         }
         return false;
-    }
+    };
 
     meta.$ind_tab.on("click", function () {
         const idx = Number($(this).attr("data-tab-id"));
@@ -138,7 +138,7 @@ export function toggle(opts: {
         maybe_go_left,
         maybe_go_right,
 
-        disable_tab(name: string) {
+        disable_tab: (name: string) => {
             const value = opts.values.find((o) => o.key === name);
             if (!value) {
                 blueslip.warn("Incorrect tab name given.");
@@ -149,7 +149,7 @@ export function toggle(opts: {
             meta.$ind_tab.eq(idx).addClass("disabled");
         },
 
-        enable_tab(name: string) {
+        enable_tab: (name: string) => {
             const value = opts.values.find((o) => o.key === name);
             if (!value) {
                 blueslip.warn("Incorrect tab name given.");
@@ -160,7 +160,7 @@ export function toggle(opts: {
             meta.$ind_tab.eq(idx).removeClass("disabled");
         },
 
-        value() {
+        value: () => {
             if (meta.idx >= 0) {
                 return opts.values[meta.idx]!.label;
             }
@@ -168,12 +168,10 @@ export function toggle(opts: {
             return undefined;
         },
 
-        get() {
-            return $component;
-        },
+        get: () => $component,
         // go through the process of finding the correct tab for a given name,
         // and when found, select that one and provide the proper callback.
-        goto(name: string) {
+        goto: (name: string) => {
             const value = opts.values.find((o) => o.label === name || o.key === name);
             if (!value) {
                 blueslip.warn("Incorrect tab name given.");

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -33,17 +33,17 @@ import * as zcommand from "./zcommand";
 
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
 
-export function clear_invites() {
+export const clear_invites = () => {
     $(
         `#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
     ).remove();
-}
+};
 
-export function clear_private_stream_alert() {
+export const clear_private_stream_alert = () => {
     $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.private_stream_warning)}`).remove();
-}
+};
 
-export function clear_preview_area() {
+export const clear_preview_area = () => {
     $("textarea#compose-textarea").show();
     $("textarea#compose-textarea").trigger("focus");
     $("#compose .undo_markdown_preview").hide();
@@ -56,9 +56,9 @@ export function clear_preview_area() {
     // so here we are re-enabling those compose_control_buttons
     $("#compose").removeClass("preview_mode");
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", 0);
-}
+};
 
-export function show_preview_area() {
+export const show_preview_area = () => {
     // Disable unneeded compose_control_buttons as we don't
     // need them in preview mode.
     $("#compose").addClass("preview_mode");
@@ -76,9 +76,9 @@ export function show_preview_area() {
         $("#compose .preview_content"),
         content,
     );
-}
+};
 
-export function create_message_object(message_content = compose_state.message_content()) {
+export const create_message_object = (message_content = compose_state.message_content()) => {
     // Topics are optional, and we provide a placeholder if one isn't given.
     let topic = compose_state.topic();
     if (topic === "") {
@@ -118,9 +118,9 @@ export function create_message_object(message_content = compose_state.message_co
         message.to = stream_id;
     }
     return message;
-}
+};
 
-export function clear_compose_box() {
+export const clear_compose_box = () => {
     /* Before clearing the compose box, we reset it to the
      * default/normal size. Note that for locally echoed messages, we
      * will have already done this action before echoing the message
@@ -141,9 +141,9 @@ export function clear_compose_box() {
     compose_ui.hide_compose_spinner();
     scheduled_messages.reset_selected_schedule_timestamp();
     $(".compose_control_button_container:has(.add-poll)").removeClass("disabled-on-hover");
-}
+};
 
-export function send_message_success(request, data) {
+export const send_message_success = (request, data) => {
     if (!request.locally_echoed) {
         clear_compose_box();
     }
@@ -167,9 +167,9 @@ export function send_message_success(request, data) {
             compose_notifications.notify_unmute(muted_narrow, request.stream_id, request.topic);
         }
     }
-}
+};
 
-export function send_message(request = create_message_object()) {
+export const send_message = (request = create_message_object()) => {
     compose_state.set_recipient_edited_manually(false);
     compose_state.set_is_content_unedited_restored_draft(false);
     if (request.type === "private") {
@@ -209,11 +209,11 @@ export function send_message(request = create_message_object()) {
     request.locally_echoed = locally_echoed;
     request.resend = false;
 
-    function success(data) {
+    const success = (data) => {
         send_message_success(request, data);
-    }
+    };
 
-    function error(response, server_error_code) {
+    const error = (response, server_error_code) => {
         // Error callback for failed message send attempts.
         if (!locally_echoed) {
             if (server_error_code === "TOPIC_WILDCARD_MENTION_NOT_ALLOWED") {
@@ -255,7 +255,7 @@ export function send_message(request = create_message_object()) {
         const draft = drafts.draft_model.getDraft(request.draft_id);
         draft.is_sending_saving = false;
         drafts.draft_model.editDraft(request.draft_id, draft);
-    }
+    };
 
     transmit.send_message(request, success, error);
     server_events.assert_get_events_running(
@@ -268,9 +268,9 @@ export function send_message(request = create_message_object()) {
         // taking a longtime to send.
         setTimeout(() => echo.display_slow_send_loading_spinner(message), 5000);
     }
-}
+};
 
-export function enter_with_preview_open(ctrl_pressed = false) {
+export const enter_with_preview_open = (ctrl_pressed = false) => {
     if (
         (user_settings.enter_sends && !ctrl_pressed) ||
         (!user_settings.enter_sends && ctrl_pressed)
@@ -281,12 +281,12 @@ export function enter_with_preview_open(ctrl_pressed = false) {
         // Otherwise, we return to the normal compose state.
         clear_preview_area();
     }
-}
+};
 
 // Common entrypoint for asking the server to send the message
 // currently drafted in the compose box, including for scheduled
 // messages.
-export function finish(scheduling_message = false) {
+export const finish = (scheduling_message = false) => {
     if (compose_ui.compose_spinner_visible) {
         // Avoid sending a message twice in parallel in races where
         // the user clicks the `Send` button very quickly twice or
@@ -325,17 +325,17 @@ export function finish(scheduling_message = false) {
     }
     do_post_send_tasks();
     return true;
-}
+};
 
-export function do_post_send_tasks() {
+export const do_post_send_tasks = () => {
     clear_preview_area();
     // TODO: Do we want to fire the event even if the send failed due
     // to a server-side error?
     $(document).trigger("compose_finished.zulip");
-}
+};
 
-export function render_and_show_preview($preview_spinner, $preview_content_box, content) {
-    function show_preview(rendered_content, raw_content) {
+export const render_and_show_preview = ($preview_spinner, $preview_content_box, content) => {
+    const show_preview = (rendered_content, raw_content) => {
         // content is passed to check for status messages ("/me ...")
         // and will be undefined in case of errors
         let rendered_preview_html;
@@ -352,7 +352,7 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
 
         $preview_content_box.html(util.clean_user_content_links(rendered_preview_html));
         rendered_markdown.update_elements($preview_content_box);
-    }
+    };
 
     if (content.length === 0) {
         show_preview($t_html({defaultMessage: "Nothing to preview"}));
@@ -374,13 +374,13 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
         channel.post({
             url: "/json/messages/render",
             data: {content},
-            success(response_data) {
+            success: (response_data) => {
                 if (markdown.contains_backend_only_syntax(content)) {
                     loading.destroy_indicator($preview_spinner);
                 }
                 show_preview(response_data.rendered, content);
             },
-            error() {
+            error: () => {
                 if (markdown.contains_backend_only_syntax(content)) {
                     loading.destroy_indicator($preview_spinner);
                 }
@@ -388,9 +388,9 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
             },
         });
     }
-}
+};
 
-function schedule_message_to_custom_date() {
+const schedule_message_to_custom_date = () => {
     const compose_message_object = create_message_object();
 
     const deliver_at = scheduled_messages.get_formatted_selected_send_later_time();
@@ -420,7 +420,7 @@ function schedule_message_to_custom_date() {
     });
 
     const $banner_container = $("#compose_banners");
-    const success = function (data) {
+    const success = (data) => {
         drafts.draft_model.deleteDraft(draft_id);
         clear_compose_box();
         const new_row_html = render_success_message_scheduled_banner({
@@ -431,7 +431,7 @@ function schedule_message_to_custom_date() {
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
     };
 
-    const error = function (xhr) {
+    const error = (xhr) => {
         const response = channel.xhr_error_message("Error sending message", xhr);
         compose_ui.hide_compose_spinner();
         compose_banner.show_error_message(
@@ -451,4 +451,4 @@ function schedule_message_to_custom_date() {
         success,
         error,
     });
-}
+};

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -56,25 +56,25 @@ type ComposeHook = () => void;
 const compose_clear_box_hooks: ComposeHook[] = [];
 const compose_cancel_hooks: ComposeHook[] = [];
 
-export function register_compose_box_clear_hook(hook: ComposeHook): void {
+export const register_compose_box_clear_hook = (hook: ComposeHook): void => {
     compose_clear_box_hooks.push(hook);
-}
+};
 
-export function register_compose_cancel_hook(hook: ComposeHook): void {
+export const register_compose_cancel_hook = (hook: ComposeHook): void => {
     compose_cancel_hooks.push(hook);
-}
+};
 
-function call_hooks(hooks: ComposeHook[]): void {
+const call_hooks = (hooks: ComposeHook[]): void => {
     for (const f of hooks) {
         f();
     }
-}
+};
 
-export function blur_compose_inputs(): void {
+export const blur_compose_inputs = (): void => {
     $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
-}
+};
 
-function hide_box(): void {
+const hide_box = (): void => {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
     blur_compose_inputs();
@@ -84,9 +84,9 @@ function hide_box(): void {
     compose_fade.clear_compose();
     $(".message_comp").hide();
     $("#compose_controls").show();
-}
+};
 
-function show_compose_box(opts: ComposeActionsOpts): void {
+const show_compose_box = (opts: ComposeActionsOpts): void => {
     let opts_by_message_type: ComposeTriggeredOptions;
     if (opts.message_type === "private") {
         opts_by_message_type = {
@@ -107,13 +107,13 @@ function show_compose_box(opts: ComposeActionsOpts): void {
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");
     compose_ui.set_focus(opts_by_message_type);
-}
+};
 
-export function clear_textarea(): void {
+export const clear_textarea = (): void => {
     $("#compose").find("input[type=text], textarea").val("");
-}
+};
 
-function clear_box(): void {
+const clear_box = (): void => {
     call_hooks(compose_clear_box_hooks);
 
     // TODO: Better encapsulate at-mention warnings.
@@ -132,10 +132,10 @@ function clear_box(): void {
     compose_banner.clear_warnings();
     compose_banner.clear_uploads();
     $(".compose_control_button_container:has(.add-poll)").removeClass("disabled-on-hover");
-}
+};
 
 let autosize_callback_opts: ComposeActionsStartOpts;
-export function autosize_message_content(opts: ComposeActionsStartOpts): void {
+export const autosize_message_content = (opts: ComposeActionsStartOpts): void => {
     if (!compose_ui.is_full_size()) {
         autosize_callback_opts = opts;
         $("textarea#compose-textarea")
@@ -145,16 +145,16 @@ export function autosize_message_content(opts: ComposeActionsStartOpts): void {
             });
         autosize($("textarea#compose-textarea"));
     }
-}
+};
 
-export function expand_compose_box(): void {
+export const expand_compose_box = (): void => {
     $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
     $("#compose_close").show();
     $("#compose_controls").hide();
     $(".message_comp").show();
-}
+};
 
-export function complete_starting_tasks(opts: ComposeActionsOpts): void {
+export const complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     // This is sort of a kitchen sink function, and it's called only
     // by compose.start() for now.  Having this as a separate function
     // makes testing a bit easier.
@@ -164,9 +164,9 @@ export function complete_starting_tasks(opts: ComposeActionsOpts): void {
     $(document).trigger(new $.Event("compose_started.zulip", opts));
     compose_recipient.update_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
-}
+};
 
-export function maybe_scroll_up_selected_message(opts: ComposeActionsStartOpts): void {
+export const maybe_scroll_up_selected_message = (opts: ComposeActionsStartOpts): void => {
     if (opts.skip_scrolling_selected_message) {
         return;
     }
@@ -197,38 +197,33 @@ export function maybe_scroll_up_selected_message(opts: ComposeActionsStartOpts):
     if (cover > 0) {
         message_viewport.user_initiated_animate_scroll(cover + 20);
     }
-}
+};
 
-export function fill_in_opts_from_current_narrowed_view(
+export const fill_in_opts_from_current_narrowed_view = (
     opts: ComposeActionsStartOpts,
-): ComposeActionsOpts {
-    return {
-        stream_id: undefined,
-        topic: "",
-        private_message_recipient: "",
-        trigger: "unknown",
+): ComposeActionsOpts => ({
+    stream_id: undefined,
+    topic: "",
+    private_message_recipient: "",
+    trigger: "unknown",
 
-        // Set default parameters based on the current narrowed view.
-        ...narrow_state.set_compose_defaults(),
+    // Set default parameters based on the current narrowed view.
+    ...narrow_state.set_compose_defaults(),
 
-        // Set parameters based on provided opts, overwriting
-        // those set based on current narrowed view, if necessary.
-        ...opts,
-    };
-}
+    // Set parameters based on provided opts, overwriting
+    // those set based on current narrowed view, if necessary.
+    ...opts,
+});
 
-function same_recipient_as_before(opts: ComposeActionsOpts): boolean {
-    return (
-        compose_state.get_message_type() === opts.message_type &&
-        ((opts.message_type === "stream" &&
-            opts.stream_id === compose_state.stream_id() &&
-            opts.topic === compose_state.topic()) ||
-            (opts.message_type === "private" &&
-                opts.private_message_recipient === compose_state.private_message_recipient()))
-    );
-}
+const same_recipient_as_before = (opts: ComposeActionsOpts): boolean =>
+    compose_state.get_message_type() === opts.message_type &&
+    ((opts.message_type === "stream" &&
+        opts.stream_id === compose_state.stream_id() &&
+        opts.topic === compose_state.topic()) ||
+        (opts.message_type === "private" &&
+            opts.private_message_recipient === compose_state.private_message_recipient()));
 
-export function start(raw_opts: ComposeActionsStartOpts): void {
+export const start = (raw_opts: ComposeActionsStartOpts): void => {
     if (page_params.is_spectator) {
         spectators.login_to_access();
         return;
@@ -373,9 +368,9 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
     resize.reset_compose_message_max_height();
 
     complete_starting_tasks(opts);
-}
+};
 
-export function cancel(): void {
+export const cancel = (): void => {
     // As user closes the compose box, restore the compose box max height
     if (compose_ui.is_full_size()) {
         compose_ui.make_compose_box_original_size();
@@ -402,9 +397,9 @@ export function cancel(): void {
     compose_state.set_message_type(undefined);
     compose_pm_pill.clear();
     $(document).trigger("compose_canceled.zulip");
-}
+};
 
-export function on_show_navigation_view(): void {
+export const on_show_navigation_view = (): void => {
     /* This function dictates the behavior of the compose box
      * when navigating to a view, as opposed to a narrow. */
 
@@ -420,9 +415,9 @@ export function on_show_navigation_view(): void {
 
     // Otherwise, close the compose box.
     cancel();
-}
+};
 
-export function on_topic_narrow(): void {
+export const on_topic_narrow = (): void => {
     if (!compose_state.composing()) {
         // If our compose box is closed, then just
         // leave it closed, assuming that the user is
@@ -473,7 +468,7 @@ export function on_topic_narrow(): void {
     compose_fade.update_message_list();
     drafts.update_compose_draft_count();
     $("textarea#compose-textarea").trigger("focus");
-}
+};
 
 // TODO/typescript: Fill this in when converting narrow.js to typescripot.
 type NarrowActivateOpts = {
@@ -482,7 +477,7 @@ type NarrowActivateOpts = {
     private_message_recipient?: string;
 };
 
-export function on_narrow(opts: NarrowActivateOpts): void {
+export const on_narrow = (opts: NarrowActivateOpts): void => {
     // We use force_close when jumping between direct message narrows with
     // the "p" key, so that we don't have an open compose box that makes
     // it difficult to cycle quickly through unread messages.
@@ -559,4 +554,4 @@ export function on_narrow(opts: NarrowActivateOpts): void {
     // mode, so we close the compose box to make it easier to use navigation
     // hotkeys and to provide more screen real estate for messages.
     cancel();
-}
+};

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -9,9 +9,9 @@ import * as stream_data from "./stream_data";
 import type {StreamSubscription} from "./sub_store";
 
 export let scroll_to_message_banner_message_id: number | null = null;
-export function set_scroll_to_message_banner_message_id(val: number | null): void {
+export const set_scroll_to_message_banner_message_id = (val: number | null): void => {
     scroll_to_message_banner_message_id = val;
-}
+};
 
 // banner types
 export const WARNING = "warning";
@@ -58,39 +58,38 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
-export function get_compose_banner_container($textarea: JQuery): JQuery {
-    return $textarea.attr("id") === "compose-textarea"
+export const get_compose_banner_container = ($textarea: JQuery): JQuery =>
+    $textarea.attr("id") === "compose-textarea"
         ? $("#compose_banners")
         : $textarea.closest(".message_edit_form").find(".edit_form_banners");
-}
 
 // This function provides a convenient way to add new elements
 // to a banner container. The function accepts a container element
 // as a parameter, to which a banner should be appended.
-export function append_compose_banner_to_banner_list(
+export const append_compose_banner_to_banner_list = (
     $banner: JQuery,
     $list_container: JQuery,
-): void {
+): void => {
     scroll_util.get_content_element($list_container).append($banner);
-}
+};
 
-export function update_or_append_banner(
+export const update_or_append_banner = (
     $banner: JQuery,
     banner_classname: string,
     $list_container: JQuery,
-): void {
+): void => {
     const $existing_banner = $list_container.find(`.${CSS.escape(banner_classname)}`);
     if ($existing_banner.length === 0) {
         append_compose_banner_to_banner_list($banner, $list_container);
     } else {
         $existing_banner.replaceWith($banner);
     }
-}
+};
 
-export function clear_message_sent_banners(
+export const clear_message_sent_banners = (
     include_unmute_banner = true,
     skip_automatic_new_visibility_policy_banner = false,
-): void {
+): void => {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
         if (
             skip_automatic_new_visibility_policy_banner &&
@@ -111,50 +110,50 @@ export function clear_message_sent_banners(
         clear_unmute_topic_notifications();
     }
     scroll_to_message_banner_message_id = null;
-}
+};
 
 // TODO: Replace with compose_ui.hide_compose_spinner() when it is converted to ts.
-function hide_compose_spinner(): void {
+const hide_compose_spinner = (): void => {
     $(".compose-submit-button .loader").hide();
     $(".compose-submit-button span").show();
     $(".compose-submit-button").removeClass("disable-btn");
-}
+};
 
-export function clear_errors(): void {
+export const clear_errors = (): void => {
     $(`#compose_banners .${CSS.escape(ERROR)}`).remove();
-}
+};
 
-export function clear_warnings(): void {
+export const clear_warnings = (): void => {
     $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
-}
+};
 
-export function clear_uploads(): void {
+export const clear_uploads = (): void => {
     $("#compose_banners .upload_banner").remove();
-}
+};
 
-export function clear_unmute_topic_notifications(): void {
+export const clear_unmute_topic_notifications = (): void => {
     $(
         `#compose_banners .${CLASSNAMES.unmute_topic_notification
             .split(" ")
             .map((classname) => CSS.escape(classname))
             .join(".")}`,
     ).remove();
-}
+};
 
-export function clear_search_view_banner(): void {
+export const clear_search_view_banner = (): void => {
     $(`#compose_banners .${CSS.escape(CLASSNAMES.search_view)}`).remove();
-}
+};
 
-export function clear_all(): void {
+export const clear_all = (): void => {
     scroll_util.get_content_element($(`#compose_banners`)).empty();
-}
+};
 
-export function show_error_message(
+export const show_error_message = (
     message: string,
     classname: string,
     $container: JQuery,
     $bad_input?: JQuery,
-): void {
+): void => {
     // Important: This API intentionally does not support passing an
     // HTML message; doing so creates unnecessary XSS risk. If you
     // want HTML in your compose banner, use a partial subclassing
@@ -180,9 +179,9 @@ export function show_error_message(
     if ($bad_input !== undefined) {
         $bad_input.trigger("focus").trigger("select");
     }
-}
+};
 
-export function show_stream_does_not_exist_error(stream_name: string): void {
+export const show_stream_does_not_exist_error = (stream_name: string): void => {
     // Remove any existing banners with this warning.
     $(`#compose_banners .${CSS.escape(CLASSNAMES.stream_does_not_exist)}`).remove();
 
@@ -196,9 +195,9 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
 
     // Open stream select dropdown.
     $("#compose_select_recipient_widget").trigger("click");
-}
+};
 
-export function show_stream_not_subscribed_error(sub: StreamSubscription): void {
+export const show_stream_not_subscribed_error = (sub: StreamSubscription): void => {
     const $banner_container = $("#compose_banners");
     if ($(`#compose_banners .${CSS.escape(CLASSNAMES.user_not_subscribed)}`).length) {
         return;
@@ -218,4 +217,4 @@ export function show_stream_not_subscribed_error(sub: StreamSubscription): void 
         hide_close_button: true,
     });
     append_compose_banner_to_banner_list($(new_row_html), $banner_container);
-}
+};

--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -3,20 +3,19 @@ import {realm} from "./state_data";
 export const zoom_token_callbacks = new Map();
 export const video_call_xhrs = new Map<string, JQuery.jqXHR<unknown>>();
 
-export function get_jitsi_server_url(): string | null {
-    return realm.realm_jitsi_server_url ?? realm.server_jitsi_server_url;
-}
+export const get_jitsi_server_url = (): string | null =>
+    realm.realm_jitsi_server_url ?? realm.server_jitsi_server_url;
 
-export function abort_video_callbacks(edit_message_id = ""): void {
+export const abort_video_callbacks = (edit_message_id = ""): void => {
     zoom_token_callbacks.delete(edit_message_id);
     const xhr = video_call_xhrs.get(edit_message_id);
     if (xhr !== undefined) {
         xhr.abort();
         video_call_xhrs.delete(edit_message_id);
     }
-}
+};
 
-export function compute_show_video_chat_button(): boolean {
+export const compute_show_video_chat_button = (): boolean => {
     const available_providers = realm.realm_available_video_chat_providers;
     if (realm.realm_video_chat_provider === available_providers.disabled.id) {
         return false;
@@ -30,9 +29,9 @@ export function compute_show_video_chat_button(): boolean {
     }
 
     return true;
-}
+};
 
-export function compute_show_audio_chat_button(): boolean {
+export const compute_show_audio_chat_button = (): boolean => {
     const available_providers = realm.realm_available_video_chat_providers;
     if (
         (available_providers.jitsi_meet &&
@@ -44,4 +43,4 @@ export function compute_show_audio_chat_button(): boolean {
         return true;
     }
     return false;
-}
+};

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -17,37 +17,43 @@ const call_response_schema = z.object({
     url: z.string(),
 });
 
-export function update_audio_and_video_chat_button_display(): void {
+export const update_audio_and_video_chat_button_display = (): void => {
     update_audio_chat_button_display();
     update_video_chat_button_display();
-}
+};
 
-export function update_video_chat_button_display(): void {
+export const update_video_chat_button_display = (): void => {
     const show_video_chat_button = compose_call.compute_show_video_chat_button();
     $(".compose-control-buttons-container .video_link").toggle(show_video_chat_button);
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
-}
+};
 
-export function update_audio_chat_button_display(): void {
+export const update_audio_chat_button_display = (): void => {
     const show_audio_chat_button = compose_call.compute_show_audio_chat_button();
     $(".compose-control-buttons-container .audio_link").toggle(show_audio_chat_button);
     $(".message-edit-feature-group .audio_link").toggle(show_audio_chat_button);
-}
+};
 
-function insert_video_call_url(url: string, $target_textarea: JQuery<HTMLTextAreaElement>): void {
+const insert_video_call_url = (
+    url: string,
+    $target_textarea: JQuery<HTMLTextAreaElement>,
+): void => {
     const link_text = $t({defaultMessage: "Join video call."});
     compose_ui.insert_syntax_and_focus(`[${link_text}](${url})`, $target_textarea, "block", 1);
-}
+};
 
-function insert_audio_call_url(url: string, $target_textarea: JQuery<HTMLTextAreaElement>): void {
+const insert_audio_call_url = (
+    url: string,
+    $target_textarea: JQuery<HTMLTextAreaElement>,
+): void => {
     const link_text = $t({defaultMessage: "Join voice call."});
     compose_ui.insert_syntax_and_focus(`[${link_text}](${url})`, $target_textarea, "block", 1);
-}
+};
 
-export function generate_and_insert_audio_or_video_call_link(
+export const generate_and_insert_audio_or_video_call_link = (
     $target_element: JQuery,
     is_audio_call: boolean,
-): void {
+): void => {
     let $target_textarea: JQuery<HTMLTextAreaElement>;
     let edit_message_id: string | undefined;
     if ($target_element.parents(".message_edit_form").length === 1) {
@@ -74,7 +80,7 @@ export function generate_and_insert_audio_or_video_call_link(
             const xhr = channel.post({
                 url: "/json/calls/zoom/create",
                 data: request,
-                success(res) {
+                success: (res) => {
                     const data = call_response_schema.parse(res);
                     compose_call.video_call_xhrs.delete(key);
                     if (is_audio_call) {
@@ -83,7 +89,7 @@ export function generate_and_insert_audio_or_video_call_link(
                         insert_video_call_url(data.url, $target_textarea);
                     }
                 },
-                error(xhr, status) {
+                error: (xhr, status) => {
                     compose_call.video_call_xhrs.delete(key);
                     let parsed;
                     if (
@@ -130,7 +136,7 @@ export function generate_and_insert_audio_or_video_call_link(
             data: {
                 meeting_name,
             },
-            success(response) {
+            success: (response) => {
                 const data = call_response_schema.parse(response);
                 insert_video_call_url(data.url, $target_textarea);
             },
@@ -164,4 +170,4 @@ export function generate_and_insert_audio_or_video_call_link(
             );
         }
     }
-}
+};

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -8,13 +8,13 @@ import * as narrow_state from "./narrow_state";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
 
-function format_stream_recipient_label(stream_id: number, topic: string): string {
+const format_stream_recipient_label = (stream_id: number, topic: string): string => {
     const stream = stream_data.get_sub_by_id(stream_id);
     if (stream) {
         return "#" + stream.name + " > " + topic;
     }
     return "";
-}
+};
 
 type ComposeClosedMessage = {
     stream_id?: number | undefined;
@@ -22,7 +22,7 @@ type ComposeClosedMessage = {
     display_reply_to?: string | undefined;
 };
 
-export function get_recipient_label(message?: ComposeClosedMessage): string {
+export const get_recipient_label = (message?: ComposeClosedMessage): string => {
     // TODO: This code path is bit of a type-checking disaster; we mix
     // actual message objects with fake objects containing just a
     // couple fields, both those constructed here and potentially
@@ -57,9 +57,9 @@ export function get_recipient_label(message?: ComposeClosedMessage): string {
         }
     }
     return "";
-}
+};
 
-function update_reply_button_state(disable = false): void {
+const update_reply_button_state = (disable = false): void => {
     $(".compose_reply_button").attr("disabled", disable ? "disabled" : null);
     if (disable) {
         $("#compose_buttons .compose-reply-button-wrapper").attr(
@@ -79,12 +79,12 @@ function update_reply_button_state(disable = false): void {
             "selected_conversation",
         );
     }
-}
+};
 
-function update_new_conversation_button(
+const update_new_conversation_button = (
     btn_text: string,
     is_direct_message_narrow?: boolean,
-): void {
+): void => {
     const $new_conversation_button = $("#new_conversation_button");
     $new_conversation_button.text(btn_text);
     // In a direct-message narrow, the new conversation button should act
@@ -98,34 +98,34 @@ function update_new_conversation_button(
         $new_conversation_button.addClass("compose_new_conversation_button");
         $new_conversation_button.removeClass("compose_new_direct_message_button");
     }
-}
+};
 
-function update_new_direct_message_button(btn_text: string): void {
+const update_new_direct_message_button = (btn_text: string): void => {
     $("#new_direct_message_button").text(btn_text);
-}
+};
 
-function toggle_direct_message_button_visibility(is_direct_message_narrow?: boolean): void {
+const toggle_direct_message_button_visibility = (is_direct_message_narrow?: boolean): void => {
     const $new_direct_message_button_container = $(".new_direct_message_button_container");
     if (is_direct_message_narrow) {
         $new_direct_message_button_container.hide();
     } else {
         $new_direct_message_button_container.show();
     }
-}
+};
 
-function update_buttons(
+const update_buttons = (
     text_stream: string,
     is_direct_message_narrow?: boolean,
     disable_reply?: boolean,
-): void {
+): void => {
     const text_conversation = $t({defaultMessage: "New direct message"});
     update_new_conversation_button(text_stream, is_direct_message_narrow);
     update_new_direct_message_button(text_conversation);
     update_reply_button_state(disable_reply);
     toggle_direct_message_button_visibility(is_direct_message_narrow);
-}
+};
 
-export function update_buttons_for_private(): void {
+export const update_buttons_for_private = (): void => {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     const is_direct_message_narrow = true;
     const pm_ids_string = narrow_state.pm_ids_string();
@@ -138,29 +138,29 @@ export function update_buttons_for_private(): void {
     // if the user cannot dm the current recipient
     const disable_reply = true;
     update_buttons(text_stream, is_direct_message_narrow, disable_reply);
-}
+};
 
-export function update_buttons_for_stream_views(): void {
+export const update_buttons_for_stream_views = (): void => {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     $("#new_conversation_button").attr("data-conversation-type", "stream");
     update_buttons(text_stream);
-}
+};
 
-export function update_buttons_for_non_specific_views(): void {
+export const update_buttons_for_non_specific_views = (): void => {
     const text_stream = $t({defaultMessage: "Start new conversation"});
     $("#new_conversation_button").attr("data-conversation-type", "non-specific");
     update_buttons(text_stream);
-}
+};
 
-function set_reply_button_label(label: string): void {
+const set_reply_button_label = (label: string): void => {
     $("#left_bar_compose_reply_button_big").text(label);
-}
+};
 
-export function set_standard_text_for_reply_button(): void {
+export const set_standard_text_for_reply_button = (): void => {
     set_reply_button_label($t({defaultMessage: "Compose message"}));
-}
+};
 
-export function update_reply_recipient_label(message?: ComposeClosedMessage): void {
+export const update_reply_recipient_label = (message?: ComposeClosedMessage): void => {
     const recipient_label = get_recipient_label(message);
     if (recipient_label) {
         set_reply_button_label(
@@ -169,9 +169,9 @@ export function update_reply_recipient_label(message?: ComposeClosedMessage): vo
     } else {
         set_standard_text_for_reply_button();
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
         if (narrow_state.is_message_feed_visible()) {
@@ -198,4 +198,4 @@ export function initialize(): void {
             keep_composebox_empty: true,
         });
     });
-}
+};

--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -77,7 +77,7 @@ type MessageGroup = {
 
 let normal_display = false;
 
-export function set_focused_recipient(msg_type?: "private" | "stream"): void {
+export const set_focused_recipient = (msg_type?: "private" | "stream"): void => {
     if (msg_type === undefined) {
         compose_fade_helper.clear_focused_recipient();
     }
@@ -108,23 +108,23 @@ export function set_focused_recipient(msg_type?: "private" | "stream"): void {
     }
 
     compose_fade_helper.set_focused_recipient(focused_recipient);
-}
+};
 
-function display_messages_normally(): void {
+const display_messages_normally = (): void => {
     message_lists.current?.view.$list.find(".recipient_row").removeClass("message-fade");
 
     normal_display = true;
-}
+};
 
-function change_fade_state($elt: JQuery, should_fade_group: boolean): void {
+const change_fade_state = ($elt: JQuery, should_fade_group: boolean): void => {
     if (should_fade_group) {
         $elt.addClass("message-fade");
     } else {
         $elt.removeClass("message-fade");
     }
-}
+};
 
-function fade_messages(): void {
+const fade_messages = (): void => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -167,9 +167,9 @@ function fade_messages(): void {
         message_lists.current,
         compose_state.private_message_recipient(),
     );
-}
+};
 
-function do_update_all(): void {
+const do_update_all = (): void => {
     if (compose_fade_helper.want_normal_display()) {
         if (!normal_display) {
             display_messages_normally();
@@ -177,33 +177,33 @@ function do_update_all(): void {
     } else {
         fade_messages();
     }
-}
+};
 
 // This gets called on keyup events, hence the throttling.
 export const update_all = _.debounce(do_update_all, 50);
 
-export function start_compose(msg_type?: "private" | "stream"): void {
+export const start_compose = (msg_type?: "private" | "stream"): void => {
     set_focused_recipient(msg_type);
     do_update_all();
-}
+};
 
-export function clear_compose(): void {
+export const clear_compose = (): void => {
     compose_fade_helper.clear_focused_recipient();
     display_messages_normally();
-}
+};
 
-export function update_message_list(): void {
+export const update_message_list = (): void => {
     if (compose_fade_helper.want_normal_display()) {
         display_messages_normally();
     } else {
         fade_messages();
     }
-}
+};
 
-export function update_rendered_message_groups(
+export const update_rendered_message_groups = (
     message_groups: MessageGroup[],
     get_element: (message_group: MessageGroup) => JQuery,
-): void {
+): void => {
     if (compose_fade_helper.want_normal_display()) {
         return;
     }
@@ -217,4 +217,4 @@ export function update_rendered_message_groups(
         const should_fade = compose_fade_helper.should_fade_message(first_message);
         change_fade_state($elt, should_fade);
     }
-}
+};

--- a/web/src/compose_fade_helper.ts
+++ b/web/src/compose_fade_helper.ts
@@ -5,19 +5,18 @@ import * as util from "./util";
 
 let focused_recipient: Recipient | undefined;
 
-export function should_fade_message(message: Message): boolean {
-    return !util.same_recipient(focused_recipient, message);
-}
+export const should_fade_message = (message: Message): boolean =>
+    !util.same_recipient(focused_recipient, message);
 
-export function clear_focused_recipient(): void {
+export const clear_focused_recipient = (): void => {
     focused_recipient = undefined;
-}
+};
 
-export function set_focused_recipient(recipient?: Recipient): void {
+export const set_focused_recipient = (recipient?: Recipient): void => {
     focused_recipient = recipient;
-}
+};
 
-export function want_normal_display(): boolean {
+export const want_normal_display = (): boolean => {
     // If we're not composing show a normal display.
     if (focused_recipient === undefined) {
         return true;
@@ -41,4 +40,4 @@ export function want_normal_display(): boolean {
     }
 
     return focused_recipient.type === "private" && focused_recipient.reply_to === "";
-}
+};

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -18,7 +18,11 @@ import * as people from "./people";
 import * as stream_data from "./stream_data";
 import * as user_topics from "./user_topics";
 
-export function notify_unmute(muted_narrow: string, stream_id: number, topic_name: string): void {
+export const notify_unmute = (
+    muted_narrow: string,
+    stream_id: number,
+    topic_name: string,
+): void => {
     const $unmute_notification = $(
         render_unmute_topic_banner({
             muted_narrow,
@@ -34,15 +38,15 @@ export function notify_unmute(muted_narrow: string, stream_id: number, topic_nam
         $unmute_notification,
         $("#compose_banners"),
     );
-}
+};
 
-export function notify_above_composebox(
+export const notify_above_composebox = (
     banner_text: string,
     classname: string,
     above_composebox_narrow_url: string | null,
     link_msg_id: number,
     link_text: string,
-): void {
+): void => {
     const $notification = $(
         render_message_sent_banner({
             banner_text,
@@ -56,12 +60,12 @@ export function notify_above_composebox(
     // clear any unmute_banner associated with this same message.
     compose_banner.clear_message_sent_banners(false);
     compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
-}
+};
 
-export function notify_automatic_new_visibility_policy(
+export const notify_automatic_new_visibility_policy = (
     message: Message,
     data: {automatic_new_visibility_policy: number; id: number},
-): void {
+): void => {
     const followed =
         data.automatic_new_visibility_policy === user_topics.all_visibility_policies.FOLLOWED;
     const stream_topic = get_message_header(message);
@@ -80,11 +84,11 @@ export function notify_automatic_new_visibility_policy(
         }),
     );
     compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
-}
+};
 
 // Note that this returns values that are not HTML-escaped, for use in
 // Handlebars templates that will do further escaping.
-function get_message_header(message: Message): string {
+const get_message_header = (message: Message): string => {
     if (message.type === "stream") {
         const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
         return `#${stream_name} > ${message.topic}`;
@@ -102,9 +106,9 @@ function get_message_header(message: Message): string {
         {defaultMessage: "direct messages with {recipient}"},
         {recipient: message.display_reply_to},
     );
-}
+};
 
-export function get_muted_narrow(message: Message): string | undefined {
+export const get_muted_narrow = (message: Message): string | undefined => {
     if (
         message.type === "stream" &&
         stream_data.is_muted(message.stream_id) &&
@@ -116,9 +120,9 @@ export function get_muted_narrow(message: Message): string | undefined {
         return "topic";
     }
     return undefined;
-}
+};
 
-export function is_local_mix(message: Message): boolean {
+export const is_local_mix = (message: Message): boolean => {
     if (message_lists.current === undefined) {
         // For non-message list views like Inbox, the message is not visible after sending it.
         return true;
@@ -133,13 +137,13 @@ export function is_local_mix(message: Message): boolean {
     }
 
     return true;
-}
+};
 
-export function notify_local_mixes(
+export const notify_local_mixes = (
     messages: Message[],
     need_user_to_scroll: boolean,
     {narrow_to_recipient}: {narrow_to_recipient: (message_id: number) => void},
-): void {
+): void => {
     /*
         This code should only be called when we are displaying
         messages sent by current client. It notifies users that
@@ -207,9 +211,9 @@ export function notify_local_mixes(
             );
         }
     }
-}
+};
 
-function get_above_composebox_narrow_url(message: Message): string {
+const get_above_composebox_narrow_url = (message: Message): string => {
     let above_composebox_narrow_url;
     if (message.type === "stream") {
         above_composebox_narrow_url = hash_util.by_stream_topic_url(
@@ -220,9 +224,9 @@ function get_above_composebox_narrow_url(message: Message): string {
         above_composebox_narrow_url = message.pm_with_url;
     }
     return above_composebox_narrow_url;
-}
+};
 
-export function reify_message_id(opts: {old_id: number; new_id: number}): void {
+export const reify_message_id = (opts: {old_id: number; new_id: number}): void => {
     const old_id = opts.old_id;
     const new_id = opts.new_id;
 
@@ -237,12 +241,12 @@ export function reify_message_id(opts: {old_id: number; new_id: number}): void {
             compose_banner.set_scroll_to_message_banner_message_id(new_id);
         }
     }
-}
+};
 
-export function initialize(opts: {
+export const initialize = (opts: {
     on_click_scroll_to_selected: () => void;
     on_narrow_to_recipient: (message_id: number) => void;
-}): void {
+}): void => {
     const {on_click_scroll_to_selected, on_narrow_to_recipient} = opts;
     $("#compose_banners").on(
         "click",
@@ -267,4 +271,4 @@ export function initialize(opts: {
             e.preventDefault();
         },
     );
-}
+};

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -15,7 +15,7 @@ const pill_config: InputPillConfig = {
     exclude_inaccessible_users: true,
 };
 
-export function initialize_pill(): UserPillWidget {
+export const initialize_pill = (): UserPillWidget => {
     const $container = $("#private_message_recipient").parent();
 
     const pill = input_pill.create({
@@ -26,13 +26,13 @@ export function initialize_pill(): UserPillWidget {
     });
 
     return pill;
-}
+};
 
-export function initialize({
+export const initialize = ({
     on_pill_create_or_remove,
 }: {
     on_pill_create_or_remove: () => void;
-}): void {
+}): void => {
     widget = initialize_pill();
 
     widget.onPillCreate(() => {
@@ -43,47 +43,42 @@ export function initialize({
     widget.onPillRemove(() => {
         on_pill_create_or_remove();
     });
-}
+};
 
-export function clear(): void {
+export const clear = (): void => {
     widget.clear();
-}
+};
 
-export function set_from_typeahead(person: User): void {
+export const set_from_typeahead = (person: User): void => {
     user_pill.append_person({
         pill_widget: widget,
         person,
     });
-}
+};
 
-export function set_from_emails(value: string): void {
+export const set_from_emails = (value: string): void => {
     // value is something like "alice@example.com,bob@example.com"
     clear();
     widget.appendValue(value);
-}
+};
 
-export function get_user_ids(): number[] {
-    return user_pill.get_user_ids(widget);
-}
+export const get_user_ids = (): number[] => user_pill.get_user_ids(widget);
 
-export function has_unconverted_data(): boolean {
-    return user_pill.has_unconverted_data(widget);
-}
+export const has_unconverted_data = (): boolean => user_pill.has_unconverted_data(widget);
 
-export function get_user_ids_string(): string {
+export const get_user_ids_string = (): string => {
     const user_ids = get_user_ids();
     const sorted_user_ids = util.sorted_ids(user_ids);
     const user_ids_string = sorted_user_ids.join(",");
     return user_ids_string;
-}
+};
 
-export function get_emails(): string {
+export const get_emails = (): string => {
     // return something like "alice@example.com,bob@example.com"
     const user_ids = get_user_ids();
     const emails = user_ids.map((id) => people.get_by_user_id(id).email).join(",");
     return emails;
-}
+};
 
-export function filter_taken_users(persons: User[]): User[] {
-    return user_pill.filter_taken_users(persons, widget);
-}
+export const filter_taken_users = (persons: User[]): User[] =>
+    user_pill.filter_taken_users(persons, widget);

--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -12,7 +12,7 @@ import * as popovers from "./popovers";
 import * as rows from "./rows";
 import {parse_html} from "./ui_util";
 
-export function initialize() {
+export const initialize = () => {
     // compose box buttons popover shown on mobile widths.
     // We want this click event to propagate and hide other popovers
     // that could possibly obstruct user from using this popover.
@@ -25,7 +25,7 @@ export function initialize() {
         // actions
         target: ".mobile_button_container",
         placement: "top",
-        onShow(instance) {
+        onShow: (instance) => {
             popover_menus.popover_instances.compose_mobile_button = instance;
             popover_menus.on_show_prep(instance);
             instance.setContent(
@@ -36,7 +36,7 @@ export function initialize() {
                 ),
             );
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             $popper.one("click", ".compose_mobile_stream_button", (e) => {
                 compose_actions.start({
@@ -54,7 +54,7 @@ export function initialize() {
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             // Destroy instance so that event handlers
             // are destroyed too.
             instance.destroy();
@@ -67,7 +67,7 @@ export function initialize() {
     // only if user clicked outside it.
     popover_menus.register_popover_menu(".compose_control_menu_wrapper", {
         placement: "top",
-        onShow(instance) {
+        onShow: (instance) => {
             const parent_row = rows.get_closest_row(instance.reference);
             let preview_mode_on;
             // If the popover is opened from a message edit form, we want to
@@ -89,9 +89,9 @@ export function initialize() {
             popover_menus.popover_instances.compose_control_buttons = instance;
             popovers.hide_all();
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.compose_control_buttons = undefined;
         },
     });
-}
+};

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -34,14 +34,11 @@ type DirectMessagesOption = {
     name: string;
 };
 
-function composing_to_current_topic_narrow(): boolean {
-    return (
-        util.lower_same(compose_state.stream_name(), narrow_state.stream_name() ?? "") &&
-        util.lower_same(compose_state.topic(), narrow_state.topic() ?? "")
-    );
-}
+const composing_to_current_topic_narrow = (): boolean =>
+    util.lower_same(compose_state.stream_name(), narrow_state.stream_name() ?? "") &&
+    util.lower_same(compose_state.topic(), narrow_state.topic() ?? "");
 
-function composing_to_current_private_message_narrow(): boolean {
+const composing_to_current_private_message_narrow = (): boolean => {
     const compose_state_recipient = compose_state.private_message_recipient();
     const narrow_state_recipient = narrow_state.pm_emails_string();
     if (narrow_state_recipient === undefined) {
@@ -61,9 +58,9 @@ function composing_to_current_private_message_narrow(): boolean {
                 .sort(),
         )
     );
-}
+};
 
-export function update_narrow_to_recipient_visibility(): void {
+export const update_narrow_to_recipient_visibility = (): void => {
     const message_type = compose_state.get_message_type();
     if (message_type === "stream") {
         const stream_exists = Boolean(compose_state.stream_id());
@@ -88,9 +85,9 @@ export function update_narrow_to_recipient_visibility(): void {
         }
     }
     $(".conversation-arrow").toggleClass("narrow_to_compose_recipients", false);
-}
+};
 
-function update_fade(): void {
+const update_fade = (): void => {
     if (!compose_state.composing()) {
         return;
     }
@@ -104,16 +101,16 @@ function update_fade(): void {
     compose_validate.warn_if_topic_resolved(true);
     compose_fade.set_focused_recipient(msg_type);
     compose_fade.update_all();
-}
+};
 
-export function update_on_recipient_change(): void {
+export const update_on_recipient_change = (): void => {
     update_fade();
     update_narrow_to_recipient_visibility();
     drafts.update_compose_draft_count();
     check_posting_policy_for_compose_box();
-}
+};
 
-export function get_posting_policy_error_message(): string {
+export const get_posting_policy_error_message = (): string => {
     if (compose_state.selected_recipient_id === "direct") {
         const recipients = compose_pm_pill.get_user_ids_string();
         if (!people.user_can_direct_message(recipients)) {
@@ -135,9 +132,9 @@ export function get_posting_policy_error_message(): string {
         });
     }
     return "";
-}
+};
 
-export function check_posting_policy_for_compose_box(): void {
+export const check_posting_policy_for_compose_box = (): void => {
     const banner_text = get_posting_policy_error_message();
     if (banner_text === "") {
         compose_validate.set_recipient_disallowed(false);
@@ -151,9 +148,9 @@ export function check_posting_policy_for_compose_box(): void {
     }
     compose_validate.set_recipient_disallowed(true);
     compose_banner.show_error_message(banner_text, banner_classname, $("#compose_banners"));
-}
+};
 
-function switch_message_type(message_type: MessageType): void {
+const switch_message_type = (message_type: MessageType): void => {
     $("#compose-content .alert").hide();
 
     compose_state.set_message_type(message_type);
@@ -168,9 +165,9 @@ function switch_message_type(message_type: MessageType): void {
     update_compose_for_message_type(opts);
     update_placeholder_text();
     compose_ui.set_focus(opts);
-}
+};
 
-function update_recipient_label(stream_id?: number): void {
+const update_recipient_label = (stream_id?: number): void => {
     const stream = stream_id !== undefined ? stream_data.get_sub_by_id(stream_id) : undefined;
     if (stream === undefined) {
         $("#compose_select_recipient_widget .dropdown_widget_value").text(
@@ -181,9 +178,9 @@ function update_recipient_label(stream_id?: number): void {
             render_inline_decorated_stream_name({stream, show_colored_icon: true}),
         );
     }
-}
+};
 
-export function update_compose_for_message_type(opts: ComposeTriggeredOptions): void {
+export const update_compose_for_message_type = (opts: ComposeTriggeredOptions): void => {
     if (opts.message_type === "stream") {
         $("#compose-direct-recipient").hide();
         $("#compose_recipient_box").show();
@@ -209,9 +206,9 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     compose_banner.clear_uploads();
-}
+};
 
-export function on_compose_select_recipient_update(): void {
+export const on_compose_select_recipient_update = (): void => {
     const prev_message_type = compose_state.get_message_type();
 
     let curr_message_type: MessageType = "stream";
@@ -230,15 +227,15 @@ export function on_compose_select_recipient_update(): void {
     }
 
     update_on_recipient_change();
-}
+};
 
-export function possibly_update_stream_name_in_compose(stream_id: number): void {
+export const possibly_update_stream_name_in_compose = (stream_id: number): void => {
     if (compose_state.selected_recipient_id === stream_id) {
         on_compose_select_recipient_update();
     }
-}
+};
 
-function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance): void {
+const item_click_callback = (event: JQuery.ClickEvent, dropdown: tippy.Instance): void => {
     const recipient_id_str = $(event.currentTarget).attr("data-unique-id");
     assert(recipient_id_str !== undefined);
     let recipient_id: string | number = recipient_id_str;
@@ -251,9 +248,9 @@ function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance)
     dropdown.hide();
     event.preventDefault();
     event.stopPropagation();
-}
+};
 
-function get_options_for_recipient_widget(): Option[] {
+const get_options_for_recipient_widget = (): Option[] => {
     const options: (Option | DirectMessagesOption)[] =
         stream_data.get_options_for_dropdown_widget();
 
@@ -272,9 +269,9 @@ function get_options_for_recipient_widget(): Option[] {
         options.push(direct_messages_option);
     }
     return options;
-}
+};
 
-function compose_recipient_dropdown_on_show(dropdown: tippy.Instance): void {
+const compose_recipient_dropdown_on_show = (dropdown: tippy.Instance): void => {
     // Offset to display dropdown above compose.
     let top_offset = 5;
     const window_height = window.innerHeight;
@@ -299,18 +296,18 @@ function compose_recipient_dropdown_on_show(dropdown: tippy.Instance): void {
     );
     const $popper = $(dropdown.popper);
     $popper.find(".dropdown-list-wrapper").css("max-height", height + "px");
-}
+};
 
-export function open_compose_recipient_dropdown(): void {
+export const open_compose_recipient_dropdown = (): void => {
     $("#compose_select_recipient_widget").trigger("click");
-}
+};
 
-function focus_compose_recipient(): void {
+const focus_compose_recipient = (): void => {
     $("#compose_select_recipient_widget_wrapper").trigger("focus");
-}
+};
 
 // NOTE: Since tippy triggers this on `mousedown` it is always triggered before say a `click` on `textarea`.
-function on_hidden_callback(): void {
+const on_hidden_callback = (): void => {
     if (compose_state.get_message_type() === "stream") {
         // Always move focus to the topic input even if it's not empty,
         // since it's likely the user will want to update the topic
@@ -323,15 +320,15 @@ function on_hidden_callback(): void {
             $("textarea#compose-textarea").trigger("focus");
         }
     }
-}
+};
 
-export function handle_middle_pane_transition(): void {
+export const handle_middle_pane_transition = (): void => {
     if (compose_state.composing()) {
         update_narrow_to_recipient_visibility();
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     new dropdown_widget.DropdownWidget({
         widget_name: "compose_select_recipient",
         get_options: get_options_for_recipient_widget,
@@ -355,9 +352,9 @@ export function initialize(): void {
         update_on_recipient_change();
         compose_state.set_recipient_edited_manually(true);
     });
-}
+};
 
-export function update_placeholder_text(): void {
+export const update_placeholder_text = (): void => {
     // Change compose placeholder text only if compose box is open.
     if (!$("textarea#compose-textarea").is(":visible")) {
         return;
@@ -380,4 +377,4 @@ export function update_placeholder_text(): void {
     }
 
     $("textarea#compose-textarea").attr("placeholder", placeholder);
-}
+};

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -22,12 +22,12 @@ import * as recent_view_util from "./recent_view_util";
 import * as stream_data from "./stream_data";
 import * as unread_ops from "./unread_ops";
 
-export function respond_to_message(opts: {
+export const respond_to_message = (opts: {
     keep_composebox_empty?: boolean;
     message_id?: number;
     reply_type?: "personal";
     trigger?: string;
-}): void {
+}): void => {
     let message;
     let msg_type: "private" | "stream";
     if (recent_view_util.is_visible()) {
@@ -152,14 +152,14 @@ export function respond_to_message(opts: {
         is_reply: true,
         keep_composebox_empty: opts.keep_composebox_empty,
     });
-}
+};
 
-export function reply_with_mention(opts: {
+export const reply_with_mention = (opts: {
     keep_composebox_empty?: boolean;
     message_id?: number;
     reply_type?: "personal";
     trigger?: string;
-}): void {
+}): void => {
     assert(message_lists.current !== undefined);
     respond_to_message({
         ...opts,
@@ -168,9 +168,11 @@ export function reply_with_mention(opts: {
     const message = message_lists.current.selected_message();
     const mention = people.get_mention_syntax(message.sender_full_name, message.sender_id);
     compose_ui.insert_syntax_and_focus(mention);
-}
+};
 
-export function selection_within_message_id(selection = window.getSelection()): number | undefined {
+export const selection_within_message_id = (
+    selection = window.getSelection(),
+): number | undefined => {
     // Returns the message_id if the selection is entirely within a message,
     // otherwise returns undefined.
     assert(selection !== null);
@@ -182,13 +184,16 @@ export function selection_within_message_id(selection = window.getSelection()): 
         return start_id;
     }
     return undefined;
-}
+};
 
-function get_quote_target(opts: {message_id?: number; quote_content?: string}): {
+const get_quote_target = (opts: {
+    message_id?: number;
+    quote_content?: string;
+}): {
     message_id: number;
     message: Message;
     quote_content: string | undefined;
-} {
+} => {
     assert(message_lists.current !== undefined);
     let message_id;
     let quote_content;
@@ -217,15 +222,15 @@ function get_quote_target(opts: {message_id?: number; quote_content?: string}): 
     // we quote that entire message.
     quote_content ??= message.raw_content;
     return {message_id, message, quote_content};
-}
+};
 
-export function quote_and_reply(opts: {
+export const quote_and_reply = (opts: {
     message_id: number;
     quote_content?: string;
     keep_composebox_empty?: boolean;
     reply_type?: "personal";
     trigger?: string;
-}): void {
+}): void => {
     const {message_id, message, quote_content} = get_quote_target(opts);
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
@@ -252,7 +257,7 @@ export function quote_and_reply(opts: {
 
     compose_ui.insert_syntax_and_focus(quoting_placeholder, $textarea, "block");
 
-    function replace_content(message: Message, raw_content: string): void {
+    const replace_content = (message: Message, raw_content: string): void => {
         // Final message looks like:
         //     @_**Iago|5** [said](link to message):
         //     ```quote
@@ -271,7 +276,7 @@ export function quote_and_reply(opts: {
 
         compose_ui.replace_syntax(quoting_placeholder, content, $textarea);
         compose_ui.autosize_textarea($textarea);
-    }
+    };
 
     if (message && quote_content) {
         replace_content(message, quote_content);
@@ -280,14 +285,14 @@ export function quote_and_reply(opts: {
 
     void channel.get({
         url: "/json/messages/" + message_id,
-        success(raw_data) {
+        success: (raw_data) => {
             const data = z.object({raw_content: z.string()}).parse(raw_data);
             replace_content(message, data.raw_content);
         },
     });
-}
+};
 
-function extract_range_html(range: Range, preserve_ancestors = false): string {
+const extract_range_html = (range: Range, preserve_ancestors = false): string => {
     // Returns the html of the range as a string, optionally preserving 2
     // levels of ancestors.
     const temp_div = document.createElement("div");
@@ -313,9 +318,9 @@ function extract_range_html(range: Range, preserve_ancestors = false): string {
     outer_container.append(container_clone);
     temp_div.append(outer_container);
     return temp_div.innerHTML;
-}
+};
 
-function get_range_intersection_with_element(range: Range, element: Node): Range {
+const get_range_intersection_with_element = (range: Range, element: Node): Range => {
     // Returns a new range that is a subset of range and is inside element.
     const intersection = document.createRange();
     intersection.selectNodeContents(element);
@@ -329,9 +334,9 @@ function get_range_intersection_with_element(range: Range, element: Node): Range
     }
 
     return intersection;
-}
+};
 
-export function get_message_selection(selection = window.getSelection()): string {
+export const get_message_selection = (selection = window.getSelection()): string => {
     assert(selection !== null);
     let selected_message_content_raw = "";
 
@@ -374,10 +379,10 @@ export function get_message_selection(selection = window.getSelection()): string
     }
     selected_message_content_raw = selected_message_content_raw.trim();
     return selected_message_content_raw;
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("body").on("click", ".compose_reply_button", () => {
         respond_to_message({trigger: "reply button"});
     });
-}
+};

--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -24,12 +24,12 @@ const ENTER_SENDS_SELECTION_DELAY = 600;
 
 let send_later_popover_keyboard_toggle = false;
 
-function set_compose_box_schedule(element) {
+const set_compose_box_schedule = (element) => {
     const selected_send_at_time = element.dataset.sendStamp / 1000;
     return selected_send_at_time;
-}
+};
 
-export function open_send_later_menu() {
+export const open_send_later_menu = () => {
     if (!compose_validate.validate(true)) {
         return;
     }
@@ -42,7 +42,7 @@ export function open_send_later_menu() {
 
     modals.open("send_later_modal", {
         autoremove: true,
-        on_show() {
+        on_show: () => {
             interval = setInterval(
                 update_send_later_options,
                 SCHEDULING_MODAL_UPDATE_INTERVAL_IN_MILLISECONDS,
@@ -75,7 +75,7 @@ export function open_send_later_menu() {
                             current_time.getTime() +
                                 scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
                         ),
-                        onClose() {
+                        onClose: () => {
                             // Return to normal state.
                             $send_later_modal_content.css("pointer-events", "all");
                         },
@@ -97,18 +97,18 @@ export function open_send_later_menu() {
                 },
             );
         },
-        on_shown() {
+        on_shown: () => {
             // When shown, we should give the modal focus to correctly handle keyboard events.
             const $send_later_modal_overlay = $("#send_later_modal .modal__overlay");
             $send_later_modal_overlay.trigger("focus");
         },
-        on_hide() {
+        on_hide: () => {
             clearInterval(interval);
         },
     });
-}
+};
 
-export function do_schedule_message(send_at_time) {
+export const do_schedule_message = (send_at_time) => {
     modals.close_if_open("send_later_modal");
 
     if (!Number.isInteger(send_at_time)) {
@@ -117,9 +117,9 @@ export function do_schedule_message(send_at_time) {
     }
     scheduled_messages.set_selected_schedule_timestamp(send_at_time);
     compose.finish(true);
-}
+};
 
-function get_send_later_menu_items() {
+const get_send_later_menu_items = () => {
     const $current_schedule_popover_elem = $("[data-tippy-root] #send_later_popover");
     if (!$current_schedule_popover_elem) {
         blueslip.error("Trying to get menu items when schedule popover is closed.");
@@ -127,29 +127,29 @@ function get_send_later_menu_items() {
     }
 
     return $current_schedule_popover_elem.find("li:not(.divider):visible a");
-}
+};
 
-function focus_first_send_later_popover_item() {
+const focus_first_send_later_popover_item = () => {
     // It is recommended to only call this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_send_later_menu_items();
     popover_menus.focus_first_popover_item($items);
-}
+};
 
-export function toggle() {
+export const toggle = () => {
     send_later_popover_keyboard_toggle = true;
     $("#send_later i").trigger("click");
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     tippy.delegate("body", {
         ...popover_menus.default_popover_props,
         target: "#send_later i",
-        onUntrigger() {
+        onUntrigger: () => {
             // This is only called when the popover is closed by clicking on `target`.
             $("textarea#compose-textarea").trigger("focus");
         },
-        onShow(instance) {
+        onShow: (instance) => {
             const formatted_send_later_time =
                 scheduled_messages.get_formatted_selected_send_later_time();
             // If there's existing text in the composebox, show an option
@@ -166,7 +166,7 @@ export function initialize() {
             );
             popover_menus.popover_instances.send_later = instance;
         },
-        onMount(instance) {
+        onMount: (instance) => {
             if (send_later_popover_keyboard_toggle) {
                 focus_first_send_later_popover_item();
                 send_later_popover_keyboard_toggle = false;
@@ -222,16 +222,16 @@ export function initialize() {
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.send_later = undefined;
             send_later_popover_keyboard_toggle = false;
         },
     });
-}
+};
 
 // This function is exported for unit testing purposes.
-export function should_update_send_later_options(date) {
+export const should_update_send_later_options = (date) => {
     const current_minute = date.getMinutes();
     const current_hour = date.getHours();
 
@@ -244,9 +244,9 @@ export function should_update_send_later_options(date) {
     // Rerender at MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS before the
     // hour, so we don't offer a 4:00PM send time at 3:59 PM.
     return current_minute === 60 - scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60;
-}
+};
 
-export function update_send_later_options() {
+export const update_send_later_options = () => {
     const now = new Date();
     if (should_update_send_later_options(now)) {
         const filtered_send_opts = scheduled_messages.get_filtered_send_opts(now);
@@ -254,4 +254,4 @@ export function update_send_later_options() {
             $(render_send_later_modal_options(filtered_send_opts)),
         );
     }
-}
+};

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -34,19 +34,19 @@ import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as user_topics from "./user_topics";
 
-export function abort_xhr() {
+export const abort_xhr = () => {
     $("#compose-send-button").prop("disabled", false);
     upload.compose_upload_cancel();
-}
+};
 
-function setup_compose_actions_hooks() {
+const setup_compose_actions_hooks = () => {
     compose_actions.register_compose_box_clear_hook(compose.clear_invites);
     compose_actions.register_compose_box_clear_hook(compose.clear_private_stream_alert);
     compose_actions.register_compose_box_clear_hook(compose.clear_preview_area);
 
     compose_actions.register_compose_cancel_hook(abort_xhr);
     compose_actions.register_compose_cancel_hook(compose_call.abort_video_callbacks);
-}
+};
 
 export function initialize() {
     // Register hooks for compose_actions.
@@ -107,14 +107,14 @@ export function initialize() {
     const update_compose_max_height = new ResizeObserver(resize.reset_compose_message_max_height);
     update_compose_max_height.observe(document.querySelector("#compose"));
 
-    function get_input_info(event) {
+    const get_input_info = (event) => {
         const $edit_banners_container = $(event.target).closest(".edit_form_banners");
         const is_edit_input = Boolean($edit_banners_container.length);
         const $banner_container = $edit_banners_container.length
             ? $edit_banners_container
             : $("#compose_banners");
         return {is_edit_input, $banner_container};
-    }
+    };
 
     $("body").on(
         "click",
@@ -257,11 +257,11 @@ export function initialize() {
             const user_id = Number($invite_row.attr("data-user-id"));
             const stream_id = Number($invite_row.attr("data-stream-id"));
 
-            function success() {
+            const success = () => {
                 $invite_row.remove();
-            }
+            };
 
-            function xhr_failure(xhr) {
+            const xhr_failure = (xhr) => {
                 let error_message = "Failed to subscribe user!";
                 if (xhr.responseJSON?.msg) {
                     error_message = xhr.responseJSON.msg;
@@ -274,7 +274,7 @@ export function initialize() {
                     $("textarea#compose-textarea"),
                 );
                 $(event.target).prop("disabled", true);
-            }
+            };
 
             const sub = sub_store.get(stream_id);
 
@@ -387,7 +387,7 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
-        function validate_input() {
+        const validate_input = () => {
             const question = $("#poll-question-input").val().trim();
 
             if (question === "") {
@@ -399,14 +399,14 @@ export function initialize() {
                 return false;
             }
             return true;
-        }
+        };
 
         dialog_widget.launch({
             html_heading: $t_html({defaultMessage: "Create a poll"}),
             html_body: render_add_poll_modal(),
             html_submit_button: $t_html({defaultMessage: "Add poll"}),
             close_on_submit: true,
-            on_click(e) {
+            on_click: (e) => {
                 // frame a message using data input in modal, then populate the compose textarea with it
                 e.preventDefault();
                 e.stopPropagation();

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -18,61 +18,48 @@ let last_focused_compose_type_input: HTMLTextAreaElement | undefined;
 // performing these actions
 let recipient_viewed_topic_resolved_banner = false;
 
-export function set_recipient_edited_manually(flag: boolean): void {
+export const set_recipient_edited_manually = (flag: boolean): void => {
     recipient_edited_manually = flag;
-}
+};
 
-export function is_recipient_edited_manually(): boolean {
-    return recipient_edited_manually;
-}
+export const is_recipient_edited_manually = (): boolean => recipient_edited_manually;
 
-export function set_is_content_unedited_restored_draft(flag: boolean): void {
+export const set_is_content_unedited_restored_draft = (flag: boolean): void => {
     is_content_unedited_restored_draft = flag;
-}
+};
 
-export function get_is_content_unedited_restored_draft(): boolean {
-    return is_content_unedited_restored_draft;
-}
+export const get_is_content_unedited_restored_draft = (): boolean =>
+    is_content_unedited_restored_draft;
 
-export function set_last_focused_compose_type_input(element: HTMLTextAreaElement): void {
+export const set_last_focused_compose_type_input = (element: HTMLTextAreaElement): void => {
     last_focused_compose_type_input = element;
-}
+};
 
-export function get_last_focused_compose_type_input(): HTMLTextAreaElement | undefined {
-    return last_focused_compose_type_input;
-}
+export const get_last_focused_compose_type_input = (): HTMLTextAreaElement | undefined =>
+    last_focused_compose_type_input;
 
-export function set_message_type(msg_type: "stream" | "private" | undefined): void {
+export const set_message_type = (msg_type: "stream" | "private" | undefined): void => {
     message_type = msg_type;
-}
+};
 
-export function get_message_type(): "stream" | "private" | undefined {
-    return message_type;
-}
+export const get_message_type = (): "stream" | "private" | undefined => message_type;
 
-export function set_recipient_viewed_topic_resolved_banner(flag: boolean): void {
+export const set_recipient_viewed_topic_resolved_banner = (flag: boolean): void => {
     recipient_viewed_topic_resolved_banner = flag;
-}
+};
 
-export function has_recipient_viewed_topic_resolved_banner(): boolean {
-    return recipient_viewed_topic_resolved_banner;
-}
+export const has_recipient_viewed_topic_resolved_banner = (): boolean =>
+    recipient_viewed_topic_resolved_banner;
 
-export function composing(): boolean {
-    // This is very similar to get_message_type(), but it returns
-    // a boolean.
-    return Boolean(message_type);
-}
+export const composing = (): boolean => Boolean(message_type);
 
-function get_or_set(
-    input_selector: string,
-    keep_leading_whitespace?: boolean,
-    no_trim?: boolean,
-): (newval?: string) => string {
-    // We can't hoist the assignment of '$elem' out of this lambda,
-    // because the DOM element might not exist yet when get_or_set
-    // is called.
-    return function (newval) {
+const get_or_set =
+    (
+        input_selector: string,
+        keep_leading_whitespace?: boolean,
+        no_trim?: boolean,
+    ): ((newval?: string) => string) =>
+    (newval) => {
         const $elem = $<HTMLInputElement | HTMLTextAreaElement>(input_selector);
         const oldval = $elem.val()!;
         if (newval !== undefined) {
@@ -85,7 +72,6 @@ function get_or_set(
         }
         return oldval.trim();
     };
-}
 
 // selected_recipient_id is the current state for the stream picker widget:
 // "" -> stream message but no stream is selected
@@ -94,40 +80,38 @@ function get_or_set(
 export let selected_recipient_id: number | "direct" | "" = "";
 export const DIRECT_MESSAGE_ID = "direct";
 
-export function set_selected_recipient_id(recipient_id: number | "direct" | ""): void {
+export const set_selected_recipient_id = (recipient_id: number | "direct" | ""): void => {
     selected_recipient_id = recipient_id;
-}
+};
 
-export function stream_id(): number | undefined {
+export const stream_id = (): number | undefined => {
     const stream_id = selected_recipient_id;
     if (typeof stream_id === "number") {
         return stream_id;
     }
     return undefined;
-}
+};
 
-export function stream_name(): string {
+export const stream_name = (): string => {
     const stream_id = selected_recipient_id;
     if (typeof stream_id === "number") {
         return sub_store.maybe_get_stream_name(stream_id) ?? "";
     }
     return "";
-}
+};
 
-export function set_stream_id(stream_id: number | ""): void {
+export const set_stream_id = (stream_id: number | ""): void => {
     set_selected_recipient_id(stream_id);
-}
+};
 
-export function set_compose_recipient_id(recipient_id: number | "direct"): void {
+export const set_compose_recipient_id = (recipient_id: number | "direct"): void => {
     set_selected_recipient_id(recipient_id);
-}
+};
 
 // TODO: Break out setter and getter into their own functions.
 export const topic = get_or_set("input#stream_message_recipient_topic");
 
-export function empty_topic_placeholder(): string {
-    return $t({defaultMessage: "(no topic)"});
-}
+export const empty_topic_placeholder = (): string => $t({defaultMessage: "(no topic)"});
 
 // We can't trim leading whitespace in `compose_textarea` because
 // of the indented syntax for multi-line code blocks.
@@ -135,14 +119,14 @@ export const message_content = get_or_set("textarea#compose-textarea", true);
 
 const untrimmed_message_content = get_or_set("textarea#compose-textarea", true, true);
 
-function cursor_at_start_of_whitespace_in_compose(): boolean {
+const cursor_at_start_of_whitespace_in_compose = (): boolean => {
     const cursor_position = $("textarea#compose-textarea").caret();
     return message_content() === "" && cursor_position === 0;
-}
+};
 
-export function focus_in_empty_compose(
+export const focus_in_empty_compose = (
     consider_start_of_whitespace_message_empty = false,
-): boolean {
+): boolean => {
     // A user trying to press arrow keys in an empty compose is mostly
     // likely trying to navigate messages. This helper function
     // decides whether the compose box is empty for this purpose.
@@ -183,7 +167,7 @@ export function focus_in_empty_compose(
     }
 
     return false;
-}
+};
 
 export function private_message_recipient(): string;
 export function private_message_recipient(value: string): undefined;
@@ -195,27 +179,23 @@ export function private_message_recipient(value?: string): string | undefined {
     return compose_pm_pill.get_emails();
 }
 
-export function has_message_content(): boolean {
-    return message_content() !== "";
-}
+export const has_message_content = (): boolean => message_content() !== "";
 
-export function has_novel_message_content(): boolean {
-    return message_content() !== "" && !get_is_content_unedited_restored_draft();
-}
+export const has_novel_message_content = (): boolean =>
+    message_content() !== "" && !get_is_content_unedited_restored_draft();
 
 const MINIMUM_MESSAGE_LENGTH_TO_SAVE_DRAFT = 2;
-export function has_savable_message_content(): boolean {
-    return message_content().length > MINIMUM_MESSAGE_LENGTH_TO_SAVE_DRAFT;
-}
+export const has_savable_message_content = (): boolean =>
+    message_content().length > MINIMUM_MESSAGE_LENGTH_TO_SAVE_DRAFT;
 
-export function has_full_recipient(): boolean {
+export const has_full_recipient = (): boolean => {
     if (message_type === "stream") {
         return stream_id() !== undefined && topic() !== "";
     }
     return private_message_recipient() !== "";
-}
+};
 
-export function update_email(user_id: number, new_email: string): void {
+export const update_email = (user_id: number, new_email: string): void => {
     let reply_to = private_message_recipient();
 
     if (!reply_to) {
@@ -225,17 +205,15 @@ export function update_email(user_id: number, new_email: string): void {
     reply_to = people.update_email_in_reply_to(reply_to, user_id, new_email);
 
     private_message_recipient(reply_to);
-}
+};
 
 let _can_restore_drafts = true;
-export function prevent_draft_restoring(): void {
+export const prevent_draft_restoring = (): void => {
     _can_restore_drafts = false;
-}
+};
 
-export function allow_draft_restoring(): void {
+export const allow_draft_restoring = (): void => {
     _can_restore_drafts = true;
-}
+};
 
-export function can_restore_drafts(): boolean {
-    return _can_restore_drafts;
-}
+export const can_restore_drafts = (): boolean => _can_restore_drafts;

--- a/web/src/compose_textarea.ts
+++ b/web/src/compose_textarea.ts
@@ -16,10 +16,10 @@ function set_compose_textarea_handlers(): void {
     });
 }
 
-export function restore_compose_cursor(): void {
+export const restore_compose_cursor = (): void => {
     $("textarea#compose-textarea").trigger("focus").caret(saved_compose_cursor);
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     set_compose_textarea_handlers();
-}
+};

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -16,7 +16,7 @@ import {EXTRA_LONG_HOVER_DELAY, INSTANT_HOVER_DELAY, LONG_HOVER_DELAY} from "./t
 import {parse_html} from "./ui_util";
 import {user_settings} from "./user_settings";
 
-export function initialize(): void {
+export const initialize = (): void => {
     tippy.delegate("body", {
         target: [
             // Ideally this would be `#compose_buttons .button`, but the
@@ -30,7 +30,7 @@ export function initialize(): void {
         // trigger after it closes, which results in tooltip being displayed.
         trigger: "mouseenter",
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -42,7 +42,7 @@ export function initialize(): void {
         // trigger after it closes, which results in tooltip being displayed.
         trigger: "mouseenter",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const $elem = $(instance.reference);
             const button_type = $elem.attr("data-reply-button-type");
             switch (button_type) {
@@ -76,7 +76,7 @@ export function initialize(): void {
                 }
             }
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -89,7 +89,7 @@ export function initialize(): void {
         // trigger after it closes, which results in tooltip being displayed.
         trigger: "mouseenter",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const $elem = $(instance.reference);
             const conversation_type = $elem.attr("data-conversation-type");
             if (conversation_type === "direct") {
@@ -110,7 +110,7 @@ export function initialize(): void {
             );
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -139,7 +139,7 @@ export function initialize(): void {
         // If the button is `.disabled-on-hover`, then we want to show the
         // tooltip instantly, to make it clear to the user that the button
         // is disabled, and why.
-        onTrigger(instance, event) {
+        onTrigger: (instance, event) => {
             assert(event.currentTarget instanceof HTMLElement);
             if (event.currentTarget.classList.contains("disabled-on-hover")) {
                 instance.setProps({delay: INSTANT_HOVER_DELAY});
@@ -153,7 +153,7 @@ export function initialize(): void {
         target: ".send-control-button",
         delay: LONG_HOVER_DELAY,
         placement: "top",
-        onShow(instance) {
+        onShow: (instance) => {
             // Don't show send-area tooltips if the popover is displayed.
             if (popover_menus.is_scheduled_messages_popover_displayed()) {
                 return false;
@@ -184,7 +184,7 @@ export function initialize(): void {
         // Send tooltip when tabbing to the Send button.
         trigger: "mouseenter",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             // Don't show Send button tooltip if the popover is displayed.
             if (popover_menus.is_scheduled_messages_popover_displayed()) {
                 return false;
@@ -202,7 +202,7 @@ export function initialize(): void {
         target: ".narrow_to_compose_recipients",
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
-        content() {
+        content: () => {
             const narrow_filter = narrow_state.filter();
             let display_current_view;
             if (narrow_state.is_message_feed_visible()) {
@@ -231,7 +231,7 @@ export function initialize(): void {
 
             return parse_html(render_narrow_to_compose_recipients_tooltip({display_current_view}));
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -245,8 +245,8 @@ export function initialize(): void {
             compose_recipient.get_posting_policy_error_message() ||
             compose_validate.get_disabled_send_tooltip(),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
-}
+};

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -63,40 +63,38 @@ export let code_formatting_button_triggered = false; // true or false
 export let compose_textarea_typeahead: Typeahead<TypeaheadSuggestion> | undefined;
 let full_size_status = false; // true or false
 
-export function set_compose_textarea_typeahead(typeahead: Typeahead<TypeaheadSuggestion>): void {
+export const set_compose_textarea_typeahead = (typeahead: Typeahead<TypeaheadSuggestion>): void => {
     compose_textarea_typeahead = typeahead;
-}
+};
 
-export function set_code_formatting_button_triggered(value: boolean): void {
+export const set_code_formatting_button_triggered = (value: boolean): void => {
     code_formatting_button_triggered = value;
-}
+};
 
 // Some functions to handle the full size status explicitly
-export function set_full_size(is_full: boolean): void {
+export const set_full_size = (is_full: boolean): void => {
     full_size_status = is_full;
     // Show typeahead at bottom of textarea on compose full size.
     if (compose_textarea_typeahead) {
         compose_textarea_typeahead.dropup = !is_full;
     }
-}
+};
 
-export function is_full_size(): boolean {
-    return full_size_status;
-}
+export const is_full_size = (): boolean => full_size_status;
 
-export function autosize_textarea($textarea: JQuery<HTMLTextAreaElement>): void {
+export const autosize_textarea = ($textarea: JQuery<HTMLTextAreaElement>): void => {
     // Since this supports both compose and file upload, one must pass
     // in the text area to autosize.
     if (!is_full_size()) {
         autosize.update($textarea);
     }
-}
+};
 
-export function insert_and_scroll_into_view(
+export const insert_and_scroll_into_view = (
     content: string,
     $textarea: JQuery<HTMLTextAreaElement>,
     replace_all = false,
-): void {
+): void => {
     if (replace_all) {
         setFieldText($textarea[0]!, content);
     } else {
@@ -107,9 +105,9 @@ export function insert_and_scroll_into_view(
     $textarea.trigger("blur");
     $textarea.trigger("focus");
     autosize_textarea($textarea);
-}
+};
 
-function get_focus_area(opts: ComposeTriggeredOptions): string {
+const get_focus_area = (opts: ComposeTriggeredOptions): string => {
     // Set focus to "Topic" when narrowed to a stream+topic
     // and "Start new conversation" button clicked.
     if (opts.message_type === "stream" && opts.stream_id && !opts.topic) {
@@ -128,12 +126,12 @@ function get_focus_area(opts: ComposeTriggeredOptions): string {
         return "#compose_select_recipient_widget_wrapper";
     }
     return "#private_message_recipient";
-}
+};
 
 // Export for testing
 export const _get_focus_area = get_focus_area;
 
-export function set_focus(opts: ComposeTriggeredOptions): void {
+export const set_focus = (opts: ComposeTriggeredOptions): void => {
     // Called mainly when opening the compose box or switching the
     // message type to set the focus in the first empty input in the
     // compose box.
@@ -141,12 +139,13 @@ export function set_focus(opts: ComposeTriggeredOptions): void {
         const focus_area = get_focus_area(opts);
         $(focus_area).trigger("focus");
     }
-}
+};
 
-export function smart_insert_inline($textarea: JQuery<HTMLTextAreaElement>, syntax: string): void {
-    function is_space(c: string | undefined): boolean {
-        return c === " " || c === "\t" || c === "\n";
-    }
+export const smart_insert_inline = (
+    $textarea: JQuery<HTMLTextAreaElement>,
+    syntax: string,
+): void => {
+    const is_space = (c: string | undefined): boolean => c === " " || c === "\t" || c === "\n";
 
     const pos = $textarea.caret();
     const before_str = $textarea.val()!.slice(0, pos);
@@ -175,13 +174,13 @@ export function smart_insert_inline($textarea: JQuery<HTMLTextAreaElement>, synt
     }
 
     insert_and_scroll_into_view(syntax, $textarea);
-}
+};
 
-export function smart_insert_block(
+export const smart_insert_block = (
     $textarea: JQuery<HTMLTextAreaElement>,
     syntax: string,
     padding_newlines = 2,
-): void {
+): void => {
     const pos = $textarea.caret();
     const before_str = $textarea.val()!.slice(0, pos);
     const after_str = $textarea.val()!.slice(pos);
@@ -225,14 +224,14 @@ export function smart_insert_block(
     syntax = syntax + "\n".repeat(new_lines_needed_after_count);
 
     insert_and_scroll_into_view(syntax, $textarea);
-}
+};
 
-export function insert_syntax_and_focus(
+export const insert_syntax_and_focus = (
     syntax: string,
     $textarea = $<HTMLTextAreaElement>("textarea#compose-textarea"),
     mode = "inline",
     padding_newlines?: number,
-): void {
+): void => {
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
     // wrapper around smart_insert_inline and smart_inline_block.
@@ -252,13 +251,13 @@ export function insert_syntax_and_focus(
     } else if (mode === "block") {
         smart_insert_block($textarea, syntax, padding_newlines);
     }
-}
+};
 
-export function replace_syntax(
+export const replace_syntax = (
     old_syntax: string,
     new_syntax: string,
     $textarea = $<HTMLTextAreaElement>("textarea#compose-textarea"),
-): boolean {
+): boolean => {
     // The following couple lines are needed to later restore the initial
     // logical position of the cursor after the replacement
     const prev_caret = $textarea.caret();
@@ -297,9 +296,9 @@ export function replace_syntax(
 
     // Return if anything was actually replaced.
     return old_text !== new_text;
-}
+};
 
-export function compute_placeholder_text(opts: ComposePlaceholderOptions): string {
+export const compute_placeholder_text = (opts: ComposePlaceholderOptions): string => {
     // Computes clear placeholder text for the compose box, depending
     // on what heading values have already been filled out.
     //
@@ -347,9 +346,9 @@ export function compute_placeholder_text(opts: ComposePlaceholderOptions): strin
         return $t({defaultMessage: "Message {recipient_names}"}, {recipient_names});
     }
     return DEFAULT_COMPOSE_PLACEHOLDER;
-}
+};
 
-export function set_compose_box_top(set_top: boolean): void {
+export const set_compose_box_top = (set_top: boolean): void => {
     if (set_top) {
         // As `#compose` has `position: fixed` property, we cannot
         // make the compose-box to attain the correct height just by
@@ -361,9 +360,9 @@ export function set_compose_box_top(set_top: boolean): void {
     } else {
         $("#compose").css("top", "");
     }
-}
+};
 
-export function make_compose_box_full_size(): void {
+export const make_compose_box_full_size = (): void => {
     set_full_size(true);
 
     // The autosize should be destroyed for the full size compose
@@ -379,9 +378,9 @@ export function make_compose_box_full_size(): void {
     $(".expand_composebox_button").hide();
     $("#scroll-to-bottom-button-container").removeClass("show");
     $("textarea#compose-textarea").trigger("focus");
-}
+};
 
-export function make_compose_box_original_size(): void {
+export const make_compose_box_original_size = (): void => {
     set_full_size(false);
 
     $("#compose").removeClass("compose-fullscreen");
@@ -396,12 +395,12 @@ export function make_compose_box_original_size(): void {
     $(".collapse_composebox_button").hide();
     $(".expand_composebox_button").show();
     $("textarea#compose-textarea").trigger("focus");
-}
+};
 
-export function handle_keydown(
+export const handle_keydown = (
     event: JQuery.KeyboardEventBase,
     $textarea: JQuery<HTMLTextAreaElement>,
-): void {
+): void => {
     if (event.key === "Shift") {
         shift_pressed = true;
     }
@@ -427,29 +426,29 @@ export function handle_keydown(
         autosize_textarea($textarea);
         event.preventDefault();
     }
-}
+};
 
-export function handle_keyup(
+export const handle_keyup = (
     _event: JQuery.KeyboardEventBase,
     $textarea: JQuery<HTMLTextAreaElement>,
-): void {
+): void => {
     if (_event?.key === "Shift") {
         shift_pressed = false;
     }
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     rtl.set_rtl_class_for_textarea($textarea);
-}
+};
 
-export function cursor_inside_code_block($textarea: JQuery<HTMLTextAreaElement>): boolean {
+export const cursor_inside_code_block = ($textarea: JQuery<HTMLTextAreaElement>): boolean => {
     // Returns whether the cursor is at a point that would be inside
     // a code block on rendering the textarea content as markdown.
     const cursor_position = $textarea.caret();
     const current_content = $textarea.val()!;
 
     return position_inside_code_block(current_content, cursor_position);
-}
+};
 
-export function position_inside_code_block(content: string, position: number): boolean {
+export const position_inside_code_block = (content: string, position: number): boolean => {
     let unique_insert = "UNIQUEINSERT:" + Math.random();
     while (content.includes(unique_insert)) {
         unique_insert = "UNIQUEINSERT:" + Math.random();
@@ -460,13 +459,13 @@ export function position_inside_code_block(content: string, position: number): b
     const rendered_html = new DOMParser().parseFromString(rendered_content, "text/html");
     const code_blocks = rendered_html.querySelectorAll("pre > code");
     return [...code_blocks].some((code_block) => code_block?.textContent?.includes(unique_insert));
-}
+};
 
-export function format_text(
+export const format_text = (
     $textarea: JQuery<HTMLTextAreaElement>,
     type: string,
     inserted_content = "",
-): void {
+): void => {
     const italic_syntax = "*";
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
@@ -1114,26 +1113,26 @@ export function format_text(
             break;
         }
     }
-}
+};
 
 /* TODO: This functions don't belong in this module, as they have
  * nothing to do with the compose textarea. */
-export function hide_compose_spinner(): void {
+export const hide_compose_spinner = (): void => {
     compose_spinner_visible = false;
     $(".compose-submit-button .loader").hide();
     $(".compose-submit-button .zulip-icon-send").show();
     $(".compose-submit-button").removeClass("disable-btn");
-}
+};
 
-export function show_compose_spinner(): void {
+export const show_compose_spinner = (): void => {
     compose_spinner_visible = true;
     // Always use white spinner.
     loading.show_button_spinner($(".compose-submit-button .loader"), true);
     $(".compose-submit-button .zulip-icon-send").hide();
     $(".compose-submit-button").addClass("disable-btn");
-}
+};
 
-export function get_compose_click_target(element: HTMLElement): Element {
+export const get_compose_click_target = (element: HTMLElement): Element => {
     const compose_control_buttons_popover = popover_menus.get_compose_control_buttons_popover();
     if (
         compose_control_buttons_popover &&
@@ -1142,4 +1141,4 @@ export function get_compose_click_target(element: HTMLElement): Element {
         return compose_control_buttons_popover.reference;
     }
     return element;
-}
+};

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -42,29 +42,29 @@ type StreamWildcardOptions = {
 
 export let wildcard_mention_threshold = 15;
 
-export function set_upload_in_progress(status: boolean): void {
+export const set_upload_in_progress = (status: boolean): void => {
     upload_in_progress = status;
     update_send_button_status();
-}
+};
 
-function set_message_too_long(status: boolean): void {
+const set_message_too_long = (status: boolean): void => {
     message_too_long = status;
     update_send_button_status();
-}
+};
 
-export function set_recipient_disallowed(status: boolean): void {
+export const set_recipient_disallowed = (status: boolean): void => {
     recipient_disallowed = status;
     update_send_button_status();
-}
+};
 
-function update_send_button_status(): void {
+const update_send_button_status = (): void => {
     $(".message-send-controls").toggleClass(
         "disabled-message-send-controls",
         message_too_long || upload_in_progress || recipient_disallowed,
     );
-}
+};
 
-export function get_disabled_send_tooltip(): string {
+export const get_disabled_send_tooltip = (): string => {
     if (message_too_long) {
         return $t(
             {defaultMessage: `Message length shouldn't be greater than {max_length} characters.`},
@@ -74,9 +74,9 @@ export function get_disabled_send_tooltip(): string {
         return $t({defaultMessage: "Cannot send message while files are being uploaded."});
     }
     return "";
-}
+};
 
-export function needs_subscribe_warning(user_id: number, stream_id: number): boolean {
+export const needs_subscribe_warning = (user_id: number, stream_id: number): boolean => {
     // This returns true if all of these conditions are met:
     //  * the user is valid
     //  * the user is not already subscribed to the stream
@@ -108,9 +108,9 @@ export function needs_subscribe_warning(user_id: number, stream_id: number): boo
     }
 
     return true;
-}
+};
 
-function get_stream_id_for_textarea($textarea: JQuery<HTMLTextAreaElement>): number | undefined {
+const get_stream_id_for_textarea = ($textarea: JQuery<HTMLTextAreaElement>): number | undefined => {
     // Returns the stream ID, if any, associated with the textarea:
     // The recipient of a message being edited, or the target
     // recipient of a message being drafted in the compose box.
@@ -131,12 +131,12 @@ function get_stream_id_for_textarea($textarea: JQuery<HTMLTextAreaElement>): num
     }
 
     return compose_state.stream_id();
-}
+};
 
-export function warn_if_private_stream_is_linked(
+export const warn_if_private_stream_is_linked = (
     linked_stream: StreamSubscription,
     $textarea: JQuery<HTMLTextAreaElement>,
-): void {
+): void => {
     const stream_id = get_stream_id_for_textarea($textarea);
 
     if (!stream_id) {
@@ -195,12 +195,12 @@ export function warn_if_private_stream_is_linked(
         });
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
     }
-}
+};
 
-export function warn_if_mentioning_unsubscribed_user(
+export const warn_if_mentioning_unsubscribed_user = (
     mentioned: UserOrMention,
     $textarea: JQuery<HTMLTextAreaElement>,
-): void {
+): void => {
     // Disable for Zephyr mirroring realms, since we never have subscriber lists there
     if (realm.realm_is_zephyr_mirror_realm) {
         return;
@@ -247,18 +247,18 @@ export function warn_if_mentioning_unsubscribed_user(
             compose_banner.append_compose_banner_to_banner_list($(new_row_html), $container);
         }
     }
-}
+};
 
 // Called when clearing the compose box and similar contexts to clear
 // the warning for composing to a resolved topic, if present. Also clears
 // the state for whether this warning has already been shown in the
 // current narrow.
-export function clear_topic_resolved_warning(): void {
+export const clear_topic_resolved_warning = (): void => {
     compose_state.set_recipient_viewed_topic_resolved_banner(false);
     $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.topic_resolved)}`).remove();
-}
+};
 
-export function warn_if_topic_resolved(topic_changed: boolean): void {
+export const warn_if_topic_resolved = (topic_changed: boolean): void => {
     // This function is called with topic_changed=false on every
     // keypress when typing a message, so it should not do anything
     // expensive in that case.
@@ -309,9 +309,9 @@ export function warn_if_topic_resolved(topic_changed: boolean): void {
     } else {
         clear_topic_resolved_warning();
     }
-}
+};
 
-export function warn_if_in_search_view(): void {
+export const warn_if_in_search_view = (): void => {
     const filter = narrow_state.filter();
     if (filter && !filter.supports_collapsing_recipients()) {
         const context = {
@@ -327,9 +327,9 @@ export function warn_if_in_search_view(): void {
         const new_row_html = render_compose_banner(context);
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
     }
-}
+};
 
-function show_stream_wildcard_warnings(opts: StreamWildcardOptions): void {
+const show_stream_wildcard_warnings = (opts: StreamWildcardOptions): void => {
     const subscriber_count = peer_data.get_subscriber_count(opts.stream_id) || 0;
     const stream_name = sub_store.maybe_get_stream_name(opts.stream_id);
     const is_edit_container = opts.$banner_container.closest(".edit_form_banners").length > 0;
@@ -370,18 +370,18 @@ function show_stream_wildcard_warnings(opts: StreamWildcardOptions): void {
     }
 
     user_acknowledged_stream_wildcard = false;
-}
+};
 
-export function clear_stream_wildcard_warnings($banner_container: JQuery): void {
+export const clear_stream_wildcard_warnings = ($banner_container: JQuery): void => {
     const classname = compose_banner.CLASSNAMES.wildcard_warning;
     $banner_container.find(`.${CSS.escape(classname)}`).remove();
-}
+};
 
-export function set_user_acknowledged_stream_wildcard_flag(value: boolean): void {
+export const set_user_acknowledged_stream_wildcard_flag = (value: boolean): void => {
     user_acknowledged_stream_wildcard = value;
-}
+};
 
-export function get_invalid_recipient_emails(): string[] {
+export const get_invalid_recipient_emails = (): string[] => {
     const private_recipients = util.extract_pm_recipients(
         compose_state.private_message_recipient(),
     );
@@ -390,20 +390,20 @@ export function get_invalid_recipient_emails(): string[] {
     );
 
     return invalid_recipients;
-}
+};
 
-function is_recipient_large_stream(): boolean {
+const is_recipient_large_stream = (): boolean => {
     const stream_id = compose_state.stream_id();
     if (stream_id === undefined) {
         return false;
     }
     return peer_data.get_subscriber_count(stream_id) > wildcard_mention_threshold;
-}
+};
 
-export function topic_participant_count_more_than_threshold(
+export const topic_participant_count_more_than_threshold = (
     stream_id: number,
     topic: string,
-): boolean {
+): boolean => {
     // Topic participants:
     // Users who either sent or reacted to the messages in the topic.
     const participant_ids = new Set();
@@ -440,17 +440,17 @@ export function topic_participant_count_more_than_threshold(
     }
 
     return false;
-}
+};
 
-function is_recipient_large_topic(): boolean {
+const is_recipient_large_topic = (): boolean => {
     const stream_id = compose_state.stream_id();
     if (stream_id === undefined) {
         return false;
     }
     return topic_participant_count_more_than_threshold(stream_id, compose_state.topic());
-}
+};
 
-function wildcard_mention_policy_authorizes_user(): boolean {
+const wildcard_mention_policy_authorizes_user = (): boolean => {
     if (
         realm.realm_wildcard_mention_policy ===
         settings_config.wildcard_mention_policy_values.by_everyone.code
@@ -492,21 +492,19 @@ function wildcard_mention_policy_authorizes_user(): boolean {
         return days >= realm.realm_waiting_period_threshold && !current_user.is_guest;
     }
     return !current_user.is_guest;
-}
+};
 
-export function stream_wildcard_mention_allowed(): boolean {
-    return !is_recipient_large_stream() || wildcard_mention_policy_authorizes_user();
-}
+export const stream_wildcard_mention_allowed = (): boolean =>
+    !is_recipient_large_stream() || wildcard_mention_policy_authorizes_user();
 
-export function topic_wildcard_mention_allowed(): boolean {
-    return !is_recipient_large_topic() || wildcard_mention_policy_authorizes_user();
-}
+export const topic_wildcard_mention_allowed = (): boolean =>
+    !is_recipient_large_topic() || wildcard_mention_policy_authorizes_user();
 
-export function set_wildcard_mention_threshold(value: number): void {
+export const set_wildcard_mention_threshold = (value: number): void => {
     wildcard_mention_threshold = value;
-}
+};
 
-export function validate_stream_message_mentions(opts: StreamWildcardOptions): boolean {
+export const validate_stream_message_mentions = (opts: StreamWildcardOptions): boolean => {
     const subscriber_count = peer_data.get_subscriber_count(opts.stream_id) || 0;
 
     // If the user is attempting to do a wildcard mention in a large
@@ -541,17 +539,17 @@ export function validate_stream_message_mentions(opts: StreamWildcardOptions): b
     user_acknowledged_stream_wildcard = false;
 
     return true;
-}
+};
 
-export function validate_stream_message_address_info(sub: StreamSubscription): boolean {
+export const validate_stream_message_address_info = (sub: StreamSubscription): boolean => {
     if (sub.subscribed) {
         return true;
     }
     compose_banner.show_stream_not_subscribed_error(sub);
     return false;
-}
+};
 
-function validate_stream_message(scheduling_message: boolean): boolean {
+const validate_stream_message = (scheduling_message: boolean): boolean => {
     const stream_id = compose_state.stream_id();
     const $banner_container = $("#compose_banners");
     if (stream_id === undefined) {
@@ -613,11 +611,11 @@ function validate_stream_message(scheduling_message: boolean): boolean {
     }
 
     return true;
-}
+};
 
 // The function checks whether the recipients are users of the realm or cross realm users (bots
 // for now)
-function validate_private_message(): boolean {
+const validate_private_message = (): boolean => {
     const user_ids = compose_pm_pill.get_user_ids();
     const $banner_container = $("#compose_banners");
 
@@ -684,9 +682,9 @@ function validate_private_message(): boolean {
     }
 
     return true;
-}
+};
 
-export function check_overflow_text(): number {
+export const check_overflow_text = (): number => {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
     // expensive.
@@ -721,18 +719,18 @@ export function check_overflow_text(): number {
     }
 
     return text.length;
-}
+};
 
-export function validate_message_length(): boolean {
+export const validate_message_length = (): boolean => {
     if (compose_state.message_content().length > realm.max_message_length) {
         $("textarea#compose-textarea").addClass("flash");
         setTimeout(() => $("textarea#compose-textarea").removeClass("flash"), 1500);
         return false;
     }
     return true;
-}
+};
 
-export function validate(scheduling_message: boolean): boolean {
+export const validate = (scheduling_message: boolean): boolean => {
     const message_content = compose_state.message_content();
     if (/^\s*$/.test(message_content)) {
         $("textarea#compose-textarea").toggleClass("invalid", true);
@@ -758,13 +756,13 @@ export function validate(scheduling_message: boolean): boolean {
         return validate_private_message();
     }
     return validate_stream_message(scheduling_message);
-}
+};
 
-export function convert_mentions_to_silent_in_direct_messages(
+export const convert_mentions_to_silent_in_direct_messages = (
     mention_text: string,
     full_name: string,
     user_id: number,
-): string {
+): string => {
     if (compose_state.get_message_type() !== "private") {
         return mention_text;
     }
@@ -783,4 +781,4 @@ export function convert_mentions_to_silent_in_direct_messages(
 
     const silent_mention_text = people.get_mention_syntax(full_name, user_id, true);
     return silent_mention_text;
-}
+};

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -115,21 +115,21 @@ export let emoji_collection: Emoji[] = [];
 let completing: string | null;
 let token: string;
 
-export function get_or_set_token_for_testing(val?: string): string {
+export const get_or_set_token_for_testing = (val?: string): string => {
     if (val !== undefined) {
         token = val;
     }
     return token;
-}
+};
 
-export function get_or_set_completing_for_tests(val?: string): string | null {
+export const get_or_set_completing_for_tests = (val?: string): string | null => {
     if (val !== undefined) {
         completing = val;
     }
     return completing;
-}
+};
 
-export function update_emoji_data(initial_emojis: EmojiDict[]): void {
+export const update_emoji_data = (initial_emojis: EmojiDict[]): void => {
     emoji_collection = [];
     for (const emoji_dict of initial_emojis) {
         const {reaction_type} = emoji.get_emoji_details_by_name(emoji_dict.name);
@@ -154,9 +154,9 @@ export function update_emoji_data(initial_emojis: EmojiDict[]): void {
             }
         }
     }
-}
+};
 
-export function topics_seen_for(stream_id?: number): string[] {
+export const topics_seen_for = (stream_id?: number): string[] => {
     if (!stream_id) {
         return [];
     }
@@ -169,46 +169,38 @@ export function topics_seen_for(stream_id?: number): string[] {
         // select/click an option.
     });
     return stream_topic_history.get_recent_topic_names(stream_id);
-}
+};
 
-export function get_language_matcher(query: string): (language: string) => boolean {
+export const get_language_matcher = (query: string): ((language: string) => boolean) => {
     query = query.toLowerCase();
-    return function (language: string): boolean {
-        return language.includes(query);
-    };
-}
+    return (language: string): boolean => language.includes(query);
+};
 
-export function get_stream_or_user_group_matcher(
+export const get_stream_or_user_group_matcher = (
     query: string,
-): (user_group_or_stream: UserGroupPillData | StreamPillData) => boolean {
+): ((user_group_or_stream: UserGroupPillData | StreamPillData) => boolean) => {
     // Case-insensitive.
     query = typeahead.clean_query_lowercase(query);
 
-    return function (user_group_or_stream: UserGroupPillData | StreamPillData) {
-        return typeahead_helper.query_matches_name(query, user_group_or_stream);
-    };
-}
+    return (user_group_or_stream: UserGroupPillData | StreamPillData) =>
+        typeahead_helper.query_matches_name(query, user_group_or_stream);
+};
 
-export function get_slash_matcher(query: string): (item: SlashCommand) => boolean {
+export const get_slash_matcher = (query: string): ((item: SlashCommand) => boolean) => {
     query = typeahead.clean_query_lowercase(query);
 
-    return function (item: SlashCommand) {
-        return (
-            typeahead.query_matches_string_in_order(query, item.name, " ") ||
-            typeahead.query_matches_string_in_order(query, item.aliases, " ")
-        );
-    };
-}
+    return (item: SlashCommand) =>
+        typeahead.query_matches_string_in_order(query, item.name, " ") ||
+        typeahead.query_matches_string_in_order(query, item.aliases, " ");
+};
 
-function get_topic_matcher(query: string): (topic: string) => boolean {
+const get_topic_matcher = (query: string): ((topic: string) => boolean) => {
     query = typeahead.clean_query_lowercase(query);
 
-    return function (topic: string): boolean {
-        return typeahead.query_matches_string_in_order(query, topic, " ");
-    };
-}
+    return (topic: string): boolean => typeahead.query_matches_string_in_order(query, topic, " ");
+};
 
-export function should_enter_send(e: JQuery.KeyDownEvent): boolean {
+export const should_enter_send = (e: JQuery.KeyDownEvent): boolean => {
     const has_non_shift_modifier_key = e.ctrlKey || e.metaKey || e.altKey;
     const has_modifier_key = e.shiftKey || has_non_shift_modifier_key;
     let this_enter_sends;
@@ -228,12 +220,12 @@ export function should_enter_send(e: JQuery.KeyDownEvent): boolean {
         this_enter_sends = has_non_shift_modifier_key;
     }
     return this_enter_sends;
-}
+};
 
-function handle_bulleting_or_numbering(
+const handle_bulleting_or_numbering = (
     $textarea: JQuery<HTMLTextAreaElement>,
     e: JQuery.KeyDownEvent,
-): void {
+): void => {
     // We only want this functionality if the cursor is not in a code block
     if (compose_ui.cursor_inside_code_block($textarea)) {
         return;
@@ -280,9 +272,12 @@ function handle_bulleting_or_numbering(
     // else we add the bulleting / numbering syntax to the new line
     compose_ui.insert_and_scroll_into_view("\n" + to_append, $textarea);
     e.preventDefault();
-}
+};
 
-export function handle_enter($textarea: JQuery<HTMLTextAreaElement>, e: JQuery.KeyDownEvent): void {
+export const handle_enter = (
+    $textarea: JQuery<HTMLTextAreaElement>,
+    e: JQuery.KeyDownEvent,
+): void => {
     // Used only if Enter doesn't send. We need to emulate the
     // browser's native "Enter" behavior because this code path
     // includes `Ctrl+Enter` and other modifier key variants that
@@ -309,7 +304,7 @@ export function handle_enter($textarea: JQuery<HTMLTextAreaElement>, e: JQuery.K
         // insertion or removal of bulleting / numbering.
         handle_bulleting_or_numbering($textarea, e);
     }
-}
+};
 
 // nextFocus is set on a keydown event to indicate where we should focus on keyup.
 // We can't focus at the time of keydown because we need to wait for typeahead.
@@ -317,10 +312,10 @@ export function handle_enter($textarea: JQuery<HTMLTextAreaElement>, e: JQuery.K
 // has reliable information about whether it was a Tab or a Shift+Tab.
 let $nextFocus: JQuery | undefined;
 
-function handle_keydown(
+const handle_keydown = (
     e: JQuery.KeyDownEvent,
     on_enter_send: (scheduling_message?: boolean) => boolean | undefined,
-): void {
+): void => {
     const key = e.key;
 
     if (keydown_util.is_enter_event(e) || (key === "Tab" && !e.shiftKey)) {
@@ -373,9 +368,9 @@ function handle_keydown(
             $nextFocus = $("textarea#compose-textarea");
         }
     }
-}
+};
 
-function handle_keyup(e: JQuery.KeyUpEvent): void {
+const handle_keyup = (e: JQuery.KeyUpEvent): void => {
     if (
         // Enter key or Tab key
         (keydown_util.is_enter_event(e) || (e.key === "Tab" && !e.shiftKey)) &&
@@ -387,14 +382,14 @@ function handle_keyup(e: JQuery.KeyUpEvent): void {
         // Prevent the form from submitting
         e.preventDefault();
     }
-}
+};
 
-export function split_at_cursor(query: string, $input: JQuery): [string, string] {
+export const split_at_cursor = (query: string, $input: JQuery): [string, string] => {
     const cursor = $input.caret();
     return [query.slice(0, cursor), query.slice(cursor)];
-}
+};
 
-export function tokenize_compose_str(s: string): string {
+export const tokenize_compose_str = (s: string): string => {
     // This basically finds a token like "@alic" or
     // "#Veron" as close to the end of the string as it
     // can find it.  It wants to find white space or
@@ -460,9 +455,9 @@ export function tokenize_compose_str(s: string): string {
     }
 
     return "";
-}
+};
 
-function get_wildcard_string(mention: string): string {
+const get_wildcard_string = (mention: string): string => {
     if (compose_state.get_message_type() === "private") {
         return $t({defaultMessage: "Notify recipients"});
     }
@@ -470,9 +465,9 @@ function get_wildcard_string(mention: string): string {
         return $t({defaultMessage: "Notify topic"});
     }
     return $t({defaultMessage: "Notify channel"});
-}
+};
 
-export function broadcast_mentions(): PseudoMentionUser[] {
+export const broadcast_mentions = (): PseudoMentionUser[] => {
     let wildcard_mention_array: string[] = [];
     if (compose_state.get_message_type() === "private") {
         wildcard_mention_array = ["all", "everyone"];
@@ -497,9 +492,9 @@ export function broadcast_mentions(): PseudoMentionUser[] {
         // used for sorting
         idx,
     }));
-}
+};
 
-function filter_mention_name(current_token: string): string | undefined {
+const filter_mention_name = (current_token: string): string | undefined => {
     if (current_token.startsWith("**")) {
         current_token = current_token.slice(2);
     } else if (current_token.startsWith("*")) {
@@ -514,9 +509,9 @@ function filter_mention_name(current_token: string): string | undefined {
         return undefined;
     }
     return current_token;
-}
+};
 
-function should_show_custom_query(query: string, items: string[]): boolean {
+const should_show_custom_query = (query: string, items: string[]): boolean => {
     // returns true if the custom query doesn't match one of the
     // choices in the items list.
     if (!query) {
@@ -524,7 +519,7 @@ function should_show_custom_query(query: string, items: string[]): boolean {
     }
     const matched = items.some((elem) => elem.toLowerCase() === query.toLowerCase());
     return !matched;
-}
+};
 
 export const dev_only_slash_commands = [
     {
@@ -562,15 +557,15 @@ export const slash_commands = [
 
 export const all_slash_commands: SlashCommand[] = [...dev_only_slash_commands, ...slash_commands];
 
-export function filter_and_sort_mentions(
+export const filter_and_sort_mentions = (
     is_silent: boolean,
     query: string,
     opts: {
         stream_id: number | undefined;
         topic: string | undefined;
     },
-): (UserGroupPillData | UserOrMentionPillData)[] {
-    return get_person_suggestions(query, {
+): (UserGroupPillData | UserOrMentionPillData)[] =>
+    get_person_suggestions(query, {
         want_broadcast: !is_silent,
         filter_pills: false,
         filter_groups_for_mention: !is_silent,
@@ -579,9 +574,8 @@ export function filter_and_sort_mentions(
         ...item,
         is_silent,
     }));
-}
 
-export function get_pm_people(query: string): (UserGroupPillData | UserPillData)[] {
+export const get_pm_people = (query: string): (UserGroupPillData | UserPillData)[] => {
     const opts = {
         want_broadcast: false,
         filter_pills: true,
@@ -599,7 +593,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         user_suggestions.push(suggestion);
     }
     return user_suggestions;
-}
+};
 
 type PersonSuggestionOpts = {
     want_broadcast: boolean;
@@ -610,13 +604,13 @@ type PersonSuggestionOpts = {
     filter_groups_for_mention?: boolean;
 };
 
-export function get_person_suggestions(
+export const get_person_suggestions = (
     query: string,
     opts: PersonSuggestionOpts,
-): (UserOrMentionPillData | UserGroupPillData)[] {
+): (UserOrMentionPillData | UserGroupPillData)[] => {
     query = typeahead.clean_query_lowercase(query);
 
-    function filter_persons(all_persons: User[]): UserOrMentionPillData[] {
+    const filter_persons = (all_persons: User[]): UserOrMentionPillData[] => {
         let persons;
 
         if (opts.filter_pills) {
@@ -642,7 +636,7 @@ export function get_person_suggestions(
         }
 
         return person_items.filter((item) => typeahead_helper.query_matches_person(query, item));
-    }
+    };
 
     let groups: UserGroup[];
     if (opts.filter_groups_for_mention) {
@@ -713,12 +707,14 @@ export function get_person_suggestions(
         groups: filtered_groups,
         max_num_items,
     });
-}
+};
 
-function get_stream_topic_data(input_element: TypeaheadInputElement): {
+const get_stream_topic_data = (
+    input_element: TypeaheadInputElement,
+): {
     stream_id: number | undefined;
     topic: string | undefined;
-} {
+} => {
     let stream_id;
     let topic;
     const $message_row = input_element.$element.closest(".message_row");
@@ -738,7 +734,7 @@ function get_stream_topic_data(input_element: TypeaheadInputElement): {
         stream_id,
         topic,
     };
-}
+};
 
 const ALLOWED_MARKDOWN_FEATURES = {
     mention: true,
@@ -751,10 +747,10 @@ const ALLOWED_MARKDOWN_FEATURES = {
     timestamp: true,
 };
 
-export function get_candidates(
+export const get_candidates = (
     query: string,
     input_element: TypeaheadInputElement,
-): TypeaheadSuggestion[] {
+): TypeaheadSuggestion[] => {
     const split = split_at_cursor(query, input_element.$element);
     let current_token: string | boolean = tokenize_compose_str(split[0]);
     if (current_token === "") {
@@ -856,10 +852,10 @@ export function get_candidates(
         return filter_and_sort_mentions(is_silent, token, opts);
     }
 
-    function get_slash_commands_data(): SlashCommand[] {
+    const get_slash_commands_data = (): SlashCommand[] => {
         const commands = page_params.development_environment ? all_slash_commands : slash_commands;
         return commands;
-    }
+    };
 
     if (ALLOWED_MARKDOWN_FEATURES.slash && current_token.startsWith("/")) {
         current_token = current_token.slice(1);
@@ -962,9 +958,9 @@ export function get_candidates(
         }
     }
     return [];
-}
+};
 
-export function content_highlighter_html(item: TypeaheadSuggestion): string | undefined {
+export const content_highlighter_html = (item: TypeaheadSuggestion): string | undefined => {
     switch (item.type) {
         case "emoji":
             return typeahead_helper.render_emoji(item);
@@ -989,14 +985,14 @@ export function content_highlighter_html(item: TypeaheadSuggestion): string | un
         default:
             return undefined;
     }
-}
+};
 
-export function content_typeahead_selected(
+export const content_typeahead_selected = (
     item: TypeaheadSuggestion,
     query: string,
     input_element: TypeaheadInputElement,
     event?: JQuery.ClickEvent | JQuery.KeyUpEvent | JQuery.KeyDownEvent,
-): string {
+): string => {
     const pieces = split_at_cursor(query, input_element.$element);
     let beginning = pieces[0];
     let rest = pieces[1];
@@ -1177,55 +1173,54 @@ export function content_typeahead_selected(
         compose_ui.autosize_textarea($textbox);
     }, 0);
     return beginning + rest;
-}
+};
 
-export function compose_automated_selection(): boolean {
+export const compose_automated_selection = (): boolean => {
     if (completing === "topic_jump") {
         // automatically jump inside stream mention on typing > just after
         // a stream mention, to begin stream+topic mention typeahead (topic_list).
         return true;
     }
     return false;
-}
+};
 
-function compose_trigger_selection(event: JQuery.KeyDownEvent): boolean {
+const compose_trigger_selection = (event: JQuery.KeyDownEvent): boolean => {
     if (completing === "stream" && event.key === ">") {
         // complete stream typeahead partially to immediately start the topic_list typeahead.
         return true;
     }
     return false;
-}
+};
 
-export function initialize_topic_edit_typeahead(
+export const initialize_topic_edit_typeahead = (
     form_field: JQuery<HTMLInputElement>,
     stream_name: string,
     dropup: boolean,
-): Typeahead<string> {
+): Typeahead<string> => {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: form_field,
         type: "input",
     };
     return new Typeahead(bootstrap_typeahead_input, {
         dropup,
-        highlighter_html(item: string): string {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
-        sorter(items: string[], query: string): string[] {
+        highlighter_html: (item: string): string =>
+            typeahead_helper.render_typeahead_item({primary: item}),
+        sorter: (items: string[], query: string): string[] => {
             const sorted = typeahead_helper.sorter(query, items, (x) => x);
             if (sorted.length > 0 && !sorted.includes(query)) {
                 sorted.unshift(query);
             }
             return sorted;
         },
-        source(): string[] {
+        source: (): string[] => {
             const stream_id = stream_data.get_stream_id(stream_name);
             return topics_seen_for(stream_id);
         },
         items: 5,
     });
-}
+};
 
-function get_header_html(): string | false {
+const get_header_html = (): string | false => {
     let tip_text = "";
     switch (completing) {
         case "stream":
@@ -1247,9 +1242,9 @@ function get_header_html(): string | false {
             return false;
     }
     return `<em>${_.escape(tip_text)}</em>`;
-}
+};
 
-export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElement>): void {
+export const initialize_compose_typeahead = ($element: JQuery<HTMLTextAreaElement>): void => {
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element,
         type: "textarea",
@@ -1265,12 +1260,8 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             // inside the typeahead library.
             source: get_candidates,
             highlighter_html: content_highlighter_html,
-            matcher() {
-                return true;
-            },
-            sorter(items) {
-                return items;
-            },
+            matcher: () => true,
+            sorter: (items) => items,
             updater: content_typeahead_selected,
             stopAdvance: true, // Do not advance to the next field on a Tab or Enter
             automated: compose_automated_selection,
@@ -1278,13 +1269,13 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             header_html: get_header_html,
         }),
     );
-}
+};
 
-export function initialize({
+export const initialize = ({
     on_enter_send,
 }: {
     on_enter_send: (scheduling_message?: boolean) => boolean | undefined;
-}): void {
+}): void => {
     // These handlers are at the "form" level so that they are called after typeahead
     $("form#send_message_form").on("keydown", (e) => {
         handle_keydown(e, on_enter_send);
@@ -1296,21 +1287,18 @@ export function initialize({
         type: "input",
     };
     new Typeahead(stream_message_typeahead_input, {
-        source(): string[] {
-            return topics_seen_for(compose_state.stream_id());
-        },
+        source: (): string[] => topics_seen_for(compose_state.stream_id()),
         items: 3,
-        highlighter_html(item: string): string {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
-        sorter(items: string[], query: string): string[] {
+        highlighter_html: (item: string): string =>
+            typeahead_helper.render_typeahead_item({primary: item}),
+        sorter: (items: string[], query: string): string[] => {
             const sorted = typeahead_helper.sorter(query, items, (x) => x);
             if (sorted.length > 0 && !sorted.includes(query)) {
                 sorted.unshift(query);
             }
             return sorted;
         },
-        option_label(matching_items: string[], item: string): string | false {
+        option_label: (matching_items: string[], item: string): string | false => {
             if (!matching_items.includes(item)) {
                 return `<em>${$t({defaultMessage: "New"})}</em>`;
             }
@@ -1327,16 +1315,13 @@ export function initialize({
         source: get_pm_people,
         items: max_num_items,
         dropup: true,
-        highlighter_html(item: UserGroupPillData | UserPillData) {
-            return typeahead_helper.render_person_or_user_group(item);
-        },
-        matcher(): boolean {
-            return true;
-        },
-        sorter(items: (UserGroupPillData | UserPillData)[]): (UserGroupPillData | UserPillData)[] {
-            return items;
-        },
-        updater(item: UserGroupPillData | UserPillData): undefined {
+        highlighter_html: (item: UserGroupPillData | UserPillData) =>
+            typeahead_helper.render_person_or_user_group(item),
+        matcher: (): boolean => true,
+        sorter: (
+            items: (UserGroupPillData | UserPillData)[],
+        ): (UserGroupPillData | UserPillData)[] => items,
+        updater: (item: UserGroupPillData | UserPillData): undefined => {
             if (item.type === "user_group") {
                 for (const user_id of item.members) {
                     const user = people.get_by_user_id(user_id);
@@ -1365,4 +1350,4 @@ export function initialize({
     });
 
     initialize_compose_typeahead($("textarea#compose-textarea"));
-}
+};

--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -19,35 +19,35 @@ This library implements two related, similar concepts:
 
 */
 
-function show_more_link($row: JQuery): void {
+const show_more_link = ($row: JQuery): void => {
     $row.find(".message_condenser").hide();
     $row.find(".message_expander").show();
-}
+};
 
-function show_condense_link($row: JQuery): void {
+const show_condense_link = ($row: JQuery): void => {
     $row.find(".message_expander").hide();
     $row.find(".message_condenser").show();
-}
+};
 
-function condense_row($row: JQuery): void {
+const condense_row = ($row: JQuery): void => {
     const $content = $row.find(".message_content");
     $content.addClass("condensed");
     show_more_link($row);
-}
+};
 
-function uncondense_row($row: JQuery): void {
+const uncondense_row = ($row: JQuery): void => {
     const $content = $row.find(".message_content");
     $content.removeClass("condensed");
     show_condense_link($row);
-}
+};
 
-export function uncollapse(message: Message): void {
+export const uncollapse = (message: Message): void => {
     // Uncollapse a message, restoring the condensed message "Show more" or
     // "Show less" button if necessary.
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
 
-    const process_row = function process_row($row: JQuery): void {
+    const process_row = ($row: JQuery): void => {
         const $content = $row.find(".message_content");
         $content.removeClass("collapsed");
 
@@ -74,9 +74,9 @@ export function uncollapse(message: Message): void {
             process_row($rendered_row);
         }
     }
-}
+};
 
-export function collapse(message: Message): void {
+export const collapse = (message: Message): void => {
     message.collapsed = true;
 
     if (message.locally_echoed) {
@@ -89,7 +89,7 @@ export function collapse(message: Message): void {
 
     message_flags.save_collapsed(message);
 
-    const process_row = function process_row($row: JQuery): void {
+    const process_row = ($row: JQuery): void => {
         $row.find(".message_content").addClass("collapsed");
         show_more_link($row);
     };
@@ -100,9 +100,9 @@ export function collapse(message: Message): void {
             process_row($rendered_row);
         }
     }
-}
+};
 
-export function toggle_collapse(message: Message): void {
+export const toggle_collapse = (message: Message): void => {
     if (message.is_me_message) {
         // Disabled temporarily because /me messages don't have a
         // styling for collapsing /me messages (they only recently
@@ -145,40 +145,36 @@ export function toggle_collapse(message: Message): void {
             collapse(message);
         }
     }
-}
+};
 
-function get_message_height(elem: HTMLElement): number {
-    // This needs to be very fast. This function runs hundreds of times
-    // when displaying a message feed view that has hundreds of message
-    // history, which ideally should render in <100ms.
-    return $(elem).find(".message_content")[0]!.scrollHeight;
-}
+const get_message_height = (elem: HTMLElement): number =>
+    $(elem).find(".message_content")[0]!.scrollHeight;
 
-export function hide_message_expander($row: JQuery): void {
+export const hide_message_expander = ($row: JQuery): void => {
     if ($row.find(".could-be-condensed").length !== 0) {
         $row.find(".message_expander").hide();
     }
-}
+};
 
-export function hide_message_condenser($row: JQuery): void {
+export const hide_message_condenser = ($row: JQuery): void => {
     if ($row.find(".could-be-condensed").length !== 0) {
         $row.find(".message_condenser").hide();
     }
-}
+};
 
-export function show_message_expander($row: JQuery): void {
+export const show_message_expander = ($row: JQuery): void => {
     if ($row.find(".could-be-condensed").length !== 0) {
         $row.find(".message_expander").show();
     }
-}
+};
 
-export function show_message_condenser($row: JQuery): void {
+export const show_message_condenser = ($row: JQuery): void => {
     if ($row.find(".could-be-condensed").length !== 0) {
         $row.find(".message_condenser").show();
     }
-}
+};
 
-export function condense_and_collapse(elems: JQuery): void {
+export const condense_and_collapse = (elems: JQuery): void => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -256,7 +252,7 @@ export function condense_and_collapse(elems: JQuery): void {
             $(elem).find(".message_expander").show();
         }
     }
-}
+};
 
 export function initialize(): void {
     $("#message_feed_container").on("click", ".message_expander", function (this: HTMLElement, e) {

--- a/web/src/confirm_dialog.ts
+++ b/web/src/confirm_dialog.ts
@@ -2,11 +2,10 @@ import * as dialog_widget from "./dialog_widget";
 import type {DialogWidgetConfig} from "./dialog_widget";
 import {$t_html} from "./i18n";
 
-export function launch(conf: DialogWidgetConfig): string {
-    return dialog_widget.launch({
+export const launch = (conf: DialogWidgetConfig): string =>
+    dialog_widget.launch({
         close_on_submit: true,
         focus_submit_on_open: true,
         html_submit_button: $t_html({defaultMessage: "Confirm"}),
         ...conf,
     });
-}

--- a/web/src/copied_tooltip.ts
+++ b/web/src/copied_tooltip.ts
@@ -2,19 +2,19 @@ import * as tippy from "tippy.js";
 
 import {$t} from "./i18n";
 
-export function show_copied_confirmation(
+export const show_copied_confirmation = (
     copy_button: HTMLElement,
     on_hide_callback?: () => void,
     timeout_in_ms = 1000,
-): void {
+): void => {
     // Display a tooltip to notify the user the message or code was copied.
     const instance = tippy.default(copy_button, {
         placement: "top",
         appendTo: () => document.body,
-        onUntrigger() {
+        onUntrigger: () => {
             remove_instance();
         },
-        onHide() {
+        onHide: () => {
             if (on_hide_callback) {
                 on_hide_callback();
             }
@@ -22,10 +22,10 @@ export function show_copied_confirmation(
     });
     instance.setContent($t({defaultMessage: "Copied!"}));
     instance.show();
-    function remove_instance(): void {
+    const remove_instance = (): void => {
         if (!instance.state.isDestroyed) {
             instance.destroy();
         }
-    }
+    };
     setTimeout(remove_instance, timeout_in_ms);
-}
+};

--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -16,10 +16,10 @@ declare global {
     }
 }
 
-function find_boundary_tr(
+const find_boundary_tr = (
     $initial_tr: JQuery,
     iterate_row: ($tr: JQuery) => JQuery,
-): [number, boolean] | undefined {
+): [number, boolean] | undefined => {
     let j;
     let skip_same_td_check = false;
     let $tr = $initial_tr;
@@ -50,9 +50,9 @@ function find_boundary_tr(
         skip_same_td_check = true;
     }
     return [rows.id($tr), skip_same_td_check];
-}
+};
 
-function construct_recipient_header($message_row: JQuery): JQuery {
+const construct_recipient_header = ($message_row: JQuery): JQuery => {
     const message_header_content = rows
         .get_message_recipient_header($message_row)
         .text()
@@ -60,7 +60,7 @@ function construct_recipient_header($message_row: JQuery): JQuery {
         .replace(/^\s/, "")
         .replace(/\s$/, "");
     return $("<p>").append($("<strong>").text(message_header_content));
-}
+};
 
 /*
 The techniques we use in this code date back to
@@ -77,7 +77,7 @@ Do not be afraid to change this code if you understand
 how modern browsers deal with copy/paste.  Just test
 your changes carefully.
 */
-function construct_copy_div($div: JQuery, start_id: number, end_id: number): void {
+const construct_copy_div = ($div: JQuery, start_id: number, end_id: number): void => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -115,9 +115,9 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
     if (should_include_start_recipient_header) {
         construct_recipient_header($start_row).prependTo($div);
     }
-}
+};
 
-function select_div($div: JQuery, selection: Selection): void {
+const select_div = ($div: JQuery, selection: Selection): void => {
     $div.css({
         position: "absolute",
         left: "-99999px",
@@ -133,9 +133,9 @@ function select_div($div: JQuery, selection: Selection): void {
     }).attr("id", "copytempdiv");
     $("body").append($div);
     selection.selectAllChildren($div[0]!);
-}
+};
 
-function remove_div(_div: JQuery, ranges: Range[]): void {
+const remove_div = (_div: JQuery, ranges: Range[]): void => {
     window.setTimeout(() => {
         const selection = window.getSelection();
         assert(selection !== null);
@@ -147,9 +147,9 @@ function remove_div(_div: JQuery, ranges: Range[]): void {
 
         $("#copytempdiv").remove();
     }, 0);
-}
+};
 
-export function copy_handler(): void {
+export const copy_handler = (): void => {
     // This is the main handler for copying message content via
     // `Ctrl+C` in Zulip (note that this is totally independent of the
     // "select region" copy behavior on Linux; that is handled
@@ -216,14 +216,16 @@ export function copy_handler(): void {
     select_div($div, selection);
     document.execCommand("copy");
     remove_div($div, ranges);
-}
+};
 
-export function analyze_selection(selection: Selection): {
+export const analyze_selection = (
+    selection: Selection,
+): {
     ranges: Range[];
     start_id: number | undefined;
     end_id: number | undefined;
     skip_same_td_check: boolean;
-} {
+} => {
     // Here we analyze our selection to determine if part of a message
     // or multiple messages are selected.
     //
@@ -294,9 +296,9 @@ export function analyze_selection(selection: Selection): {
         end_id,
         skip_same_td_check,
     };
-}
+};
 
-function get_end_tr_from_endc($endc: JQuery<Node>): JQuery {
+const get_end_tr_from_endc = ($endc: JQuery<Node>): JQuery => {
     if ($endc.attr("id") === "bottom_whitespace" || $endc.attr("id") === "compose_close") {
         // If the selection ends in the bottom whitespace, we should
         // act as though the selection ends on the final message.
@@ -334,18 +336,15 @@ function get_end_tr_from_endc($endc: JQuery<Node>): JQuery {
     }
 
     return $endc.parents(".selectable_row").first();
-}
+};
 
-function deduplicate_newlines(attribute: string): string {
-    // We replace any occurrences of one or more consecutive newlines followed by
-    // zero or more whitespace characters with a single newline character.
-    return attribute ? attribute.replaceAll(/(\n+\s*)+/g, "\n") : "";
-}
+const deduplicate_newlines = (attribute: string): string =>
+    attribute ? attribute.replaceAll(/(\n+\s*)+/g, "\n") : "";
 
-function image_to_zulip_markdown(
+const image_to_zulip_markdown = (
     _content: string,
     node: Element | Document | DocumentFragment,
-): string {
+): string => {
     assert(node instanceof Element);
     if (node.nodeName === "IMG" && node.classList.contains("emoji") && node.hasAttribute("alt")) {
         // For Zulip's custom emoji
@@ -355,17 +354,14 @@ function image_to_zulip_markdown(
     const title = deduplicate_newlines(node.getAttribute("title") ?? "");
     // Using Zulip's link like syntax for images
     return src ? "[" + title + "](" + src + ")" : node.getAttribute("alt") ?? "";
-}
+};
 
-function within_single_element(html_fragment: HTMLElement): boolean {
-    return (
-        html_fragment.childNodes.length === 1 &&
-        html_fragment.firstElementChild !== null &&
-        html_fragment.firstElementChild.innerHTML !== ""
-    );
-}
+const within_single_element = (html_fragment: HTMLElement): boolean =>
+    html_fragment.childNodes.length === 1 &&
+    html_fragment.firstElementChild !== null &&
+    html_fragment.firstElementChild.innerHTML !== "";
 
-export function is_white_space_pre(paste_html: string): boolean {
+export const is_white_space_pre = (paste_html: string): boolean => {
     const html_fragment = new DOMParser()
         .parseFromString(paste_html, "text/html")
         .querySelector("body");
@@ -375,9 +371,9 @@ export function is_white_space_pre(paste_html: string): boolean {
         html_fragment.firstElementChild instanceof HTMLElement &&
         html_fragment.firstElementChild.style.whiteSpace === "pre"
     );
-}
+};
 
-function is_single_image(paste_html: string): boolean {
+const is_single_image = (paste_html: string): boolean => {
     const html_fragment = new DOMParser()
         .parseFromString(paste_html, "text/html")
         .querySelector("body");
@@ -387,9 +383,9 @@ function is_single_image(paste_html: string): boolean {
         html_fragment.firstElementChild !== null &&
         html_fragment.firstElementChild.nodeName === "IMG"
     );
-}
+};
 
-export function paste_handler_converter(paste_html: string): string {
+export const paste_handler_converter = (paste_html: string): string => {
     const copied_html_fragment = new DOMParser()
         .parseFromString(paste_html, "text/html")
         .querySelector("body");
@@ -418,19 +414,15 @@ export function paste_handler_converter(paste_html: string): string {
     });
     turndownService.addRule("style", {
         filter: "style",
-        replacement() {
-            return "";
-        },
+        replacement: () => "",
     });
     turndownService.addRule("strikethrough", {
         filter: ["del", "s", "strike"],
-        replacement(content) {
-            return "~~" + content + "~~";
-        },
+        replacement: (content) => "~~" + content + "~~",
     });
     turndownService.addRule("links", {
         filter: ["a"],
-        replacement(content, node) {
+        replacement: (content, node) => {
             assert(node instanceof HTMLAnchorElement);
             if (node.href === content) {
                 // Checks for raw links without custom text.
@@ -448,7 +440,7 @@ export function paste_handler_converter(paste_html: string): string {
         // to have a custom indent of 2 spaces for list items, instead of
         // the default 4 spaces. Everything else is the same as upstream.
         filter: "li",
-        replacement(content, node) {
+        replacement: (content, node) => {
             content = content
                 .replace(/^\n+/, "") // remove leading newlines
                 .replace(/\n+$/, "\n") // replace trailing newlines with just a single one
@@ -465,14 +457,10 @@ export function paste_handler_converter(paste_html: string): string {
         },
     });
     turndownService.addRule("zulipImagePreview", {
-        filter(node) {
-            // select image previews in Zulip messages
-            return (
-                node.classList.contains("message_inline_image") && node.firstChild?.nodeName === "A"
-            );
-        },
+        filter: (node) =>
+            node.classList.contains("message_inline_image") && node.firstChild?.nodeName === "A",
 
-        replacement(content, node) {
+        replacement: (content, node) => {
             // We parse the copied html to then check if the generating link (which, if
             // present, always comes before the preview in the copied html) is also there.
 
@@ -507,9 +495,7 @@ export function paste_handler_converter(paste_html: string): string {
         // if we wanted to paste the original LaTeX for Zulip messages.
         filter: "math",
 
-        replacement() {
-            return "";
-        },
+        replacement: () => "",
     });
 
     // We override the original upstream implementation of this rule to make
@@ -522,7 +508,7 @@ export function paste_handler_converter(paste_html: string): string {
     // any) correctly.
     // Everything else works the same.
     turndownService.addRule("fencedCodeBlock", {
-        filter(node, options) {
+        filter: (node, options) => {
             let text_children;
             return (
                 options.codeBlockStyle === "fenced" &&
@@ -534,7 +520,7 @@ export function paste_handler_converter(paste_html: string): string {
             );
         },
 
-        replacement(_content, node, options) {
+        replacement: (_content, node, options) => {
             assert(node instanceof HTMLElement);
             const codeElement = [...node.children].find((child) => child.nodeName === "CODE");
             assert(codeElement !== undefined);
@@ -593,9 +579,9 @@ export function paste_handler_converter(paste_html: string): string {
     // Removes newlines before the start of a list and between list elements.
     markdown_text = markdown_text.replaceAll(/\n+([*+-])/g, "\n$1");
     return markdown_text;
-}
+};
 
-function is_safe_url_paste_target($textarea: JQuery<HTMLTextAreaElement>): boolean {
+const is_safe_url_paste_target = ($textarea: JQuery<HTMLTextAreaElement>): boolean => {
     const range = $textarea.range();
 
     if (!range.text) {
@@ -624,9 +610,9 @@ function is_safe_url_paste_target($textarea: JQuery<HTMLTextAreaElement>): boole
     }
 
     return true;
-}
+};
 
-export function maybe_transform_html(html: string, text: string): string {
+export const maybe_transform_html = (html: string, text: string): string => {
     if (is_white_space_pre(html)) {
         // Copied content styled with `white-space: pre` is pasted as is
         // but formatted as code. We need this for content copied from
@@ -634,7 +620,7 @@ export function maybe_transform_html(html: string, text: string): string {
         return "<pre><code>" + _.escape(text) + "</code></pre>";
     }
     return html;
-}
+};
 
 export function paste_handler(this: HTMLTextAreaElement, event: JQuery.TriggeredEvent): void {
     assert(event.originalEvent instanceof ClipboardEvent);
@@ -687,7 +673,7 @@ export function paste_handler(this: HTMLTextAreaElement, event: JQuery.Triggered
     }
 }
 
-export function initialize(): void {
+export const initialize = (): void => {
     $<HTMLTextAreaElement>("textarea#compose-textarea").on("paste", paste_handler);
     $("body").on("paste", "textarea.message_edit_content", paste_handler);
-}
+};

--- a/web/src/csrf.ts
+++ b/web/src/csrf.ts
@@ -11,7 +11,7 @@ $(() => {
     }
 
     $.ajaxSetup({
-        beforeSend(xhr: JQuery.jqXHR, settings: JQuery.AjaxSettings) {
+        beforeSend: (xhr: JQuery.jqXHR, settings: JQuery.AjaxSettings) => {
             if (settings.url === undefined || csrf_token === undefined) {
                 throw new Error("settings.url and/or csrf_token are missing.");
             }

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -17,7 +17,7 @@ import * as user_pill from "./user_pill";
 
 const user_value_schema = z.array(z.number());
 
-export function append_custom_profile_fields(element_id: string, user_id: number): void {
+export const append_custom_profile_fields = (element_id: string, user_id: number): void => {
     const person = people.get_by_user_id(user_id);
     if (person.is_bot) {
         return;
@@ -73,9 +73,9 @@ export function append_custom_profile_fields(element_id: string, user_id: number
         });
         $(element_id).append($(html));
     }
-}
+};
 
-export function initialize_custom_user_type_fields(
+export const initialize_custom_user_type_fields = (
     element_id: string,
     user_id: number,
     is_editable: boolean,
@@ -92,7 +92,7 @@ export function initialize_custom_user_type_fields(
         },
         pills: UserPillWidget,
     ) => void,
-): Map<number, UserPillWidget> {
+): Map<number, UserPillWidget> => {
     const field_types = realm.custom_profile_field_types;
     const user_pills = new Map<number, UserPillWidget>();
 
@@ -148,7 +148,7 @@ export function initialize_custom_user_type_fields(
     }
 
     return user_pills;
-}
+};
 
 export function initialize_custom_date_type_fields(element_id: string): void {
     flatpickr($(element_id).find(".custom_user_field .datepicker")[0]!, {
@@ -177,7 +177,7 @@ export function initialize_custom_date_type_fields(element_id: string): void {
         });
 }
 
-export function initialize_custom_pronouns_type_fields(element_id: string): void {
+export const initialize_custom_pronouns_type_fields = (element_id: string): void => {
     const commonly_used_pronouns = [
         $t({defaultMessage: "he/him"}),
         $t({defaultMessage: "she/her"}),
@@ -190,14 +190,8 @@ export function initialize_custom_pronouns_type_fields(element_id: string): void
     new Typeahead(bootstrap_typeahead_input, {
         items: 3,
         helpOnEmptyStrings: true,
-        source() {
-            return commonly_used_pronouns;
-        },
-        sorter(items, query) {
-            return bootstrap_typeahead.defaultSorter(items, query);
-        },
-        highlighter_html(item) {
-            return typeahead_helper.render_typeahead_item({primary: item});
-        },
+        source: () => commonly_used_pronouns,
+        sorter: (items, query) => bootstrap_typeahead.defaultSorter(items, query),
+        highlighter_html: (item) => typeahead_helper.render_typeahead_item({primary: item}),
     });
-}
+};

--- a/web/src/dark_theme.ts
+++ b/web/src/dark_theme.ts
@@ -5,7 +5,7 @@ import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import {user_settings} from "./user_settings";
 
-export function enable(): void {
+export const enable = (): void => {
     $(":root").removeClass("color-scheme-automatic").addClass("dark-theme");
 
     if (page_params.is_spectator) {
@@ -13,9 +13,9 @@ export function enable(): void {
         ls.set("spectator-theme-preference", "dark");
         user_settings.color_scheme = settings_config.color_scheme_values.night.code;
     }
-}
+};
 
-export function disable(): void {
+export const disable = (): void => {
     $(":root").removeClass("color-scheme-automatic").removeClass("dark-theme");
 
     if (page_params.is_spectator) {
@@ -23,8 +23,8 @@ export function disable(): void {
         ls.set("spectator-theme-preference", "light");
         user_settings.color_scheme = settings_config.color_scheme_values.day.code;
     }
-}
+};
 
-export function default_preference_checker(): void {
+export const default_preference_checker = (): void => {
     $(":root").removeClass("dark-theme").addClass("color-scheme-automatic");
-}
+};

--- a/web/src/debug.ts
+++ b/web/src/debug.ts
@@ -10,7 +10,7 @@ type Collision = {
     node: string;
 };
 
-export function check_duplicate_ids(): {collisions: Collision[]; total_collisions: number} {
+export const check_duplicate_ids = (): {collisions: Collision[]; total_collisions: number} => {
     const ids = new Set<string>();
     const collisions: Collision[] = [];
     let total_collisions = 0;
@@ -41,7 +41,7 @@ export function check_duplicate_ids(): {collisions: Collision[]; total_collision
         collisions,
         total_collisions,
     };
-}
+};
 
 /* An IterationProfiler is used for profiling parts of looping
  * constructs (like a for loop or _.each).  You mark sections of the

--- a/web/src/demo_organizations_ui.js
+++ b/web/src/demo_organizations_ui.js
@@ -13,7 +13,7 @@ import * as settings_data from "./settings_data";
 import * as settings_org from "./settings_org";
 import {current_user, realm} from "./state_data";
 
-export function insert_demo_organization_warning() {
+export const insert_demo_organization_warning = () => {
     const days_remaining = get_demo_organization_deadline_days_remaining();
     const rendered_demo_organization_warning = render_demo_organization_warning({
         is_demo_organization: realm.demo_organization_scheduled_deletion_date,
@@ -21,7 +21,7 @@ export function insert_demo_organization_warning() {
         days_remaining,
     });
     $(".organization-box").find(".settings-section").prepend($(rendered_demo_organization_warning));
-}
+};
 
 export function handle_demo_organization_conversion() {
     $(".convert-demo-organization-button").on("click", () => {
@@ -39,7 +39,7 @@ export function handle_demo_organization_conversion() {
             realm_org_type_values: settings_org.get_org_type_dropdown_options(),
         });
 
-        function demo_organization_conversion_post_render() {
+        const demo_organization_conversion_post_render = () => {
             const $convert_submit_button = $(
                 "#demo-organization-conversion-modal .dialog_submit_button",
             );
@@ -63,9 +63,9 @@ export function handle_demo_organization_conversion() {
                     );
                 });
             }
-        }
+        };
 
-        function submit_subdomain() {
+        const submit_subdomain = () => {
             const $string_id = $("#new_subdomain");
             const $organization_type = $("#add_organization_type");
             const data = {
@@ -73,12 +73,12 @@ export function handle_demo_organization_conversion() {
                 org_type: $organization_type.val(),
             };
             const opts = {
-                success_continuation(data) {
+                success_continuation: (data) => {
                     window.location.href = data.realm_url;
                 },
             };
             dialog_widget.submit_api_request(channel.patch, "/json/realm", data, opts);
-        }
+        };
 
         dialog_widget.launch({
             html_heading: $t({defaultMessage: "Make organization permanent"}),

--- a/web/src/deprecated_feature_notice.ts
+++ b/web/src/deprecated_feature_notice.ts
@@ -6,22 +6,21 @@ import * as dialog_widget from "./dialog_widget";
 import {$t_html} from "./i18n";
 import {localstorage} from "./localstorage";
 
-export function get_hotkey_deprecation_notice(
+export const get_hotkey_deprecation_notice = (
     originalHotkey: string,
     replacementHotkey: string,
-): string {
-    return $t_html(
+): string =>
+    $t_html(
         {
             defaultMessage:
                 'We\'ve replaced the "{originalHotkey}" hotkey with "{replacementHotkey}" to make this common shortcut easier to trigger.',
         },
         {originalHotkey, replacementHotkey},
     );
-}
 
 let shown_deprecation_notices: string[] = [];
 
-export function maybe_show_deprecation_notice(key: string): void {
+export const maybe_show_deprecation_notice = (key: string): void => {
     let message;
     const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
     switch (key) {
@@ -59,7 +58,7 @@ export function maybe_show_deprecation_notice(key: string): void {
             html_heading: $t_html({defaultMessage: "Deprecation notice"}),
             html_body: message,
             html_submit_button: $t_html({defaultMessage: "Got it"}),
-            on_click() {
+            on_click: () => {
                 // Do nothing
             },
             close_on_submit: true,
@@ -75,4 +74,4 @@ export function maybe_show_deprecation_notice(key: string): void {
             );
         }
     }
-}
+};

--- a/web/src/deprecated_feature_notice.ts
+++ b/web/src/deprecated_feature_notice.ts
@@ -60,7 +60,7 @@ export function maybe_show_deprecation_notice(key: string): void {
             html_body: message,
             html_submit_button: $t_html({defaultMessage: "Got it"}),
             on_click() {
-                return;
+                // Do nothing
             },
             close_on_submit: true,
             focus_submit_on_open: true,

--- a/web/src/desktop_integration.js
+++ b/web/src/desktop_integration.js
@@ -8,7 +8,7 @@ import * as message_store from "./message_store";
 import * as message_view from "./message_view";
 import * as stream_data from "./stream_data";
 
-export function initialize() {
+export const initialize = () => {
     if (window.electron_bridge === undefined) {
         return;
     }
@@ -45,7 +45,7 @@ export function initialize() {
             data.to = stream_data.get_stream_name_from_id(message.stream_id);
         }
 
-        function success() {
+        const success = () => {
             if (message.type === "stream") {
                 message_view.narrow_by_topic(message_id, {trigger: "desktop_notification_reply"});
             } else {
@@ -53,15 +53,15 @@ export function initialize() {
                     trigger: "desktop_notification_reply",
                 });
             }
-        }
+        };
 
-        function error(error) {
+        const error = (error) => {
             window.electron_bridge.send_event("send_notification_reply_message_failed", {
                 data,
                 message_id,
                 error,
             });
-        }
+        };
 
         channel.post({
             url: "/json/messages",
@@ -78,13 +78,13 @@ export function initialize() {
 
         channel.get({
             url,
-            success(data) {
+            success: (data) => {
                 window.open(data.billing_access_url, "_blank", "noopener,noreferrer");
             },
-            error(xhr) {
+            error: (xhr) => {
                 if (xhr.responseJSON?.msg) {
                     feedback_widget.show({
-                        populate($container) {
+                        populate: ($container) => {
                             $container.text(xhr.responseJSON.msg);
                         },
                         title_text: $t({defaultMessage: "Error"}),
@@ -93,4 +93,4 @@ export function initialize() {
             },
         });
     });
-}
+};

--- a/web/src/desktop_notifications.ts
+++ b/web/src/desktop_notifications.ts
@@ -17,9 +17,9 @@ export const notice_memory: NoticeMemory = new Map();
 export let NotificationAPI: typeof ElectronBridgeNotification | typeof Notification | undefined;
 
 // Used for testing
-export function set_notification_api(n: typeof NotificationAPI): void {
+export const set_notification_api = (n: typeof NotificationAPI): void => {
     NotificationAPI = n;
-}
+};
 
 class ElectronBridgeNotification extends EventTarget {
     title: string;
@@ -69,43 +69,40 @@ if (window.electron_bridge?.new_notification) {
     NotificationAPI = window.Notification;
 }
 
-export function get_notifications(): NoticeMemory {
-    return notice_memory;
-}
+export const get_notifications = (): NoticeMemory => notice_memory;
 
-export function initialize(): void {
+export const initialize = (): void => {
     $(window).on("focus", () => {
         for (const notice_mem_entry of notice_memory.values()) {
             notice_mem_entry.obj.close();
         }
         notice_memory.clear();
     });
-}
+};
 
-export function permission_state(): string {
+export const permission_state = (): string => {
     if (NotificationAPI === undefined) {
         // act like notifications are blocked if they do not have access to
         // the notification API.
         return "denied";
     }
     return NotificationAPI.permission;
-}
+};
 
-export function close_notification(message: Message): void {
+export const close_notification = (message: Message): void => {
     for (const [key, notice_mem_entry] of notice_memory) {
         if (notice_mem_entry.message_id === message.id) {
             notice_mem_entry.obj.close();
             notice_memory.delete(key);
         }
     }
-}
+};
 
-export function granted_desktop_notifications_permission(): boolean {
-    return NotificationAPI?.permission === "granted";
-}
+export const granted_desktop_notifications_permission = (): boolean =>
+    NotificationAPI?.permission === "granted";
 
-export function request_desktop_notifications_permission(): void {
+export const request_desktop_notifications_permission = (): void => {
     if (NotificationAPI) {
         void NotificationAPI.requestPermission();
     }
-}
+};

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -16,13 +16,9 @@ import * as ui_report from "./ui_report";
 // the caller has already checked that the dialog widget is open.
 let widget_id_counter = 0;
 
-function current_dialog_widget_id(): string {
-    return `dialog_widget_modal_${widget_id_counter}`;
-}
+const current_dialog_widget_id = (): string => `dialog_widget_modal_${widget_id_counter}`;
 
-function current_dialog_widget_selector(): string {
-    return `#${current_dialog_widget_id()}`;
-}
+const current_dialog_widget_selector = (): string => `#${current_dialog_widget_id()}`;
 
 /*
  *  Look for confirm_dialog in settings_user_groups
@@ -87,16 +83,16 @@ type RequestOpts = {
     error_continuation?: Parameters<AjaxRequestHandler>[0]["error"];
 };
 
-export function hide_dialog_spinner(): void {
+export const hide_dialog_spinner = (): void => {
     $(".dialog_submit_button span").show();
     const dialog_widget_selector = current_dialog_widget_selector();
     $(`${dialog_widget_selector} .modal__btn`).prop("disabled", false);
 
     const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
     loading.destroy_indicator($spinner);
-}
+};
 
-export function show_dialog_spinner(): void {
+export const show_dialog_spinner = (): void => {
     const dialog_widget_selector = current_dialog_widget_selector();
     // Disable both the buttons.
     $(`${dialog_widget_selector} .modal__btn`).prop("disabled", true);
@@ -113,12 +109,12 @@ export function show_dialog_spinner(): void {
         width: dialog_submit_button_span_width,
         height: dialog_submit_button_span_height,
     });
-}
+};
 
 // Supports a callback to be called once the modal finishes closing.
-export function close(on_hidden_callback?: () => void): void {
+export const close = (on_hidden_callback?: () => void): void => {
     modals.close(current_dialog_widget_id(), {on_hidden: on_hidden_callback});
-}
+};
 
 export function get_current_values($inputs: JQuery): Record<string, unknown> {
     const current_values: Record<string, unknown> = {};
@@ -143,7 +139,7 @@ export function get_current_values($inputs: JQuery): Record<string, unknown> {
     return current_values;
 }
 
-export function launch(conf: DialogWidgetConfig): string {
+export const launch = (conf: DialogWidgetConfig): string => {
     // Mandatory fields:
     // * html_heading
     // * html_body
@@ -242,7 +238,7 @@ export function launch(conf: DialogWidgetConfig): string {
 
     modals.open(modal_unique_id, {
         autoremove: true,
-        on_show() {
+        on_show: () => {
             if (conf.focus_submit_on_open) {
                 $submit_button.trigger("focus");
             }
@@ -255,9 +251,9 @@ export function launch(conf: DialogWidgetConfig): string {
         on_hidden: conf?.on_hidden,
     });
     return modal_unique_id;
-}
+};
 
-export function submit_api_request(
+export const submit_api_request = (
     request_method: AjaxRequestHandler,
     url: string,
     data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
@@ -266,18 +262,18 @@ export function submit_api_request(
         success_continuation,
         error_continuation,
     }: RequestOpts = {},
-): void {
+): void => {
     show_dialog_spinner();
     void request_method({
         url,
         data,
-        success(response_data, textStatus, jqXHR) {
+        success: (response_data, textStatus, jqXHR) => {
             close();
             if (success_continuation !== undefined) {
                 success_continuation(response_data, textStatus, jqXHR);
             }
         },
-        error(xhr, error_type, xhn) {
+        error: (xhr, error_type, xhn) => {
             ui_report.error(failure_msg_html, xhr, $("#dialog_error"));
             hide_dialog_spinner();
             if (error_continuation !== undefined) {
@@ -285,4 +281,4 @@ export function submit_api_request(
             }
         },
     });
-}
+};

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -14,7 +14,7 @@ import * as people from "./people";
 import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 
-function restore_draft(draft_id) {
+const restore_draft = (draft_id) => {
     const draft = drafts.draft_model.getDraft(draft_id);
     if (!draft) {
         return;
@@ -48,9 +48,9 @@ function restore_draft(draft_id) {
         ...compose_args,
         message_type: compose_args.type,
     });
-}
+};
 
-function remove_draft($draft_row) {
+const remove_draft = ($draft_row) => {
     // Deletes the draft and removes it from the list
     const draft_id = $draft_row.attr("data-draft-id");
 
@@ -65,9 +65,9 @@ function remove_draft($draft_row) {
         $("#drafts-from-conversation .overlay-message-row").length > 0,
         $("#other-drafts .overlay-message-row").length > 0,
     );
-}
+};
 
-function update_rendered_drafts(has_drafts_from_conversation, has_other_drafts) {
+const update_rendered_drafts = (has_drafts_from_conversation, has_other_drafts) => {
     if (has_drafts_from_conversation) {
         $("#drafts-from-conversation").show();
     } else {
@@ -79,10 +79,10 @@ function update_rendered_drafts(has_drafts_from_conversation, has_other_drafts) 
     if (!has_other_drafts) {
         $("#other-drafts").hide();
     }
-}
+};
 
 const keyboard_handling_context = {
-    get_items_ids() {
+    get_items_ids: () => {
         const draft_arrow = drafts.draft_model.get();
         return Object.getOwnPropertyNames(draft_arrow);
     },
@@ -115,12 +115,12 @@ const keyboard_handling_context = {
     id_attribute_name: "data-draft-id",
 };
 
-export function handle_keyboard_events(event_key) {
+export const handle_keyboard_events = (event_key) => {
     messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
-}
+};
 
 export function launch() {
-    function format_drafts(data) {
+    const format_drafts = (data) => {
         for (const [id, draft] of Object.entries(data)) {
             draft.id = id;
         }
@@ -136,9 +136,9 @@ export function launch() {
             .filter(Boolean);
 
         return sorted_formatted_drafts;
-    }
+    };
 
-    function get_header_for_narrow_drafts() {
+    const get_header_for_narrow_drafts = () => {
         const {stream_name, topic, private_recipients} = drafts.current_recipient_data();
         if (private_recipients) {
             return $t(
@@ -150,7 +150,7 @@ export function launch() {
         }
         const recipient = topic ? `#${stream_name} > ${topic}` : `#${stream_name}`;
         return $t({defaultMessage: "Drafts from {recipient}"}, {recipient});
-    }
+    };
 
     function render_widgets(narrow_drafts, other_drafts) {
         $("#drafts_table").empty();
@@ -281,33 +281,31 @@ export function update_bulk_delete_ui() {
     }
 }
 
-export function open_overlay() {
+export const open_overlay = () => {
     drafts.sync_count();
     overlays.open_overlay({
         name: "drafts",
         $overlay: $("#draft_overlay"),
-        on_close() {
+        on_close: () => {
             browser_history.exit_overlay();
             drafts.sync_count();
         },
     });
-}
+};
 
-export function is_checkbox_icon_checked($checkbox) {
-    return $checkbox.hasClass("fa-check-square");
-}
+export const is_checkbox_icon_checked = ($checkbox) => $checkbox.hasClass("fa-check-square");
 
-export function toggle_checkbox_icon_state($checkbox, checked) {
+export const toggle_checkbox_icon_state = ($checkbox, checked) => {
     $checkbox.parent().attr("aria-checked", checked);
     if (checked) {
         $checkbox.removeClass("fa-square-o").addClass("fa-check-square");
     } else {
         $checkbox.removeClass("fa-check-square").addClass("fa-square-o");
     }
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $("body").on("focus", "#drafts_table .overlay-message-info-box", (e) => {
         messages_overlay_ui.activate_element(e.target, keyboard_handling_context);
     });
-}
+};

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -225,13 +225,13 @@ export class DropdownWidget {
 
                 // Keyboard handler
                 $popper.on("keydown", (e) => {
-                    function trigger_element_focus($element: JQuery): void {
+                    const trigger_element_focus = ($element: JQuery): void => {
                         e.preventDefault();
                         e.stopPropagation();
                         // When bringing a non-visible element into view, scroll as minimum as possible.
                         $element[0]?.scrollIntoView({block: "nearest"});
                         $element.trigger("focus");
-                    }
+                    };
 
                     const $search_input = $popper.find(".dropdown-list-search-input");
                     assert(this.list_widget !== undefined);
@@ -241,17 +241,17 @@ export class DropdownWidget {
                         return;
                     }
 
-                    function first_item(): JQuery {
+                    const first_item = (): JQuery => {
                         const first_item = list_items[0];
                         assert(first_item !== undefined);
                         return $popper.find(`.list-item[data-unique-id="${first_item.unique_id}"]`);
-                    }
+                    };
 
-                    function last_item(): JQuery {
+                    const last_item = (): JQuery => {
                         const last_item = list_items.at(-1);
                         assert(last_item !== undefined);
                         return $popper.find(`.list-item[data-unique-id="${last_item.unique_id}"]`);
-                    }
+                    };
 
                     const render_all_items_and_focus_last_item = (): void => {
                         assert(this.list_widget !== undefined);

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -29,7 +29,7 @@ let waiting_for_ack = new Map();
 // These retry spinner functions return true if and only if the
 // spinner already is in the requested state, which can be used to
 // avoid sending duplicate requests.
-function show_retry_spinner($row) {
+const show_retry_spinner = ($row) => {
     const $retry_spinner = $row.find(".refresh-failed-message");
 
     if (!$retry_spinner.hasClass("rotating")) {
@@ -37,9 +37,9 @@ function show_retry_spinner($row) {
         return false;
     }
     return true;
-}
+};
 
-function hide_retry_spinner($row) {
+const hide_retry_spinner = ($row) => {
     const $retry_spinner = $row.find(".refresh-failed-message");
 
     if ($retry_spinner.hasClass("rotating")) {
@@ -47,9 +47,9 @@ function hide_retry_spinner($row) {
         return false;
     }
     return true;
-}
+};
 
-function show_message_failed(message_id, failed_msg) {
+const show_message_failed = (message_id, failed_msg) => {
     // Failed to send message, so display inline retry/cancel
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         $row.find(".slow-send-spinner").addClass("hidden");
@@ -57,21 +57,21 @@ function show_message_failed(message_id, failed_msg) {
         $failed_div.toggleClass("hide", false);
         $failed_div.find(".failed_text").attr("title", failed_msg);
     });
-}
+};
 
-function show_failed_message_success(message_id) {
+const show_failed_message_success = (message_id) => {
     // Previously failed message succeeded
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         $row.find(".message_failed").toggleClass("hide", true);
     });
-}
+};
 
-function failed_message_success(message_id) {
+const failed_message_success = (message_id) => {
     message_store.get(message_id).failed_request = false;
     show_failed_message_success(message_id);
-}
+};
 
-function resend_message(message, $row, {on_send_message_success, send_message}) {
+const resend_message = (message, $row, {on_send_message_success, send_message}) => {
     message.content = message.raw_content;
     if (show_retry_spinner($row)) {
         // retry already in in progress
@@ -80,7 +80,7 @@ function resend_message(message, $row, {on_send_message_success, send_message}) 
 
     message.resend = true;
 
-    function on_success(data) {
+    const on_success = (data) => {
         const message_id = data.id;
         message.locally_echoed = true;
 
@@ -90,20 +90,20 @@ function resend_message(message, $row, {on_send_message_success, send_message}) 
 
         // Resend succeeded, so mark as no longer failed
         failed_message_success(message_id);
-    }
+    };
 
-    function on_error(response, _server_error_code) {
+    const on_error = (response, _server_error_code) => {
         message_send_error(message.id, response);
         setTimeout(() => {
             hide_retry_spinner($row);
         }, 300);
         blueslip.log("Manual resend of message failed");
-    }
+    };
 
     send_message(message, on_success, on_error);
-}
+};
 
-export function build_display_recipient(message) {
+export const build_display_recipient = (message) => {
     if (message.type === "stream") {
         return stream_data.get_stream_name_from_id(message.stream_id);
     }
@@ -164,9 +164,9 @@ export function build_display_recipient(message) {
         });
     }
     return display_recipient;
-}
+};
 
-export function insert_local_message(message_request, local_id_float, insert_new_messages) {
+export const insert_local_message = (message_request, local_id_float, insert_new_messages) => {
     // Shallow clone of message request object that is turned into something suitable
     // for zulip.js:add_message
     // Keep this in sync with changes to compose.create_message_object
@@ -202,13 +202,11 @@ export function insert_local_message(message_request, local_id_float, insert_new
     waiting_for_ack.set(message.local_id, message);
 
     return message;
-}
+};
 
-export function is_slash_command(content) {
-    return !content.startsWith("/me") && content.startsWith("/");
-}
+export const is_slash_command = (content) => !content.startsWith("/me") && content.startsWith("/");
 
-export function try_deliver_locally(message_request, insert_new_messages) {
+export const try_deliver_locally = (message_request, insert_new_messages) => {
     // Checks if the message request can be locally echoed, and if so,
     // adds a local echoed copy of the message to appropriate message lists.
     //
@@ -253,9 +251,9 @@ export function try_deliver_locally(message_request, insert_new_messages) {
 
     const message = insert_local_message(message_request, local_id_float, insert_new_messages);
     return message;
-}
+};
 
-export function edit_locally(message, request) {
+export const edit_locally = (message, request) => {
     // Responsible for doing the rendering work of locally editing the
     // content of a message.  This is used in several code paths:
     // * Editing a message where a message was locally echoed but
@@ -333,9 +331,9 @@ export function edit_locally(message, request) {
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
     return message;
-}
+};
 
-export function reify_message_id(local_id, server_id) {
+export const reify_message_id = (local_id, server_id) => {
     const message = waiting_for_id.get(local_id);
     waiting_for_id.delete(local_id);
 
@@ -355,9 +353,9 @@ export function reify_message_id(local_id, server_id) {
     update_message_lists(opts);
     compose_notifications.reify_message_id(opts);
     recent_view_data.reify_message_id_if_available(opts);
-}
+};
 
-export function update_message_lists({old_id, new_id}) {
+export const update_message_lists = ({old_id, new_id}) => {
     if (all_messages_data !== undefined) {
         all_messages_data.change_message_id(old_id, new_id);
     }
@@ -365,9 +363,9 @@ export function update_message_lists({old_id, new_id}) {
         msg_list.change_message_id(old_id, new_id);
         msg_list.view.change_message_id(old_id, new_id);
     }
-}
+};
 
-export function process_from_server(messages) {
+export const process_from_server = (messages) => {
     const msgs_to_rerender = [];
     const non_echo_messages = [];
 
@@ -430,31 +428,31 @@ export function process_from_server(messages) {
     }
 
     return non_echo_messages;
-}
+};
 
-export function _patch_waiting_for_ack(data) {
+export const _patch_waiting_for_ack = (data) => {
     // Only for testing
     waiting_for_ack = data;
-}
+};
 
-export function message_send_error(message_id, error_response) {
+export const message_send_error = (message_id, error_response) => {
     // Error sending message, show inline
     const message = message_store.get(message_id);
     message.failed_request = true;
     message.show_slow_send_spinner = false;
 
     show_message_failed(message_id, error_response);
-}
+};
 
-function abort_message(message) {
+const abort_message = (message) => {
     // Remove in all lists in which it exists
     all_messages_data.remove([message.id]);
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         msg_list.remove_and_rerender([message.id]);
     }
-}
+};
 
-export function display_slow_send_loading_spinner(message) {
+export const display_slow_send_loading_spinner = (message) => {
     const $rows = message_lists.all_rendered_row_for_message_id(message.id);
     if (message.locally_echoed && !message.failed_request) {
         message.show_slow_send_spinner = true;
@@ -464,7 +462,7 @@ export function display_slow_send_loading_spinner(message) {
         // message's HTML gets replaced once the message is
         // successfully sent.
     }
-}
+};
 
 export function initialize({on_send_message_success, send_message}) {
     function on_failed_action(selector, callback) {

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -9,10 +9,10 @@ export type EmailPillWidget = InputPillContainer<EmailPill>;
 
 const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function create_item_from_email(
+export const create_item_from_email = (
     email: string,
     current_items: InputPillItem<EmailPill>[],
-): InputPillItem<EmailPill> | undefined {
+): InputPillItem<EmailPill> | undefined => {
     if (!email_regex.test(email)) {
         return undefined;
     }
@@ -27,26 +27,24 @@ export function create_item_from_email(
         display_value: email,
         email,
     };
-}
+};
 
-export function get_email_from_item(item: InputPillItem<EmailPill>): string {
-    return item.email;
-}
+export const get_email_from_item = (item: InputPillItem<EmailPill>): string => item.email;
 
-export function get_current_email(
+export const get_current_email = (
     pill_container: input_pill.InputPillContainer<EmailPill>,
-): string | null {
+): string | null => {
     const current_text = pill_container.getCurrentText();
     if (current_text !== null && email_regex.test(current_text)) {
         return current_text;
     }
     return null;
-}
+};
 
-export function create_pills(
+export const create_pills = (
     $pill_container: JQuery,
     pill_config?: InputPillConfig | undefined,
-): input_pill.InputPillContainer<EmailPill> {
+): input_pill.InputPillContainer<EmailPill> => {
     const pill_container = input_pill.create({
         $container: $pill_container,
         pill_config,
@@ -54,4 +52,4 @@ export function create_pills(
         get_text_from_item: get_email_from_item,
     });
     return pill_container;
-}
+};

--- a/web/src/emoji.ts
+++ b/web/src/emoji.ts
@@ -95,15 +95,13 @@ let default_emoji_aliases = new Map<string, string[]>();
 let server_realm_emoji_data: RealmEmojiMap = {};
 
 // We really want to deprecate this, too.
-export function get_server_realm_emoji_data(): RealmEmojiMap {
-    return server_realm_emoji_data;
-}
+export const get_server_realm_emoji_data = (): RealmEmojiMap => server_realm_emoji_data;
 
 let emoticon_translations: EmoticonTranslation[] = [];
 
-function build_emoticon_translations({
+const build_emoticon_translations = ({
     emoticon_conversions,
-}: Pick<ServerUnicodeEmojiData, "emoticon_conversions">): EmoticonTranslation[] {
+}: Pick<ServerUnicodeEmojiData, "emoticon_conversions">): EmoticonTranslation[] => {
     /*
 
     Please keep this as a pure function so that we can
@@ -142,7 +140,7 @@ function build_emoticon_translations({
     }
 
     return translations;
-}
+};
 
 const zulip_emoji = {
     id: "zulip",
@@ -156,23 +154,23 @@ const zulip_emoji = {
     deactivated: false,
 };
 
-export function get_emoji_name(codepoint: string): string | undefined {
+export const get_emoji_name = (codepoint: string): string | undefined => {
     // get_emoji_name('1f384') === 'holiday_tree'
     if (Object.hasOwn(emoji_codes.codepoint_to_name, codepoint)) {
         return emoji_codes.codepoint_to_name[codepoint];
     }
     return undefined;
-}
+};
 
-export function get_emoji_codepoint(emoji_name: string): string | undefined {
+export const get_emoji_codepoint = (emoji_name: string): string | undefined => {
     // get_emoji_codepoint('avocado') === '1f951'
     if (Object.hasOwn(emoji_codes.name_to_codepoint, emoji_name)) {
         return emoji_codes.name_to_codepoint[emoji_name];
     }
     return undefined;
-}
+};
 
-export function get_realm_emoji_url(emoji_name: string): string | undefined {
+export const get_realm_emoji_url = (emoji_name: string): string | undefined => {
     // If the emoji name is a realm emoji, returns the URL for it.
     // Returns undefined for Unicode emoji.
     // get_realm_emoji_url('shrug') === '/user_avatars/2/emoji/images/31.png'
@@ -190,9 +188,9 @@ export function get_realm_emoji_url(emoji_name: string): string | undefined {
     }
 
     return data.emoji_url;
-}
+};
 
-function build_emojis_by_name({
+const build_emojis_by_name = ({
     realm_emojis,
     emoji_catalog,
     get_emoji_name,
@@ -202,7 +200,7 @@ function build_emojis_by_name({
     emoji_catalog: ServerUnicodeEmojiData["emoji_catalog"];
     get_emoji_name: (codepoint: string) => string | undefined;
     default_emoji_aliases: Map<string, string[]>;
-}): Map<string, EmojiDict> {
+}): Map<string, EmojiDict> => {
     // Please keep this as a pure function so that we can
     // eventually share this code with the mobile codebase.
     const map = new Map<string, EmojiDict>();
@@ -241,9 +239,9 @@ function build_emojis_by_name({
     }
 
     return map;
-}
+};
 
-export function update_emojis(realm_emojis: RealmEmojiMap): void {
+export const update_emojis = (realm_emojis: RealmEmojiMap): void => {
     // The settings code still works with the
     // server format of the data.
     server_realm_emoji_data = realm_emojis;
@@ -289,11 +287,11 @@ export function update_emojis(realm_emojis: RealmEmojiMap): void {
         get_emoji_name,
         default_emoji_aliases,
     });
-}
+};
 
 // This function will provide required parameters that would
 // need by template to render an emoji.
-export function get_emoji_details_by_name(emoji_name: string): EmojiRenderingDetails {
+export const get_emoji_details_by_name = (emoji_name: string): EmojiRenderingDetails => {
     // To call this function you must pass an emoji name.
     if (!emoji_name) {
         throw new Error("Emoji name must be passed.");
@@ -320,13 +318,13 @@ export function get_emoji_details_by_name(emoji_name: string): EmojiRenderingDet
         reaction_type: "unicode_emoji",
         emoji_code: codepoint,
     };
-}
+};
 
-export function get_emoji_details_for_rendering(opts: {
+export const get_emoji_details_for_rendering = (opts: {
     emoji_name: string;
     emoji_code: string;
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
-}): EmojiRenderingDetails {
+}): EmojiRenderingDetails => {
     if (opts.reaction_type !== "unicode_emoji") {
         const realm_emoji = all_realm_emojis.get(opts.emoji_code);
         if (!realm_emoji) {
@@ -346,15 +344,15 @@ export function get_emoji_details_for_rendering(opts: {
         emoji_code: opts.emoji_code,
         reaction_type: opts.reaction_type,
     };
-}
+};
 
-function build_default_emoji_aliases({
+const build_default_emoji_aliases = ({
     names,
     get_emoji_codepoint,
 }: {
     names: string[];
     get_emoji_codepoint: (name: string) => string | undefined;
-}): Map<string, string[]> {
+}): Map<string, string[]> => {
     // Please keep this as a pure function so that we can
     // eventually share this code with the mobile codebase.
 
@@ -377,9 +375,9 @@ function build_default_emoji_aliases({
     }
 
     return map;
-}
+};
 
-export function initialize(params: EmojiParams): void {
+export const initialize = (params: EmojiParams): void => {
     emoji_codes = params.emoji_codes;
 
     emoticon_translations = build_emoticon_translations({
@@ -392,9 +390,9 @@ export function initialize(params: EmojiParams): void {
     });
 
     update_emojis(params.realm_emoji);
-}
+};
 
-export function get_canonical_name(emoji_name: string): string | undefined {
+export const get_canonical_name = (emoji_name: string): string | undefined => {
     if (active_realm_emojis.has(emoji_name)) {
         return emoji_name;
     }
@@ -405,8 +403,6 @@ export function get_canonical_name(emoji_name: string): string | undefined {
     }
 
     return get_emoji_name(codepoint);
-}
+};
 
-export function get_emoticon_translations(): EmoticonTranslation[] {
-    return emoticon_translations;
-}
+export const get_emoticon_translations = (): EmoticonTranslation[] => emoticon_translations;

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -56,32 +56,32 @@ const EMOJI_CATEGORIES = [
     {name: "Custom", icon: "fa-cog"},
 ];
 
-function get_total_sections() {
+const get_total_sections = () => {
     if (search_is_active) {
         return 1;
     }
     return complete_emoji_catalog.length;
-}
+};
 
-function get_max_index(section) {
+const get_max_index = (section) => {
     if (search_is_active) {
         return search_results.length;
     } else if (section >= 0 && section < get_total_sections()) {
         return complete_emoji_catalog[section].emojis.length;
     }
     return undefined;
-}
+};
 
-function get_emoji_id(section, index) {
+const get_emoji_id = (section, index) => {
     let type = "emoji_picker_emoji";
     if (search_is_active) {
         type = "emoji_search_result";
     }
     const emoji_id = [type, section, index].join(",");
     return emoji_id;
-}
+};
 
-function get_emoji_coordinates(emoji_id) {
+const get_emoji_coordinates = (emoji_id) => {
     // Emoji id is of the following form:
     //    <emoji_type>_<section_number>_<index>.
     // See `get_emoji_id()`.
@@ -90,9 +90,9 @@ function get_emoji_coordinates(emoji_id) {
         section: Number.parseInt(emoji_info[1], 10),
         index: Number.parseInt(emoji_info[2], 10),
     };
-}
+};
 
-function show_search_results() {
+const show_search_results = () => {
     $(".emoji-popover-emoji-map").hide();
     $(".emoji-popover-category-tabs").hide();
     $(".emoji-search-results-container").show();
@@ -103,9 +103,9 @@ function show_search_results() {
     current_section = 0;
     current_index = 0;
     search_is_active = true;
-}
+};
 
-function show_emoji_catalog() {
+const show_emoji_catalog = () => {
     reset_emoji_showcase();
     $(".emoji-popover-emoji-map").show();
     $(".emoji-popover-category-tabs").show();
@@ -113,9 +113,9 @@ function show_emoji_catalog() {
     current_section = emoji_catalog_last_coordinates.section;
     current_index = emoji_catalog_last_coordinates.index;
     search_is_active = false;
-}
+};
 
-export function rebuild_catalog() {
+export const rebuild_catalog = () => {
     const realm_emojis = emoji.active_realm_emojis;
 
     const catalog = new Map();
@@ -166,9 +166,9 @@ export function rebuild_catalog() {
         return category.emojis;
     });
     composebox_typeahead.update_emoji_data(emojis_by_category);
-}
+};
 
-const generate_emoji_picker_content = function (id) {
+const generate_emoji_picker_content = (id) => {
     let emojis_used = [];
 
     if (id) {
@@ -195,11 +195,9 @@ function refill_section_head_offsets($popover) {
     });
 }
 
-export function is_open() {
-    return Boolean(emoji_popover_instance);
-}
+export const is_open = () => Boolean(emoji_popover_instance);
 
-export function hide_emoji_popover() {
+export const hide_emoji_popover = () => {
     if (!is_open()) {
         return;
     }
@@ -214,18 +212,18 @@ export function hide_emoji_popover() {
     $(emoji_popover_instance.reference).parent().removeClass("active-emoji-picker-reference");
     emoji_popover_instance.destroy();
     emoji_popover_instance = null;
-}
+};
 
-function get_rendered_emoji(section, index) {
+const get_rendered_emoji = (section, index) => {
     const emoji_id = get_emoji_id(section, index);
     const $emoji = $(`.emoji-popover-emoji[data-emoji-id='${CSS.escape(emoji_id)}']`);
     if ($emoji.length > 0) {
         return $emoji;
     }
     return undefined;
-}
+};
 
-export function is_emoji_present_in_text(text, emoji_dict) {
+export const is_emoji_present_in_text = (text, emoji_dict) => {
     // fetching emoji details to ensure emoji_code and reaction_type are present
     const emoji_info = emoji.get_emoji_details_by_name(emoji_dict.name);
     if (emoji_info.reaction_type === "unicode_emoji") {
@@ -236,9 +234,9 @@ export function is_emoji_present_in_text(text, emoji_dict) {
     }
 
     return false;
-}
+};
 
-function filter_emojis() {
+const filter_emojis = () => {
     const $elt = $(".emoji-popover-filter").expectOne();
     const query = $elt.val().trim().toLowerCase();
     const message_id = Number($(".emoji-search-results-container").attr("data-message-id"));
@@ -284,9 +282,9 @@ function filter_emojis() {
     } else {
         show_emoji_catalog();
     }
-}
+};
 
-function toggle_reaction(emoji_name, event) {
+const toggle_reaction = (emoji_name, event) => {
     // The emoji picker for setting user status
     // doesn't have a concept of toggling.
     // TODO: Ideally we never even get here in
@@ -309,9 +307,9 @@ function toggle_reaction(emoji_name, event) {
     }
 
     $(event.target).closest(".reaction").toggleClass("reacted");
-}
+};
 
-function process_enter_while_filtering(e) {
+const process_enter_while_filtering = (e) => {
     if (keydown_util.is_enter_event(e)) {
         e.preventDefault();
         e.stopPropagation();
@@ -320,17 +318,16 @@ function process_enter_while_filtering(e) {
             handle_emoji_clicked($first_emoji, e);
         }
     }
-}
+};
 
-function round_off_to_previous_multiple(number_to_round, multiple) {
-    return number_to_round - (number_to_round % multiple);
-}
+const round_off_to_previous_multiple = (number_to_round, multiple) =>
+    number_to_round - (number_to_round % multiple);
 
-function reset_emoji_showcase() {
+const reset_emoji_showcase = () => {
     $(".emoji-showcase-container").empty();
-}
+};
 
-function update_emoji_showcase($focused_emoji) {
+const update_emoji_showcase = ($focused_emoji) => {
     // Don't use jQuery's data() function here. It has the side-effect
     // of converting emoji names like :100:, :1234: etc to number.
     const focused_emoji_name = $focused_emoji.attr("data-emoji-name");
@@ -352,9 +349,9 @@ function update_emoji_showcase($focused_emoji) {
     });
 
     $(".emoji-showcase-container").html(rendered_showcase);
-}
+};
 
-function maybe_change_focused_emoji($emoji_map, next_section, next_index, preserve_scroll) {
+const maybe_change_focused_emoji = ($emoji_map, next_section, next_index, preserve_scroll) => {
     const $next_emoji = get_rendered_emoji(next_section, next_index);
     if ($next_emoji) {
         current_section = next_section;
@@ -372,9 +369,9 @@ function maybe_change_focused_emoji($emoji_map, next_section, next_index, preser
         return true;
     }
     return false;
-}
+};
 
-function maybe_change_active_section(next_section) {
+const maybe_change_active_section = (next_section) => {
     const $emoji_map = $(".emoji-popover-emoji-map");
 
     if (next_section >= 0 && next_section < get_total_sections()) {
@@ -386,9 +383,9 @@ function maybe_change_active_section(next_section) {
             maybe_change_focused_emoji($emoji_map, current_section, current_index);
         }
     }
-}
+};
 
-function get_next_emoji_coordinates(move_by) {
+const get_next_emoji_coordinates = (move_by) => {
     let next_section = current_section;
     let next_index = current_index + move_by;
     let max_len;
@@ -419,9 +416,9 @@ function get_next_emoji_coordinates(move_by) {
         section: next_section,
         index: next_index,
     };
-}
+};
 
-function change_focus_to_filter() {
+const change_focus_to_filter = () => {
     const $popover = $(emoji_popover_instance.popper);
     $popover.find(".emoji-popover-filter").trigger("focus");
     // If search is active reset current selected emoji to first emoji.
@@ -430,9 +427,9 @@ function change_focus_to_filter() {
         current_index = 0;
     }
     reset_emoji_showcase();
-}
+};
 
-export function navigate(event_name, e) {
+export const navigate = (event_name, e) => {
     if (
         event_name === "toggle_reactions_popover" &&
         is_open() &&
@@ -523,9 +520,9 @@ export function navigate(event_name, e) {
         default:
             return false;
     }
-}
+};
 
-function process_keypress(e) {
+const process_keypress = (e) => {
     const is_filter_focused = $(".emoji-popover-filter").is(":focus");
     const pressed_key = e.which;
     if (
@@ -555,9 +552,9 @@ function process_keypress(e) {
         change_focus_to_filter();
         filter_emojis();
     }
-}
+};
 
-export function emoji_select_tab($elt) {
+export const emoji_select_tab = ($elt) => {
     const scrolltop = $elt.scrollTop();
     const scrollheight = $elt.prop("scrollHeight");
     const elt_height = $elt.height();
@@ -590,9 +587,9 @@ export function emoji_select_tab($elt) {
             "active",
         );
     }
-}
+};
 
-function register_popover_events($popover) {
+const register_popover_events = ($popover) => {
     const $emoji_map = $popover.find(".emoji-popover-emoji-map");
 
     scroll_util.get_scroll_element($emoji_map).on("scroll", () => {
@@ -611,71 +608,67 @@ function register_popover_events($popover) {
             process_keypress(e);
         }
     });
-}
+};
 
-function get_default_emoji_popover_options() {
-    return {
-        placement: "top",
-        popperOptions: {
-            modifiers: [
-                {
-                    // The placement is set to top, but if that placement does not fit,
-                    // the opposite bottom or left placement will be used.
-                    name: "flip",
-                    options: {
-                        // We list both bottom and top here, because
-                        // some callers override the default
-                        // placement.
-                        fallbackPlacements: ["bottom", "top", "left", "right"],
-                    },
+const get_default_emoji_popover_options = () => ({
+    placement: "top",
+    popperOptions: {
+        modifiers: [
+            {
+                // The placement is set to top, but if that placement does not fit,
+                // the opposite bottom or left placement will be used.
+                name: "flip",
+                options: {
+                    // We list both bottom and top here, because
+                    // some callers override the default
+                    // placement.
+                    fallbackPlacements: ["bottom", "top", "left", "right"],
                 },
-            ],
-        },
-        onCreate(instance) {
-            emoji_popover_instance = instance;
-            const $popover = $(instance.popper);
-            $popover.addClass("emoji-popover-root");
-            instance.setContent(
-                ui_util.parse_html(generate_emoji_picker_content(current_message_id)),
-            );
-            emoji_catalog_last_coordinates = {
-                section: 0,
-                index: 0,
-            };
-        },
-        onShow(instance) {
-            const $reference = $(instance.reference);
-            $reference.addClass("active-emoji-picker-reference");
-            $reference.parent().addClass("active-emoji-picker-reference");
-        },
-        onMount(instance) {
-            const $popover = $(instance.popper);
-            // Render the emojis after simplebar has been initialized which
-            // saves us ~30% time rendering them.
-            $popover.find(".emoji-popover-emoji-map .simplebar-content").html(
-                render_emoji_popover_emoji_map({
-                    message_id: current_message_id,
-                    emoji_categories: complete_emoji_catalog,
-                    is_status_emoji_popover: user_status_ui.user_status_picker_open(),
-                }),
-            );
-            refill_section_head_offsets($popover);
-            show_emoji_catalog();
-            register_popover_events($popover);
-            // Don't focus filter box on mobile since it leads to window resize due
-            // to keyboard being open and scrolls the emoji popover out of view while
-            // still open in Chrome Android and can hide it based on device height in Firefox Android.
-            if (!util.is_mobile()) {
-                change_focus_to_filter();
-            }
-        },
-        onHidden() {
-            hide_emoji_popover();
-        },
-    };
-}
+            },
+        ],
+    },
+    onCreate: (instance) => {
+        emoji_popover_instance = instance;
+        const $popover = $(instance.popper);
+        $popover.addClass("emoji-popover-root");
+        instance.setContent(ui_util.parse_html(generate_emoji_picker_content(current_message_id)));
+        emoji_catalog_last_coordinates = {
+            section: 0,
+            index: 0,
+        };
+    },
+    onShow: (instance) => {
+        const $reference = $(instance.reference);
+        $reference.addClass("active-emoji-picker-reference");
+        $reference.parent().addClass("active-emoji-picker-reference");
+    },
+    onMount: (instance) => {
+        const $popover = $(instance.popper);
+        // Render the emojis after simplebar has been initialized which
+        // saves us ~30% time rendering them.
+        $popover.find(".emoji-popover-emoji-map .simplebar-content").html(
+            render_emoji_popover_emoji_map({
+                message_id: current_message_id,
+                emoji_categories: complete_emoji_catalog,
+                is_status_emoji_popover: user_status_ui.user_status_picker_open(),
+            }),
+        );
+        refill_section_head_offsets($popover);
+        show_emoji_catalog();
+        register_popover_events($popover);
+        // Don't focus filter box on mobile since it leads to window resize due
+        // to keyboard being open and scrolls the emoji popover out of view while
+        // still open in Chrome Android and can hide it based on device height in Firefox Android.
+        if (!util.is_mobile()) {
+            change_focus_to_filter();
+        }
+    },
+    onHidden: () => {
+        hide_emoji_popover();
+    },
+});
 
-export function toggle_emoji_popover(target, id, additional_popover_options) {
+export const toggle_emoji_popover = (target, id, additional_popover_options) => {
     if (id) {
         current_message_id = id;
     }
@@ -690,17 +683,17 @@ export function toggle_emoji_popover(target, id, additional_popover_options) {
             show_as_overlay_on_mobile: true,
         },
     );
-}
+};
 
-function handle_reaction_emoji_clicked(emoji_name, event) {
+const handle_reaction_emoji_clicked = (emoji_name, event) => {
     // When an emoji is clicked in the popover,
     // if the user has reacted to this message with this emoji
     // the reaction is removed
     // otherwise, the reaction is added
     toggle_reaction(emoji_name, event);
-}
+};
 
-function handle_status_emoji_clicked(emoji_name) {
+const handle_status_emoji_clicked = (emoji_name) => {
     hide_emoji_popover();
     let emoji_info = {
         emoji_name,
@@ -712,9 +705,9 @@ function handle_status_emoji_clicked(emoji_name) {
     user_status_ui.set_selected_emoji_info(emoji_info);
     user_status_ui.update_button();
     user_status_ui.toggle_clear_message_button();
-}
+};
 
-function handle_composition_emoji_clicked(emoji_name) {
+const handle_composition_emoji_clicked = (emoji_name) => {
     hide_emoji_popover();
     const emoji_text = ":" + emoji_name + ":";
     // The following check will return false if emoji was not selected in
@@ -730,9 +723,9 @@ function handle_composition_emoji_clicked(emoji_name) {
     } else {
         compose_ui.insert_syntax_and_focus(emoji_text);
     }
-}
+};
 
-function handle_emoji_clicked($emoji, event) {
+const handle_emoji_clicked = ($emoji, event) => {
     const emoji_name = $emoji.attr("data-emoji-name");
     const emoji_destination = $emoji
         .closest(".emoji-picker-popover")
@@ -752,7 +745,7 @@ function handle_emoji_clicked($emoji, event) {
             break;
         }
     }
-}
+};
 
 function register_click_handlers() {
     $("body").on("click", ".emoji-popover-emoji", (e) => {
@@ -847,7 +840,7 @@ function register_click_handlers() {
     );
 }
 
-export function initialize() {
+export const initialize = () => {
     rebuild_catalog();
     register_click_handlers();
-}
+};

--- a/web/src/emojisets.ts
+++ b/web/src/emojisets.ts
@@ -28,7 +28,7 @@ emojisets.set("text", emojisets.get("google")!);
 
 let current_emojiset: EmojiSet | undefined;
 
-async function fetch_emojiset(name: string, url: string): Promise<void> {
+const fetch_emojiset = async (name: string, url: string): Promise<void> => {
     const MAX_RETRIES = 3;
     const RETRY_DELAY = 10000; // 10 seconds
 
@@ -76,9 +76,9 @@ async function fetch_emojiset(name: string, url: string): Promise<void> {
             }
         }
     }
-}
+};
 
-export async function select(name: string): Promise<void> {
+export const select = async (name: string): Promise<void> => {
     const new_emojiset = emojisets.get(name);
     if (new_emojiset === current_emojiset) {
         return;
@@ -95,9 +95,9 @@ export async function select(name: string): Promise<void> {
     }
     new_emojiset.css.use();
     current_emojiset = new_emojiset;
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     void select(user_settings.emojiset);
 
     // Load the octopus image in the background, so that the browser
@@ -107,4 +107,4 @@ export function initialize(): void {
     // TODO: We should probably just make this work just like the Zulip emoji.
     const octopus_image = new Image();
     octopus_image.src = octopus_url;
-}
+};

--- a/web/src/favicon.ts
+++ b/web/src/favicon.ts
@@ -8,7 +8,7 @@ import favicon_font_url from "./favicon_font_url!=!url-loader!font-subset-loader
 
 let favicon_state: {image: HTMLImageElement; url: string} | undefined;
 
-function load_and_set_favicon(rendered_favicon: string): void {
+const load_and_set_favicon = (rendered_favicon: string): void => {
     favicon_state = {
         url: URL.createObjectURL(new Blob([rendered_favicon], {type: "image/svg+xml"})),
         image: new Image(),
@@ -18,14 +18,14 @@ function load_and_set_favicon(rendered_favicon: string): void {
     // render the webfont (https://crbug.com/1140920).
     favicon_state.image.src = favicon_state.url;
     favicon_state.image.addEventListener("load", set_favicon);
-}
-function set_favicon(): void {
+};
+const set_favicon = (): void => {
     if (favicon_state === undefined) {
         throw new Error("Programming error: favicon_state must be set.");
     }
     $("#favicon").attr("href", favicon_state.url);
-}
-export function update_favicon(new_message_count: number, pm_count: number): void {
+};
+export const update_favicon = (new_message_count: number, pm_count: number): void => {
     try {
         if (favicon_state !== undefined) {
             favicon_state.image.removeEventListener("load", set_favicon);
@@ -65,4 +65,4 @@ export function update_favicon(new_message_count: number, pm_count: number): voi
     } catch (error) {
         blueslip.error("Failed to update favicon", undefined, error);
     }
-}
+};

--- a/web/src/feedback_widget.ts
+++ b/web/src/feedback_widget.ts
@@ -46,7 +46,7 @@ const meta: FeedbackWidgetMeta = {
 };
 
 const animate = {
-    maybe_close() {
+    maybe_close: () => {
         if (!meta.opened) {
             return;
         }
@@ -60,7 +60,7 @@ const animate = {
             animate.maybe_close();
         }, 100);
     },
-    fadeOut() {
+    fadeOut: () => {
         if (!meta.opened) {
             return;
         }
@@ -80,7 +80,7 @@ const animate = {
             meta.alert_hover_state = false;
         }
     },
-    fadeIn() {
+    fadeIn: () => {
         if (meta.opened) {
             return;
         }
@@ -95,7 +95,7 @@ const animate = {
     },
 };
 
-function set_up_handlers(): void {
+const set_up_handlers = (): void => {
     if (meta.handlers_set) {
         return;
     }
@@ -138,17 +138,15 @@ function set_up_handlers(): void {
         }
         animate.fadeOut();
     });
-}
+};
 
-export function is_open(): boolean {
-    return meta.opened;
-}
+export const is_open = (): boolean => meta.opened;
 
-export function dismiss(): void {
+export const dismiss = (): void => {
     animate.fadeOut();
-}
+};
 
-export function show(opts: FeedbackWidgetOptions): void {
+export const show = (opts: FeedbackWidgetOptions): void => {
     if (!opts.populate) {
         blueslip.error("programmer needs to supply populate callback.");
         return;
@@ -175,4 +173,4 @@ export function show(opts: FeedbackWidgetOptions): void {
     opts.populate(meta.$container.find(".feedback_content"));
 
     animate.fadeIn();
-}
+};

--- a/web/src/fetch_status.ts
+++ b/web/src/fetch_status.ts
@@ -1,13 +1,13 @@
 import * as message_feed_loading from "./message_feed_loading";
 import type {Message, RawMessage} from "./message_store";
 
-function max_id_for_messages(messages: (Message | RawMessage)[]): number {
+const max_id_for_messages = (messages: (Message | RawMessage)[]): number => {
     let max_id = 0;
     for (const msg of messages) {
         max_id = Math.max(max_id, msg.id);
     }
     return max_id;
-}
+};
 
 export class FetchStatus {
     // The FetchStatus object tracks the state of a

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -62,7 +62,10 @@ type Part =
 const CHANNEL_SYNONYM = "stream";
 const CHANNELS_SYNONYM = "streams";
 
-function zephyr_stream_name_match(message: Message & {type: "stream"}, operand: string): boolean {
+const zephyr_stream_name_match = (
+    message: Message & {type: "stream"},
+    operand: string,
+): boolean => {
     // Zephyr users expect narrowing to "social" to also show messages to /^(un)*social(.d)*$/
     // (unsocial, ununsocial, social.d, etc)
     // TODO: hoist the regex compiling out of the closure
@@ -77,9 +80,9 @@ function zephyr_stream_name_match(message: Message & {type: "stream"}, operand: 
     );
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     return related_regexp.test(stream_name);
-}
+};
 
-function zephyr_topic_name_match(message: Message & {type: "stream"}, operand: string): boolean {
+const zephyr_topic_name_match = (message: Message & {type: "stream"}, operand: string): boolean => {
     // Zephyr users expect narrowing to topic "foo" to also show messages to /^foo(.d)*$/
     // (foo, foo.d, foo.d.d, etc)
     // TODO: hoist the regex compiling out of the closure
@@ -105,9 +108,9 @@ function zephyr_topic_name_match(message: Message & {type: "stream"}, operand: s
     }
 
     return related_regexp.test(message.topic);
-}
+};
 
-function message_in_home(message: Message): boolean {
+const message_in_home = (message: Message): boolean => {
     // The home view contains messages not sent to muted channels,
     // with additional logic for unmuted topics, mentions, and
     // single-channel windows.
@@ -133,9 +136,13 @@ function message_in_home(message: Message): boolean {
         !stream_data.is_muted(message.stream_id) ||
         user_topics.is_topic_unmuted_or_followed(message.stream_id, message.topic)
     );
-}
+};
 
-function message_matches_search_term(message: Message, operator: string, operand: string): boolean {
+const message_matches_search_term = (
+    message: Message,
+    operator: string,
+    operand: string,
+): boolean => {
     switch (operator) {
         case "has":
             switch (operand) {
@@ -245,7 +252,7 @@ function message_matches_search_term(message: Message, operator: string, operand
     }
 
     return true; // unknown operators return true (effectively ignored)
-}
+};
 
 export class Filter {
     _terms: NarrowTerm[];
@@ -381,7 +388,7 @@ export class Filter {
         let operand;
         let term;
 
-        function maybe_add_search_terms(): void {
+        const maybe_add_search_terms = (): void => {
             if (search_term.length > 0) {
                 operator = "search";
                 const _operand = search_term.join(" ");
@@ -389,7 +396,7 @@ export class Filter {
                 terms.push(term);
                 search_term = [];
             }
-        }
+        };
 
         // Match all operands that either have no spaces, or are surrounded by
         // quotes, preceded by an optional operator that may have a space after it.

--- a/web/src/flatpickr.ts
+++ b/web/src/flatpickr.ts
@@ -9,20 +9,17 @@ import {user_settings} from "./user_settings";
 
 export let flatpickr_instance: flatpickr.Instance;
 
-export function is_open(): boolean {
-    return Boolean(flatpickr_instance?.isOpen);
-}
+export const is_open = (): boolean => Boolean(flatpickr_instance?.isOpen);
 
-function is_numeric_key(key: string): boolean {
-    return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
-}
+const is_numeric_key = (key: string): boolean =>
+    ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key);
 
-export function show_flatpickr(
+export const show_flatpickr = (
     element: HTMLElement,
     callback: (time: string) => void,
     default_timestamp: flatpickr.Options.DateOption,
     options: flatpickr.Options.Options = {},
-): flatpickr.Instance {
+): flatpickr.Instance => {
     const $flatpickr_input = $<HTMLInputElement>("<input>").attr("id", "#timestamp_flatpickr");
 
     flatpickr_instance = flatpickr($flatpickr_input[0]!, {
@@ -43,7 +40,7 @@ export function show_flatpickr(
         disableMobile: true,
         time_24hr: user_settings.twenty_four_hour_time,
         minuteIncrement: 1,
-        onKeyDown(_selectedDates, _dateStr, instance, event: KeyboardEvent) {
+        onKeyDown: (_selectedDates, _dateStr, instance, event: KeyboardEvent) => {
             // See also the keydown handler below.
             //
             // TODO: Add a clear explanation of exactly how key
@@ -140,8 +137,8 @@ export function show_flatpickr(
     flatpickr_instance.selectedDateElem.focus();
 
     return flatpickr_instance;
-}
+};
 
-export function close_all(): void {
+export const close_all = (): void => {
     $(".flatpickr-calendar").removeClass("open");
-}
+};

--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -85,14 +85,14 @@ The click handler uses "[data-overlay-trigger]" as
 the selector and then calls browser_history.go_to_location.
 */
 
-function render(instance) {
+const render = (instance) => {
     const rendered_gear_menu = render_navbar_gear_menu_popover(
         popover_menus_data.get_gear_menu_content_context(),
     );
     instance.setContent(parse_html(rendered_gear_menu));
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     popover_menus.register_popover_menu("#gear-menu", {
         theme: "popover-menu",
         placement: "bottom",
@@ -108,7 +108,7 @@ export function initialize() {
                 },
             ],
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.gear_menu = instance;
             $popper.on("click", ".webathena_login", (e) => {
@@ -136,10 +136,10 @@ export function initialize() {
                         channel.post({
                             url: "/accounts/webathena_kerberos_login/",
                             data: {cred: JSON.stringify(r.session)},
-                            success() {
+                            success: () => {
                                 $("#zephyr-mirror-error").removeClass("show");
                             },
-                            error() {
+                            error: () => {
                                 $("#zephyr-mirror-error").addClass("show");
                             },
                         });
@@ -182,14 +182,14 @@ export function initialize() {
             });
         },
         onShow: render,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.gear_menu = undefined;
         },
     });
-}
+};
 
-export function toggle() {
+export const toggle = () => {
     if (popover_menus.is_gear_menu_popover_displayed()) {
         popovers.hide_all();
         return;
@@ -202,10 +202,10 @@ export function toggle() {
     }
 
     $("#gear-menu").trigger("click");
-}
+};
 
-export function rerender() {
+export const rerender = () => {
     if (popover_menus.is_gear_menu_popover_displayed()) {
         render(popover_menus.get_gear_menu_instance());
     }
-}
+};

--- a/web/src/gear_menu_util.ts
+++ b/web/src/gear_menu_util.ts
@@ -1,7 +1,7 @@
 import {$t} from "./i18n";
 import {realm} from "./state_data";
 
-export function version_display_string(): string {
+export const version_display_string = (): string => {
     const version = realm.zulip_version;
     const is_fork = realm.zulip_merge_base && realm.zulip_merge_base !== version;
 
@@ -31,4 +31,4 @@ export function version_display_string(): string {
 
     const display_version = version.replace(/\+git.*/, "").replace(/-dev.*/, "-dev");
     return $t({defaultMessage: "Zulip Server {display_version}"}, {display_version});
-}
+};

--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -18,22 +18,18 @@ let giphy_popover_instance = null;
 // Only used if popover called from edit message, otherwise it is `undefined`.
 let edit_message_id;
 
-export function is_popped_from_edit_message() {
-    return giphy_popover_instance && edit_message_id !== undefined;
-}
+export const is_popped_from_edit_message = () =>
+    giphy_popover_instance && edit_message_id !== undefined;
 
-export function focus_current_edit_message() {
+export const focus_current_edit_message = () => {
     $(`#edit_form_${CSS.escape(edit_message_id)} .message_edit_content`).trigger("focus");
-}
+};
 
-export function is_giphy_enabled() {
-    return (
-        realm.giphy_api_key !== "" &&
-        realm.realm_giphy_rating !== realm.giphy_rating_options.disabled.id
-    );
-}
+export const is_giphy_enabled = () =>
+    realm.giphy_api_key !== "" &&
+    realm.realm_giphy_rating !== realm.giphy_rating_options.disabled.id;
 
-export function update_giphy_rating() {
+export const update_giphy_rating = () => {
     if (
         realm.realm_giphy_rating === realm.giphy_rating_options.disabled.id ||
         realm.giphy_api_key === ""
@@ -42,9 +38,9 @@ export function update_giphy_rating() {
     } else {
         $(".compose_gif_icon").show();
     }
-}
+};
 
-function get_rating() {
+const get_rating = () => {
     const options = realm.giphy_rating_options;
     for (const rating in realm.giphy_rating_options) {
         if (options[rating].id === realm.realm_giphy_rating) {
@@ -56,9 +52,9 @@ function get_rating() {
     // `giphy_rating` value not present in `giphy_rating_options`.
     blueslip.error("Invalid giphy_rating value: " + realm.realm_giphy_rating);
     return "g";
-}
+};
 
-async function renderGIPHYGrid(targetEl) {
+const renderGIPHYGrid = async (targetEl) => {
     const {renderGrid} = await import(/* webpackChunkName: "giphy-sdk" */ "@giphy/js-components");
     const {GiphyFetch} = await import(/* webpackChunkName: "giphy-sdk" */ "@giphy/js-fetch-api");
 
@@ -66,7 +62,7 @@ async function renderGIPHYGrid(targetEl) {
         giphy_fetch = new GiphyFetch(realm.giphy_api_key);
     }
 
-    function fetchGifs(offset) {
+    const fetchGifs = (offset) => {
         const config = {
             offset,
             limit: 25,
@@ -78,7 +74,7 @@ async function renderGIPHYGrid(targetEl) {
             return giphy_fetch.trending(config);
         }
         return giphy_fetch.search(search_term, config);
-    }
+    };
 
     const render = () =>
         // See https://github.com/Giphy/giphy-js/blob/master/packages/components/README.md#grid
@@ -93,7 +89,7 @@ async function renderGIPHYGrid(targetEl) {
                 // Hide the creator attribution that appears over a
                 // GIF; nice in principle but too distracting.
                 hideAttribution: true,
-                onGifClick(props) {
+                onGifClick: (props) => {
                     let $textarea = $("textarea#compose-textarea");
                     if (edit_message_id !== undefined) {
                         $textarea = $(
@@ -109,7 +105,7 @@ async function renderGIPHYGrid(targetEl) {
                     );
                     hide_giphy_popover();
                 },
-                onGifVisible(_gif, e) {
+                onGifVisible: (_gif, e) => {
                     // Set tabindex for all the GIFs that
                     // are visible to the user. This allows
                     // user to navigate the GIFs using tab.
@@ -128,14 +124,14 @@ async function renderGIPHYGrid(targetEl) {
     window.addEventListener("resize", resizeRender, false);
     const remove = render();
     return {
-        remove() {
+        remove: () => {
             remove();
             window.removeEventListener("resize", resizeRender, false);
         },
     };
-}
+};
 
-async function update_grid_with_search_term() {
+const update_grid_with_search_term = async () => {
     if (!gifs_grid) {
         return;
     }
@@ -152,9 +148,9 @@ async function update_grid_with_search_term() {
 
     // Set to undefined to stop searching.
     gifs_grid = undefined;
-}
+};
 
-export function hide_giphy_popover() {
+export const hide_giphy_popover = () => {
     // Returns `true` if the popover was open.
     if (giphy_popover_instance) {
         giphy_popover_instance.destroy();
@@ -164,18 +160,18 @@ export function hide_giphy_popover() {
         return true;
     }
     return false;
-}
+};
 
-function toggle_giphy_popover(target) {
+const toggle_giphy_popover = (target) => {
     popover_menus.toggle_popover_menu(
         target,
         {
             placement: "top",
-            onCreate(instance) {
+            onCreate: (instance) => {
                 instance.setContent(ui_util.parse_html(render_giphy_picker()));
                 $(instance.popper).addClass("giphy-popover");
             },
-            async onShow(instance) {
+            onShow: async (instance) => {
                 giphy_popover_instance = instance;
                 const $popper = $(giphy_popover_instance.popper).trigger("focus");
                 gifs_grid = await renderGIPHYGrid($popper.find(".giphy-content")[0]);
@@ -217,7 +213,7 @@ function toggle_giphy_popover(target) {
                 // navigating via keyboard.
                 $("#giphy-search-query").trigger("focus");
             },
-            onHidden() {
+            onHidden: () => {
                 hide_giphy_popover();
             },
         },
@@ -225,14 +221,14 @@ function toggle_giphy_popover(target) {
             show_as_overlay_on_mobile: true,
         },
     );
-}
+};
 
-function register_click_handlers() {
+const register_click_handlers = () => {
     $("body").on("click", ".compose_control_button.compose_gif_icon", (e) => {
         toggle_giphy_popover(e.currentTarget);
     });
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     register_click_handlers();
-}
+};

--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -1,10 +1,10 @@
 import {realm} from "./state_data";
 import type {GroupPermissionSetting} from "./state_data";
 
-export function get_group_permission_setting_config(
+export const get_group_permission_setting_config = (
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
-): GroupPermissionSetting | undefined {
+): GroupPermissionSetting | undefined => {
     const permission_settings_dict = realm.server_supported_permission_settings;
 
     const permission_config_dict = permission_settings_dict[setting_type][setting_name];
@@ -13,4 +13,4 @@ export function get_group_permission_setting_config(
         throw new Error(`Invalid setting: ${setting_name}`);
     }
     return permission_config_dict;
-}
+};

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -1,9 +1,7 @@
-export function get_hash_category(hash?: string): string {
-    // given "#channels/subscribed", returns "channels"
-    return hash ? hash.replace(/^#/, "").split(/\//)[0]! : "";
-}
+export const get_hash_category = (hash?: string): string =>
+    hash ? hash.replace(/^#/, "").split(/\//)[0]! : "";
 
-export function get_hash_section(hash?: string): string {
+export const get_hash_section = (hash?: string): string => {
     // given "#settings/profile", returns "profile"
     // given '#channels/5/social", returns "5"
     if (!hash) {
@@ -13,40 +11,29 @@ export function get_hash_section(hash?: string): string {
     const parts = hash.replace(/\/$/, "").split(/\//);
 
     return parts[1] ?? "";
-}
+};
 
-function get_nth_hash_section(hash: string, n: number): string {
+const get_nth_hash_section = (hash: string, n: number): string => {
     // given "#settings/profile" and n=1, returns "profile"
     // given '#channels/5/social" and n=2, returns "social"
     const parts = hash.replace(/\/$/, "").split(/\//);
     return parts.at(n) ?? "";
-}
+};
 
-export function get_current_nth_hash_section(n: number): string {
-    return get_nth_hash_section(window.location.hash, n);
-}
+export const get_current_nth_hash_section = (n: number): string =>
+    get_nth_hash_section(window.location.hash, n);
 
-export function get_current_hash_category(): string {
-    return get_hash_category(window.location.hash);
-}
+export const get_current_hash_category = (): string => get_hash_category(window.location.hash);
 
-export function get_current_hash_section(): string {
-    return get_hash_section(window.location.hash);
-}
+export const get_current_hash_section = (): string => get_hash_section(window.location.hash);
 
-export function is_same_server_message_link(url: string): boolean {
-    // A same server message link always has category `narrow`,
-    // section `stream` or `dm`, and ends with `/near/<message_id>`,
-    // where <message_id> is a sequence of digits.
-    return (
-        get_hash_category(url) === "narrow" &&
-        (get_hash_section(url) === "stream" || get_hash_section(url) === "dm") &&
-        get_nth_hash_section(url, -2) === "near" &&
-        /^\d+$/.test(get_nth_hash_section(url, -1))
-    );
-}
+export const is_same_server_message_link = (url: string): boolean =>
+    get_hash_category(url) === "narrow" &&
+    (get_hash_section(url) === "stream" || get_hash_section(url) === "dm") &&
+    get_nth_hash_section(url, -2) === "near" &&
+    /^\d+$/.test(get_nth_hash_section(url, -1));
 
-export function is_overlay_hash(hash: string): boolean {
+export const is_overlay_hash = (hash: string): boolean => {
     // Hash changes within this list are overlays and should not unnarrow (etc.)
     const overlay_list = [
         // In 2024, stream was renamed to channel in the Zulip API and UI.
@@ -71,11 +58,11 @@ export function is_overlay_hash(hash: string): boolean {
     const main_hash = get_hash_category(hash);
 
     return overlay_list.includes(main_hash);
-}
+};
 
 // this finds the stream that is actively open in the settings and focused in
 // the left side.
-export function is_editing_stream(desired_stream_id: number): boolean {
+export const is_editing_stream = (desired_stream_id: number): boolean => {
     const hash_components = window.location.hash.slice(1).split(/\//);
 
     if (hash_components[0] !== "channels") {
@@ -91,15 +78,13 @@ export function is_editing_stream(desired_stream_id: number): boolean {
     const stream_id = Number.parseFloat(hash_components[1]!);
 
     return stream_id === desired_stream_id;
-}
+};
 
-export function is_create_new_stream_narrow(): boolean {
-    return window.location.hash === "#channels/new";
-}
+export const is_create_new_stream_narrow = (): boolean => window.location.hash === "#channels/new";
 
 // This checks whether the user is in the stream settings menu
 // and is opening the 'Subscribers' tab on the right panel.
-export function is_subscribers_section_opened_for_stream(): boolean {
+export const is_subscribers_section_opened_for_stream = (): boolean => {
     const hash_components = window.location.hash.slice(1).split(/\//);
 
     if (hash_components[0] !== "channels") {
@@ -109,12 +94,12 @@ export function is_subscribers_section_opened_for_stream(): boolean {
         return false;
     }
     return hash_components[3] === "subscribers";
-}
+};
 
-export function is_in_specified_hash_category(hash_categories: string[]): boolean {
+export const is_in_specified_hash_category = (hash_categories: string[]): boolean => {
     const main_hash = get_hash_category(window.location.hash);
     return hash_categories.includes(main_hash);
-}
+};
 
 export const allowed_web_public_narrows = [
     "channels",
@@ -129,7 +114,7 @@ export const allowed_web_public_narrows = [
     "id",
 ];
 
-export function is_spectator_compatible(hash: string): boolean {
+export const is_spectator_compatible = (hash: string): boolean => {
     // Defines which views are supported for spectators.
     // This implementation should agree with the similar function in zerver/lib/narrow.py.
     const web_public_allowed_hashes = [
@@ -163,4 +148,4 @@ export function is_spectator_compatible(hash: string): boolean {
     }
 
     return web_public_allowed_hashes.includes(main_hash);
-}
+};

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -13,15 +13,15 @@ import * as user_groups from "./user_groups";
 import type {UserGroup} from "./user_groups";
 import * as util from "./util";
 
-export function build_reload_url(): string {
+export const build_reload_url = (): string => {
     let hash = window.location.hash;
     if (hash.length !== 0 && hash.startsWith("#")) {
         hash = hash.slice(1);
     }
     return "+oldhash=" + encodeURIComponent(hash);
-}
+};
 
-export function encode_operand(operator: string, operand: string): string {
+export const encode_operand = (operator: string, operand: string): string => {
     if (
         operator === "group-pm-with" ||
         operator === "dm-including" ||
@@ -40,17 +40,17 @@ export function encode_operand(operator: string, operand: string): string {
     }
 
     return internal_url.encodeHashComponent(operand);
-}
+};
 
-export function encode_stream_name(operand: string): string {
+export const encode_stream_name = (operand: string): string => {
     // stream_data prefixes the stream id, but it does not do the
     // URI encoding piece
     operand = stream_data.name_to_slug(operand);
 
     return internal_url.encodeHashComponent(operand);
-}
+};
 
-export function decode_operand(operator: string, operand: string): string {
+export const decode_operand = (operator: string, operand: string): string => {
     if (
         operator === "group-pm-with" ||
         operator === "dm-including" ||
@@ -71,22 +71,18 @@ export function decode_operand(operator: string, operand: string): string {
     }
 
     return operand;
-}
+};
 
-export function by_stream_url(stream_id: number): string {
-    // Wrapper for web use of internal_url.by_stream_url
-    return internal_url.by_stream_url(stream_id, sub_store.maybe_get_stream_name);
-}
+export const by_stream_url = (stream_id: number): string =>
+    internal_url.by_stream_url(stream_id, sub_store.maybe_get_stream_name);
 
-export function by_stream_topic_url(stream_id: number, topic: string): string {
-    // Wrapper for web use of internal_url.by_stream_topic_url
-    return internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
-}
+export const by_stream_topic_url = (stream_id: number, topic: string): string =>
+    internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
 
 // Encodes a term list into the
 // corresponding hash: the # component
 // of the narrow URL
-export function search_terms_to_hash(terms?: NarrowTerm[]): string {
+export const search_terms_to_hash = (terms?: NarrowTerm[]): string => {
     // Note: This does not return the correct hash for combined feed, recent and inbox view.
     // These views can have multiple hashes that lead to them, so this function cannot support them.
     let hash = "#";
@@ -110,26 +106,20 @@ export function search_terms_to_hash(terms?: NarrowTerm[]): string {
     }
 
     return hash;
-}
+};
 
-export function by_sender_url(reply_to: string): string {
-    return search_terms_to_hash([{operator: "sender", operand: reply_to}]);
-}
+export const by_sender_url = (reply_to: string): string =>
+    search_terms_to_hash([{operator: "sender", operand: reply_to}]);
 
-export function pm_with_url(reply_to: string): string {
+export const pm_with_url = (reply_to: string): string => {
     const slug = people.emails_to_slug(reply_to);
     return "#narrow/dm/" + slug;
-}
+};
 
-export function huddle_with_url(user_ids_string: string): string {
-    // This method is convenient for callers
-    // that have already converted emails to a comma-delimited
-    // list of user_ids.  We should be careful to keep this
-    // consistent with hash_util.decode_operand.
-    return "#narrow/dm/" + user_ids_string + "-group";
-}
+export const huddle_with_url = (user_ids_string: string): string =>
+    "#narrow/dm/" + user_ids_string + "-group";
 
-export function by_conversation_and_time_url(message: Message): string {
+export const by_conversation_and_time_url = (message: Message): string => {
     const absolute_url =
         window.location.protocol +
         "//" +
@@ -144,19 +134,19 @@ export function by_conversation_and_time_url(message: Message): string {
     }
 
     return absolute_url + people.pm_perma_link(message) + suffix;
-}
+};
 
-export function group_edit_url(group: UserGroup, right_side_tab: string): string {
+export const group_edit_url = (group: UserGroup, right_side_tab: string): string => {
     const hash = `#groups/${group.id}/${internal_url.encodeHashComponent(group.name)}/${right_side_tab}`;
     return hash;
-}
+};
 
-export function search_public_streams_notice_url(terms: NarrowTerm[]): string {
+export const search_public_streams_notice_url = (terms: NarrowTerm[]): string => {
     const public_operator = {operator: "channels", operand: "public"};
     return search_terms_to_hash([public_operator, ...terms]);
-}
+};
 
-export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
+export const parse_narrow = (hash: string[]): NarrowTerm[] | undefined => {
     // This will throw an exception when passed an invalid hash
     // at the decodeHashComponent call, handle appropriately.
     let i;
@@ -186,27 +176,24 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
         terms.push({negated, operator, operand});
     }
     return terms;
-}
+};
 
-export function channels_settings_edit_url(
+export const channels_settings_edit_url = (
     sub: StreamSubscription,
     right_side_tab: string,
-): string {
-    return `#channels/${sub.stream_id}/${internal_url.encodeHashComponent(
-        sub.name,
-    )}/${right_side_tab}`;
-}
+): string =>
+    `#channels/${sub.stream_id}/${internal_url.encodeHashComponent(sub.name)}/${right_side_tab}`;
 
-export function channels_settings_section_url(section = "subscribed"): string {
+export const channels_settings_section_url = (section = "subscribed"): string => {
     const valid_section_values = new Set(["new", "subscribed", "all", "notsubscribed"]);
     if (!valid_section_values.has(section)) {
         blueslip.warn("invalid section for channels settings: " + section);
         return "#channels/subscribed";
     }
     return `#channels/${section}`;
-}
+};
 
-export function validate_channels_settings_hash(hash: string): string {
+export const validate_channels_settings_hash = (hash: string): string => {
     const hash_components = hash.slice(1).split(/\//);
     const section = hash_components[1];
 
@@ -242,9 +229,9 @@ export function validate_channels_settings_hash(hash: string): string {
     }
 
     return channels_settings_section_url(section);
-}
+};
 
-export function validate_group_settings_hash(hash: string): string {
+export const validate_group_settings_hash = (hash: string): string => {
     const hash_components = hash.slice(1).split(/\//);
     const section = hash_components[1];
 
@@ -284,4 +271,4 @@ export function validate_group_settings_hash(hash: string): string {
         return "#groups/your";
     }
     return hash;
-}
+};

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -37,23 +37,23 @@ import {user_settings} from "./user_settings";
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 // or locally: docs/subsystems/hashchange-system.md
 
-function maybe_hide_recent_view() {
+const maybe_hide_recent_view = () => {
     if (recent_view_util.is_visible()) {
         recent_view_ui.hide();
         return true;
     }
     return false;
-}
+};
 
-function maybe_hide_inbox() {
+const maybe_hide_inbox = () => {
     if (inbox_util.is_visible()) {
         inbox_ui.hide();
         return true;
     }
     return false;
-}
+};
 
-function show_all_message_view() {
+const show_all_message_view = () => {
     // Don't export this function outside of this module since
     // `change_hash` is false here which means it is should only
     // be called after hash is updated in the URL.
@@ -63,16 +63,13 @@ function show_all_message_view() {
         then_select_id: history.state?.narrow_pointer,
         then_select_offset: history.state?.narrow_offset,
     });
-}
+};
 
-function is_somebody_else_profile_open() {
-    return (
-        user_profile.get_user_id_if_user_profile_modal_open() !== undefined &&
-        user_profile.get_user_id_if_user_profile_modal_open() !== people.my_current_user_id()
-    );
-}
+const is_somebody_else_profile_open = () =>
+    user_profile.get_user_id_if_user_profile_modal_open() !== undefined &&
+    user_profile.get_user_id_if_user_profile_modal_open() !== people.my_current_user_id();
 
-export function set_hash_to_home_view(triggered_by_escape_key = false) {
+export const set_hash_to_home_view = (triggered_by_escape_key = false) => {
     const current_hash = window.location.hash;
     if (current_hash === "") {
         // Empty hash for home view is always valid.
@@ -111,9 +108,9 @@ export function set_hash_to_home_view(triggered_by_escape_key = false) {
         browser_history.set_hash("");
         hashchanged(false);
     }
-}
+};
 
-function show_home_view() {
+const show_home_view = () => {
     // This function should only be called from the hashchange
     // handlers, as it does not set the hash to "".
     //
@@ -145,10 +142,10 @@ function show_home_view() {
             window.location.hash = user_settings.web_home_view;
         }
     }
-}
+};
 
 // Returns true if this function performed a narrow
-function do_hashchange_normal(from_reload) {
+const do_hashchange_normal = (from_reload) => {
     message_viewport.stop_auto_scrolling();
 
     // NB: In Firefox, window.location.hash is URI-decoded.
@@ -252,9 +249,9 @@ function do_hashchange_normal(from_reload) {
             show_home_view();
     }
     return false;
-}
+};
 
-function do_hashchange_overlay(old_hash) {
+const do_hashchange_overlay = (old_hash) => {
     if (old_hash === undefined) {
         // The user opened the app with an overlay hash; we need to
         // show the user's home view behind it.
@@ -471,9 +468,9 @@ function do_hashchange_overlay(old_hash) {
             user_profile.show_user_profile(user);
         }
     }
-}
+};
 
-function hashchanged(from_reload, e) {
+const hashchanged = (from_reload, e) => {
     const current_hash = window.location.hash;
     const old_hash = e && (e.oldURL ? new URL(e.oldURL).hash : browser_history.old_hash());
     const is_hash_web_public_compatible = browser_history.update_web_public_hash(current_hash);
@@ -512,9 +509,9 @@ function hashchanged(from_reload, e) {
     const ret = do_hashchange_normal(from_reload);
     browser_history.state.changing_hash = false;
     return ret;
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     // We don't want browser to restore the scroll
     // position of the new hash in the current hash.
     window.history.scrollRestoration = "manual";
@@ -523,4 +520,4 @@ export function initialize() {
         hashchanged(false, e.originalEvent);
     });
     hashchanged(true);
-}
+};

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -64,14 +64,14 @@ import * as user_group_popover from "./user_group_popover";
 import {user_settings} from "./user_settings";
 import * as user_topics_ui from "./user_topics_ui";
 
-function do_narrow_action(action) {
+const do_narrow_action = (action) => {
     if (message_lists.current === undefined) {
         return false;
     }
 
     action(message_lists.current.selected_id(), {trigger: "hotkey"});
     return true;
-}
+};
 
 // For message actions and user profile menu.
 const menu_dropdown_hotkeys = new Set(["down_arrow", "up_arrow", "vim_up", "vim_down", "enter"]);
@@ -196,7 +196,7 @@ const keypress_mappings = {
     122: {name: "zoom_to_message_near", message_view_only: true}, // 'z'
 };
 
-export function get_keydown_hotkey(e) {
+export const get_keydown_hotkey = (e) => {
     let hotkey;
 
     if (e.altKey) {
@@ -240,17 +240,17 @@ export function get_keydown_hotkey(e) {
     }
 
     return keydown_either_mappings[e.which];
-}
+};
 
-export function get_keypress_hotkey(e) {
+export const get_keypress_hotkey = (e) => {
     if (e.metaKey || e.ctrlKey || e.altKey) {
         return undefined;
     }
 
     return keypress_mappings[e.which];
-}
+};
 
-export function processing_text() {
+export const processing_text = () => {
     const $focused_elt = $(":focus");
     return (
         $focused_elt.is("input") ||
@@ -260,14 +260,12 @@ export function processing_text() {
         $focused_elt.attr("id") === "compose-send-button" ||
         $focused_elt.parents(".dropdown-list-container").length >= 1
     );
-}
+};
 
-export function in_content_editable_widget(e) {
-    return $(e.target).is(".editable-section");
-}
+export const in_content_editable_widget = (e) => $(e.target).is(".editable-section");
 
 // Returns true if we handled it, false if the browser should.
-export function process_escape_key(e) {
+export const process_escape_key = (e) => {
     if (
         recent_view_ui.is_in_focus() &&
         // This will return false if `e.target` is not
@@ -390,9 +388,9 @@ export function process_escape_key(e) {
     }
 
     return false;
-}
+};
 
-function handle_popover_events(event_name) {
+const handle_popover_events = (event_name) => {
     const popover_menu_visible_instance = popover_menus.get_visible_instance();
 
     if (popover_menu_visible_instance) {
@@ -439,10 +437,10 @@ function handle_popover_events(event_name) {
     }
 
     return false;
-}
+};
 
 // Returns true if we handled it, false if the browser should.
-export function process_enter_key(e) {
+export const process_enter_key = (e) => {
     if (popovers.any_active() && $(e.target).hasClass("navigate-link-on-enter")) {
         // If a popover is open and we pressed Enter on a menu item,
         // call click directly on the item to navigate to the `href`.
@@ -573,9 +571,9 @@ export function process_enter_key(e) {
 
     compose_reply.respond_to_message({trigger: "hotkey enter"});
     return true;
-}
+};
 
-export function process_ctrl_enter_key() {
+export const process_ctrl_enter_key = () => {
     if ($("#preview_message_area").is(":visible")) {
         const ctrl_pressed = true;
         compose.enter_with_preview_open(ctrl_pressed);
@@ -583,9 +581,9 @@ export function process_ctrl_enter_key() {
     }
 
     return false;
-}
+};
 
-export function process_tab_key() {
+export const process_tab_key = () => {
     // Returns true if we handled it, false if the browser should.
     // TODO: See if browsers like Safari can now handle tabbing correctly
     // without our intervention.
@@ -612,9 +610,9 @@ export function process_tab_key() {
     }
 
     return false;
-}
+};
 
-export function process_shift_tab_key() {
+export const process_shift_tab_key = () => {
     // Returns true if we handled it, false if the browser should.
     // TODO: See if browsers like Safari can now handle tabbing correctly
     // without our intervention.
@@ -653,12 +651,12 @@ export function process_shift_tab_key() {
     }
 
     return false;
-}
+};
 
 // Process a keydown or keypress event.
 //
 // Returns true if we handled it, false if the browser should.
-export function process_hotkey(e, hotkey) {
+export const process_hotkey = (e, hotkey) => {
     const event_name = hotkey.name;
 
     // This block needs to be before the `Tab` handler.
@@ -1223,7 +1221,7 @@ export function process_hotkey(e, hotkey) {
     }
 
     return false;
-}
+};
 
 /* We register both a keydown and a keypress function because
    we want to intercept PgUp/PgDn, Esc, etc, and process them
@@ -1235,24 +1233,24 @@ export function process_hotkey(e, hotkey) {
    so we bail in .keydown if the event is a letter or number and
    instead just let keypress go for it. */
 
-export function process_keydown(e) {
+export const process_keydown = (e) => {
     activity.set_new_user_input(true);
     const hotkey = get_keydown_hotkey(e);
     if (!hotkey) {
         return false;
     }
     return process_hotkey(e, hotkey);
-}
+};
 
-export function process_keypress(e) {
+export const process_keypress = (e) => {
     const hotkey = get_keypress_hotkey(e);
     if (!hotkey) {
         return false;
     }
     return process_hotkey(e, hotkey);
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $(document).on("keydown", (e) => {
         if (process_keydown(e)) {
             e.preventDefault();
@@ -1264,4 +1262,4 @@ export function initialize() {
             e.preventDefault();
         }
     });
-}
+};

--- a/web/src/huddle_data.ts
+++ b/web/src/huddle_data.ts
@@ -5,11 +5,11 @@ import * as people from "./people";
 
 const huddle_timestamps = new Map<string, number>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     huddle_timestamps.clear();
-}
+};
 
-export function process_loaded_messages(messages: Message[]): void {
+export const process_loaded_messages = (messages: Message[]): void => {
     for (const message of messages) {
         const huddle_string = people.huddle_string(message);
 
@@ -21,10 +21,10 @@ export function process_loaded_messages(messages: Message[]): void {
             }
         }
     }
-}
+};
 
-export function get_huddles(): string[] {
+export const get_huddles = (): string[] => {
     let huddles = [...huddle_timestamps.keys()];
     huddles = _.sortBy(huddles, (huddle) => huddle_timestamps.get(huddle));
     return huddles.reverse();
-}
+};

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -14,8 +14,7 @@ export const intl = createIntl(
         locale: page_params.request_language,
         defaultLocale: "en",
         messages: "translation_data" in page_params ? page_params.translation_data : {},
-        /* istanbul ignore next */
-        onError(error) {
+        onError: /* istanbul ignore next */ (error) => {
             // Ignore complaints about untranslated strings that were
             // added since the last sync-translations run.
             if (error.code !== IntlErrorCode.MISSING_TRANSLATION) {
@@ -35,11 +34,11 @@ export const default_html_elements = Object.fromEntries(
     ]),
 );
 
-export function $t_html(
+export const $t_html = (
     descriptor: MessageDescriptor,
     values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
-): string {
-    return intl.formatMessage(descriptor, {
+): string =>
+    intl.formatMessage(descriptor, {
         ...default_html_elements,
         ...Object.fromEntries(
             Object.entries(values ?? {}).map(([key, value]) => [
@@ -48,15 +47,13 @@ export function $t_html(
             ]),
         ),
     });
-}
 
 export let language_list: (typeof page_params & {page_type: "home"})["language_list"];
 
-export function get_language_name(language_code: string): string | undefined {
-    return language_list.find((language) => language.code === language_code)?.name;
-}
+export const get_language_name = (language_code: string): string | undefined =>
+    language_list.find((language) => language.code === language_code)?.name;
 
-export function initialize(language_params: {language_list: typeof language_list}): void {
+export const initialize = (language_params: {language_list: typeof language_list}): void => {
     const language_list_raw = language_params.language_list;
 
     // Limit offered languages to options with percentage translation >= 5%
@@ -71,7 +68,7 @@ export function initialize(language_params: {language_list: typeof language_list
             });
         }
     }
-}
+};
 
 type Language = {
     code: string;
@@ -80,7 +77,7 @@ type Language = {
     selected: boolean;
 };
 
-export function get_language_list_columns(default_language: string): Language[] {
+export const get_language_list_columns = (default_language: string): Language[] => {
     const formatted_list: Language[] = [];
     for (const language of language_list) {
         let name_with_percent = language.name;
@@ -97,4 +94,4 @@ export function get_language_list_columns(default_language: string): Language[] 
         });
     }
     return formatted_list;
-}
+};

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -169,16 +169,15 @@ const CONVERSATION_ID_PREFIX = "inbox-row-conversation-";
 const LEFT_NAVIGATION_KEYS = ["left_arrow", "shift_tab", "vim_left"];
 const RIGHT_NAVIGATION_KEYS = ["right_arrow", "tab", "vim_right"];
 
-function get_row_from_conversation_key(key: string): JQuery {
-    return $(`#${CSS.escape(CONVERSATION_ID_PREFIX + key)}`);
-}
+const get_row_from_conversation_key = (key: string): JQuery =>
+    $(`#${CSS.escape(CONVERSATION_ID_PREFIX + key)}`);
 
-function save_data_to_ls(): void {
+const save_data_to_ls = (): void => {
     ls.set(ls_filter_key, [...filters]);
     ls.set(ls_collapsed_containers_key, [...collapsed_containers]);
-}
+};
 
-export function show(): void {
+export const show = (): void => {
     // Avoid setting col_focus to recipient when moving to inbox from other narrows.
     // We prefer to focus entire row instead of stream name for inbox-header.
     // Since inbox-row doesn't has a collapse button, focus on COLUMNS.COLLAPSE_BUTTON
@@ -207,7 +206,7 @@ export function show(): void {
             html_heading: $t_html({defaultMessage: "Welcome to your <b>inbox</b>!"}),
             html_body,
             html_submit_button: $t_html({defaultMessage: "Continue"}),
-            on_click() {
+            on_click: () => {
                 // Do nothing
             },
             single_footer_button: true,
@@ -215,40 +214,34 @@ export function show(): void {
         });
         onboarding_steps.post_onboarding_step_as_read("intro_inbox_view_modal");
     }
-}
+};
 
-export function hide(): void {
+export const hide = (): void => {
     views_util.hide({
         $view: $("#inbox-view"),
         set_visible,
     });
-}
+};
 
-function get_topic_key(stream_id: number, topic: string): string {
-    return stream_id + ":" + topic;
-}
+const get_topic_key = (stream_id: number, topic: string): string => stream_id + ":" + topic;
 
-function get_stream_key(stream_id: number): string {
-    return "stream_" + stream_id;
-}
+const get_stream_key = (stream_id: number): string => "stream_" + stream_id;
 
-function get_stream_container(stream_key: string): JQuery {
-    return $(`#${CSS.escape(stream_key)}`);
-}
+const get_stream_container = (stream_key: string): JQuery => $(`#${CSS.escape(stream_key)}`);
 
-function get_topics_container(stream_id: number): JQuery {
+const get_topics_container = (stream_id: number): JQuery => {
     const $topics_container = get_stream_header_row(stream_id)
         .next(".inbox-topic-container")
         .expectOne();
     return $topics_container;
-}
+};
 
-function get_stream_header_row(stream_id: number): JQuery {
+const get_stream_header_row = (stream_id: number): JQuery => {
     const $stream_header_row = $(`#${CSS.escape(STREAM_HEADER_PREFIX + stream_id)}`);
     return $stream_header_row;
-}
+};
 
-function load_data_from_ls(): void {
+const load_data_from_ls = (): void => {
     const saved_filters = new Set(z.array(z.string()).optional().parse(ls.get(ls_filter_key)));
     const valid_filters = new Set(Object.values(views_util.FILTERS));
     // If saved filters are not in the list of valid filters, we reset to default.
@@ -261,13 +254,13 @@ function load_data_from_ls(): void {
     collapsed_containers = new Set(
         z.array(z.string()).optional().parse(ls.get(ls_collapsed_containers_key)),
     );
-}
+};
 
-function format_dm(
+const format_dm = (
     user_ids_string: string,
     unread_count: number,
     latest_msg_id: number,
-): DirectMessageContext {
+): DirectMessageContext => {
     const recipient_ids = people.user_ids_string_to_ids_array(user_ids_string);
     if (!recipient_ids.length) {
         // Self DM
@@ -307,9 +300,9 @@ function format_dm(
     };
 
     return context;
-}
+};
 
-function insert_dms(keys_to_insert: string[]): void {
+const insert_dms = (keys_to_insert: string[]): void => {
     const sorted_keys = [...dms_dict.keys()];
     // If we need to insert at the top, we do it separately to avoid edge case in loop below.
     if (sorted_keys[0] !== undefined && keys_to_insert.includes(sorted_keys[0])) {
@@ -328,13 +321,13 @@ function insert_dms(keys_to_insert: string[]): void {
             $previous_row.after($(render_inbox_row(dms_dict.get(key))));
         }
     }
-}
+};
 
-function rerender_dm_inbox_row_if_needed(
+const rerender_dm_inbox_row_if_needed = (
     new_dm_data: DirectMessageContext,
     old_dm_data: DirectMessageContext | undefined,
     dm_keys_to_insert: string[],
-): void {
+): void => {
     if (old_dm_data === undefined) {
         // This row is not rendered yet.
         dm_keys_to_insert.push(new_dm_data.conversation_key);
@@ -356,9 +349,9 @@ function rerender_dm_inbox_row_if_needed(
             return;
         }
     }
-}
+};
 
-function format_stream(stream_id: number): StreamContext {
+const format_stream = (stream_id: number): StreamContext => {
     // NOTE: Unread count is not included in this function as it is more
     // efficient for the callers to calculate it based on filters.
     const stream_info = sub_store.get(stream_id);
@@ -380,13 +373,13 @@ function format_stream(stream_id: number): StreamContext {
         is_collapsed: collapsed_containers.has(STREAM_HEADER_PREFIX + stream_id),
         mention_in_unread: unread.stream_has_any_unread_mentions(stream_id),
     };
-}
+};
 
-function update_stream_data(
+const update_stream_data = (
     stream_id: number,
     stream_key: string,
     topic_dict: Map<string, {topic_count: number; latest_msg_id: number}>,
-): void {
+): void => {
     const stream_topics_data = new Map<string, TopicContext>();
     const stream_data = format_stream(stream_id);
     let stream_post_filter_unread_count = 0;
@@ -404,12 +397,12 @@ function update_stream_data(
     stream_data.is_hidden = stream_post_filter_unread_count === 0;
     stream_data.unread_count = stream_post_filter_unread_count;
     streams_dict.set(stream_key, stream_data);
-}
+};
 
-function rerender_stream_inbox_header_if_needed(
+const rerender_stream_inbox_header_if_needed = (
     new_stream_data: StreamContext,
     old_stream_data: StreamContext,
-): void {
+): void => {
     for (const property of stream_context_properties) {
         if (new_stream_data[property] !== old_stream_data[property]) {
             const $rendered_row = get_stream_header_row(new_stream_data.stream_id);
@@ -417,14 +410,14 @@ function rerender_stream_inbox_header_if_needed(
             return;
         }
     }
-}
+};
 
-function format_topic(
+const format_topic = (
     stream_id: number,
     topic: string,
     topic_unread_count: number,
     latest_msg_id: number,
-): TopicContext {
+): TopicContext => {
     const context = {
         is_topic: true,
         stream_id,
@@ -444,12 +437,12 @@ function format_topic(
     };
 
     return context;
-}
+};
 
-function insert_stream(
+const insert_stream = (
     stream_id: number,
     topic_dict: Map<string, {topic_count: number; latest_msg_id: number}>,
-): boolean {
+): boolean => {
     const stream_key = get_stream_key(stream_id);
     update_stream_data(stream_id, stream_key, topic_dict);
     const sorted_stream_keys = get_sorted_stream_keys();
@@ -466,9 +459,9 @@ function insert_stream(
         $(rendered_stream).insertAfter(get_stream_container(previous_stream_key));
     }
     return !streams_dict.get(stream_key)!.is_hidden;
-}
+};
 
-function insert_topics(keys: string[], stream_key: string): void {
+const insert_topics = (keys: string[], stream_key: string): void => {
     const stream_topics_data = topics_dict.get(stream_key);
     assert(stream_topics_data !== undefined);
     const sorted_keys = [...stream_topics_data.keys()];
@@ -490,13 +483,13 @@ function insert_topics(keys: string[], stream_key: string): void {
             $previous_row.after($(render_inbox_row(stream_topics_data.get(key))));
         }
     }
-}
+};
 
-function rerender_topic_inbox_row_if_needed(
+const rerender_topic_inbox_row_if_needed = (
     new_topic_data: TopicContext,
     old_topic_data: TopicContext | undefined,
     topic_keys_to_insert: string[],
-): void {
+): void => {
     if (old_topic_data === undefined) {
         // This row is not rendered yet.
         topic_keys_to_insert.push(new_topic_data.conversation_key);
@@ -516,10 +509,10 @@ function rerender_topic_inbox_row_if_needed(
             return;
         }
     }
-}
+};
 
-function get_sorted_stream_keys(): string[] {
-    function compare_function(a: string, b: string): number {
+const get_sorted_stream_keys = (): string[] => {
+    const compare_function = (a: string, b: string): number => {
         const stream_a = streams_dict.get(a);
         const stream_b = streams_dict.get(b);
         assert(stream_a !== undefined && stream_b !== undefined);
@@ -546,12 +539,12 @@ function get_sorted_stream_keys(): string[] {
         const stream_name_a = stream_a ? stream_a.stream_name : "";
         const stream_name_b = stream_b ? stream_b.stream_name : "";
         return util.strcmp(stream_name_a, stream_name_b);
-    }
+    };
 
     return [...topics_dict.keys()].sort(compare_function);
-}
+};
 
-function get_sorted_stream_topic_dict(): Map<string, Map<string, TopicContext>> {
+const get_sorted_stream_topic_dict = (): Map<string, Map<string, TopicContext>> => {
     const sorted_stream_keys = get_sorted_stream_keys();
     const sorted_topic_dict = new Map<string, Map<string, TopicContext>>();
     for (const sorted_stream_key of sorted_stream_keys) {
@@ -559,20 +552,19 @@ function get_sorted_stream_topic_dict(): Map<string, Map<string, TopicContext>> 
     }
 
     return sorted_topic_dict;
-}
+};
 
-function get_sorted_row_dict<T extends DirectMessageContext | TopicContext>(
+const get_sorted_row_dict = <T extends DirectMessageContext | TopicContext>(
     row_dict: Map<string, T>,
-): Map<string, T> {
-    return new Map([...row_dict].sort(([, a], [, b]) => b.latest_msg_id - a.latest_msg_id));
-}
+): Map<string, T> =>
+    new Map([...row_dict].sort(([, a], [, b]) => b.latest_msg_id - a.latest_msg_id));
 
-function reset_data(): {
+const reset_data = (): {
     unread_dms_count: number;
     is_dms_collapsed: boolean;
     has_dms_post_filter: boolean;
     has_visible_unreads: boolean;
-} {
+} => {
     dms_dict = new Map();
     topics_dict = new Map();
     streams_dict = new Map();
@@ -626,9 +618,9 @@ function reset_data(): {
         has_dms_post_filter,
         has_visible_unreads,
     };
-}
+};
 
-function show_empty_inbox_text(has_visible_unreads: boolean): void {
+const show_empty_inbox_text = (has_visible_unreads: boolean): void => {
     if (!has_visible_unreads) {
         $("#inbox-list").css("border-width", 0);
         if (search_keyword) {
@@ -643,13 +635,13 @@ function show_empty_inbox_text(has_visible_unreads: boolean): void {
         $(".inbox-empty-text").hide();
         $("#inbox-list").css("border-width", "1px");
     }
-}
+};
 
-function filter_click_handler(
+const filter_click_handler = (
     event: JQuery.TriggeredEvent,
     dropdown: tippy.Instance,
     widget: dropdown_widget.DropdownWidget,
-): void {
+): void => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -661,9 +653,9 @@ function filter_click_handler(
     dropdown.hide();
     widget.render();
     update();
-}
+};
 
-export function complete_rerender(): void {
+export const complete_rerender = (): void => {
     if (!is_visible()) {
         return;
     }
@@ -699,9 +691,9 @@ export function complete_rerender(): void {
         default_id: first_filter.done ? undefined : first_filter.value,
     });
     filters_dropdown_widget.setup();
-}
+};
 
-export function search_and_update(): void {
+export const search_and_update = (): void => {
     const new_keyword = $<HTMLInputElement>("input#inbox-search").val() ?? "";
     if (new_keyword === search_keyword) {
         return;
@@ -710,17 +702,17 @@ export function search_and_update(): void {
     current_focus_id = INBOX_SEARCH_ID;
     update_triggered_by_user = true;
     update();
-}
+};
 
-function row_in_search_results(keyword: string, text: string): boolean {
+const row_in_search_results = (keyword: string, text: string): boolean => {
     if (keyword === "") {
         return true;
     }
     const search_words = keyword.toLowerCase().split(/\s+/);
     return search_words.every((word) => text.includes(word));
-}
+};
 
-function filter_should_hide_dm_row({dm_key}: {dm_key: string}): boolean {
+const filter_should_hide_dm_row = ({dm_key}: {dm_key: string}): boolean => {
     const recipients_string = people.get_recipients(dm_key);
     const text = recipients_string.toLowerCase();
 
@@ -729,15 +721,15 @@ function filter_should_hide_dm_row({dm_key}: {dm_key: string}): boolean {
     }
 
     return false;
-}
+};
 
-function filter_should_hide_stream_row({
+const filter_should_hide_stream_row = ({
     stream_id,
     topic,
 }: {
     stream_id: number;
     topic: string;
-}): boolean {
+}): boolean => {
     const sub = sub_store.get(stream_id);
     if (!sub?.subscribed) {
         return true;
@@ -765,9 +757,9 @@ function filter_should_hide_stream_row({
     }
 
     return false;
-}
+};
 
-export function collapse_or_expand(container_id: string): void {
+export const collapse_or_expand = (container_id: string): void => {
     let $toggle_icon;
     let $container;
     if (container_id === "inbox-dm-header") {
@@ -791,49 +783,45 @@ export function collapse_or_expand(container_id: string): void {
     }
 
     save_data_to_ls();
-}
+};
 
-function focus_current_id(): void {
+const focus_current_id = (): void => {
     assert(current_focus_id !== undefined);
     $(`#${CSS.escape(current_focus_id)}`).trigger("focus");
-}
+};
 
-function focus_inbox_search(): void {
+const focus_inbox_search = (): void => {
     current_focus_id = INBOX_SEARCH_ID;
     focus_current_id();
-}
+};
 
-function is_list_focused(): boolean {
-    return (
-        current_focus_id === undefined ||
-        ![INBOX_SEARCH_ID, INBOX_FILTERS_DROPDOWN_ID].includes(current_focus_id)
-    );
-}
+const is_list_focused = (): boolean =>
+    current_focus_id === undefined ||
+    ![INBOX_SEARCH_ID, INBOX_FILTERS_DROPDOWN_ID].includes(current_focus_id);
 
-function get_all_rows(): JQuery {
-    return $(".inbox-header, .inbox-row").not(".hidden_by_filters, .collapsed_container");
-}
+const get_all_rows = (): JQuery =>
+    $(".inbox-header, .inbox-row").not(".hidden_by_filters, .collapsed_container");
 
-function get_row_index($elt: JQuery): number {
+const get_row_index = ($elt: JQuery): number => {
     const $all_rows = get_all_rows();
     const $row = $elt.closest(".inbox-row, .inbox-header");
     return $all_rows.index($row);
-}
+};
 
-function focus_clicked_list_element($elt: JQuery): void {
+const focus_clicked_list_element = ($elt: JQuery): void => {
     row_focus = get_row_index($elt);
     update_triggered_by_user = true;
-}
+};
 
-function revive_current_focus(): void {
+const revive_current_focus = (): void => {
     if (is_list_focused()) {
         set_list_focus();
     } else {
         focus_current_id();
     }
-}
+};
 
-function update_closed_compose_text($row: JQuery, is_header_row: boolean): void {
+const update_closed_compose_text = ($row: JQuery, is_header_row: boolean): void => {
     // TODO: This fake "message" object is designed to allow using the
     // get_recipient_label helper inside compose_closed_ui. Surely
     // there's a more readable way to write this code.
@@ -858,13 +846,13 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
         };
     }
     compose_closed_ui.update_reply_recipient_label(message);
-}
+};
 
-export function get_focused_row_message(): {message?: Message | undefined} & (
+export const get_focused_row_message = (): {message?: Message | undefined} & (
     | {msg_type: "private"; private_message_recipient?: string}
     | {msg_type: "stream"; stream_id: number; topic?: string}
     | {msg_type?: never}
-) {
+) => {
     if (!is_list_focused()) {
         return {message: undefined};
     }
@@ -920,9 +908,9 @@ export function get_focused_row_message(): {message?: Message | undefined} & (
         };
     }
     return {message};
-}
+};
 
-export function toggle_topic_visibility_policy(): boolean {
+export const toggle_topic_visibility_policy = (): boolean => {
     const inbox_message = get_focused_row_message();
     if (inbox_message.message !== undefined) {
         user_topics_ui.toggle_topic_visibility_policy(inbox_message.message);
@@ -935,13 +923,11 @@ export function toggle_topic_visibility_policy(): boolean {
         }
     }
     return false;
-}
+};
 
-function is_row_a_header($row: JQuery): boolean {
-    return $row.hasClass("inbox-header");
-}
+const is_row_a_header = ($row: JQuery): boolean => $row.hasClass("inbox-header");
 
-function set_list_focus(input_key?: string): void {
+const set_list_focus = (input_key?: string): void => {
     // This function is used for both revive_current_focus and
     // setting focus after modify col_focus and row_focus as per
     // hotkey pressed by user.
@@ -1020,22 +1006,18 @@ function set_list_focus(input_key?: string): void {
     const col_to_focus = $cols_to_focus[col_focus];
     assert(col_to_focus !== undefined);
     $(col_to_focus).trigger("focus");
-}
+};
 
-function focus_filters_dropdown(): void {
+const focus_filters_dropdown = (): void => {
     current_focus_id = INBOX_FILTERS_DROPDOWN_ID;
     $(`#${CSS.escape(INBOX_FILTERS_DROPDOWN_ID)}`).trigger("focus");
-}
+};
 
-function is_search_focused(): boolean {
-    return current_focus_id === INBOX_SEARCH_ID;
-}
+const is_search_focused = (): boolean => current_focus_id === INBOX_SEARCH_ID;
 
-function is_filters_dropdown_focused(): boolean {
-    return current_focus_id === INBOX_FILTERS_DROPDOWN_ID;
-}
+const is_filters_dropdown_focused = (): boolean => current_focus_id === INBOX_FILTERS_DROPDOWN_ID;
 
-function get_page_up_down_delta(): number {
+const get_page_up_down_delta = (): number => {
     const element_above = document.querySelector("#inbox-filters");
     const element_down = document.querySelector("#compose");
     assert(element_above !== null && element_down !== null);
@@ -1050,9 +1032,9 @@ function get_page_up_down_delta(): number {
 
     const delta = visible_bottom - visible_top - scrolling_reduction_to_maintain_context;
     return delta;
-}
+};
 
-function page_up_navigation(): void {
+const page_up_navigation = (): void => {
     const delta = get_page_up_down_delta();
     const scroll_element = document.documentElement;
     const new_scrollTop = scroll_element.scrollTop - delta;
@@ -1061,9 +1043,9 @@ function page_up_navigation(): void {
     }
     scroll_element.scrollTop = new_scrollTop;
     set_list_focus();
-}
+};
 
-function page_down_navigation(): void {
+const page_down_navigation = (): void => {
     const delta = get_page_up_down_delta();
     const scroll_element = document.documentElement;
     const new_scrollTop = scroll_element.scrollTop + delta;
@@ -1076,9 +1058,9 @@ function page_down_navigation(): void {
     }
     scroll_element.scrollTop = new_scrollTop;
     set_list_focus();
-}
+};
 
-export function change_focused_element(input_key: string): boolean {
+export const change_focused_element = (input_key: string): boolean => {
     if (is_search_focused()) {
         const textInput = $<HTMLInputElement>(`input#${CSS.escape(INBOX_SEARCH_ID)}`).get(0);
         assert(textInput !== undefined);
@@ -1180,9 +1162,9 @@ export function change_focused_element(input_key: string): boolean {
     }
 
     return false;
-}
+};
 
-export function update(): void {
+export const update = (): void => {
     if (!is_visible()) {
         return;
     }
@@ -1294,9 +1276,9 @@ export function update(): void {
         setTimeout(revive_current_focus, 0);
         update_triggered_by_user = false;
     }
-}
+};
 
-function get_focus_class_for_header(): string {
+const get_focus_class_for_header = (): string => {
     let focus_class = ".collapsible-button";
 
     switch (col_focus) {
@@ -1314,9 +1296,9 @@ function get_focus_class_for_header(): string {
     }
 
     return focus_class;
-}
+};
 
-function get_focus_class_for_row(): string {
+const get_focus_class_for_row = (): string => {
     let focus_class = ".inbox-left-part";
     switch (col_focus) {
         case COLUMNS.UNREAD_COUNT: {
@@ -1333,9 +1315,9 @@ function get_focus_class_for_row(): string {
         }
     }
     return focus_class;
-}
+};
 
-function is_element_visible(element_position: DOMRect): boolean {
+const is_element_visible = (element_position: DOMRect): boolean => {
     const element_above = document.querySelector("#inbox-filters");
     const element_down = document.querySelector("#compose");
     assert(element_above !== null && element_down !== null);
@@ -1346,9 +1328,9 @@ function is_element_visible(element_position: DOMRect): boolean {
         return true;
     }
     return false;
-}
+};
 
-function center_focus_if_offscreen(): void {
+const center_focus_if_offscreen = (): void => {
     // Move focused to row to visible area so to avoid
     // it being under compose box or inbox filters.
     const $elt = $(".inbox-row:focus, .inbox-header:focus");
@@ -1364,9 +1346,9 @@ function center_focus_if_offscreen(): void {
 
     // Scroll element into center if offscreen.
     $elt[0].scrollIntoView({block: "center"});
-}
+};
 
-function move_focus_to_visible_area(): void {
+const move_focus_to_visible_area = (): void => {
     // Focus on the row below inbox filters if the focused
     // row is not visible.
     if (!is_list_focused()) {
@@ -1418,21 +1400,16 @@ function move_focus_to_visible_area(): void {
 
     row_focus = $all_rows.index($inbox_row.get(0));
     revive_current_focus();
-}
+};
 
-export function is_in_focus(): boolean {
-    // Check if user is focused on
-    // inbox
-    return (
-        is_visible() &&
-        !compose_state.composing() &&
-        !popovers.any_active() &&
-        !sidebar_ui.any_sidebar_expanded_as_overlay() &&
-        !overlays.any_active() &&
-        !modals.any_active() &&
-        !$(".home-page-input").is(":focus")
-    );
-}
+export const is_in_focus = (): boolean =>
+    is_visible() &&
+    !compose_state.composing() &&
+    !popovers.any_active() &&
+    !sidebar_ui.any_sidebar_expanded_as_overlay() &&
+    !overlays.any_active() &&
+    !modals.any_active() &&
+    !$(".home-page-input").is(":focus");
 
 export function initialize(): void {
     $(document).on(

--- a/web/src/inbox_util.ts
+++ b/web/src/inbox_util.ts
@@ -5,15 +5,13 @@ import * as stream_data from "./stream_data";
 
 let is_inbox_visible = false;
 
-export function set_visible(value: boolean): void {
+export const set_visible = (value: boolean): void => {
     is_inbox_visible = value;
-}
+};
 
-export function is_visible(): boolean {
-    return is_inbox_visible;
-}
+export const is_visible = (): boolean => is_inbox_visible;
 
-export function update_stream_colors(): void {
+export const update_stream_colors = (): void => {
     if (!is_visible()) {
         return;
     }
@@ -29,4 +27,4 @@ export function update_stream_colors(): void {
         const background_color = stream_color.get_recipient_bar_color(color);
         $stream_header.css("background", background_color);
     });
-}
+};

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -21,7 +21,7 @@ import * as util from "./util";
 // set_up_toggler is called.
 export let toggler: Toggle | undefined;
 
-function format_usage_html(...keys: string[]): string {
+const format_usage_html = (...keys: string[]): string => {
     const get_formatted_keys: () => string = () => keys.map((key) => `<kbd>${key}</kbd>`).join("+");
     return $t_html(
         {
@@ -31,7 +31,7 @@ function format_usage_html(...keys: string[]): string {
             "key-html": get_formatted_keys,
         },
     );
-}
+};
 
 const markdown_help_rows = [
     {
@@ -291,7 +291,7 @@ export function set_up_toggler(): void {
             {label: $t({defaultMessage: "Message formatting"}), key: "message-formatting"},
             {label: $t({defaultMessage: "Search filters"}), key: "search-operators"},
         ],
-        callback(_name: string, key: string) {
+        callback: (_name: string, key: string) => {
             $(".overlay-modal").hide();
             $(`#${CSS.escape(key)}`).show();
             scroll_util
@@ -331,14 +331,14 @@ export function set_up_toggler(): void {
     common.adjust_mac_kbd_tags("#markdown-instructions kbd");
 }
 
-export function show(target: string | undefined): void {
+export const show = (target: string | undefined): void => {
     const $overlay = $(".informational-overlays");
 
     if (!$overlay.hasClass("show")) {
         overlays.open_overlay({
             name: "informationalOverlays",
             $overlay,
-            on_close() {
+            on_close: () => {
                 browser_history.exit_overlay();
             },
         });
@@ -351,4 +351,4 @@ export function show(target: string | undefined): void {
     if (target) {
         toggler!.goto(target);
     }
-}
+};

--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 import {user_settings} from "./user_settings";
 
-export function set_base_typography_css_variables(): void {
+export const set_base_typography_css_variables = (): void => {
     const font_size_px = user_settings.web_font_size_px;
     const line_height_percent = user_settings.web_line_height_percent;
     const line_height_unitless = line_height_percent / 100;
@@ -20,8 +20,8 @@ export function set_base_typography_css_variables(): void {
         "--markdown-interelement-doubled-space-px",
         `${markdown_interelement_space_px * 2}px`,
     );
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     set_base_typography_css_variables();
-}
+};

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -103,32 +103,22 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
     // of the `this` arg in the `Function.prototype.bind` use in the prototype.
     const funcs = {
         // return the value of the contenteditable input form.
-        value(input_elem: HTMLElement) {
-            return input_elem.textContent ?? "";
-        },
+        value: (input_elem: HTMLElement) => input_elem.textContent ?? "",
 
         // clear the value of the input form.
-        clear(input_elem: HTMLElement) {
+        clear: (input_elem: HTMLElement) => {
             input_elem.textContent = "";
         },
 
-        clear_text() {
+        clear_text: () => {
             store.$input.text("");
         },
 
-        getCurrentText() {
-            return store.$input.text();
-        },
+        getCurrentText: () => store.$input.text(),
 
-        is_pending() {
-            // This function returns true if we have text
-            // in out widget that hasn't been turned into
-            // pills.  We use it to decide things like
-            // whether we're ready to send typing indicators.
-            return store.$input.text().trim() !== "";
-        },
+        is_pending: () => store.$input.text().trim() !== "",
 
-        create_item(text: string) {
+        create_item: (text: string) => {
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
 
@@ -142,7 +132,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
         // This is generally called by typeahead logic, where we have all
         // the data we need (as opposed to, say, just a user-typed email).
-        appendValidatedData(item: InputPillItem<T>) {
+        appendValidatedData: (item: InputPillItem<T>) => {
             if (!item.display_value) {
                 blueslip.error("no display_value returned");
                 return;
@@ -221,7 +211,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         // from the DOM, removes it from the array and returns it.
         // this would generally be used for DOM-provoked actions, such as a user
         // clicking on a pill to remove it.
-        removePill(element: HTMLElement) {
+        removePill: (element: HTMLElement) => {
             const idx = store.pills.findIndex((pill) => pill.$element[0] === element);
 
             if (idx !== -1) {
@@ -248,7 +238,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         // If quiet is a truthy value, the event handler associated with the
         // pill will not be evaluated. This is useful when using clear to reset
         // the pills.
-        removeLastPill(quiet?: boolean) {
+        removeLastPill: (quiet?: boolean) => {
             const pill = store.pills.pop();
 
             if (pill) {
@@ -267,7 +257,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             this.clear(store.$input[0]!);
         },
 
-        insertManyPills(pills: string | string[]) {
+        insertManyPills: (pills: string | string[]) => {
             if (typeof pills === "string") {
                 pills = pills.split(/,/g).map((pill) => pill.trim());
             }
@@ -293,19 +283,14 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             return drafts.length === 0;
         },
 
-        getByElement(element: HTMLElement) {
-            return store.pills.find((pill) => pill.$element[0] === element);
-        },
+        getByElement: (element: HTMLElement) =>
+            store.pills.find((pill) => pill.$element[0] === element),
 
-        _get_pills_for_testing() {
-            return store.pills;
-        },
+        _get_pills_for_testing: () => store.pills,
 
-        items() {
-            return store.pills.map((pill) => pill.item);
-        },
+        items: () => store.pills.map((pill) => pill.item),
 
-        createPillonPaste() {
+        createPillonPaste: () => {
             if (store.createPillonPaste !== undefined) {
                 store.createPillonPaste();
                 return undefined;
@@ -466,19 +451,19 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
         getCurrentText: funcs.getCurrentText.bind(funcs),
         items: funcs.items.bind(funcs),
 
-        onPillCreate(callback) {
+        onPillCreate: (callback) => {
             store.onPillCreate = callback;
         },
 
-        onPillRemove(callback) {
+        onPillRemove: (callback) => {
             store.onPillRemove = callback;
         },
 
-        onTextInputHook(callback) {
+        onTextInputHook: (callback) => {
             store.onTextInputHook = callback;
         },
 
-        createPillonPaste(callback) {
+        createPillonPaste: (callback) => {
             store.createPillonPaste = callback;
         },
 

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -47,9 +47,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         $("#integration-url-stream_widget").prop("disabled", true);
 
         const clipboard = new ClipboardJS("#generate-integration-url-modal .dialog_submit_button", {
-            text() {
-                return $integration_url.text();
-            },
+            text: () => $integration_url.text(),
         });
         clipboard.on("success", () => {
             show_copied_confirmation(
@@ -88,7 +86,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             update_url();
         });
 
-        function update_url(render_events = false): void {
+        const update_url = (render_events = false): void => {
             selected_integration = integration_input_dropdown_widget.value()!.toString();
             if (previous_selected_integration !== selected_integration) {
                 reset_to_blank_state();
@@ -149,7 +147,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             ) {
                 $dialog_submit_button.prop("disabled", true);
             }
-        }
+        };
 
         integration_input_dropdown_widget = new dropdown_widget.DropdownWidget({
             widget_name: "integration-name",
@@ -164,7 +162,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         });
         integration_input_dropdown_widget.setup();
 
-        function get_options_for_integration_input_dropdown_widget(): Option[] {
+        const get_options_for_integration_input_dropdown_widget = (): Option[] => {
             const options = [
                 default_integration_option,
                 ...realm.realm_incoming_webhook_bots
@@ -175,19 +173,19 @@ export function show_generate_integration_url_modal(api_key: string): void {
                     })),
             ];
             return options;
-        }
+        };
 
-        function integration_item_click_callback(
+        const integration_item_click_callback = (
             event: JQuery.ClickEvent,
             dropdown: tippy.Instance,
-        ): void {
+        ): void => {
             integration_input_dropdown_widget.render();
             $(".integration-url-name-wrapper").trigger("input");
 
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
-        }
+        };
 
         stream_input_dropdown_widget = new dropdown_widget.DropdownWidget({
             widget_name: "integration-url-stream",
@@ -202,7 +200,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         });
         stream_input_dropdown_widget.setup();
 
-        function get_options_for_stream_dropdown_widget(): Option[] {
+        const get_options_for_stream_dropdown_widget = (): Option[] => {
             const options = [
                 direct_messages_option,
                 ...streams
@@ -214,12 +212,12 @@ export function show_generate_integration_url_modal(api_key: string): void {
                     })),
             ];
             return options;
-        }
+        };
 
-        function stream_item_click_callback(
+        const stream_item_click_callback = (
             event: JQuery.ClickEvent,
             dropdown: tippy.Instance,
-        ): void {
+        ): void => {
             stream_input_dropdown_widget.render();
             $(".integration-url-stream-wrapper").trigger("input");
             const user_selected_option = stream_input_dropdown_widget.value();
@@ -236,7 +234,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
-        }
+        };
 
         function set_events_param(params: URLSearchParams): boolean {
             if (!$show_integration_events.prop("checked")) {
@@ -258,7 +256,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             return false;
         }
 
-        function reset_to_blank_state(): void {
+        const reset_to_blank_state = (): void => {
             $("#integration-events-parameter").addClass("hide");
             $("#integrations-event-container").addClass("hide");
             $("#integrations-event-options").empty();
@@ -271,7 +269,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             $topic_input.parent().addClass("hide");
 
             stream_input_dropdown_widget.render(direct_messages_option.unique_id);
-        }
+        };
     }
 
     dialog_widget.launch({
@@ -280,7 +278,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         id: "generate-integration-url-modal",
         html_submit_button: $t_html({defaultMessage: "Copy URL"}),
         html_exit_button: $t_html({defaultMessage: "Close"}),
-        on_click() {
+        on_click: () => {
             // Do nothing
         },
         post_render: generate_integration_url_post_render,

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -281,7 +281,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
         html_submit_button: $t_html({defaultMessage: "Copy URL"}),
         html_exit_button: $t_html({defaultMessage: "Close"}),
         on_click() {
-            return;
+            // Do nothing
         },
         post_render: generate_integration_url_post_render,
     });

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -34,13 +34,13 @@ let custom_expiration_time_input = 10;
 let custom_expiration_time_unit = "days";
 let pills: email_pill.EmailPillWidget;
 
-function reset_error_messages(): void {
+const reset_error_messages = (): void => {
     $("#dialog_error").hide().text("").removeClass(common.status_classes);
 
     if (page_params.development_environment) {
         $("#dev_env_msg").hide().text("").removeClass(common.status_classes);
     }
-}
+};
 
 function get_common_invitation_data(): {
     csrfmiddlewaretoken: string;
@@ -102,7 +102,7 @@ function get_common_invitation_data(): {
     return data;
 }
 
-function beforeSend(): void {
+const beforeSend = (): void => {
     reset_error_messages();
     // TODO: You could alternatively parse the emails here, and return errors to
     // the user if they don't match certain constraints (i.e. not real email addresses,
@@ -113,9 +113,9 @@ function beforeSend(): void {
     assert(loading_text !== undefined);
     $("#invite-user-modal .dialog_submit_button").text(loading_text);
     $("#invite-user-modal .dialog_submit_button").prop("disabled", true);
-}
+};
 
-function submit_invitation_form(): void {
+const submit_invitation_form = (): void => {
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
     const $invite_status = $("#dialog_error");
     const data = get_common_invitation_data();
@@ -124,7 +124,7 @@ function submit_invitation_form(): void {
         url: "/json/invites",
         data,
         beforeSend,
-        success() {
+        success: () => {
             const number_of_invites_sent = pills.items().length;
             ui_report.success(
                 $t_html(
@@ -156,7 +156,7 @@ function submit_invitation_form(): void {
                 }
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             const parsed = z
                 .object({
                     result: z.literal("error"),
@@ -202,23 +202,23 @@ function submit_invitation_form(): void {
                 }
             }
         },
-        complete() {
+        complete: () => {
             $("#invite-user-modal .dialog_submit_button").text($t({defaultMessage: "Invite"}));
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
             $invite_status[0]!.scrollIntoView();
         },
     });
-}
+};
 
-function generate_multiuse_invite(): void {
+const generate_multiuse_invite = (): void => {
     const $invite_status = $("#dialog_error");
     const data = get_common_invitation_data();
     void channel.post({
         url: "/json/invites/multiuse",
         data,
         beforeSend,
-        success(data) {
+        success: (data) => {
             const copy_link_html = copy_invite_link(data);
             ui_report.success(copy_link_html, $invite_status);
             const clipboard = new ClipboardJS("#copy_generated_invite_link");
@@ -234,10 +234,10 @@ function generate_multiuse_invite(): void {
                 );
             });
         },
-        error(xhr) {
+        error: (xhr) => {
             ui_report.error("", xhr, $invite_status);
         },
-        complete() {
+        complete: () => {
             $("#invite-user-modal .dialog_submit_button").text(
                 $t({defaultMessage: "Generate invite link"}),
             );
@@ -246,15 +246,15 @@ function generate_multiuse_invite(): void {
             $invite_status[0]!.scrollIntoView();
         },
     });
-}
+};
 
-export function get_invite_streams(): stream_data.InviteStreamData[] {
+export const get_invite_streams = (): stream_data.InviteStreamData[] => {
     const streams = stream_data.get_invite_stream_data();
     streams.sort((a, b) => util.strcmp(a.name, b.name));
     return streams;
-}
+};
 
-function valid_to(time_valid: number): string {
+const valid_to = (time_valid: number): string => {
     if (!time_valid) {
         return $t({defaultMessage: "Never expires"});
     }
@@ -265,9 +265,9 @@ function valid_to(time_valid: number): string {
     const time = timerender.get_localized_date_or_time_for_format(valid_to, "time");
 
     return $t({defaultMessage: "Expires on {date} at {time}"}, {date, time});
-}
+};
 
-function get_expiration_time_in_minutes(): number {
+const get_expiration_time_in_minutes = (): number => {
     switch (custom_expiration_time_unit) {
         case "hours":
             return custom_expiration_time_input * 60;
@@ -278,9 +278,9 @@ function get_expiration_time_in_minutes(): number {
         default:
             return custom_expiration_time_input;
     }
-}
+};
 
-function set_expires_on_text(): void {
+const set_expires_on_text = (): void => {
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
     if ($expires_in.val() === "custom") {
         $("#expires_on").hide();
@@ -289,9 +289,9 @@ function set_expires_on_text(): void {
         $("#expires_on").show();
         $("#expires_on").text(valid_to(Number.parseFloat($expires_in.val()!)));
     }
-}
+};
 
-function set_custom_time_inputs_visibility(): void {
+const set_custom_time_inputs_visibility = (): void => {
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
     if ($expires_in.val() === "custom") {
         $("#custom-expiration-time-input").val(custom_expiration_time_input);
@@ -302,9 +302,9 @@ function set_custom_time_inputs_visibility(): void {
     } else {
         $("#custom-invite-expiration-time").hide();
     }
-}
+};
 
-function set_streams_to_join_list_visibility(): void {
+const set_streams_to_join_list_visibility = (): void => {
     const realm_has_default_streams = stream_data.get_default_stream_ids().length !== 0;
     const hide_streams_list =
         realm_has_default_streams &&
@@ -316,9 +316,9 @@ function set_streams_to_join_list_visibility(): void {
         $("#streams_to_add .invite-stream-controls").show();
         $("#invite-stream-checkboxes").show();
     }
-}
+};
 
-function generate_invite_tips_data(): Record<string, boolean> {
+const generate_invite_tips_data = (): Record<string, boolean> => {
     const {realm_description, realm_icon_source, custom_profile_fields} = realm;
 
     return {
@@ -328,9 +328,9 @@ function generate_invite_tips_data(): Record<string, boolean> {
         realm_has_user_set_icon: realm_icon_source !== "G",
         realm_has_custom_profile_fields: custom_profile_fields.length > 0,
     };
-}
+};
 
-function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void {
+const open_invite_user_modal = (e: JQuery.ClickEvent<Document, undefined>): void => {
     e.stopPropagation();
     e.preventDefault();
 
@@ -349,7 +349,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         can_subscribe_other_users: settings_data.user_can_subscribe_other_users(),
     });
 
-    function invite_user_modal_post_render(): void {
+    const invite_user_modal_post_render = (): void => {
         const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
         const $pill_container = $("#invitee_emails_container .pill-container");
         pills = input_pill.create({
@@ -378,7 +378,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             $(e.target).parent().remove();
         });
 
-        function toggle_invite_submit_button(selected_tab?: string): void {
+        const toggle_invite_submit_button = (selected_tab?: string): void => {
             if (selected_tab === undefined) {
                 selected_tab = $(".invite_users_option_tabs")
                     .find(".selected")
@@ -398,7 +398,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
                 $button.text($t({defaultMessage: "Generate invite link"}));
                 $button.attr("data-loading-text", $t({defaultMessage: "Generating link..."}));
             }
-        }
+        };
 
         pills.onPillCreate(toggle_invite_submit_button);
         pills.onPillRemove(() => {
@@ -464,7 +464,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
                 {label: $t({defaultMessage: "Send invite email"}), key: "invite-email-tab"},
                 {label: $t({defaultMessage: "Create invite link"}), key: "invite-link-tab"},
             ],
-            callback(_name, key) {
+            callback: (_name, key) => {
                 switch (key) {
                     case "invite-email-tab":
                         $("#invitee_emails_container").show();
@@ -490,9 +490,9 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         setTimeout(() => {
             $(".invite_users_option_tabs .ind-tab.selected").trigger("focus");
         }, 0);
-    }
+    };
 
-    function invite_users(): void {
+    const invite_users = (): void => {
         const is_generate_invite_link =
             $(".invite_users_option_tabs").find(".selected").attr("data-tab-key") ===
             "invite-link-tab";
@@ -501,7 +501,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         } else {
             submit_invitation_form();
         }
-    }
+    };
 
     dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Invite users to organization"}),
@@ -513,8 +513,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         post_render: invite_user_modal_post_render,
         always_visible_scrollbar: true,
     });
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $(document).on("click", ".invite-user-link", open_invite_user_modal);
-}
+};

--- a/web/src/keydown_util.ts
+++ b/web/src/keydown_util.ts
@@ -7,10 +7,10 @@ export const vim_down = "j";
 export const vim_up = "k";
 export const vim_right = "l";
 
-export function handle(opts: {
+export const handle = (opts: {
     $elem: JQuery;
     handlers: Record<string, (() => boolean) | undefined>;
-}): void {
+}): void => {
     opts.$elem.on("keydown", (e) => {
         if (e.altKey || e.ctrlKey || e.shiftKey) {
             return;
@@ -28,9 +28,9 @@ export function handle(opts: {
             e.stopPropagation();
         }
     });
-}
+};
 
-export function is_enter_event(event: JQuery.KeyboardEventBase): boolean {
+export const is_enter_event = (event: JQuery.KeyboardEventBase): boolean => {
     // In addition to checking whether the key pressed was an Enter
     // key, we need to check whether the keypress was part of an IME
     // composing session, such as selecting a character using a
@@ -39,4 +39,4 @@ export function is_enter_event(event: JQuery.KeyboardEventBase): boolean {
     // https://developer.mozilla.org/en-US/docs/Glossary/Input_method_editor
     const isComposing = event.originalEvent?.isComposing ?? false;
     return !isComposing && event.key === "Enter";
-}
+};

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -18,7 +18,7 @@ const STATES = {
     CONDENSED: "condensed",
 };
 
-function restore_views_state(): void {
+const restore_views_state = (): void => {
     if (page_params.is_spectator) {
         // Spectators should always see the expanded view.
         return;
@@ -29,18 +29,18 @@ function restore_views_state(): void {
     if (views_state === STATES.CONDENSED) {
         toggle_condensed_navigation_area();
     }
-}
+};
 
-function save_state(state: string): void {
+const save_state = (state: string): void => {
     ls.set(ls_key, state);
-}
+};
 
-export function update_starred_count(count: number): void {
+export const update_starred_count = (count: number): void => {
     const $starred_li = $(".top_left_starred_messages");
     ui_util.update_unread_count_in_dom($starred_li, count);
-}
+};
 
-export function update_scheduled_messages_row(): void {
+export const update_scheduled_messages_row = (): void => {
     const $scheduled_li = $(".top_left_scheduled_messages");
     const count = scheduled_messages.get_count();
     if (count > 0) {
@@ -49,12 +49,12 @@ export function update_scheduled_messages_row(): void {
         $scheduled_li.removeClass("show-with-scheduled-messages");
     }
     ui_util.update_unread_count_in_dom($scheduled_li, count);
-}
+};
 
-export function update_dom_with_unread_counts(
+export const update_dom_with_unread_counts = (
     counts: unread.FullUnreadCountsData,
     skip_animations: boolean,
-): void {
+): void => {
     // Note that direct message counts are handled in pm_list.ts.
 
     // mentioned/home views have simple integer counts
@@ -71,24 +71,24 @@ export function update_dom_with_unread_counts(
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);
     }
-}
+};
 
 // TODO: Rewrite how we handle activation of narrows when doing the redesign.
 // We don't want to adjust class for all the buttons when switching narrows.
 
-function remove($elem: JQuery): void {
+const remove = ($elem: JQuery): void => {
     $elem.removeClass("active-filter active-sub-filter");
-}
+};
 
-function deselect_top_left_corner_items(): void {
+const deselect_top_left_corner_items = (): void => {
     remove($(".top_left_all_messages"));
     remove($(".top_left_starred_messages"));
     remove($(".top_left_mentions"));
     remove($(".top_left_recent_view"));
     remove($(".top_left_inbox"));
-}
+};
 
-export function handle_narrow_activated(filter: Filter): void {
+export const handle_narrow_activated = (filter: Filter): void => {
     deselect_top_left_corner_items();
 
     let ops: string[];
@@ -114,9 +114,9 @@ export function handle_narrow_activated(filter: Filter): void {
             $filter_li.addClass("active-filter");
         }
     }
-}
+};
 
-function toggle_condensed_navigation_area(): void {
+const toggle_condensed_navigation_area = (): void => {
     const $views_label_container = $("#views-label-container");
     const $views_label_icon = $("#toggle-top-left-navigation-area-icon");
     if ($views_label_container.hasClass("showing-expanded-navigation")) {
@@ -135,56 +135,56 @@ function toggle_condensed_navigation_area(): void {
         save_state(STATES.EXPANDED);
     }
     resize.resize_stream_filters_container();
-}
+};
 
-export function animate_mention_changes($li: JQuery, new_mention_count: number): void {
+export const animate_mention_changes = ($li: JQuery, new_mention_count: number): void => {
     if (new_mention_count > last_mention_count) {
         do_new_messages_animation($li);
     }
     last_mention_count = new_mention_count;
-}
+};
 
-function do_new_messages_animation($li: JQuery): void {
+const do_new_messages_animation = ($li: JQuery): void => {
     $li.addClass("new_messages");
-    function mid_animation(): void {
+    const mid_animation = (): void => {
         $li.removeClass("new_messages");
         $li.addClass("new_messages_fadeout");
-    }
-    function end_animation(): void {
+    };
+    const end_animation = (): void => {
         $li.removeClass("new_messages_fadeout");
-    }
+    };
     setTimeout(mid_animation, 3000);
     setTimeout(end_animation, 6000);
-}
+};
 
-export function highlight_inbox_view(): void {
+export const highlight_inbox_view = (): void => {
     deselect_top_left_corner_items();
 
     $(".top_left_inbox").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
-}
+};
 
-export function highlight_recent_view(): void {
+export const highlight_recent_view = (): void => {
     deselect_top_left_corner_items();
 
     $(".top_left_recent_view").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
-}
+};
 
-export function highlight_all_messages_view(): void {
+export const highlight_all_messages_view = (): void => {
     deselect_top_left_corner_items();
 
     $(".top_left_all_messages").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
-}
+};
 
-function handle_home_view_order(home_view: string): void {
+const handle_home_view_order = (home_view: string): void => {
     // Remove class and tabindex from current home view
     const $current_home_view = $(".selected-home-view");
     $current_home_view.removeClass("selected-home-view");
@@ -209,9 +209,9 @@ function handle_home_view_order(home_view: string): void {
         $inbox_rows.find("a").attr("tabindex", 0);
     }
     update_dom_with_unread_counts(res, true);
-}
+};
 
-export function handle_home_view_changed(new_home_view: string): void {
+export const handle_home_view_changed = (new_home_view: string): void => {
     const $recent_view_sidebar_menu_icon = $(".recent-view-sidebar-menu-icon");
     const $all_messages_sidebar_menu_icon = $(".all-messages-sidebar-menu-icon");
     if (new_home_view === settings_config.web_home_view_values.all_messages.code) {
@@ -226,9 +226,9 @@ export function handle_home_view_changed(new_home_view: string): void {
         $all_messages_sidebar_menu_icon.removeClass("hide");
     }
     handle_home_view_order(new_home_view);
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     update_scheduled_messages_row();
     restore_views_state();
 
@@ -240,4 +240,4 @@ export function initialize(): void {
             toggle_condensed_navigation_area();
         },
     );
-}
+};

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -19,7 +19,7 @@ import * as ui_util from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
-function common_click_handlers() {
+const common_click_handlers = () => {
     $("body").on("click", ".set-home-view", (e) => {
         e.preventDefault();
         e.preventDefault();
@@ -33,19 +33,19 @@ function common_click_handlers() {
 
         popovers.hide_all();
     });
-}
+};
 // This callback is called from the popovers on all home views
-function register_mark_all_read_handler(event) {
+const register_mark_all_read_handler = (event) => {
     const {instance} = event.data;
     unread_ops.confirm_mark_all_as_read();
     popover_menus.hide_current_popover_if_visible(instance);
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     // Starred messages popover
     popover_menus.register_popover_menu(".starred-messages-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.starred_messages = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
@@ -66,7 +66,7 @@ export function initialize() {
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popovers.hide_all();
             const show_unstar_all_button = starred_messages.get_count() > 0;
 
@@ -79,7 +79,7 @@ export function initialize() {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.starred_messages = undefined;
             ui_util.hide_left_sidebar_menu_icon();
@@ -89,7 +89,7 @@ export function initialize() {
     // Drafts popover
     popover_menus.register_popover_menu(".drafts-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             $popper.addClass("drafts-popover");
             popover_menus.popover_instances.drafts = instance;
@@ -100,12 +100,12 @@ export function initialize() {
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popovers.hide_all();
 
             instance.setContent(ui_util.parse_html(render_left_sidebar_drafts_popover({})));
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.drafts = undefined;
             ui_util.hide_left_sidebar_menu_icon();
@@ -115,7 +115,7 @@ export function initialize() {
     // Inbox popover
     popover_menus.register_popover_menu(".inbox-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.left_sidebar_inbox_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
@@ -127,7 +127,7 @@ export function initialize() {
                 register_mark_all_read_handler,
             );
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popovers.hide_all();
             const view_code = settings_config.web_home_view_values.inbox.code;
             instance.setContent(
@@ -139,7 +139,7 @@ export function initialize() {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.left_sidebar_inbox_popover = undefined;
             ui_util.hide_left_sidebar_menu_icon();
@@ -149,7 +149,7 @@ export function initialize() {
     // Combined feed popover
     popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             $popper.one(
                 "click",
@@ -158,7 +158,7 @@ export function initialize() {
                 register_mark_all_read_handler,
             );
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popover_menus.popover_instances.left_sidebar_all_messages_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
             popovers.hide_all();
@@ -172,7 +172,7 @@ export function initialize() {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.left_sidebar_all_messages_popover = undefined;
             ui_util.hide_left_sidebar_menu_icon();
@@ -182,7 +182,7 @@ export function initialize() {
     // Recent view popover
     popover_menus.register_popover_menu(".recent-view-sidebar-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             $popper.one(
                 "click",
@@ -191,7 +191,7 @@ export function initialize() {
                 register_mark_all_read_handler,
             );
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popover_menus.popover_instances.left_sidebar_recent_view_popover = instance;
             ui_util.show_left_sidebar_menu_icon(instance.reference);
             popovers.hide_all();
@@ -205,7 +205,7 @@ export function initialize() {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.left_sidebar_recent_view_popover = undefined;
             ui_util.hide_left_sidebar_menu_icon();
@@ -214,7 +214,7 @@ export function initialize() {
 
     popover_menus.register_popover_menu(".left-sidebar-navigation-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
-        onShow(instance) {
+        onShow: (instance) => {
             // Determine at show time whether there are scheduled messages,
             // so that Tippy properly calculates the height of the popover
             const scheduled_message_count = scheduled_messages.get_count();
@@ -229,7 +229,7 @@ export function initialize() {
                 ),
             );
         },
-        onMount() {
+        onMount: () => {
             ui_util.update_unread_count_in_dom(
                 $(".condensed-views-popover-menu-drafts"),
                 drafts.draft_model.getDraftCount(),
@@ -239,11 +239,11 @@ export function initialize() {
                 scheduled_messages.get_count(),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.top_left_sidebar = undefined;
         },
     });
 
     common_click_handlers();
-}
+};

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -195,12 +195,12 @@ export class PanZoomControl {
     }
 }
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     is_open = false;
     asset_map.clear();
-}
+};
 
-export function render_lightbox_media_list(preview_source: string): void {
+export const render_lightbox_media_list = (preview_source: string): void => {
     if (!is_open) {
         const media_list = $(
             ".focused-message-list .message_inline_image img, .focused-message-list .message_inline_video video",
@@ -241,9 +241,9 @@ export function render_lightbox_media_list(preview_source: string): void {
             parse_media_data(media);
         }
     }
-}
+};
 
-function display_image(payload: Payload): void {
+const display_image = (payload: Payload): void => {
     render_lightbox_media_list(payload.preview);
 
     $(".player-container, .video-player").hide();
@@ -279,9 +279,9 @@ function display_image(payload: Payload): void {
         // element.
         $(".media-actions .download").hide();
     }
-}
+};
 
-function display_video(payload: Payload): void {
+const display_video = (payload: Payload): void => {
     render_lightbox_media_list(payload.preview);
 
     $(
@@ -342,13 +342,13 @@ function display_video(payload: Payload): void {
     $("#lightbox_overlay .player-container").empty();
     $("#lightbox_overlay .player-container").append($iframe);
     $(".media-actions .open").attr("href", payload.url);
-}
+};
 
-export function build_open_media_function(
+export const build_open_media_function = (
     on_close: (() => void) | undefined,
-): ($media: JQuery) => void {
+): (($media: JQuery) => void) => {
     if (on_close === undefined) {
-        on_close = function () {
+        on_close = () => {
             remove_video_players();
             is_open = false;
             assert(document.activeElement instanceof HTMLElement);
@@ -356,7 +356,7 @@ export function build_open_media_function(
         };
     }
 
-    return function ($media: JQuery): void {
+    return ($media: JQuery): void => {
         // if the asset_map already contains the metadata required to display the
         // asset, just recall that metadata.
         let $preview_src = $media.attr("src")!;
@@ -402,9 +402,9 @@ export function build_open_media_function(
         popovers.hide_all();
         is_open = true;
     };
-}
+};
 
-export function show_from_selected_message(): void {
+export const show_from_selected_message = (): void => {
     const $message_selected = $(".selected_message");
     let $message = $message_selected;
     // This is a function to satisfy eslint unicorn/no-array-callback-reference
@@ -457,10 +457,10 @@ export function show_from_selected_message(): void {
         const open_media = build_open_media_function(undefined);
         open_media($media);
     }
-}
+};
 
 // retrieve the metadata from the DOM and store into the asset_map.
-export function parse_media_data(media: HTMLElement): Payload {
+export const parse_media_data = (media: HTMLElement): Payload => {
     const $media = $(media);
     const preview_src = $media.attr("src")!;
 
@@ -537,22 +537,22 @@ export function parse_media_data(media: HTMLElement): Payload {
 
     asset_map.set(preview_src, payload);
     return payload;
-}
+};
 
-export function prev(): void {
+export const prev = (): void => {
     $(".image-list .image.selected").prev().trigger("click");
-}
+};
 
-export function next(): void {
+export const next = (): void => {
     $(".image-list .image.selected").next().trigger("click");
-}
+};
 
-function remove_video_players(): void {
+const remove_video_players = (): void => {
     // Remove video players from the DOM. Used when closing lightbox
     // so that videos doesn't keep playing in the background.
     $(".player-container iframe").remove();
     $("#lightbox_overlay .video-player").html("");
-}
+};
 
 // this is a block of events that are required for the lightbox to work.
 export function initialize(): void {
@@ -565,7 +565,7 @@ export function initialize(): void {
         $("#lightbox_overlay .image-preview > .zoom-element")[0]!,
     );
 
-    const reset_lightbox_state = function (): void {
+    const reset_lightbox_state = (): void => {
         remove_video_players();
         is_open = false;
         assert(document.activeElement instanceof HTMLElement);

--- a/web/src/linkifiers.ts
+++ b/web/src/linkifiers.ts
@@ -14,14 +14,12 @@ type Linkifier = {
     id: number;
 };
 
-export function get_linkifier_map(): LinkifierMap {
-    return linkifier_map;
-}
+export const get_linkifier_map = (): LinkifierMap => linkifier_map;
 
-function python_to_js_linkifier(
+const python_to_js_linkifier = (
     pattern: string,
     url: string,
-): [RegExp | null, url_template_lib.Template, Record<number, string>] {
+): [RegExp | null, url_template_lib.Template, Record<number, string>] => {
     // Converts a python named-group regex to a javascript-compatible numbered
     // group regex... with a regex!
     const named_group_re = /\(?P<([^>]+?)>/g;
@@ -85,9 +83,9 @@ function python_to_js_linkifier(
     }
     const url_template = url_template_lib.parse(url);
     return [final_regex, url_template, group_number_to_name];
-}
+};
 
-export function update_linkifier_rules(linkifiers: Linkifier[]): void {
+export const update_linkifier_rules = (linkifiers: Linkifier[]): void => {
     linkifier_map.clear();
 
     for (const linkifier of linkifiers) {
@@ -105,8 +103,8 @@ export function update_linkifier_rules(linkifiers: Linkifier[]): void {
             group_number_to_name,
         });
     }
-}
+};
 
-export function initialize(linkifiers: Linkifier[]): void {
+export const initialize = (linkifiers: Linkifier[]): void => {
     update_linkifier_rules(linkifiers);
-}
+};

--- a/web/src/list_util.ts
+++ b/web/src/list_util.ts
@@ -8,18 +8,18 @@ const list_selectors = [
     "#send_later_options",
 ];
 
-export function inside_list(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): boolean {
+export const inside_list = (e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): boolean => {
     const $target = $(e.target);
     const in_list = $target.closest(list_selectors.join(", ")).length > 0;
     return in_list;
-}
+};
 
-export function go_down(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void {
+export const go_down = (e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void => {
     const $target = $(e.target);
     $target.closest("li").next().find("a").trigger("focus");
-}
+};
 
-export function go_up(e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void {
+export const go_up = (e: JQuery.KeyDownEvent | JQuery.KeyPressEvent): void => {
     const $target = $(e.target);
     $target.closest("li").prev().find("a").trigger("focus");
-}
+};

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -95,11 +95,11 @@ const DEFAULTS = {
 // This function describes (programmatically) how to use the ListWidget.
 // ----------------------------------------------------
 
-export function get_filtered_items<Key, Item>(
+export const get_filtered_items = <Key, Item>(
     value: string,
     list: Key[],
     opts: ListWidgetOpts<Key, Item>,
-): Item[] {
+): Item[] => {
     /*
         This is used by the main object (see `create`),
         but we split it out to make it a bit easier
@@ -130,12 +130,11 @@ export function get_filtered_items<Key, Item>(
     }
 
     return result;
-}
+};
 
-export function alphabetic_sort<Prop extends string>(
-    prop: Prop,
-): SortingFunction<Record<Prop, string>> {
-    return (a, b) => {
+export const alphabetic_sort =
+    <Prop extends string>(prop: Prop): SortingFunction<Record<Prop, string>> =>
+    (a, b) => {
         // The conversion to uppercase helps make the sorting case insensitive.
         const str1 = a[prop].toUpperCase();
         const str2 = b[prop].toUpperCase();
@@ -148,12 +147,10 @@ export function alphabetic_sort<Prop extends string>(
 
         return -1;
     };
-}
 
-export function numeric_sort<Prop extends string>(
-    prop: Prop,
-): SortingFunction<Record<Prop, number>> {
-    return (a, b) => {
+export const numeric_sort =
+    <Prop extends string>(prop: Prop): SortingFunction<Record<Prop, number>> =>
+    (a, b) => {
         const a_prop = a[prop];
         const b_prop = b[prop];
 
@@ -165,7 +162,6 @@ export function numeric_sort<Prop extends string>(
 
         return -1;
     };
-}
 
 type GenericSortKeys = {
     alphabetic: string;
@@ -181,39 +177,34 @@ const generic_sorts: {
     numeric: numeric_sort,
 };
 
-export function generic_sort_functions<
+export const generic_sort_functions = <
     GenericFunc extends keyof GenericSortKeys,
     Prop extends string,
 >(
     generic_func: GenericFunc,
     props: Prop[],
-): Record<string, SortingFunction<Record<Prop, GenericSortKeys[GenericFunc]>>> {
-    return Object.fromEntries(
+): Record<string, SortingFunction<Record<Prop, GenericSortKeys[GenericFunc]>>> =>
+    Object.fromEntries(
         props.map((prop) => [`${prop}_${generic_func}`, generic_sorts[generic_func](prop)]),
     );
-}
 
-function is_scroll_position_for_render(scroll_container: HTMLElement): boolean {
-    return (
-        scroll_container.scrollHeight -
-            (scroll_container.scrollTop + scroll_container.clientHeight) <
-        10
-    );
-}
+const is_scroll_position_for_render = (scroll_container: HTMLElement): boolean =>
+    scroll_container.scrollHeight - (scroll_container.scrollTop + scroll_container.clientHeight) <
+    10;
 
-function get_column_count_for_table($table: JQuery): number {
+const get_column_count_for_table = ($table: JQuery): number => {
     let column_count = 0;
     const $thead = $table.find("thead");
     if ($thead.length) {
         column_count = $thead.find("tr").children().length;
     }
     return column_count;
-}
+};
 
-export function render_empty_list_message_if_needed(
+export const render_empty_list_message_if_needed = (
     $container: JQuery,
     filter_value: string,
-): void {
+): void => {
     let empty_list_message = $container.attr("data-empty");
 
     const empty_search_results_message = $container.attr("data-search-results-empty");
@@ -245,7 +236,7 @@ export function render_empty_list_message_if_needed(
     }
 
     $container.append($(empty_list_widget_html));
-}
+};
 
 // @params
 // $container: jQuery object to append to.
@@ -286,11 +277,9 @@ export function create<Key, Item = Key>(
     };
 
     const widget: ListWidget<Key, Item> = {
-        get_current_list() {
-            return meta.filtered_list;
-        },
+        get_current_list: () => meta.filtered_list,
 
-        filter_and_sort() {
+        filter_and_sort: () => {
             meta.filtered_list = get_filtered_items(meta.filter_value, meta.list, opts);
 
             if (meta.sorting_function) {
@@ -304,7 +293,7 @@ export function create<Key, Item = Key>(
 
         // Used in case of Multiselect DropdownListWidget to retain
         // previously checked items even after widget redraws.
-        retain_selected_items() {
+        retain_selected_items: () => {
             const items = opts.multiselect;
 
             if (items?.selected_items) {
@@ -323,9 +312,7 @@ export function create<Key, Item = Key>(
         },
 
         // Returns if all available items are rendered.
-        all_rendered() {
-            return meta.offset >= meta.filtered_list.length;
-        },
+        all_rendered: () => meta.offset >= meta.filtered_list.length,
 
         // Reads the provided list (in the scope directly above)
         // and renders the next block of messages automatically
@@ -374,7 +361,7 @@ export function create<Key, Item = Key>(
             }
         },
 
-        render_item(item) {
+        render_item: (item) => {
             if (!opts.html_selector) {
                 // We don't have any way to find the existing item.
                 return;
@@ -397,16 +384,16 @@ export function create<Key, Item = Key>(
             $html_item.replaceWith($(html));
         },
 
-        clear() {
+        clear: () => {
             $container.empty();
             meta.offset = 0;
         },
 
-        set_filter_value(filter_value) {
+        set_filter_value: (filter_value) => {
             meta.filter_value = filter_value;
         },
 
-        set_reverse_mode(reverse_mode) {
+        set_reverse_mode: (reverse_mode) => {
             meta.reverse_mode = reverse_mode;
         },
 
@@ -414,7 +401,7 @@ export function create<Key, Item = Key>(
         // for the sorting_functions map to get the function. In case of generic sort
         // functions like numeric and alphabetic, we pass the string in the given format -
         // "{property}_{numeric|alphabetic}" - e.g. "email_alphabetic" or "age_numeric".
-        set_sorting_function(sorting_function) {
+        set_sorting_function: (sorting_function) => {
             if (typeof sorting_function === "function") {
                 meta.sorting_function = sorting_function;
             } else if (typeof sorting_function === "string") {
@@ -465,7 +452,7 @@ export function create<Key, Item = Key>(
             });
         },
 
-        clear_event_handlers() {
+        clear_event_handlers: () => {
             meta.$scroll_listening_element.off("scroll.list_widget_container");
 
             if (opts.$parent_container) {
@@ -475,34 +462,34 @@ export function create<Key, Item = Key>(
             opts.filter?.$element?.off("input.list_widget_filter");
         },
 
-        increase_rendered_offset() {
+        increase_rendered_offset: () => {
             meta.offset = Math.min(meta.offset + 1, meta.filtered_list.length);
         },
 
-        reduce_rendered_offset() {
+        reduce_rendered_offset: () => {
             meta.offset = Math.max(meta.offset - 1, 0);
         },
 
-        remove_rendered_row(rendered_row) {
+        remove_rendered_row: (rendered_row) => {
             rendered_row.remove();
             // We removed a rendered row, so we need to reduce one offset.
             widget.reduce_rendered_offset();
         },
 
-        clean_redraw() {
+        clean_redraw: () => {
             widget.filter_and_sort();
             widget.clear();
             widget.render(DEFAULTS.INITIAL_RENDER_COUNT);
         },
 
-        hard_redraw() {
+        hard_redraw: () => {
             widget.clean_redraw();
             if (opts.filter?.onupdate) {
                 opts.filter.onupdate();
             }
         },
 
-        insert_rendered_row(item, get_insert_index) {
+        insert_rendered_row: (item, get_insert_index) => {
             // NOTE: Caller should call `filter_and_sort` before calling this function
             // so that `meta.filtered_list` already has the `item`.
             if (meta.filtered_list.length <= 2) {
@@ -544,13 +531,13 @@ export function create<Key, Item = Key>(
             }
         },
 
-        sort(sorting_function, prop) {
+        sort: (sorting_function, prop) => {
             const key = prop ? `${prop}_${sorting_function}` : sorting_function;
             widget.set_sorting_function(key);
             widget.hard_redraw();
         },
 
-        replace_list_data(list, should_redraw = true) {
+        replace_list_data: (list, should_redraw = true) => {
             /*
                 We mostly use this widget for lists where you are
                 not adding or removing rows, so when you do modify
@@ -590,7 +577,7 @@ export function create<Key, Item = Key>(
     return widget;
 }
 
-export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>): void {
+export const handle_sort = <Key, Item>($th: JQuery, list: ListWidget<Key, Item>): void => {
     /*
         one would specify sort parameters like this:
             - name => sort alphabetic.
@@ -624,6 +611,6 @@ export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>)
     // if `prop_name` is defined, it will trigger the generic sort functions,
     // and not if it is undefined.
     list.sort(sort_type, prop_name);
-}
+};
 
 export const default_get_item = <T>(item: T): T => item;

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -4,7 +4,7 @@ import loading_black_image from "../../static/images/loading/loader-black.svg";
 import loading_white_image from "../../static/images/loading/loader-white.svg";
 import render_loader from "../templates/loader.hbs";
 
-export function make_indicator(
+export const make_indicator = (
     $outer_container: JQuery,
     {
         abs_positioned = false,
@@ -17,7 +17,7 @@ export function make_indicator(
         width?: number | undefined;
         height?: number | undefined;
     } = {},
-): void {
+): void => {
     let $container = $outer_container;
 
     // TODO: We set white-space to 'nowrap' because under some
@@ -72,22 +72,22 @@ export function make_indicator(
     }
 
     $outer_container.data("destroying", false);
-}
+};
 
-export function destroy_indicator($container: JQuery): void {
+export const destroy_indicator = ($container: JQuery): void => {
     if ($container.data("destroying")) {
         return;
     }
     $container.data("destroying", true);
     $container.empty();
     $container.css({width: 0, height: 0});
-}
+};
 
-export function show_button_spinner($elt: JQuery, using_dark_theme: boolean): void {
+export const show_button_spinner = ($elt: JQuery, using_dark_theme: boolean): void => {
     if (!using_dark_theme) {
         $elt.attr("src", loading_black_image);
     } else {
         $elt.attr("src", loading_white_image);
     }
     $elt.css("display", "inline-block");
-}
+};

--- a/web/src/local_message.ts
+++ b/web/src/local_message.ts
@@ -3,14 +3,12 @@ import * as blueslip from "./blueslip";
 
 let max_message_id: number;
 
-function truncate_precision(float: number): number {
-    return Number.parseFloat(float.toFixed(3));
-}
+const truncate_precision = (float: number): number => Number.parseFloat(float.toFixed(3));
 
-export const get_next_id_float = (function () {
+export const get_next_id_float = (() => {
     const already_used = new Set();
 
-    return function (): number | undefined {
+    return (): number | undefined => {
         const local_id_increment = 0.01;
         let latest = all_messages_data.last()?.id ?? max_message_id;
         latest = Math.max(0, latest);
@@ -41,6 +39,6 @@ export const get_next_id_float = (function () {
     };
 })();
 
-export function initialize(params: {max_message_id: number}): void {
+export const initialize = (params: {max_message_id: number}): void => {
     max_message_id = params.max_message_id;
-}
+};

--- a/web/src/localstorage.ts
+++ b/web/src/localstorage.ts
@@ -33,24 +33,18 @@ export type LocalStorage = {
 
 const ls = {
     // check if the datestamp is from before now and if so return true.
-    isExpired(stamp: number): boolean {
-        return new Date(stamp) < new Date();
-    },
+    isExpired: (stamp: number): boolean => new Date(stamp) < new Date(),
 
     // return the localStorage key that is bound to a version of a key.
-    formGetter(version: number, name: string): string {
-        return `ls__${version}__${name}`;
-    },
+    formGetter: (version: number, name: string): string => `ls__${version}__${name}`,
 
     // create a formData object to put in the data, a signature that it was
     // created with this library, and when it expires (if ever).
-    formData(data: unknown, expires: number): FormData {
-        return {
-            data,
-            __valid: true,
-            expires: Date.now() + expires,
-        };
-    },
+    formData: (data: unknown, expires: number): FormData => ({
+        data,
+        __valid: true,
+        expires: Date.now() + expires,
+    }),
 
     getData(version: number, name: string): FormData | undefined {
         const key = this.formGetter(version, name);
@@ -168,7 +162,7 @@ export const localstorage = function (): LocalStorage {
             return this;
         },
 
-        get(name: string): unknown {
+        get: (name: string): unknown => {
             const data = ls.getData(_data.VERSION, name);
 
             if (data) {
@@ -178,7 +172,7 @@ export const localstorage = function (): LocalStorage {
             return undefined;
         },
 
-        set(name: string, data: unknown): boolean {
+        set: (name: string, data: unknown): boolean => {
             if (_data.VERSION !== undefined) {
                 ls.setData(_data.VERSION, name, data, _data.expires);
 
@@ -196,28 +190,26 @@ export const localstorage = function (): LocalStorage {
         },
 
         // remove a key with a given version.
-        remove(name: string): void {
+        remove: (name: string): void => {
             ls.removeData(_data.VERSION, name);
         },
 
         // Remove keys which (1) map to a value that satisfies a
         // property tested by `condition_checker` AND (2) which
         // match the pattern given by `name`.
-        removeDataRegexWithCondition(
+        removeDataRegexWithCondition: (
             name: string,
             condition_checker: (value: string | null | undefined) => boolean,
-        ): void {
+        ): void => {
             ls.removeDataRegexWithCondition(_data.VERSION, name, condition_checker);
         },
 
-        migrate<T = unknown>(
+        migrate: <T = unknown>(
             name: string,
             v1: number,
             v2: number,
             callback: (data: unknown) => T,
-        ): T | undefined {
-            return ls.migrate(name, v1, v2, callback);
-        },
+        ): T | undefined => ls.migrate(name, v1, v2, callback),
 
         // set a new master version for the LocalStorage instance.
         get version() {
@@ -233,7 +225,7 @@ export const localstorage = function (): LocalStorage {
 
 let warned_of_localstorage = false;
 
-localstorage.supported = function supports_localstorage(): boolean {
+localstorage.supported = (): boolean => {
     try {
         return window.localStorage !== undefined && window.localStorage !== null;
     } catch {

--- a/web/src/markdown_config.ts
+++ b/web/src/markdown_config.ts
@@ -30,15 +30,13 @@ import {user_settings} from "./user_settings";
     when the lookups fail.
 */
 
-function abstract_map<K, V>(map: Map<K, V>): AbstractMap<K, V> {
-    return {
-        keys: () => map.keys(),
-        entries: () => map.entries(),
-        get: (k) => map.get(k),
-    };
-}
+const abstract_map = <K, V>(map: Map<K, V>): AbstractMap<K, V> => ({
+    keys: () => map.keys(),
+    entries: () => map.entries(),
+    get: (k) => map.get(k),
+});
 
-function stream(obj: Stream | undefined): {stream_id: number; name: string} | undefined {
+const stream = (obj: Stream | undefined): {stream_id: number; name: string} | undefined => {
     if (obj === undefined) {
         return undefined;
     }
@@ -47,11 +45,11 @@ function stream(obj: Stream | undefined): {stream_id: number; name: string} | un
         stream_id: obj.stream_id,
         name: obj.name,
     };
-}
+};
 
-function user_group(
+const user_group = (
     obj: user_groups.UserGroup | undefined,
-): {id: number; name: string} | undefined {
+): {id: number; name: string} | undefined => {
     if (obj === undefined) {
         return undefined;
     }
@@ -60,7 +58,7 @@ function user_group(
         id: obj.id,
         name: obj.name,
     };
-}
+};
 
 export const get_helpers = (): MarkdownHelpers => ({
     // user stuff

--- a/web/src/message_actions_popover.js
+++ b/web/src/message_actions_popover.js
@@ -23,7 +23,7 @@ import * as unread_ops from "./unread_ops";
 
 let message_actions_popover_keyboard_toggle = false;
 
-function get_action_menu_menu_items() {
+const get_action_menu_menu_items = () => {
     const $current_actions_popover_elem = $("[data-tippy-root] #message-actions-menu-dropdown");
     if (!$current_actions_popover_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
@@ -31,16 +31,16 @@ function get_action_menu_menu_items() {
     }
 
     return $current_actions_popover_elem.find("li:not(.divider):visible a");
-}
+};
 
-function focus_first_action_popover_item() {
+const focus_first_action_popover_item = () => {
     // For now I recommend only calling this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_action_menu_menu_items();
     popover_menus.focus_first_popover_item($items);
-}
+};
 
-export function toggle_message_actions_menu(message) {
+export const toggle_message_actions_menu = (message) => {
     if (popover_menus.is_message_actions_popover_displayed()) {
         popovers.hide_all();
         return true;
@@ -67,9 +67,9 @@ export function toggle_message_actions_menu(message) {
     message_actions_popover_keyboard_toggle = true;
     $popover_reference.trigger("click");
     return true;
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     popover_menus.register_popover_menu(".actions_hover .message-actions-menu-button", {
         theme: "popover-menu",
         placement: "bottom",
@@ -85,7 +85,7 @@ export function initialize() {
                 },
             ],
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popover_menus.on_show_prep(instance);
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
@@ -93,7 +93,7 @@ export function initialize() {
             instance.setContent(parse_html(render_message_actions_popover(args)));
             $row.addClass("has_actions_popover");
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
             let quote_content;
@@ -227,7 +227,7 @@ export function initialize() {
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             const $row = $(instance.reference).closest(".message_row");
             $row.removeClass("has_actions_popover");
             instance.destroy();
@@ -235,4 +235,4 @@ export function initialize() {
             message_actions_popover_keyboard_toggle = false;
         },
     });
-}
+};

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -64,7 +64,7 @@ export let notify_old_thread_default = false;
 
 export let notify_new_thread_default = true;
 
-export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
+export const is_topic_editable = (message, edit_limit_seconds_buffer = 0) => {
     if (!is_message_editable_ignoring_permissions(message)) {
         return false;
     }
@@ -96,16 +96,16 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
             (message.timestamp - Date.now() / 1000) >
         0
     );
-}
+};
 
-function is_widget_message(message) {
+const is_widget_message = (message) => {
     if (message.submessages && message.submessages.length !== 0) {
         return true;
     }
     return false;
-}
+};
 
-export function is_message_editable_ignoring_permissions(message) {
+export const is_message_editable_ignoring_permissions = (message) => {
     if (!message) {
         return false;
     }
@@ -131,9 +131,9 @@ export function is_message_editable_ignoring_permissions(message) {
         return false;
     }
     return true;
-}
+};
 
-export function is_content_editable(message, edit_limit_seconds_buffer = 0) {
+export const is_content_editable = (message, edit_limit_seconds_buffer = 0) => {
     if (!is_message_editable_ignoring_permissions(message)) {
         return false;
     }
@@ -163,9 +163,9 @@ export function is_content_editable(message, edit_limit_seconds_buffer = 0) {
         return true;
     }
     return false;
-}
+};
 
-export function is_message_sent_by_my_bot(message) {
+export const is_message_sent_by_my_bot = (message) => {
     const user = people.get_by_user_id(message.sender_id);
     if (user.bot_owner_id === undefined || user.bot_owner_id === null) {
         // The message was not sent by a bot or the message was sent
@@ -174,9 +174,9 @@ export function is_message_sent_by_my_bot(message) {
     }
 
     return people.is_my_user_id(user.bot_owner_id);
-}
+};
 
-export function get_deletability(message) {
+export const get_deletability = (message) => {
     if (current_user.is_admin) {
         return true;
     }
@@ -203,9 +203,9 @@ export function get_deletability(message) {
         return true;
     }
     return false;
-}
+};
 
-export function is_stream_editable(message, edit_limit_seconds_buffer = 0) {
+export const is_stream_editable = (message, edit_limit_seconds_buffer = 0) => {
     if (!is_message_editable_ignoring_permissions(message)) {
         return false;
     }
@@ -236,13 +236,12 @@ export function is_stream_editable(message, edit_limit_seconds_buffer = 0) {
             (message.timestamp - Date.now() / 1000) >
         0
     );
-}
+};
 
-export function can_move_message(message) {
-    return is_topic_editable(message) || is_stream_editable(message);
-}
+export const can_move_message = (message) =>
+    is_topic_editable(message) || is_stream_editable(message);
 
-export function stream_and_topic_exist_in_edit_history(message, stream_id, topic) {
+export const stream_and_topic_exist_in_edit_history = (message, stream_id, topic) => {
     /*  Checks to see if a stream_id and a topic match any historical
         stream_id and topic state in the message's edit history.
 
@@ -287,61 +286,61 @@ export function stream_and_topic_exist_in_edit_history(message, stream_id, topic
     }
 
     return false;
-}
+};
 
-export function hide_message_edit_spinner($row) {
+export const hide_message_edit_spinner = ($row) => {
     $row.find(".loader").hide();
     $row.find(".message_edit_save span").show();
     $row.find(".message_edit_save").removeClass("disable-btn");
     $row.find(".message_edit_cancel").removeClass("disable-btn");
-}
+};
 
-export function show_message_edit_spinner($row) {
+export const show_message_edit_spinner = ($row) => {
     // Always show the white spinner like we
     // do for send button in compose box.
     loading.show_button_spinner($row.find(".loader"), true);
     $row.find(".message_edit_save span").hide();
     $row.find(".message_edit_save").addClass("disable-btn");
     $row.find(".message_edit_cancel").addClass("disable-btn");
-}
+};
 
-export function show_topic_edit_spinner($row) {
+export const show_topic_edit_spinner = ($row) => {
     const $spinner = $row.find(".topic_edit_spinner");
     loading.make_indicator($spinner);
     $spinner.css({height: ""});
     $(".topic_edit_save").hide();
     $(".topic_edit_cancel").hide();
     $(".topic_edit_spinner").show();
-}
+};
 
-export function end_if_focused_on_inline_topic_edit() {
+export const end_if_focused_on_inline_topic_edit = () => {
     const $focused_elem = $(".topic_edit_form").find(":focus");
     if ($focused_elem.length === 1) {
         $focused_elem.trigger("blur");
         const $recipient_row = $focused_elem.closest(".recipient_row");
         end_inline_topic_edit($recipient_row);
     }
-}
+};
 
-export function end_if_focused_on_message_row_edit() {
+export const end_if_focused_on_message_row_edit = () => {
     const $focused_elem = $(".message_edit").find(":focus");
     if ($focused_elem.length === 1) {
         $focused_elem.trigger("blur");
         const $row = $focused_elem.closest(".message_row");
         end_message_row_edit($row);
     }
-}
+};
 
-export function update_inline_topic_edit_ui() {
+export const update_inline_topic_edit_ui = () => {
     // This function is called when
     // "realm_move_messages_within_stream_limit_seconds" setting is
     // changed. This is a rare event, so it's OK to be lazy and just
     // do a full rerender, even though the only thing we need to
     // change is the inline topic edit icons in recipient bars.
     message_live_update.rerender_messages_view();
-}
+};
 
-function handle_message_row_edit_keydown(e) {
+const handle_message_row_edit_keydown = (e) => {
     if (keydown_util.is_enter_event(e)) {
         if ($(e.target).hasClass("message_edit_content")) {
             // Pressing Enter to save edits is coupled with Enter to send
@@ -381,9 +380,9 @@ function handle_message_row_edit_keydown(e) {
         e.stopPropagation();
         e.preventDefault();
     }
-}
+};
 
-function handle_inline_topic_edit_keydown(e) {
+const handle_inline_topic_edit_keydown = (e) => {
     if (keydown_util.is_enter_event(e)) {
         // Handle Enter key in the recipient bar/inline topic edit form
         if ($(".typeahead:visible").length > 0) {
@@ -401,9 +400,9 @@ function handle_inline_topic_edit_keydown(e) {
         e.stopPropagation();
         e.preventDefault();
     }
-}
+};
 
-function timer_text(seconds_left) {
+const timer_text = (seconds_left) => {
     const minutes = Math.floor(seconds_left / 60);
     const seconds = seconds_left % 60;
     if (minutes >= 1) {
@@ -415,9 +414,9 @@ function timer_text(seconds_left) {
         );
     }
     return $t({defaultMessage: "{seconds} sec to edit"}, {seconds: seconds.toString()});
-}
+};
 
-function create_copy_to_clipboard_handler($row, source, $message_edit_content) {
+const create_copy_to_clipboard_handler = ($row, source, $message_edit_content) => {
     const clipboard = new ClipboardJS(source, {
         target: () => $message_edit_content[0],
     });
@@ -433,9 +432,9 @@ function create_copy_to_clipboard_handler($row, source, $message_edit_content) {
             tippy_timeout_in_ms,
         );
     });
-}
+};
 
-function edit_message($row, raw_content) {
+const edit_message = ($row, raw_content) => {
     // Open the message-edit UI for a given message.
     //
     // Notably, when switching views, this can be called for a row
@@ -558,9 +557,9 @@ function edit_message($row, raw_content) {
         $message_edit_content.val("");
         $message_edit_content.val(contents);
     }
-}
+};
 
-function start_edit_maintaining_scroll($row, content) {
+const start_edit_maintaining_scroll = ($row, content) => {
     // This function makes the bottom of the edit form visible, so
     // call this for cases where it is important to show the bottom
     // like showing error messages or upload status.
@@ -570,18 +569,18 @@ function start_edit_maintaining_scroll($row, content) {
     if (row_bottom > composebox_top) {
         message_viewport.scrollTop(message_viewport.scrollTop() + row_bottom - composebox_top);
     }
-}
+};
 
-function start_edit_with_content($row, content, edit_box_open_callback) {
+const start_edit_with_content = ($row, content, edit_box_open_callback) => {
     start_edit_maintaining_scroll($row, content);
     if (edit_box_open_callback) {
         edit_box_open_callback();
     }
     const row_id = rows.id($row);
     upload.setup_upload(upload.edit_config(row_id));
-}
+};
 
-export function start($row, edit_box_open_callback) {
+export const start = ($row, edit_box_open_callback) => {
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(rows.id($row));
     if (message === undefined) {
@@ -601,24 +600,28 @@ export function start($row, edit_box_open_callback) {
     const msg_list = message_lists.current;
     channel.get({
         url: "/json/messages/" + message.id,
-        success(data) {
+        success: (data) => {
             if (message_lists.current === msg_list) {
                 message.raw_content = data.raw_content;
                 start_edit_with_content($row, message.raw_content, edit_box_open_callback);
             }
         },
     });
-}
+};
 
-function show_toggle_resolve_topic_spinner($row) {
+const show_toggle_resolve_topic_spinner = ($row) => {
     const $spinner = $row.find(".toggle_resolve_topic_spinner");
     loading.make_indicator($spinner);
     $spinner.css({width: "18px"});
     $row.find(".on_hover_topic_resolve, .on_hover_topic_unresolve").hide();
     $row.find(".toggle_resolve_topic_spinner").show();
-}
+};
 
-function get_resolve_topic_time_limit_error_string(time_limit, time_limit_unit, topic_is_resolved) {
+const get_resolve_topic_time_limit_error_string = (
+    time_limit,
+    time_limit_unit,
+    topic_is_resolved,
+) => {
     if (topic_is_resolved) {
         if (time_limit_unit === "minute") {
             return $t(
@@ -670,9 +673,9 @@ function get_resolve_topic_time_limit_error_string(time_limit, time_limit_unit, 
         },
         {N: time_limit},
     );
-}
+};
 
-function handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved) {
+const handle_resolve_topic_failure_due_to_time_limit = (topic_is_resolved) => {
     const time_limit_for_resolving_topic = timerender.get_time_limit_setting_in_appropriate_unit(
         realm.realm_move_messages_within_stream_limit_seconds,
     );
@@ -696,18 +699,18 @@ function handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved) {
         html_heading: modal_heading,
         html_body,
         html_submit_button: $t_html({defaultMessage: "Close"}),
-        on_click() {},
+        on_click: () => {},
         single_footer_button: true,
         focus_submit_on_open: true,
     });
-}
+};
 
-export function toggle_resolve_topic(
+export const toggle_resolve_topic = (
     message_id,
     old_topic_name,
     report_errors_in_global_banner,
     $row,
-) {
+) => {
     let new_topic_name;
     const topic_is_resolved = resolved_topic.is_resolved(old_topic_name);
     if (topic_is_resolved) {
@@ -730,13 +733,13 @@ export function toggle_resolve_topic(
     channel.patch({
         url: "/json/messages/" + message_id,
         data: request,
-        success() {
+        success: () => {
             if ($row) {
                 const $spinner = $row.find(".toggle_resolve_topic_spinner");
                 loading.destroy_indicator($spinner);
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             if ($row) {
                 const $spinner = $row.find(".toggle_resolve_topic_spinner");
                 loading.destroy_indicator($spinner);
@@ -754,9 +757,9 @@ export function toggle_resolve_topic(
             }
         },
     });
-}
+};
 
-export function start_inline_topic_edit($recipient_row) {
+export const start_inline_topic_edit = ($recipient_row) => {
     assert(message_lists.current !== undefined);
     const $form = $(
         render_topic_edit_form({
@@ -780,14 +783,14 @@ export function start_inline_topic_edit($recipient_row) {
         stream_name,
         false,
     );
-}
+};
 
-export function end_inline_topic_edit($row) {
+export const end_inline_topic_edit = ($row) => {
     assert(message_lists.current !== undefined);
     message_lists.current.hide_edit_topic_on_recipient_row($row);
-}
+};
 
-export function end_message_row_edit($row) {
+export const end_message_row_edit = ($row) => {
     assert(message_lists.current !== undefined);
     const row_id = rows.id($row);
 
@@ -812,9 +815,9 @@ export function end_message_row_edit($row) {
     $row.find(".message_edit").trigger("blur");
     // We should hide the editing typeahead if it is visible
     $row.find("input.message_edit_topic").trigger("blur");
-}
+};
 
-export function end_message_edit(message_id) {
+export const end_message_edit = (message_id) => {
     const $row = message_lists.current?.get_row(message_id);
     if (message_lists.current !== undefined && $row.length > 0) {
         end_message_row_edit($row);
@@ -823,9 +826,9 @@ export function end_message_edit(message_id) {
         // if it exists there but we cannot find the row.
         currently_editing_messages.delete(message_id);
     }
-}
+};
 
-export function try_save_inline_topic_edit($row) {
+export const try_save_inline_topic_edit = ($row) => {
     assert(message_lists.current !== undefined);
     const message_id = rows.id_for_recipient_row($row);
     const message = message_lists.current.get(message_id);
@@ -856,9 +859,9 @@ export function try_save_inline_topic_edit($row) {
     } else {
         do_save_inline_topic_edit($row, message, new_topic);
     }
-}
+};
 
-export function do_save_inline_topic_edit($row, message, new_topic) {
+export const do_save_inline_topic_edit = ($row, message, new_topic) => {
     const msg_list = message_lists.current;
     show_topic_edit_spinner($row);
 
@@ -880,11 +883,11 @@ export function do_save_inline_topic_edit($row, message, new_topic) {
     channel.patch({
         url: "/json/messages/" + message.id,
         data: request,
-        success() {
+        success: () => {
             const $spinner = $row.find(".topic_edit_spinner");
             loading.destroy_indicator($spinner);
         },
-        error(xhr) {
+        error: (xhr) => {
             const $spinner = $row.find(".topic_edit_spinner");
             if (xhr.responseJSON?.code === "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED") {
                 const allowed_message_id = xhr.responseJSON.first_message_id_allowed_to_move;
@@ -892,7 +895,7 @@ export function do_save_inline_topic_edit($row, message, new_topic) {
                 const send_notification_to_new_thread = false;
                 // We are not changing stream in this UI.
                 const new_stream_id = undefined;
-                function handle_confirm() {
+                const handle_confirm = () => {
                     move_topic_containing_message_to_stream(
                         allowed_message_id,
                         new_stream_id,
@@ -901,7 +904,7 @@ export function do_save_inline_topic_edit($row, message, new_topic) {
                         send_notification_to_old_thread,
                         "change_later",
                     );
-                }
+                };
                 const on_hide_callback = () => {
                     loading.destroy_indicator($spinner);
                     end_inline_topic_edit($row);
@@ -924,9 +927,9 @@ export function do_save_inline_topic_edit($row, message, new_topic) {
             }
         },
     });
-}
+};
 
-export function save_message_row_edit($row) {
+export const save_message_row_edit = ($row) => {
     assert(message_lists.current !== undefined);
     const $banner_container = compose_banner.get_compose_banner_container(
         $row.find(".message_edit_form textarea"),
@@ -1027,7 +1030,7 @@ export function save_message_row_edit($row) {
     channel.patch({
         url: "/json/messages/" + message.id,
         data: request,
-        success() {
+        success: () => {
             if (edit_locally_echoed) {
                 delete message.local_edit_timestamp;
                 currently_echoing_messages.delete(message_id);
@@ -1040,7 +1043,7 @@ export function save_message_row_edit($row) {
             // create a fresh Save button, without the spinner
             // class attached.
         },
-        error(xhr) {
+        error: (xhr) => {
             if (msg_list === message_lists.current) {
                 message_id = rows.id($row);
 
@@ -1099,9 +1102,9 @@ export function save_message_row_edit($row) {
         },
     });
     // The message will automatically get replaced via message_list.update_message.
-}
+};
 
-export function maybe_show_edit($row, id) {
+export const maybe_show_edit = ($row, id) => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -1110,9 +1113,9 @@ export function maybe_show_edit($row, id) {
         const $message_edit_content = currently_editing_messages.get(id);
         edit_message($row, $message_edit_content.val());
     }
-}
+};
 
-export function edit_last_sent_message() {
+export const edit_last_sent_message = () => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -1147,23 +1150,23 @@ export function edit_last_sent_message() {
     start($msg_row, () => {
         $(".message_edit_content").trigger("focus");
     });
-}
+};
 
-export function delete_message(msg_id) {
+export const delete_message = (msg_id) => {
     const html_body = render_delete_message_modal();
 
-    function do_delete_message() {
+    const do_delete_message = () => {
         currently_deleting_messages.push(msg_id);
         channel.del({
             url: "/json/messages/" + msg_id,
-            success() {
+            success: () => {
                 currently_deleting_messages = currently_deleting_messages.filter(
                     (id) => id !== msg_id,
                 );
                 dialog_widget.hide_dialog_spinner();
                 dialog_widget.close();
             },
-            error(xhr) {
+            error: (xhr) => {
                 currently_deleting_messages = currently_deleting_messages.filter(
                     (id) => id !== msg_id,
                 );
@@ -1176,7 +1179,7 @@ export function delete_message(msg_id) {
                 );
             },
         });
-    }
+    };
 
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Delete message?"}),
@@ -1185,15 +1188,15 @@ export function delete_message(msg_id) {
         on_click: do_delete_message,
         loading_spinner: true,
     });
-}
+};
 
-export function delete_topic(stream_id, topic_name, failures = 0) {
+export const delete_topic = (stream_id, topic_name, failures = 0) => {
     channel.post({
         url: "/json/streams/" + stream_id + "/delete_topic",
         data: {
             topic_name,
         },
-        success(data) {
+        success: (data) => {
             if (data.complete === false) {
                 if (failures >= 9) {
                     // Don't keep retrying indefinitely to avoid DoSing the server.
@@ -1213,9 +1216,9 @@ export function delete_topic(stream_id, topic_name, failures = 0) {
             }
         },
     });
-}
+};
 
-export function restore_edit_state_after_message_view_change() {
+export const restore_edit_state_after_message_view_change = () => {
     assert(message_lists.current !== undefined);
     for (const [idx, $content] of currently_editing_messages) {
         if (message_lists.current.get(idx) !== undefined) {
@@ -1223,9 +1226,9 @@ export function restore_edit_state_after_message_view_change() {
             edit_message($row, $content.val());
         }
     }
-}
+};
 
-function handle_message_move_failure_due_to_time_limit(xhr, handle_confirm, on_hide_callback) {
+const handle_message_move_failure_due_to_time_limit = (xhr, handle_confirm, on_hide_callback) => {
     const total_messages_allowed_to_move = xhr.responseJSON.total_messages_allowed_to_move;
     const messages_allowed_to_move_text = $t(
         {
@@ -1256,9 +1259,9 @@ function handle_message_move_failure_due_to_time_limit(xhr, handle_confirm, on_h
         loading_spinner: true,
         on_hide: on_hide_callback,
     });
-}
+};
 
-function show_message_moved_toast(toast_params) {
+const show_message_moved_toast = (toast_params) => {
     const new_stream_name = sub_store.maybe_get_stream_name(toast_params.new_stream_id);
     const stream_topic = `#${new_stream_name} > ${toast_params.new_topic_name}`;
     const new_location_url = hash_util.by_stream_topic_url(
@@ -1266,7 +1269,7 @@ function show_message_moved_toast(toast_params) {
         toast_params.new_topic_name,
     );
     feedback_widget.show({
-        populate($container) {
+        populate: ($container) => {
             const widget_body_html = render_message_moved_widget_body({
                 stream_topic,
                 new_location_url,
@@ -1275,9 +1278,9 @@ function show_message_moved_toast(toast_params) {
         },
         title_text: $t({defaultMessage: "Message moved"}),
     });
-}
+};
 
-export function move_topic_containing_message_to_stream(
+export const move_topic_containing_message_to_stream = (
     message_id,
     new_stream_id,
     new_topic_name,
@@ -1285,13 +1288,13 @@ export function move_topic_containing_message_to_stream(
     send_notification_to_old_thread,
     propagate_mode,
     toast_params,
-) {
-    function reset_modal_ui() {
+) => {
+    const reset_modal_ui = () => {
         currently_topic_editing_messages = currently_topic_editing_messages.filter(
             (id) => id !== message_id,
         );
         dialog_widget.hide_dialog_spinner();
-    }
+    };
     if (currently_topic_editing_messages.includes(message_id)) {
         ui_report.client_error(
             $t_html({defaultMessage: "A Topic Move already in progress."}),
@@ -1313,7 +1316,7 @@ export function move_topic_containing_message_to_stream(
     channel.patch({
         url: "/json/messages/" + message_id,
         data: request,
-        success() {
+        success: () => {
             // The main UI will update via receiving the event
             // from server_events.js.
             reset_modal_ui();
@@ -1322,11 +1325,11 @@ export function move_topic_containing_message_to_stream(
                 show_message_moved_toast(toast_params);
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             reset_modal_ui();
             if (xhr.responseJSON?.code === "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED") {
                 const allowed_message_id = xhr.responseJSON.first_message_id_allowed_to_move;
-                function handle_confirm() {
+                const handle_confirm = () => {
                     move_topic_containing_message_to_stream(
                         allowed_message_id,
                         new_stream_id,
@@ -1335,7 +1338,7 @@ export function move_topic_containing_message_to_stream(
                         send_notification_to_old_thread,
                         "change_later",
                     );
-                }
+                };
 
                 const partial_move_confirmation_modal_callback = () =>
                     handle_message_move_failure_due_to_time_limit(xhr, handle_confirm);
@@ -1345,9 +1348,9 @@ export function move_topic_containing_message_to_stream(
             ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
         },
     });
-}
+};
 
-export function with_first_message_id(stream_id, topic_name, success_cb, error_cb) {
+export const with_first_message_id = (stream_id, topic_name, success_cb, error_cb) => {
     // The API endpoint for editing messages to change their
     // content, topic, or stream requires a message ID.
     //
@@ -1375,21 +1378,21 @@ export function with_first_message_id(stream_id, topic_name, success_cb, error_c
     channel.get({
         url: "/json/messages",
         data,
-        success(data) {
+        success: (data) => {
             const message_id = data.messages[0]?.id;
             success_cb(message_id);
         },
         error: error_cb,
     });
-}
+};
 
-export function is_message_oldest_or_newest(
+export const is_message_oldest_or_newest = (
     stream_id,
     topic_name,
     message_id,
     success_callback,
     error_callback,
-) {
+) => {
     const data = {
         anchor: message_id,
         num_before: 1,
@@ -1403,7 +1406,7 @@ export function is_message_oldest_or_newest(
     channel.get({
         url: "/json/messages",
         data,
-        success(data) {
+        success: (data) => {
             let is_oldest = true;
             let is_newest = true;
             for (const message of data.messages) {
@@ -1417,4 +1420,4 @@ export function is_message_oldest_or_newest(
         },
         error: error_callback,
     });
-}
+};

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -79,10 +79,10 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
         return edited_messages_ids;
     },
     on_enter() {
-        return;
+        // Do nothing
     },
     on_delete() {
-        return;
+        // Do nothing
     },
 };
 

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -66,7 +66,7 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
     row_item_selector: "overlay-message-row",
     box_item_selector: "overlay-message-info-box",
     id_attribute_name: "data-message-edit-history-id",
-    get_items_ids(): number[] {
+    get_items_ids: (): number[] => {
         const edited_messages_ids: number[] = [];
         const $message_history_list: JQuery = $(
             "#message-history-overlay .message-edit-history-list",
@@ -78,35 +78,35 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
         }
         return edited_messages_ids;
     },
-    on_enter() {
+    on_enter: () => {
         // Do nothing
     },
-    on_delete() {
+    on_delete: () => {
         // Do nothing
     },
 };
 
-function get_display_stream_name(stream_id: number): string {
+const get_display_stream_name = (stream_id: number): string => {
     const stream_name = sub_store.maybe_get_stream_name(stream_id);
     if (stream_name === undefined) {
         return $t({defaultMessage: "Unknown channel"});
     }
     return stream_name;
-}
+};
 
-function show_loading_indicator(): void {
+const show_loading_indicator = (): void => {
     loading.make_indicator($(".message-edit-history-container .loading_indicator"));
     $(".message-edit-history-container .loading_indicator").addClass(
         "overlay_loading_indicator_style",
     );
-}
+};
 
-function hide_loading_indicator(): void {
+const hide_loading_indicator = (): void => {
     loading.destroy_indicator($(".message-edit-history-container .loading_indicator"));
     $(".message-edit-history-container .loading_indicator").removeClass(
         "overlay_loading_indicator_style",
     );
-}
+};
 
 export function fetch_and_render_message_history(message: Message): void {
     $("#message-edit-history-overlay-container").html(render_message_history_overlay());
@@ -246,7 +246,7 @@ export function fetch_and_render_message_history(message: Message): void {
                 keyboard_handling_context,
             );
         },
-        error(xhr) {
+        error: (xhr) => {
             ui_report.error(
                 $t_html({defaultMessage: "Error fetching message edit history."}),
                 xhr,
@@ -258,23 +258,23 @@ export function fetch_and_render_message_history(message: Message): void {
     });
 }
 
-export function open_overlay(): void {
+export const open_overlay = (): void => {
     if (overlays.any_active()) {
         return;
     }
     overlays.open_overlay({
         name: "message_edit_history",
         $overlay: $("#message-history-overlay"),
-        on_close() {
+        on_close: () => {
             exit_overlay();
             $("#message-edit-history-overlay-container").empty();
         },
     });
-}
+};
 
-export function handle_keyboard_events(event_key: string): void {
+export const handle_keyboard_events = (event_key: string): void => {
     messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
-}
+};
 
 export function initialize(): void {
     $("body").on("mouseenter", ".message_edit_notice", (e) => {

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -35,7 +35,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
-function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) {
+const maybe_add_narrowed_messages = (messages, msg_list, callback, attempt = 1) => {
     const ids = [];
 
     for (const elem of messages) {
@@ -49,7 +49,7 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
             narrow: JSON.stringify(narrow_state.public_search_terms()),
         },
         timeout: 5000,
-        success(data) {
+        success: (data) => {
             if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
                 // We unnarrowed or moved to Recent Conversations in the meantime.
                 return;
@@ -78,7 +78,7 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
             callback(new_messages, msg_list);
             unread_ops.process_visible();
         },
-        error(xhr) {
+        error: (xhr) => {
             if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
                 return;
             }
@@ -108,9 +108,9 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
             }, delay);
         },
     });
-}
+};
 
-export function insert_new_messages(messages, sent_by_this_client) {
+export const insert_new_messages = (messages, sent_by_this_client) => {
     messages = messages.map((message) => message_helper.process_new_message(message));
 
     const any_untracked_unread_messages = unread.process_loaded_messages(messages, false);
@@ -151,7 +151,7 @@ export function insert_new_messages(messages, sent_by_this_client) {
     // will filter out any not sent by us.
     if (sent_by_this_client) {
         compose_notifications.notify_local_mixes(messages, need_user_to_scroll, {
-            narrow_to_recipient(message_id) {
+            narrow_to_recipient: (message_id) => {
                 message_view.narrow_by_topic(message_id, {trigger: "outside_current_view"});
             },
         });
@@ -167,9 +167,9 @@ export function insert_new_messages(messages, sent_by_this_client) {
     pm_list.update_private_messages();
 
     return messages;
-}
+};
 
-export function update_messages(events) {
+export const update_messages = (events) => {
     const messages_to_rerender = [];
     let any_topic_edited = false;
     let changed_narrow = false;
@@ -573,9 +573,9 @@ export function update_messages(events) {
     unread_ui.update_unread_counts();
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
-}
+};
 
-export function remove_messages(message_ids) {
+export const remove_messages = (message_ids) => {
     all_messages_data.remove(message_ids);
     for (const list of message_lists.all_rendered_message_lists()) {
         list.remove_and_rerender(message_ids);
@@ -584,4 +584,4 @@ export function remove_messages(message_ids) {
     recent_view_ui.update_topics_of_deleted_message_ids(message_ids);
     starred_messages.remove(message_ids);
     starred_messages_ui.rerender_ui();
-}
+};

--- a/web/src/message_feed_loading.ts
+++ b/web/src/message_feed_loading.ts
@@ -5,41 +5,41 @@ import * as loading from "./loading";
 let loading_older_messages_indicator_showing = false;
 let loading_newer_messages_indicator_showing = false;
 
-export function show_loading_older(): void {
+export const show_loading_older = (): void => {
     if (!loading_older_messages_indicator_showing) {
         $(".top-messages-logo").toggleClass("loading", true);
         loading.make_indicator($("#loading_older_messages_indicator"), {abs_positioned: true});
         loading_older_messages_indicator_showing = true;
     }
-}
+};
 
-export function hide_loading_older(): void {
+export const hide_loading_older = (): void => {
     if (loading_older_messages_indicator_showing) {
         $(".top-messages-logo").toggleClass("loading", false);
         loading.destroy_indicator($("#loading_older_messages_indicator"));
         loading_older_messages_indicator_showing = false;
     }
-}
+};
 
-export function show_loading_newer(): void {
+export const show_loading_newer = (): void => {
     if (!loading_newer_messages_indicator_showing) {
         $(".bottom-messages-logo").show();
         $(".bottom-messages-logo").toggleClass("loading", true);
         loading.make_indicator($("#loading_newer_messages_indicator"), {abs_positioned: true});
         loading_newer_messages_indicator_showing = true;
     }
-}
+};
 
-export function hide_loading_newer(): void {
+export const hide_loading_newer = (): void => {
     if (loading_newer_messages_indicator_showing) {
         $(".bottom-messages-logo").hide();
         $(".bottom-messages-logo").toggleClass("loading", false);
         loading.destroy_indicator($("#loading_newer_messages_indicator"));
         loading_newer_messages_indicator_showing = false;
     }
-}
+};
 
-export function hide_indicators(): void {
+export const hide_indicators = (): void => {
     hide_loading_older();
     hide_loading_newer();
-}
+};

--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -7,22 +7,22 @@ import type {MessageList} from "./message_lists";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
 
-function show_history_limit_notice(): void {
+const show_history_limit_notice = (): void => {
     $(".top-messages-logo").hide();
     $(".history-limited-box").show();
     narrow_banner.hide_empty_narrow_message();
-}
+};
 
-function hide_history_limit_notice(): void {
+const hide_history_limit_notice = (): void => {
     $(".top-messages-logo").show();
     $(".history-limited-box").hide();
-}
+};
 
-function hide_end_of_results_notice(): void {
+const hide_end_of_results_notice = (): void => {
     $(".all-messages-search-caution").hide();
-}
+};
 
-function show_end_of_results_notice(): void {
+const show_end_of_results_notice = (): void => {
     $(".all-messages-search-caution").show();
 
     // Set the link to point to this search with streams:public added.
@@ -32,9 +32,9 @@ function show_end_of_results_notice(): void {
     const terms = narrow_filter.terms();
     const update_hash = hash_util.search_public_streams_notice_url(terms);
     $(".all-messages-search-caution a.search-shared-history").attr("href", update_hash);
-}
+};
 
-export function update_top_of_narrow_notices(msg_list: MessageList): void {
+export const update_top_of_narrow_notices = (msg_list: MessageList): void => {
     // Assumes that the current state is all notices hidden (i.e. this
     // will not hide a notice that should not be there)
     if (message_lists.current === undefined || msg_list !== message_lists.current) {
@@ -63,9 +63,9 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
     if (msg_list.data.fetch_status.history_limited()) {
         show_history_limit_notice();
     }
-}
+};
 
-export function hide_top_of_narrow_notices(): void {
+export const hide_top_of_narrow_notices = (): void => {
     hide_end_of_results_notice();
     hide_history_limit_notice();
-}
+};

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -55,7 +55,7 @@ const consts = {
     recent_view_minimum_load_more_fetch_size: 50000,
 };
 
-function process_result(data, opts) {
+const process_result = (data, opts) => {
     let messages = data.messages;
 
     messages = messages.map((message) => message_helper.process_new_message(message));
@@ -109,9 +109,9 @@ function process_result(data, opts) {
     if (opts.cont !== undefined) {
         opts.cont(data, opts);
     }
-}
+};
 
-function get_messages_success(data, opts) {
+const get_messages_success = (data, opts) => {
     const update_loading_indicator =
         message_lists.current !== undefined && opts.msg_list === message_lists.current;
     const msg_list_data = opts.msg_list_data ?? opts.msg_list.data;
@@ -156,14 +156,14 @@ function get_messages_success(data, opts) {
     }
 
     process_result(data, opts);
-}
+};
 
 // This function modifies the data.narrow filters to use integer IDs
 // instead of strings if it is supported. We currently don't set or
 // convert user emails to user IDs directly in the Filter code
 // because doing so breaks the app in various modules that expect a
 // string of user emails.
-function handle_operators_supporting_id_based_api(data) {
+const handle_operators_supporting_id_based_api = (data) => {
     const operators_supporting_ids = new Set(["dm", "pm-with"]);
     const operators_supporting_id = new Set([
         "id",
@@ -211,9 +211,9 @@ function handle_operators_supporting_id_based_api(data) {
 
     data.narrow = JSON.stringify(data.narrow);
     return data;
-}
+};
 
-export function load_messages(opts, attempt = 1) {
+export const load_messages = (opts, attempt = 1) => {
     if (typeof opts.anchor === "number") {
         // Messages that have been locally echoed messages have
         // floating point temporary IDs, which is intended to be a.
@@ -295,14 +295,14 @@ export function load_messages(opts, attempt = 1) {
     channel.get({
         url: "/json/messages",
         data,
-        success(data) {
+        success: (data) => {
             if (!$("#connection-error").hasClass("get-events-error")) {
                 ui_report.hide_error($("#connection-error"));
             }
 
             get_messages_success(data, opts);
         },
-        error(xhr) {
+        error: (xhr) => {
             if (xhr.status === 400 && !$("#connection-error").hasClass("get-events-error")) {
                 // We successfully reached the server, so hide the
                 // connection error notice, even if the request failed
@@ -371,9 +371,9 @@ export function load_messages(opts, attempt = 1) {
             }, delay_secs * 1000);
         },
     });
-}
+};
 
-export function load_messages_for_narrow(opts) {
+export const load_messages_for_narrow = (opts) => {
     load_messages({
         anchor: opts.anchor,
         num_before: consts.narrow_before,
@@ -381,18 +381,18 @@ export function load_messages_for_narrow(opts) {
         msg_list: opts.msg_list,
         cont: opts.cont,
     });
-}
+};
 
-export function get_backfill_anchor(msg_list_data) {
+export const get_backfill_anchor = (msg_list_data) => {
     const oldest_msg = msg_list_data.first_including_muted();
     if (oldest_msg) {
         return oldest_msg.id;
     }
 
     return "first_unread";
-}
+};
 
-export function get_frontfill_anchor(msg_list) {
+export const get_frontfill_anchor = (msg_list) => {
     const last_msg = msg_list.data.last_including_muted();
 
     if (last_msg) {
@@ -423,9 +423,9 @@ export function get_frontfill_anchor(msg_list) {
     // * When the first browser window's `GET /messages` request finishes,
     //   this code path will be reached.
     return "oldest";
-}
+};
 
-export function maybe_load_older_messages(opts) {
+export const maybe_load_older_messages = (opts) => {
     // This function gets called when you scroll to the top
     // of your window, and you want to get messages older
     // than what the browsers originally fetched.
@@ -474,9 +474,9 @@ export function maybe_load_older_messages(opts) {
             ? consts.recent_view_fetch_more_batch_size
             : consts.narrowed_view_backward_batch_size,
     });
-}
+};
 
-export function do_backfill(opts) {
+export const do_backfill = (opts) => {
     const msg_list_data = opts.msg_list_data ?? opts.msg_list.data;
     const anchor = get_backfill_anchor(msg_list_data);
 
@@ -489,15 +489,15 @@ export function do_backfill(opts) {
         num_after: 0,
         msg_list: opts.msg_list,
         msg_list_data: opts.msg_list_data,
-        cont() {
+        cont: () => {
             if (opts.cont) {
                 opts.cont();
             }
         },
     });
-}
+};
 
-export function maybe_load_newer_messages(opts) {
+export const maybe_load_newer_messages = (opts) => {
     // This function gets called when you scroll to the bottom
     // of your window, and you want to get messages newer
     // than what the browsers originally fetched.
@@ -511,7 +511,7 @@ export function maybe_load_newer_messages(opts) {
 
     const anchor = get_frontfill_anchor(msg_list);
 
-    function load_more(_data, args) {
+    const load_more = (_data, args) => {
         if (
             args.fetch_again &&
             message_lists.current !== undefined &&
@@ -519,7 +519,7 @@ export function maybe_load_newer_messages(opts) {
         ) {
             maybe_load_newer_messages({msg_list: message_lists.current});
         }
-    }
+    };
 
     load_messages({
         anchor,
@@ -528,18 +528,18 @@ export function maybe_load_newer_messages(opts) {
         msg_list,
         cont: load_more,
     });
-}
+};
 
-export function set_initial_pointer_and_offset({narrow_pointer, narrow_offset}) {
+export const set_initial_pointer_and_offset = ({narrow_pointer, narrow_offset}) => {
     initial_narrow_pointer = narrow_pointer;
     initial_narrow_offset = narrow_offset;
-}
+};
 
-export function initialize(finished_initial_fetch) {
+export const initialize = (finished_initial_fetch) => {
     const fetch_target_day_timestamp =
         Date.now() / 1000 - consts.target_days_of_history * 24 * 60 * 60;
     // get the initial message list
-    function load_more(data) {
+    const load_more = (data) => {
         if (first_messages_fetch) {
             // See server_events.js for this callback.
             // Start processing server events.
@@ -582,7 +582,7 @@ export function initialize(finished_initial_fetch) {
                 cont: load_more,
             });
         }, consts.catch_up_backfill_delay);
-    }
+    };
 
     // Since `all_messages_data` contains continuous message history
     // which always contains the latest message, it makes sense for
@@ -603,4 +603,4 @@ export function initialize(finished_initial_fetch) {
         msg_list_data: all_messages_data,
         cont: load_more,
     });
-}
+};

--- a/web/src/message_helper.ts
+++ b/web/src/message_helper.ts
@@ -14,7 +14,7 @@ import * as stream_topic_history from "./stream_topic_history";
 import * as user_status from "./user_status";
 import * as util from "./util";
 
-export function process_new_message(raw_message: RawMessage): Message {
+export const process_new_message = (raw_message: RawMessage): Message => {
     // Call this function when processing a new message.  After
     // a message is processed and inserted into the message store
     // cache, most modules use message_store.get to look at
@@ -124,4 +124,4 @@ export function process_new_message(raw_message: RawMessage): Message {
     alert_words.process_message(message);
     message_store.update_message_cache(message);
     return message;
-}
+};

--- a/web/src/message_list_hover.js
+++ b/web/src/message_list_hover.js
@@ -8,15 +8,15 @@ import * as message_lists from "./message_lists";
 import * as rows from "./rows";
 
 let $current_message_hover;
-export function message_unhover() {
+export const message_unhover = () => {
     if ($current_message_hover === undefined) {
         return;
     }
     $current_message_hover.find("span.edit_content").empty();
     $current_message_hover = undefined;
-}
+};
 
-export function message_hover($message_row) {
+export const message_hover = ($message_row) => {
     const id = rows.id($message_row);
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(id);
@@ -51,7 +51,7 @@ export function message_hover($message_row) {
     } else if (args.can_move_message) {
         $edit_content.attr("data-tooltip-template-id", "move-message-tooltip-template");
     }
-}
+};
 
 export function initialize() {
     $("#main_div").on("mouseover", ".message-list .message_row", function () {
@@ -73,7 +73,7 @@ export function initialize() {
         $row.removeClass("sender_info_hovered");
     });
 
-    function handle_video_preview_mouseenter($elem) {
+    const handle_video_preview_mouseenter = ($elem) => {
         // Set image height and css vars for play button position, if not done already
         const setPosition = !$elem.data("entered-before");
         if (setPosition) {
@@ -88,7 +88,7 @@ export function initialize() {
             $elem.data("entered-before", true);
         }
         $elem.addClass("fa fa-play");
-    }
+    };
 
     $("#main_div").on("mouseenter", ".youtube-video a", function () {
         handle_video_preview_mouseenter($(this));

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -27,27 +27,25 @@ const message_list_tippy_instances = new Set<tippy.Instance>();
 
 // This keeps track of all the instances created and destroyed.
 const store_message_list_instances_plugin = {
-    fn() {
-        return {
-            onCreate(instance: tippy.Instance) {
-                message_list_tippy_instances.add(instance);
-            },
-            onDestroy(instance: tippy.Instance) {
-                // To make sure the `message_list_tippy_instances` contains only instances
-                // that are present in the DOM, we need to delete instances that are destroyed
-                message_list_tippy_instances.delete(instance);
-            },
-        };
-    },
+    fn: () => ({
+        onCreate: (instance: tippy.Instance) => {
+            message_list_tippy_instances.add(instance);
+        },
+        onDestroy: (instance: tippy.Instance) => {
+            // To make sure the `message_list_tippy_instances` contains only instances
+            // that are present in the DOM, we need to delete instances that are destroyed
+            message_list_tippy_instances.delete(instance);
+        },
+    }),
 };
 
-function message_list_tooltip(target: string, props: Partial<tippy.Props> = {}): void {
+const message_list_tooltip = (target: string, props: Partial<tippy.Props> = {}): void => {
     const {onShow, ...other_props} = props;
     tippy.delegate("body", {
         target,
         appendTo: () => document.body,
         plugins: [store_message_list_instances_plugin],
-        onShow(instance) {
+        onShow: (instance) => {
             if (message_lists.current === undefined) {
                 // Since tooltips is called with a delay, it is possible that the
                 // message feed is not visible when the tooltip is shown.
@@ -64,16 +62,16 @@ function message_list_tooltip(target: string, props: Partial<tippy.Props> = {}):
         },
         ...other_props,
     });
-}
+};
 
 // Defining observer outside ensures that at max only one observer is active at all times.
 let observer;
-function hide_tooltip_if_reference_removed(
+const hide_tooltip_if_reference_removed = (
     target_node: HTMLElement,
     config: Config,
     instance: tippy.Instance,
     nodes_to_check_for_removal: tippy.ReferenceElement[],
-): void {
+): void => {
     // Use MutationObserver to check for removal of nodes on which tooltips
     // are still active.
     if (!target_node) {
@@ -86,7 +84,7 @@ function hide_tooltip_if_reference_removed(
         }, 0);
         return;
     }
-    const callback = function (mutationsList: MutationRecord[]): void {
+    const callback = (mutationsList: MutationRecord[]): void => {
         for (const mutation of mutationsList) {
             for (const node of nodes_to_check_for_removal) {
                 // Hide instance if reference's class changes.
@@ -102,12 +100,12 @@ function hide_tooltip_if_reference_removed(
     };
     observer = new MutationObserver(callback);
     observer.observe(target_node, config);
-}
+};
 
 // To prevent the appearance of tooltips whose reference is hidden or removed from the
 // DOM during re-rendering, we need to destroy all the message list present instances,
 // and then initialize triggers of the tooltips again after re-rendering.
-export function destroy_all_message_list_tooltips(): void {
+export const destroy_all_message_list_tooltips = (): void => {
     for (const instance of message_list_tippy_instances) {
         if (instance.reference === document.body) {
             continue;
@@ -115,12 +113,12 @@ export function destroy_all_message_list_tooltips(): void {
         instance.destroy();
     }
     message_list_tippy_instances.clear();
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     message_list_tooltip(".tippy-narrow-tooltip", {
         delay: LONG_HOVER_DELAY,
-        onCreate(instance) {
+        onCreate: (instance) => {
             instance.setContent(
                 parse_html(render_narrow_tooltip({content: instance.props.content})),
             );
@@ -132,7 +130,7 @@ export function initialize(): void {
     message_list_tooltip(".message_reaction", {
         delay: INTERACTIVE_HOVER_DELAY,
         placement: "bottom",
-        onShow(instance) {
+        onShow: (instance) => {
             if (!document.body.contains(instance.reference)) {
                 // It is possible for reaction to be removed before `onShow` is triggered,
                 // so, we check if the element exists before proceeding.
@@ -157,7 +155,7 @@ export function initialize(): void {
             hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             if (observer) {
                 observer.disconnect();
@@ -168,7 +166,7 @@ export function initialize(): void {
     message_list_tooltip(".message_reactions .reaction_button", {
         delay: LONG_HOVER_DELAY,
         placement: "bottom",
-        onShow(instance) {
+        onShow: (instance) => {
             if (!document.body.contains(instance.reference)) {
                 // It is possible for the single reaction necessary for
                 // displaying the reaction button to be removed before
@@ -194,14 +192,14 @@ export function initialize(): void {
             hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".message_control_button", {
         delay: LONG_HOVER_DELAY,
-        onShow(instance) {
+        onShow: (instance) => {
             // Handle dynamic "starred messages" and "edit" widgets.
             const $elem = $(instance.reference);
             const tippy_content = $elem.attr("data-tippy-content");
@@ -212,13 +210,13 @@ export function initialize(): void {
                 instance.setContent(parse_html($template.html()));
             }
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".slow-send-spinner", {
-        onShow(instance) {
+        onShow: (instance) => {
             const $elem = $(instance.reference);
 
             // We need to check for removal of local class from message_row since
@@ -229,13 +227,13 @@ export function initialize(): void {
             const nodes_to_check_for_removal = [$elem.get(0)!];
             hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".message-list .message-time", {
-        onShow(instance) {
+        onShow: (instance) => {
             const $time_elem = $(instance.reference);
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const $row = $time_elem.closest(".message_row") as JQuery;
@@ -249,13 +247,13 @@ export function initialize(): void {
             instance.setContent(timerender.get_full_datetime_clarification(time));
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".recipient_row_date > span", {
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -264,7 +262,7 @@ export function initialize(): void {
 
     message_list_tooltip(".change_visibility_policy > i", {
         delay: LONG_HOVER_DELAY,
-        onShow(instance) {
+        onShow: (instance) => {
             const $elem = $(instance.reference);
             const current_visibility_policy_str = $elem.attr("data-tippy-content");
             instance.setContent(
@@ -273,14 +271,14 @@ export function initialize(): void {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".recipient_bar_icon", {
         delay: LONG_HOVER_DELAY,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -288,7 +286,7 @@ export function initialize(): void {
     message_list_tooltip(".rendered_markdown time, .rendered_markdown .copy_codeblock", {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         content: timerender.get_markdown_time_tooltip as tippy.Content,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -297,7 +295,7 @@ export function initialize(): void {
         // Add a short delay so the user can mouseover several inline images without
         // tooltips showing and hiding rapidly
         delay: [300, 20],
-        onShow(instance) {
+        onShow: (instance) => {
             // Some message_inline_images aren't actually images with a title,
             // for example youtube videos, so we default to the actual href
             const title =
@@ -305,14 +303,14 @@ export function initialize(): void {
                 $(instance.reference).parent().attr("href");
             instance.setContent(parse_html(render_message_inline_image_tooltip({title})));
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     message_list_tooltip(".view_user_card_tooltip", {
         delay: LONG_HOVER_DELAY,
-        onShow(instance) {
+        onShow: (instance) => {
             const is_bot = $(instance.reference).attr("data-is-bot") === "true";
             if (is_bot) {
                 instance.setContent(parse_html($("#view-bot-card-tooltip-template").html()));
@@ -320,7 +318,7 @@ export function initialize(): void {
                 instance.setContent(parse_html($("#view-user-card-tooltip-template").html()));
             }
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -338,7 +336,7 @@ export function initialize(): void {
                 },
             ],
         },
-        onShow(instance) {
+        onShow: (instance) => {
             const $elem = $(instance.reference);
             const edited_notice_str = $elem.attr("data-tippy-content");
             instance.setContent(
@@ -350,8 +348,8 @@ export function initialize(): void {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
-}
+};

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -40,7 +40,7 @@ import * as timerender from "./timerender";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
 
-function same_day(earlier_msg, later_msg) {
+const same_day = (earlier_msg, later_msg) => {
     if (earlier_msg === undefined || later_msg === undefined) {
         return false;
     }
@@ -49,23 +49,23 @@ function same_day(earlier_msg, later_msg) {
         later_msg.msg.timestamp * 1000,
         timerender.display_time_zone,
     );
-}
+};
 
-function same_sender(a, b) {
+const same_sender = (a, b) => {
     if (a === undefined || b === undefined) {
         return false;
     }
     return util.same_sender(a.msg, b.msg);
-}
+};
 
-function same_recipient(a, b) {
+const same_recipient = (a, b) => {
     if (a === undefined || b === undefined) {
         return false;
     }
     return util.same_recipient(a.msg, b.msg);
-}
+};
 
-function analyze_edit_history(message, last_edit_timestr) {
+const analyze_edit_history = (message, last_edit_timestr) => {
     // Returns a dict of booleans that describe the message's history:
     //   * edited: if the message has had its content edited
     //   * moved: if the message has had its stream/topic edited
@@ -115,33 +115,33 @@ function analyze_edit_history(message, last_edit_timestr) {
         edited = true;
     }
     return {edited, moved, resolve_toggled};
-}
+};
 
-function render_group_display_date(group, message_container) {
+const render_group_display_date = (group, message_container) => {
     const time = new Date(message_container.msg.timestamp * 1000);
     const date_element = timerender.render_date(time)[0];
 
     group.date = date_element.outerHTML;
-}
+};
 
-function update_group_date(group, message_container, prev) {
+const update_group_date = (group, message_container, prev) => {
     // Mark whether we should display a date marker because this
     // message has a different date than the previous one.
     group.date_unchanged = same_day(message_container, prev);
-}
+};
 
-function clear_group_date(group) {
+const clear_group_date = (group) => {
     group.date_unchanged = false;
-}
+};
 
-function clear_message_date_divider(msg) {
+const clear_message_date_divider = (msg) => {
     // see update_message_date_divider for how
     // these get set
     msg.want_date_divider = false;
     msg.date_divider_html = undefined;
-}
+};
 
-function update_message_date_divider(opts) {
+const update_message_date_divider = (opts) => {
     const prev_msg_container = opts.prev_msg_container;
     const curr_msg_container = opts.curr_msg_container;
 
@@ -154,14 +154,14 @@ function update_message_date_divider(opts) {
 
     curr_msg_container.want_date_divider = true;
     curr_msg_container.date_divider_html = timerender.render_date(curr_time)[0].outerHTML;
-}
+};
 
-function set_timestr(message_container) {
+const set_timestr = (message_container) => {
     const time = new Date(message_container.msg.timestamp * 1000);
     message_container.timestr = timerender.stringify_time(time);
-}
+};
 
-function set_topic_edit_properties(group, message) {
+const set_topic_edit_properties = (group, message) => {
     group.always_visible_topic_edit = false;
     group.on_hover_topic_edit = false;
 
@@ -181,9 +181,9 @@ function set_topic_edit_properties(group, message) {
     } else {
         group.on_hover_topic_edit = true;
     }
-}
+};
 
-function get_users_for_recipient_row(message) {
+const get_users_for_recipient_row = (message) => {
     const user_ids = people.pm_with_user_ids(message);
     const users = user_ids.map((user_id) => {
         let full_name;
@@ -198,12 +198,11 @@ function get_users_for_recipient_row(message) {
         };
     });
 
-    function compare_by_name(a, b) {
-        return a.full_name < b.full_name ? -1 : a.full_name > b.full_name ? 1 : 0;
-    }
+    const compare_by_name = (a, b) =>
+        a.full_name < b.full_name ? -1 : a.full_name > b.full_name ? 1 : 0;
 
     return users.sort(compare_by_name);
-}
+};
 
 let message_id_to_focus_after_processing_message_events = {
     id: undefined,
@@ -211,15 +210,15 @@ let message_id_to_focus_after_processing_message_events = {
     selectionEnd: undefined,
 };
 
-function reset_restore_message_edit_focus_state() {
+const reset_restore_message_edit_focus_state = () => {
     message_id_to_focus_after_processing_message_events = {
         id: undefined,
         selectionStart: undefined,
         selectionEnd: undefined,
     };
-}
+};
 
-function capture_user_message_editing_state() {
+const capture_user_message_editing_state = () => {
     if (document.activeElement?.classList.contains("message_edit_content")) {
         message_id_to_focus_after_processing_message_events = {
             id: rows.get_message_id(document.activeElement),
@@ -229,9 +228,9 @@ function capture_user_message_editing_state() {
     } else {
         reset_restore_message_edit_focus_state();
     }
-}
+};
 
-function maybe_restore_focus_to_message_edit_form() {
+const maybe_restore_focus_to_message_edit_form = () => {
     if (
         // It is possible that selected message might not be the one
         // user was editing but is less likely the case. It makes
@@ -264,9 +263,9 @@ function maybe_restore_focus_to_message_edit_form() {
         );
         reset_restore_message_edit_focus_state();
     }, 0);
-}
+};
 
-function populate_group_from_message_container(group, message_container) {
+const populate_group_from_message_container = (group, message_container) => {
     group.is_stream = message_container.msg.is_stream;
     group.is_private = message_container.msg.is_private;
 
@@ -314,7 +313,7 @@ function populate_group_from_message_container(group, message_container) {
 
     set_topic_edit_properties(group, message_container.msg);
     render_group_display_date(group, message_container);
-}
+};
 
 export class MessageListView {
     // MessageListView is the module responsible for rendering a
@@ -1714,7 +1713,7 @@ export class MessageListView {
            who are about to be scrolled out of view are not acceptable. */
         const partially_hidden_header_position = visible_top - 1;
 
-        function is_sticky(header) {
+        const is_sticky = (header) => {
             // header has a box-shadow of `1px` at top but since it doesn't impact
             // `y` position of the header, we don't take it into account during calculations.
             const header_props = header.getBoundingClientRect();
@@ -1733,7 +1732,7 @@ export class MessageListView {
                date on any of them. Which header is chosen will depend on which
                comes first when iterating on the headers. */
             return 0;
-        }
+        };
 
         const $headers = this.$list.find(".message_header");
         const iterable_headers = $headers.toArray();

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -71,13 +71,13 @@ export type MessageList = {
 export let current: MessageList | undefined;
 export const rendered_message_lists = new Map<number, MessageList>();
 
-export function set_current(msg_list: MessageList | undefined): void {
+export const set_current = (msg_list: MessageList | undefined): void => {
     // NOTE: Strictly used for mocking in node tests.
     // Use `update_current_message_list` instead in production.
     current = msg_list;
-}
+};
 
-export function update_current_message_list(msg_list: MessageList | undefined): void {
+export const update_current_message_list = (msg_list: MessageList | undefined): void => {
     // Since we change `current` message list in the function, we need to decide if the
     // current message list needs to be cached or discarded.
     //
@@ -113,41 +113,39 @@ export function update_current_message_list(msg_list: MessageList | undefined): 
         rendered_message_lists.set(current.id, current);
         current.view.$list.addClass("focused-message-list");
     }
-}
+};
 
-export function all_rendered_message_lists(): MessageList[] {
-    return [...rendered_message_lists.values()];
-}
+export const all_rendered_message_lists = (): MessageList[] => [...rendered_message_lists.values()];
 
-export function add_rendered_message_list(msg_list: MessageList): void {
+export const add_rendered_message_list = (msg_list: MessageList): void => {
     rendered_message_lists.set(msg_list.id, msg_list);
-}
+};
 
-export function all_rendered_row_for_message_id(message_id: number): JQuery {
+export const all_rendered_row_for_message_id = (message_id: number): JQuery => {
     let $rows = $();
     for (const msg_list of all_rendered_message_lists()) {
         const $row = msg_list.get_row(message_id);
         $rows = $rows.add($row);
     }
     return $rows;
-}
+};
 
-export function all_current_message_rows(): JQuery {
+export const all_current_message_rows = (): JQuery => {
     if (current === undefined) {
         return $();
     }
 
     return current.view.$list.find(".message_row");
-}
+};
 
-export function update_recipient_bar_background_color(): void {
+export const update_recipient_bar_background_color = (): void => {
     for (const msg_list of all_rendered_message_lists()) {
         msg_list.view.update_recipient_bar_background_color();
     }
     inbox_util.update_stream_colors();
-}
+};
 
-export function calculate_timestamp_widths(): void {
+export const calculate_timestamp_widths = (): void => {
     const $temp_time_div = $("<div>");
     $temp_time_div.attr("id", "calculated-timestamp-widths");
     // Size the div to the width of the largest timestamp,
@@ -179,13 +177,13 @@ export function calculate_timestamp_widths(): void {
     $(":root").css("--message-box-timestamp-column-width", `${max_timestamp_width}px`);
     // Clean up by removing the temporary <div> element
     $temp_time_div.remove();
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     // We calculate the widths of a candidate set of timestamps,
     // and use the largest to set `--message-box-timestamp-column-width`
     calculate_timestamp_widths();
     // For users with automatic color scheme, we need to detect change
     // in `prefers-color-scheme` as it changes based on time.
     ui_util.listener_for_preferred_color_scheme_change(update_recipient_bar_background_color);
-}
+};

--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -3,13 +3,13 @@ import * as message_store from "./message_store";
 import * as people from "./people";
 import type {UserStatusEmojiInfo} from "./user_status";
 
-export function rerender_messages_view(): void {
+export const rerender_messages_view = (): void => {
     for (const list of message_lists.all_rendered_message_lists()) {
         list.rerender_view();
     }
-}
+};
 
-export function rerender_messages_view_by_message_ids(message_ids: number[]): void {
+export const rerender_messages_view_by_message_ids = (message_ids: number[]): void => {
     const messages_to_render = [];
     for (const id of message_ids) {
         const message = message_store.get(id);
@@ -20,9 +20,9 @@ export function rerender_messages_view_by_message_ids(message_ids: number[]): vo
     for (const list of message_lists.all_rendered_message_lists()) {
         list.view.rerender_messages(messages_to_render);
     }
-}
+};
 
-function rerender_messages_view_for_user(user_id: number): void {
+const rerender_messages_view_for_user = (user_id: number): void => {
     for (const list of message_lists.all_rendered_message_lists()) {
         const messages = list.data.get_messages_sent_by_user(user_id);
         if (messages.length === 0) {
@@ -30,12 +30,12 @@ function rerender_messages_view_for_user(user_id: number): void {
         }
         list.view.rerender_messages(messages);
     }
-}
+};
 
-export function update_message_in_all_views(
+export const update_message_in_all_views = (
     message_id: number,
     callback: ($row: JQuery) => void,
-): void {
+): void => {
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         const $row = msg_list.get_row(message_id);
         if ($row === undefined) {
@@ -45,9 +45,9 @@ export function update_message_in_all_views(
         }
         callback($row);
     }
-}
+};
 
-export function update_starred_view(message_id: number, new_value: boolean): void {
+export const update_starred_view = (message_id: number, new_value: boolean): void => {
     const starred = new_value;
 
     // Avoid a full re-render, but update the star in each message
@@ -67,29 +67,29 @@ export function update_starred_view(message_id: number, new_value: boolean): voi
             : "star-message-tooltip-template";
         $star_container.attr("data-tooltip-template-id", data_template_id);
     });
-}
+};
 
-export function update_stream_name(stream_id: number, new_name: string): void {
+export const update_stream_name = (stream_id: number, new_name: string): void => {
     message_store.update_stream_name(stream_id, new_name);
     rerender_messages_view();
-}
+};
 
-export function update_user_full_name(user_id: number, full_name: string): void {
+export const update_user_full_name = (user_id: number, full_name: string): void => {
     message_store.update_sender_full_name(user_id, full_name);
     rerender_messages_view_for_user(user_id);
-}
+};
 
-export function update_avatar(user_id: number, avatar_url: string): void {
+export const update_avatar = (user_id: number, avatar_url: string): void => {
     let url = avatar_url;
     url = people.format_small_avatar_url(url);
     message_store.update_small_avatar_url(user_id, url);
     rerender_messages_view_for_user(user_id);
-}
+};
 
-export function update_user_status_emoji(
+export const update_user_status_emoji = (
     user_id: number,
     status_emoji_info: UserStatusEmojiInfo | undefined,
-): void {
+): void => {
     message_store.update_status_emoji_info(user_id, status_emoji_info);
     rerender_messages_view_for_user(user_id);
-}
+};

--- a/web/src/message_notifications.js
+++ b/web/src/message_notifications.js
@@ -14,7 +14,7 @@ import * as unread from "./unread";
 import {user_settings} from "./user_settings";
 import * as user_topics from "./user_topics";
 
-function get_notification_content(message) {
+const get_notification_content = (message) => {
     let content;
     // Convert the content to plain text, replacing emoji with their alt text
     const $content = $("<div>").html(message.content);
@@ -48,9 +48,9 @@ function get_notification_content(message) {
     }
 
     return content;
-}
+};
 
-function debug_notification_source_value(message) {
+const debug_notification_source_value = (message) => {
     let notification_source;
 
     if (message.type === "private" || message.type === "test-notification") {
@@ -64,9 +64,9 @@ function debug_notification_source_value(message) {
     }
 
     blueslip.debug("Desktop notification from source " + notification_source);
-}
+};
 
-function get_notification_key(message) {
+const get_notification_key = (message) => {
     let key;
 
     if (message.type === "private" || message.type === "test-notification") {
@@ -77,15 +77,14 @@ function get_notification_key(message) {
     }
 
     return key;
-}
+};
 
-function remove_sender_from_list_of_recipients(message) {
-    return `, ${message.display_reply_to}, `
+const remove_sender_from_list_of_recipients = (message) =>
+    `, ${message.display_reply_to}, `
         .replace(`, ${message.sender_full_name}, `, ", ")
         .slice(", ".length, -", ".length);
-}
 
-function get_notification_title(message, msg_count) {
+const get_notification_title = (message, msg_count) => {
     let title = message.sender_full_name;
     let other_recipients;
 
@@ -122,9 +121,9 @@ function get_notification_title(message, msg_count) {
     }
 
     return title;
-}
+};
 
-export function process_notification(notification) {
+export const process_notification = (notification) => {
     const message = notification.message;
     const content = get_notification_content(message);
     const key = get_notification_key(message);
@@ -171,9 +170,9 @@ export function process_notification(notification) {
             });
         }
     }
-}
+};
 
-export function message_is_notifiable(message) {
+export const message_is_notifiable = (message) => {
     // Independent of the user's notification settings, are there
     // properties of the message that unconditionally mean we
     // shouldn't notify about it.
@@ -218,9 +217,9 @@ export function message_is_notifiable(message) {
     // Everything else is on the table; next filter based on notification
     // settings.
     return true;
-}
+};
 
-export function should_send_desktop_notification(message) {
+export const should_send_desktop_notification = (message) => {
     // Always notify for testing notifications.
     if (message.type === "test-notification") {
         return true;
@@ -287,9 +286,9 @@ export function should_send_desktop_notification(message) {
     }
 
     return false;
-}
+};
 
-export function should_send_audible_notification(message) {
+export const should_send_audible_notification = (message) => {
     // If `None` is selected as the notification sound, never send
     // audible notifications regardless of other configuration.
     if (user_settings.notification_sound === "none") {
@@ -357,9 +356,9 @@ export function should_send_audible_notification(message) {
     }
 
     return false;
-}
+};
 
-export function received_messages(messages) {
+export const received_messages = (messages) => {
     for (const message of messages) {
         if (!message_is_notifiable(message)) {
             continue;
@@ -381,9 +380,9 @@ export function received_messages(messages) {
             ui_util.play_audio($("#user-notification-sound-audio")[0]);
         }
     }
-}
+};
 
-export function send_test_notification(content) {
+export const send_test_notification = (content) => {
     received_messages([
         {
             id: Math.random(),
@@ -395,4 +394,4 @@ export function send_test_notification(content) {
             unread: true,
         },
     ]);
-}
+};

--- a/web/src/message_parser.ts
+++ b/web/src/message_parser.ts
@@ -8,18 +8,14 @@ import type {Message} from "./message_store";
 // important because $("Text <a>link</a>").find("a") returns nothing;
 // one needs an outer element wrapping an object to use this
 // construction.
-function is_element_in_message_content(message: Message, element_selector: string): boolean {
-    return $(`<div>${message.content}</div>`).find(element_selector).length > 0;
-}
+const is_element_in_message_content = (message: Message, element_selector: string): boolean =>
+    $(`<div>${message.content}</div>`).find(element_selector).length > 0;
 
-export function message_has_link(message: Message): boolean {
-    return is_element_in_message_content(message, "a");
-}
+export const message_has_link = (message: Message): boolean =>
+    is_element_in_message_content(message, "a");
 
-export function message_has_image(message: Message): boolean {
-    return is_element_in_message_content(message, ".message_inline_image");
-}
+export const message_has_image = (message: Message): boolean =>
+    is_element_in_message_content(message, ".message_inline_image");
 
-export function message_has_attachment(message: Message): boolean {
-    return is_element_in_message_content(message, "a[href^='/user_uploads']");
-}
+export const message_has_attachment = (message: Message): boolean =>
+    is_element_in_message_content(message, "a[href^='/user_uploads']");

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -12,7 +12,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 
 let hide_scroll_to_bottom_timer;
-export function hide_scroll_to_bottom() {
+export const hide_scroll_to_bottom = () => {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
     if (message_lists.current === undefined) {
         // Scroll to bottom button is not for non-message views.
@@ -40,9 +40,9 @@ export function hide_scroll_to_bottom() {
             $show_scroll_to_bottom_button.removeClass("show");
         }
     }, 3000);
-}
+};
 
-export function show_scroll_to_bottom_button() {
+export const show_scroll_to_bottom_button = () => {
     if (message_viewport.bottom_rendered_message_visible()) {
         // Only show scroll to bottom button when
         // last message is not visible in the
@@ -52,7 +52,7 @@ export function show_scroll_to_bottom_button() {
 
     clearTimeout(hide_scroll_to_bottom_timer);
     $("#scroll-to-bottom-button-container").addClass("show");
-}
+};
 
 $(document).on("keydown", (e) => {
     if (e.shiftKey || e.ctrlKey || e.metaKey) {
@@ -64,7 +64,7 @@ $(document).on("keydown", (e) => {
     $("#scroll-to-bottom-button-container").removeClass("show");
 });
 
-export function scroll_finished() {
+export const scroll_finished = () => {
     message_scroll_state.set_actively_scrolling(false);
     hide_scroll_to_bottom();
 
@@ -114,10 +114,10 @@ export function scroll_finished() {
     // unread_ops.process_visible will update necessary
     // data structures and DOM elements.
     setTimeout(unread_ops.process_visible, 0);
-}
+};
 
 let scroll_timer;
-function scroll_finish() {
+const scroll_finish = () => {
     message_scroll_state.set_actively_scrolling(true);
 
     // Don't present the "scroll to bottom" widget if the current
@@ -129,9 +129,9 @@ function scroll_finish() {
 
     clearTimeout(scroll_timer);
     scroll_timer = setTimeout(scroll_finished, 100);
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $(document).on(
         "scroll",
         _.throttle(() => {
@@ -191,4 +191,4 @@ export function initialize() {
             }
         }
     });
-}
+};

--- a/web/src/message_scroll_state.ts
+++ b/web/src/message_scroll_state.ts
@@ -3,20 +3,20 @@
 // message.
 export let update_selection_on_next_scroll = true;
 
-export function set_update_selection_on_next_scroll(value: boolean): void {
+export const set_update_selection_on_next_scroll = (value: boolean): void => {
     update_selection_on_next_scroll = value;
-}
+};
 
 // Whether a keyboard shortcut is triggering a message feed scroll event.
 export let keyboard_triggered_current_scroll = false;
 
-export function set_keyboard_triggered_current_scroll(value: boolean): void {
+export const set_keyboard_triggered_current_scroll = (value: boolean): void => {
     keyboard_triggered_current_scroll = value;
-}
+};
 
 // Whether a scroll is currently occurring.
 export let actively_scrolling = false;
 
-export function set_actively_scrolling(value: boolean): void {
+export const set_actively_scrolling = (value: boolean): void => {
     actively_scrolling = value;
-}
+};

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -155,26 +155,21 @@ export type Message = (
           }
     );
 
-export function update_message_cache(message: Message): void {
+export const update_message_cache = (message: Message): void => {
     // You should only call this from message_helper (or in tests).
     stored_messages.set(message.id, message);
-}
+};
 
-export function get_cached_message(message_id: number): Message | undefined {
-    // You should only call this from message_helper.
-    // Use the get() wrapper below for most other use cases.
-    return stored_messages.get(message_id);
-}
+export const get_cached_message = (message_id: number): Message | undefined =>
+    stored_messages.get(message_id);
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     stored_messages.clear();
-}
+};
 
-export function get(message_id: number): Message | undefined {
-    return stored_messages.get(message_id);
-}
+export const get = (message_id: number): Message | undefined => stored_messages.get(message_id);
 
-export function get_pm_emails(message: Message | MessageWithBooleans): string {
+export const get_pm_emails = (message: Message | MessageWithBooleans): string => {
     const user_ids = people.pm_with_user_ids(message) ?? [];
     const emails = user_ids
         .map((user_id) => {
@@ -188,23 +183,21 @@ export function get_pm_emails(message: Message | MessageWithBooleans): string {
         .sort();
 
     return emails.join(", ");
-}
+};
 
-export function get_pm_full_names(user_ids: number[]): string {
+export const get_pm_full_names = (user_ids: number[]): string => {
     user_ids = people.sorted_other_user_ids(user_ids);
     const names = people.get_display_full_names(user_ids).sort();
 
     return names.join(", ");
-}
+};
 
-export function convert_raw_message_to_message_with_booleans(
+export const convert_raw_message_to_message_with_booleans = (
     message: RawMessage,
-): MessageWithBooleans {
+): MessageWithBooleans => {
     const flags = message.flags ?? [];
 
-    function convert_flag(flag_name: string): boolean {
-        return flags.includes(flag_name);
-    }
+    const convert_flag = (flag_name: string): boolean => flags.includes(flag_name);
 
     const converted_flags = {
         unread: !convert_flag("read"),
@@ -237,15 +230,13 @@ export function convert_raw_message_to_message_with_booleans(
         ..._.omit(message, "flags"),
         ...converted_flags,
     };
-}
+};
 
-export function update_booleans(message: Message, flags: string[]): void {
+export const update_booleans = (message: Message, flags: string[]): void => {
     // When we get server flags for local echo or message edits,
     // we are vulnerable to race conditions, so only update flags
     // that are driven by message content.
-    function convert_flag(flag_name: string): boolean {
-        return flags.includes(flag_name);
-    }
+    const convert_flag = (flag_name: string): boolean => flags.includes(flag_name);
 
     message.mentioned =
         convert_flag("mentioned") ||
@@ -255,44 +246,44 @@ export function update_booleans(message: Message, flags: string[]): void {
     message.stream_wildcard_mentioned = convert_flag("stream_wildcard_mentioned");
     message.topic_wildcard_mentioned = convert_flag("topic_wildcard_mentioned");
     message.alerted = convert_flag("has_alert_word");
-}
+};
 
-export function update_sender_full_name(user_id: number, new_name: string): void {
+export const update_sender_full_name = (user_id: number, new_name: string): void => {
     for (const msg of stored_messages.values()) {
         if (msg.sender_id && msg.sender_id === user_id) {
             msg.sender_full_name = new_name;
         }
     }
-}
+};
 
-export function update_small_avatar_url(user_id: number, new_url: string): void {
+export const update_small_avatar_url = (user_id: number, new_url: string): void => {
     for (const msg of stored_messages.values()) {
         if (msg.sender_id && msg.sender_id === user_id) {
             msg.small_avatar_url = new_url;
         }
     }
-}
+};
 
-export function update_stream_name(stream_id: number, new_name: string): void {
+export const update_stream_name = (stream_id: number, new_name: string): void => {
     for (const msg of stored_messages.values()) {
         if (msg.type === "stream" && msg.stream_id === stream_id) {
             msg.display_recipient = new_name;
         }
     }
-}
+};
 
-export function update_status_emoji_info(
+export const update_status_emoji_info = (
     user_id: number,
     new_info: UserStatusEmojiInfo | undefined,
-): void {
+): void => {
     for (const msg of stored_messages.values()) {
         if (msg.sender_id && msg.sender_id === user_id) {
             msg.status_emoji_info = new_info;
         }
     }
-}
+};
 
-export function reify_message_id({old_id, new_id}: {old_id: number; new_id: number}): void {
+export const reify_message_id = ({old_id, new_id}: {old_id: number; new_id: number}): void => {
     const message = stored_messages.get(old_id);
     if (message !== undefined) {
         message.id = new_id;
@@ -300,4 +291,4 @@ export function reify_message_id({old_id, new_id}: {old_id: number; new_id: numb
         stored_messages.set(new_id, message);
         stored_messages.delete(old_id);
     }
-}
+};

--- a/web/src/message_user_ids.ts
+++ b/web/src/message_user_ids.ts
@@ -13,14 +13,12 @@
 */
 const user_set = new Set<number>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     user_set.clear();
-}
+};
 
-export function user_ids(): number[] {
-    return [...user_set];
-}
+export const user_ids = (): number[] => [...user_set];
 
-export function add_user_id(user_id: number): void {
+export const add_user_id = (user_id: number): void => {
     user_set.add(user_id);
-}
+};

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -6,7 +6,10 @@ import type {Message} from "./message_store";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
-export function do_unread_count_updates(messages: Message[], expect_no_new_unreads = false): void {
+export const do_unread_count_updates = (
+    messages: Message[],
+    expect_no_new_unreads = false,
+): void => {
     const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);
 
     if (any_new_unreads) {
@@ -14,13 +17,13 @@ export function do_unread_count_updates(messages: Message[], expect_no_new_unrea
         // only happen if we found any unread messages justifying it.
         unread_ui.update_unread_counts();
     }
-}
+};
 
-export function add_messages(
+export const add_messages = (
     messages: Message[],
     msg_list: MessageList,
     append_to_view_opts: {messages_are_new: boolean},
-): RenderInfo | undefined {
+): RenderInfo | undefined => {
     if (!messages) {
         return undefined;
     }
@@ -28,19 +31,17 @@ export function add_messages(
     const render_info = msg_list.add_messages(messages, append_to_view_opts);
 
     return render_info;
-}
+};
 
-export function add_old_messages(
+export const add_old_messages = (
     messages: Message[],
     msg_list: MessageList,
-): RenderInfo | undefined {
-    return add_messages(messages, msg_list, {messages_are_new: false});
-}
+): RenderInfo | undefined => add_messages(messages, msg_list, {messages_are_new: false});
 
-export function add_new_messages(
+export const add_new_messages = (
     messages: Message[],
     msg_list: MessageList,
-): RenderInfo | undefined {
+): RenderInfo | undefined => {
     if (!msg_list.data.fetch_status.has_found_newest()) {
         // We don't render newly received messages for the message list,
         // if we haven't found the latest messages to be displayed in the
@@ -50,9 +51,9 @@ export function add_new_messages(
         return undefined;
     }
     return add_messages(messages, msg_list, {messages_are_new: true});
-}
+};
 
-export function add_new_messages_data(
+export const add_new_messages_data = (
     messages: Message[],
     msg_list_data: MessageListData,
 ):
@@ -61,7 +62,7 @@ export function add_new_messages_data(
           bottom_messages: Message[];
           interior_messages: Message[];
       }
-    | undefined {
+    | undefined => {
     if (!msg_list_data.fetch_status.has_found_newest()) {
         // The reasoning in add_new_messages applies here as well;
         // we're trying to maintain a data structure that's a
@@ -71,10 +72,10 @@ export function add_new_messages_data(
         return undefined;
     }
     return msg_list_data.add_messages(messages);
-}
+};
 
-export function get_messages_in_topic(stream_id: number, topic: string): Message[] {
-    return all_messages_data
+export const get_messages_in_topic = (stream_id: number, topic: string): Message[] =>
+    all_messages_data
         .all_messages()
         .filter(
             (x) =>
@@ -82,9 +83,8 @@ export function get_messages_in_topic(stream_id: number, topic: string): Message
                 x.stream_id === stream_id &&
                 x.topic.toLowerCase() === topic.toLowerCase(),
         );
-}
 
-export function get_max_message_id_in_stream(stream_id: number): number {
+export const get_max_message_id_in_stream = (stream_id: number): number => {
     let max_message_id = 0;
     for (const msg of all_messages_data.all_messages()) {
         if (msg.type === "stream" && msg.stream_id === stream_id && msg.id > max_message_id) {
@@ -92,9 +92,11 @@ export function get_max_message_id_in_stream(stream_id: number): number {
         }
     }
     return max_message_id;
-}
+};
 
-export function get_topics_for_message_ids(message_ids: number[]): Map<string, [number, string]> {
+export const get_topics_for_message_ids = (
+    message_ids: number[],
+): Map<string, [number, string]> => {
     const topics = new Map<string, [number, string]>(); // key = stream_id:topic
     for (const msg_id of message_ids) {
         // message_store still has data on deleted messages when this runs.
@@ -111,4 +113,4 @@ export function get_topics_for_message_ids(message_ids: number[]): Map<string, [
         }
     }
     return topics;
-}
+};

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -59,7 +59,7 @@ import * as util from "./util";
 
 const LARGER_THAN_MAX_MESSAGE_ID = 10000000000000000;
 
-export function reset_ui_state(opts) {
+export const reset_ui_state = (opts) => {
     // Resets the state of various visual UI elements that are
     // a function of the current narrow.
     narrow_banner.hide_empty_narrow_message();
@@ -75,9 +75,9 @@ export function reset_ui_state(opts) {
         skip_automatic_new_visibility_policy_banner = true;
     }
     compose_banner.clear_message_sent_banners(true, skip_automatic_new_visibility_policy_banner);
-}
+};
 
-export function changehash(newhash, trigger) {
+export const changehash = (newhash, trigger) => {
     if (browser_history.state.changing_hash) {
         // If we retargeted the narrow operation because a message was moved,
         // we want to have the current narrow hash in the browser history.
@@ -88,9 +88,9 @@ export function changehash(newhash, trigger) {
     }
     message_viewport.stop_auto_scrolling();
     browser_history.set_hash(newhash);
-}
+};
 
-export function update_hash_to_match_filter(filter, trigger) {
+export const update_hash_to_match_filter = (filter, trigger) => {
     if (browser_history.state.changing_hash && trigger !== "retarget message location") {
         return;
     }
@@ -100,9 +100,9 @@ export function update_hash_to_match_filter(filter, trigger) {
     if (stream_list.is_zoomed_in()) {
         browser_history.update_current_history_state_data({show_more_topics: true});
     }
-}
+};
 
-function create_and_update_message_list(filter, id_info, opts) {
+const create_and_update_message_list = (filter, id_info, opts) => {
     const excludes_muted_topics = filter.excludes_muted_topics();
 
     // Check if we already have a rendered message list for the `filter`.
@@ -184,16 +184,16 @@ function create_and_update_message_list(filter, id_info, opts) {
     // reflect the requested narrow.
     message_lists.update_current_message_list(msg_list);
     return {msg_list, restore_rendered_list};
-}
+};
 
-function handle_post_message_list_change(
+const handle_post_message_list_change = (
     id_info,
     msg_list,
     opts,
     select_immediately,
     select_opts,
     then_select_offset,
-) {
+) => {
     // Important: We need to consider opening the compose box
     // before calling render_message_list_with_selected_message, so that the logic in
     // recenter_view for positioning the currently selected
@@ -217,9 +217,9 @@ function handle_post_message_list_change(
     // It is important to call this after other important updates
     // like narrow filter and compose recipients happen.
     compose_recipient.handle_middle_pane_transition();
-}
+};
 
-export function show(raw_terms, opts) {
+export const show = (raw_terms, opts) => {
     /* Main entry point for switching to a new view / message list.
 
        Supported parameters:
@@ -353,7 +353,7 @@ export function show(raw_terms, opts) {
         if (id_info.target_id && filter.has_operator("channel") && filter.has_operator("topic")) {
             const target_message = message_store.get(id_info.target_id);
 
-            function adjusted_terms_if_moved(raw_terms, message) {
+            const adjusted_terms_if_moved = (raw_terms, message) => {
                 const adjusted_terms = [];
                 let terms_changed = false;
 
@@ -383,7 +383,7 @@ export function show(raw_terms, opts) {
                 }
 
                 return adjusted_terms;
-            }
+            };
 
             if (target_message) {
                 // If we have the target message ID for the narrow in our
@@ -453,7 +453,7 @@ export function show(raw_terms, opts) {
                 // for it.
                 channel.get({
                     url: `/json/messages/${id_info.target_id}`,
-                    success(data) {
+                    success: (data) => {
                         // After the message is fetched, we make the
                         // message locally available and then call
                         // message_view.show recursively, setting a flag to
@@ -464,7 +464,7 @@ export function show(raw_terms, opts) {
                             fetched_target_message: true,
                         });
                     },
-                    error() {
+                    error: () => {
                         // Message doesn't exist or user doesn't have
                         // access to the target message ID. This will
                         // happen, for example, if a user types
@@ -613,7 +613,7 @@ export function show(raw_terms, opts) {
                 }
                 message_fetch.load_messages_for_narrow({
                     anchor,
-                    cont() {
+                    cont: () => {
                         if (!select_immediately) {
                             render_message_list_with_selected_message({
                                 id_info,
@@ -659,9 +659,9 @@ export function show(raw_terms, opts) {
         }
         Sentry.getCurrentHub().popScope();
     }
-}
+};
 
-function min_defined(a, b) {
+const min_defined = (a, b) => {
     if (a === undefined) {
         return b;
     }
@@ -669,9 +669,9 @@ function min_defined(a, b) {
         return a;
     }
     return a < b ? a : b;
-}
+};
 
-function load_local_messages(msg_data) {
+const load_local_messages = (msg_data) => {
     // This little helper loads messages into our narrow message
     // data and returns true unless it's visibly empty.  We use this for
     // cases when our local cache (all_messages_data) has at least
@@ -681,9 +681,9 @@ function load_local_messages(msg_data) {
     msg_data.add_messages(in_msgs);
 
     return !msg_data.visibly_empty();
-}
+};
 
-export function maybe_add_local_messages(opts) {
+export const maybe_add_local_messages = (opts) => {
     // This function determines whether we need to go to the server to
     // fetch messages for the requested narrow, or whether we have the
     // data cached locally to render the narrow correctly without
@@ -836,9 +836,9 @@ export function maybe_add_local_messages(opts) {
     // !can_apply_locally + target_id is a rare combination in the
     // first place, so we don't bother.
     return;
-}
+};
 
-export function render_message_list_with_selected_message(opts) {
+export const render_message_list_with_selected_message = (opts) => {
     if (message_lists.current !== undefined && message_lists.current !== opts.msg_list) {
         // If we navigated away from a view while we were fetching
         // messages for it, don't attempt to move the currently
@@ -885,15 +885,15 @@ export function render_message_list_with_selected_message(opts) {
     }
     unread_ops.process_visible();
     narrow_history.save_narrow_state_and_flush();
-}
+};
 
-export function activate_stream_for_cycle_hotkey(stream_name) {
+export const activate_stream_for_cycle_hotkey = (stream_name) => {
     // This is the common code for A/D hotkeys.
     const filter_expr = [{operator: "channel", operand: stream_name}];
     show(filter_expr, {});
-}
+};
 
-export function stream_cycle_backward() {
+export const stream_cycle_backward = () => {
     const curr_stream = narrow_state.stream_name();
 
     if (!curr_stream) {
@@ -907,9 +907,9 @@ export function stream_cycle_backward() {
     }
 
     activate_stream_for_cycle_hotkey(stream_name);
-}
+};
 
-export function stream_cycle_forward() {
+export const stream_cycle_forward = () => {
     const curr_stream = narrow_state.stream_name();
 
     if (!curr_stream) {
@@ -923,9 +923,9 @@ export function stream_cycle_forward() {
     }
 
     activate_stream_for_cycle_hotkey(stream_name);
-}
+};
 
-export function narrow_to_next_topic(opts = {}) {
+export const narrow_to_next_topic = (opts = {}) => {
     const curr_info = {
         stream: narrow_state.stream_name(),
         topic: narrow_state.topic(),
@@ -939,7 +939,7 @@ export function narrow_to_next_topic(opts = {}) {
 
     if (!next_narrow && opts.only_followed_topics) {
         feedback_widget.show({
-            populate($container) {
+            populate: ($container) => {
                 $container.text(
                     $t({defaultMessage: "You have no unread messages in followed topics."}),
                 );
@@ -951,7 +951,7 @@ export function narrow_to_next_topic(opts = {}) {
 
     if (!next_narrow) {
         feedback_widget.show({
-            populate($container) {
+            populate: ($container) => {
                 $container.text($t({defaultMessage: "You have no more unread topics."}));
             },
             title_text: $t({defaultMessage: "You're done!"}),
@@ -965,16 +965,16 @@ export function narrow_to_next_topic(opts = {}) {
     ];
 
     show(filter_expr, opts);
-}
+};
 
-export function narrow_to_next_pm_string(opts = {}) {
+export const narrow_to_next_pm_string = (opts = {}) => {
     const current_direct_message = narrow_state.pm_ids_string();
 
     const next_direct_message = topic_generator.get_next_unread_pm_string(current_direct_message);
 
     if (!next_direct_message) {
         feedback_widget.show({
-            populate($container) {
+            populate: ($container) => {
                 $container.text($t({defaultMessage: "You have no more unread direct messages."}));
             },
             title_text: $t({defaultMessage: "You're done!"}),
@@ -995,9 +995,9 @@ export function narrow_to_next_pm_string(opts = {}) {
     };
 
     show(filter_expr, updated_opts);
-}
+};
 
-export function narrow_by_topic(target_id, opts) {
+export const narrow_by_topic = (target_id, opts) => {
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const original = message_store.get(target_id);
     if (original.type !== "stream") {
@@ -1025,9 +1025,9 @@ export function narrow_by_topic(target_id, opts) {
     ];
     opts = {then_select_id: target_id, ...opts};
     show(search_terms, opts);
-}
+};
 
-export function narrow_by_recipient(target_id, opts) {
+export const narrow_by_recipient = (target_id, opts) => {
     opts = {then_select_id: target_id, ...opts};
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const message = message_store.get(target_id);
@@ -1069,9 +1069,9 @@ export function narrow_by_recipient(target_id, opts) {
             );
             break;
     }
-}
+};
 
-export function to_compose_target() {
+export const to_compose_target = () => {
     if (!compose_state.composing()) {
         return;
     }
@@ -1111,9 +1111,9 @@ export function to_compose_target() {
         }
         show([{operator: "dm", operand: util.normalize_recipients(recipient_string)}], opts);
     }
-}
+};
 
-function handle_post_view_change(msg_list, opts) {
+const handle_post_view_change = (msg_list, opts) => {
     const filter = msg_list.data.filter;
     scheduled_messages_feed_ui.update_schedule_message_indicator();
     typing_events.render_notifications_for_narrow();
@@ -1133,4 +1133,4 @@ function handle_post_view_change(msg_list, opts) {
     stream_list.handle_narrow_activated(filter, opts.change_hash, opts.show_more_topics);
     pm_list.handle_narrow_activated(filter);
     activity_ui.build_user_sidebar();
-}
+};

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -37,7 +37,7 @@ type MessageViewHeaderContext = {
       }
 );
 
-function get_message_view_header_context(filter: Filter | undefined): MessageViewHeaderContext {
+const get_message_view_header_context = (filter: Filter | undefined): MessageViewHeaderContext => {
     if (recent_view_util.is_visible()) {
         return {
             title: $t({defaultMessage: "Recent conversations"}),
@@ -119,18 +119,18 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     }
 
     return context;
-}
+};
 
-export function colorize_message_view_header(): void {
+export const colorize_message_view_header = (): void => {
     const filter = narrow_state.filter();
     if (filter === undefined || !filter._sub) {
         return;
     }
     // selecting i instead of .fa because web public streams have custom icon.
     $("#message_view_header a.stream i").css("color", filter._sub.color);
-}
+};
 
-function append_and_display_title_area(context: MessageViewHeaderContext): void {
+const append_and_display_title_area = (context: MessageViewHeaderContext): void => {
     const $message_view_header_elem = $("#message_view_header");
     $message_view_header_elem.html(render_message_view_header(context));
     if (context.stream_settings_link) {
@@ -142,9 +142,9 @@ function append_and_display_title_area(context: MessageViewHeaderContext): void 
         // Update syntax like stream names, emojis, mentions, timestamps.
         rendered_markdown.update_elements($content);
     }
-}
+};
 
-function build_message_view_header(filter: Filter | undefined): void {
+const build_message_view_header = (filter: Filter | undefined): void => {
     // This makes sure we don't waste time appending
     // message_view_header on a template where it's never used
     if (filter && !filter.is_common_narrow()) {
@@ -155,23 +155,23 @@ function build_message_view_header(filter: Filter | undefined): void {
         append_and_display_title_area(context);
         search.close_search_bar_and_open_narrow_description();
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     render_title_area();
-}
+};
 
-export function render_title_area(): void {
+export const render_title_area = (): void => {
     const filter = narrow_state.filter();
     build_message_view_header(filter);
-}
+};
 
 // This function checks if "modified_sub" which is the stream whose values
 // have been updated is the same as the stream which is currently
 // narrowed (filter._sub) and rerenders if necessary
-export function maybe_rerender_title_area_for_stream(modified_sub: SettingsSubscription): void {
+export const maybe_rerender_title_area_for_stream = (modified_sub: SettingsSubscription): void => {
     const filter = narrow_state.filter();
     if (filter && filter._sub && filter._sub.stream_id === modified_sub.stream_id) {
         render_title_area();
     }
-}
+};

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -26,23 +26,19 @@ export const height = cached_height.get.bind(cached_height);
 // TODO: This function lets us use the DOM API instead of jquery
 // (<10x faster) for condense.js, but we want to eventually do a
 // bigger of refactor `height` and `width` above to do the same.
-export function max_message_height(): number {
-    return document.querySelector("html")!.offsetHeight * 0.65;
-}
+export const max_message_height = (): number => document.querySelector("html")!.offsetHeight * 0.65;
 
 // Includes both scroll and arrow events. Negative means scroll up,
 // positive means scroll down.
 export let last_movement_direction = 1;
 
-export function set_last_movement_direction(value: number): void {
+export const set_last_movement_direction = (value: number): void => {
     last_movement_direction = value;
-}
+};
 
-export function at_rendered_top(): boolean {
-    return scrollTop() <= 0;
-}
+export const at_rendered_top = (): boolean => scrollTop() <= 0;
 
-export function message_viewport_info(): MessageViewportInfo {
+export const message_viewport_info = (): MessageViewportInfo => {
     // Return a structure that tells us details of the viewport
     // accounting for fixed elements like the top navbar.
     //
@@ -69,13 +65,13 @@ export function message_viewport_info(): MessageViewportInfo {
         visible_bottom,
         visible_height,
     };
-}
+};
 
 // Important note: These functions just look at the state of the
 // rendered message feed; messages that are not displayed due to a
 // limited render window or because they have not been fetched from
 // the server are not considered.
-export function at_rendered_bottom(): boolean {
+export const at_rendered_bottom = (): boolean => {
     const bottom = scrollTop() + height();
     // This also includes bottom whitespace.
     const full_height = $scroll_container[0]!.scrollHeight;
@@ -85,12 +81,12 @@ export function at_rendered_bottom(): boolean {
     // and we err on the side of saying that we are at
     // the bottom.
     return bottom + 2 >= full_height;
-}
+};
 
 // This differs from at_rendered_bottom in that it only requires the
 // bottom message to be visible, but you may be able to scroll down
 // further to see the rest of that message.
-export function bottom_rendered_message_visible(): boolean {
+export const bottom_rendered_message_visible = (): boolean => {
     const $last_row = rows.last_visible();
     if ($last_row[0] !== undefined) {
         const message_bottom = $last_row[0].getBoundingClientRect().bottom;
@@ -98,13 +94,12 @@ export function bottom_rendered_message_visible(): boolean {
         return bottom_of_feed > message_bottom;
     }
     return false;
-}
+};
 
-export function is_below_visible_bottom(offset: number): boolean {
-    return offset > scrollTop() + height() - ($("#compose").height() ?? 0);
-}
+export const is_below_visible_bottom = (offset: number): boolean =>
+    offset > scrollTop() + height() - ($("#compose").height() ?? 0);
 
-export function is_scrolled_up(): boolean {
+export const is_scrolled_up = (): boolean => {
     // Let's determine whether the user was already dealing
     // with messages off the screen, which can guide auto
     // scrolling decisions.
@@ -116,9 +111,9 @@ export function is_scrolled_up(): boolean {
     const offset = offset_from_bottom($last_row);
 
     return offset > 0;
-}
+};
 
-export function offset_from_bottom($last_row: JQuery): number {
+export const offset_from_bottom = ($last_row: JQuery): number => {
     // A positive return value here means the last row is
     // below the bottom of the feed (i.e. obscured by the compose
     // box or even further below the bottom).
@@ -126,14 +121,14 @@ export function offset_from_bottom($last_row: JQuery): number {
     const info = message_viewport_info();
 
     return message_bottom - info.visible_bottom;
-}
+};
 
-export function set_message_position(
+export const set_message_position = (
     message_top: number,
     message_height: number,
     viewport_info: MessageViewportInfo,
     ratio: number,
-): void {
+): void => {
     // message_top = offset of the top of a message that you are positioning
     // message_height = height of the message that you are positioning
     // viewport_info = result of calling message_viewport.message_viewport_info
@@ -162,14 +157,14 @@ export function set_message_position(
 
     message_scroll_state.set_update_selection_on_next_scroll(false);
     scrollTop(new_scroll_top);
-}
+};
 
-function in_viewport_or_tall(
+const in_viewport_or_tall = (
     rect: DOMRect,
     top_of_feed: number,
     bottom_of_feed: number,
     require_fully_visible: boolean,
-): boolean {
+): boolean => {
     if (require_fully_visible) {
         return (
             rect.top > top_of_feed && // Message top is in view and
@@ -178,16 +173,16 @@ function in_viewport_or_tall(
         ); // message is tall.
     }
     return rect.bottom > top_of_feed && rect.top < bottom_of_feed;
-}
+};
 
-function add_to_visible<T>(
+const add_to_visible = <T>(
     $candidates: JQuery,
     visible: T[],
     top_of_feed: number,
     bottom_of_feed: number,
     require_fully_visible: boolean,
     row_to_output: ($row: HTMLElement) => T,
-): void {
+): void => {
     for (const row of $candidates) {
         const row_rect = row.getBoundingClientRect();
         // Mark very tall messages as read once we've gotten past them
@@ -197,10 +192,10 @@ function add_to_visible<T>(
             break;
         }
     }
-}
+};
 
 const top_of_feed = new util.CachedValue({
-    compute_value() {
+    compute_value: () => {
         const $header = $("#navbar-fixed-container");
         let visible_top = $header.outerHeight() ?? 0;
 
@@ -213,18 +208,16 @@ const top_of_feed = new util.CachedValue({
 });
 
 const bottom_of_feed = new util.CachedValue({
-    compute_value() {
-        return $("#compose")[0]!.getBoundingClientRect().top;
-    },
+    compute_value: () => $("#compose")[0]!.getBoundingClientRect().top,
 });
 
-function _visible_divs<T>(
+const _visible_divs = <T>(
     $selected_row: JQuery,
     row_min_height: number,
     row_to_output: ($row: HTMLElement) => T,
     div_class: string,
     require_fully_visible: boolean,
-): T[] {
+): T[] => {
     // Note that when using getBoundingClientRect() we are getting offsets
     // relative to the visible window, but when using jQuery's offset() we are
     // getting offsets relative to the full scrollable window. You can't try to
@@ -267,9 +260,9 @@ function _visible_divs<T>(
     );
 
     return visible;
-}
+};
 
-export function visible_groups(require_fully_visible: boolean): HTMLElement[] {
+export const visible_groups = (require_fully_visible: boolean): HTMLElement[] => {
     assert(message_lists.current !== undefined);
     const $selected_row = message_lists.current.selected_row();
     if ($selected_row === undefined || $selected_row.length === 0) {
@@ -278,9 +271,7 @@ export function visible_groups(require_fully_visible: boolean): HTMLElement[] {
 
     const $selected_group = rows.get_message_recipient_row($selected_row);
 
-    function get_row(row: HTMLElement): HTMLElement {
-        return row;
-    }
+    const get_row = (row: HTMLElement): HTMLElement => row;
 
     // Being simplistic about this, the smallest group is about 75 px high.
     return _visible_divs<HTMLElement>(
@@ -290,16 +281,16 @@ export function visible_groups(require_fully_visible: boolean): HTMLElement[] {
         "recipient_row",
         require_fully_visible,
     );
-}
+};
 
-export function visible_messages(require_fully_visible: boolean): Message[] {
+export const visible_messages = (require_fully_visible: boolean): Message[] => {
     assert(message_lists.current !== undefined);
     const $selected_row = message_lists.current.selected_row();
 
-    function row_to_id(row: HTMLElement): Message {
+    const row_to_id = (row: HTMLElement): Message => {
         assert(message_lists.current !== undefined);
         return message_lists.current.get(rows.id($(row)))!;
-    }
+    };
 
     // Being simplistic about this, the smallest message is 25 px high.
     return _visible_divs<Message>(
@@ -309,7 +300,7 @@ export function visible_messages(require_fully_visible: boolean): Message[] {
         "message_row",
         require_fully_visible,
     );
-}
+};
 
 export function scrollTop(): number;
 export function scrollTop(target_scrollTop: number): JQuery;
@@ -353,28 +344,28 @@ export function scrollTop(target_scrollTop?: number): JQuery | number {
     return $ret;
 }
 
-export function stop_auto_scrolling(): void {
+export const stop_auto_scrolling = (): void => {
     if (in_stoppable_autoscroll) {
         $scroll_container.stop();
     }
-}
+};
 
-export function system_initiated_animate_scroll(
+export const system_initiated_animate_scroll = (
     scroll_amount: number,
     update_selection_on_scroll = false,
-): void {
+): void => {
     message_scroll_state.set_update_selection_on_next_scroll(update_selection_on_scroll);
     const viewport_offset = scrollTop();
     in_stoppable_autoscroll = true;
     $scroll_container.animate({
         scrollTop: viewport_offset + scroll_amount,
-        always() {
+        always: () => {
             in_stoppable_autoscroll = false;
         },
     });
-}
+};
 
-export function user_initiated_animate_scroll(scroll_amount: number): void {
+export const user_initiated_animate_scroll = (scroll_amount: number): void => {
     message_scroll_state.set_update_selection_on_next_scroll(false);
     in_stoppable_autoscroll = false; // defensive
 
@@ -383,12 +374,12 @@ export function user_initiated_animate_scroll(scroll_amount: number): void {
     $scroll_container.animate({
         scrollTop: viewport_offset + scroll_amount,
     });
-}
+};
 
-export function recenter_view(
+export const recenter_view = (
     $message: JQuery,
     {from_scroll = false, force_center = false} = {},
-): void {
+): void => {
     // BarnOwl-style recentering: if the pointer is too high, move it to
     // the 1/2 marks. If the pointer is too low, move it to the 1/7 mark.
     // See keep_pointer_in_view() for related logic to keep the pointer onscreen.
@@ -424,9 +415,9 @@ export function recenter_view(
     } else if (is_below) {
         set_message_position(message_top, message_height, viewport_info, 1 / 7);
     }
-}
+};
 
-export function maybe_scroll_to_show_message_top(): void {
+export const maybe_scroll_to_show_message_top = (): void => {
     assert(message_lists.current !== undefined);
     // Sets the top of the message to the top of the viewport.
     // Only applies if the top of the message is out of view above the visible area.
@@ -437,15 +428,15 @@ export function maybe_scroll_to_show_message_top(): void {
     if (message_top < viewport_info.visible_top) {
         set_message_position(message_top, message_height, viewport_info, 0);
     }
-}
+};
 
-export function is_message_below_viewport($message_row: JQuery): boolean {
+export const is_message_below_viewport = ($message_row: JQuery): boolean => {
     const info = message_viewport_info();
     const offset = $message_row.get_offset_to_window();
     return offset.top >= info.visible_bottom;
-}
+};
 
-export function keep_pointer_in_view(): void {
+export const keep_pointer_in_view = (): void => {
     assert(message_lists.current !== undefined);
     // See message_viewport.recenter_view() for related logic to keep the pointer onscreen.
     // This function mostly comes into place for mouse scrollers, and it
@@ -464,7 +455,7 @@ export function keep_pointer_in_view(): void {
     const top_threshold = info.visible_top + (1 / 10) * info.visible_height;
     const bottom_threshold = info.visible_top + (9 / 10) * info.visible_height;
 
-    function message_is_far_enough_down(): boolean {
+    const message_is_far_enough_down = (): boolean => {
         if (at_rendered_top()) {
             return true;
         }
@@ -487,16 +478,15 @@ export function keep_pointer_in_view(): void {
 
         // If we got this far, the message is not "in view."
         return false;
-    }
+    };
 
-    function message_is_far_enough_up(): boolean {
-        return at_rendered_bottom() || $next_row.get_offset_to_window().top <= bottom_threshold;
-    }
+    const message_is_far_enough_up = (): boolean =>
+        at_rendered_bottom() || $next_row.get_offset_to_window().top <= bottom_threshold;
 
-    function adjust(
+    const adjust = (
         in_view: () => boolean,
         get_next_row: ($message_row: JQuery) => JQuery,
-    ): boolean {
+    ): boolean => {
         // return true only if we make an actual adjustment, so
         // that we know to short circuit the other direction
         if (in_view()) {
@@ -510,39 +500,39 @@ export function keep_pointer_in_view(): void {
             $next_row = $candidate;
         }
         return true;
-    }
+    };
 
     if (!adjust(message_is_far_enough_down, rows.next_visible)) {
         adjust(message_is_far_enough_up, rows.prev_visible);
     }
 
     message_lists.current.select_id(rows.id($next_row), {from_scroll: true});
-}
+};
 
-export function scroll_to_selected(): void {
+export const scroll_to_selected = (): void => {
     assert(message_lists.current !== undefined);
     const $selected_row = message_lists.current.selected_row();
     if ($selected_row && $selected_row.length !== 0) {
         recenter_view($selected_row);
     }
-}
+};
 
 export let scroll_to_selected_planned = false;
 
-export function plan_scroll_to_selected(): void {
+export const plan_scroll_to_selected = (): void => {
     scroll_to_selected_planned = true;
-}
+};
 
-export function maybe_scroll_to_selected(): void {
+export const maybe_scroll_to_selected = (): void => {
     // If we have made a plan to scroll to the selected message but
     // deferred doing so, do so here.
     if (scroll_to_selected_planned) {
         scroll_to_selected();
         scroll_to_selected_planned = false;
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     // This handler must be placed before all resize handlers in our application
     $(window).on("resize", () => {
         cached_width.reset();
@@ -562,4 +552,4 @@ export function initialize(): void {
     $(document).on("message_selected.zulip wheel", () => {
         stop_auto_scrolling();
     });
-}
+};

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -12,22 +12,21 @@ export type Context = {
     on_delete: () => void;
 };
 
-export function row_with_focus(context: Context): JQuery {
+export const row_with_focus = (context: Context): JQuery => {
     const $focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`);
     return $focused_item.parent(`.${CSS.escape(context.row_item_selector)}`);
-}
+};
 
-export function activate_element(elem: HTMLElement, context: Context): void {
+export const activate_element = (elem: HTMLElement, context: Context): void => {
     $(`.${CSS.escape(context.box_item_selector)}`).removeClass("active");
     elem.classList.add("active");
     elem.focus();
-}
+};
 
-export function get_focused_element_id(context: Context): string | undefined {
-    return row_with_focus(context).attr(context.id_attribute_name);
-}
+export const get_focused_element_id = (context: Context): string | undefined =>
+    row_with_focus(context).attr(context.id_attribute_name);
 
-export function focus_on_sibling_element(context: Context): void {
+export const focus_on_sibling_element = (context: Context): void => {
     const $next_row = row_after_focus(context);
     const $prev_row = row_before_focus(context);
     let elem_to_be_focused_id: string | undefined;
@@ -45,9 +44,9 @@ export function focus_on_sibling_element(context: Context): void {
         assert($new_focus_element[0].children[0] instanceof HTMLElement);
         activate_element($new_focus_element[0].children[0], context);
     }
-}
+};
 
-export function modals_handle_events(event_key: string, context: Context): void {
+export const modals_handle_events = (event_key: string, context: Context): void => {
     initialize_focus(event_key, context);
 
     // This detects up arrow key presses when the overlay
@@ -69,9 +68,9 @@ export function modals_handle_events(event_key: string, context: Context): void 
     if (event_key === "enter") {
         context.on_enter();
     }
-}
+};
 
-export function set_initial_element(element_id: string, context: Context): void {
+export const set_initial_element = (element_id: string, context: Context): void => {
     if (element_id) {
         const $current_element = get_element_by_id(element_id, context);
         const focus_element = $current_element[0]!.children[0];
@@ -79,9 +78,9 @@ export function set_initial_element(element_id: string, context: Context): void 
         activate_element(focus_element, context);
         $(`.${CSS.escape(context.items_list_selector)}`)[0]!.scrollTop = 0;
     }
-}
+};
 
-function row_before_focus(context: Context): JQuery {
+const row_before_focus = (context: Context): JQuery => {
     const $focused_row = row_with_focus(context);
     const $prev_row = $focused_row.prev(`.${CSS.escape(context.row_item_selector)}:visible`);
     // The draft modal can have two sub-sections. This handles the edge case
@@ -96,9 +95,9 @@ function row_before_focus(context: Context): JQuery {
     }
 
     return $prev_row;
-}
+};
 
-function row_after_focus(context: Context): JQuery {
+const row_after_focus = (context: Context): JQuery => {
     const $focused_row = row_with_focus(context);
     const $next_row = $focused_row.next(`.${CSS.escape(context.row_item_selector)}:visible`);
     // The draft modal can have two sub-sections. This handles the edge case
@@ -112,9 +111,9 @@ function row_after_focus(context: Context): JQuery {
         return $("#other-drafts").children(".overlay-message-row:visible").first();
     }
     return $next_row;
-}
+};
 
-function initialize_focus(event_name: string, context: Context): void {
+const initialize_focus = (event_name: string, context: Context): void => {
     // If an item is not focused in modal, then focus the last item
     // if up_arrow is clicked or the first item if down_arrow is clicked.
     if (
@@ -135,9 +134,9 @@ function initialize_focus(event_name: string, context: Context): void {
     const focus_element = $element[0]!.children[0];
     assert(focus_element instanceof HTMLElement);
     activate_element(focus_element, context);
-}
+};
 
-function scroll_to_element($element: JQuery, context: Context): void {
+const scroll_to_element = ($element: JQuery, context: Context): void => {
     if ($element[0] === undefined) {
         return;
     }
@@ -175,8 +174,7 @@ function scroll_to_element($element: JQuery, context: Context): void {
         // -4 is the min dist from the bottom that will require extra scrolling.
         $items_list[0]!.scrollTop += $items_list[0]!.clientHeight / 2;
     }
-}
+};
 
-function get_element_by_id(id: number | string, context: Context): JQuery {
-    return $(`[${CSS.escape(context.id_attribute_name)}='${CSS.escape(id.toString())}']`);
-}
+const get_element_by_id = (id: number | string, context: Context): JQuery =>
+    $(`[${CSS.escape(context.id_attribute_name)}='${CSS.escape(id.toString())}']`);

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -18,25 +18,23 @@ export type ModalConfig = {
 const pre_open_hooks: Hook[] = [];
 const pre_close_hooks: Hook[] = [];
 
-export function register_pre_open_hook(func: Hook): void {
+export const register_pre_open_hook = (func: Hook): void => {
     pre_open_hooks.push(func);
-}
+};
 
-export function register_pre_close_hook(func: Hook): void {
+export const register_pre_close_hook = (func: Hook): void => {
     pre_close_hooks.push(func);
-}
+};
 
-function call_hooks(func_list: Hook[]): void {
+const call_hooks = (func_list: Hook[]): void => {
     for (const element of func_list) {
         element();
     }
-}
+};
 
-export function any_active(): boolean {
-    return $(".micromodal").hasClass("modal--open");
-}
+export const any_active = (): boolean => $(".micromodal").hasClass("modal--open");
 
-export function active_modal(): string | undefined {
+export const active_modal = (): string | undefined => {
     if (!any_active()) {
         blueslip.error("Programming error — Called active_modal when there is no modal open");
         return undefined;
@@ -44,12 +42,12 @@ export function active_modal(): string | undefined {
 
     const $micromodal = $(".micromodal.modal--open");
     return `#${CSS.escape($micromodal.attr("id")!)}`;
-}
+};
 
-export function is_active(modal_id: string): boolean {
+export const is_active = (modal_id: string): boolean => {
     const $micromodal = $(".micromodal.modal--open");
     return $micromodal.attr("id") === modal_id;
-}
+};
 
 // If conf.autoremove is true, the modal element will be removed from the DOM
 // once the modal is hidden.
@@ -58,10 +56,10 @@ export function is_active(modal_id: string): boolean {
 // on_shown: Callback to run when the modal is shown.
 // on_hide: Callback to run when the modal is triggered to hide.
 // on_hidden: Callback to run when the modal is hidden.
-export function open(
+export const open = (
     modal_id: string,
     conf: ModalConfig & {recursive_call_count?: number} = {},
-): void {
+): void => {
     if (modal_id === undefined) {
         blueslip.error("Undefined id was passed into open");
         return;
@@ -153,21 +151,21 @@ export function open(
         close(modal_id);
     });
 
-    function on_show_callback(): void {
+    const on_show_callback = (): void => {
         if (conf.on_show) {
             conf.on_show();
         }
         overlay_util.disable_scrolling();
         call_hooks(pre_open_hooks);
-    }
+    };
 
-    function on_close_callback(): void {
+    const on_close_callback = (): void => {
         if (conf.on_hide) {
             conf.on_hide();
         }
         overlay_util.enable_scrolling();
         call_hooks(pre_close_hooks);
-    }
+    };
 
     Micromodal.show(modal_id, {
         disableFocus: true,
@@ -175,11 +173,11 @@ export function open(
         onShow: on_show_callback,
         onClose: on_close_callback,
     });
-}
+};
 
 // `conf` is an object with the following optional properties:
 // * on_hidden: Callback to run when the modal finishes hiding.
-export function close(modal_id: string, conf: Pick<ModalConfig, "on_hidden"> = {}): void {
+export const close = (modal_id: string, conf: Pick<ModalConfig, "on_hidden"> = {}): void => {
     if (modal_id === undefined) {
         blueslip.error("Undefined id was passed into close");
         return;
@@ -213,9 +211,9 @@ export function close(modal_id: string, conf: Pick<ModalConfig, "on_hidden"> = {
     });
 
     Micromodal.close(modal_id);
-}
+};
 
-export function close_if_open(modal_id: string): void {
+export const close_if_open = (modal_id: string): void => {
     if (modal_id === undefined) {
         blueslip.error("Undefined id was passed into close_if_open");
         return;
@@ -234,9 +232,9 @@ export function close_if_open(modal_id: string): void {
             `${active_modal_id} is the currently active modal and ${modal_id} is already closed.`,
         );
     }
-}
+};
 
-export function close_active(): void {
+export const close_active = (): void => {
     if (!any_active()) {
         blueslip.warn("close_active() called without checking any_active()");
         return;
@@ -244,10 +242,10 @@ export function close_active(): void {
 
     const $micromodal = $(".micromodal.modal--open");
     Micromodal.close(CSS.escape($micromodal.attr("id") ?? ""));
-}
+};
 
-export function close_active_if_any(): void {
+export const close_active_if_any = (): void => {
     if (any_active()) {
         close_active();
     }
-}
+};

--- a/web/src/muted_users.ts
+++ b/web/src/muted_users.ts
@@ -15,40 +15,40 @@ type MutedUser = {
 
 const muted_users = new Map<number, number>();
 
-export function add_muted_user(user_id: number, date_muted?: number): void {
+export const add_muted_user = (user_id: number, date_muted?: number): void => {
     const time = get_time_from_date_muted(date_muted);
     if (user_id) {
         muted_users.set(user_id, time);
     }
-}
+};
 
-export function remove_muted_user(user_id: number): void {
+export const remove_muted_user = (user_id: number): void => {
     if (user_id) {
         muted_users.delete(user_id);
     }
-}
+};
 
-export function is_user_muted(user_id: number): boolean {
+export const is_user_muted = (user_id: number): boolean => {
     if (user_id === undefined) {
         return false;
     }
 
     return muted_users.has(user_id);
-}
+};
 
-export function filter_muted_user_ids(user_ids: number[]): number[] {
+export const filter_muted_user_ids = (user_ids: number[]): number[] => {
     // Returns a copy of the user ID list, after removing muted user IDs.
     const base_user_ids = [...user_ids];
     return base_user_ids.filter((user_id) => !is_user_muted(user_id));
-}
+};
 
-export function filter_muted_users<T extends {user_id: number}>(persons: T[]): T[] {
+export const filter_muted_users = <T extends {user_id: number}>(persons: T[]): T[] => {
     // Returns a copy of the people list, after removing muted users.
     const base_users = [...persons];
     return base_users.filter((person) => !is_user_muted(person.user_id));
-}
+};
 
-export function get_muted_users(): MutedUser[] {
+export const get_muted_users = (): MutedUser[] => {
     const users = [];
     for (const [id, date_muted] of muted_users) {
         const date_muted_str = timerender.render_now(new Date(date_muted)).time_str;
@@ -59,28 +59,28 @@ export function get_muted_users(): MutedUser[] {
         });
     }
     return users;
-}
+};
 
-export function set_muted_users(list: RawMutedUser[]): void {
+export const set_muted_users = (list: RawMutedUser[]): void => {
     muted_users.clear();
 
     for (const user of list) {
         add_muted_user(user.id, user.timestamp);
     }
-}
+};
 
-export function mute_user(user_id: number): void {
+export const mute_user = (user_id: number): void => {
     void channel.post({
         url: "/json/users/me/muted_users/" + user_id,
     });
-}
+};
 
-export function unmute_user(user_id: number): void {
+export const unmute_user = (user_id: number): void => {
     void channel.del({
         url: "/json/users/me/muted_users/" + user_id,
     });
-}
+};
 
-export function initialize(params: {muted_users: RawMutedUser[]}): void {
+export const initialize = (params: {muted_users: RawMutedUser[]}): void => {
     set_muted_users(params.muted_users);
-}
+};

--- a/web/src/muted_users_ui.ts
+++ b/web/src/muted_users_ui.ts
@@ -8,7 +8,7 @@ import * as popovers from "./popovers";
 import * as recent_view_ui from "./recent_view_ui";
 import * as settings_muted_users from "./settings_muted_users";
 
-export function rerender_for_muted_user(): void {
+export const rerender_for_muted_user = (): void => {
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         msg_list.update_muting_and_rerender();
     }
@@ -27,10 +27,10 @@ export function rerender_for_muted_user(): void {
     // because muting a user marks every message the user has sent as
     // read, it will update the inbox UI, if necessary through that
     // mechanism.
-}
+};
 
-export function handle_user_updates(raw_muted_users: RawMutedUser[]): void {
+export const handle_user_updates = (raw_muted_users: RawMutedUser[]): void => {
     popovers.hide_all();
     muted_users.set_muted_users(raw_muted_users);
     rerender_for_muted_user();
-}
+};

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -27,7 +27,7 @@ const SPECTATOR_STREAM_NARROW_BANNER = {
     ),
 };
 
-function retrieve_search_query_data(): SearchData {
+const retrieve_search_query_data = (): SearchData => {
     // when search bar contains multiple filters, only retrieve search queries
     const current_filter = narrow_state.filter();
     assert(current_filter !== undefined);
@@ -68,9 +68,9 @@ function retrieve_search_query_data(): SearchData {
     }
 
     return search_string_result;
-}
+};
 
-function pick_empty_narrow_banner(): NarrowBannerData {
+const pick_empty_narrow_banner = (): NarrowBannerData => {
     const default_banner = {
         title: $t({defaultMessage: "There are no messages here."}),
         // Spectators cannot start a conversation.
@@ -252,7 +252,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                     return SPECTATOR_STREAM_NARROW_BANNER;
                 }
 
-                function can_toggle_narrowed_stream(): boolean | undefined {
+                const can_toggle_narrowed_stream = (): boolean | undefined => {
                     const stream_name = narrow_state.stream_name();
 
                     if (!stream_name) {
@@ -261,7 +261,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
 
                     const stream_sub = stream_data.get_sub(first_operand);
                     return stream_sub && stream_data.can_toggle_subscription(stream_sub);
-                }
+                };
 
                 if (can_toggle_narrowed_stream()) {
                     return default_banner;
@@ -408,14 +408,14 @@ function pick_empty_narrow_banner(): NarrowBannerData {
         }
     }
     return default_banner;
-}
+};
 
-export function show_empty_narrow_message(): void {
+export const show_empty_narrow_message = (): void => {
     $(".empty_feed_notice_main").empty();
     const rendered_narrow_banner = narrow_error(pick_empty_narrow_banner());
     $(".empty_feed_notice_main").html(rendered_narrow_banner);
-}
+};
 
-export function hide_empty_narrow_message(): void {
+export const hide_empty_narrow_message = (): void => {
     $(".empty_feed_notice_main").empty();
-}
+};

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -18,11 +18,11 @@ export type NarrowBannerData = {
     search_data?: SearchData;
 };
 
-export function narrow_error(narrow_banner_data: NarrowBannerData): string {
+export const narrow_error = (narrow_banner_data: NarrowBannerData): string => {
     const title = narrow_banner_data.title;
     const html = narrow_banner_data.html;
     const search_data = narrow_banner_data.search_data;
 
     const empty_feed_notice = render_empty_feed_notice({title, html, search_data});
     return empty_feed_notice;
-}
+};

--- a/web/src/narrow_history.ts
+++ b/web/src/narrow_history.ts
@@ -8,7 +8,7 @@ import * as narrow_state from "./narrow_state";
 // Saves the selected message of the narrow in the browser
 // history, so that we are able to restore it if the user
 // navigates back to this page.
-function _save_narrow_state(): void {
+const _save_narrow_state = (): void => {
     const current_filter = narrow_state.filter();
     if (current_filter === undefined) {
         return;
@@ -35,13 +35,13 @@ function _save_narrow_state(): void {
         narrow_offset,
     };
     browser_history.update_current_history_state_data(narrow_data);
-}
+};
 
 // Safari limits you to 100 replaceState calls in 30 seconds.
 export const save_narrow_state = _.throttle(_save_narrow_state, 500);
 
 // This causes the save to happen right away.
-export function save_narrow_state_and_flush(): void {
+export const save_narrow_state_and_flush = (): void => {
     save_narrow_state();
     save_narrow_state.flush();
-}
+};

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -8,12 +8,9 @@ import * as stream_data from "./stream_data";
 import type {StreamSubscription} from "./sub_store";
 import * as unread from "./unread";
 
-export function filter(): Filter | undefined {
-    // `Recent Conversations` and `Inbox` return undefined;
-    return message_lists.current?.data.filter;
-}
+export const filter = (): Filter | undefined => message_lists.current?.data.filter;
 
-export function search_terms(current_filter: Filter | undefined = filter()): NarrowTerm[] {
+export const search_terms = (current_filter: Filter | undefined = filter()): NarrowTerm[] => {
     if (current_filter === undefined) {
         if (page_params.narrow !== undefined) {
             return new Filter(page_params.narrow).terms();
@@ -21,43 +18,35 @@ export function search_terms(current_filter: Filter | undefined = filter()): Nar
         return new Filter([]).terms();
     }
     return current_filter.terms();
-}
+};
 
-export function is_message_feed_visible(): boolean {
-    // It's important that `message_lists.current` is the
-    // source of truth for this since during the initial app load,
-    // `message_lists.current` is `undefined` and we don't want
-    // to return `true` if we haven't loaded the message feed yet.
-    return message_lists.current !== undefined;
-}
+export const is_message_feed_visible = (): boolean => message_lists.current !== undefined;
 
-export function update_email(
+export const update_email = (
     user_id: number,
     new_email: string,
     current_filter: Filter | undefined = filter(),
-): void {
+): void => {
     if (current_filter !== undefined) {
         current_filter.update_email(user_id, new_email);
     }
-}
+};
 
 /* Search terms we should send to the server. */
-export function public_search_terms(
+export const public_search_terms = (
     current_filter: Filter | undefined = filter(),
-): NarrowTerm[] | undefined {
+): NarrowTerm[] | undefined => {
     if (current_filter === undefined) {
         return undefined;
     }
     return current_filter.public_terms();
-}
+};
 
-export function search_string(filter?: Filter): string {
-    return Filter.unparse(search_terms(filter));
-}
+export const search_string = (filter?: Filter): string => Filter.unparse(search_terms(filter));
 
 // Collect terms which appear only once into a map,
 // and discard those which appear more than once.
-function collect_single(terms: NarrowTerm[]): Map<string, string> {
+const collect_single = (terms: NarrowTerm[]): Map<string, string> => {
     const seen = new Set<string>();
     const result = new Map<string, string>();
 
@@ -72,7 +61,7 @@ function collect_single(terms: NarrowTerm[]): Map<string, string> {
     }
 
     return result;
-}
+};
 
 // Modify default compose parameters (stream etc.) based on
 // the current narrowed view.
@@ -80,11 +69,11 @@ function collect_single(terms: NarrowTerm[]): Map<string, string> {
 // This logic is here and not in the 'compose' module because
 // it will get more complicated as we add things to the narrow
 // search term language.
-export function set_compose_defaults(): {
+export const set_compose_defaults = (): {
     stream_id?: number;
     topic?: string;
     private_message_recipient?: string;
-} {
+} => {
     const opts: {stream_id?: number; topic?: string; private_message_recipient?: string} = {};
     const single = collect_single(search_terms());
 
@@ -114,9 +103,9 @@ export function set_compose_defaults(): {
         opts.private_message_recipient = private_message_recipient;
     }
     return opts;
-}
+};
 
-export function stream_name(current_filter: Filter | undefined = filter()): string | undefined {
+export const stream_name = (current_filter: Filter | undefined = filter()): string | undefined => {
     if (current_filter === undefined) {
         return undefined;
     }
@@ -129,11 +118,11 @@ export function stream_name(current_filter: Filter | undefined = filter()): stri
         return stream_data.get_name(name);
     }
     return undefined;
-}
+};
 
-export function stream_sub(
+export const stream_sub = (
     current_filter: Filter | undefined = filter(),
-): StreamSubscription | undefined {
+): StreamSubscription | undefined => {
     if (current_filter === undefined) {
         return undefined;
     }
@@ -147,17 +136,17 @@ export function stream_sub(
     const sub = stream_data.get_sub_by_name(name);
 
     return sub;
-}
+};
 
-export function stream_id(filter?: Filter): number | undefined {
+export const stream_id = (filter?: Filter): number | undefined => {
     const sub = stream_sub(filter);
     if (sub === undefined) {
         return undefined;
     }
     return sub.stream_id;
-}
+};
 
-export function topic(current_filter: Filter | undefined = filter()): string | undefined {
+export const topic = (current_filter: Filter | undefined = filter()): string | undefined => {
     if (current_filter === undefined) {
         return undefined;
     }
@@ -166,9 +155,9 @@ export function topic(current_filter: Filter | undefined = filter()): string | u
         return operands[0];
     }
     return undefined;
-}
+};
 
-export function pm_ids_string(filter?: Filter): string | undefined {
+export const pm_ids_string = (filter?: Filter): string | undefined => {
     // If you are narrowed to a group direct message with
     // users 4, 5, and 99, this will return "4,5,99"
     const emails_string = pm_emails_string(filter);
@@ -180,17 +169,17 @@ export function pm_ids_string(filter?: Filter): string | undefined {
     const user_ids_string = people.reply_to_to_user_ids_string(emails_string);
 
     return user_ids_string;
-}
+};
 
-export function pm_ids_set(filter?: Filter): Set<number> {
+export const pm_ids_set = (filter?: Filter): Set<number> => {
     const ids_string = pm_ids_string(filter);
     const pm_ids_list = ids_string ? people.user_ids_string_to_ids_array(ids_string) : [];
     return new Set(pm_ids_list);
-}
+};
 
-export function pm_emails_string(
+export const pm_emails_string = (
     current_filter: Filter | undefined = filter(),
-): string | undefined {
+): string | undefined => {
     if (current_filter === undefined) {
         return undefined;
     }
@@ -201,11 +190,11 @@ export function pm_emails_string(
     }
 
     return operands[0];
-}
+};
 
-export function get_first_unread_info(
+export const get_first_unread_info = (
     current_filter: Filter | undefined = filter(),
-): {flavor: "cannot_compute" | "not_found"} | {flavor: "found"; msg_id: number} {
+): {flavor: "cannot_compute" | "not_found"} | {flavor: "found"; msg_id: number} => {
     if (current_filter === undefined) {
         // we don't yet support the all-messages view
         blueslip.error("unexpected call to get_first_unread_info");
@@ -245,11 +234,11 @@ export function get_first_unread_info(
         flavor: "found",
         msg_id,
     };
-}
+};
 
-export function _possible_unread_message_ids(
+export const _possible_unread_message_ids = (
     current_filter: Filter | undefined = filter(),
-): number[] | undefined {
+): number[] | undefined => {
     // This function currently only returns valid results for
     // certain types of narrows, mostly left sidebar narrows.
     // For more complicated narrows we may return undefined.
@@ -312,26 +301,26 @@ export function _possible_unread_message_ids(
     }
 
     return undefined;
-}
+};
 
 // Are we narrowed to direct messages: the direct message feed or a
 // specific direct message conversation.
-export function narrowed_to_pms(current_filter: Filter | undefined = filter()): boolean {
+export const narrowed_to_pms = (current_filter: Filter | undefined = filter()): boolean => {
     if (current_filter === undefined) {
         return false;
     }
     return current_filter.has_operator("dm") || current_filter.has_operand("is", "dm");
-}
+};
 
-export function narrowed_by_pm_reply(current_filter: Filter | undefined = filter()): boolean {
+export const narrowed_by_pm_reply = (current_filter: Filter | undefined = filter()): boolean => {
     if (current_filter === undefined) {
         return false;
     }
     const terms = current_filter.terms();
     return terms.length === 1 && current_filter.has_operator("dm");
-}
+};
 
-export function narrowed_by_topic_reply(current_filter: Filter | undefined = filter()): boolean {
+export const narrowed_by_topic_reply = (current_filter: Filter | undefined = filter()): boolean => {
     if (current_filter === undefined) {
         return false;
     }
@@ -341,24 +330,25 @@ export function narrowed_by_topic_reply(current_filter: Filter | undefined = fil
         current_filter.operands("channel").length === 1 &&
         current_filter.operands("topic").length === 1
     );
-}
+};
 
 // We auto-reply under certain conditions, namely when you're narrowed
 // to a 1:1 or group direct message conversation, and when you're
 // narrowed to some stream/topic pair.
-export function narrowed_by_reply(filter?: Filter): boolean {
-    return narrowed_by_pm_reply(filter) || narrowed_by_topic_reply(filter);
-}
+export const narrowed_by_reply = (filter?: Filter): boolean =>
+    narrowed_by_pm_reply(filter) || narrowed_by_topic_reply(filter);
 
-export function narrowed_by_stream_reply(current_filter: Filter | undefined = filter()): boolean {
+export const narrowed_by_stream_reply = (
+    current_filter: Filter | undefined = filter(),
+): boolean => {
     if (current_filter === undefined) {
         return false;
     }
     const terms = current_filter.terms();
     return terms.length === 1 && current_filter.operands("channel").length === 1;
-}
+};
 
-export function is_for_stream_id(stream_id: number, filter?: Filter): boolean {
+export const is_for_stream_id = (stream_id: number, filter?: Filter): boolean => {
     // This is not perfect, since we still track narrows by
     // name, not id, but at least the interface is good going
     // forward.
@@ -369,4 +359,4 @@ export function is_for_stream_id(stream_id: number, filter?: Filter): boolean {
     }
 
     return stream_id === narrow_sub.stream_id;
-}
+};

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -14,7 +14,7 @@ export let unread_count = 0;
 let pm_count = 0;
 export let narrow_title = "home";
 
-export function compute_narrow_title(filter?: Filter): string {
+export const compute_narrow_title = (filter?: Filter): string => {
     if (filter === undefined) {
         // Views without a message feed in the center pane.
         if (recent_view_util.is_visible()) {
@@ -76,9 +76,9 @@ export function compute_narrow_title(filter?: Filter): string {
     }
 
     return filter_title;
-}
+};
 
-export function redraw_title(): void {
+export const redraw_title = (): void => {
     // Update window title to reflect unread messages in current view
     const new_title =
         (unread_count ? "(" + unread_count + ") " : "") +
@@ -89,9 +89,9 @@ export function redraw_title(): void {
         "Zulip";
 
     document.title = new_title;
-}
+};
 
-export function update_unread_counts(counts: FullUnreadCountsData): void {
+export const update_unread_counts = (counts: FullUnreadCountsData): void => {
     const new_unread_count = unread.calculate_notifiable_count(counts);
     const new_pm_count = counts.direct_message_count;
     if (new_unread_count === unread_count && new_pm_count === pm_count) {
@@ -111,9 +111,9 @@ export function update_unread_counts(counts: FullUnreadCountsData): void {
 
     // TODO: Add a `window.electron_bridge.updateDirectMessageCount(new_pm_count);` call?
     redraw_title();
-}
+};
 
-export function update_narrow_title(filter?: Filter): void {
+export const update_narrow_title = (filter?: Filter): void => {
     narrow_title = compute_narrow_title(filter);
     redraw_title();
-}
+};

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -25,10 +25,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
-const show_step: ($process: JQuery, step: number) => void = function (
-    $process: JQuery,
-    step: number,
-) {
+const show_step: ($process: JQuery, step: number) => void = ($process: JQuery, step: number) => {
     $process
         .find("[data-step]")
         .hide()
@@ -36,11 +33,10 @@ const show_step: ($process: JQuery, step: number) => void = function (
         .show();
 };
 
-const get_step = function ($process: JQuery): number {
-    return Number($process.find("[data-step]:visible").attr("data-step"));
-};
+const get_step = ($process: JQuery): number =>
+    Number($process.find("[data-step]:visible").attr("data-step"));
 
-export function should_show_notifications(ls: LocalStorage): boolean {
+export const should_show_notifications = (ls: LocalStorage): boolean => {
     // if the user said to never show banner on this computer again, it will
     // be stored as `true` so we want to negate that.
     if (localstorage.supported() && ls.get("dontAskForNotifications") === true) {
@@ -60,9 +56,9 @@ export function should_show_notifications(ls: LocalStorage): boolean {
         // if permission is allowed to be requested (e.g. not in "denied" state).
         desktop_notifications.permission_state() !== "denied"
     );
-}
+};
 
-export function should_show_server_upgrade_notification(ls: LocalStorage): boolean {
+export const should_show_server_upgrade_notification = (ls: LocalStorage): boolean => {
     // We do not show the server upgrade nag for a week after the user
     // clicked "dismiss".
     if (!localstorage.supported() || ls.get("lastUpgradeNagDismissalTime") === undefined) {
@@ -78,9 +74,9 @@ export function should_show_server_upgrade_notification(ls: LocalStorage): boole
 
     // show the notification only if the time duration is completed.
     return Date.now() > upgrade_nag_dismissal_duration;
-}
+};
 
-export function maybe_show_empty_required_profile_fields_alert(): void {
+export const maybe_show_empty_required_profile_fields_alert = (): void => {
     const $navbar_alert = $("#navbar_alerts_wrapper").children(".alert").first();
     const empty_required_profile_fields_exist = realm.custom_profile_fields
         .map((f) => ({
@@ -101,16 +97,16 @@ export function maybe_show_empty_required_profile_fields_alert(): void {
             rendered_alert_content_html: render_empty_required_profile_fields(),
         });
     }
-}
+};
 
-export function dismiss_upgrade_nag(ls: LocalStorage): void {
+export const dismiss_upgrade_nag = (ls: LocalStorage): void => {
     $(".alert[data-process='server-needs-upgrade'").hide();
     if (localstorage.supported()) {
         ls.set("lastUpgradeNagDismissalTime", Date.now());
     }
-}
+};
 
-export function check_profile_incomplete(): boolean {
+export const check_profile_incomplete = (): boolean => {
     if (!current_user.is_admin) {
         return false;
     }
@@ -128,9 +124,9 @@ export function check_profile_incomplete(): boolean {
         return true;
     }
     return false;
-}
+};
 
-export function show_profile_incomplete(is_profile_incomplete: boolean): void {
+export const show_profile_incomplete = (is_profile_incomplete: boolean): void => {
     if (is_profile_incomplete) {
         // Note that this will be a noop unless we'd already displayed
         // the notice in this session.  This seems OK, given that
@@ -139,16 +135,16 @@ export function show_profile_incomplete(is_profile_incomplete: boolean): void {
     } else {
         $("[data-process='profile-incomplete']").hide();
     }
-}
+};
 
-export function get_demo_organization_deadline_days_remaining(): number {
+export const get_demo_organization_deadline_days_remaining = (): number => {
     const now = Date.now();
     assert(realm.demo_organization_scheduled_deletion_date !== undefined);
     const deadline = realm.demo_organization_scheduled_deletion_date * 1000;
     const day = 24 * 60 * 60 * 1000; // hours * minutes * seconds * milliseconds
     const days_remaining = Math.round(Math.abs(deadline - now) / day);
     return days_remaining;
-}
+};
 
 export function initialize(): void {
     const ls = localstorage();
@@ -263,11 +259,11 @@ export function initialize(): void {
     });
 }
 
-export function open(args: {
+export const open = (args: {
     data_process: string;
     rendered_alert_content_html: string;
     custom_class?: string | undefined;
-}): void {
+}): void => {
     const rendered_alert_wrapper_html = render_navbar_alert_wrapper(args);
 
     // Note: We only support one alert being rendered at a time; as a
@@ -276,4 +272,4 @@ export function open(args: {
     // to have more than one alert visible at a time.
     $("#navbar_alerts_wrapper").html(rendered_alert_wrapper_html);
     $(window).trigger("resize");
-}
+};

--- a/web/src/navbar_help_menu.ts
+++ b/web/src/navbar_help_menu.ts
@@ -6,7 +6,7 @@ import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
 import {parse_html} from "./ui_util";
 
-export function initialize(): void {
+export const initialize = (): void => {
     popover_menus.register_popover_menu("#help-menu", {
         theme: "popover-menu",
         placement: "bottom",
@@ -25,10 +25,10 @@ export function initialize(): void {
                 },
             ],
         },
-        onMount(instance) {
+        onMount: (instance) => {
             popover_menus.popover_instances.help_menu = instance;
         },
-        onShow(instance) {
+        onShow: (instance) => {
             instance.setContent(
                 parse_html(
                     render_navbar_help_menu({
@@ -37,16 +37,16 @@ export function initialize(): void {
                 ),
             );
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.help_menu = null;
         },
     });
-}
+};
 
-export function toggle(): void {
+export const toggle = (): void => {
     // NOTE: Since to open help menu, you need to click on help navbar icon (which calls
     // tippyjs.hideAll()), or go via gear menu if using hotkeys, we don't need to
     // call tippyjs.hideAll() for it.
     $("#help-menu").trigger("click");
-}
+};

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -4,15 +4,12 @@ import {page_params} from "./page_params";
 import * as personal_menu_popover from "./personal_menu_popover";
 import * as popover_menus from "./popover_menus";
 
-export function is_navbar_menus_displayed() {
-    return (
-        popover_menus.is_personal_menu_popover_displayed() ||
-        popover_menus.is_gear_menu_popover_displayed() ||
-        popover_menus.is_help_menu_popover_displayed()
-    );
-}
+export const is_navbar_menus_displayed = () =>
+    popover_menus.is_personal_menu_popover_displayed() ||
+    popover_menus.is_gear_menu_popover_displayed() ||
+    popover_menus.is_help_menu_popover_displayed();
 
-export function handle_keyboard_events(event_name) {
+export const handle_keyboard_events = (event_name) => {
     // We don't need to process arrow keys in navbar menus for spectators
     // since they only have gear menu present.
     if (
@@ -54,4 +51,4 @@ export function handle_keyboard_events(event_name) {
     }
 
     return false;
-}
+};

--- a/web/src/navigate.ts
+++ b/web/src/navigate.ts
@@ -4,12 +4,12 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as unread_ops from "./unread_ops";
 
-function go_to_row(msg_id: number): void {
+const go_to_row = (msg_id: number): void => {
     assert(message_lists.current !== undefined);
     message_lists.current.select_id(msg_id, {then_scroll: true, from_scroll: true});
-}
+};
 
-export function up(): void {
+export const up = (): void => {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(-1);
     const msg_id = message_lists.current.prev();
@@ -17,9 +17,9 @@ export function up(): void {
         return;
     }
     go_to_row(msg_id);
-}
+};
 
-export function down(with_centering = false): void {
+export const down = (with_centering = false): void => {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(1);
 
@@ -43,26 +43,26 @@ export function down(with_centering = false): void {
         return;
     }
     go_to_row(msg_id);
-}
+};
 
-export function to_home(): void {
+export const to_home = (): void => {
     assert(message_lists.current !== undefined);
     message_viewport.set_last_movement_direction(-1);
     const first_message = message_lists.current.first();
     assert(first_message !== undefined);
     message_lists.current.select_id(first_message.id, {then_scroll: true, from_scroll: true});
-}
+};
 
-export function to_end(): void {
+export const to_end = (): void => {
     assert(message_lists.current !== undefined);
     const last_message = message_lists.current.last();
     assert(last_message !== undefined);
     message_viewport.set_last_movement_direction(1);
     message_lists.current.select_id(last_message.id, {then_scroll: true, from_scroll: true});
     unread_ops.process_visible();
-}
+};
 
-function amount_to_paginate(): number {
+const amount_to_paginate = (): number => {
     // Some day we might have separate versions of this function
     // for Page Up vs. Page Down, but for now it's the same
     // strategy in either direction.
@@ -88,9 +88,9 @@ function amount_to_paginate(): number {
     }
 
     return delta;
-}
+};
 
-export function page_up_the_right_amount(): void {
+export const page_up_the_right_amount = (): void => {
     // This function's job is to scroll up the right amount,
     // after the user hits Page Up.  We do this ourselves
     // because we can't rely on the browser to account for certain
@@ -100,15 +100,15 @@ export function page_up_the_right_amount(): void {
     // scroll handlers, not here.
     const delta = amount_to_paginate();
     message_viewport.scrollTop(message_viewport.scrollTop() - delta);
-}
+};
 
-export function page_down_the_right_amount(): void {
+export const page_down_the_right_amount = (): void => {
     // see also: page_up_the_right_amount
     const delta = amount_to_paginate();
     message_viewport.scrollTop(message_viewport.scrollTop() + delta);
-}
+};
 
-export function page_up(): void {
+export const page_up = (): void => {
     assert(message_lists.current !== undefined);
     if (message_viewport.at_rendered_top() && !message_lists.current.visibly_empty()) {
         if (message_lists.current.view.is_fetched_start_rendered()) {
@@ -125,9 +125,9 @@ export function page_up(): void {
     } else {
         page_up_the_right_amount();
     }
-}
+};
 
-export function page_down(): void {
+export const page_down = (): void => {
     assert(message_lists.current !== undefined);
     if (message_viewport.at_rendered_bottom() && !message_lists.current.visibly_empty()) {
         if (message_lists.current.view.is_fetched_end_rendered()) {
@@ -145,4 +145,4 @@ export function page_down(): void {
     } else {
         page_down_the_right_amount();
     }
-}
+};

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -19,11 +19,11 @@ export type OnboardingStep = z.output<typeof onboarding_step_schema>;
 
 export const ONE_TIME_NOTICES_TO_DISPLAY = new Set<string>();
 
-export function post_onboarding_step_as_read(onboarding_step_name: string): void {
+export const post_onboarding_step_as_read = (onboarding_step_name: string): void => {
     void channel.post({
         url: "/json/users/me/onboarding_steps",
         data: {onboarding_step: onboarding_step_name},
-        error(err) {
+        error: (err) => {
             if (err.readyState !== 0) {
                 blueslip.error("Failed to fetch onboarding steps", {
                     readyState: err.readyState,
@@ -33,9 +33,9 @@ export function post_onboarding_step_as_read(onboarding_step_name: string): void
             }
         },
     });
-}
+};
 
-export function update_onboarding_steps_to_display(onboarding_steps: OnboardingStep[]): void {
+export const update_onboarding_steps_to_display = (onboarding_steps: OnboardingStep[]): void => {
     ONE_TIME_NOTICES_TO_DISPLAY.clear();
 
     for (const onboarding_step of onboarding_steps) {
@@ -43,8 +43,8 @@ export function update_onboarding_steps_to_display(onboarding_steps: OnboardingS
             ONE_TIME_NOTICES_TO_DISPLAY.add(onboarding_step.name);
         }
     }
-}
+};
 
-export function initialize(params: {onboarding_steps: OnboardingStep[]}): void {
+export const initialize = (params: {onboarding_steps: OnboardingStep[]}): void => {
     update_onboarding_steps_to_display(params.onboarding_steps);
-}
+};

--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-export function disable_scrolling(): void {
+export const disable_scrolling = (): void => {
     // Why disable scrolling?
     // Since fixed / absolute positioned elements don't capture the scroll event unless
     // they overflow their defined container. Since fixed / absolute elements are not treated
@@ -8,8 +8,8 @@ export function disable_scrolling(): void {
     // as event bubbling doesn't work naturally.
     const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
     $("html").css({"overflow-y": "hidden", "--disabled-scrollbar-width": `${scrollbar_width}px`});
-}
+};
 
-export function enable_scrolling(): void {
+export const enable_scrolling = (): void => {
     $("html").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
-}
+};

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -22,62 +22,45 @@ let open_overlay_name: string | undefined;
 const pre_open_hooks: Hook[] = [];
 const pre_close_hooks: Hook[] = [];
 
-function reset_state(): void {
+const reset_state = (): void => {
     active_overlay = undefined;
     open_overlay_name = undefined;
-}
+};
 
-export function register_pre_open_hook(func: Hook): void {
+export const register_pre_open_hook = (func: Hook): void => {
     pre_open_hooks.push(func);
-}
+};
 
-export function register_pre_close_hook(func: Hook): void {
+export const register_pre_close_hook = (func: Hook): void => {
     pre_close_hooks.push(func);
-}
+};
 
-function call_hooks(func_list: Hook[]): void {
+const call_hooks = (func_list: Hook[]): void => {
     for (const element of func_list) {
         element();
     }
-}
+};
 
-export function any_active(): boolean {
-    return Boolean(open_overlay_name);
-}
+export const any_active = (): boolean => Boolean(open_overlay_name);
 
-export function info_overlay_open(): boolean {
-    return open_overlay_name === "informationalOverlays";
-}
+export const info_overlay_open = (): boolean => open_overlay_name === "informationalOverlays";
 
-export function settings_open(): boolean {
-    return open_overlay_name === "settings";
-}
+export const settings_open = (): boolean => open_overlay_name === "settings";
 
-export function streams_open(): boolean {
-    return open_overlay_name === "subscriptions";
-}
+export const streams_open = (): boolean => open_overlay_name === "subscriptions";
 
-export function groups_open(): boolean {
-    return open_overlay_name === "group_subscriptions";
-}
+export const groups_open = (): boolean => open_overlay_name === "group_subscriptions";
 
-export function lightbox_open(): boolean {
-    return open_overlay_name === "lightbox";
-}
+export const lightbox_open = (): boolean => open_overlay_name === "lightbox";
 
-export function drafts_open(): boolean {
-    return open_overlay_name === "drafts";
-}
+export const drafts_open = (): boolean => open_overlay_name === "drafts";
 
-export function scheduled_messages_open(): boolean {
-    return open_overlay_name === "scheduled";
-}
+export const scheduled_messages_open = (): boolean => open_overlay_name === "scheduled";
 
-export function message_edit_history_open(): boolean {
-    return open_overlay_name === "message_edit_history";
-}
+export const message_edit_history_open = (): boolean =>
+    open_overlay_name === "message_edit_history";
 
-export function open_overlay(opts: OverlayOptions): void {
+export const open_overlay = (opts: OverlayOptions): void => {
     call_hooks(pre_open_hooks);
 
     if (!opts.name || !opts.$overlay || !opts.on_close) {
@@ -106,7 +89,7 @@ export function open_overlay(opts: OverlayOptions): void {
     open_overlay_name = opts.name;
     active_overlay = {
         $element: opts.$overlay,
-        close_handler() {
+        close_handler: () => {
             opts.on_close();
             reset_state();
         },
@@ -119,9 +102,9 @@ export function open_overlay(opts: OverlayOptions): void {
     opts.$overlay.attr("aria-hidden", "false");
     $(".app").attr("aria-hidden", "true");
     $("#navbar-fixed-container").attr("aria-hidden", "true");
-}
+};
 
-export function close_overlay(name: string): void {
+export const close_overlay = (name: string): void => {
     call_hooks(pre_close_hooks);
 
     if (name !== open_overlay_name) {
@@ -148,24 +131,24 @@ export function close_overlay(name: string): void {
 
     active_overlay.close_handler();
     overlay_util.enable_scrolling();
-}
+};
 
-export function close_active(): void {
+export const close_active = (): void => {
     if (!open_overlay_name) {
         blueslip.warn("close_active() called without checking any_active()");
         return;
     }
 
     close_overlay(open_overlay_name);
-}
+};
 
-export function close_for_hash_change(): void {
+export const close_for_hash_change = (): void => {
     if (open_overlay_name) {
         close_overlay(open_overlay_name);
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("body").on("click", "div.overlay, div.overlay .exit", (e) => {
         let $target = $(e.target);
 
@@ -194,4 +177,4 @@ export function initialize(): void {
         e.preventDefault();
         e.stopPropagation();
     });
-}
+};

--- a/web/src/padded_widget.ts
+++ b/web/src/padded_widget.ts
@@ -1,11 +1,11 @@
 import $ from "jquery";
 
-export function update_padding(opts: {
+export const update_padding = (opts: {
     content_selector: string;
     padding_selector: string;
     total_rows: number;
     shown_rows: number;
-}): void {
+}): void => {
     const $content = $(opts.content_selector);
     const $padding = $(opts.padding_selector);
     const total_rows = opts.total_rows;
@@ -28,4 +28,4 @@ export function update_padding(opts: {
 
     $padding.height(new_padding_height);
     $padding.width(1);
-}
+};

--- a/web/src/password_quality.ts
+++ b/web/src/password_quality.ts
@@ -19,11 +19,11 @@ zxcvbnOptions.setOptions({
 // Return a boolean indicating whether the password is acceptable.
 // Also updates a Bootstrap progress bar control (a jQuery object)
 // if provided.
-export function password_quality(
+export const password_quality = (
     password: string,
     $bar: JQuery | undefined,
     $password_field: JQuery,
-): boolean {
+): boolean => {
     const min_length = Number($password_field.attr("data-min-length"));
     const min_guesses = Number($password_field.attr("data-min-guesses"));
 
@@ -48,9 +48,9 @@ export function password_quality(
     }
 
     return acceptable;
-}
+};
 
-export function password_warning(password: string, $password_field: JQuery): string {
+export const password_warning = (password: string, $password_field: JQuery): string => {
     const min_length = Number($password_field.attr("data-min-length"));
 
     if (password.length < min_length) {
@@ -60,4 +60,4 @@ export function password_warning(password: string, $password_field: JQuery): str
         );
     }
     return zxcvbn(password).feedback.warning ?? $t({defaultMessage: "Password is too weak"});
-}
+};

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -7,11 +7,11 @@ import * as sub_store from "./sub_store";
 // This maps a stream_id to a LazySet of user_ids who are subscribed.
 const stream_subscribers = new Map<number, LazySet>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     stream_subscribers.clear();
-}
+};
 
-function get_user_set(stream_id: number): LazySet {
+const get_user_set = (stream_id: number): LazySet => {
     // This is an internal function to get the LazySet of users.
     // We create one on the fly as necessary, but we warn in that case.
     if (!sub_store.get(stream_id)) {
@@ -26,16 +26,16 @@ function get_user_set(stream_id: number): LazySet {
     }
 
     return subscribers;
-}
+};
 
-export function is_subscriber_subset(stream_id1: number, stream_id2: number): boolean {
+export const is_subscriber_subset = (stream_id1: number, stream_id2: number): boolean => {
     const sub1_set = get_user_set(stream_id1);
     const sub2_set = get_user_set(stream_id2);
 
     return [...sub1_set.keys()].every((key) => sub2_set.has(key));
-}
+};
 
-export function potential_subscribers(stream_id: number): User[] {
+export const potential_subscribers = (stream_id: number): User[] => {
     /*
         This is a list of unsubscribed users
         for the current stream, who the current
@@ -55,7 +55,7 @@ export function potential_subscribers(stream_id: number): User[] {
 
     const subscribers = get_user_set(stream_id);
 
-    function is_potential_subscriber(person: User): boolean {
+    const is_potential_subscriber = (person: User): boolean => {
         // Use verbose style to force better test
         // coverage, plus we may add more conditions over
         // time.
@@ -64,12 +64,12 @@ export function potential_subscribers(stream_id: number): User[] {
         }
 
         return true;
-    }
+    };
 
     return people.filter_all_users(is_potential_subscriber);
-}
+};
 
-export function get_subscriber_count(stream_id: number, include_bots = true): number {
+export const get_subscriber_count = (stream_id: number, include_bots = true): number => {
     if (include_bots) {
         return get_user_set(stream_id).size;
     }
@@ -81,22 +81,22 @@ export function get_subscriber_count(stream_id: number, include_bots = true): nu
         }
     }
     return count;
-}
+};
 
-export function get_subscribers(stream_id: number): number[] {
+export const get_subscribers = (stream_id: number): number[] => {
     // This is our external interface for callers who just
     // want an array of user_ids who are subscribed to a stream.
     const subscribers = get_user_set(stream_id);
 
     return [...subscribers.keys()];
-}
+};
 
-export function set_subscribers(stream_id: number, user_ids: number[]): void {
+export const set_subscribers = (stream_id: number, user_ids: number[]): void => {
     const subscribers = new LazySet(user_ids);
     stream_subscribers.set(stream_id, subscribers);
-}
+};
 
-export function add_subscriber(stream_id: number, user_id: number): void {
+export const add_subscriber = (stream_id: number, user_id: number): void => {
     // If stream_id/user_id are unknown to us, we will
     // still track it, but we will warn.
     const subscribers = get_user_set(stream_id);
@@ -105,9 +105,9 @@ export function add_subscriber(stream_id: number, user_id: number): void {
         blueslip.warn(`We tried to add invalid subscriber: ${user_id}`);
     }
     subscribers.add(user_id);
-}
+};
 
-export function remove_subscriber(stream_id: number, user_id: number): boolean {
+export const remove_subscriber = (stream_id: number, user_id: number): boolean => {
     const subscribers = get_user_set(stream_id);
     if (!subscribers.has(user_id)) {
         blueslip.warn(`We tried to remove invalid subscriber: ${user_id}`);
@@ -117,15 +117,15 @@ export function remove_subscriber(stream_id: number, user_id: number): boolean {
     subscribers.delete(user_id);
 
     return true;
-}
+};
 
-export function bulk_add_subscribers({
+export const bulk_add_subscribers = ({
     stream_ids,
     user_ids,
 }: {
     stream_ids: number[];
     user_ids: number[];
-}): void {
+}): void => {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
         const subscribers = get_user_set(stream_id);
@@ -133,15 +133,15 @@ export function bulk_add_subscribers({
             subscribers.add(user_id);
         }
     }
-}
+};
 
-export function bulk_remove_subscribers({
+export const bulk_remove_subscribers = ({
     stream_ids,
     user_ids,
 }: {
     stream_ids: number[];
     user_ids: number[];
-}): void {
+}): void => {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
         const subscribers = get_user_set(stream_id);
@@ -149,12 +149,12 @@ export function bulk_remove_subscribers({
             subscribers.delete(user_id);
         }
     }
-}
+};
 
-export function is_user_subscribed(stream_id: number, user_id: number): boolean {
+export const is_user_subscribed = (stream_id: number, user_id: number): boolean => {
     // Most callers should call stream_data.is_user_subscribed,
     // which does additional checks.
 
     const subscribers = get_user_set(stream_id);
     return subscribers.has(user_id);
-}
+};

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -96,7 +96,7 @@ export let INACCESSIBLE_USER_NAME: string;
 
 // We have an init() function so that our automated tests
 // can easily clear data.
-export function init(): void {
+export const init = (): void => {
     // The following three dicts point to the same objects
     // (all people we've seen), but people_dict can have duplicate
     // keys related to email changes.  We want to deprecate
@@ -117,36 +117,34 @@ export function init(): void {
     duplicate_full_name_data = new FoldDict();
 
     INACCESSIBLE_USER_NAME = $t({defaultMessage: "Unknown user"});
-}
+};
 
 // WE INITIALIZE DATA STRUCTURES HERE!
 init();
 
-export function split_to_ints(lst: string): number[] {
-    return lst.split(",").map((s) => Number.parseInt(s, 10));
-}
+export const split_to_ints = (lst: string): number[] =>
+    lst.split(",").map((s) => Number.parseInt(s, 10));
 
-export function get_users_from_ids(user_ids: number[]): User[] {
-    return user_ids.map((user_id) => get_by_user_id(user_id));
-}
+export const get_users_from_ids = (user_ids: number[]): User[] =>
+    user_ids.map((user_id) => get_by_user_id(user_id));
 
 // Use this function only when you are sure that user_id is valid.
-export function get_by_user_id(user_id: number): User {
+export const get_by_user_id = (user_id: number): User => {
     const person = people_by_user_id_dict.get(user_id);
     assert(person, `Unknown user_id in get_by_user_id: ${user_id}`);
     return person;
-}
+};
 
 // This is type unsafe version of get_by_user_id for the callers that expects undefined values.
-export function maybe_get_user_by_id(user_id: number, ignore_missing = false): User | undefined {
+export const maybe_get_user_by_id = (user_id: number, ignore_missing = false): User | undefined => {
     if (!people_by_user_id_dict.has(user_id) && !ignore_missing) {
         blueslip.error("Unknown user_id in maybe_get_user_by_id", {user_id});
         return undefined;
     }
     return people_by_user_id_dict.get(user_id);
-}
+};
 
-export function validate_user_ids(user_ids: number[]): number[] {
+export const validate_user_ids = (user_ids: number[]): number[] => {
     const good_ids = [];
     const bad_ids = [];
 
@@ -163,9 +161,9 @@ export function validate_user_ids(user_ids: number[]): number[] {
     }
 
     return good_ids;
-}
+};
 
-export function get_by_email(email: string): User | undefined {
+export const get_by_email = (email: string): User | undefined => {
     const person = people_dict.get(email);
 
     if (!person) {
@@ -179,9 +177,9 @@ export function get_by_email(email: string): User | undefined {
     }
 
     return person;
-}
+};
 
-export function get_bot_owner_user(user: User & {is_bot: true}): User | undefined {
+export const get_bot_owner_user = (user: User & {is_bot: true}): User | undefined => {
     const owner_id = user.bot_owner_id;
 
     if (owner_id === undefined || owner_id === null) {
@@ -190,16 +188,13 @@ export function get_bot_owner_user(user: User & {is_bot: true}): User | undefine
     }
 
     return get_user_by_id_assert_valid(owner_id);
-}
+};
 
-export function can_admin_user(user: User): boolean {
-    return (
-        (user.is_bot && user.bot_owner_id !== null && user.bot_owner_id === current_user.user_id) ||
-        is_my_user_id(user.user_id)
-    );
-}
+export const can_admin_user = (user: User): boolean =>
+    (user.is_bot && user.bot_owner_id !== null && user.bot_owner_id === current_user.user_id) ||
+    is_my_user_id(user.user_id);
 
-export function id_matches_email_operand(user_id: number, email: string): boolean {
+export const id_matches_email_operand = (user_id: number, email: string): boolean => {
     const person = get_by_email(email);
 
     if (!person) {
@@ -210,9 +205,9 @@ export function id_matches_email_operand(user_id: number, email: string): boolea
     }
 
     return person.user_id === user_id;
-}
+};
 
-export function update_email(user_id: number, new_email: string): void {
+export const update_email = (user_id: number, new_email: string): void => {
     const person = get_by_user_id(user_id);
     person.email = new_email;
     people_dict.set(new_email, person);
@@ -220,16 +215,16 @@ export function update_email(user_id: number, new_email: string): void {
     // For legacy reasons we don't delete the old email
     // keys in our dictionaries, so that reverse lookups
     // still work correctly.
-}
+};
 
-export function get_visible_email(user: User): string {
+export const get_visible_email = (user: User): string => {
     if (user.delivery_email) {
         return user.delivery_email;
     }
     return user.email;
-}
+};
 
-export function get_user_id(email: string): number | undefined {
+export const get_user_id = (email: string): number | undefined => {
     const person = get_by_email(email);
     if (person === undefined) {
         blueslip.error("Unknown email for get_user_id", {email});
@@ -242,9 +237,9 @@ export function get_user_id(email: string): number | undefined {
     }
 
     return user_id;
-}
+};
 
-export function is_known_user_id(user_id: number): boolean {
+export const is_known_user_id = (user_id: number): boolean => {
     /*
     We may get a user_id from mention syntax that we don't
     know about if a user includes some random number in
@@ -262,15 +257,15 @@ export function is_known_user_id(user_id: number): boolean {
         return false;
     }
     return true;
-}
+};
 
-function sort_numerically(user_ids: number[]): number[] {
+const sort_numerically = (user_ids: number[]): number[] => {
     user_ids.sort((a, b) => a - b);
 
     return user_ids;
-}
+};
 
-export function huddle_string(message: Message): string | undefined {
+export const huddle_string = (message: Message): string | undefined => {
     if (message.type !== "private") {
         return undefined;
     }
@@ -292,9 +287,9 @@ export function huddle_string(message: Message): string | undefined {
     user_ids = sort_numerically(user_ids);
 
     return user_ids.join(",");
-}
+};
 
-export function user_ids_string_to_emails_string(user_ids_string: string): string | undefined {
+export const user_ids_string_to_emails_string = (user_ids_string: string): string | undefined => {
     const user_ids = split_to_ints(user_ids_string);
 
     let emails = util.try_parse_as_truthy(
@@ -314,15 +309,15 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
     emails.sort();
 
     return emails.join(",");
-}
+};
 
-export function user_ids_string_to_ids_array(user_ids_string: string): number[] {
+export const user_ids_string_to_ids_array = (user_ids_string: string): number[] => {
     const user_ids = user_ids_string.length === 0 ? [] : user_ids_string.split(",");
     const ids = user_ids.map(Number);
     return ids;
-}
+};
 
-export function get_participants_from_user_ids_string(user_ids_string: string): Set<number> {
+export const get_participants_from_user_ids_string = (user_ids_string: string): Set<number> => {
     // Convert to set to ensure there are no duplicate ids.
     const user_ids = new Set(user_ids_string_to_ids_array(user_ids_string));
     // For group or 1:1 direct messages, the user_ids_string contains
@@ -332,9 +327,9 @@ export function get_participants_from_user_ids_string(user_ids_string: string): 
     // which is take care of by user_ids being a `Set`.
     user_ids.add(my_user_id);
     return user_ids;
-}
+};
 
-export function emails_strings_to_user_ids_array(emails_string: string): number[] | undefined {
+export const emails_strings_to_user_ids_array = (emails_string: string): number[] | undefined => {
     const user_ids_string = emails_strings_to_user_ids_string(emails_string);
     if (user_ids_string === undefined) {
         return undefined;
@@ -342,9 +337,9 @@ export function emails_strings_to_user_ids_array(emails_string: string): number[
 
     const user_ids_array = user_ids_string_to_ids_array(user_ids_string);
     return user_ids_array;
-}
+};
 
-export function reply_to_to_user_ids_string(emails_string: string): string | undefined {
+export const reply_to_to_user_ids_string = (emails_string: string): string | undefined => {
     // This is basically emails_strings_to_user_ids_string
     // without blueslip warnings, since it can be called with
     // invalid data.
@@ -364,10 +359,10 @@ export function reply_to_to_user_ids_string(emails_string: string): string | und
     user_ids = sort_numerically(user_ids);
 
     return user_ids.join(",");
-}
+};
 
-export function emails_to_full_names_string(emails: string[]): string {
-    return emails
+export const emails_to_full_names_string = (emails: string[]): string =>
+    emails
         .map((email) => {
             email = email.trim();
             const person = get_by_email(email);
@@ -377,9 +372,8 @@ export function emails_to_full_names_string(emails: string[]): string {
             return INACCESSIBLE_USER_NAME;
         })
         .join(", ");
-}
 
-export function get_user_time(user_id: number): string | undefined {
+export const get_user_time = (user_id: number): string | undefined => {
     const user_timezone = get_by_user_id(user_id).timezone;
     if (user_timezone) {
         try {
@@ -395,19 +389,19 @@ export function get_user_time(user_id: number): string | undefined {
         }
     }
     return undefined;
-}
+};
 
-export function get_user_type(user_id: number): string | undefined {
+export const get_user_type = (user_id: number): string | undefined => {
     const user_profile = get_by_user_id(user_id);
     return settings_config.user_role_map.get(user_profile.role);
-}
+};
 
-export function emails_strings_to_user_ids_string(emails_string: string): string | undefined {
+export const emails_strings_to_user_ids_string = (emails_string: string): string | undefined => {
     const emails = emails_string.split(",");
     return email_list_to_user_ids_string(emails);
-}
+};
 
-export function email_list_to_user_ids_string(emails: string[]): string | undefined {
+export const email_list_to_user_ids_string = (emails: string[]): string | undefined => {
     let user_ids = util.try_parse_as_truthy(
         emails.map((email) => {
             const person = get_by_email(email);
@@ -423,13 +417,12 @@ export function email_list_to_user_ids_string(emails: string[]): string | undefi
     user_ids = sort_numerically(user_ids);
 
     return user_ids.join(",");
-}
+};
 
-export function get_full_names_for_poll_option(user_ids: number[]): string {
-    return get_display_full_names(user_ids).join(", ");
-}
+export const get_full_names_for_poll_option = (user_ids: number[]): string =>
+    get_display_full_names(user_ids).join(", ");
 
-export function get_display_full_name(user_id: number): string {
+export const get_display_full_name = (user_id: number): string => {
     const person = get_user_by_id_assert_valid(user_id);
 
     if (muted_users.is_user_muted(user_id)) {
@@ -445,27 +438,28 @@ export function get_display_full_name(user_id: number): string {
     }
 
     return person.full_name;
-}
+};
 
-export function get_display_full_names(user_ids: number[]): string[] {
-    return user_ids.map((user_id) => get_display_full_name(user_id));
-}
+export const get_display_full_names = (user_ids: number[]): string[] =>
+    user_ids.map((user_id) => get_display_full_name(user_id));
 
-export function get_full_name(user_id: number): string {
+export const get_full_name = (user_id: number): string => {
     const person = get_by_user_id(user_id);
     return person.full_name;
-}
+};
 
-function _calc_user_and_other_ids(user_ids_string: string): {
+const _calc_user_and_other_ids = (
+    user_ids_string: string,
+): {
     user_ids: number[];
     other_ids: number[];
-} {
+} => {
     const user_ids = split_to_ints(user_ids_string);
     const other_ids = user_ids.filter((user_id) => !is_my_user_id(user_id));
     return {user_ids, other_ids};
-}
+};
 
-export function get_recipients(user_ids_string: string): string {
+export const get_recipients = (user_ids_string: string): string => {
     // See message_store.get_pm_full_names() for a similar function.
 
     const {other_ids} = _calc_user_and_other_ids(user_ids_string);
@@ -477,9 +471,11 @@ export function get_recipients(user_ids_string: string): string {
 
     const names = get_display_full_names(other_ids).sort();
     return names.join(", ");
-}
+};
 
-export function pm_reply_user_string(message: Message | MessageWithBooleans): string | undefined {
+export const pm_reply_user_string = (
+    message: Message | MessageWithBooleans,
+): string | undefined => {
     const user_ids = pm_with_user_ids(message);
 
     if (!user_ids) {
@@ -487,9 +483,9 @@ export function pm_reply_user_string(message: Message | MessageWithBooleans): st
     }
 
     return user_ids.join(",");
-}
+};
 
-export function pm_reply_to(message: Message): string | undefined {
+export const pm_reply_to = (message: Message): string | undefined => {
     const user_ids = pm_with_user_ids(message);
 
     if (!user_ids) {
@@ -510,9 +506,9 @@ export function pm_reply_to(message: Message): string | undefined {
     const reply_to = emails.join(",");
 
     return reply_to;
-}
+};
 
-export function sorted_other_user_ids(user_ids: number[]): number[] {
+export const sorted_other_user_ids = (user_ids: number[]): number[] => {
     // This excludes your own user id unless you're the only user
     // (i.e. you sent a message to yourself).
 
@@ -527,9 +523,9 @@ export function sorted_other_user_ids(user_ids: number[]): number[] {
     user_ids = sort_numerically(user_ids);
 
     return user_ids;
-}
+};
 
-export function concat_huddle(user_ids: number[], user_id: number): string {
+export const concat_huddle = (user_ids: number[], user_id: number): string => {
     /*
         We assume user_ids and user_id have already
         been validated by the caller.
@@ -539,9 +535,9 @@ export function concat_huddle(user_ids: number[], user_id: number): string {
     */
     const sorted_ids = sort_numerically([...user_ids, user_id]);
     return sorted_ids.join(",");
-}
+};
 
-export function pm_lookup_key_from_user_ids(user_ids: number[]): string {
+export const pm_lookup_key_from_user_ids = (user_ids: number[]): string => {
     /*
         The server will sometimes include our own user id
         in keys for direct messages, but we only want our
@@ -549,14 +545,14 @@ export function pm_lookup_key_from_user_ids(user_ids: number[]): string {
     */
     user_ids = sorted_other_user_ids(user_ids);
     return user_ids.join(",");
-}
+};
 
-export function pm_lookup_key(user_ids_string: string): string {
+export const pm_lookup_key = (user_ids_string: string): string => {
     const user_ids = split_to_ints(user_ids_string);
     return pm_lookup_key_from_user_ids(user_ids);
-}
+};
 
-export function all_user_ids_in_pm(message: Message): number[] | undefined {
+export const all_user_ids_in_pm = (message: Message): number[] | undefined => {
     if (message.type !== "private") {
         return undefined;
     }
@@ -575,9 +571,9 @@ export function all_user_ids_in_pm(message: Message): number[] | undefined {
 
     user_ids = sort_numerically(user_ids);
     return user_ids;
-}
+};
 
-export function pm_with_user_ids(message: Message | MessageWithBooleans): number[] | undefined {
+export const pm_with_user_ids = (message: Message | MessageWithBooleans): number[] | undefined => {
     if (message.type !== "private") {
         return undefined;
     }
@@ -595,9 +591,9 @@ export function pm_with_user_ids(message: Message | MessageWithBooleans): number
     const user_ids = message.display_recipient.map((recip) => recip.id);
 
     return sorted_other_user_ids(user_ids);
-}
+};
 
-export function pm_perma_link(message: Message): string | undefined {
+export const pm_perma_link = (message: Message): string | undefined => {
     const user_ids = all_user_ids_in_pm(message);
 
     if (!user_ids) {
@@ -615,9 +611,9 @@ export function pm_perma_link(message: Message): string | undefined {
     const slug = user_ids.join(",") + "-" + suffix;
     const url = "#narrow/dm/" + slug;
     return url;
-}
+};
 
-export function pm_with_url(message: Message | MessageWithBooleans): string | undefined {
+export const pm_with_url = (message: Message | MessageWithBooleans): string | undefined => {
     const user_ids = pm_with_user_ids(message);
 
     if (user_ids?.[0] === undefined) {
@@ -641,13 +637,13 @@ export function pm_with_url(message: Message | MessageWithBooleans): string | un
     const slug = user_ids.join(",") + "-" + suffix;
     const url = "#narrow/dm/" + slug;
     return url;
-}
+};
 
-export function update_email_in_reply_to(
+export const update_email_in_reply_to = (
     reply_to: string,
     user_id: number,
     new_email: string,
-): string {
+): string => {
     // We try to replace an old email with a new email in a reply_to,
     // but we try to avoid changing the reply_to if we don't have to,
     // and we don't warn on any errors.
@@ -673,9 +669,9 @@ export function update_email_in_reply_to(
     });
 
     return emails.join(",");
-}
+};
 
-export function pm_with_operand_ids(operand: string): number[] | undefined {
+export const pm_with_operand_ids = (operand: string): number[] | undefined => {
     let emails = operand.split(",");
     emails = emails.map((email) => email.trim());
     let persons = util.try_parse_as_truthy(emails.map((email) => people_dict.get(email)));
@@ -696,9 +692,9 @@ export function pm_with_operand_ids(operand: string): number[] | undefined {
     user_ids = sort_numerically(user_ids);
 
     return user_ids;
-}
+};
 
-export function emails_to_slug(emails_string: string): string | undefined {
+export const emails_to_slug = (emails_string: string): string | undefined => {
     let slug = reply_to_to_user_ids_string(emails_string);
 
     if (!slug) {
@@ -719,9 +715,9 @@ export function emails_to_slug(emails_string: string): string | undefined {
     }
 
     return slug;
-}
+};
 
-export function slug_to_emails(slug: string): string | undefined {
+export const slug_to_emails = (slug: string): string | undefined => {
     /*
         It's not super important to be flexible about
         direct message related slugs, since you would
@@ -742,9 +738,9 @@ export function slug_to_emails(slug: string): string | undefined {
     }
     /* istanbul ignore next */
     return undefined;
-}
+};
 
-export function exclude_me_from_string(user_ids_string: string): string {
+export const exclude_me_from_string = (user_ids_string: string): string => {
     // Exclude me from a user_ids_string UNLESS I'm the
     // only one in it.
     let user_ids = split_to_ints(user_ids_string);
@@ -759,45 +755,45 @@ export function exclude_me_from_string(user_ids_string: string): string {
     user_ids = user_ids.filter((user_id) => !is_my_user_id(user_id));
 
     return user_ids.join(",");
-}
+};
 
-export function format_small_avatar_url(raw_url: string): string {
+export const format_small_avatar_url = (raw_url: string): string => {
     const url = new URL(raw_url, location.origin);
     url.search += (url.search ? "&" : "") + "s=50";
     return url.href;
-}
+};
 
-export function sender_is_bot(message: Message): boolean {
+export const sender_is_bot = (message: Message): boolean => {
     if (message.sender_id) {
         const person = get_by_user_id(message.sender_id);
         return person.is_bot;
     }
     return false;
-}
+};
 
-export function sender_is_guest(message: Message): boolean {
+export const sender_is_guest = (message: Message): boolean => {
     if (message.sender_id) {
         const person = get_by_user_id(message.sender_id);
         return person.is_guest;
     }
     return false;
-}
+};
 
-export function is_valid_bot_user(user_id: number): boolean {
+export const is_valid_bot_user = (user_id: number): boolean => {
     const user = maybe_get_user_by_id(user_id, true);
     return user?.is_bot ?? false;
-}
+};
 
-export function should_add_guest_user_indicator(user_id: number): boolean {
+export const should_add_guest_user_indicator = (user_id: number): boolean => {
     if (!realm.realm_enable_guest_user_indicator) {
         return false;
     }
 
     const user = get_by_user_id(user_id);
     return user.is_guest;
-}
+};
 
-export function user_can_direct_message(recipient_ids_string: string): boolean {
+export const user_can_direct_message = (recipient_ids_string: string): boolean => {
     // Common function for checking if a user can send a direct
     // message to the target user (or group of users) represented by a
     // user ids string.
@@ -819,16 +815,16 @@ export function user_can_direct_message(recipient_ids_string: string): boolean {
         return false;
     }
     return true;
-}
+};
 
-function gravatar_url_for_email(email: string): string {
+const gravatar_url_for_email = (email: string): string => {
     const hash = md5(email.toLowerCase());
     const avatar_url = "https://secure.gravatar.com/avatar/" + hash + "?d=identicon";
     const small_avatar_url = format_small_avatar_url(avatar_url);
     return small_avatar_url;
-}
+};
 
-export function small_avatar_url_for_person(person: User): string {
+export const small_avatar_url_for_person = (person: User): string => {
     if (person.avatar_url) {
         return format_small_avatar_url(person.avatar_url);
     }
@@ -838,17 +834,17 @@ export function small_avatar_url_for_person(person: User): string {
     }
 
     return format_small_avatar_url(`/avatar/${person.user_id}`);
-}
+};
 
-function medium_gravatar_url_for_email(email: string): string {
+const medium_gravatar_url_for_email = (email: string): string => {
     const hash = md5(email.toLowerCase());
     const avatar_url = "https://secure.gravatar.com/avatar/" + hash + "?d=identicon";
     const url = new URL(avatar_url, location.origin);
     url.search += (url.search ? "&" : "") + "s=500";
     return url.href;
-}
+};
 
-export function medium_avatar_url_for_person(person: User): string {
+export const medium_avatar_url_for_person = (person: User): string => {
     /* Unlike the small avatar URL case, we don't generally have a
      * medium avatar URL included in person objects. So only have the
      * gravatar and server endpoints here. */
@@ -865,9 +861,9 @@ export function medium_avatar_url_for_person(person: User): string {
     // metadata. Long term, we should clean up that possibility, but
     // until it is, we fallback to using a version number of 0.
     return `/avatar/${person.user_id}/medium?version=${person.avatar_version ?? 0}`;
-}
+};
 
-export function sender_info_for_recent_view_row(sender_ids: number[]): SenderInfo[] {
+export const sender_info_for_recent_view_row = (sender_ids: number[]): SenderInfo[] => {
     const senders_info = [];
     for (const id of sender_ids) {
         // TODO: Better handling for optional values w/o the assertion.
@@ -880,9 +876,9 @@ export function sender_info_for_recent_view_row(sender_ids: number[]): SenderInf
         senders_info.push(sender);
     }
     return senders_info;
-}
+};
 
-export function small_avatar_url(message: Message): string {
+export const small_avatar_url = (message: Message): string => {
     // Try to call this function in all places where we need 25px
     // avatar images, so that the browser can help
     // us avoid unnecessary network trips.  (For user-uploaded avatars,
@@ -932,9 +928,9 @@ export function small_avatar_url(message: Message): string {
     }
 
     return gravatar_url_for_email(email);
-}
+};
 
-export function is_valid_email_for_compose(email: string): boolean {
+export const is_valid_email_for_compose = (email: string): boolean => {
     if (is_cross_realm_email(email)) {
         return true;
     }
@@ -947,19 +943,17 @@ export function is_valid_email_for_compose(email: string): boolean {
     // we allow deactivated users in compose so that
     // one can attempt to reply to threads that contained them.
     return true;
-}
+};
 
-export function is_valid_bulk_emails_for_compose(emails: string[]): boolean {
-    // Returns false if at least one of the emails is invalid.
-    return emails.every((email) => {
+export const is_valid_bulk_emails_for_compose = (emails: string[]): boolean =>
+    emails.every((email) => {
         if (!is_valid_email_for_compose(email)) {
             return false;
         }
         return true;
     });
-}
 
-export function is_active_user_for_popover(user_id: number): boolean {
+export const is_active_user_for_popover = (user_id: number): boolean => {
     // For popover menus, we include cross-realm bots as active
     // users.
 
@@ -977,9 +971,9 @@ export function is_active_user_for_popover(user_id: number): boolean {
     }
 
     return false;
-}
+};
 
-export function is_current_user_only_owner(): boolean {
+export const is_current_user_only_owner = (): boolean => {
     if (!current_user.is_owner) {
         return false;
     }
@@ -990,9 +984,9 @@ export function is_current_user_only_owner(): boolean {
         }
     }
     return true;
-}
+};
 
-export function filter_all_persons(pred: (person: User) => boolean): User[] {
+export const filter_all_persons = (pred: (person: User) => boolean): User[] => {
     const ret = [];
     for (const person of people_by_user_id_dict.values()) {
         if (person.is_inaccessible_user) {
@@ -1004,9 +998,9 @@ export function filter_all_persons(pred: (person: User) => boolean): User[] {
         }
     }
     return ret;
-}
+};
 
-export function filter_all_users(pred: (person: User) => boolean): User[] {
+export const filter_all_users = (pred: (person: User) => boolean): User[] => {
     const ret = [];
     for (const person of active_user_dict.values()) {
         if (pred(person)) {
@@ -1014,14 +1008,11 @@ export function filter_all_users(pred: (person: User) => boolean): User[] {
         }
     }
     return ret;
-}
+};
 
-export function get_realm_users(): User[] {
-    // includes humans and bots from your realm
-    return [...active_user_dict.values()];
-}
+export const get_realm_users = (): User[] => [...active_user_dict.values()];
 
-export function get_realm_active_human_users(): User[] {
+export const get_realm_active_human_users = (): User[] => {
     // includes ONLY humans from your realm
     const humans = [];
 
@@ -1032,9 +1023,9 @@ export function get_realm_active_human_users(): User[] {
     }
 
     return humans;
-}
+};
 
-export function get_realm_active_human_user_ids(): number[] {
+export const get_realm_active_human_user_ids = (): number[] => {
     const human_ids = [];
 
     for (const user of active_user_dict.values()) {
@@ -1044,9 +1035,9 @@ export function get_realm_active_human_user_ids(): number[] {
     }
 
     return human_ids;
-}
+};
 
-export function get_non_active_human_ids(): number[] {
+export const get_non_active_human_ids = (): number[] => {
     const human_ids = [];
 
     for (const user of non_active_user_dict.values()) {
@@ -1056,9 +1047,9 @@ export function get_non_active_human_ids(): number[] {
     }
 
     return human_ids;
-}
+};
 
-export function get_bot_ids(): number[] {
+export const get_bot_ids = (): number[] => {
     const bot_ids = [];
 
     for (const user of people_by_user_id_dict.values()) {
@@ -1068,9 +1059,9 @@ export function get_bot_ids(): number[] {
     }
 
     return bot_ids;
-}
+};
 
-export function get_active_human_count(): number {
+export const get_active_human_count = (): number => {
     let count = 0;
     for (const person of active_user_dict.values()) {
         if (!person.is_bot) {
@@ -1078,26 +1069,21 @@ export function get_active_human_count(): number {
         }
     }
     return count;
-}
+};
 
-export function get_active_user_ids(): number[] {
-    // This includes active users and active bots.
-    return [...active_user_dict.keys()];
-}
+export const get_active_user_ids = (): number[] => [...active_user_dict.keys()];
 
-export function get_non_active_realm_users(): User[] {
-    return [...non_active_user_dict.values()];
-}
+export const get_non_active_realm_users = (): User[] => [...non_active_user_dict.values()];
 
-export function is_cross_realm_email(email: string): boolean {
+export const is_cross_realm_email = (email: string): boolean => {
     const person = get_by_email(email);
     if (!person) {
         return false;
     }
     return cross_realm_dict.has(person.user_id);
-}
+};
 
-export function get_recipient_count(person: User | PseudoMentionUser): number {
+export const get_recipient_count = (person: User | PseudoMentionUser): number => {
     // We can have fake person objects like the "all"
     // pseudo-person in at-mentions.  They will have
     // the pm_recipient_count on the object itself.
@@ -1121,22 +1107,22 @@ export function get_recipient_count(person: User | PseudoMentionUser): number {
     const count = pm_recipient_count_dict.get(person.user_id);
 
     return count ?? 0;
-}
+};
 
-export function incr_recipient_count(user_id: number): void {
+export const incr_recipient_count = (user_id: number): void => {
     const old_count = pm_recipient_count_dict.get(user_id) ?? 0;
     pm_recipient_count_dict.set(user_id, old_count + 1);
-}
+};
 
-export function clear_recipient_counts_for_testing(): void {
+export const clear_recipient_counts_for_testing = (): void => {
     pm_recipient_count_dict.clear();
-}
+};
 
-export function set_recipient_count_for_testing(user_id: number, count: number): void {
+export const set_recipient_count_for_testing = (user_id: number, count: number): void => {
     pm_recipient_count_dict.set(user_id, count);
-}
+};
 
-export function get_message_people(): User[] {
+export const get_message_people = (): User[] => {
     /*
         message_people are roughly the people who have
         actually sent messages that are currently
@@ -1161,17 +1147,17 @@ export function get_message_people(): User[] {
     );
 
     return message_people ?? [];
-}
+};
 
-export function get_active_message_people(): User[] {
+export const get_active_message_people = (): User[] => {
     const message_people = get_message_people();
     const active_message_people = message_people.filter((item) =>
         active_user_dict.has(item.user_id),
     );
     return active_message_people;
-}
+};
 
-export function get_people_for_search_bar(query: string): User[] {
+export const get_people_for_search_bar = (query: string): User[] => {
     const pred = build_person_matcher(query);
 
     const message_people = get_message_people().filter((user) => !user.is_inaccessible_user);
@@ -1183,14 +1169,14 @@ export function get_people_for_search_bar(query: string): User[] {
     }
 
     return filter_all_persons(pred);
-}
+};
 
-export function build_termlet_matcher(termlet: string): (user: User) => boolean {
+export const build_termlet_matcher = (termlet: string): ((user: User) => boolean) => {
     termlet = termlet.trim();
 
     const is_ascii = /^[a-z]+$/.test(termlet);
 
-    return function (user: User): boolean {
+    return (user: User): boolean => {
         let full_name = user.full_name;
         // Only ignore diacritics if the query is plain ascii
         if (is_ascii) {
@@ -1203,15 +1189,15 @@ export function build_termlet_matcher(termlet: string): (user: User) => boolean 
 
         return names.some((name) => name.startsWith(termlet));
     };
-}
+};
 
-export function build_person_matcher(query: string): (user: User) => boolean {
+export const build_person_matcher = (query: string): ((user: User) => boolean) => {
     query = query.trim();
 
     const termlets = query.toLowerCase().split(/\s+/);
     const termlet_matchers = termlets.map((termlet) => build_termlet_matcher(termlet));
 
-    return function (user: User): boolean {
+    return (user: User): boolean => {
         const email = user.email.toLowerCase();
 
         if (email.startsWith(query)) {
@@ -1220,9 +1206,12 @@ export function build_person_matcher(query: string): (user: User) => boolean {
 
         return termlet_matchers.every((matcher) => matcher(user));
     };
-}
+};
 
-export function filter_people_by_search_terms(users: User[], search_string: string): Set<number> {
+export const filter_people_by_search_terms = (
+    users: User[],
+    search_string: string,
+): Set<number> => {
     let search_terms = search_string.toLowerCase().split(/[,|]+/);
     search_terms = search_terms.map((s) => s.trim());
 
@@ -1244,7 +1233,7 @@ export function filter_people_by_search_terms(users: User[], search_string: stri
     }
 
     return filtered_users;
-}
+};
 
 export const is_valid_full_name_and_user_id = (full_name: string, user_id: number): boolean => {
     /*
@@ -1282,7 +1271,7 @@ export const get_actual_name_from_user_id = (user_id: number): string | undefine
     return person.full_name;
 };
 
-export function get_user_id_from_name(full_name: string): number | undefined {
+export const get_user_id_from_name = (full_name: string): number | undefined => {
     // get_user_id_from_name('Alice Smith') === 42
 
     /*
@@ -1318,13 +1307,13 @@ export function get_user_id_from_name(full_name: string): number | undefined {
     }
 
     return person.user_id;
-}
+};
 
-export function track_duplicate_full_name(
+export const track_duplicate_full_name = (
     full_name: string,
     user_id: number,
     to_remove?: boolean,
-): void {
+): void => {
     let ids: Set<number>;
     if (duplicate_full_name_data.has(full_name)) {
         // TODO: Better handling for optional values w/o the assertion.
@@ -1339,15 +1328,15 @@ export function track_duplicate_full_name(
         ids.delete(user_id);
     }
     duplicate_full_name_data.set(full_name, ids);
-}
+};
 
-export function is_duplicate_full_name(full_name: string): boolean {
+export const is_duplicate_full_name = (full_name: string): boolean => {
     const ids = duplicate_full_name_data.get(full_name);
 
     return ids !== undefined && ids.size > 1;
-}
+};
 
-export function get_mention_syntax(full_name: string, user_id?: number, silent = false): string {
+export const get_mention_syntax = (full_name: string, user_id?: number, silent = false): string => {
     let mention = "";
     if (silent) {
         mention += "@_**";
@@ -1372,13 +1361,12 @@ export function get_mention_syntax(full_name: string, user_id?: number, silent =
     }
     mention += "**";
     return mention;
-}
+};
 
-function full_name_matches_wildcard_mention(full_name: string): boolean {
-    return ["all", "everyone", "stream", "channel", "topic"].includes(full_name);
-}
+const full_name_matches_wildcard_mention = (full_name: string): boolean =>
+    ["all", "everyone", "stream", "channel", "topic"].includes(full_name);
 
-export function _add_user(person: User): void {
+export const _add_user = (person: User): void => {
     /*
         This is common code to add any user, even
         users who may be deactivated or outside
@@ -1403,13 +1391,13 @@ export function _add_user(person: User): void {
     track_duplicate_full_name(person.full_name, person.user_id);
     people_dict.set(person.email, person);
     people_by_name_dict.set(person.full_name, person);
-}
+};
 
-export function add_active_user(person: User): void {
+export const add_active_user = (person: User): void => {
     active_user_dict.set(person.user_id, person);
     _add_user(person);
     non_active_user_dict.delete(person.user_id);
-}
+};
 
 export const is_person_active = (user_id: number): boolean => {
     if (!people_by_user_id_dict.has(user_id)) {
@@ -1423,22 +1411,22 @@ export const is_person_active = (user_id: number): boolean => {
     return active_user_dict.has(user_id);
 };
 
-export function add_cross_realm_user(person: CrossRealmBot): void {
+export const add_cross_realm_user = (person: CrossRealmBot): void => {
     if (!people_dict.has(person.email)) {
         _add_user(person);
     }
     cross_realm_dict.set(person.user_id, person);
-}
+};
 
-export function deactivate(person: User): void {
+export const deactivate = (person: User): void => {
     // We don't fully remove a person from all of our data
     // structures, because deactivated users can be part
     // of somebody's direct message list.
     active_user_dict.delete(person.user_id);
     non_active_user_dict.set(person.user_id, person);
-}
+};
 
-export function remove_inaccessible_user(user_id: number): void {
+export const remove_inaccessible_user = (user_id: number): void => {
     // We do not track inaccessible users in active_user_dict.
     active_user_dict.delete(user_id);
 
@@ -1446,9 +1434,9 @@ export function remove_inaccessible_user(user_id: number): void {
     const email = "user" + user_id + "@" + realm.realm_bot_domain;
     const unknown_user = make_user(user_id, email, INACCESSIBLE_USER_NAME);
     _add_user(unknown_user);
-}
+};
 
-export function report_late_add(user_id: number, email: string): void {
+export const report_late_add = (user_id: number, email: string): void => {
     // If the events system is not running, then it is expected that
     // we will fetch messages from the server that were sent by users
     // who don't exist in our users data set. This can happen because
@@ -1462,63 +1450,51 @@ export function report_late_add(user_id: number, email: string): void {
     } else {
         blueslip.error("Added user late", {user_id, email});
     }
-}
+};
 
-export function make_user(user_id: number, email: string, full_name: string): User {
-    // Used to create fake user objects for users who we see via some
-    // API call, such as fetching a message sent by the user, before
-    // we receive a full user object for the user via the events
-    // system.
-    //
-    // This function is an ugly hack in that it makes up a lot of
-    // values, but usually thesefake user objects only persist for
-    // less than a second before being replaced by a real user when
-    // the events system receives the user-created event for the new
-    // or newly visible user.
-    return {
-        user_id,
-        email,
-        full_name,
-        role: settings_config.user_role_values.member.code,
-        is_active: true,
-        is_admin: false,
-        is_owner: false,
-        is_guest: false,
-        is_bot: false,
-        is_moderator: false,
-        is_billing_admin: false,
-        // We explicitly don't set `avatar_url` for fake person objects so that fallback code
-        // will ask the server or compute a gravatar URL only once we need the avatar URL,
-        // it's important for performance that we not hash every user's email to get gravatar URLs.
-        avatar_version: 0,
-        timezone: "",
-        date_joined: "",
-        delivery_email: null,
-        profile_data: {},
-        bot_type: null,
-        // This may lead to cases where this field is set to
-        // true for an accessible user also and such user would
-        // not be shown in the right sidebar for some time till
-        // the user's correct data is received from the server.
-        is_inaccessible_user: !settings_data.user_can_access_all_other_users(),
+export const make_user = (user_id: number, email: string, full_name: string): User => ({
+    user_id,
+    email,
+    full_name,
+    role: settings_config.user_role_values.member.code,
+    is_active: true,
+    is_admin: false,
+    is_owner: false,
+    is_guest: false,
+    is_bot: false,
+    is_moderator: false,
+    is_billing_admin: false,
+    // We explicitly don't set `avatar_url` for fake person objects so that fallback code
+    // will ask the server or compute a gravatar URL only once we need the avatar URL,
+    // it's important for performance that we not hash every user's email to get gravatar URLs.
+    avatar_version: 0,
+    timezone: "",
+    date_joined: "",
+    delivery_email: null,
+    profile_data: {},
+    bot_type: null,
+    // This may lead to cases where this field is set to
+    // true for an accessible user also and such user would
+    // not be shown in the right sidebar for some time till
+    // the user's correct data is received from the server.
+    is_inaccessible_user: !settings_data.user_can_access_all_other_users(),
 
-        // This property allows us to distinguish actual server person
-        // objects from fake person objects generated by this function.
-        is_missing_server_data: true,
-    };
-}
+    // This property allows us to distinguish actual server person
+    // objects from fake person objects generated by this function.
+    is_missing_server_data: true,
+});
 
-export function add_inaccessible_user(user_id: number): User {
+export const add_inaccessible_user = (user_id: number): User => {
     const email = "user" + user_id + "@" + realm.realm_bot_domain;
     const unknown_user = make_user(user_id, email, INACCESSIBLE_USER_NAME);
     _add_user(unknown_user);
     return unknown_user;
-}
+};
 
-export function get_user_by_id_assert_valid(
+export const get_user_by_id_assert_valid = (
     user_id: number,
     allow_missing_user = !settings_data.user_can_access_all_other_users(),
-): User {
+): User => {
     if (!allow_missing_user) {
         return get_by_user_id(user_id);
     }
@@ -1528,9 +1504,9 @@ export function get_user_by_id_assert_valid(
         person = add_inaccessible_user(user_id);
     }
     return person;
-}
+};
 
-function get_involved_people(message: MessageWithBooleans): DisplayRecipientUser[] {
+const get_involved_people = (message: MessageWithBooleans): DisplayRecipientUser[] => {
     let involved_people: DisplayRecipientUser[] = [];
 
     if (message.type === "stream") {
@@ -1551,9 +1527,9 @@ function get_involved_people(message: MessageWithBooleans): DisplayRecipientUser
     }
 
     return involved_people;
-}
+};
 
-export function extract_people_from_message(message: MessageWithBooleans): void {
+export const extract_people_from_message = (message: MessageWithBooleans): void => {
     const involved_people = get_involved_people(message);
 
     // Add new people involved in this message to the people list
@@ -1572,55 +1548,38 @@ export function extract_people_from_message(message: MessageWithBooleans): void 
 
         _add_user(make_user(user_id, person.email, person.full_name));
     }
-}
+};
 
-function safe_lower(s?: string | null): string {
-    return (s ?? "").toLowerCase();
-}
+const safe_lower = (s?: string | null): string => (s ?? "").toLowerCase();
 
-export function matches_user_settings_search(person: User, value: string): boolean {
+export const matches_user_settings_search = (person: User, value: string): boolean => {
     const email = person.delivery_email;
 
     return safe_lower(person.full_name).includes(value) || safe_lower(email).includes(value);
-}
+};
 
-function matches_user_settings_role(person: User, role_code: number): boolean {
+const matches_user_settings_role = (person: User, role_code: number): boolean => {
     if (role_code === 0 || role_code === person.role) {
         return true;
     }
     return false;
-}
+};
 
 type SettingsUsersFilterQuery = {
     text_search: string;
     role_code: number;
 };
 
-export function predicate_for_user_settings_filters(
+export const predicate_for_user_settings_filters = (
     person: User,
     query: SettingsUsersFilterQuery,
-): boolean {
-    /*
-        TODO: For text_search:
-              For large realms, we can optimize this a couple
-              different ways.  For realms that don't show
-              emails, we can make a simpler filter predicate
-              that works solely with full names.  And we can
-              also consider two-pass filters that try more
-              stingy criteria first, such as exact prefix
-              matches, before widening the search.
+): boolean =>
+    matches_user_settings_search(person, query.text_search) &&
+    matches_user_settings_role(person, query.role_code);
 
-              See #13554 for more context.
-    */
-    return (
-        matches_user_settings_search(person, query.text_search) &&
-        matches_user_settings_role(person, query.role_code)
-    );
-}
-
-export function maybe_incr_recipient_count(
+export const maybe_incr_recipient_count = (
     message: MessageWithBooleans & {sent_by_me: boolean},
-): void {
+): void => {
     if (message.type !== "private") {
         return;
     }
@@ -1644,9 +1603,9 @@ export function maybe_incr_recipient_count(
         const user_id = recip.id;
         incr_recipient_count(user_id);
     }
-}
+};
 
-export function set_full_name(person_obj: User, new_full_name: string): void {
+export const set_full_name = (person_obj: User, new_full_name: string): void => {
     if (people_by_name_dict.has(person_obj.full_name)) {
         people_by_name_dict.delete(person_obj.full_name);
     }
@@ -1656,12 +1615,12 @@ export function set_full_name(person_obj: User, new_full_name: string): void {
     people_by_name_dict.set(new_full_name, person_obj);
     person_obj.full_name = new_full_name;
     person_obj.name_with_diacritics_removed = undefined;
-}
+};
 
-export function set_custom_profile_field_data(
+export const set_custom_profile_field_data = (
     user_id: number,
     field: {id: number} & ProfileDatum,
-): void {
+): void => {
     if (field.id === undefined) {
         blueslip.error("Trying to set undefined field id");
         return;
@@ -1671,58 +1630,56 @@ export function set_custom_profile_field_data(
         value: field.value,
         rendered_value: field.rendered_value,
     };
-}
+};
 
-export function is_current_user(email?: string | null): boolean {
+export const is_current_user = (email?: string | null): boolean => {
     if (email === null || email === undefined || page_params.is_spectator) {
         return false;
     }
 
     return email.toLowerCase() === my_current_email().toLowerCase();
-}
+};
 
-export function initialize_current_user(user_id: number): void {
+export const initialize_current_user = (user_id: number): void => {
     my_user_id = user_id;
-}
+};
 
-export function my_full_name(): string {
+export const my_full_name = (): string => {
     const person = get_by_user_id(my_user_id);
     return person.full_name;
-}
+};
 
-export function my_current_email(): string {
+export const my_current_email = (): string => {
     const person = get_by_user_id(my_user_id);
     return person.email;
-}
+};
 
-export function my_current_user_id(): number {
-    return my_user_id;
-}
+export const my_current_user_id = (): number => my_user_id;
 
-export function my_custom_profile_data(field_id: number): ProfileDatum | null | undefined {
+export const my_custom_profile_data = (field_id: number): ProfileDatum | null | undefined => {
     if (field_id === undefined) {
         blueslip.error("Undefined field id");
         return undefined;
     }
     return get_custom_profile_data(my_user_id, field_id);
-}
+};
 
-export function get_custom_profile_data(
+export const get_custom_profile_data = (
     user_id: number,
     field_id: number,
-): ProfileDatum | null | undefined {
+): ProfileDatum | null | undefined => {
     const person = get_by_user_id(user_id);
     const profile_data = person.profile_data;
     if (profile_data === undefined) {
         return null;
     }
     return profile_data[field_id];
-}
+};
 
-export function get_custom_fields_by_type(
+export const get_custom_fields_by_type = (
     user_id: number,
     field_type: number,
-): (ProfileDatum | undefined)[] | null {
+): (ProfileDatum | undefined)[] | null => {
     const person = get_by_user_id(user_id);
     const profile_data = person.profile_data;
     if (profile_data === undefined) {
@@ -1735,17 +1692,13 @@ export function get_custom_fields_by_type(
         }
     }
     return filteredProfileData;
-}
+};
 
-export function is_my_user_id(user_id: number): boolean {
-    return user_id === my_user_id;
-}
+export const is_my_user_id = (user_id: number): boolean => user_id === my_user_id;
 
-export function compare_by_name(a: User, b: User): number {
-    return util.strcmp(a.full_name, b.full_name);
-}
+export const compare_by_name = (a: User, b: User): number => util.strcmp(a.full_name, b.full_name);
 
-export function sort_but_pin_current_user_on_top(users: User[]): void {
+export const sort_but_pin_current_user_on_top = (users: User[]): void => {
     const my_user = get_by_user_id(my_user_id);
     if (users.includes(my_user)) {
         users.splice(users.indexOf(my_user), 1);
@@ -1754,9 +1707,9 @@ export function sort_but_pin_current_user_on_top(users: User[]): void {
     } else {
         users.sort(compare_by_name);
     }
-}
+};
 
-export function initialize(my_user_id: number, params: PeopleParams): void {
+export const initialize = (my_user_id: number, params: PeopleParams): void => {
     for (const person of params.realm_users) {
         add_active_user(person);
     }
@@ -1771,4 +1724,4 @@ export function initialize(my_user_id: number, params: PeopleParams): void {
     }
 
     initialize_current_user(my_user_id);
-}
+};

--- a/web/src/personal_menu_popover.js
+++ b/web/src/personal_menu_popover.js
@@ -14,7 +14,7 @@ import {parse_html} from "./ui_util";
 import {user_settings} from "./user_settings";
 import * as user_status from "./user_status";
 
-export function initialize() {
+export const initialize = () => {
     popover_menus.register_popover_menu("#personal-menu", {
         theme: "popover-menu",
         placement: "bottom",
@@ -33,7 +33,7 @@ export function initialize() {
                 },
             ],
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             popover_menus.popover_instances.personal_menu = instance;
 
@@ -47,7 +47,7 @@ export function initialize() {
                 channel.patch({
                     url: "/json/settings",
                     data: {color_scheme: new_theme_code},
-                    error() {
+                    error: () => {
                         // NOTE: The additional delay allows us to visually communicate
                         // that an error occurred due to which we are reverting back
                         // to the previously used value.
@@ -70,7 +70,7 @@ export function initialize() {
                     status_text: "",
                     emoji_name: "",
                     emoji_code: "",
-                    success() {
+                    success: () => {
                         popover_menus.hide_current_popover_if_visible(instance);
                     },
                 });
@@ -115,20 +115,20 @@ export function initialize() {
             });
             instance.popperInstance.update();
         },
-        onShow(instance) {
+        onShow: (instance) => {
             const args = popover_menus_data.get_personal_menu_content_context();
             instance.setContent(parse_html(render_navbar_personal_menu_popover(args)));
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
             popover_menus.popover_instances.personal_menu = undefined;
         },
     });
-}
+};
 
-export function toggle() {
+export const toggle = () => {
     // NOTE: Since to open personal menu, you need to click on your avatar (which calls
     // tippyjs.hideAll()), or go via gear menu if using hotkeys, we don't need to
     // call tippyjs.hideAll() for it.
     $("#personal-menu").trigger("click");
-}
+};

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -14,27 +14,23 @@ import type {UserGroupPillData} from "./user_group_pill";
 import * as user_pill from "./user_pill";
 import type {UserPillData, UserPillWidget} from "./user_pill";
 
-function person_matcher(query: string, item: UserPillData): boolean {
-    return (
-        people.is_known_user_id(item.user.user_id) &&
-        typeahead_helper.query_matches_person(query, item)
-    );
-}
+const person_matcher = (query: string, item: UserPillData): boolean =>
+    people.is_known_user_id(item.user.user_id) &&
+    typeahead_helper.query_matches_person(query, item);
 
-function group_matcher(query: string, item: UserGroupPillData): boolean {
-    return typeahead_helper.query_matches_name(query, item);
-}
+const group_matcher = (query: string, item: UserGroupPillData): boolean =>
+    typeahead_helper.query_matches_name(query, item);
 
 type TypeaheadItem = UserGroupPillData | StreamPillData | UserPillData;
 
-export function set_up_user(
+export const set_up_user = (
     $input: JQuery,
     pills: UserPillWidget,
     opts: {
         exclude_bots?: boolean;
         update_func?: () => void;
     },
-): void {
+): void => {
     const exclude_bots = opts.exclude_bots;
     const bootstrap_typeahead_input: TypeaheadInputElement = {
         $element: $input,
@@ -43,25 +39,22 @@ export function set_up_user(
     new Typeahead(bootstrap_typeahead_input, {
         items: 5,
         dropup: true,
-        source(_query: string): UserPillData[] {
-            return user_pill.typeahead_source(pills, exclude_bots);
-        },
-        highlighter_html(item: UserPillData, _query: string): string {
-            return typeahead_helper.render_person(item);
-        },
-        matcher(item: UserPillData, query: string): boolean {
+        source: (_query: string): UserPillData[] => user_pill.typeahead_source(pills, exclude_bots),
+        highlighter_html: (item: UserPillData, _query: string): string =>
+            typeahead_helper.render_person(item),
+        matcher: (item: UserPillData, query: string): boolean => {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
             return person_matcher(query, item);
         },
-        sorter(matches: UserPillData[], query: string): UserPillData[] {
+        sorter: (matches: UserPillData[], query: string): UserPillData[] => {
             const users = matches.filter((match) => people.is_known_user_id(match.user.user_id));
             return typeahead_helper.sort_recipients({users, query}).map((item) => {
                 assert(item.type === "user");
                 return item;
             });
         },
-        updater(item: UserPillData, _query: string): undefined {
+        updater: (item: UserPillData, _query: string): undefined => {
             if (people.is_known_user_id(item.user.user_id)) {
                 user_pill.append_user(item.user, pills);
             }
@@ -70,9 +63,9 @@ export function set_up_user(
         },
         stopAdvance: true,
     });
-}
+};
 
-export function set_up_combined(
+export const set_up_combined = (
     $input: JQuery,
     pills: CombinedPillContainer,
     opts: {
@@ -83,7 +76,7 @@ export function set_up_combined(
         exclude_bots?: boolean;
         update_func?: () => void;
     },
-): void {
+): void => {
     if (!opts.user && !opts.user_group && !opts.stream) {
         blueslip.error("Unspecified possible item types");
         return;
@@ -101,7 +94,7 @@ export function set_up_combined(
     new Typeahead(bootstrap_typeahead_input, {
         items: 5,
         dropup: true,
-        source(query: string): TypeaheadItem[] {
+        source: (query: string): TypeaheadItem[] => {
             let source: TypeaheadItem[] = [];
             if (include_streams(query)) {
                 // If query starts with # we expect,
@@ -129,7 +122,7 @@ export function set_up_combined(
             }
             return source;
         },
-        highlighter_html(item: TypeaheadItem, query: string): string {
+        highlighter_html: (item: TypeaheadItem, query: string): string => {
             if (include_streams(query) && item.type === "stream") {
                 return typeahead_helper.render_stream(item);
             }
@@ -145,7 +138,7 @@ export function set_up_combined(
             assert(item.type === "user");
             return typeahead_helper.render_person(item);
         },
-        matcher(item: TypeaheadItem, query: string): boolean {
+        matcher: (item: TypeaheadItem, query: string): boolean => {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
 
@@ -164,7 +157,7 @@ export function set_up_combined(
             }
             return matches;
         },
-        sorter(matches: TypeaheadItem[], query: string): TypeaheadItem[] {
+        sorter: (matches: TypeaheadItem[], query: string): TypeaheadItem[] => {
             if (include_streams(query)) {
                 const stream_matches: StreamPillData[] = [];
                 for (const match of matches) {
@@ -201,7 +194,7 @@ export function set_up_combined(
                 max_num_items: undefined,
             });
         },
-        updater(item: TypeaheadItem, query: string): undefined {
+        updater: (item: TypeaheadItem, query: string): undefined => {
             if (include_streams(query) && item.type === "stream") {
                 stream_pill.append_stream(item, pills);
             } else if (include_user_groups && item.type === "user_group") {
@@ -221,4 +214,4 @@ export function set_up_combined(
         },
         stopAdvance: true,
     });
-}
+};

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -17,10 +17,10 @@ let playground_links_popover_instance: tippy.Instance;
 // Playground_store contains all the data we need to generate a popover of
 // playground links for each code block. The element is the target element
 // to pop off of.
-function toggle_playground_links_popover(
+const toggle_playground_links_popover = (
     element: tippy.ReferenceElement,
     playground_store: Map<number, RealmPlaygroundWithURL>,
-): void {
+): void => {
     if (is_open()) {
         return;
     }
@@ -37,7 +37,7 @@ function toggle_playground_links_popover(
                 },
             ],
         },
-        onCreate(instance) {
+        onCreate: (instance) => {
             // We extract all the values out of playground_store map into
             // the playground_info array. Each element of the array is an
             // object with all properties the template needs for rendering.
@@ -47,30 +47,28 @@ function toggle_playground_links_popover(
                 ui_util.parse_html(render_playground_links_popover({playground_info})),
             );
         },
-        onShow(instance) {
+        onShow: (instance) => {
             const $reference = $(instance.reference);
             $reference.parent().addClass("active-playground-links-reference");
         },
-        onHidden() {
+        onHidden: () => {
             hide();
         },
     });
-}
+};
 
-export function is_open(): boolean {
-    return Boolean(playground_links_popover_instance);
-}
+export const is_open = (): boolean => Boolean(playground_links_popover_instance);
 
-export function hide(): void {
+export const hide = (): void => {
     if (is_open()) {
         $(playground_links_popover_instance.reference)
             .parent()
             .removeClass("active-playground-links-reference");
         playground_links_popover_instance.destroy();
     }
-}
+};
 
-function get_playground_links_popover_items(): JQuery | undefined {
+const get_playground_links_popover_items = (): JQuery | undefined => {
     if (!is_open()) {
         blueslip.error("Trying to get menu items when playground links popover is closed.");
         return undefined;
@@ -83,12 +81,12 @@ function get_playground_links_popover_items(): JQuery | undefined {
     }
 
     return $("li:not(.divider):visible a", $popover);
-}
+};
 
-export function handle_keyboard(key: string): void {
+export const handle_keyboard = (key: string): void => {
     const $items = get_playground_links_popover_items();
     popover_menus.popover_items_handle_keyboard(key, $items);
-}
+};
 
 function register_click_handlers(): void {
     $("#main_div, #preview_content, #message-history").on(
@@ -138,6 +136,6 @@ function register_click_handlers(): void {
     });
 }
 
-export function initialize(): void {
+export const initialize = (): void => {
     register_click_handlers();
-}
+};

--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -10,15 +10,13 @@ type PMConversation = {
 
 const partners = new Set<number>();
 
-export function set_partner(user_id: number): void {
+export const set_partner = (user_id: number): void => {
     partners.add(user_id);
-}
+};
 
-export function is_partner(user_id: number): boolean {
-    return partners.has(user_id);
-}
+export const is_partner = (user_id: number): boolean => partners.has(user_id);
 
-function filter_muted_pms(conversation: PMConversation): boolean {
+const filter_muted_pms = (conversation: PMConversation): boolean => {
     // We hide muted users from the top left corner, as well as those huddles
     // in which all participants are muted.
     const recipients = people.split_to_ints(conversation.user_ids_string);
@@ -28,7 +26,7 @@ function filter_muted_pms(conversation: PMConversation): boolean {
     }
 
     return true;
-}
+};
 
 class RecentDirectMessages {
     // This data structure keeps track of the sets of users you've had
@@ -103,7 +101,7 @@ class RecentDirectMessages {
 
 export let recent = new RecentDirectMessages();
 
-export function process_message(message: Message): void {
+export const process_message = (message: Message): void => {
     const user_ids = people.pm_with_user_ids(message);
     if (!user_ids) {
         return;
@@ -114,9 +112,9 @@ export function process_message(message: Message): void {
     }
 
     recent.insert(user_ids, message.id);
-}
+};
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     recent = new RecentDirectMessages();
     partners.clear();
-}
+};

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -22,25 +22,22 @@ let private_messages_collapsed = false;
 // This keeps track of if we're zoomed in or not.
 let zoomed = false;
 
-function get_private_messages_section_header(): JQuery {
-    return $(
-        ".direct-messages-container #private_messages_section #private_messages_section_header",
-    );
-}
+const get_private_messages_section_header = (): JQuery =>
+    $(".direct-messages-container #private_messages_section #private_messages_section_header");
 
-export function set_count(count: number): void {
+export const set_count = (count: number): void => {
     ui_util.update_unread_count_in_dom(get_private_messages_section_header(), count);
-}
+};
 
-export function close(): void {
+export const close = (): void => {
     private_messages_collapsed = true;
     $("#toggle_private_messages_section_icon").removeClass("fa-caret-down");
     $("#toggle_private_messages_section_icon").addClass("fa-caret-right");
 
     update_private_messages();
-}
+};
 
-export function _build_direct_messages_list(): vdom.Tag<PMNode> {
+export const _build_direct_messages_list = (): vdom.Tag<PMNode> => {
     const conversations = pm_list_data.get_conversations();
     const pm_list_info = pm_list_data.get_list_info(zoomed);
     const conversations_to_be_shown = pm_list_info.conversations_to_be_shown;
@@ -58,24 +55,22 @@ export function _build_direct_messages_list(): vdom.Tag<PMNode> {
     }
     const dom_ast = pm_list_dom.pm_ul(pm_list_nodes);
     return dom_ast;
-}
+};
 
-function set_dom_to(new_dom: vdom.Tag<PMNode>): void {
+const set_dom_to = (new_dom: vdom.Tag<PMNode>): void => {
     const $container = scroll_util.get_content_element($("#direct-messages-list"));
 
-    function replace_content(html: string): void {
+    const replace_content = (html: string): void => {
         $container.html(html);
-    }
+    };
 
-    function find(): JQuery {
-        return $container.find("ul");
-    }
+    const find = (): JQuery => $container.find("ul");
 
     vdom.update(replace_content, find, new_dom, prior_dom);
     prior_dom = new_dom;
-}
+};
 
-export function update_private_messages(): void {
+export const update_private_messages = (): void => {
     if (private_messages_collapsed) {
         // In the collapsed state, we will still display the current
         // conversation, to preserve the UI invariant that there's
@@ -99,17 +94,17 @@ export function update_private_messages(): void {
     // Make sure to update the left sidebar heights after updating
     // direct messages.
     setTimeout(resize.resize_stream_filters_container, 0);
-}
+};
 
-export function expand(): void {
+export const expand = (): void => {
     private_messages_collapsed = false;
 
     $("#toggle_private_messages_section_icon").addClass("fa-caret-down");
     $("#toggle_private_messages_section_icon").removeClass("fa-caret-right");
     update_private_messages();
-}
+};
 
-export function update_dom_with_unread_counts(counts: FullUnreadCountsData): void {
+export const update_dom_with_unread_counts = (counts: FullUnreadCountsData): void => {
     // In theory, we could support passing the counts object through
     // to pm_list_data, rather than fetching it directly there. But
     // it's not an important optimization, because it's unlikely a
@@ -118,31 +113,31 @@ export function update_dom_with_unread_counts(counts: FullUnreadCountsData): voi
     update_private_messages();
     // This is just the global unread count.
     set_count(counts.direct_message_count);
-}
+};
 
-export function highlight_all_private_messages_view(): void {
+export const highlight_all_private_messages_view = (): void => {
     $(".direct-messages-container").addClass("active_private_messages_section");
-}
+};
 
-function unhighlight_all_private_messages_view(): void {
+const unhighlight_all_private_messages_view = (): void => {
     $(".direct-messages-container").removeClass("active_private_messages_section");
-}
+};
 
-function scroll_pm_into_view($target_li: JQuery): void {
+const scroll_pm_into_view = ($target_li: JQuery): void => {
     const $container = $("#left_sidebar_scroll_container");
     const pm_header_height = $("#private_messages_section_header").outerHeight();
     if ($target_li.length > 0) {
         scroll_util.scroll_element_into_container($target_li, $container, pm_header_height);
     }
-}
+};
 
-function scroll_all_private_into_view(): void {
+const scroll_all_private_into_view = (): void => {
     const $container = $("#left_sidebar_scroll_container");
     const $scroll_element = scroll_util.get_scroll_element($container);
     $scroll_element.scrollTop(0);
-}
+};
 
-export function handle_narrow_activated(filter: Filter): void {
+export const handle_narrow_activated = (filter: Filter): void => {
     const active_filter = filter;
     const is_all_private_message_view = _.isEqual(active_filter.sorted_term_types(), ["is-dm"]);
     const narrow_to_private_messages_section = active_filter.operands("dm").length !== 0;
@@ -170,20 +165,18 @@ export function handle_narrow_activated(filter: Filter): void {
     } else if (!is_private_messages_in_view) {
         update_private_messages();
     }
-}
+};
 
-export function handle_message_view_deactivated(): void {
+export const handle_message_view_deactivated = (): void => {
     // Since one can renarrow via the keyboard shortcut or similar, we
     // avoid disturbing the zoomed state here.
     unhighlight_all_private_messages_view();
     update_private_messages();
-}
+};
 
-export function is_private_messages_collapsed(): boolean {
-    return private_messages_collapsed;
-}
+export const is_private_messages_collapsed = (): boolean => private_messages_collapsed;
 
-export function toggle_private_messages_section(): void {
+export const toggle_private_messages_section = (): void => {
     // change the state of direct message section depending on
     // the previous state.
     if (private_messages_collapsed) {
@@ -191,25 +184,25 @@ export function toggle_private_messages_section(): void {
     } else {
         close();
     }
-}
+};
 
-function zoom_in(): void {
+const zoom_in = (): void => {
     zoomed = true;
     update_private_messages();
     $(".direct-messages-container").removeClass("zoom-out").addClass("zoom-in");
     $("#streams_list").hide();
     $(".left-sidebar .right-sidebar-items").hide();
-}
+};
 
-function zoom_out(): void {
+const zoom_out = (): void => {
     zoomed = false;
     update_private_messages();
     $(".direct-messages-container").removeClass("zoom-in").addClass("zoom-out");
     $("#streams_list").show();
     $(".left-sidebar .right-sidebar-items").show();
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $(".direct-messages-container").on("click", "#show-more-direct-messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -223,4 +216,4 @@ export function initialize(): void {
 
         zoom_out();
     });
-}
+};

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -15,7 +15,7 @@ const max_conversations_to_show = 8;
 // Maximum number of conversation threads to show in default view with unreads.
 const max_conversations_to_show_with_unreads = 15;
 
-export function get_active_user_ids_string(): string | undefined {
+export const get_active_user_ids_string = (): string | undefined => {
     const filter = narrow_state.filter();
 
     if (!filter) {
@@ -29,7 +29,7 @@ export function get_active_user_ids_string(): string | undefined {
     }
 
     return people.emails_strings_to_user_ids_string(emails);
-}
+};
 
 type DisplayObject = {
     recipients: string;
@@ -44,7 +44,7 @@ type DisplayObject = {
     is_bot: boolean;
 };
 
-export function get_conversations(): DisplayObject[] {
+export const get_conversations = (): DisplayObject[] => {
     const private_messages = pm_conversations.recent.get();
     const display_objects = [];
 
@@ -101,13 +101,15 @@ export function get_conversations(): DisplayObject[] {
     }
 
     return display_objects;
-}
+};
 
 // Designed to closely match topic_list_data.get_list_info().
-export function get_list_info(zoomed: boolean): {
+export const get_list_info = (
+    zoomed: boolean,
+): {
     conversations_to_be_shown: DisplayObject[];
     more_conversations_unread_count: number;
-} {
+} => {
     const conversations = get_conversations();
 
     if (zoomed || conversations.length <= max_conversations_to_show) {
@@ -119,7 +121,7 @@ export function get_list_info(zoomed: boolean): {
 
     const conversations_to_be_shown = [];
     let more_conversations_unread_count = 0;
-    function should_show_conversation(idx: number, conversation: DisplayObject): boolean {
+    const should_show_conversation = (idx: number, conversation: DisplayObject): boolean => {
         // We always show the active conversation; see the similar
         // comment in topic_list_data.ts.
         if (conversation.is_active) {
@@ -149,7 +151,7 @@ export function get_list_info(zoomed: boolean): {
         // Otherwise, this conversation should only be visible in
         // the unzoomed view.
         return false;
-    }
+    };
     for (const [idx, conversation] of conversations.entries()) {
         if (should_show_conversation(idx, conversation)) {
             conversations_to_be_shown.push(conversation);
@@ -162,4 +164,4 @@ export function get_list_info(zoomed: boolean): {
         conversations_to_be_shown,
         more_conversations_unread_count,
     };
-}
+};

--- a/web/src/pm_list_dom.ts
+++ b/web/src/pm_list_dom.ts
@@ -20,7 +20,7 @@ export type PMNode =
           more_conversations_unread_count: number;
       };
 
-export function keyed_pm_li(conversation: PMListConversation): vdom.Node<PMNode> {
+export const keyed_pm_li = (conversation: PMListConversation): vdom.Node<PMNode> => {
     const render = (): string => render_pm_list_item(conversation);
 
     const eq = (other: PMNode): boolean =>
@@ -35,11 +35,11 @@ export function keyed_pm_li(conversation: PMListConversation): vdom.Node<PMNode>
         type: "conversation",
         conversation,
     };
-}
+};
 
-export function more_private_conversations_li(
+export const more_private_conversations_li = (
     more_conversations_unread_count: number,
-): vdom.Node<PMNode> {
+): vdom.Node<PMNode> => {
     const render = (): string =>
         render_more_private_conversations({more_conversations_unread_count});
 
@@ -59,9 +59,9 @@ export function more_private_conversations_li(
         type: "more_items",
         more_conversations_unread_count,
     };
-}
+};
 
-export function pm_ul(nodes: vdom.Node<PMNode>[]): vdom.Tag<PMNode> {
+export const pm_ul = (nodes: vdom.Node<PMNode>[]): vdom.Tag<PMNode> => {
     const attrs: [string, string][] = [
         ["class", "dm-list"],
         ["data-name", "private"],
@@ -70,4 +70,4 @@ export function pm_ul(nodes: vdom.Node<PMNode>[]): vdom.Tag<PMNode> {
         attrs,
         keyed_nodes: nodes,
     });
-}
+};

--- a/web/src/poll_modal.ts
+++ b/web/src/poll_modal.ts
@@ -3,11 +3,11 @@ import SortableJS from "sortablejs";
 
 import render_poll_modal_option from "../templates/poll_modal_option.hbs";
 
-function create_option_row($last_option_row_input: JQuery): void {
+const create_option_row = ($last_option_row_input: JQuery): void => {
     const row_html = render_poll_modal_option();
     const $row_container = $last_option_row_input.closest(".simplebar-content");
     $row_container.append($(row_html));
-}
+};
 
 function add_option_row(this: HTMLElement): void {
     // if the option triggering the input event e is not the last,
@@ -26,7 +26,7 @@ function delete_option_row(this: HTMLElement): void {
     $row.remove();
 }
 
-export function poll_options_setup(): void {
+export const poll_options_setup = (): void => {
     const $poll_options_list = $("#add-poll-form .poll-options-list");
     const $submit_button = $("#add-poll-modal .dialog_submit_button");
     const $question_input = $<HTMLInputElement>("#add-poll-form input#poll-question-input");
@@ -47,7 +47,7 @@ export function poll_options_setup(): void {
     // setTimeout is needed to here to give time for simplebar to initialise
     setTimeout(() => {
         SortableJS.create($("#add-poll-form .poll-options-list .simplebar-content")[0]!, {
-            onUpdate() {
+            onUpdate: () => {
                 // Do nothing on drag; the order is only processed on submission.
             },
             // We don't want the last (empty) row to be draggable, as a new row
@@ -56,7 +56,7 @@ export function poll_options_setup(): void {
             preventOnFilter: false,
         });
     }, 0);
-}
+};
 
 export function frame_poll_message_content(): string {
     const question = $<HTMLInputElement>("input#poll-question-input").val()!.trim();

--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -23,7 +23,7 @@ export type PollWidgetExtraData = {
     options?: string[] | undefined;
 };
 
-export function activate({
+export const activate = ({
     $elem,
     callback,
     extra_data: {question = "", options = []} = {},
@@ -35,7 +35,7 @@ export function activate({
     ) => void;
     extra_data: PollWidgetExtraData;
     message: Message;
-}): (events: Event[]) => void {
+}): ((events: Event[]) => void) => {
     const is_my_poll = people.is_my_user_id(message.sender_id);
     const poll_data = new PollData({
         message_sender_id: message.sender_id,
@@ -47,13 +47,13 @@ export function activate({
         report_error_function: blueslip.warn,
     });
 
-    function update_edit_controls(): void {
+    const update_edit_controls = (): void => {
         const has_question =
             $elem.find<HTMLInputElement>("input.poll-question").val()!.trim() !== "";
         $elem.find("button.poll-question-check").toggle(has_question);
-    }
+    };
 
-    function render_question(): void {
+    const render_question = (): void => {
         const question = poll_data.get_question();
         const input_mode = poll_data.get_input_mode();
         const can_edit = is_my_poll && !input_mode;
@@ -73,23 +73,23 @@ export function activate({
         $elem.find(".poll-please-wait").toggle(waiting);
 
         $elem.find(".poll-author-help").toggle(author_help);
-    }
+    };
 
-    function start_editing(): void {
+    const start_editing = (): void => {
         poll_data.set_input_mode();
 
         const question = poll_data.get_question();
         $elem.find("input.poll-question").val(question);
         render_question();
         $elem.find("input.poll-question").trigger("focus");
-    }
+    };
 
-    function abort_edit(): void {
+    const abort_edit = (): void => {
         poll_data.clear_input_mode();
         render_question();
-    }
+    };
 
-    function submit_question(): void {
+    const submit_question = (): void => {
         const $poll_question_input = $elem.find<HTMLInputElement>("input.poll-question");
         let new_question = $poll_question_input.val()!.trim();
         const old_question = poll_data.get_question();
@@ -112,9 +112,9 @@ export function activate({
         // Broadcast the new question to our peers.
         const data = poll_data.handle.question.outbound(new_question);
         callback(data);
-    }
+    };
 
-    function submit_option(): void {
+    const submit_option = (): void => {
         const $poll_option_input = $elem.find<HTMLInputElement>("input.poll-option");
         const option = $poll_option_input.val()!.trim();
         const options = poll_data.get_widget_data().options;
@@ -131,14 +131,14 @@ export function activate({
 
         const data = poll_data.handle.new_option.outbound(option);
         callback(data);
-    }
+    };
 
-    function submit_vote(key: string): void {
+    const submit_vote = (key: string): void => {
         const data = poll_data.handle.vote.outbound(key);
         callback(data);
-    }
+    };
 
-    function build_widget(): void {
+    const build_widget = (): void => {
         const html = render_widgets_poll_widget({});
         $elem.html(html);
 
@@ -196,9 +196,9 @@ export function activate({
                 return;
             }
         });
-    }
+    };
 
-    function check_option_button(): void {
+    const check_option_button = (): void => {
         const $poll_option_input = $elem.find<HTMLInputElement>("input.poll-option");
         const option = $poll_option_input.val()!.trim();
         const options = poll_data.get_widget_data().options;
@@ -212,9 +212,9 @@ export function activate({
             $elem.find("button.poll-option").prop("disabled", false);
             $elem.find("button.poll-option").removeAttr("title");
         }
-    }
+    };
 
-    function render_results(): void {
+    const render_results = (): void => {
         const widget_data = poll_data.get_widget_data();
 
         const html = render_widgets_poll_widget_results(widget_data);
@@ -228,9 +228,9 @@ export function activate({
                 const key = $(e.target).attr("data-key")!;
                 submit_vote(key);
             });
-    }
+    };
 
-    const handle_events = function (events: Event[]): void {
+    const handle_events = (events: Event[]): void => {
         for (const event of events) {
             poll_data.handle_event(event.sender_id, event.data);
         }
@@ -244,4 +244,4 @@ export function activate({
     render_results();
 
     return handle_events;
-}
+};

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -50,7 +50,7 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
 };
 
 /* Keyboard UI functions */
-export function popover_items_handle_keyboard(key: string, $items?: JQuery): void {
+export const popover_items_handle_keyboard = (key: string, $items?: JQuery): void => {
     if (!$items) {
         return;
     }
@@ -74,74 +74,62 @@ export function popover_items_handle_keyboard(key: string, $items?: JQuery): voi
         index -= 1;
     }
     $items.eq(index).trigger("focus");
-}
+};
 
-export function focus_first_popover_item($items: JQuery, index = 0): void {
+export const focus_first_popover_item = ($items: JQuery, index = 0): void => {
     if (!$items) {
         return;
     }
 
     $items.eq(index).expectOne().trigger("focus");
-}
+};
 
-export function sidebar_menu_instance_handle_keyboard(instance: tippy.Instance, key: string): void {
+export const sidebar_menu_instance_handle_keyboard = (
+    instance: tippy.Instance,
+    key: string,
+): void => {
     const items = get_popover_items_for_instance(instance);
     popover_items_handle_keyboard(key, items);
-}
+};
 
-export function get_visible_instance(): tippy.Instance | null | undefined {
-    return Object.values(popover_instances).find(Boolean);
-}
+export const get_visible_instance = (): tippy.Instance | null | undefined =>
+    Object.values(popover_instances).find(Boolean);
 
-export function get_topic_menu_popover(): tippy.Instance | null {
-    return popover_instances.topics_menu;
-}
+export const get_topic_menu_popover = (): tippy.Instance | null => popover_instances.topics_menu;
 
-export function is_topic_menu_popover_displayed(): boolean | undefined {
-    return popover_instances.topics_menu?.state.isVisible;
-}
+export const is_topic_menu_popover_displayed = (): boolean | undefined =>
+    popover_instances.topics_menu?.state.isVisible;
 
-export function is_visibility_policy_popover_displayed(): boolean | undefined {
-    return popover_instances.change_visibility_policy?.state.isVisible;
-}
+export const is_visibility_policy_popover_displayed = (): boolean | undefined =>
+    popover_instances.change_visibility_policy?.state.isVisible;
 
-export function get_scheduled_messages_popover(): tippy.Instance | null {
-    return popover_instances.send_later;
-}
+export const get_scheduled_messages_popover = (): tippy.Instance | null =>
+    popover_instances.send_later;
 
-export function is_scheduled_messages_popover_displayed(): boolean | undefined {
-    return popover_instances.send_later?.state.isVisible;
-}
+export const is_scheduled_messages_popover_displayed = (): boolean | undefined =>
+    popover_instances.send_later?.state.isVisible;
 
-export function get_compose_control_buttons_popover(): tippy.Instance | null {
-    return popover_instances.compose_control_buttons;
-}
+export const get_compose_control_buttons_popover = (): tippy.Instance | null =>
+    popover_instances.compose_control_buttons;
 
-export function get_starred_messages_popover(): tippy.Instance | null {
-    return popover_instances.starred_messages;
-}
+export const get_starred_messages_popover = (): tippy.Instance | null =>
+    popover_instances.starred_messages;
 
-export function is_personal_menu_popover_displayed(): boolean | undefined {
-    return popover_instances.personal_menu?.state.isVisible;
-}
+export const is_personal_menu_popover_displayed = (): boolean | undefined =>
+    popover_instances.personal_menu?.state.isVisible;
 
-export function is_gear_menu_popover_displayed(): boolean | undefined {
-    return popover_instances.gear_menu?.state.isVisible;
-}
+export const is_gear_menu_popover_displayed = (): boolean | undefined =>
+    popover_instances.gear_menu?.state.isVisible;
 
-export function get_gear_menu_instance(): tippy.Instance | null {
-    return popover_instances.gear_menu;
-}
+export const get_gear_menu_instance = (): tippy.Instance | null => popover_instances.gear_menu;
 
-export function is_help_menu_popover_displayed(): boolean | undefined {
-    return popover_instances.help_menu?.state.isVisible;
-}
+export const is_help_menu_popover_displayed = (): boolean | undefined =>
+    popover_instances.help_menu?.state.isVisible;
 
-export function is_message_actions_popover_displayed(): boolean | undefined {
-    return popover_instances.message_actions?.state.isVisible;
-}
+export const is_message_actions_popover_displayed = (): boolean | undefined =>
+    popover_instances.message_actions?.state.isVisible;
 
-function get_popover_items_for_instance(instance: tippy.Instance): JQuery | undefined {
+const get_popover_items_for_instance = (instance: tippy.Instance): JQuery | undefined => {
     const $current_elem = $(instance.popper);
     const class_name = $current_elem.attr("class");
 
@@ -151,16 +139,16 @@ function get_popover_items_for_instance(instance: tippy.Instance): JQuery | unde
     }
 
     return $current_elem.find("a, [tabindex='0']").filter(":visible");
-}
+};
 
-export function hide_current_popover_if_visible(instance: tippy.Instance | null): void {
+export const hide_current_popover_if_visible = (instance: tippy.Instance | null): void => {
     // Call this function instead of `instance.hide` to avoid tippy
     // logging about the possibility of already hidden instances,
     // which can occur when a click handler does a hide_all().
     if (instance?.state.isVisible) {
         instance.hide();
     }
-}
+};
 
 export const default_popover_props: Partial<tippy.Props> = {
     delay: 0,
@@ -188,7 +176,7 @@ export const default_popover_props: Partial<tippy.Props> = {
                 enabled: true,
                 phase: "beforeWrite",
                 requires: ["$$tippy"],
-                fn({state}) {
+                fn: ({state}) => {
                     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     const instance = (state.elements.reference as tippy.ReferenceElement)._tippy!;
                     const $popover = $(state.elements.popper);
@@ -285,7 +273,7 @@ export const left_sidebar_tippy_options = {
     },
 };
 
-export function on_show_prep(instance: tippy.Instance): void {
+export const on_show_prep = (instance: tippy.Instance): void => {
     $(instance.popper).on("click", (e) => {
         // Popover is not hidden on click inside it unless the click handler for the
         // element explicitly hides the popover when handling the event.
@@ -298,80 +286,78 @@ export function on_show_prep(instance: tippy.Instance): void {
         e.stopPropagation();
         hide_current_popover_if_visible(instance);
     });
-}
+};
 
-function get_props_for_popover_centering(
+const get_props_for_popover_centering = (
     popover_props: Partial<tippy.Props>,
-): Partial<tippy.Props> {
-    return {
-        arrow: false,
-        getReferenceClientRect: () => new DOMRect(0, 0, 0, 0),
-        placement: "top",
-        popperOptions: {
-            modifiers: [
-                {
-                    name: "offset",
-                    options: {
-                        offset({popper}: {popper: DOMRect}) {
-                            // Calculate the offset needed to place the reference in the center
-                            const x_offset_to_center = window.innerWidth / 2;
-                            let y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
+): Partial<tippy.Props> => ({
+    arrow: false,
+    getReferenceClientRect: () => new DOMRect(0, 0, 0, 0),
+    placement: "top",
+    popperOptions: {
+        modifiers: [
+            {
+                name: "offset",
+                options: {
+                    offset: ({popper}: {popper: DOMRect}) => {
+                        // Calculate the offset needed to place the reference in the center
+                        const x_offset_to_center = window.innerWidth / 2;
+                        let y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
 
-                            // Move popover to the top of the screen if user is focused on an element which can
-                            // open keyboard on a mobile device causing the screen to resize.
-                            // Resize doesn't happen on iOS when keyboard is open, and typing text in input field just works.
-                            // For other browsers, we need to check if the focused element is an text field and
-                            // is causing a resize (thus calling this `offset` modifier function), in which case
-                            // we need to move the popover to the top of the screen.
-                            if (util.is_mobile()) {
-                                const $focused_element = $(document.activeElement!);
-                                if (
-                                    $focused_element.is(
-                                        "input[type=text], input[type=number], textarea",
-                                    )
-                                ) {
-                                    y_offset_to_center = 10;
-                                }
+                        // Move popover to the top of the screen if user is focused on an element which can
+                        // open keyboard on a mobile device causing the screen to resize.
+                        // Resize doesn't happen on iOS when keyboard is open, and typing text in input field just works.
+                        // For other browsers, we need to check if the focused element is an text field and
+                        // is causing a resize (thus calling this `offset` modifier function), in which case
+                        // we need to move the popover to the top of the screen.
+                        if (util.is_mobile()) {
+                            const $focused_element = $(document.activeElement!);
+                            if (
+                                $focused_element.is(
+                                    "input[type=text], input[type=number], textarea",
+                                )
+                            ) {
+                                y_offset_to_center = 10;
                             }
-                            return [x_offset_to_center, y_offset_to_center];
-                        },
+                        }
+                        return [x_offset_to_center, y_offset_to_center];
                     },
                 },
-            ],
-        },
-        onShow(instance) {
-            // By default, Tippys with the `data-reference-hidden` attribute aren't displayed.
-            // But when we render them as centered overlays on mobile and use
-            // `getReferenceClientRect` for a virtual reference, Tippy slaps this
-            // hidden attribute on our element, making it invisible. We want to bypass
-            // this in scenarios where we're centering popovers on mobile screens.
-            $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
-            if (popover_props.onShow) {
-                popover_props.onShow(instance);
-            }
-        },
-        onMount(instance) {
-            $("body").append($("<div>").attr("id", "popover-overlay-background"));
-            if (popover_props.onMount) {
-                popover_props.onMount(instance);
-            }
-        },
-        onHidden(instance) {
-            $("#popover-overlay-background").remove();
-            if (popover_props.onHidden) {
-                popover_props.onHidden(instance);
-            }
-        },
-    };
-}
+            },
+        ],
+    },
+    onShow: (instance) => {
+        // By default, Tippys with the `data-reference-hidden` attribute aren't displayed.
+        // But when we render them as centered overlays on mobile and use
+        // `getReferenceClientRect` for a virtual reference, Tippy slaps this
+        // hidden attribute on our element, making it invisible. We want to bypass
+        // this in scenarios where we're centering popovers on mobile screens.
+        $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
+        if (popover_props.onShow) {
+            popover_props.onShow(instance);
+        }
+    },
+    onMount: (instance) => {
+        $("body").append($("<div>").attr("id", "popover-overlay-background"));
+        if (popover_props.onMount) {
+            popover_props.onMount(instance);
+        }
+    },
+    onHidden: (instance) => {
+        $("#popover-overlay-background").remove();
+        if (popover_props.onHidden) {
+            popover_props.onHidden(instance);
+        }
+    },
+});
 
 // Toggles a popover menu directly; intended for use in keyboard
 // shortcuts and similar alternative ways to open a popover menu.
-export function toggle_popover_menu(
+export const toggle_popover_menu = (
     target: tippy.ReferenceElement,
     popover_props: Partial<tippy.Props>,
     options?: {show_as_overlay_on_mobile: boolean},
-): tippy.Instance {
+): tippy.Instance => {
     const instance = target._tippy;
     if (instance) {
         hide_current_popover_if_visible(instance);
@@ -401,7 +387,7 @@ export function toggle_popover_menu(
         ...popover_props,
         ...mobile_popover_props,
     });
-}
+};
 
 // Main function to define a popover menu, opened via clicking on the
 // target selector.
@@ -433,10 +419,10 @@ export function register_popover_menu(target: string, popover_props: Partial<tip
     });
 }
 
-export function initialize(): void {
+export const initialize = (): void => {
     /* Configure popovers to hide when toggling overlays. */
     overlays.register_pre_open_hook(popovers.hide_all);
     overlays.register_pre_close_hook(popovers.hide_all);
     modals.register_pre_open_hook(popovers.hide_all);
     modals.register_pre_close_hook(popovers.hide_all);
-}
+};

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -25,7 +25,7 @@ import {user_settings} from "./user_settings";
 import * as user_status from "./user_status";
 import * as user_topics from "./user_topics";
 
-export function get_actions_popover_content_context(message_id) {
+export const get_actions_popover_content_context = (message_id) => {
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(message_id);
     const message_container = message_lists.current.view.message_containers.get(message.id);
@@ -90,10 +90,10 @@ export function get_actions_popover_content_context(message_id) {
     const should_display_delete_option = message_edit.get_deletability(message) && not_spectator;
     const should_display_read_receipts_option = realm.realm_enable_read_receipts && not_spectator;
 
-    function is_add_reaction_icon_visible() {
+    const is_add_reaction_icon_visible = () => {
         const $message_row = message_lists.current.get_row(message_id);
         return $message_row.find(".message_controls .reaction_button").is(":visible");
-    }
+    };
 
     // Since we only display msg actions and star icons on windows smaller than
     // `media_breakpoints.sm_min`, we need to include the reaction button in the
@@ -117,9 +117,9 @@ export function get_actions_popover_content_context(message_id) {
         should_display_read_receipts_option,
         should_display_quote_and_reply,
     };
-}
+};
 
-export function get_topic_popover_content_context({stream_id, topic_name, url}) {
+export const get_topic_popover_content_context = ({stream_id, topic_name, url}) => {
     const sub = sub_store.get(stream_id);
     const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
@@ -146,9 +146,9 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         visibility_policy,
         all_visibility_policies,
     };
-}
+};
 
-export function get_change_visibility_policy_popover_content_context(stream_id, topic_name) {
+export const get_change_visibility_policy_popover_content_context = (stream_id, topic_name) => {
     const visibility_policy = user_topics.get_topic_visibility_policy(stream_id, topic_name);
     const sub = sub_store.get(stream_id);
     const all_visibility_policies = user_topics.all_visibility_policies;
@@ -161,9 +161,9 @@ export function get_change_visibility_policy_popover_content_context(stream_id, 
         topic_unmuted,
         all_visibility_policies,
     };
-}
+};
 
-export function get_personal_menu_content_context() {
+export const get_personal_menu_content_context = () => {
     const my_user_id = current_user.user_id;
     const invisible_mode = !user_settings.presence_enabled;
     const status_text = user_status.get_status_text(my_user_id);
@@ -193,9 +193,9 @@ export function get_personal_menu_content_context() {
         user_color_scheme: user_settings.color_scheme,
         color_scheme_values: settings_config.color_scheme_values,
     };
-}
+};
 
-export function get_gear_menu_content_context() {
+export const get_gear_menu_content_context = () => {
     const user_has_billing_access = current_user.is_billing_admin || current_user.is_owner;
     const is_plan_standard = realm.realm_plan_type === 3;
     const is_plan_plus = realm.realm_plan_type === 10;
@@ -231,4 +231,4 @@ export function get_gear_menu_content_context() {
         sponsorship_pending: page_params.sponsorship_pending,
         user_has_billing_access,
     };
-}
+};

--- a/web/src/popovers.ts
+++ b/web/src/popovers.ts
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import * as tippy from "tippy.js";
 
-export function any_active(): boolean {
+export const any_active = (): boolean => {
     // Checks if there are any interactive tippy instances (= popovers) present.
     const $tippy_instances = $<tippy.PopperElement>("div[data-tippy-root]");
     // Tippy instances with `interactive: true` are popovers by definition.
@@ -9,9 +9,9 @@ export function any_active(): boolean {
         (_i, elt) => elt._tippy?.props.interactive === true,
     ).length;
     return Boolean(num_interactive_instances);
-}
+};
 
-export function hide_all(): void {
+export const hide_all = (): void => {
     // Hides all tippy instances (tooltips and popovers).
     tippy.hideAll();
-}
+};

--- a/web/src/portico/communities.ts
+++ b/web/src/portico/communities.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-function sync_open_organizations_page_with_current_hash(): void {
+const sync_open_organizations_page_with_current_hash = (): void => {
     const hash = window.location.hash;
     if (!hash || hash === "#all" || hash === "#undefined") {
         $(".eligible_realm").show();
@@ -12,12 +12,12 @@ function sync_open_organizations_page_with_current_hash(): void {
         $(".realm-category").removeClass("selected");
         $(`[data-category="${CSS.escape(hash.slice(1))}"]`).addClass("selected");
     }
-}
+};
 
-function toggle_categories_dropdown(): void {
+const toggle_categories_dropdown = (): void => {
     const $dropdown_list = $(".integration-categories-dropdown .dropdown-list");
     $dropdown_list.slideToggle(250);
-}
+};
 
 // init
 $(() => {

--- a/web/src/portico/desktop-login.ts
+++ b/web/src/portico/desktop-login.ts
@@ -3,7 +3,7 @@ document.querySelector<HTMLFormElement>("form#form")!.addEventListener("submit",
 });
 document.querySelector<HTMLInputElement>("input#token")!.focus();
 
-async function decrypt_manual(): Promise<{key: Uint8Array; pasted: Promise<string>}> {
+const decrypt_manual = async (): Promise<{key: Uint8Array; pasted: Promise<string>}> => {
     const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["decrypt"]);
     return {
         key: new Uint8Array(await crypto.subtle.exportKey("raw", key)),
@@ -34,7 +34,7 @@ async function decrypt_manual(): Promise<{key: Uint8Array; pasted: Promise<strin
             });
         }),
     };
-}
+};
 
 void (async () => {
     // Sufficiently new versions of the desktop app provide the

--- a/web/src/portico/email_log.ts
+++ b/web/src/portico/email_log.ts
@@ -40,7 +40,7 @@ $(() => {
         void channel.post({
             url: "/emails/",
             data,
-            success() {
+            success: () => {
                 $("#smtp_form_status").show();
                 setTimeout(() => {
                     $("#smtp_form_status").hide();

--- a/web/src/portico/header.ts
+++ b/web/src/portico/header.ts
@@ -3,7 +3,7 @@ import $ from "jquery";
 const EXTRA_SUBMENU_BOTTOM_PADDING = 16;
 
 $(() => {
-    function on_tab_menu_selection_change(changed_element?: HTMLElement): void {
+    const on_tab_menu_selection_change = (changed_element?: HTMLElement): void => {
         // Pass event to open menu and if it is undefined, we close the menu.
         if (!changed_element) {
             $("#top-menu-submenu-backdrop").css("height", "0px");
@@ -18,15 +18,15 @@ $(() => {
         } else {
             $("#top-menu-submenu-backdrop").css("height", 0);
         }
-    }
+    };
 
-    function on_top_menu_tab_unselect_click(): void {
+    const on_top_menu_tab_unselect_click = (): void => {
         // Close the menu.
         $("#top-menu-tab-close").prop("checked", true);
         on_tab_menu_selection_change();
-    }
+    };
 
-    function update_submenu_height_if_visible(): void {
+    const update_submenu_height_if_visible = (): void => {
         if ($(".top-menu-tab-input:checked").length === 1) {
             const sub_menu_height =
                 $(".top-menu-tab-input:checked ~ .top-menu-submenu").height() ?? 0;
@@ -35,7 +35,7 @@ $(() => {
                 sub_menu_height + EXTRA_SUBMENU_BOTTOM_PADDING,
             );
         }
-    }
+    };
 
     // In case user presses `back` with menu open.
     // See https://github.com/zulip/zulip/pull/24301#issuecomment-1418547337.

--- a/web/src/portico/hello.ts
+++ b/web/src/portico/hello.ts
@@ -1,15 +1,15 @@
 import assert from "minimalistic-assert";
 
-function get_new_rand(old_random_int: number, max: number): number {
+const get_new_rand = (old_random_int: number, max: number): number => {
     assert(max >= 2);
     const random_int = Math.floor(Math.random() * max);
     return random_int === old_random_int ? get_new_rand(random_int, max) : random_int;
-}
+};
 
-function get_random_item_from_array<T>(array: T[]): T {
+const get_random_item_from_array = <T>(array: T[]): T => {
     assert(array.length >= 1);
     return array[Math.floor(Math.random() * array.length)]!;
-}
+};
 
 const current_client_logo_class_names = new Set([
     "client-logos__logo_akamai",
@@ -31,7 +31,7 @@ const future_client_logo_class_names = new Set([
     "client-logos__logo_asciidoc",
 ]);
 let current_client_logo_class_names_index = 0;
-function update_client_logo(): void {
+const update_client_logo = (): void => {
     if (document.hidden) {
         return;
     }
@@ -52,6 +52,6 @@ function update_client_logo(): void {
     client_logo_elt.className = next_logo_class;
     current_client_logo_class_names.add(next_logo_class);
     future_client_logo_class_names.add(current_logo_class);
-}
+};
 
 setInterval(update_client_logo, 2500);

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -31,18 +31,14 @@ function register_tabbed_section($tabbed_section) {
 
 // Display the copy-to-clipboard button inside the .codehilite element
 // within the API and Help Center docs using clipboard.js
-function add_copy_to_clipboard_element($codehilite) {
+const add_copy_to_clipboard_element = ($codehilite) => {
     const $copy_button = $("<button>").addClass("copy-codeblock");
     $copy_button.html(copy_to_clipboard_svg());
 
     $($codehilite).append($copy_button);
 
     const clipboard = new ClipboardJS($copy_button[0], {
-        text(copy_element) {
-            // trim to remove trailing whitespace introduced
-            // by additional elements inside <pre>
-            return $(copy_element).siblings("pre").text().trim();
-        },
+        text: (copy_element) => $(copy_element).siblings("pre").text().trim(),
     });
 
     // Show a tippy tooltip when the button is hovered
@@ -74,7 +70,7 @@ function add_copy_to_clipboard_element($codehilite) {
             tooltip_copied.hide();
         }, 1000);
     });
-}
+};
 
 function render_tabbed_sections() {
     $(".tabbed-section").each(function () {

--- a/web/src/portico/integrations.js
+++ b/web/src/portico/integrations.js
@@ -13,7 +13,7 @@ import {path_parts} from "./landing-page";
 const INTEGRATIONS = new Map();
 const CATEGORIES = new Map();
 
-function load_data() {
+const load_data = () => {
     for (const integration of $(".integration-lozenge")) {
         const name = $(integration).data("name");
         const display_name = $(integration).find(".integration-name").text().trim();
@@ -31,7 +31,7 @@ function load_data() {
             CATEGORIES.set(name, display_name);
         }
     }
-}
+};
 
 const INITIAL_STATE = {
     category: "all",
@@ -41,7 +41,7 @@ const INITIAL_STATE = {
 
 let state = {...INITIAL_STATE};
 
-function adjust_font_sizing() {
+const adjust_font_sizing = () => {
     for (const integration of $(".integration-lozenge")) {
         const $integration_name = $(integration).find(".integration-name");
         const $integration_category = $(integration).find(".integration-category");
@@ -61,9 +61,9 @@ function adjust_font_sizing() {
             }
         }
     }
-}
+};
 
-function update_path() {
+const update_path = () => {
     let next_path;
     if (state.integration) {
         next_path = $(`.integration-lozenge[data-name="${CSS.escape(state.integration)}"]`)
@@ -79,9 +79,9 @@ function update_path() {
 
     window.history.pushState(state, "", next_path);
     google_analytics.config({page_path: next_path});
-}
+};
 
-function update_categories() {
+const update_categories = () => {
     $(".integration-lozenges").css("opacity", 0);
 
     $(".integration-category").removeClass("selected");
@@ -97,7 +97,7 @@ function update_categories() {
     $(".integration-lozenges").animate({opacity: 1}, {duration: 400});
 
     adjust_font_sizing();
-}
+};
 
 const update_integrations = _.debounce(() => {
     const max_scrollY = window.scrollY;
@@ -134,7 +134,7 @@ const update_integrations = _.debounce(() => {
     adjust_font_sizing();
 }, 50);
 
-function hide_catalog_show_integration() {
+const hide_catalog_show_integration = () => {
     const $lozenge_icon = $(
         `.integration-lozenge.integration-${CSS.escape(state.integration)}`,
     ).clone(false);
@@ -146,7 +146,7 @@ function hide_catalog_show_integration() {
         .split(",")
         .map((category) => category.trim().slice(1, -1));
 
-    function show_integration(doc) {
+    const show_integration = (doc) => {
         $("#integration-instructions-group .name").text(INTEGRATIONS.get(state.integration));
         $("#integration-instructions-group .categories .integration-category").remove();
         for (const category of categories) {
@@ -180,22 +180,22 @@ function hide_catalog_show_integration() {
         $("#integration-instructions-group").animate({opacity: 1}, {duration: 300});
 
         adjust_font_sizing();
-    }
+    };
 
-    function hide_catalog(doc) {
+    const hide_catalog = (doc) => {
         $(".integration-categories-dropdown").css("display", "none");
         $(".integrations .catalog").addClass("hide");
         $(".extra, .integration-main-text, #integration-search").css("display", "none");
 
         show_integration(doc);
         $(".main").css("visibility", "visible");
-    }
+    };
 
     $.get({
         url: "/integrations/doc-html/" + state.integration,
         dataType: "html",
         success: hide_catalog,
-        error(err) {
+        error: (err) => {
             if (err.readyState !== 0) {
                 blueslip.error(`Integration documentation for '${state.integration}' not found.`, {
                     readyState: err.readyState,
@@ -205,30 +205,30 @@ function hide_catalog_show_integration() {
             }
         },
     });
-}
+};
 
-function hide_integration_show_catalog() {
-    function show_catalog() {
+const hide_integration_show_catalog = () => {
+    const show_catalog = () => {
         $("html, body").animate({scrollTop: 0}, {duration: 200});
 
         $(".integration-categories-dropdown").css("display", "");
         $(".integrations .catalog").removeClass("hide");
         $(".extra, .integration-main-text, #integration-search").css("display", "block");
         adjust_font_sizing();
-    }
+    };
 
-    function hide_integration() {
+    const hide_integration = () => {
         $("#integration-instruction-block").css("display", "none");
         $("#integration-instructions-group").css("display", "none");
         $(".inner-content").css({padding: ""});
         $("#integration-instruction-block .integration-lozenge").remove();
         show_catalog();
-    }
+    };
 
     hide_integration();
-}
+};
 
-function get_state_from_path() {
+const get_state_from_path = () => {
     const result = {...INITIAL_STATE};
     result.query = state.query;
 
@@ -240,9 +240,9 @@ function get_state_from_path() {
     }
 
     return result;
-}
+};
 
-function render(next_state) {
+const render = (next_state) => {
     const previous_state = {...state};
     state = next_state;
 
@@ -264,9 +264,9 @@ function render(next_state) {
 
         $(".main").css("visibility", "visible");
     }
-}
+};
 
-function dispatch(action, payload) {
+const dispatch = (action, payload) => {
     switch (action) {
         case "CHANGE_CATEGORY":
             render({...state, category: payload.category});
@@ -301,14 +301,14 @@ function dispatch(action, payload) {
             blueslip.error("Invalid action dispatched on /integrations.");
             break;
     }
-}
+};
 
-function toggle_categories_dropdown() {
+const toggle_categories_dropdown = () => {
     const $dropdown_list = $(".integration-categories-dropdown .dropdown-list");
     $dropdown_list.slideToggle(250);
-}
+};
 
-function integration_events() {
+const integration_events = () => {
     $('#integration-search input[type="text"]').on("keypress", (e) => {
         if (e.key === "Enter" && e.target.value !== "") {
             $(".integration-lozenges .integration-lozenge:visible")[0]?.closest("a").click();
@@ -373,7 +373,7 @@ function integration_events() {
             window.location = window.location.href;
         }
     });
-}
+};
 
 // init
 $(() => {

--- a/web/src/portico/integrations_dev_panel.js
+++ b/web/src/portico/integrations_dev_panel.js
@@ -16,27 +16,27 @@ const clear_handlers = {
     topic_name: "#topic_name",
     URL: "#URL",
     results_notice: "#results_notice",
-    bot_name() {
+    bot_name: () => {
         $("#bot_name").children()[0].selected = true;
     },
-    integration_name() {
+    integration_name: () => {
         $("#integration_name").children()[0].selected = true;
     },
-    fixture_name() {
+    fixture_name: () => {
         $("#fixture_name").empty();
     },
-    fixture_body() {
+    fixture_body: () => {
         $("#fixture_body")[0].value = "";
     },
-    custom_http_headers() {
+    custom_http_headers: () => {
         $("#custom_http_headers")[0].value = "{}";
     },
-    results() {
+    results: () => {
         $("#idp-results")[0].value = "";
     },
 };
 
-function clear_elements(elements) {
+const clear_elements = (elements) => {
     // Supports strings (a selector to clear) or calling a function
     // (for more complex logic).
     for (const element_name of elements) {
@@ -48,7 +48,7 @@ function clear_elements(elements) {
         }
     }
     return;
-}
+};
 
 // Success/failure colors used for displaying results to the user.
 const results_notice_level_to_color_map = {
@@ -56,23 +56,17 @@ const results_notice_level_to_color_map = {
     success: "#085d44",
 };
 
-function set_results_notice(msg, level) {
+const set_results_notice = (msg, level) => {
     $("#results_notice").text(msg).css("color", results_notice_level_to_color_map[level]);
-}
+};
 
-function get_api_key_from_selected_bot() {
-    return $("#bot_name").val();
-}
+const get_api_key_from_selected_bot = () => $("#bot_name").val();
 
-function get_selected_integration_name() {
-    return $("#integration_name").val();
-}
+const get_selected_integration_name = () => $("#integration_name").val();
 
-function get_fixture_format(fixture_name) {
-    return fixture_name.split(".").at(-1);
-}
+const get_fixture_format = (fixture_name) => fixture_name.split(".").at(-1);
 
-function get_custom_http_headers() {
+const get_custom_http_headers = () => {
     let custom_headers = $("#custom_http_headers").val();
     if (custom_headers !== "") {
         // JSON.parse("") would trigger an error, as empty strings do not qualify as JSON.
@@ -85,9 +79,9 @@ function get_custom_http_headers() {
         }
     }
     return custom_headers;
-}
+};
 
-function set_results(response) {
+const set_results = (response) => {
     /* The backend returns the JSON responses for each of the
     send_message actions included in our request (which is just 1 for
     send, but usually is several for send all).  We display these
@@ -107,9 +101,9 @@ function set_results(response) {
         data += "\nResponse:       " + response.message + "\n\n";
     }
     $("#idp-results")[0].value = data;
-}
+};
 
-function load_fixture_body(fixture_name) {
+const load_fixture_body = (fixture_name) => {
     /* Given a fixture name, use the loaded_fixtures dictionary to set
      * the fixture body field. */
     const integration_name = get_selected_integration_name();
@@ -128,9 +122,9 @@ function load_fixture_body(fixture_name) {
     $("#custom_http_headers")[0].value = JSON.stringify(headers, null, 4);
 
     return;
-}
+};
 
-function load_fixture_options(integration_name) {
+const load_fixture_options = (integration_name) => {
     /* Using the integration name and loaded_fixtures object to set
     the fixture options for the fixture_names dropdown and also set
     the fixture body to the first fixture by default. */
@@ -146,9 +140,9 @@ function load_fixture_options(integration_name) {
     load_fixture_body(fixtures_names[0]);
 
     return;
-}
+};
 
-function update_url() {
+const update_url = () => {
     /* Construct the URL that the webhook should be targeting, using
     the bot's API key and the integration name.  The stream and topic
     are both optional, and for the sake of completeness, it should be
@@ -176,10 +170,10 @@ function update_url() {
     }
 
     return;
-}
+};
 
 // API callers: These methods handle communicating with the Python backend API.
-function handle_unsuccessful_response(response) {
+const handle_unsuccessful_response = (response) => {
     if (response.responseJSON?.msg) {
         const status_code = response.statusCode().status;
         set_results_notice(`Result: (${status_code}) ${response.responseJSON.msg}`, "warning");
@@ -191,9 +185,9 @@ function handle_unsuccessful_response(response) {
         document.write(response.responseText);
     }
     return;
-}
+};
 
-function get_fixtures(integration_name) {
+const get_fixtures = (integration_name) => {
     /* Request fixtures from the backend for any integrations that we
     don't already have fixtures cached in loaded_fixtures). */
     if (integration_name === "") {
@@ -217,7 +211,7 @@ function get_fixtures(integration_name) {
     // /devtools/integrations/<integration_name>/fixtures
     channel.get({
         url: "/devtools/integrations/" + integration_name + "/fixtures",
-        success(response) {
+        success: (response) => {
             loaded_fixtures.set(integration_name, response.fixtures);
             load_fixture_options(integration_name);
             return;
@@ -226,9 +220,9 @@ function get_fixtures(integration_name) {
     });
 
     return;
-}
+};
 
-function send_webhook_fixture_message() {
+const send_webhook_fixture_message = () => {
     /* Make sure that the user is sending valid JSON in the fixture
     body and that the URL is not empty. Then simply send the fixture
     body to the target URL. */
@@ -265,10 +259,10 @@ function send_webhook_fixture_message() {
     channel.post({
         url: "/devtools/integrations/check_send_webhook_fixture_message",
         data: {url, body, custom_headers, is_json},
-        beforeSend(xhr) {
+        beforeSend: (xhr) => {
             xhr.setRequestHeader("X-CSRFToken", csrftoken);
         },
-        success(response) {
+        success: (response) => {
             // If the previous fixture body was sent successfully,
             // then we should change the success message up a bit to
             // let the user easily know that this fixture body was
@@ -285,9 +279,9 @@ function send_webhook_fixture_message() {
     });
 
     return;
-}
+};
 
-function send_all_fixture_messages() {
+const send_all_fixture_messages = () => {
     /* Send all fixture messages for a given integration. */
     const url = $("#URL").val();
     const integration = get_selected_integration_name();
@@ -300,17 +294,17 @@ function send_all_fixture_messages() {
     channel.post({
         url: "/devtools/integrations/send_all_webhook_fixture_messages",
         data: {url, integration_name: integration},
-        beforeSend(xhr) {
+        beforeSend: (xhr) => {
             xhr.setRequestHeader("X-CSRFToken", csrftoken);
         },
-        success(response) {
+        success: (response) => {
             set_results(response);
         },
         error: handle_unsuccessful_response,
     });
 
     return;
-}
+};
 
 // Initialization
 $(() => {

--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -6,11 +6,9 @@ import {page_params} from "../base_page_params";
 import {detect_user_os} from "./tabbed-instructions";
 import render_tabs from "./team";
 
-export function path_parts() {
-    return window.location.pathname.split("/").filter((chunk) => chunk !== "");
-}
+export const path_parts = () => window.location.pathname.split("/").filter((chunk) => chunk !== "");
 
-const apps_events = function () {
+const apps_events = () => {
     const info = {
         windows: {
             alt: "Windows",
@@ -67,7 +65,7 @@ const apps_events = function () {
 
     let version;
 
-    function get_version_from_path() {
+    const get_version_from_path = () => {
         let result;
         const parts = path_parts();
 
@@ -79,9 +77,9 @@ const apps_events = function () {
 
         result = result || detect_user_os();
         return result;
-    }
+    };
 
-    const update_page = function () {
+    const update_page = () => {
         const $download_instructions = $(".download-instructions");
         const $third_party_apps = $("#third-party-apps");
         const $download_android_apk = $("#download-android-apk");
@@ -117,7 +115,7 @@ const apps_events = function () {
     update_page();
 };
 
-const events = function () {
+const events = () => {
     if (path_parts().includes("apps")) {
         apps_events();
     }

--- a/web/src/portico/portico_modals.ts
+++ b/web/src/portico/portico_modals.ts
@@ -4,11 +4,9 @@ import assert from "minimalistic-assert";
 
 import * as blueslip from "../blueslip";
 
-function is_open(): boolean {
-    return $(".micromodal").hasClass("modal--open");
-}
+const is_open = (): boolean => $(".micromodal").hasClass("modal--open");
 
-function active_modal(): string | undefined {
+const active_modal = (): string | undefined => {
     if (!is_open()) {
         blueslip.error("Programming error — Called active_modal when there is no modal open");
         return undefined;
@@ -16,9 +14,9 @@ function active_modal(): string | undefined {
 
     const $micromodal = $(".micromodal.modal--open");
     return `#${CSS.escape($micromodal.attr("id")!)}`;
-}
+};
 
-export function close_active(): void {
+export const close_active = (): void => {
     if (!is_open()) {
         blueslip.warn("close_active() called without checking is_open()");
         return;
@@ -26,9 +24,9 @@ export function close_active(): void {
 
     const $micromodal = $(".micromodal.modal--open");
     Micromodal.close(CSS.escape($micromodal.attr("id") ?? ""));
-}
+};
 
-export function open(modal_id: string, recursive_call_count = 0): void {
+export const open = (modal_id: string, recursive_call_count = 0): void => {
     if (modal_id === undefined) {
         blueslip.error("Undefined id was passed into open");
         return;
@@ -112,9 +110,9 @@ export function open(modal_id: string, recursive_call_count = 0): void {
         disableFocus: true,
         openClass: "modal--opening",
     });
-}
+};
 
-export function close(modal_id: string): void {
+export const close = (modal_id: string): void => {
     if (modal_id === undefined) {
         blueslip.error("Undefined id was passed into close");
         return;
@@ -133,4 +131,4 @@ export function close(modal_id: string): void {
     blueslip.debug("close modal: " + modal_id);
 
     Micromodal.close(modal_id);
-}
+};

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -54,7 +54,7 @@ $(() => {
             new_password1: "password_strength",
         },
         errorElement: "p",
-        errorPlacement($error: JQuery, $element: JQuery) {
+        errorPlacement: ($error: JQuery, $element: JQuery) => {
             // NB: this is called at most once, when the error element
             // is created.
             $element.next(".help-inline.alert.alert-error").remove();
@@ -140,12 +140,12 @@ $(() => {
 
     $("#send_confirm").validate({
         errorElement: "div",
-        errorPlacement($error: JQuery) {
+        errorPlacement: ($error: JQuery) => {
             $(".email-frontend-error").empty();
             $("#send_confirm .alert.email-backend-error").remove();
             $error.appendTo($(".email-frontend-error")).addClass("text-error");
         },
-        success() {
+        success: () => {
             $("#errors").empty();
         },
     });
@@ -161,7 +161,7 @@ $(() => {
         },
     );
 
-    const show_subdomain_section = function (bool: boolean): void {
+    const show_subdomain_section = (bool: boolean): void => {
         const action = bool ? "hide" : "show";
         $("#subdomain_section")[action]();
     };
@@ -173,13 +173,13 @@ $(() => {
     $("#login_form").validate({
         errorClass: "text-error",
         wrapper: "div",
-        submitHandler(form) {
+        submitHandler: (form) => {
             $("#login_form").find(".loader").css("display", "inline-block");
             $("#login_form").find("button .text").hide();
 
             form.submit();
         },
-        invalidHandler() {
+        invalidHandler: () => {
             // this removes all previous errors that were put on screen
             // by the server.
             $("#login_form .alert.alert-error").remove();
@@ -192,7 +192,7 @@ $(() => {
         },
     });
 
-    function check_subdomain_available(subdomain: string): void {
+    const check_subdomain_available = (subdomain: string): void => {
         const url = "/json/realm/subdomain/" + subdomain;
         void $.get(url, (response) => {
             const {msg} = z.object({msg: z.string()}).parse(response);
@@ -201,9 +201,9 @@ $(() => {
                 $("#id_team_subdomain_error_client").show();
             }
         });
-    }
+    };
 
-    function update_full_name_section(): void {
+    const update_full_name_section = (): void => {
         if ($("#source_realm_select").length && $("#source_realm_select").val() !== "") {
             $("#full_name_input_section").hide();
             $("#profile_info_section").show();
@@ -220,7 +220,7 @@ $(() => {
             $("#full_name_input_section").show();
             $("#profile_info_section").hide();
         }
-    }
+    };
 
     $("#source_realm_select").on("change", update_full_name_section);
     update_full_name_section();

--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -5,7 +5,7 @@ import * as common from "../common";
 
 export type UserOS = "android" | "ios" | "mac" | "windows" | "linux";
 
-export function detect_user_os(): UserOS {
+export const detect_user_os = (): UserOS => {
     if (/android/i.test(navigator.userAgent)) {
         return "android";
     }
@@ -22,7 +22,7 @@ export function detect_user_os(): UserOS {
         return "linux";
     }
     return "mac"; // if unable to determine OS return Mac by default
-}
+};
 
 export function activate_correct_tab($tabbed_section: JQuery): void {
     const user_os = detect_user_os();

--- a/web/src/portico/team.ts
+++ b/web/src/portico/team.ts
@@ -88,15 +88,15 @@ type ContributorData = {
 // if a user leaves and then revisits the same tab.
 const loaded_tabs: string[] = [];
 
-function calculate_total_commits(contributor: Contributor): number {
+const calculate_total_commits = (contributor: Contributor): number => {
     let commits = 0;
     for (const repo_name of all_repository_names) {
         commits += contributor[repo_name] ?? 0;
     }
     return commits;
-}
+};
 
-function get_profile_url(contributor: Contributor, tab_name?: string): string | undefined {
+const get_profile_url = (contributor: Contributor, tab_name?: string): string | undefined => {
     if (contributor.github_username) {
         return `https://github.com/${contributor.github_username}`;
     }
@@ -117,23 +117,22 @@ function get_profile_url(contributor: Contributor, tab_name?: string): string | 
     }
 
     return undefined;
-}
+};
 
-function get_display_name(contributor: Contributor): string {
+const get_display_name = (contributor: Contributor): string => {
     if (contributor.github_username) {
         return "@" + contributor.github_username;
     }
     return contributor.name;
-}
+};
 
-function exclude_bot_contributors(contributor: Contributor): boolean {
-    return contributor.github_username !== "dependabot[bot]";
-}
+const exclude_bot_contributors = (contributor: Contributor): boolean =>
+    contributor.github_username !== "dependabot[bot]";
 
 // TODO (for v2 of /team/ contributors):
 //   - Make tab header responsive.
 //   - Display full name instead of GitHub username.
-export default function render_tabs(contributors: Contributor[]): void {
+const render_tabs = (contributors: Contributor[]): void => {
     const template = _.template($("#contributors-template").html());
     const count_template = _.template($("#count-template").html());
     const total_count_template = _.template($("#total-count-template").html());
@@ -231,4 +230,5 @@ export default function render_tabs(contributors: Contributor[]): void {
             }
         });
     }
-}
+};
+export default render_tabs;

--- a/web/src/portico/tippyjs.ts
+++ b/web/src/portico/tippyjs.ts
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import * as tippy from "tippy.js";
 
-function initialize(): void {
+const initialize = (): void => {
     tippy.default("[data-tippy-content]", {
         // Same defaults as set in web app tippyjs module.
         maxWidth: 300,
@@ -11,7 +11,7 @@ function initialize(): void {
         animation: true,
         placement: "bottom",
     });
-}
+};
 
 $(() => {
     initialize();

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -39,16 +39,16 @@ export const presence_info = new Map<number, PresenceStatus>();
 export let presence_last_update_id = -1;
 
 // We keep and export this for testing convenience.
-export function clear_internal_data(): void {
+export const clear_internal_data = (): void => {
     raw_info.clear();
     presence_info.clear();
 
     presence_last_update_id = -1;
-}
+};
 
 const BIG_REALM_COUNT = 250;
 
-export function get_status(user_id: number): PresenceStatus["status"] {
+export const get_status = (user_id: number): PresenceStatus["status"] => {
     if (people.is_my_user_id(user_id)) {
         if (user_settings.presence_enabled) {
             // if the current user is sharing presence, they always see themselves as online.
@@ -61,13 +61,11 @@ export function get_status(user_id: number): PresenceStatus["status"] {
         return presence_info.get(user_id)!.status;
     }
     return "offline";
-}
+};
 
-export function get_user_ids(): number[] {
-    return [...presence_info.keys()];
-}
+export const get_user_ids = (): number[] => [...presence_info.keys()];
 
-export function status_from_raw(raw: RawPresence): PresenceStatus {
+export const status_from_raw = (raw: RawPresence): PresenceStatus => {
     /*
         Example of `raw`:
 
@@ -81,9 +79,7 @@ export function status_from_raw(raw: RawPresence): PresenceStatus {
     /* Mark users as offline after this many seconds since their last check-in, */
     const offline_threshold_secs = realm.server_presence_offline_threshold_seconds;
 
-    function age(timestamp = 0): number {
-        return raw.server_timestamp - timestamp;
-    }
+    const age = (timestamp = 0): number => raw.server_timestamp - timestamp;
 
     const active_timestamp = raw.active_timestamp;
     const idle_timestamp = raw.idle_timestamp;
@@ -120,13 +116,13 @@ export function status_from_raw(raw: RawPresence): PresenceStatus {
         status: "offline",
         last_active,
     };
-}
+};
 
-export function update_info_from_event(
+export const update_info_from_event = (
     user_id: number,
     info: PresenceInfoFromEvent,
     server_timestamp: number,
-): void {
+): void => {
     /*
         Example of `info`:
 
@@ -167,13 +163,13 @@ export function update_info_from_event(
 
     const status = status_from_raw(raw);
     presence_info.set(user_id, status);
-}
+};
 
-export function set_info(
+export const set_info = (
     presences: Record<number, Omit<RawPresence, "server_timestamp">>,
     server_timestamp: number,
     last_update_id: number,
-): void {
+): void => {
     /*
         Example `presences` data:
 
@@ -232,9 +228,9 @@ export function set_info(
         presence_info.set(user_id, status);
     }
     update_info_for_small_realm();
-}
+};
 
-export function update_info_for_small_realm(): void {
+export const update_info_for_small_realm = (): void => {
     if (people.get_active_human_count() >= BIG_REALM_COUNT) {
         // For big realms, we don't want to bloat our buddy
         // lists with lots of long-time-inactive users.
@@ -269,9 +265,9 @@ export function update_info_for_small_realm(): void {
             last_active: undefined,
         });
     }
-}
+};
 
-export function last_active_date(user_id: number): Date | undefined {
+export const last_active_date = (user_id: number): Date | undefined => {
     const info = presence_info.get(user_id);
 
     if (!info?.last_active) {
@@ -279,12 +275,12 @@ export function last_active_date(user_id: number): Date | undefined {
     }
 
     return new Date(info.last_active * 1000);
-}
+};
 
-export function initialize(params: {
+export const initialize = (params: {
     presences: Record<number, Omit<RawPresence, "server_timestamp">>;
     server_timestamp: number;
     presence_last_update_id: number;
-}): void {
+}): void => {
     set_info(params.presences, params.server_timestamp, params.presence_last_update_id);
-}
+};

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -18,11 +18,11 @@ const read_receipts_api_response_schema = z.object({
     user_ids: z.array(z.number()),
 });
 
-export function show_user_list(message_id: number): void {
+export const show_user_list = (message_id: number): void => {
     $("#read-receipts-modal-container").html(render_read_receipts_modal({message_id}));
     modals.open("read_receipts_modal", {
         autoremove: true,
-        on_shown() {
+        on_shown: () => {
             const message = message_store.get(message_id);
             assert(message !== undefined, "message is undefined");
 
@@ -38,7 +38,7 @@ export function show_user_list(message_id: number): void {
                 loading.make_indicator($("#read_receipts_modal .loading_indicator"));
                 void channel.get({
                     url: `/json/messages/${message_id}/read_receipts`,
-                    success(raw_data) {
+                    success: (raw_data) => {
                         const $modal = $("#read_receipts_modal").filter(
                             "[data-message-id=" + message_id + "]",
                         );
@@ -92,7 +92,7 @@ export function show_user_list(message_id: number): void {
                             new SimpleBar($("#read_receipts_modal .modal__content")[0]!);
                         }
                     },
-                    error(xhr) {
+                    error: (xhr) => {
                         ui_report.error("", xhr, $("#read_receipts_error"));
                         loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
                     },
@@ -100,8 +100,8 @@ export function show_user_list(message_id: number): void {
             }
         },
     });
-}
+};
 
-export function hide_user_list(): void {
+export const hide_user_list = (): void => {
     modals.close_if_open("read_receipts_modal");
-}
+};

--- a/web/src/realm_icon.ts
+++ b/web/src/realm_icon.ts
@@ -5,10 +5,9 @@ import {current_user, realm} from "./state_data";
 import * as upload_widget from "./upload_widget";
 import type {UploadFunction} from "./upload_widget";
 
-export function build_realm_icon_widget(upload_function: UploadFunction): void {
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $<HTMLInputElement>("#realm-icon-upload-widget .image_file_input").expectOne();
-    };
+export const build_realm_icon_widget = (upload_function: UploadFunction): void => {
+    const get_file_input = (): JQuery<HTMLInputElement> =>
+        $<HTMLInputElement>("#realm-icon-upload-widget .image_file_input").expectOne();
 
     if (!current_user.is_admin) {
         return;
@@ -33,9 +32,9 @@ export function build_realm_icon_widget(upload_function: UploadFunction): void {
         upload_function,
         realm.max_icon_file_size_mib,
     );
-}
+};
 
-export function rerender(): void {
+export const rerender = (): void => {
     $("#realm-icon-upload-widget .image-block").attr("src", realm.realm_icon_url);
     if (realm.realm_icon_source === "U") {
         $("#realm-icon-upload-widget .image-delete-button").show();
@@ -46,4 +45,4 @@ export function rerender(): void {
         const $file_input = $("#realm-icon-upload-widget .image_file_input");
         $file_input.val("");
     }
-}
+};

--- a/web/src/realm_logo.ts
+++ b/web/src/realm_logo.ts
@@ -7,7 +7,10 @@ import * as ui_util from "./ui_util";
 import * as upload_widget from "./upload_widget";
 import type {UploadFunction} from "./upload_widget";
 
-export function build_realm_logo_widget(upload_function: UploadFunction, is_night: boolean): void {
+export const build_realm_logo_widget = (
+    upload_function: UploadFunction,
+    is_night: boolean,
+): void => {
     let logo_section_id = "#realm-day-logo-upload-widget";
     let logo_source = realm.realm_logo_source;
 
@@ -21,9 +24,7 @@ export function build_realm_logo_widget(upload_function: UploadFunction, is_nigh
     const $file_input_error_elem = $(logo_section_id + " .image_file_input_error");
     const $upload_button_elem = $(logo_section_id + " .image_upload_button");
 
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $file_input_elem.expectOne();
-    };
+    const get_file_input = (): JQuery<HTMLInputElement> => $file_input_elem.expectOne();
 
     if (!current_user.is_admin) {
         return;
@@ -52,13 +53,13 @@ export function build_realm_logo_widget(upload_function: UploadFunction, is_nigh
         upload_function,
         realm.max_logo_file_size_mib,
     );
-}
+};
 
-function change_logo_delete_button(
+const change_logo_delete_button = (
     logo_source: string,
     $logo_delete_button: JQuery,
     $file_input: JQuery<HTMLInputElement>,
-): void {
+): void => {
     if (logo_source === "U") {
         $logo_delete_button.show();
     } else {
@@ -67,9 +68,9 @@ function change_logo_delete_button(
         // where you try to upload the same image you just deleted.
         $file_input.val("");
     }
-}
+};
 
-export function render(): void {
+export const render = (): void => {
     const $file_input = $<HTMLInputElement>("#realm-day-logo-upload-widget input.image_file_input");
     const $night_file_input = $<HTMLInputElement>(
         "#realm-night-logo-upload-widget input.image_file_input",
@@ -103,12 +104,12 @@ export function render(): void {
         $("#realm-night-logo-upload-widget .image-delete-button"),
         $night_file_input,
     );
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     // render once
     render();
 
     // Rerender the realm-logo when the browser detects color scheme changes.
     ui_util.listener_for_preferred_color_scheme_change(render);
-}
+};

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -15,7 +15,7 @@ export type RealmPlayground = {
 const map_language_to_playground_info = new Map<string, RealmPlayground[]>();
 const map_pygments_pretty_name_to_aliases = new Map<string, string[]>();
 
-export function update_playgrounds(playgrounds_data: RealmPlayground[]): void {
+export const update_playgrounds = (playgrounds_data: RealmPlayground[]): void => {
     map_language_to_playground_info.clear();
 
     for (const data of playgrounds_data) {
@@ -31,15 +31,14 @@ export function update_playgrounds(playgrounds_data: RealmPlayground[]): void {
             map_language_to_playground_info.set(data.pygments_language, [element_to_push]);
         }
     }
-}
+};
 
-export function get_playground_info_for_languages(lang: string): RealmPlayground[] | undefined {
-    return map_language_to_playground_info.get(lang);
-}
+export const get_playground_info_for_languages = (lang: string): RealmPlayground[] | undefined =>
+    map_language_to_playground_info.get(lang);
 
-function sort_pygments_pretty_names_by_priority(
+const sort_pygments_pretty_names_by_priority = (
     comparator_func: (a: string, b: string) => number,
-): void {
+): void => {
     const priority_sorted_pygments_data = Object.entries(pygments_data.langs).sort(([a], [b]) =>
         comparator_func(a, b),
     );
@@ -53,7 +52,7 @@ function sort_pygments_pretty_names_by_priority(
             map_pygments_pretty_name_to_aliases.set(pretty_name, [alias]);
         }
     }
-}
+};
 
 // This gets the candidate list for showing autocomplete for a code block in
 // the composebox. The candidate list will include pygments data as well as any
@@ -62,16 +61,16 @@ function sort_pygments_pretty_names_by_priority(
 // May return duplicates, since it's common for playground languages
 // to also be pygments languages! retain_unique_language_aliases will
 // deduplicate them.
-export function get_pygments_typeahead_list_for_composebox(): string[] {
+export const get_pygments_typeahead_list_for_composebox = (): string[] => {
     const playground_pygment_langs = [...map_language_to_playground_info.keys()];
     const pygment_langs = Object.keys(pygments_data.langs);
 
     return [...playground_pygment_langs, ...pygment_langs];
-}
+};
 
 // This gets the candidate list for showing autocomplete in settings when
 // adding a new Code Playground.
-export function get_pygments_typeahead_list_for_settings(query: string): Map<string, string> {
+export const get_pygments_typeahead_list_for_settings = (query: string): Map<string, string> => {
     const language_labels = new Map<string, string>();
 
     // Adds a typeahead that allows selecting a custom language, by adding a
@@ -94,15 +93,15 @@ export function get_pygments_typeahead_list_for_settings(query: string): Map<str
     }
 
     return language_labels;
-}
+};
 
-export function initialize({
+export const initialize = ({
     playground_data,
     pygments_comparator_func,
 }: {
     playground_data: RealmPlayground[];
     pygments_comparator_func: (a: string, b: string) => number;
-}): void {
+}): void => {
     update_playgrounds(playground_data);
     sort_pygments_pretty_names_by_priority(pygments_comparator_func);
-}
+};

--- a/web/src/realm_user_settings_defaults.ts
+++ b/web/src/realm_user_settings_defaults.ts
@@ -54,6 +54,6 @@ export type RealmDefaultSettings = {
 
 export let realm_user_settings_defaults: RealmDefaultSettings;
 
-export function initialize(params: {realm_user_settings_defaults: RealmDefaultSettings}): void {
+export const initialize = (params: {realm_user_settings_defaults: RealmDefaultSettings}): void => {
     realm_user_settings_defaults = params.realm_user_settings_defaults;
-}
+};

--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -51,16 +51,16 @@ const topic_senders = new Map<number, FoldDict<Map<number, IdTracker>>>();
 // pm_senders[user_ids_string][user_id] = IdTracker
 const pm_senders = new Map<string, Map<number, IdTracker>>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     stream_senders.clear();
     topic_senders.clear();
-}
+};
 
-function max_id_for_stream_topic_sender(opts: {
+const max_id_for_stream_topic_sender = (opts: {
     stream_id: number;
     topic: string;
     sender_id: number;
-}): number {
+}): number => {
     const {stream_id, topic, sender_id} = opts;
     const topic_dict = topic_senders.get(stream_id);
     if (!topic_dict) {
@@ -72,9 +72,9 @@ function max_id_for_stream_topic_sender(opts: {
     }
     const id_tracker = sender_dict.get(sender_id);
     return id_tracker ? id_tracker.max_id() : -1;
-}
+};
 
-function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}): number {
+const max_id_for_stream_sender = (opts: {stream_id: number; sender_id: number}): number => {
     const {stream_id, sender_id} = opts;
     const sender_dict = stream_senders.get(stream_id);
     if (!sender_dict) {
@@ -82,27 +82,27 @@ function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}):
     }
     const id_tracker = sender_dict.get(sender_id);
     return id_tracker ? id_tracker.max_id() : -1;
-}
+};
 
-function add_stream_message(opts: {
+const add_stream_message = (opts: {
     stream_id: number;
     sender_id: number;
     message_id: number;
-}): void {
+}): void => {
     const {stream_id, sender_id, message_id} = opts;
     const sender_dict = stream_senders.get(stream_id) ?? new Map<number, IdTracker>();
     const id_tracker = sender_dict.get(sender_id) ?? new IdTracker();
     stream_senders.set(stream_id, sender_dict);
     sender_dict.set(sender_id, id_tracker);
     id_tracker.add(message_id);
-}
+};
 
-function add_topic_message(opts: {
+const add_topic_message = (opts: {
     stream_id: number;
     topic: string;
     sender_id: number;
     message_id: number;
-}): void {
+}): void => {
     const {stream_id, topic, sender_id, message_id} = opts;
     const topic_dict = topic_senders.get(stream_id) ?? new FoldDict();
     const sender_dict = topic_dict.get(topic) ?? new Map<number, IdTracker>();
@@ -111,14 +111,14 @@ function add_topic_message(opts: {
     topic_dict.set(topic, sender_dict);
     sender_dict.set(sender_id, id_tracker);
     id_tracker.add(message_id);
-}
+};
 
-export function process_stream_message(message: {
+export const process_stream_message = (message: {
     stream_id: number;
     topic: string;
     sender_id: number;
     id: number;
-}): void {
+}): void => {
     const stream_id = message.stream_id;
     const topic = message.topic;
     const sender_id = message.sender_id;
@@ -126,14 +126,14 @@ export function process_stream_message(message: {
 
     add_stream_message({stream_id, sender_id, message_id});
     add_topic_message({stream_id, topic, sender_id, message_id});
-}
+};
 
-function remove_topic_message(opts: {
+const remove_topic_message = (opts: {
     stream_id: number;
     topic: string;
     sender_id: number;
     message_id: number;
-}): void {
+}): void => {
     const {stream_id, topic, sender_id, message_id} = opts;
     const topic_dict = topic_senders.get(stream_id);
     if (!topic_dict) {
@@ -160,15 +160,15 @@ function remove_topic_message(opts: {
     if (sender_dict.size === 0) {
         topic_dict.delete(topic);
     }
-}
+};
 
-export function process_topic_edit(opts: {
+export const process_topic_edit = (opts: {
     message_ids: number[];
     old_stream_id: number;
     old_topic: string;
     new_stream_id: number;
     new_topic: string;
-}): void {
+}): void => {
     const {message_ids, old_stream_id, old_topic, new_stream_id, new_topic} = opts;
     // Note that we don't delete anything from stream_senders here.
     // Our view is that it's probably better to not do so; users who
@@ -187,9 +187,9 @@ export function process_topic_edit(opts: {
 
         add_stream_message({stream_id: new_stream_id, sender_id, message_id});
     }
-}
+};
 
-export function update_topics_of_deleted_message_ids(message_ids: number[]): void {
+export const update_topics_of_deleted_message_ids = (message_ids: number[]): void => {
     for (const message_id of message_ids) {
         const message = message_store.get(message_id);
         if (!message || message.type !== "stream") {
@@ -202,14 +202,14 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
 
         remove_topic_message({stream_id, topic, sender_id, message_id});
     }
-}
+};
 
-export function compare_by_recency(
+export const compare_by_recency = (
     user_a: User,
     user_b: User,
     stream_id: number,
     topic: string,
-): number {
+): number => {
     let a_message_id;
     let b_message_id;
 
@@ -224,9 +224,9 @@ export function compare_by_recency(
     b_message_id = max_id_for_stream_sender({stream_id, sender_id: user_b.user_id});
 
     return b_message_id - a_message_id;
-}
+};
 
-export function get_topic_recent_senders(stream_id: number, topic: string): number[] {
+export const get_topic_recent_senders = (stream_id: number, topic: string): number[] => {
     const topic_dict = topic_senders.get(stream_id);
     if (topic_dict === undefined) {
         return [];
@@ -237,11 +237,11 @@ export function get_topic_recent_senders(stream_id: number, topic: string): numb
         return [];
     }
 
-    function by_max_message_id(item1: [number, IdTracker], item2: [number, IdTracker]): number {
+    const by_max_message_id = (item1: [number, IdTracker], item2: [number, IdTracker]): number => {
         const list1 = item1[1];
         const list2 = item2[1];
         return list2.max_id() - list1.max_id();
-    }
+    };
 
     const sorted_senders = [...sender_dict.entries()].sort(by_max_message_id);
     const recent_senders = [];
@@ -249,23 +249,23 @@ export function get_topic_recent_senders(stream_id: number, topic: string): numb
         recent_senders.push(item[0]);
     }
     return recent_senders;
-}
+};
 
-export function process_private_message(opts: {
+export const process_private_message = (opts: {
     to_user_ids: string;
     sender_id: number;
     id: number;
-}): void {
+}): void => {
     const {to_user_ids, sender_id, id} = opts;
     const sender_dict = pm_senders.get(to_user_ids) ?? new Map<number, IdTracker>();
     const id_tracker = sender_dict.get(sender_id) ?? new IdTracker();
     pm_senders.set(to_user_ids, sender_dict);
     sender_dict.set(sender_id, id_tracker);
     id_tracker.add(id);
-}
+};
 
 type DirectMessageSendersInfo = {participants: number[]; non_participants: number[]};
-export function get_pm_recent_senders(user_ids_string: string): DirectMessageSendersInfo {
+export const get_pm_recent_senders = (user_ids_string: string): DirectMessageSendersInfo => {
     const user_ids = [...people.get_participants_from_user_ids_string(user_ids_string)];
     const sender_dict = pm_senders.get(user_ids_string);
     const pm_senders_info: DirectMessageSendersInfo = {participants: [], non_participants: []};
@@ -286,16 +286,16 @@ export function get_pm_recent_senders(user_ids_string: string): DirectMessageSen
         return max_id2 - max_id1;
     });
     return pm_senders_info;
-}
+};
 
-export function get_topic_message_ids_for_sender(
+export const get_topic_message_ids_for_sender = (
     stream_id: number,
     topic: string,
     sender_id: number,
-): Set<number> {
+): Set<number> => {
     const id_tracker = topic_senders?.get(stream_id)?.get(topic)?.get(sender_id);
     if (id_tracker === undefined) {
         return new Set();
     }
     return id_tracker.ids;
-}
+};

--- a/web/src/recent_view_data.ts
+++ b/web/src/recent_view_data.ts
@@ -11,7 +11,7 @@ export const conversations = new Map<string, ConversationData>();
 // For stream messages, key is stream-id:topic.
 // For pms, key is the user IDs to whom the message is being sent.
 
-export function process_message(msg: Message): boolean {
+export const process_message = (msg: Message): boolean => {
     // Important: This function must correctly handle processing a
     // given message more than once; this happens during the loading
     // process because of how recent_view_message_list_data duplicates
@@ -51,20 +51,15 @@ export function process_message(msg: Message): boolean {
         conversation_data_updated = true;
     }
     return conversation_data_updated;
-}
+};
 
-function get_sorted_conversations(): Map<string | undefined, ConversationData> {
-    // Sort all recent conversations by last message time.
-    return new Map(
-        [...conversations.entries()].sort((a, b) => b[1].last_msg_id - a[1].last_msg_id),
-    );
-}
+const get_sorted_conversations = (): Map<string | undefined, ConversationData> =>
+    new Map([...conversations.entries()].sort((a, b) => b[1].last_msg_id - a[1].last_msg_id));
 
-export function get_conversations(): Map<string | undefined, ConversationData> {
-    return get_sorted_conversations();
-}
+export const get_conversations = (): Map<string | undefined, ConversationData> =>
+    get_sorted_conversations();
 
-export function reify_message_id_if_available(opts: {old_id: number; new_id: number}): boolean {
+export const reify_message_id_if_available = (opts: {old_id: number; new_id: number}): boolean => {
     // We don't need to reify the message_id of the conversation
     // if a new message arrives in the conversation from another user,
     // since it replaces the last_msg_id of the conversation which
@@ -76,4 +71,4 @@ export function reify_message_id_if_available(opts: {old_id: number; new_id: num
         }
     }
     return false;
-}
+};

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -117,51 +117,47 @@ let is_waiting_for_revive_current_focus = true;
 // it is hidden to avoid scroll jumping when it is shown again.
 let last_scroll_offset: number | undefined;
 
-export function set_initial_message_fetch_status(value: boolean): void {
+export const set_initial_message_fetch_status = (value: boolean): void => {
     is_initial_message_fetch_pending = value;
-}
+};
 
-export function set_backfill_in_progress(value: boolean): void {
+export const set_backfill_in_progress = (value: boolean): void => {
     is_backfill_in_progress = value;
     update_load_more_banner();
-}
+};
 
-export function clear_for_tests(): void {
+export const clear_for_tests = (): void => {
     filters.clear();
     dropdown_filters.clear();
     recent_view_data.conversations.clear();
     topics_widget = undefined;
-}
+};
 
-export function set_filters_for_tests(new_filters = [views_util.FILTERS.UNMUTED_TOPICS]): void {
+export const set_filters_for_tests = (new_filters = [views_util.FILTERS.UNMUTED_TOPICS]): void => {
     dropdown_filters = new Set(new_filters);
-}
+};
 
-export function save_filters(): void {
+export const save_filters = (): void => {
     ls.set(ls_key, [...filters]);
     ls.set(ls_dropdown_key, [...dropdown_filters]);
-}
+};
 
-export function is_in_focus(): boolean {
-    // Check if user is focused on Recent Conversations.
-    return (
-        recent_view_util.is_visible() &&
-        !compose_state.composing() &&
-        !popovers.any_active() &&
-        !sidebar_ui.any_sidebar_expanded_as_overlay() &&
-        !overlays.any_active() &&
-        !modals.any_active() &&
-        !$(".home-page-input").is(":focus")
-    );
-}
+export const is_in_focus = (): boolean =>
+    recent_view_util.is_visible() &&
+    !compose_state.composing() &&
+    !popovers.any_active() &&
+    !sidebar_ui.any_sidebar_expanded_as_overlay() &&
+    !overlays.any_active() &&
+    !modals.any_active() &&
+    !$(".home-page-input").is(":focus");
 
-export function set_default_focus(): void {
+export const set_default_focus = (): void => {
     // If at any point we are confused about the currently
     // focused element, we switch focus to search.
     $current_focus_elem = $("#recent_view_search");
     $current_focus_elem.trigger("focus");
     compose_closed_ui.set_standard_text_for_reply_button();
-}
+};
 
 // When there are no messages loaded, we don't show a banner yet.
 const NO_MESSAGES_LOADED = 0;
@@ -177,7 +173,7 @@ const ALL_MESSAGES_LOADED = 3;
 let loading_state = NO_MESSAGES_LOADED;
 let oldest_message_timestamp = Number.POSITIVE_INFINITY;
 
-function set_oldest_message_date(msg_list_data: MessageListData): void {
+const set_oldest_message_date = (msg_list_data: MessageListData): void => {
     const has_found_oldest = msg_list_data.fetch_status.has_found_oldest();
     const has_found_newest = msg_list_data.fetch_status.has_found_newest();
     const oldest_message_in_data = msg_list_data.first_including_muted();
@@ -211,9 +207,9 @@ function set_oldest_message_date(msg_list_data: MessageListData): void {
     if ($("#recent-view-content-tbody tr").length) {
         update_load_more_banner();
     }
-}
+};
 
-function update_load_more_banner(): void {
+const update_load_more_banner = (): void => {
     if (loading_state === NO_MESSAGES_LOADED) {
         return;
     }
@@ -262,21 +258,19 @@ function update_load_more_banner(): void {
     loading.destroy_indicator(
         $(".recent-view-load-more-container .fetch-messages-button .loading-indicator"),
     );
-}
+};
 
-function get_min_load_count(already_rendered_count: number, load_count: number): number {
+const get_min_load_count = (already_rendered_count: number, load_count: number): number => {
     const extra_rows_for_viewing_pleasure = 15;
     if (row_focus > already_rendered_count + load_count) {
         return row_focus + extra_rows_for_viewing_pleasure - already_rendered_count;
     }
     return load_count;
-}
+};
 
-function is_table_focused(): boolean {
-    return $current_focus_elem === "table";
-}
+const is_table_focused = (): boolean => $current_focus_elem === "table";
 
-function get_row_type(row: number): string {
+const get_row_type = (row: number): string => {
     // Return "private" or "stream"
     // We use CSS method for finding row type until topics_widget gets initialized.
     if (!topics_widget) {
@@ -293,18 +287,18 @@ function get_row_type(row: number): string {
     const current_row = current_list[row];
     assert(current_row !== undefined);
     return current_row.type;
-}
+};
 
-function get_max_selectable_cols(row: number): number {
+const get_max_selectable_cols = (row: number): number => {
     // returns maximum number of columns in stream message or direct message row.
     const type = get_row_type(row);
     if (type === "private") {
         return MAX_SELECTABLE_DIRECT_MESSAGE_COLS;
     }
     return MAX_SELECTABLE_TOPIC_COLS;
-}
+};
 
-function set_table_focus(row: number, col: number, using_keyboard = false): boolean {
+const set_table_focus = (row: number, col: number, using_keyboard = false): boolean => {
     assert(topics_widget !== undefined);
     if (topics_widget.get_current_list().length === 0) {
         // If there are no topics to show, we don't want to focus on the table.
@@ -370,9 +364,9 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
     }
     compose_closed_ui.update_reply_recipient_label(message);
     return true;
-}
+};
 
-export function get_focused_row_message(): Message | undefined {
+export const get_focused_row_message = (): Message | undefined => {
     if (is_table_focused()) {
         assert(topics_widget !== undefined);
         if (topics_widget.get_current_list().length === 0) {
@@ -390,9 +384,9 @@ export function get_focused_row_message(): Message | undefined {
         return message_store.get(topic_last_msg_id);
     }
     return undefined;
-}
+};
 
-export function revive_current_focus(): boolean {
+export const revive_current_focus = (): boolean => {
     // After re-render, the current_focus_elem is no longer linked
     // to the focused element, this function attempts to revive the
     // link and focus to the element prior to the rerender.
@@ -452,22 +446,22 @@ export function revive_current_focus(): boolean {
         $current_focus_elem.trigger("focus");
     }
     return true;
-}
+};
 
-export function show_loading_indicator(): void {
+export const show_loading_indicator = (): void => {
     loading.make_indicator($("#recent_view_loading_messages_indicator"));
-}
+};
 
-export function hide_loading_indicator(): void {
+export const hide_loading_indicator = (): void => {
     $("#recent_view_bottom_whitespace").hide();
     loading.destroy_indicator($("#recent_view_loading_messages_indicator"));
-}
+};
 
-export function process_messages(
+export const process_messages = (
     messages: Message[],
     rows_order_changed = true,
     msg_list_data?: MessageListData,
-): void {
+): void => {
     // Always synced with messages in all_messages_data.
 
     let conversation_data_updated = false;
@@ -497,20 +491,22 @@ export function process_messages(
             complete_rerender();
         }
     }
-}
+};
 
-function message_to_conversation_unread_count(msg: Message): number {
+const message_to_conversation_unread_count = (msg: Message): number => {
     if (msg.type === "private") {
         return unread.num_unread_for_user_ids_string(msg.to_user_ids);
     }
     return unread.num_unread_for_topic(msg.stream_id, msg.topic);
-}
+};
 
-export function get_pm_tooltip_data(user_ids_string: string): {
+export const get_pm_tooltip_data = (
+    user_ids_string: string,
+): {
     first_line: string;
     second_line: string;
     third_line?: string;
-} {
+} => {
     const user_id = Number.parseInt(user_ids_string, 10);
     const person = people.get_by_user_id(user_id);
 
@@ -545,7 +541,7 @@ export function get_pm_tooltip_data(user_ids_string: string): {
         second_line: "",
         third_line: "",
     };
-}
+};
 
 type ConversationContext = {
     full_last_msg_date_time: string;
@@ -589,7 +585,7 @@ type ConversationContext = {
       }
 );
 
-function format_conversation(conversation_data: ConversationData): ConversationContext {
+const format_conversation = (conversation_data: ConversationData): ConversationContext => {
     const last_msg = message_store.get(conversation_data.last_msg_id);
     assert(last_msg !== undefined);
     const time = new Date(last_msg.timestamp * 1000);
@@ -758,21 +754,21 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         is_private: false,
         ...stream_context,
     };
-}
+};
 
-function get_topic_row(topic_data: ConversationData): JQuery {
+const get_topic_row = (topic_data: ConversationData): JQuery => {
     const msg = message_store.get(topic_data.last_msg_id);
     assert(msg !== undefined);
     const topic_key = recent_view_util.get_key_from_message(msg);
     return $(`#${CSS.escape(recent_conversation_key_prefix + topic_key)}`);
-}
+};
 
-export function process_topic_edit(
+export const process_topic_edit = (
     old_stream_id: number,
     old_topic: string,
     new_topic: string,
     new_stream_id: number,
-): void {
+): void => {
     // See `recent_senders.process_topic_edit` for
     // logic behind this and important notes on use of this function.
     recent_view_data.conversations.delete(recent_view_util.get_topic_key(old_stream_id, old_topic));
@@ -783,21 +779,21 @@ export function process_topic_edit(
     new_stream_id = new_stream_id || old_stream_id;
     const new_topic_msgs = message_util.get_messages_in_topic(new_stream_id, new_topic);
     process_messages(new_topic_msgs);
-}
+};
 
-export function topic_in_search_results(
+export const topic_in_search_results = (
     keyword: string,
     stream_name: string,
     topic: string,
-): boolean {
+): boolean => {
     if (keyword === "") {
         return true;
     }
     const text = (stream_name + " " + topic).toLowerCase();
     return typeahead.query_matches_string_in_any_order(keyword, text, " ");
-}
+};
 
-export function update_topics_of_deleted_message_ids(message_ids: number[]): void {
+export const update_topics_of_deleted_message_ids = (message_ids: number[]): void => {
     const topics_to_rerender = message_util.get_topics_for_message_ids(message_ids);
 
     for (const [stream_id, topic] of topics_to_rerender.values()) {
@@ -805,9 +801,9 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
         const msgs = message_util.get_messages_in_topic(stream_id, topic);
         process_messages(msgs);
     }
-}
+};
 
-export function filters_should_hide_row(topic_data: ConversationData): boolean {
+export const filters_should_hide_row = (topic_data: ConversationData): boolean => {
     const msg = message_store.get(topic_data.last_msg_id);
     assert(msg !== undefined);
 
@@ -891,9 +887,9 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
     }
 
     return false;
-}
+};
 
-export function bulk_inplace_rerender(row_keys: string[]): void {
+export const bulk_inplace_rerender = (row_keys: string[]): void => {
     if (!topics_widget) {
         return;
     }
@@ -908,9 +904,9 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     }
 
     setTimeout(revive_current_focus, 0);
-}
+};
 
-export function inplace_rerender(topic_key: string, is_bulk_rerender?: boolean): boolean {
+export const inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): boolean => {
     if (!recent_view_util.is_visible()) {
         return false;
     }
@@ -970,9 +966,9 @@ export function inplace_rerender(topic_key: string, is_bulk_rerender?: boolean):
         setTimeout(revive_current_focus, 0);
     }
     return true;
-}
+};
 
-export function update_topic_visibility_policy(stream_id: number, topic: string): boolean {
+export const update_topic_visibility_policy = (stream_id: number, topic: string): boolean => {
     const key = recent_view_util.get_topic_key(stream_id, topic);
     if (!recent_view_data.conversations.has(key)) {
         // we receive mute request for a topic we are
@@ -982,14 +978,14 @@ export function update_topic_visibility_policy(stream_id: number, topic: string)
 
     inplace_rerender(key);
     return true;
-}
+};
 
-export function update_topic_unread_count(message: Message): void {
+export const update_topic_unread_count = (message: Message): void => {
     const topic_key = recent_view_util.get_key_from_message(message);
     inplace_rerender(topic_key);
-}
+};
 
-export function set_filter(filter: string): void {
+export const set_filter = (filter: string): void => {
     // This function updates the `filters` variable
     // after user clicks on one of the filter buttons
     // based on `btn-recent-selected` class and current
@@ -1008,9 +1004,9 @@ export function set_filter(filter: string): void {
     }
 
     save_filters();
-}
+};
 
-function show_selected_filters(): void {
+const show_selected_filters = (): void => {
     // Add `btn-selected-filter` to the buttons to show
     // which filters are applied.
     for (const filter of filters) {
@@ -1019,25 +1015,23 @@ function show_selected_filters(): void {
             .addClass("btn-recent-selected")
             .attr("aria-checked", "true");
     }
-}
+};
 
-function get_recent_view_filters_params(): {
+const get_recent_view_filters_params = (): {
     filter_unread: boolean;
     filter_participated: boolean;
     filter_muted: boolean;
     filter_pm: boolean;
     is_spectator: boolean;
-} {
-    return {
-        filter_unread: filters.has("unread"),
-        filter_participated: filters.has("participated"),
-        filter_muted: filters.has("include_muted"),
-        filter_pm: filters.has("include_private"),
-        is_spectator: page_params.is_spectator,
-    };
-}
+} => ({
+    filter_unread: filters.has("unread"),
+    filter_participated: filters.has("participated"),
+    filter_muted: filters.has("include_muted"),
+    filter_pm: filters.has("include_private"),
+    is_spectator: page_params.is_spectator,
+});
 
-function setup_dropdown_filters_widget(): void {
+const setup_dropdown_filters_widget = (): void => {
     const dropdown_filter = dropdown_filters.values().next();
     assert(dropdown_filter.done === false);
     filters_dropdown_widget = new dropdown_widget.DropdownWidget({
@@ -1048,18 +1042,18 @@ function setup_dropdown_filters_widget(): void {
         default_id: dropdown_filter.value,
     });
     filters_dropdown_widget.setup();
-}
+};
 
-export function update_filters_view(): void {
+export const update_filters_view = (): void => {
     const rendered_filters = render_recent_view_filters(get_recent_view_filters_params());
     $("#recent_filters_group").html(rendered_filters);
     show_selected_filters();
     filters_dropdown_widget.render();
     assert(topics_widget !== undefined);
     topics_widget.hard_redraw();
-}
+};
 
-function sort_comparator(a: string, b: string): number {
+const sort_comparator = (a: string, b: string): number => {
     // compares strings in lowercase and returns -1, 0, 1
     if (a.toLowerCase() > b.toLowerCase()) {
         return 1;
@@ -1067,9 +1061,9 @@ function sort_comparator(a: string, b: string): number {
         return 0;
     }
     return -1;
-}
+};
 
-function stream_sort(a: Row, b: Row): number {
+const stream_sort = (a: Row, b: Row): number => {
     if (a.type === b.type) {
         const a_msg = message_store.get(a.last_msg_id);
         assert(a_msg !== undefined);
@@ -1088,37 +1082,36 @@ function stream_sort(a: Row, b: Row): number {
     }
     // if type is not same sort between "private" and "stream"
     return sort_comparator(a.type, b.type);
-}
+};
 
-function topic_sort_key(conversation_data: ConversationData): string {
+const topic_sort_key = (conversation_data: ConversationData): string => {
     const message = message_store.get(conversation_data.last_msg_id);
     assert(message !== undefined);
     if (message.type === "private") {
         return message.display_reply_to;
     }
     return message.topic;
-}
+};
 
-function topic_sort(a: ConversationData, b: ConversationData): number {
-    return sort_comparator(topic_sort_key(a), topic_sort_key(b));
-}
+const topic_sort = (a: ConversationData, b: ConversationData): number =>
+    sort_comparator(topic_sort_key(a), topic_sort_key(b));
 
-function unread_count(conversation_data: ConversationData): number {
+const unread_count = (conversation_data: ConversationData): number => {
     const message = message_store.get(conversation_data.last_msg_id);
     assert(message !== undefined);
     return message_to_conversation_unread_count(message);
-}
+};
 
-function unread_sort(a: ConversationData, b: ConversationData): number {
+const unread_sort = (a: ConversationData, b: ConversationData): number => {
     const a_unread_count = unread_count(a);
     const b_unread_count = unread_count(b);
     if (a_unread_count !== b_unread_count) {
         return a_unread_count - b_unread_count;
     }
     return a.last_msg_id - b.last_msg_id;
-}
+};
 
-function topic_offset_to_visible_area($topic_row: JQuery): string | undefined {
+const topic_offset_to_visible_area = ($topic_row: JQuery): string | undefined => {
     if ($topic_row.length === 0) {
         // TODO: There is a possibility of topic_row being undefined here
         // which logically doesn't makes sense. Find out the case and
@@ -1144,9 +1137,9 @@ function topic_offset_to_visible_area($topic_row: JQuery): string | undefined {
 
     // Topic is visible
     return "visible";
-}
+};
 
-function recenter_focus_if_off_screen(): void {
+const recenter_focus_if_off_screen = (): void => {
     if (is_waiting_for_revive_current_focus) {
         return;
     }
@@ -1192,9 +1185,9 @@ function recenter_focus_if_off_screen(): void {
 
         set_table_focus(row_focus, col_focus);
     }
-}
+};
 
-function is_scroll_position_for_render(): boolean {
+const is_scroll_position_for_render = (): boolean => {
     const scroll_position = window.scrollY;
     const window_height = window.innerHeight;
     // We allocate `--max-unexpanded-compose-height` in empty space
@@ -1208,9 +1201,9 @@ function is_scroll_position_for_render(): boolean {
     assert(typeof compose_max_height === "string");
     const scroll_max = document.body.scrollHeight - Number.parseInt(compose_max_height, 10);
     return scroll_position + window_height >= (2 / 3) * scroll_max;
-}
+};
 
-function callback_after_render(): void {
+const callback_after_render = (): void => {
     // It is important to restore the scroll position as soon
     // as the rendering is complete to avoid scroll jumping.
     if (last_scroll_offset !== undefined) {
@@ -1222,13 +1215,13 @@ function callback_after_render(): void {
         revive_current_focus();
         is_waiting_for_revive_current_focus = false;
     }, 0);
-}
+};
 
-function filter_click_handler(
+const filter_click_handler = (
     event: JQuery.ClickEvent,
     dropdown: tippy.Instance,
     widget: DropdownWidget,
-): void {
+): void => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -1247,13 +1240,13 @@ function filter_click_handler(
 
     assert(topics_widget !== undefined);
     topics_widget.hard_redraw();
-}
+};
 
-function get_list_data_for_widget(): ConversationData[] {
-    return [...recent_view_data.get_conversations().values()];
-}
+const get_list_data_for_widget = (): ConversationData[] => [
+    ...recent_view_data.get_conversations().values(),
+];
 
-export function complete_rerender(): void {
+export const complete_rerender = (): void => {
     if (!recent_view_util.is_visible()) {
         return;
     }
@@ -1289,15 +1282,11 @@ export function complete_rerender(): void {
         name: "recent_view_table",
         get_item: list_widget.default_get_item,
         $parent_container: $("#recent_view_table"),
-        modifier_html(item) {
-            return render_recent_view_row(format_conversation(item));
-        },
+        modifier_html: (item) => render_recent_view_row(format_conversation(item)),
         filter: {
             // We use update_filters_view & filters_should_hide_row to do all the
             // filtering for us, which is called using click_handlers.
-            predicate(topic_data) {
-                return !filters_should_hide_row(topic_data);
-            },
+            predicate: (topic_data) => !filters_should_hide_row(topic_data),
         },
         sort_fields: {
             stream_sort,
@@ -1309,16 +1298,16 @@ export function complete_rerender(): void {
         $simplebar_container: $("html"),
         callback_after_render,
         is_scroll_position_for_render,
-        post_scroll__pre_render_callback() {
+        post_scroll__pre_render_callback: () => {
             // Update the focused element for keyboard navigation if needed.
             recenter_focus_if_off_screen();
         },
         get_min_load_count,
     });
     setup_dropdown_filters_widget();
-}
+};
 
-export function show(): void {
+export const show = (): void => {
     // We remove event handler before hiding, so they need to
     // be attached again, checking for topics_widget to be defined
     // is a reliable solution to check if recent view was displayed earlier.
@@ -1353,7 +1342,7 @@ export function show(): void {
             html_heading: $t_html({defaultMessage: "Welcome to <b>recent conversations</b>!"}),
             html_body,
             html_submit_button: $t_html({defaultMessage: "Continue"}),
-            on_click() {
+            on_click: () => {
                 /* This widget is purely informational and clicking only closes it. */
             },
             single_footer_button: true,
@@ -1361,13 +1350,11 @@ export function show(): void {
         });
         onboarding_steps.post_onboarding_step_as_read("intro_recent_view_modal");
     }
-}
+};
 
-function filter_buttons(): JQuery {
-    return $("#recent_filters_group").children();
-}
+const filter_buttons = (): JQuery => $("#recent_filters_group").children();
 
-export function hide(): void {
+export const hide = (): void => {
     // Since we have events attached to element (window) which are present in
     // views others than recent view, it is important to clear events here.
     topics_widget?.clear_event_handlers();
@@ -1377,14 +1364,14 @@ export function hide(): void {
         $view: $("#recent_view"),
         set_visible: recent_view_util.set_visible,
     });
-}
+};
 
-function is_focus_at_last_table_row(): boolean {
+const is_focus_at_last_table_row = (): boolean => {
     assert(topics_widget !== undefined);
     return row_focus >= topics_widget.get_current_list().length - 1;
-}
+};
 
-function has_unread(row: number): boolean {
+const has_unread = (row: number): boolean => {
     assert(topics_widget !== undefined);
     const current_row = topics_widget.get_current_list()[row];
     assert(current_row !== undefined);
@@ -1395,13 +1382,13 @@ function has_unread(row: number): boolean {
         return unread.num_unread_for_topic(last_msg.stream_id, last_msg.topic) > 0;
     }
     return unread.num_unread_for_user_ids_string(last_msg.to_user_ids) > 0;
-}
+};
 
-export function focus_clicked_element(
+export const focus_clicked_element = (
     topic_row_index: number,
     col: number,
     topic_key?: string,
-): void {
+): void => {
     $current_focus_elem = "table";
     col_focus = col;
     row_focus = topic_row_index;
@@ -1412,9 +1399,9 @@ export function focus_clicked_element(
     // Set compose_closed_ui reply button text.  The rest of the table
     // focus logic should be a noop.
     set_table_focus(row_focus, col_focus);
-}
+};
 
-function left_arrow_navigation(row: number, col: number): void {
+const left_arrow_navigation = (row: number, col: number): void => {
     const type = get_row_type(row);
 
     if (type === "stream" && col === MAX_SELECTABLE_TOPIC_COLS - 1 && !has_unread(row)) {
@@ -1425,9 +1412,9 @@ function left_arrow_navigation(row: number, col: number): void {
     if (col_focus < 0) {
         col_focus = get_max_selectable_cols(row) - 1;
     }
-}
+};
 
-function right_arrow_navigation(row: number, col: number): void {
+const right_arrow_navigation = (row: number, col: number): void => {
     const type = get_row_type(row);
 
     if (type === "stream" && col === 1 && !has_unread(row)) {
@@ -1438,9 +1425,9 @@ function right_arrow_navigation(row: number, col: number): void {
     if (col_focus >= get_max_selectable_cols(row)) {
         col_focus = 0;
     }
-}
+};
 
-function up_arrow_navigation(row: number, col: number): void {
+const up_arrow_navigation = (row: number, col: number): void => {
     row_focus -= 1;
     if (row_focus < 0) {
         return;
@@ -1450,13 +1437,13 @@ function up_arrow_navigation(row: number, col: number): void {
     if (type === "stream" && col === 2 && row - 1 >= 0 && !has_unread(row - 1)) {
         col_focus = 1;
     }
-}
+};
 
-function down_arrow_navigation(): void {
+const down_arrow_navigation = (): void => {
     row_focus += 1;
-}
+};
 
-function get_page_up_down_delta(): number {
+const get_page_up_down_delta = (): number => {
     const thead_bottom = $("#recent-view-table-headers")[0]!.getBoundingClientRect().bottom;
     const compose_box_top = window.innerHeight - $("#compose").outerHeight(true)!;
     // One usually wants PageDown to move what had been the bottom row
@@ -1468,9 +1455,9 @@ function get_page_up_down_delta(): number {
 
     const delta = compose_box_top - thead_bottom - scrolling_reduction_to_maintain_context;
     return delta;
-}
+};
 
-function page_up_navigation(): void {
+const page_up_navigation = (): void => {
     const delta = get_page_up_down_delta();
     const new_scrollTop = window.scrollY - delta;
     if (new_scrollTop <= 0) {
@@ -1485,9 +1472,9 @@ function page_up_navigation(): void {
     }
 
     window.scroll(0, new_scrollTop);
-}
+};
 
-function page_down_navigation(): void {
+const page_down_navigation = (): void => {
     const delta = get_page_up_down_delta();
     const new_scrollTop = window.scrollY + delta;
     const max_scroll_top = document.body.scrollHeight - window.innerHeight;
@@ -1505,9 +1492,9 @@ function page_down_navigation(): void {
     }
 
     window.scroll(0, new_scrollTop);
-}
+};
 
-function check_row_type_transition(row: number, col: number): boolean {
+const check_row_type_transition = (row: number, col: number): boolean => {
     // This function checks if the row is transitioning
     // from type "Direct messages" to "Stream" or vice versa.
     // This helps in setting the col_focus as maximum column
@@ -1520,9 +1507,9 @@ function check_row_type_transition(row: number, col: number): boolean {
         return true;
     }
     return false;
-}
+};
 
-export function change_focused_element($elt: JQuery, input_key: string): boolean {
+export const change_focused_element = ($elt: JQuery, input_key: string): boolean => {
     // Called from hotkeys.js; like all logic in that module,
     // returning true will cause the caller to do
     // preventDefault/stopPropagation; false will let the browser
@@ -1699,11 +1686,11 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
     }
 
     return false;
-}
+};
 
 const filter_schema = z.array(z.string()).default([]);
 
-function load_filters(): void {
+const load_filters = (): void => {
     // load filters from local storage.
     if (!page_params.is_spectator) {
         // A user may have a stored filter and can log out
@@ -1721,7 +1708,7 @@ function load_filters(): void {
     if (dropdown_filters.size === 0 || !is_subset) {
         dropdown_filters = new Set([views_util.FILTERS.UNMUTED_TOPICS]);
     }
-}
+};
 
 export function initialize({
     on_click_participant,

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -2,19 +2,16 @@ import type {Message} from "./message_store";
 
 let is_view_visible = false;
 
-export function set_visible(value: boolean): void {
+export const set_visible = (value: boolean): void => {
     is_view_visible = value;
-}
+};
 
-export function is_visible(): boolean {
-    return is_view_visible;
-}
+export const is_visible = (): boolean => is_view_visible;
 
-export function get_topic_key(stream_id: number, topic: string): string {
-    return stream_id + ":" + topic.toLowerCase();
-}
+export const get_topic_key = (stream_id: number, topic: string): string =>
+    stream_id + ":" + topic.toLowerCase();
 
-export function get_key_from_message(msg: Message): string {
+export const get_key_from_message = (msg: Message): string => {
     if (msg.type === "private") {
         // The to_user_ids field on a direct message object is a
         // string containing the user IDs involved in the message in
@@ -24,4 +21,4 @@ export function get_key_from_message(msg: Message): string {
 
     // For messages with type = "stream".
     return get_topic_key(msg.stream_id, msg.topic);
-}
+};

--- a/web/src/reload.js
+++ b/web/src/reload.js
@@ -16,17 +16,17 @@ import * as util from "./util";
 
 const reload_hooks = [];
 
-export function add_reload_hook(hook) {
+export const add_reload_hook = (hook) => {
     reload_hooks.push(hook);
-}
+};
 
-function call_reload_hooks() {
+const call_reload_hooks = () => {
     for (const hook of reload_hooks) {
         hook();
     }
-}
+};
 
-function preserve_state(send_after_reload, save_compose) {
+const preserve_state = (send_after_reload, save_compose) => {
     if (!localstorage.supported()) {
         // If local storage is not supported by the browser, we can't
         // save the browser's position across reloads (since there's
@@ -100,9 +100,9 @@ function preserve_state(send_after_reload, save_compose) {
     };
     ls.set("reload:" + token, metadata);
     window.location.replace("#reload:" + token);
-}
+};
 
-export function is_stale_refresh_token(token_metadata, now) {
+export const is_stale_refresh_token = (token_metadata, now) => {
     // TODO/compatibility: the metadata was changed from a string
     // to a map containing the string and a timestamp. For now we'll
     // delete all tokens that only contain the url. Remove this
@@ -119,16 +119,16 @@ export function is_stale_refresh_token(token_metadata, now) {
     const timedelta = now - token_metadata.timestamp;
     const days_since_token_creation = timedelta / milliseconds_in_a_day;
     return days_since_token_creation > 7;
-}
+};
 
-function delete_stale_tokens(ls) {
+const delete_stale_tokens = (ls) => {
     const now = Date.now();
     ls.removeDataRegexWithCondition("reload:\\d+", (metadata) =>
         is_stale_refresh_token(metadata, now),
     );
-}
+};
 
-function do_reload_app(send_after_reload, save_compose, message_html) {
+const do_reload_app = (send_after_reload, save_compose, message_html) => {
     if (reload_state.is_in_progress()) {
         blueslip.log("do_reload_app: Doing nothing since reload_in_progress");
         return;
@@ -164,10 +164,10 @@ function do_reload_app(send_after_reload, save_compose, message_html) {
         });
     }, 5000);
 
-    function retry_reload() {
+    const retry_reload = () => {
         blueslip.log("Retrying page reload due to 30s timer");
         window.location.reload(true);
-    }
+    };
     util.call_function_periodically(retry_reload, 30000);
 
     try {
@@ -177,14 +177,14 @@ function do_reload_app(send_after_reload, save_compose, message_html) {
     }
 
     window.location.reload(true);
-}
+};
 
-export function initiate({
+export const initiate = ({
     immediate = false,
     save_compose = true,
     send_after_reload = false,
     message_html = "Reloading ...",
-}) {
+}) => {
     if (immediate) {
         do_reload_app(send_after_reload, save_compose, message_html);
     }
@@ -222,9 +222,9 @@ export function initiate({
     const basic_idle_timeout = 1000 * 60 * 1 + random_variance;
     let compose_started_handler;
 
-    function reload_from_idle() {
+    const reload_from_idle = () => {
         do_reload_app(false, save_compose, message_html);
-    }
+    };
 
     // Make sure we always do a reload eventually after
     // unconditional_timeout.  Because we save cursor location and
@@ -232,7 +232,7 @@ export function initiate({
     // particularly disruptive.
     setTimeout(reload_from_idle, unconditional_timeout);
 
-    const compose_done_handler = function () {
+    const compose_done_handler = () => {
         // If the user sends their message or otherwise closes
         // compose, we return them to the not-composing timeouts.
         idle_control.cancel();
@@ -240,7 +240,7 @@ export function initiate({
         $(document).off("compose_canceled.zulip compose_finished.zulip", compose_done_handler);
         $(document).on("compose_started.zulip", compose_started_handler);
     };
-    compose_started_handler = function () {
+    compose_started_handler = () => {
         // If the user stops being idle and starts composing a
         // message, switch to the compose-open timeouts.
         idle_control.cancel();
@@ -256,7 +256,7 @@ export function initiate({
         idle_control = $(document).idle({idle: basic_idle_timeout, onIdle: reload_from_idle});
         $(document).on("compose_started.zulip", compose_started_handler);
     }
-}
+};
 
 window.addEventListener("beforeunload", () => {
     // When navigating away from the page do not try to reload.

--- a/web/src/reload_setup.js
+++ b/web/src/reload_setup.js
@@ -9,7 +9,7 @@ import * as message_view from "./message_view";
 // Check if we're doing a compose-preserving reload.  This must be
 // done before the first call to get_events
 
-export function initialize() {
+export const initialize = () => {
     // location.hash should be e.g. `#reload:12345123412312`
     if (!location.hash.startsWith("#reload:")) {
         return;
@@ -84,4 +84,4 @@ export function initialize() {
 
     activity.set_new_user_input(false);
     message_view.changehash(vars.oldhash, trigger);
-}
+};

--- a/web/src/reload_state.ts
+++ b/web/src/reload_state.ts
@@ -11,31 +11,27 @@ let reload_in_progress = false;
 let reload_pending = false;
 export let csrf_failed_handler: (() => void) | undefined;
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     reload_in_progress = false;
     reload_pending = false;
     csrf_failed_handler = undefined;
-}
+};
 
-export function is_pending(): boolean {
-    return reload_pending;
-}
+export const is_pending = (): boolean => reload_pending;
 
-export function is_in_progress(): boolean {
-    return reload_in_progress;
-}
+export const is_in_progress = (): boolean => reload_in_progress;
 
-export function set_state_to_pending(): void {
+export const set_state_to_pending = (): void => {
     // Why do we never set this back to false?
     // Because the reload is gonna happen next. :)
     // I was briefly confused by this, hence the comment.
     reload_pending = true;
-}
+};
 
-export function set_state_to_in_progress(): void {
+export const set_state_to_in_progress = (): void => {
     reload_in_progress = true;
-}
+};
 
-export function set_csrf_failed_handler(handler: () => void): void {
+export const set_csrf_failed_handler = (handler: () => void): void => {
     csrf_failed_handler = handler;
-}
+};

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -32,7 +32,7 @@ import * as util from "./util";
     is being displayed.
 */
 
-export function get_user_id_for_mention_button(elem: HTMLElement): "*" | number | undefined {
+export const get_user_id_for_mention_button = (elem: HTMLElement): "*" | number | undefined => {
     const user_id_string = $(elem).attr("data-user-id");
     // Handle legacy Markdown that was rendered before we cut
     // over to using data-user-id.
@@ -54,15 +54,15 @@ export function get_user_id_for_mention_button(elem: HTMLElement): "*" | number 
         }
     }
     return undefined;
-}
+};
 
-function get_user_group_id_for_mention_button(elem: HTMLElement): number {
+const get_user_group_id_for_mention_button = (elem: HTMLElement): number => {
     const user_group_id = $(elem).attr("data-user-group-id");
     assert(user_group_id !== undefined);
     return Number.parseInt(user_group_id, 10);
-}
+};
 
-function get_message_for_message_content($content: JQuery): Message | undefined {
+const get_message_for_message_content = ($content: JQuery): Message | undefined => {
     // TODO: This selector is designed to exclude drafts/scheduled
     // messages. Arguably those settings should be unconditionally
     // marked with user-mention-me, but rows.id doesn't support
@@ -75,14 +75,14 @@ function get_message_for_message_content($content: JQuery): Message | undefined 
     }
     const message_id = rows.id($message_row);
     return message_store.get(message_id);
-}
+};
 
 // Helper function to update a mentioned user's name.
-export function set_name_in_mention_element(
+export const set_name_in_mention_element = (
     element: HTMLElement,
     name: string,
     user_id?: number,
-): void {
+): void => {
     if (user_id !== undefined && people.should_add_guest_user_indicator(user_id)) {
         let display_text;
         if (!$(element).hasClass("silent")) {
@@ -99,7 +99,7 @@ export function set_name_in_mention_element(
     } else {
         $(element).text("@" + name);
     }
-}
+};
 
 export const update_elements = ($content: JQuery): void => {
     // Set the rtl class if the text has an rtl direction
@@ -313,7 +313,7 @@ export const update_elements = ($content: JQuery): void => {
         }
         const $copy_button = $buttonContainer.find(".copy_codeblock");
         const clipboard = new ClipboardJS($copy_button[0]!, {
-            text(copy_element) {
+            text: (copy_element) => {
                 const $code = $(copy_element).parent().siblings("code");
                 return $code.text();
             },

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -7,14 +7,12 @@ import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as message_viewport from "./message_viewport";
 
-function get_bottom_whitespace_height(): number {
-    return message_viewport.height() * 0.4;
-}
+const get_bottom_whitespace_height = (): number => message_viewport.height() * 0.4;
 
-function get_new_heights(): {
+const get_new_heights = (): {
     stream_filters_max_height: number;
     buddy_list_wrapper_max_height: number;
-} {
+} => {
     const viewport_height = message_viewport.height();
     const right_sidebar_shortcuts_height = $(".right-sidebar-shortcuts").outerHeight(true) ?? 0;
 
@@ -44,9 +42,9 @@ function get_new_heights(): {
         stream_filters_max_height,
         buddy_list_wrapper_max_height,
     };
-}
+};
 
-export function watch_manual_resize(element: string): (() => void)[] | undefined {
+export const watch_manual_resize = (element: string): (() => void)[] | undefined => {
     const box = document.querySelector(element);
 
     if (!box) {
@@ -55,13 +53,13 @@ export function watch_manual_resize(element: string): (() => void)[] | undefined
     }
 
     return watch_manual_resize_for_element(box);
-}
+};
 
-export function watch_manual_resize_for_element(box: Element): (() => void)[] {
+export const watch_manual_resize_for_element = (box: Element): (() => void)[] => {
     let height: number;
     let mousedown = false;
 
-    const box_handler = function (): void {
+    const box_handler = (): void => {
         mousedown = true;
         height = box.clientHeight;
     };
@@ -70,7 +68,7 @@ export function watch_manual_resize_for_element(box: Element): (() => void)[] {
     // If the user resizes the textarea manually, we use the
     // callback to stop autosize from adjusting the height.
     // It will be re-enabled when this component is next opened.
-    const body_handler = function (): void {
+    const body_handler = (): void => {
         if (mousedown) {
             mousedown = false;
             if (height !== box.clientHeight) {
@@ -82,9 +80,9 @@ export function watch_manual_resize_for_element(box: Element): (() => void)[] {
     document.body.addEventListener("mouseup", body_handler);
 
     return [box_handler, body_handler];
-}
+};
 
-export function reset_compose_message_max_height(bottom_whitespace_height?: number): void {
+export const reset_compose_message_max_height = (bottom_whitespace_height?: number): void => {
     // If the compose-box is open, we set the `max-height` property of
     // `compose-textarea` and `preview-textarea`, so that the
     // compose-box's maximum extent does not overlap the last message
@@ -117,9 +115,9 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
         bottom_whitespace_height - compose_non_textarea_height - 10,
     );
     $("#scroll-to-bottom-button-container").css("bottom", compose_height);
-}
+};
 
-export function resize_bottom_whitespace(): void {
+export const resize_bottom_whitespace = (): void => {
     const bottom_whitespace_height = get_bottom_whitespace_height();
     $("html").css("--max-unexpanded-compose-height", `${bottom_whitespace_height}px`);
     // The height of the compose box is tied to that of
@@ -131,7 +129,7 @@ export function resize_bottom_whitespace(): void {
     if (compose_state.composing()) {
         reset_compose_message_max_height(bottom_whitespace_height);
     }
-}
+};
 
 export function resize_stream_subscribers_list(): void {
     // Calculates the height of the subscribers list in stream settings.
@@ -172,24 +170,24 @@ export function resize_stream_subscribers_list(): void {
     $("html").css("--stream-subscriber-list-max-height", `${subscribers_list_height}px`);
 }
 
-export function resize_stream_filters_container(): void {
+export const resize_stream_filters_container = (): void => {
     const h = get_new_heights();
     resize_bottom_whitespace();
     $("#left_sidebar_scroll_container").css("max-height", h.stream_filters_max_height);
-}
+};
 
-export function resize_sidebars(): void {
+export const resize_sidebars = (): void => {
     const h = get_new_heights();
     $("#buddy_list_wrapper").css("max-height", h.buddy_list_wrapper_max_height);
     $("#left_sidebar_scroll_container").css("max-height", h.stream_filters_max_height);
-}
+};
 
-export function update_recent_view_filters_height(): void {
+export const update_recent_view_filters_height = (): void => {
     const recent_view_filters_height = $("#recent_view_filter_buttons").outerHeight(true) ?? 0;
     $("html").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
-}
+};
 
-function resize_navbar_alerts(): void {
+const resize_navbar_alerts = (): void => {
     const navbar_alerts_height = $("#navbar_alerts_wrapper").height();
     document.documentElement.style.setProperty(
         "--navbar-alerts-wrapper-height",
@@ -201,11 +199,11 @@ function resize_navbar_alerts(): void {
     if (compose_ui.is_full_size()) {
         compose_ui.set_compose_box_top(true);
     }
-}
+};
 
-export function resize_page_components(): void {
+export const resize_page_components = (): void => {
     resize_navbar_alerts();
     resize_sidebars();
     resize_bottom_whitespace();
     resize_stream_subscribers_list();
-}
+};

--- a/web/src/resize_handler.ts
+++ b/web/src/resize_handler.ts
@@ -11,7 +11,7 @@ import * as util from "./util";
 
 export let _old_width = $(window).width();
 
-export function handler(): void {
+export const handler = (): void => {
     const new_width = $(window).width();
 
     const mobile = util.is_mobile();
@@ -36,4 +36,4 @@ export function handler(): void {
     if (message_lists.current !== undefined && message_lists.current.selected_id() !== -1) {
         message_viewport.scroll_to_selected();
     }
-}
+};

--- a/web/src/rows.ts
+++ b/web/src/rows.ts
@@ -9,7 +9,7 @@ import type {Message} from "./message_store";
 // We don't need an andSelf() here because we already know
 // that our next element is *not* a message_row, so this
 // isn't going to end up empty unless we're at the bottom or top.
-export function next_visible($message_row: JQuery): JQuery {
+export const next_visible = ($message_row: JQuery): JQuery => {
     if ($message_row === undefined || $message_row.length === 0) {
         return $();
     }
@@ -23,9 +23,9 @@ export function next_visible($message_row: JQuery): JQuery {
         return $();
     }
     return $(".selectable_row", $next_recipient_rows[0]).first();
-}
+};
 
-export function prev_visible($message_row: JQuery): JQuery {
+export const prev_visible = ($message_row: JQuery): JQuery => {
     if ($message_row === undefined || $message_row.length === 0) {
         return $();
     }
@@ -39,17 +39,13 @@ export function prev_visible($message_row: JQuery): JQuery {
         return $();
     }
     return $(".selectable_row", $prev_recipient_rows[0]).last();
-}
+};
 
-export function first_visible(): JQuery {
-    return $(".focused-message-list .selectable_row").first();
-}
+export const first_visible = (): JQuery => $(".focused-message-list .selectable_row").first();
 
-export function last_visible(): JQuery {
-    return $(".focused-message-list .selectable_row").last();
-}
+export const last_visible = (): JQuery => $(".focused-message-list .selectable_row").last();
 
-export function visible_range(start_id: number, end_id: number): JQuery[] {
+export const visible_range = (start_id: number, end_id: number): JQuery[] => {
     /*
         Get all visible rows between start_id
         and end_in, being inclusive on both ends.
@@ -72,13 +68,12 @@ export function visible_range(start_id: number, end_id: number): JQuery[] {
     }
 
     return rows;
-}
+};
 
-export function is_overlay_row($row: JQuery): boolean {
-    return $row.closest(".overlay-message-row").length >= 1;
-}
+export const is_overlay_row = ($row: JQuery): boolean =>
+    $row.closest(".overlay-message-row").length >= 1;
 
-export function id($message_row: JQuery): number {
+export const id = ($message_row: JQuery): number => {
     if (is_overlay_row($message_row)) {
         throw new Error("Drafts and scheduled messages have no message id.");
     }
@@ -94,9 +89,9 @@ export function id($message_row: JQuery): number {
     }
 
     return Number.parseFloat(message_id);
-}
+};
 
-export function local_echo_id($message_row: JQuery): string {
+export const local_echo_id = ($message_row: JQuery): string => {
     const message_id = $message_row.attr("data-message-id");
 
     if (message_id === undefined) {
@@ -108,54 +103,43 @@ export function local_echo_id($message_row: JQuery): string {
     }
 
     return message_id;
-}
+};
 
-export function get_message_id(elem: HTMLElement): number {
+export const get_message_id = (elem: HTMLElement): number => {
     // Gets the message_id for elem, where elem is a DOM
     // element inside a message.  This is typically used
     // in click handlers for things like the reaction button.
     const $row = $(elem).closest(".message_row");
     const message_id = id($row);
     return message_id;
-}
+};
 
-export function get_closest_group(element: string): JQuery {
-    // This gets the closest message row to an element, whether it's
-    // a recipient bar or message.  With our current markup,
-    // this is the most reliable way to do it.
-    return $(element).closest("div.recipient_row");
-}
+export const get_closest_group = (element: string): JQuery =>
+    $(element).closest("div.recipient_row");
 
-export function get_closest_row(element: string): JQuery {
-    return $(element).closest("div.message_row");
-}
+export const get_closest_row = (element: string): JQuery => $(element).closest("div.message_row");
 
-export function first_message_in_group($message_group: JQuery): JQuery {
-    return $("div.message_row", $message_group).first();
-}
+export const first_message_in_group = ($message_group: JQuery): JQuery =>
+    $("div.message_row", $message_group).first();
 
-export function last_message_in_group($message_group: JQuery): JQuery {
-    return $("div.message_row", $message_group).last();
-}
+export const last_message_in_group = ($message_group: JQuery): JQuery =>
+    $("div.message_row", $message_group).last();
 
-export function get_message_recipient_row($message_row: JQuery): JQuery {
-    return $message_row.parent(".recipient_row").expectOne();
-}
+export const get_message_recipient_row = ($message_row: JQuery): JQuery =>
+    $message_row.parent(".recipient_row").expectOne();
 
-export function get_message_recipient_header($message_row: JQuery): JQuery {
-    return $message_row.parent(".recipient_row").find(".message_header").expectOne();
-}
+export const get_message_recipient_header = ($message_row: JQuery): JQuery =>
+    $message_row.parent(".recipient_row").find(".message_header").expectOne();
 
-export function recipient_from_group($message_group: JQuery): Message | undefined {
+export const recipient_from_group = ($message_group: JQuery): Message | undefined => {
     const message_id = id($message_group.children(".message_row").first().expectOne());
     return message_store.get(message_id);
-}
+};
 
-export function is_header_of_row_sticky($recipient_row: JQuery): boolean {
-    return $recipient_row.find(".message_header").hasClass("sticky_header");
-}
+export const is_header_of_row_sticky = ($recipient_row: JQuery): boolean =>
+    $recipient_row.find(".message_header").hasClass("sticky_header");
 
-export function id_for_recipient_row($recipient_row: JQuery): number {
+export const id_for_recipient_row = ($recipient_row: JQuery): number => {
     if (is_header_of_row_sticky($recipient_row)) {
         const msg_id = message_lists.current?.view.sticky_recipient_message_id;
         if (msg_id !== undefined) {
@@ -165,4 +149,4 @@ export function id_for_recipient_row($recipient_row: JQuery): number {
 
     const $msg_row = first_message_in_group($recipient_row);
     return id($msg_row);
-}
+};

--- a/web/src/rtl.ts
+++ b/web/src/rtl.ts
@@ -21,7 +21,7 @@ import _ from "lodash";
  * @param {string} raw
  * @returns {number[]}
  */
-function convert_from_raw(digits: string, part_length: number, raw: string): number[] {
+const convert_from_raw = (digits: string, part_length: number, raw: string): number[] => {
     const result = [];
     for (let i = 0; i < raw.length; ) {
         let t = 0;
@@ -32,7 +32,7 @@ function convert_from_raw(digits: string, part_length: number, raw: string): num
         result.push(t);
     }
     return result;
-}
+};
 
 /** Isolate initiator characters. */
 const i_chars = new Set([0x2066, 0x2067, 0x2068]);
@@ -86,7 +86,7 @@ const lr_ranges = [
  * @param {number} ch A character to get its bidirectional class.
  * @returns {'I' | 'PDI' | 'R' | 'L' | 'Other'}
  */
-function get_bidi_class(ch: number): "I" | "PDI" | "R" | "L" | "Other" {
+const get_bidi_class = (ch: number): "I" | "PDI" | "R" | "L" | "Other" => {
     if (i_chars.has(ch)) {
         return "I"; // LRI, RLI, FSI
     }
@@ -102,14 +102,14 @@ function get_bidi_class(ch: number): "I" | "PDI" | "R" | "L" | "Other" {
         return "L";
     }
     return "Other";
-}
+};
 
 /**
  * Gets the direction that should be used to show the string.
  * @param {string} str The string to get its direction.
  * @returns {'ltr' | 'rtl'}
  */
-export function get_direction(str: string): "ltr" | "rtl" {
+export const get_direction = (str: string): "ltr" | "rtl" => {
     let isolations = 0;
     for (const ch of str) {
         const bidi_class = get_bidi_class(ch.codePointAt(0)!);
@@ -137,9 +137,9 @@ export function get_direction(str: string): "ltr" | "rtl" {
         }
     }
     return "ltr";
-}
+};
 
-export function set_rtl_class_for_textarea($textarea: JQuery<HTMLTextAreaElement>): void {
+export const set_rtl_class_for_textarea = ($textarea: JQuery<HTMLTextAreaElement>): void => {
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     let text = $textarea.val()!;
     if (text.startsWith("```quote")) {
@@ -150,4 +150,4 @@ export function set_rtl_class_for_textarea($textarea: JQuery<HTMLTextAreaElement
     } else {
         $textarea.removeClass("rtl");
     }
-}
+};

--- a/web/src/scheduled_messages.ts
+++ b/web/src/scheduled_messages.ts
@@ -36,7 +36,7 @@ export const scheduled_messages_data = new Map<number, ScheduledMessage>();
 
 let selected_send_later_timestamp: number | undefined;
 
-function compute_send_times(now = new Date()): Record<TimeKey, number> {
+const compute_send_times = (now = new Date()): Record<TimeKey, number> => {
     const send_times: Record<string, number> = {};
 
     const today = new Date(now);
@@ -58,45 +58,45 @@ function compute_send_times(now = new Date()): Record<TimeKey, number> {
     // next Monday at 9am
     send_times.monday_nine_am = monday.setHours(9, 0, 0, 0);
     return send_times;
-}
+};
 
-export function add_scheduled_messages(scheduled_messages: ScheduledMessage[]): void {
+export const add_scheduled_messages = (scheduled_messages: ScheduledMessage[]): void => {
     for (const scheduled_message of scheduled_messages) {
         scheduled_messages_data.set(scheduled_message.scheduled_message_id, scheduled_message);
     }
-}
+};
 
-export function remove_scheduled_message(scheduled_message_id: number): void {
+export const remove_scheduled_message = (scheduled_message_id: number): void => {
     if (scheduled_messages_data.has(scheduled_message_id)) {
         scheduled_messages_data.delete(scheduled_message_id);
     }
-}
+};
 
-export function update_scheduled_message(scheduled_message: ScheduledMessage): void {
+export const update_scheduled_message = (scheduled_message: ScheduledMessage): void => {
     if (!scheduled_messages_data.has(scheduled_message.scheduled_message_id)) {
         return;
     }
 
     scheduled_messages_data.set(scheduled_message.scheduled_message_id, scheduled_message);
-}
+};
 
-export function delete_scheduled_message(scheduled_msg_id: number, success?: () => void): void {
+export const delete_scheduled_message = (scheduled_msg_id: number, success?: () => void): void => {
     void channel.del({
         url: "/json/scheduled_messages/" + scheduled_msg_id,
         success,
     });
-}
+};
 
-export function get_count(): number {
-    return scheduled_messages_data.size;
-}
+export const get_count = (): number => scheduled_messages_data.size;
 
-export function get_filtered_send_opts(date: Date): {
+export const get_filtered_send_opts = (
+    date: Date,
+): {
     possible_send_later_today: SendOption | false;
     send_later_tomorrow: SendOption;
     possible_send_later_monday: SendOption | false;
     send_later_custom: {text: string};
-} {
+} => {
     const send_times = compute_send_times(date);
 
     const day = date.getDay(); // Starts with 0 for Sunday.
@@ -201,32 +201,32 @@ export function get_filtered_send_opts(date: Date): {
         possible_send_later_monday,
         send_later_custom,
     };
-}
+};
 
-export function get_selected_send_later_timestamp(): number | undefined {
+export const get_selected_send_later_timestamp = (): number | undefined => {
     if (!selected_send_later_timestamp) {
         return undefined;
     }
     return selected_send_later_timestamp;
-}
+};
 
-export function get_formatted_selected_send_later_time(): string | undefined {
+export const get_formatted_selected_send_later_time = (): string | undefined => {
     if (!selected_send_later_timestamp) {
         return undefined;
     }
     return timerender.get_full_datetime(new Date(selected_send_later_timestamp * 1000), "time");
-}
+};
 
-export function set_selected_schedule_timestamp(timestamp: number): void {
+export const set_selected_schedule_timestamp = (timestamp: number): void => {
     selected_send_later_timestamp = timestamp;
-}
+};
 
-export function reset_selected_schedule_timestamp(): void {
+export const reset_selected_schedule_timestamp = (): void => {
     selected_send_later_timestamp = undefined;
-}
+};
 
-export function initialize(scheduled_messages_params: {
+export const initialize = (scheduled_messages_params: {
     scheduled_messages: ScheduledMessage[];
-}): void {
+}): void => {
     add_scheduled_messages(scheduled_messages_params.scheduled_messages);
-}
+};

--- a/web/src/scheduled_messages_feed_ui.ts
+++ b/web/src/scheduled_messages_feed_ui.ts
@@ -7,7 +7,7 @@ import * as scheduled_messages from "./scheduled_messages";
 import type {ScheduledMessage} from "./scheduled_messages";
 import * as util from "./util";
 
-function get_scheduled_messages_matching_narrow(): ScheduledMessage[] {
+const get_scheduled_messages_matching_narrow = (): ScheduledMessage[] => {
     const scheduled_messages_list = [...scheduled_messages.scheduled_messages_data.values()];
     const filter = narrow_state.filter();
     const is_conversation_view = filter === undefined ? false : filter.is_conversation_view();
@@ -54,9 +54,9 @@ function get_scheduled_messages_matching_narrow(): ScheduledMessage[] {
         return false;
     });
     return matching_scheduled_messages;
-}
+};
 
-export function update_schedule_message_indicator(): void {
+export const update_schedule_message_indicator = (): void => {
     $("#scheduled_message_indicator").empty();
     const matching_scheduled_messages = get_scheduled_messages_matching_narrow();
     const scheduled_message_count = matching_scheduled_messages.length;
@@ -67,4 +67,4 @@ export function update_schedule_message_indicator(): void {
             }),
         );
     }
-}
+};

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -15,7 +15,7 @@ import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 
 export const keyboard_handling_context = {
-    get_items_ids() {
+    get_items_ids: () => {
         const scheduled_messages_ids = [];
         const sorted_messages = sort_scheduled_messages(scheduled_messages.scheduled_messages_data);
         for (const message of sorted_messages) {
@@ -49,18 +49,18 @@ export const keyboard_handling_context = {
     id_attribute_name: "data-scheduled-message-id",
 };
 
-function sort_scheduled_messages(scheduled_messages) {
+const sort_scheduled_messages = (scheduled_messages) => {
     const sorted_messages = [...scheduled_messages.values()].sort(
         (msg1, msg2) => msg1.scheduled_delivery_timestamp - msg2.scheduled_delivery_timestamp,
     );
     return sorted_messages;
-}
+};
 
-export function handle_keyboard_events(event_key) {
+export const handle_keyboard_events = (event_key) => {
     messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
-}
+};
 
-function format(scheduled_messages) {
+const format = (scheduled_messages) => {
     const formatted_msgs = [];
     const sorted_messages = sort_scheduled_messages(scheduled_messages);
     for (const msg of sorted_messages) {
@@ -84,14 +84,14 @@ function format(scheduled_messages) {
         formatted_msgs.push(msg_render_context);
     }
     return formatted_msgs;
-}
+};
 
-export function launch() {
+export const launch = () => {
     $("#scheduled_messages_overlay_container").html(render_scheduled_messages_overlay());
     overlays.open_overlay({
         name: "scheduled",
         $overlay: $("#scheduled_messages_overlay"),
-        on_close() {
+        on_close: () => {
             browser_history.exit_overlay();
         },
     });
@@ -104,9 +104,9 @@ export function launch() {
 
     const first_element_id = keyboard_handling_context.get_items_ids()[0];
     messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
-}
+};
 
-export function rerender() {
+export const rerender = () => {
     if (!overlays.scheduled_messages_open()) {
         return;
     }
@@ -116,17 +116,17 @@ export function rerender() {
     const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
     $messages_list.find(".scheduled-message-row").remove();
     $messages_list.append($(rendered_list));
-}
+};
 
-export function remove_scheduled_message_id(scheduled_msg_id) {
+export const remove_scheduled_message_id = (scheduled_msg_id) => {
     if (overlays.scheduled_messages_open()) {
         $(
             `#scheduled_messages_overlay .scheduled-message-row[data-scheduled-message-id=${scheduled_msg_id}]`,
         ).remove();
     }
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $("body").on("click", ".scheduled-message-row .restore-overlay-message", (e) => {
         let scheduled_msg_id = $(e.currentTarget)
             .closest(".scheduled-message-row")
@@ -151,4 +151,4 @@ export function initialize() {
     $("body").on("focus", ".overlay-message-info-box", (e) => {
         messages_overlay_ui.activate_element(e.target, keyboard_handling_context);
     });
-}
+};

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -11,13 +11,13 @@ import * as scheduled_messages from "./scheduled_messages";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 
-export function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
+export const hide_scheduled_message_success_compose_banner = (scheduled_message_id) => {
     $(
         `.message_scheduled_success_compose_banner[data-scheduled-message-id=${scheduled_message_id}]`,
     ).hide();
-}
+};
 
-function narrow_via_edit_scheduled_message(compose_args) {
+const narrow_via_edit_scheduled_message = (compose_args) => {
     if (compose_args.message_type === "stream") {
         message_view.show(
             [
@@ -34,9 +34,9 @@ function narrow_via_edit_scheduled_message(compose_args) {
             trigger: "edit scheduled message",
         });
     }
-}
+};
 
-export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_to_recipient) {
+export const open_scheduled_message_in_compose = (scheduled_msg, should_narrow_to_recipient) => {
     let compose_args;
     if (scheduled_msg.type === "stream") {
         compose_args = {
@@ -69,9 +69,9 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
 
     compose_actions.start(compose_args);
     scheduled_messages.set_selected_schedule_timestamp(scheduled_msg.scheduled_delivery_timestamp);
-}
+};
 
-function show_message_unscheduled_banner(scheduled_delivery_timestamp) {
+const show_message_unscheduled_banner = (scheduled_delivery_timestamp) => {
     const deliver_at = timerender.get_full_datetime(
         new Date(scheduled_delivery_timestamp * 1000),
         "time",
@@ -88,17 +88,17 @@ function show_message_unscheduled_banner(scheduled_delivery_timestamp) {
         $(unscheduled_banner_html),
         $("#compose_banners"),
     );
-}
+};
 
-export function edit_scheduled_message(scheduled_message_id, should_narrow_to_recipient = true) {
+export const edit_scheduled_message = (scheduled_message_id, should_narrow_to_recipient = true) => {
     const scheduled_msg = scheduled_messages.scheduled_messages_data.get(scheduled_message_id);
     scheduled_messages.delete_scheduled_message(scheduled_message_id, () => {
         open_scheduled_message_in_compose(scheduled_msg, should_narrow_to_recipient);
         show_message_unscheduled_banner(scheduled_msg.scheduled_delivery_timestamp);
     });
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $("body").on("click", ".undo_scheduled_message", (e) => {
         const scheduled_message_id = Number.parseInt(
             $(e.target)
@@ -111,4 +111,4 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
     });
-}
+};

--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -2,15 +2,15 @@ import $ from "jquery";
 
 import {user_settings} from "./user_settings";
 
-export function set_layout_width(): void {
+export const set_layout_width = (): void => {
     if (user_settings.fluid_layout_width) {
         $("body").addClass("fluid_layout_width");
     } else {
         $("body").removeClass("fluid_layout_width");
     }
-}
+};
 
-export function handle_overlay_scrollbars(): void {
+export const handle_overlay_scrollbars = (): void => {
     // If right sidebar scrollbar overlaps with browser scrollbar, move the right
     // sidebar scrollbar to the left. Done on fluid screen width and when scrollbars overlap.
     const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
@@ -25,8 +25,8 @@ export function handle_overlay_scrollbars(): void {
     }
 
     $("body").removeClass("has-overlay-scrollbar");
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     set_layout_width();
-}
+};

--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -4,16 +4,16 @@ import SimpleBar from "simplebar";
 // This type is helpful for testing, where we may have a dummy object instead of an actual jquery object.
 type JQueryOrZJQuery = {__zjquery?: true} & JQuery;
 
-export function get_content_element($element: JQuery): JQuery {
+export const get_content_element = ($element: JQuery): JQuery => {
     const element = $element.expectOne()[0]!;
     const sb = SimpleBar.instances.get(element);
     if (sb) {
         return $(sb.getContentElement()!);
     }
     return $element;
-}
+};
 
-export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
+export const get_scroll_element = ($element: JQueryOrZJQuery): JQuery => {
     // For testing we just return the element itself.
     if ($element?.__zjquery) {
         return $element;
@@ -29,9 +29,9 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
         return $(new SimpleBar(element).getScrollElement()!);
     }
     return $element;
-}
+};
 
-export function reset_scrollbar($element: JQuery): void {
+export const reset_scrollbar = ($element: JQuery): void => {
     const element = $element.expectOne()[0]!;
     const sb = SimpleBar.instances.get(element);
     if (sb) {
@@ -39,13 +39,13 @@ export function reset_scrollbar($element: JQuery): void {
     } else {
         element.scrollTop = 0;
     }
-}
+};
 
-export function scroll_delta(opts: {
+export const scroll_delta = (opts: {
     elem_top: number;
     elem_bottom: number;
     container_height: number;
-}): number {
+}): number => {
     const elem_top = opts.elem_top;
     const container_height = opts.container_height;
     const elem_bottom = opts.elem_bottom;
@@ -63,13 +63,13 @@ export function scroll_delta(opts: {
     }
 
     return delta;
-}
+};
 
-export function scroll_element_into_container(
+export const scroll_element_into_container = (
     $elem: JQuery,
     $container: JQuery,
     sticky_header_height = 0,
-): void {
+): void => {
     // This does the minimum amount of scrolling that is needed to make
     // the element visible.  It doesn't try to center the element, so
     // this will be non-intrusive to users when they already have
@@ -92,4 +92,4 @@ export function scroll_element_into_container(
     }
 
     $container.scrollTop(($container.scrollTop() ?? 0) + delta);
-}
+};

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -17,15 +17,15 @@ export let is_using_input_method = false;
 
 let search_typeahead: Typeahead<string>;
 
-export function set_search_bar_text(text: string): void {
+export const set_search_bar_text = (text: string): void => {
     $("#search_query").val(text);
-}
+};
 
-function get_search_bar_text(): string {
+const get_search_bar_text = (): string => {
     const val = $<HTMLInputElement>("#search_query").val();
     assert(val !== undefined);
     return val;
-}
+};
 
 // TODO/typescript: Add the rest of the options when converting narrow.js to typescript.
 type NarrowSearchOptions = {
@@ -34,10 +34,10 @@ type NarrowSearchOptions = {
 
 type OnNarrowSearch = (terms: NarrowTerm[], options: NarrowSearchOptions) => void;
 
-function narrow_or_search_for_term(
+const narrow_or_search_for_term = (
     search_string: string,
     {on_narrow_search}: {on_narrow_search: OnNarrowSearch},
-): string {
+): string => {
     if (search_string === "") {
         exit_search({keep_search_narrow_open: true});
         return "";
@@ -61,9 +61,9 @@ function narrow_or_search_for_term(
     // so leave the current text in.
     $search_query_box.trigger("blur");
     return get_search_bar_text();
-}
+};
 
-export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch}): void {
+export const initialize = ({on_narrow_search}: {on_narrow_search: OnNarrowSearch}): void => {
     const $search_query_box = $<HTMLInputElement>("#search_query");
     const $searchbox_form = $("#searchbox_form");
 
@@ -79,7 +79,7 @@ export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch
         type: "input",
     };
     search_typeahead = new Typeahead(bootstrap_typeahead_input, {
-        source(query: string): string[] {
+        source: (query: string): string[] => {
             const suggestions = search_suggestion.get_suggestions(query);
             // Update our global search_map hash
             search_map = suggestions.lookup_table;
@@ -89,33 +89,28 @@ export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch
         items: search_suggestion.max_num_of_search_results,
         helpOnEmptyStrings: true,
         naturalSearch: true,
-        highlighter_html(item: string): string {
+        highlighter_html: (item: string): string => {
             const obj = search_map.get(item);
             return render_search_list_item(obj);
         },
-        matcher(): boolean {
-            return true;
-        },
-        updater(search_string: string): string {
-            return narrow_or_search_for_term(search_string, {on_narrow_search});
-        },
-        sorter(items: string[]): string[] {
-            return items;
-        },
+        matcher: (): boolean => true,
+        updater: (search_string: string): string =>
+            narrow_or_search_for_term(search_string, {on_narrow_search}),
+        sorter: (items: string[]): string[] => items,
         advanceKeyCodes: [8],
 
         // Use our custom typeahead `on_escape` hook to exit
         // the search bar as soon as the user hits Esc.
-        on_escape() {
+        on_escape: () => {
             exit_search({keep_search_narrow_open: false});
         },
         tabIsEnter: false,
-        openInputFieldOnKeyUp(): void {
+        openInputFieldOnKeyUp: (): void => {
             if ($(".navbar-search.expanded").length === 0) {
                 open_search_bar_and_close_narrow_description();
             }
         },
-        closeInputFieldOnHide(): void {
+        closeInputFieldOnHide: (): void => {
             // Don't close the search bar if the user has changed
             // the text from the default, they might accidentally
             // click away and not want to lose it.
@@ -212,9 +207,9 @@ export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch
             e.stopPropagation();
         }
     });
-}
+};
 
-export function initiate_search(): void {
+export const initiate_search = (): void => {
     open_search_bar_and_close_narrow_description();
 
     // Open the typeahead after opening the search bar, so that we don't
@@ -222,27 +217,27 @@ export function initiate_search(): void {
     // before the search bar expands and then wider it expands.
     search_typeahead.lookup(false);
     $("#search_query").trigger("select");
-}
+};
 
 // This is what the default searchbox text would be for this narrow,
 // NOT what might be currently displayed there. We can use this both
 // to set the initial text and to see if the user has changed it.
-function get_initial_search_string(): string {
+const get_initial_search_string = (): string => {
     let search_string = narrow_state.search_string();
     if (search_string !== "" && !narrow_state.filter()?.is_keyword_search()) {
         // saves the user a keystroke for quick searches
         search_string = search_string + " ";
     }
     return search_string;
-}
+};
 
 // we rely entirely on this function to ensure
 // the searchbar has the right text.
-function reset_searchbox_text(): void {
+const reset_searchbox_text = (): void => {
     set_search_bar_text(get_initial_search_string());
-}
+};
 
-function exit_search(opts: {keep_search_narrow_open: boolean}): void {
+const exit_search = (opts: {keep_search_narrow_open: boolean}): void => {
     const filter = narrow_state.filter();
     if (!filter || filter.is_common_narrow()) {
         // for common narrows, we change the UI (and don't redirect)
@@ -256,9 +251,9 @@ function exit_search(opts: {keep_search_narrow_open: boolean}): void {
     }
     $("#search_query").trigger("blur");
     $(".app").trigger("focus");
-}
+};
 
-export function open_search_bar_and_close_narrow_description(): void {
+export const open_search_bar_and_close_narrow_description = (): void => {
     // Preserve user input if they've already started typing, but
     // otherwise fill the input field with the text terms for
     // the current narrow.
@@ -268,9 +263,9 @@ export function open_search_bar_and_close_narrow_description(): void {
     $(".navbar-search").addClass("expanded");
     $("#message_view_header").addClass("hidden");
     popovers.hide_all();
-}
+};
 
-export function close_search_bar_and_open_narrow_description(): void {
+export const close_search_bar_and_open_narrow_description = (): void => {
     // Hide the dropdown before closing the search bar. We do this
     // to avoid being in a situation where the typeahead gets narrow
     // in width as the search bar closes, which doesn't look great.
@@ -279,4 +274,4 @@ export function close_search_bar_and_open_narrow_description(): void {
     set_search_bar_text("");
     $(".navbar-search").removeClass("expanded");
     $("#message_view_header").removeClass("hidden");
-}
+};

--- a/web/src/search_util.ts
+++ b/web/src/search_util.ts
@@ -1,12 +1,12 @@
-export function get_search_terms(input: string): string[] {
+export const get_search_terms = (input: string): string[] => {
     const search_terms = input
         .toLowerCase()
         .split(",")
         .map((s) => s.trim());
     return search_terms;
-}
+};
 
-export function vanilla_match(opts: {val: string; search_terms: string[]}): boolean {
+export const vanilla_match = (opts: {val: string; search_terms: string[]}): boolean => {
     /*
         This is a pretty vanilla search criteria
         where we see if any of our search terms
@@ -19,4 +19,4 @@ export function vanilla_match(opts: {val: string; search_terms: string[]}): bool
     */
     const val = opts.val.toLowerCase();
     return opts.search_terms.some((term) => val.includes(term));
-}
+};

--- a/web/src/sent_messages.ts
+++ b/web/src/sent_messages.ts
@@ -5,11 +5,11 @@ import * as blueslip from "./blueslip";
 export let next_local_id = 0;
 export const messages = new Map<string, MessageState>();
 
-export function get_new_local_id(): string {
+export const get_new_local_id = (): string => {
     next_local_id += 1;
     const local_id = next_local_id;
     return "loc-" + local_id.toString();
-}
+};
 
 export class MessageState {
     local_id: string;
@@ -74,7 +74,7 @@ export class MessageState {
     }
 }
 
-export function start_tracking_message(opts: {local_id: string; locally_echoed: boolean}): void {
+export const start_tracking_message = (opts: {local_id: string; locally_echoed: boolean}): void => {
     const local_id = opts.local_id;
 
     if (!opts.local_id) {
@@ -90,9 +90,9 @@ export function start_tracking_message(opts: {local_id: string; locally_echoed: 
     const state = new MessageState(opts);
 
     messages.set(local_id, state);
-}
+};
 
-export function get_message_state(local_id: string): MessageState | undefined {
+export const get_message_state = (local_id: string): MessageState | undefined => {
     const state = messages.get(local_id);
 
     if (!state) {
@@ -100,26 +100,26 @@ export function get_message_state(local_id: string): MessageState | undefined {
     }
 
     return state;
-}
+};
 
-export function start_send(local_id: string): Sentry.Transaction | undefined {
+export const start_send = (local_id: string): Sentry.Transaction | undefined => {
     const state = get_message_state(local_id);
     if (!state) {
         return undefined;
     }
 
     return state.start_send();
-}
+};
 
-export function mark_disparity(local_id: string): void {
+export const mark_disparity = (local_id: string): void => {
     const state = get_message_state(local_id);
     if (!state) {
         return;
     }
     state.mark_disparity();
-}
+};
 
-export function report_event_received(local_id: string): void {
+export const report_event_received = (local_id: string): void => {
     if (local_id === undefined) {
         return;
     }
@@ -129,4 +129,4 @@ export function report_event_received(local_id: string): void {
     }
 
     state.report_event_received();
-}
+};

--- a/web/src/sentry.ts
+++ b/web/src/sentry.ts
@@ -18,7 +18,7 @@ const sentry_key =
           ? "(root)"
           : page_params.realm_sentry_key;
 
-export function normalize_path(path: string, is_portico = false): string {
+export const normalize_path = (path: string, is_portico = false): string => {
     if (path === undefined) {
         return "unknown";
     }
@@ -32,14 +32,14 @@ export function normalize_path(path: string, is_portico = false): string {
         return "portico: " + path;
     }
     return path;
-}
+};
 
-export function shouldCreateSpanForRequest(url: string): boolean {
+export const shouldCreateSpanForRequest = (url: string): boolean => {
     const parsed = new URL(url, window.location.href);
     return parsed.pathname !== "/json/events";
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     // The current_user and realm structures are not available until this is
     // called from ui_init.initialize_everything.
     assert(page_params.page_type === "home");
@@ -66,7 +66,7 @@ export function initialize(): void {
         server_version: realm.zulip_version,
     });
     Sentry.setUser(user_info);
-}
+};
 
 if (page_params.server_sentry_dsn) {
     const sample_rates = new Map([
@@ -86,23 +86,21 @@ if (page_params.server_sentry_dsn) {
         integrations: [
             new Sentry.BrowserTracing({
                 startTransactionOnLocationChange: false,
-                beforeNavigate(context) {
-                    return {
-                        ...context,
-                        metadata: {source: "custom"},
-                        name: normalize_path(location.pathname, sentry_key === "www"),
-                    };
-                },
+                beforeNavigate: (context) => ({
+                    ...context,
+                    metadata: {source: "custom"},
+                    name: normalize_path(location.pathname, sentry_key === "www"),
+                }),
                 shouldCreateSpanForRequest,
             }),
         ],
         sampleRate: page_params.server_sentry_sample_rate ?? 0,
-        tracesSampler(samplingContext) {
+        tracesSampler: (samplingContext) => {
             const base_rate = page_params.server_sentry_trace_rate ?? 0;
             const name = samplingContext.transactionContext.name;
             return base_rate * (sample_rates.get(name) ?? 1);
         },
-        initialScope(scope) {
+        initialScope: (scope) => {
             const user_info: UserInfo = {
                 realm: sentry_key,
             };

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -31,15 +31,12 @@ const get_events_params = {};
 
 let event_queue_expired = false;
 
-function get_events_success(events) {
+const get_events_success = (events) => {
     let messages = [];
     const update_message_events = [];
     const post_message_events = [];
 
-    const clean_event = function clean_event(event) {
-        // Only log a whitelist of the event to remove private data
-        return _.pick(event, "id", "type", "op");
-    };
+    const clean_event = (event) => _.pick(event, "id", "type", "op");
 
     for (const event of events) {
         try {
@@ -63,7 +60,7 @@ function get_events_success(events) {
     // called in the default case.  The goal of this split is to avoid
     // contributors needing to read or understand the complex and
     // rarely modified logic for non-normal events.
-    const dispatch_event = function dispatch_event(event) {
+    const dispatch_event = (event) => {
         switch (event.type) {
             case "message": {
                 const msg = event.message;
@@ -142,19 +139,19 @@ function get_events_success(events) {
     for (const event of post_message_events) {
         server_events_dispatch.dispatch_normal_event(event);
     }
-}
+};
 
-function show_ui_connection_error() {
+const show_ui_connection_error = () => {
     ui_report.show_error($("#connection-error"));
     $("#connection-error").addClass("get-events-error");
-}
+};
 
-function hide_ui_connection_error() {
+const hide_ui_connection_error = () => {
     ui_report.hide_error($("#connection-error"));
     $("#connection-error").removeClass("get-events-error");
-}
+};
 
-function get_events({dont_block = false} = {}) {
+const get_events = ({dont_block = false} = {}) => {
     if (reload_state.is_in_progress()) {
         return;
     }
@@ -195,7 +192,7 @@ function get_events({dont_block = false} = {}) {
         url: "/json/events",
         data: get_events_params,
         timeout: event_queue_longpoll_timeout_seconds * 1000,
-        success(data) {
+        success: (data) => {
             watchdog.set_suspect_offline(false);
             try {
                 get_events_xhr = undefined;
@@ -208,7 +205,7 @@ function get_events({dont_block = false} = {}) {
             }
             get_events_timeout = setTimeout(get_events, 0);
         },
-        error(xhr, error_type) {
+        error: (xhr, error_type) => {
             try {
                 get_events_xhr = undefined;
                 // If we're old enough that our message queue has been
@@ -263,31 +260,31 @@ function get_events({dont_block = false} = {}) {
             get_events_timeout = setTimeout(get_events, retry_delay_secs * 1000);
         },
     });
-}
+};
 
-export function assert_get_events_running(error_message) {
+export const assert_get_events_running = (error_message) => {
     if (get_events_xhr === undefined && get_events_timeout === undefined) {
         restart_get_events({dont_block: true});
         blueslip.error(error_message);
     }
-}
+};
 
-export function restart_get_events(options) {
+export const restart_get_events = (options) => {
     get_events(options);
-}
+};
 
-export function force_get_events() {
+export const force_get_events = () => {
     get_events_timeout = setTimeout(get_events, 0);
-}
+};
 
-export function finished_initial_fetch() {
+export const finished_initial_fetch = () => {
     waiting_on_initial_fetch = false;
     get_events_success([]);
     // Destroy loading indicator after we added fetched messages.
     loading.destroy_indicator($("#page_loading_indicator"));
-}
+};
 
-export function initialize(params) {
+export const initialize = (params) => {
     queue_id = params.queue_id;
     last_event_id = params.last_event_id;
     event_queue_longpoll_timeout_seconds = params.event_queue_longpoll_timeout_seconds;
@@ -303,9 +300,9 @@ export function initialize(params) {
         restart_get_events({dont_block: true});
     });
     get_events();
-}
+};
 
-function cleanup_event_queue() {
+const cleanup_event_queue = () => {
     // Submit a request to the server to clean up our event queue
     if (event_queue_expired || page_params.no_event_queue) {
         return;
@@ -318,7 +315,7 @@ function cleanup_event_queue() {
         data: {queue_id},
         ignore_reload: true,
     });
-}
+};
 
 // For unit testing
 export const _get_events_success = get_events_success;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -87,8 +87,8 @@ import {user_settings} from "./user_settings";
 import * as user_status from "./user_status";
 import * as user_topics_ui from "./user_topics_ui";
 
-export function dispatch_normal_event(event) {
-    const noop = function () {};
+export const dispatch_normal_event = (event) => {
+    const noop = () => {};
     switch (event.type) {
         case "alert_words":
             alert_words.set_words(event.alert_words);
@@ -955,4 +955,4 @@ export function dispatch_normal_event(event) {
             user_topics_ui.handle_topic_updates(event);
             break;
     }
-}
+};

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -25,7 +25,7 @@ import {user_settings} from "./user_settings";
 
 export let settings_label;
 
-function setup_settings_label() {
+const setup_settings_label = () => {
     settings_label = {
         // settings_notification
         presence_enabled: $t({
@@ -45,24 +45,24 @@ function setup_settings_label() {
         ...settings_config.notification_settings_labels,
         ...settings_config.preferences_settings_labels,
     };
-}
+};
 
-function get_parsed_date_of_joining() {
+const get_parsed_date_of_joining = () => {
     const user_date_joined = people.get_by_user_id(current_user.user_id, false).date_joined;
     return timerender.get_localized_date_or_time_for_format(
         parseISO(user_date_joined),
         "dayofyear_year",
     );
-}
+};
 
-function user_can_change_password() {
+const user_can_change_password = () => {
     if (settings_data.user_email_not_configured()) {
         return false;
     }
     return realm.realm_email_auth_enabled;
-}
+};
 
-export function update_lock_icon_in_sidebar() {
+export const update_lock_icon_in_sidebar = () => {
     if (current_user.is_owner) {
         $(".org-settings-list .locked").hide();
         return;
@@ -82,9 +82,9 @@ export function update_lock_icon_in_sidebar() {
     if (settings_data.user_can_add_custom_emoji()) {
         $(".org-settings-list li[data-section='emoji-settings'] .locked").hide();
     }
-}
+};
 
-export function build_page() {
+export const build_page = () => {
     setup_settings_label();
 
     const rendered_settings_tab = render_settings_tab({
@@ -144,28 +144,28 @@ export function build_page() {
 
     settings_bots.update_bot_settings_tip($("#personal-bot-settings-tip"), false);
     $(".settings-box").html(rendered_settings_tab);
-}
+};
 
-export function open_settings_overlay() {
+export const open_settings_overlay = () => {
     overlays.open_overlay({
         name: "settings",
         $overlay: $("#settings_overlay_container"),
-        on_close() {
+        on_close: () => {
             browser_history.exit_overlay();
             flatpickr.close_all();
         },
     });
-}
+};
 
-export function launch(section) {
+export const launch = (section) => {
     settings_sections.reset_sections();
 
     open_settings_overlay();
     settings_panel_menu.normal_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle("settings");
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     const rendered_settings_overlay = render_settings_overlay({
         is_owner: current_user.is_owner,
         is_admin: current_user.is_admin,
@@ -192,4 +192,4 @@ export function initialize() {
         // overlay and subsequently close any open modal.
         modals.close_active();
     });
-}
+};

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -35,15 +35,15 @@ import {user_settings} from "./user_settings";
 let password_quality; // Loaded asynchronously
 let user_avatar_widget_created = false;
 
-export function update_email(new_email) {
+export const update_email = (new_email) => {
     const $email_input = $("#change_email_button");
 
     if ($email_input) {
         $email_input.text(new_email);
     }
-}
+};
 
-export function update_full_name(new_full_name) {
+export const update_full_name = (new_full_name) => {
     // Arguably, this should work more like how the `update_email`
     // flow works, where we update the name in the modal on open,
     // rather than updating it here, but this works.
@@ -51,9 +51,9 @@ export function update_full_name(new_full_name) {
     if ($full_name_input) {
         $full_name_input.val(new_full_name);
     }
-}
+};
 
-export function update_name_change_display() {
+export const update_name_change_display = () => {
     if ($("#user_details_section").length === 0) {
         return;
     }
@@ -65,9 +65,9 @@ export function update_name_change_display() {
         $("#full_name").prop("disabled", false);
         $("#full_name_input_container").removeClass("disabled_setting_tooltip");
     }
-}
+};
 
-export function update_email_change_display() {
+export const update_email_change_display = () => {
     if ($("#user_details_section").length === 0) {
         return;
     }
@@ -79,22 +79,22 @@ export function update_email_change_display() {
         $("#change_email_button").prop("disabled", false);
         $("#change_email_button_container").removeClass("disabled_setting_tooltip");
     }
-}
+};
 
-function display_avatar_upload_complete() {
+const display_avatar_upload_complete = () => {
     $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
     $("#user-avatar-upload-widget .image-upload-text").show();
     $("#user-avatar-upload-widget .image-delete-button").show();
-}
+};
 
-function display_avatar_upload_started() {
+const display_avatar_upload_started = () => {
     $("#user-avatar-source").hide();
     $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "visible"});
     $("#user-avatar-upload-widget .image-upload-text").hide();
     $("#user-avatar-upload-widget .image-delete-button").hide();
-}
+};
 
-function upload_avatar($file_input) {
+const upload_avatar = ($file_input) => {
     const form_data = new FormData();
 
     form_data.append("csrfmiddlewaretoken", csrf_token);
@@ -108,13 +108,13 @@ function upload_avatar($file_input) {
         cache: false,
         processData: false,
         contentType: false,
-        success() {
+        success: () => {
             display_avatar_upload_complete();
             $("#user-avatar-upload-widget .image_file_input_error").hide();
             $("#user-avatar-source").hide();
             // Rest of the work is done via the user_events -> avatar_url event we will get
         },
-        error(xhr) {
+        error: (xhr) => {
             display_avatar_upload_complete();
             if (current_user.avatar_source === "G") {
                 $("#user-avatar-source").show();
@@ -126,9 +126,9 @@ function upload_avatar($file_input) {
             }
         },
     });
-}
+};
 
-export function update_avatar_change_display() {
+export const update_avatar_change_display = () => {
     if ($("#user-avatar-upload-widget").length === 0) {
         return;
     }
@@ -144,9 +144,9 @@ export function update_avatar_change_display() {
         $("#user-avatar-upload-widget .image_upload_button").removeClass("hide");
         $("#user-avatar-upload-widget .image-disabled").addClass("hide");
     }
-}
+};
 
-export function update_account_settings_display() {
+export const update_account_settings_display = () => {
     if ($("#user_details_section").length === 0) {
         return;
     }
@@ -154,9 +154,9 @@ export function update_account_settings_display() {
     update_name_change_display();
     update_email_change_display();
     update_avatar_change_display();
-}
+};
 
-export function maybe_update_deactivate_account_button() {
+export const maybe_update_deactivate_account_button = () => {
     if (!current_user.is_owner) {
         return;
     }
@@ -171,21 +171,21 @@ export function maybe_update_deactivate_account_button() {
             $deactivate_account_container.removeClass("disabled_setting_tooltip");
         }
     }
-}
+};
 
-export function update_send_read_receipts_tooltip() {
+export const update_send_read_receipts_tooltip = () => {
     if (realm.realm_enable_read_receipts) {
         $("#send_read_receipts_label .settings-info-icon").hide();
     } else {
         $("#send_read_receipts_label .settings-info-icon").show();
     }
-}
+};
 
-function settings_change_error(message_html, xhr) {
+const settings_change_error = (message_html, xhr) => {
     ui_report.error(message_html, xhr, $("#account-settings-status").expectOne());
-}
+};
 
-function update_custom_profile_field(field, method) {
+const update_custom_profile_field = (field, method) => {
     let field_id;
     if (method === channel.del) {
         field_id = field;
@@ -202,9 +202,9 @@ function update_custom_profile_field(field, method) {
         {data: JSON.stringify([field])},
         $spinner_element,
     );
-}
+};
 
-function update_user_custom_profile_fields(fields, method) {
+const update_user_custom_profile_fields = (fields, method) => {
     if (method === undefined) {
         blueslip.error("Undefined method in update_user_custom_profile_fields");
     }
@@ -212,18 +212,18 @@ function update_user_custom_profile_fields(fields, method) {
     for (const field of fields) {
         update_custom_profile_field(field, method);
     }
-}
+};
 
-function update_user_type_field(field, pills) {
+const update_user_type_field = (field, pills) => {
     const user_ids = user_pill.get_user_ids(pills);
     if (user_ids.length < 1) {
         update_user_custom_profile_fields([field.id], channel.del);
     } else {
         update_user_custom_profile_fields([{id: field.id, value: user_ids}], channel.patch);
     }
-}
+};
 
-export function add_custom_profile_fields_to_settings() {
+export const add_custom_profile_fields_to_settings = () => {
     if (!overlays.settings_open()) {
         return;
     }
@@ -242,14 +242,14 @@ export function add_custom_profile_fields_to_settings() {
     );
     custom_profile_fields_ui.initialize_custom_date_type_fields(element_id);
     custom_profile_fields_ui.initialize_custom_pronouns_type_fields(element_id);
-}
+};
 
-export function hide_confirm_email_banner() {
+export const hide_confirm_email_banner = () => {
     if (!overlays.settings_open()) {
         return;
     }
     $("#account-settings-status").hide();
-}
+};
 
 export function set_up() {
     // Add custom profile fields elements to user account settings.
@@ -257,11 +257,11 @@ export function set_up() {
     $("#account-settings-status").hide();
 
     const setup_api_key_modal = () => {
-        function request_api_key(data) {
+        const request_api_key = (data) => {
             channel.post({
                 url: "/json/fetch_api_key",
                 data,
-                success(data) {
+                success: (data) => {
                     $("#get_api_key_password").val("");
                     $("#api_key_value").text(data.api_key);
                     // The display property on the error bar is set to important
@@ -273,7 +273,7 @@ export function set_up() {
                     $("#show_api_key").show();
                     $("#api_key_buttons").show();
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error(
                         $t_html({defaultMessage: "Error"}),
                         xhr,
@@ -282,7 +282,7 @@ export function set_up() {
                     $("#show_api_key").hide();
                 },
             });
-        }
+        };
 
         $("#api_key_value").text("");
         $("#show_api_key").hide();
@@ -293,12 +293,12 @@ export function set_up() {
             {tippy_tooltips: true},
         );
 
-        function do_get_api_key() {
+        const do_get_api_key = () => {
             $("#api_key_status").hide();
             const data = {};
             data.password = $("#get_api_key_password").val();
             request_api_key(data);
-        }
+        };
 
         if (realm.realm_password_auth_enabled === false) {
             // Skip the password prompt step, since the user doesn't have one.
@@ -328,10 +328,10 @@ export function set_up() {
                 // via our usual HTTP Basic auth mechanism.
                 url: "/api/v1/users/me/api_key/regenerate",
                 headers: {Authorization: authorization_header},
-                success(data) {
+                success: (data) => {
                     $("#api_key_value").text(data.api_key);
                 },
-                error(xhr) {
+                error: (xhr) => {
                     if (xhr.responseJSON?.msg) {
                         $("#user_api_key_error").text(xhr.responseJSON.msg).show();
                     }
@@ -365,7 +365,7 @@ export function set_up() {
         $("#api_key_status").hide();
         modals.open("api_key_modal", {
             autoremove: true,
-            on_show() {
+            on_show: () => {
                 $("#get_api_key_password").trigger("focus");
             },
         });
@@ -373,7 +373,7 @@ export function set_up() {
         e.stopPropagation();
     });
 
-    function clear_password_change() {
+    const clear_password_change = () => {
         // Clear the password boxes so that passwords don't linger in the DOM
         // for an XSS attacker to find.
         common.reset_password_toggle_icons(
@@ -386,9 +386,9 @@ export function set_up() {
         );
         $("#old_password, #new_password").val("");
         password_quality?.("", $("#pw_strength .bar"), $("#new_password"));
-    }
+    };
 
-    function change_password_post_render() {
+    const change_password_post_render = () => {
         $("#change_password_modal")
             .find("[data-micromodal-close]")
             .on("click", () => {
@@ -405,13 +405,13 @@ export function set_up() {
             {tippy_tooltips: true},
         );
         clear_password_change();
-    }
+    };
 
     $("#change_password").on("click", async (e) => {
         e.preventDefault();
         e.stopPropagation();
 
-        function validate_input() {
+        const validate_input = () => {
             const old_password = $("#old_password").val();
             const new_password = $("#new_password").val();
 
@@ -433,7 +433,7 @@ export function set_up() {
                 return false;
             }
             return true;
-        }
+        };
 
         dialog_widget.launch({
             html_heading: $t_html({defaultMessage: "Change password"}),
@@ -463,7 +463,7 @@ export function set_up() {
         }
     });
 
-    function do_change_password() {
+    const do_change_password = () => {
         const $change_password_error = $("#change_password_modal").find("#dialog_error");
         $change_password_error.hide();
 
@@ -490,11 +490,11 @@ export function set_up() {
 
         channel.set_password_change_in_progress(true);
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 channel.set_password_change_in_progress(false);
                 dialog_widget.close();
             },
-            error_continuation() {
+            error_continuation: () => {
                 dialog_widget.hide_dialog_spinner();
                 channel.set_password_change_in_progress(false);
             },
@@ -509,7 +509,7 @@ export function set_up() {
             opts,
         );
         clear_password_change();
-    }
+    };
 
     $("#full_name").on("change", (e) => {
         e.preventDefault();
@@ -526,13 +526,13 @@ export function set_up() {
         );
     });
 
-    function do_change_email() {
+    const do_change_email = () => {
         const $change_email_error = $("#change_email_modal").find("#dialog_error");
         const data = {};
         data.email = $("#change_email_form").find("input[name='email']").val();
 
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 if (page_params.development_environment) {
                     const email_msg = render_settings_dev_env_email_access();
                     ui_report.success(
@@ -543,7 +543,7 @@ export function set_up() {
                 }
                 dialog_widget.close();
             },
-            error_continuation() {
+            error_continuation: () => {
                 dialog_widget.hide_dialog_spinner();
             },
             $error_msg_element: $change_email_error,
@@ -560,7 +560,7 @@ export function set_up() {
             $("#account-settings-status").expectOne(),
             opts,
         );
-    }
+    };
 
     $("#change_email_button").on("click", (e) => {
         e.preventDefault();
@@ -574,7 +574,7 @@ export function set_up() {
                 id: "change_email_modal",
                 form_id: "change_email_form",
                 on_click: do_change_email,
-                on_shown() {
+                on_shown: () => {
                     ui_util.place_caret_at_end($("#change_email_form input")[0]);
                 },
                 update_submit_disabled_state_on_change: true,
@@ -582,7 +582,7 @@ export function set_up() {
         }
     });
 
-    function do_demo_organization_add_email(e) {
+    const do_demo_organization_add_email = (e) => {
         e.preventDefault();
         e.stopPropagation();
         const $change_email_error = $("#demo_organization_add_email_modal").find("#dialog_error");
@@ -591,7 +591,7 @@ export function set_up() {
         data.full_name = $("#demo_organization_update_full_name").val();
 
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 if (page_params.development_environment) {
                     const email_msg = render_settings_dev_env_email_access();
                     ui_report.success(
@@ -602,7 +602,7 @@ export function set_up() {
                 }
                 dialog_widget.close();
             },
-            error_continuation() {
+            error_continuation: () => {
                 dialog_widget.hide_dialog_spinner();
             },
             $error_msg_element: $change_email_error,
@@ -619,13 +619,13 @@ export function set_up() {
             $("#account-settings-status").expectOne(),
             opts,
         );
-    }
+    };
 
     $("#demo_organization_add_email_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
-        function demo_organization_add_email_post_render() {
+        const demo_organization_add_email_post_render = () => {
             // Disable submit button if either input is an empty string.
             const $add_email_element = $("#demo_organization_add_email");
             const $add_name_element = $("#demo_organization_update_full_name");
@@ -641,7 +641,7 @@ export function set_up() {
                     $add_email_element.val().trim() === "" || $add_name_element.val().trim() === "",
                 );
             });
-        }
+        };
 
         if (
             realm.demo_organization_scheduled_deletion_date &&
@@ -659,7 +659,7 @@ export function set_up() {
                 id: "demo_organization_add_email_modal",
                 form_id: "demo_organization_add_email_form",
                 on_click: do_demo_organization_add_email,
-                on_shown() {
+                on_shown: () => {
                     ui_util.place_caret_at_end($("#demo_organization_add_email_form input")[0]);
                 },
                 post_render: demo_organization_add_email_post_render,
@@ -701,15 +701,15 @@ export function set_up() {
         e.preventDefault();
         e.stopPropagation();
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             channel.del({
                 url: "/json/users/me",
-                success() {
+                success: () => {
                     dialog_widget.hide_dialog_spinner();
                     dialog_widget.close();
                     window.location.href = "/login/";
                 },
-                error(xhr) {
+                error: (xhr) => {
                     const error_last_owner = $t_html({
                         defaultMessage: "Error: Cannot deactivate the only organization owner.",
                     });
@@ -741,7 +741,7 @@ export function set_up() {
                         .show();
                 },
             });
-        }
+        };
         const html_body = render_confirm_deactivate_own_user();
         confirm_dialog.launch({
             html_heading: $t_html({defaultMessage: "Deactivate your account"}),

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -28,21 +28,19 @@ const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
 const EMBEDDED_BOT_TYPE = "4";
 
-function add_bot_row(info) {
+const add_bot_row = (info) => {
     const $row = $(render_bot_avatar_row(info));
     if (info.is_active) {
         $("#active_bots_list").append($row);
     } else {
         $("#inactive_bots_list").append($row);
     }
-}
+};
 
-function is_local_part(value) {
-    // Adapted from Django's EmailValidator
-    return /^[\w!#$%&'*+/=?^`{|}~-]+(\.[\w!#$%&'*+/=?^`{|}~-]+)*$/i.test(value);
-}
+const is_local_part = (value) =>
+    /^[\w!#$%&'*+/=?^`{|}~-]+(\.[\w!#$%&'*+/=?^`{|}~-]+)*$/i.test(value);
 
-export function render_bots() {
+export const render_bots = () => {
     $("#active_bots_list").empty();
     $("#inactive_bots_list").empty();
 
@@ -74,19 +72,18 @@ export function render_bots() {
 
     list_widget.render_empty_list_message_if_needed($("#active_bots_list"));
     list_widget.render_empty_list_message_if_needed($("#inactive_bots_list"));
-}
+};
 
-export function generate_zuliprc_url(bot_id) {
+export const generate_zuliprc_url = (bot_id) => {
     const bot = bot_data.get(bot_id);
     const data = generate_zuliprc_content(bot);
     return encode_zuliprc_as_url(data);
-}
+};
 
-export function encode_zuliprc_as_url(zuliprc) {
-    return "data:application/octet-stream;charset=utf-8," + encodeURIComponent(zuliprc);
-}
+export const encode_zuliprc_as_url = (zuliprc) =>
+    "data:application/octet-stream;charset=utf-8," + encodeURIComponent(zuliprc);
 
-export function generate_zuliprc_content(bot) {
+export const generate_zuliprc_content = (bot) => {
     let token;
     // For outgoing webhooks, include the token in the zuliprc.
     // It's needed for authenticating to the Botserver.
@@ -105,22 +102,19 @@ export function generate_zuliprc_content(bot) {
         // Some tools would not work in files without a trailing new line.
         "\n"
     );
-}
+};
 
-export function generate_botserverrc_content(email, api_key, token) {
-    return (
-        "[]" +
-        "\nemail=" +
-        email +
-        "\nkey=" +
-        api_key +
-        "\nsite=" +
-        realm.realm_url +
-        "\ntoken=" +
-        token +
-        "\n"
-    );
-}
+export const generate_botserverrc_content = (email, api_key, token) =>
+    "[]" +
+    "\nemail=" +
+    email +
+    "\nkey=" +
+    api_key +
+    "\nsite=" +
+    realm.realm_url +
+    "\ntoken=" +
+    token +
+    "\n";
 
 export const bot_creation_policy_values = {
     admins_only: {
@@ -139,7 +133,7 @@ export const bot_creation_policy_values = {
     },
 };
 
-export function can_create_new_bots() {
+export const can_create_new_bots = () => {
     if (current_user.is_admin) {
         return true;
     }
@@ -149,9 +143,9 @@ export function can_create_new_bots() {
     }
 
     return realm.realm_bot_creation_policy !== bot_creation_policy_values.admins_only.code;
-}
+};
 
-export function update_bot_settings_tip($tip_container, for_org_settings) {
+export const update_bot_settings_tip = ($tip_container, for_org_settings) => {
     if (
         !current_user.is_admin &&
         realm.realm_bot_creation_policy === bot_creation_policy_values.everyone.code
@@ -171,9 +165,9 @@ export function update_bot_settings_tip($tip_container, for_org_settings) {
     });
     $tip_container.show();
     $tip_container.html(rendered_tip);
-}
+};
 
-function update_add_bot_button() {
+const update_add_bot_button = () => {
     if (can_create_new_bots()) {
         $("#bot-settings .add-a-new-bot").show();
         $("#admin-bot-list .add-new-bots").show();
@@ -188,14 +182,14 @@ function update_add_bot_button() {
             $("#admin-bot-list .manage-your-bots").show();
         }
     }
-}
+};
 
-export function update_bot_permissions_ui() {
+export const update_bot_permissions_ui = () => {
     update_bot_settings_tip($("#admin-bot-settings-tip"), true);
     update_bot_settings_tip($("#personal-bot-settings-tip"), false);
     update_add_bot_button();
     $("#id_realm_bot_creation_policy").val(realm.realm_bot_creation_policy);
-}
+};
 
 export function add_a_new_bot() {
     const html_body = render_add_new_bot_form({
@@ -244,18 +238,18 @@ export function add_a_new_bot() {
             cache: false,
             processData: false,
             contentType: false,
-            success() {
+            success: () => {
                 create_avatar_widget.clear();
                 dialog_widget.close();
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
                 dialog_widget.hide_dialog_spinner();
             },
         });
     }
 
-    function set_up_form_fields() {
+    const set_up_form_fields = () => {
         $("#payload_url_inputbox").hide();
         $("#create_payload_url").val("");
         $("#service_name_list").hide();
@@ -292,9 +286,9 @@ export function add_a_new_bot() {
             const selected_bot = $("#select_service_name").val();
             $(`[name*='${CSS.escape(selected_bot)}']`).show();
         });
-    }
+    };
 
-    function validate_input() {
+    const validate_input = () => {
         const bot_short_name = $("#create_bot_short_name").val();
 
         if (is_local_part(bot_short_name)) {
@@ -308,7 +302,7 @@ export function add_a_new_bot() {
             $("#dialog_error"),
         );
         return false;
-    }
+    };
 
     dialog_widget.launch({
         form_id: "create_bot_form",
@@ -347,7 +341,7 @@ export function set_up() {
             {label: $t({defaultMessage: "Active bots"}), key: "active-bots"},
             {label: $t({defaultMessage: "Inactive bots"}), key: "inactive-bots"},
         ],
-        callback(_name, key) {
+        callback: (_name, key) => {
             $(".bots_section").hide();
             $(`[data-bot-settings-section="${CSS.escape(key)}"]`).show();
         },
@@ -361,10 +355,10 @@ export function set_up() {
     $("#active_bots_list").on("click", "button.deactivate_bot", (e) => {
         const bot_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/bots/" + encodeURIComponent(bot_id);
             const opts = {
-                success_continuation() {
+                success_continuation: () => {
                     const $row = $(e.currentTarget).closest("li");
                     $row.hide("slow", () => {
                         $row.remove();
@@ -372,7 +366,7 @@ export function set_up() {
                 },
             };
             dialog_widget.submit_api_request(channel.del, url, {}, opts);
-        }
+        };
         user_deactivation_ui.confirm_bot_deactivation(bot_id, handle_confirm, true);
     });
 
@@ -381,18 +375,18 @@ export function set_up() {
         e.stopPropagation();
         e.preventDefault();
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             channel.post({
                 url: "/json/users/" + encodeURIComponent(user_id) + "/reactivate",
-                success() {
+                success: () => {
                     dialog_widget.close();
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
                     dialog_widget.hide_dialog_spinner();
                 },
             });
-        }
+        };
 
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
@@ -401,12 +395,12 @@ export function set_up() {
         const bot_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         channel.post({
             url: "/json/bots/" + encodeURIComponent(bot_id) + "/api_key/regenerate",
-            success(data) {
+            success: (data) => {
                 const $row = $(e.currentTarget).closest("li");
                 $row.find(".bot-card-api-key").find(".value").text(data.api_key);
                 $row.find(".bot-card-api-key-error").hide();
             },
-            error(xhr) {
+            error: (xhr) => {
                 if (xhr.responseJSON?.msg) {
                     const $row = $(e.currentTarget).closest("li");
                     $row.find(".bot-card-api-key-error").text(xhr.responseJSON.msg).show();
@@ -446,7 +440,7 @@ export function set_up() {
     });
 
     const clipboard = new ClipboardJS("#copy_zuliprc", {
-        text(trigger) {
+        text: (trigger) => {
             const $bot_info = $(trigger).closest(".bot-information-box").find(".bot-card-info");
             const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
             const bot = bot_data.get(bot_id);

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -31,9 +31,9 @@ type SettingOptionValue = {
 
 type SettingOptionValueWithKey = SettingOptionValue & {key: string};
 
-export function get_sorted_options_list(
+export const get_sorted_options_list = (
     option_values_object: Record<string, SettingOptionValue>,
-): SettingOptionValueWithKey[] {
+): SettingOptionValueWithKey[] => {
     const options_list: SettingOptionValueWithKey[] = Object.entries(option_values_object).map(
         ([key, value]) => ({...value, key}),
     );
@@ -60,7 +60,7 @@ export function get_sorted_options_list(
     }
     options_list.sort(comparator);
     return options_list;
-}
+};
 
 type MessageTimeLimitSetting =
     | "realm_message_content_edit_limit_seconds"
@@ -68,7 +68,7 @@ type MessageTimeLimitSetting =
     | "realm_move_messages_within_stream_limit_seconds"
     | "realm_message_content_delete_limit_seconds";
 
-export function get_realm_time_limits_in_minutes(property: MessageTimeLimitSetting): string {
+export const get_realm_time_limits_in_minutes = (property: MessageTimeLimitSetting): string => {
     const setting_value = realm[property];
     if (setting_value === null) {
         // This represents "Anytime" case.
@@ -79,7 +79,7 @@ export function get_realm_time_limits_in_minutes(property: MessageTimeLimitSetti
         val = (setting_value / 60).toFixed(0);
     }
     return val;
-}
+};
 
 type RealmSetting = typeof realm;
 type RealmSettingProperties = keyof RealmSetting | "realm_org_join_restrictions";
@@ -93,9 +93,9 @@ type StreamSettingProperties = keyof StreamSubscription | "stream_privacy" | "is
 
 type valueof<T> = T[keyof T];
 
-export function get_realm_settings_property_value(
+export const get_realm_settings_property_value = (
     property_name: RealmSettingProperties,
-): valueof<RealmSetting> {
+): valueof<RealmSetting> => {
     if (property_name === "realm_org_join_restrictions") {
         if (realm.realm_emails_restricted_to_domains) {
             return "only_selected_domain";
@@ -110,12 +110,12 @@ export function get_realm_settings_property_value(
         return JSON.stringify(realm_authentication_methods_to_boolean_dict());
     }
     return realm[property_name];
-}
+};
 
-export function get_stream_settings_property_value(
+export const get_stream_settings_property_value = (
     property_name: StreamSettingProperties,
     sub: StreamSubscription,
-): valueof<StreamSubscription> {
+): valueof<StreamSubscription> => {
     if (property_name === "stream_privacy") {
         return stream_data.get_stream_privacy_policy(sub.stream_id);
     }
@@ -123,29 +123,27 @@ export function get_stream_settings_property_value(
         return stream_data.is_default_stream_id(sub.stream_id);
     }
     return sub[property_name];
-}
+};
 
-export function get_group_property_value(
+export const get_group_property_value = (
     property_name: keyof UserGroup,
     group: UserGroup,
-): valueof<UserGroup> {
-    return group[property_name];
-}
+): valueof<UserGroup> => group[property_name];
 
-export function get_custom_profile_property_value(
+export const get_custom_profile_property_value = (
     property_name: keyof CustomProfileField,
     custom_profile_field: CustomProfileField,
-): valueof<CustomProfileField> {
+): valueof<CustomProfileField> => {
     const value = custom_profile_field[property_name];
     if (property_name === "display_in_profile_summary" && value === undefined) {
         return false;
     }
     return value;
-}
+};
 
-export function get_realm_default_setting_property_value(
+export const get_realm_default_setting_property_value = (
     property_name: RealmUserSettingDefaultProperties,
-): valueof<RealmUserSettingDefaultType> {
+): valueof<RealmUserSettingDefaultType> => {
     if (property_name === "twenty_four_hour_time") {
         return JSON.stringify(realm_user_settings_defaults.twenty_four_hour_time);
     }
@@ -156,10 +154,10 @@ export function get_realm_default_setting_property_value(
         return realm_user_settings_defaults.email_notifications_batching_period_seconds;
     }
     return realm_user_settings_defaults[property_name];
-}
+};
 
-export function realm_authentication_methods_to_boolean_dict(): Record<string, boolean> {
-    return Object.fromEntries(
+export const realm_authentication_methods_to_boolean_dict = (): Record<string, boolean> =>
+    Object.fromEntries(
         Object.entries(realm.realm_authentication_methods)
             .sort()
             .map(([auth_method_name, auth_method_info]) => [
@@ -167,9 +165,11 @@ export function realm_authentication_methods_to_boolean_dict(): Record<string, b
                 auth_method_info.enabled,
             ]),
     );
-}
 
-export function extract_property_name($elem: JQuery, for_realm_default_settings?: boolean): string {
+export const extract_property_name = (
+    $elem: JQuery,
+    for_realm_default_settings?: boolean,
+): string => {
     const elem_id = $elem.attr("id");
     assert(elem_id !== undefined);
     if (for_realm_default_settings) {
@@ -195,11 +195,11 @@ export function extract_property_name($elem: JQuery, for_realm_default_settings?
     }
 
     return /^id_(.*)$/.exec(elem_id.replaceAll("-", "_"))![1]!;
-}
+};
 
-export function get_subsection_property_elements($subsection: JQuery): HTMLElement[] {
-    return [...$subsection.find(".prop-element")];
-}
+export const get_subsection_property_elements = ($subsection: JQuery): HTMLElement[] => [
+    ...$subsection.find(".prop-element"),
+];
 
 type simple_dropdown_realm_settings = Pick<
     typeof realm,
@@ -217,41 +217,41 @@ type simple_dropdown_realm_settings = Pick<
     | "realm_org_type"
 >;
 
-export function set_property_dropdown_value(
+export const set_property_dropdown_value = (
     property_name: keyof simple_dropdown_realm_settings,
-): void {
+): void => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const property_value = get_realm_settings_property_value(
         property_name,
     ) as valueof<simple_dropdown_realm_settings>;
     $(`#id_${CSS.escape(property_name)}`).val(property_value);
-}
+};
 
-export function change_element_block_display_property(
+export const change_element_block_display_property = (
     elem_id: string,
     show_element: boolean,
-): void {
+): void => {
     const $elem = $(`#${CSS.escape(elem_id)}`);
     if (show_element) {
         $elem.parent().show();
     } else {
         $elem.parent().hide();
     }
-}
+};
 
-export function is_video_chat_provider_jitsi_meet(): boolean {
+export const is_video_chat_provider_jitsi_meet = (): boolean => {
     const video_chat_provider_id = Number.parseInt(
         $<HTMLSelectOneElement>("select:not([multiple])#id_realm_video_chat_provider").val()!,
         10,
     );
     const jitsi_meet_id = realm.realm_available_video_chat_providers.jitsi_meet.id;
     return video_chat_provider_id === jitsi_meet_id;
-}
+};
 
-function get_jitsi_server_url_setting_value(
+const get_jitsi_server_url_setting_value = (
     $input_elem: JQuery<HTMLSelectElement>,
     for_api_data = true,
-): string | null {
+): string | null => {
     // If the video chat provider dropdown is not set to Jitsi, we return
     // `realm_jitsi_server_url` to indicate that the property remains unchanged.
     // This ensures the appropriate state of the save button and prevents the
@@ -273,9 +273,9 @@ function get_jitsi_server_url_setting_value(
         return $custom_input_elem.val()!;
     }
     return JSON.stringify($custom_input_elem.val());
-}
+};
 
-export function update_custom_value_input(property_name: MessageTimeLimitSetting): void {
+export const update_custom_value_input = (property_name: MessageTimeLimitSetting): void => {
     const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
     const custom_input_elem_id = $dropdown_elem
         .parent()
@@ -289,11 +289,11 @@ export function update_custom_value_input(property_name: MessageTimeLimitSetting
             get_realm_time_limits_in_minutes(property_name),
         );
     }
-}
+};
 
-export function get_time_limit_dropdown_setting_value(
+export const get_time_limit_dropdown_setting_value = (
     property_name: MessageTimeLimitSetting,
-): string {
+): string => {
     const value = realm[property_name];
     if (value === null) {
         return "any_time";
@@ -305,9 +305,9 @@ export function get_time_limit_dropdown_setting_value(
     }
 
     return "custom_period";
-}
+};
 
-export function set_time_limit_setting(property_name: MessageTimeLimitSetting): void {
+export const set_time_limit_setting = (property_name: MessageTimeLimitSetting): void => {
     const dropdown_elem_val = get_time_limit_dropdown_setting_value(property_name);
     $(`#id_${CSS.escape(property_name)}`).val(dropdown_elem_val);
 
@@ -320,9 +320,9 @@ export function set_time_limit_setting(property_name: MessageTimeLimitSetting): 
         $custom_input.attr("id")!,
         dropdown_elem_val === "custom_period",
     );
-}
+};
 
-function check_valid_number_input(input_value: string, keep_number_as_float = false): number {
+const check_valid_number_input = (input_value: string, keep_number_as_float = false): number => {
     // This check is important to make sure that inputs like "24a" are
     // considered invalid and this function returns NaN for such inputs.
     // Number.parseInt and Number.parseFloat will convert strings like
@@ -336,12 +336,12 @@ function check_valid_number_input(input_value: string, keep_number_as_float = fa
     }
 
     return Number.parseInt(input_value, 10);
-}
+};
 
-function get_message_retention_setting_value(
+const get_message_retention_setting_value = (
     $input_elem: JQuery<HTMLSelectElement>,
     for_api_data = true,
-): string | number | null {
+): string | number | null => {
     const select_elem_val = $input_elem.val();
     if (select_elem_val === "unlimited") {
         if (!for_api_data) {
@@ -365,7 +365,7 @@ function get_message_retention_setting_value(
         return settings_config.retain_message_forever;
     }
     return check_valid_number_input(custom_input_val);
-}
+};
 
 export const select_field_data_schema = z.record(z.object({text: z.string(), order: z.string()}));
 export type SelectFieldData = z.output<typeof select_field_data_schema>;
@@ -414,7 +414,9 @@ export const external_account_field_schema = z.object({
 
 export type ExternalAccountFieldData = z.output<typeof external_account_field_schema>;
 
-function read_external_account_field_data($profile_field_form: JQuery): ExternalAccountFieldData {
+const read_external_account_field_data = (
+    $profile_field_form: JQuery,
+): ExternalAccountFieldData => {
     const field_data: ExternalAccountFieldData = {
         subtype: $profile_field_form
             .find<HTMLSelectOneElement>("select:not([multiple])[name=external_acc_field_type]")
@@ -426,15 +428,15 @@ function read_external_account_field_data($profile_field_form: JQuery): External
             .val()!;
     }
     return field_data;
-}
+};
 
 export type FieldData = SelectFieldData | ExternalAccountFieldData;
 
-export function read_field_data_from_form(
+export const read_field_data_from_form = (
     field_type_id: number,
     $profile_field_form: JQuery,
     old_field_data: unknown,
-): FieldData | undefined {
+): FieldData | undefined => {
     const field_types = realm.custom_profile_field_types;
 
     // Only read field data if we are creating a select field
@@ -445,9 +447,9 @@ export function read_field_data_from_form(
         return read_external_account_field_data($profile_field_form);
     }
     return undefined;
-}
+};
 
-function get_field_data_input_value($input_elem: JQuery): string | undefined {
+const get_field_data_input_value = ($input_elem: JQuery): string | undefined => {
     const $profile_field_form = $input_elem.closest(".profile-field-form");
     const profile_field_id = Number.parseInt(
         $($profile_field_form).attr("data-profile-field-id")!,
@@ -461,7 +463,7 @@ function get_field_data_input_value($input_elem: JQuery): string | undefined {
         JSON.parse(field.field_data),
     );
     return JSON.stringify(proposed_value);
-}
+};
 
 export let default_code_language_widget: DropdownWidget | null = null;
 export let new_stream_announcements_stream_widget: DropdownWidget | null = null;
@@ -473,9 +475,9 @@ export let can_access_all_users_group_widget: DropdownWidget | null = null;
 export let can_mention_group_widget: DropdownWidget | null = null;
 export let new_group_can_mention_group_widget: DropdownWidget | null = null;
 
-export function get_widget_for_dropdown_list_settings(
+export const get_widget_for_dropdown_list_settings = (
     property_name: string,
-): DropdownWidget | null {
+): DropdownWidget | null => {
     switch (property_name) {
         case "realm_new_stream_announcements_stream_id":
             return new_stream_announcements_stream_widget;
@@ -497,54 +499,54 @@ export function get_widget_for_dropdown_list_settings(
             blueslip.error("No dropdown list widget for property", {property_name});
             return null;
     }
-}
+};
 
-export function set_default_code_language_widget(widget: DropdownWidget): void {
+export const set_default_code_language_widget = (widget: DropdownWidget): void => {
     default_code_language_widget = widget;
-}
+};
 
-export function set_new_stream_announcements_stream_widget(widget: DropdownWidget): void {
+export const set_new_stream_announcements_stream_widget = (widget: DropdownWidget): void => {
     new_stream_announcements_stream_widget = widget;
-}
+};
 
-export function set_signup_announcements_stream_widget(widget: DropdownWidget): void {
+export const set_signup_announcements_stream_widget = (widget: DropdownWidget): void => {
     signup_announcements_stream_widget = widget;
-}
+};
 
-export function set_zulip_update_announcements_stream_widget(widget: DropdownWidget): void {
+export const set_zulip_update_announcements_stream_widget = (widget: DropdownWidget): void => {
     zulip_update_announcements_stream_widget = widget;
-}
+};
 
-export function set_create_multiuse_invite_group_widget(widget: DropdownWidget): void {
+export const set_create_multiuse_invite_group_widget = (widget: DropdownWidget): void => {
     create_multiuse_invite_group_widget = widget;
-}
+};
 
-export function set_can_remove_subscribers_group_widget(widget: DropdownWidget): void {
+export const set_can_remove_subscribers_group_widget = (widget: DropdownWidget): void => {
     can_remove_subscribers_group_widget = widget;
-}
+};
 
-export function set_can_access_all_users_group_widget(widget: DropdownWidget): void {
+export const set_can_access_all_users_group_widget = (widget: DropdownWidget): void => {
     can_access_all_users_group_widget = widget;
-}
+};
 
-export function set_can_mention_group_widget(widget: DropdownWidget): void {
+export const set_can_mention_group_widget = (widget: DropdownWidget): void => {
     can_mention_group_widget = widget;
-}
+};
 
-export function set_new_group_can_mention_group_widget(widget: DropdownWidget): void {
+export const set_new_group_can_mention_group_widget = (widget: DropdownWidget): void => {
     new_group_can_mention_group_widget = widget;
-}
+};
 
-export function set_dropdown_list_widget_setting_value(
+export const set_dropdown_list_widget_setting_value = (
     property_name: string,
     value: number | string,
-): void {
+): void => {
     const widget = get_widget_for_dropdown_list_settings(property_name);
     assert(widget !== null);
     widget.render(value);
-}
+};
 
-export function get_dropdown_list_widget_setting_value($input_elem: JQuery): number | string {
+export const get_dropdown_list_widget_setting_value = ($input_elem: JQuery): number | string => {
     const widget_name = extract_property_name($input_elem);
     const setting_widget = get_widget_for_dropdown_list_settings(widget_name);
     assert(setting_widget !== null);
@@ -553,7 +555,7 @@ export function get_dropdown_list_widget_setting_value($input_elem: JQuery): num
     assert(setting_value !== undefined);
 
     return setting_value;
-}
+};
 
 export function change_save_button_state($element: JQuery, state: string): void {
     function show_hide_element(
@@ -649,19 +651,19 @@ export function change_save_button_state($element: JQuery, state: string): void 
     });
 }
 
-function get_input_type($input_elem: JQuery, input_type?: string): string {
+const get_input_type = ($input_elem: JQuery, input_type?: string): string => {
     if (input_type !== undefined && ["boolean", "string", "number"].includes(input_type)) {
         return input_type;
     }
     input_type = $input_elem.attr("data-setting-widget-type");
     assert(input_type !== undefined);
     return input_type;
-}
+};
 
-export function get_input_element_value(
+export const get_input_element_value = (
     input_elem: HTMLElement,
     input_type?: string,
-): boolean | number | string | null | undefined {
+): boolean | number | string | null | undefined => {
     const $input_elem = $(input_elem);
     input_type = get_input_type($input_elem, input_type);
     let input_value;
@@ -712,12 +714,12 @@ export function get_input_element_value(
         default:
             return undefined;
     }
-}
+};
 
-export function set_input_element_value(
+export const set_input_element_value = (
     $input_elem: JQuery,
     value: number | string | boolean,
-): void {
+): void => {
     const input_type = get_input_type($input_elem, typeof value);
     if (input_type) {
         if (input_type === "boolean") {
@@ -734,9 +736,9 @@ export function set_input_element_value(
         property: extract_property_name($input_elem),
     });
     return;
-}
+};
 
-export function get_auth_method_list_data(): Record<string, boolean> {
+export const get_auth_method_list_data = (): Record<string, boolean> => {
     const new_auth_methods: Record<string, boolean> = {};
     const $auth_method_rows = $("#id_realm_authentication_methods").find("div.method_row");
 
@@ -747,17 +749,17 @@ export function get_auth_method_list_data(): Record<string, boolean> {
     }
 
     return new_auth_methods;
-}
+};
 
-export function parse_time_limit($elem: JQuery<HTMLInputElement>): number {
+export const parse_time_limit = ($elem: JQuery<HTMLInputElement>): number => {
     const time_limit_in_minutes = check_valid_number_input($elem.val()!, true);
     return Math.floor(time_limit_in_minutes * 60);
-}
+};
 
-function get_time_limit_setting_value(
+const get_time_limit_setting_value = (
     $input_elem: JQuery<HTMLSelectElement>,
     for_api_data = true,
-): string | number | null {
+): string | number | null => {
     const select_elem_val = $input_elem.val()!;
 
     if (select_elem_val === "any_time") {
@@ -793,9 +795,9 @@ function get_time_limit_setting_value(
     }
 
     return parse_time_limit($custom_input_elem);
-}
+};
 
-export function check_realm_settings_property_changed(elem: HTMLElement): boolean {
+export const check_realm_settings_property_changed = (elem: HTMLElement): boolean => {
     const $elem = $(elem);
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -843,12 +845,12 @@ export function check_realm_settings_property_changed(elem: HTMLElement): boolea
             }
     }
     return current_val !== proposed_val;
-}
+};
 
-export function check_stream_settings_property_changed(
+export const check_stream_settings_property_changed = (
     elem: HTMLElement,
     sub: StreamSubscription,
-): boolean {
+): boolean => {
     const $elem = $(elem);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const property_name = extract_property_name($elem) as StreamSettingProperties;
@@ -873,9 +875,9 @@ export function check_stream_settings_property_changed(
             }
     }
     return current_val !== proposed_val;
-}
+};
 
-export function check_group_property_changed(elem: HTMLElement, group: UserGroup): boolean {
+export const check_group_property_changed = (elem: HTMLElement, group: UserGroup): boolean => {
     const $elem = $(elem);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const property_name = extract_property_name($elem) as keyof UserGroup;
@@ -893,12 +895,12 @@ export function check_group_property_changed(elem: HTMLElement, group: UserGroup
             }
     }
     return current_val !== proposed_val;
-}
+};
 
-export function check_custom_profile_property_changed(
+export const check_custom_profile_property_changed = (
     elem: HTMLElement,
     custom_profile_field: CustomProfileField,
-): boolean {
+): boolean => {
     const $elem = $(elem);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const property_name = extract_property_name($elem) as keyof CustomProfileField;
@@ -912,9 +914,9 @@ export function check_custom_profile_property_changed(
         blueslip.error("Element refers to unknown property", {property_name});
     }
     return current_val !== proposed_val;
-}
+};
 
-export function check_realm_default_settings_property_changed(elem: HTMLElement): boolean {
+export const check_realm_default_settings_property_changed = (elem: HTMLElement): boolean => {
     const $elem = $(elem);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const property_name = extract_property_name($elem, true) as RealmUserSettingDefaultProperties;
@@ -937,12 +939,14 @@ export function check_realm_default_settings_property_changed(elem: HTMLElement)
             }
     }
     return current_val !== proposed_val;
-}
+};
 
-function get_request_data_for_org_join_restrictions(selected_val: string): {
+const get_request_data_for_org_join_restrictions = (
+    selected_val: string,
+): {
     disallow_disposable_email_addresses: boolean;
     emails_restricted_to_domains: boolean;
-} {
+} => {
     switch (selected_val) {
         case "only_selected_domain": {
             return {
@@ -963,11 +967,11 @@ function get_request_data_for_org_join_restrictions(selected_val: string): {
             };
         }
     }
-}
+};
 
-export function populate_data_for_realm_settings_request(
+export const populate_data_for_realm_settings_request = (
     $subsection_elem: JQuery,
-): Record<string, string | boolean | number> {
+): Record<string, string | boolean | number> => {
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1006,12 +1010,12 @@ export function populate_data_for_realm_settings_request(
         }
     }
     return data;
-}
+};
 
-export function populate_data_for_stream_settings_request(
+export const populate_data_for_stream_settings_request = (
     $subsection_elem: JQuery,
     sub: StreamSubscription,
-): Record<string, string | boolean | number> {
+): Record<string, string | boolean | number> => {
     let data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1034,12 +1038,12 @@ export function populate_data_for_stream_settings_request(
         }
     }
     return data;
-}
+};
 
-export function populate_data_for_group_request(
+export const populate_data_for_group_request = (
     $subsection_elem: JQuery,
     group: UserGroup,
-): Record<string, string | boolean | number> {
+): Record<string, string | boolean | number> => {
     const data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1056,12 +1060,12 @@ export function populate_data_for_group_request(
         }
     }
     return data;
-}
+};
 
-export function populate_data_for_custom_profile_field_request(
+export const populate_data_for_custom_profile_field_request = (
     $subsection_elem: JQuery,
     custom_profile_field: CustomProfileField,
-): Record<string, string | boolean | number> {
+): Record<string, string | boolean | number> => {
     const data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1075,11 +1079,11 @@ export function populate_data_for_custom_profile_field_request(
         }
     }
     return data;
-}
+};
 
-export function populate_data_for_default_realm_settings_request(
+export const populate_data_for_default_realm_settings_request = (
     $subsection_elem: JQuery,
-): Record<string, string | boolean | number> {
+): Record<string, string | boolean | number> => {
     const data: Record<string, string | boolean | number> = {};
     const properties_elements = get_subsection_property_elements($subsection_elem);
     for (const input_elem of properties_elements) {
@@ -1094,9 +1098,9 @@ export function populate_data_for_default_realm_settings_request(
     }
 
     return data;
-}
+};
 
-function switching_to_private(properties_elements: HTMLElement[]): boolean {
+const switching_to_private = (properties_elements: HTMLElement[]): boolean => {
     for (const elem of properties_elements) {
         const $elem = $(elem);
         const property_name = extract_property_name($elem);
@@ -1107,9 +1111,9 @@ function switching_to_private(properties_elements: HTMLElement[]): boolean {
         return proposed_val === "invite-only-public-history" || proposed_val === "invite-only";
     }
     return false;
-}
+};
 
-export function save_discard_realm_settings_widget_status_handler($subsection: JQuery): void {
+export const save_discard_realm_settings_widget_status_handler = ($subsection: JQuery): void => {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
@@ -1120,12 +1124,12 @@ export function save_discard_realm_settings_widget_status_handler($subsection: J
     const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
-}
+};
 
-export function save_discard_stream_settings_widget_status_handler(
+export const save_discard_stream_settings_widget_status_handler = (
     $subsection: JQuery,
     sub: StreamSubscription,
-): void {
+): void => {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
@@ -1166,12 +1170,12 @@ export function save_discard_stream_settings_widget_status_handler(
     } else {
         $("#stream_permission_settings .stream-permissions-warning-banner").empty();
     }
-}
+};
 
-export function save_discard_group_widget_status_handler(
+export const save_discard_group_widget_status_handler = (
     $subsection: JQuery,
     group: UserGroup,
-): void {
+): void => {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
@@ -1181,11 +1185,11 @@ export function save_discard_group_widget_status_handler(
     const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
-}
+};
 
-export function save_discard_default_realm_settings_widget_status_handler(
+export const save_discard_default_realm_settings_widget_status_handler = (
     $subsection: JQuery,
-): void {
+): void => {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
@@ -1196,12 +1200,12 @@ export function save_discard_default_realm_settings_widget_status_handler(
     const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
-}
+};
 
-function check_maximum_valid_value(
+const check_maximum_valid_value = (
     $custom_input_elem: JQuery<HTMLInputElement>,
     property_name: string,
-): boolean {
+): boolean => {
     let setting_value = Number.parseInt($custom_input_elem.val()!, 10);
     if (
         property_name === "realm_message_content_edit_limit_seconds" ||
@@ -1211,9 +1215,9 @@ function check_maximum_valid_value(
         setting_value = parse_time_limit($custom_input_elem);
     }
     return setting_value <= MAX_CUSTOM_TIME_LIMIT_SETTING_VALUE;
-}
+};
 
-function should_disable_save_button_for_jitsi_server_url_setting(): boolean {
+const should_disable_save_button_for_jitsi_server_url_setting = (): boolean => {
     if (!is_video_chat_provider_jitsi_meet()) {
         return false;
     }
@@ -1227,11 +1231,11 @@ function should_disable_save_button_for_jitsi_server_url_setting(): boolean {
         $dropdown_elem.val()!.toString() === "custom" &&
         !util.is_valid_url($custom_input_elem.val()!, true)
     );
-}
+};
 
-function should_disable_save_button_for_time_limit_settings(
+const should_disable_save_button_for_time_limit_settings = (
     time_limit_settings: HTMLElement[],
-): boolean {
+): boolean => {
     let disable_save_btn = false;
     for (const setting_elem of time_limit_settings) {
         const $dropdown_elem = $(setting_elem).find<HTMLSelectOneElement>("select:not([multiple])");
@@ -1267,9 +1271,9 @@ function should_disable_save_button_for_time_limit_settings(
     }
 
     return disable_save_btn;
-}
+};
 
-function enable_or_disable_save_button($subsection_elem: JQuery): void {
+const enable_or_disable_save_button = ($subsection_elem: JQuery): void => {
     const time_limit_settings = [...$subsection_elem.find(".time-limit-setting")];
 
     let disable_save_btn = false;
@@ -1299,13 +1303,13 @@ function enable_or_disable_save_button($subsection_elem: JQuery): void {
     }
 
     $subsection_elem.find(".subsection-changes-save button").prop("disabled", disable_save_btn);
-}
+};
 
-export function initialize_disable_btn_hint_popover(
+export const initialize_disable_btn_hint_popover = (
     $btn_wrapper: JQuery,
     hint_text: string | undefined,
     opts: Partial<tippy.Props>,
-): void {
+): void => {
     const tippy_opts: Partial<tippy.Props> = {
         animation: false,
         hideOnClick: false,
@@ -1319,4 +1323,4 @@ export function initialize_disable_btn_hint_popover(
         tippy_opts.content = hint_text;
     }
     tippy.default($btn_wrapper[0]!, tippy_opts);
-}
+};

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -798,11 +798,11 @@ type NotificationSettingCheckbox = {
     is_mobile_checkbox: boolean;
 };
 
-export function get_notifications_table_row_data(
+export const get_notifications_table_row_data = (
     notify_settings: PageParamsItem[],
     settings_object: Settings,
-): NotificationSettingCheckbox[] {
-    return general_notifications_table_labels.realm.map((column, index) => {
+): NotificationSettingCheckbox[] =>
+    general_notifications_table_labels.realm.map((column, index) => {
         const setting_name = notify_settings[index];
         if (setting_name === undefined) {
             return {
@@ -830,7 +830,6 @@ export function get_notifications_table_row_data(
         }
         return checkbox;
     });
-}
 
 export type AllNotifications = {
     general_settings: {label: string; notification_settings: NotificationSettingCheckbox[]}[];

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -5,10 +5,10 @@ import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 
 let user_join_date: Date;
-export function initialize(current_user_join_date: Date): void {
+export const initialize = (current_user_join_date: Date): void => {
     // We keep the `user_join_date` as the present day's date if the user is a spectator
     user_join_date = current_user_join_date;
-}
+};
 
 /*
     This is a close cousin of settings_config,
@@ -20,7 +20,7 @@ export function initialize(current_user_join_date: Date): void {
     about page_params and settings_config details.
 */
 
-export function user_can_change_name(): boolean {
+export const user_can_change_name = (): boolean => {
     if (current_user.is_admin) {
         return true;
     }
@@ -28,9 +28,9 @@ export function user_can_change_name(): boolean {
         return false;
     }
     return true;
-}
+};
 
-export function user_can_change_avatar(): boolean {
+export const user_can_change_avatar = (): boolean => {
     if (current_user.is_admin) {
         return true;
     }
@@ -38,9 +38,9 @@ export function user_can_change_avatar(): boolean {
         return false;
     }
     return true;
-}
+};
 
-export function user_can_change_email(): boolean {
+export const user_can_change_email = (): boolean => {
     if (current_user.is_admin) {
         return true;
     }
@@ -48,13 +48,12 @@ export function user_can_change_email(): boolean {
         return false;
     }
     return true;
-}
+};
 
-export function user_can_change_logo(): boolean {
-    return current_user.is_admin && realm.zulip_plan_is_not_limited;
-}
+export const user_can_change_logo = (): boolean =>
+    current_user.is_admin && realm.zulip_plan_is_not_limited;
 
-function user_has_permission(policy_value: number): boolean {
+const user_has_permission = (policy_value: number): boolean => {
     /* At present, nobody and by_owners_only is not present in
      * common_policy_values, but we include a check for it here,
      * so that code using create_web_public_stream_policy_values
@@ -113,9 +112,9 @@ function user_has_permission(policy_value: number): boolean {
     const user_join_days =
         (current_datetime.getTime() - person_date_joined.getTime()) / 1000 / 86400;
     return user_join_days >= realm.realm_waiting_period_threshold;
-}
+};
 
-export function user_can_invite_users_by_email(): boolean {
+export const user_can_invite_users_by_email = (): boolean => {
     if (
         realm.realm_invite_to_realm_policy ===
         settings_config.email_invite_to_realm_policy_values.nobody.code
@@ -123,9 +122,9 @@ export function user_can_invite_users_by_email(): boolean {
         return false;
     }
     return user_has_permission(realm.realm_invite_to_realm_policy);
-}
+};
 
-export function user_can_create_multiuse_invite(): boolean {
+export const user_can_create_multiuse_invite = (): boolean => {
     if (!current_user.user_id) {
         return false;
     }
@@ -133,37 +132,32 @@ export function user_can_create_multiuse_invite(): boolean {
         realm.realm_create_multiuse_invite_group,
         current_user.user_id,
     );
-}
+};
 
-export function user_can_subscribe_other_users(): boolean {
-    return user_has_permission(realm.realm_invite_to_stream_policy);
-}
+export const user_can_subscribe_other_users = (): boolean =>
+    user_has_permission(realm.realm_invite_to_stream_policy);
 
-export function user_can_create_private_streams(): boolean {
-    return user_has_permission(realm.realm_create_private_stream_policy);
-}
+export const user_can_create_private_streams = (): boolean =>
+    user_has_permission(realm.realm_create_private_stream_policy);
 
-export function user_can_create_public_streams(): boolean {
-    return user_has_permission(realm.realm_create_public_stream_policy);
-}
+export const user_can_create_public_streams = (): boolean =>
+    user_has_permission(realm.realm_create_public_stream_policy);
 
-export function user_can_create_web_public_streams(): boolean {
+export const user_can_create_web_public_streams = (): boolean => {
     if (!realm.server_web_public_streams_enabled || !realm.realm_enable_spectator_access) {
         return false;
     }
 
     return user_has_permission(realm.realm_create_web_public_stream_policy);
-}
+};
 
-export function user_can_move_messages_between_streams(): boolean {
-    return user_has_permission(realm.realm_move_messages_between_streams_policy);
-}
+export const user_can_move_messages_between_streams = (): boolean =>
+    user_has_permission(realm.realm_move_messages_between_streams_policy);
 
-export function user_can_edit_user_groups(): boolean {
-    return user_has_permission(realm.realm_user_group_edit_policy);
-}
+export const user_can_edit_user_groups = (): boolean =>
+    user_has_permission(realm.realm_user_group_edit_policy);
 
-export function can_edit_user_group(group_id: number): boolean {
+export const can_edit_user_group = (group_id: number): boolean => {
     if (!current_user.user_id) {
         return false;
     }
@@ -180,21 +174,18 @@ export function can_edit_user_group(group_id: number): boolean {
     }
 
     return user_groups.is_direct_member_of(current_user.user_id, group_id);
-}
+};
 
-export function user_can_add_custom_emoji(): boolean {
-    return user_has_permission(realm.realm_add_custom_emoji_policy);
-}
+export const user_can_add_custom_emoji = (): boolean =>
+    user_has_permission(realm.realm_add_custom_emoji_policy);
 
-export function user_can_move_messages_to_another_topic(): boolean {
-    return user_has_permission(realm.realm_edit_topic_policy);
-}
+export const user_can_move_messages_to_another_topic = (): boolean =>
+    user_has_permission(realm.realm_edit_topic_policy);
 
-export function user_can_delete_own_message(): boolean {
-    return user_has_permission(realm.realm_delete_own_message_policy);
-}
+export const user_can_delete_own_message = (): boolean =>
+    user_has_permission(realm.realm_delete_own_message_policy);
 
-export function should_mask_unread_count(sub_muted: boolean): boolean {
+export const should_mask_unread_count = (sub_muted: boolean): boolean => {
     if (
         user_settings.web_stream_unreads_count_display_policy ===
         settings_config.web_stream_unreads_count_display_policy_values.no_streams.code
@@ -210,9 +201,9 @@ export function should_mask_unread_count(sub_muted: boolean): boolean {
     }
 
     return false;
-}
+};
 
-export function using_dark_theme(): boolean {
+export const using_dark_theme = (): boolean => {
     if (user_settings.color_scheme === settings_config.color_scheme_values.night.code) {
         return true;
     }
@@ -225,16 +216,12 @@ export function using_dark_theme(): boolean {
         return true;
     }
     return false;
-}
+};
 
-export function user_email_not_configured(): boolean {
-    // The following should also be true in the only circumstance
-    // under which we expect this condition to be possible:
-    // realm.demo_organization_scheduled_deletion_date
-    return current_user.is_owner && current_user.delivery_email === "";
-}
+export const user_email_not_configured = (): boolean =>
+    current_user.is_owner && current_user.delivery_email === "";
 
-export function bot_type_id_to_string(type_id: number): string | undefined {
+export const bot_type_id_to_string = (type_id: number): string | undefined => {
     const bot_type = page_params.bot_types.find((bot_type) => bot_type.type_id === type_id);
 
     if (bot_type === undefined) {
@@ -242,9 +229,9 @@ export function bot_type_id_to_string(type_id: number): string | undefined {
     }
 
     return bot_type.name;
-}
+};
 
-export function user_can_access_all_other_users(): boolean {
+export const user_can_access_all_other_users = (): boolean => {
     if (!current_user.user_id) {
         return true;
     }
@@ -253,14 +240,16 @@ export function user_can_access_all_other_users(): boolean {
         realm.realm_can_access_all_users_group,
         current_user.user_id,
     );
-}
+};
 
 /* istanbul ignore next */
-export function get_request_data_for_stream_privacy(selected_val: string): {
+export const get_request_data_for_stream_privacy = (
+    selected_val: string,
+): {
     is_private: boolean;
     history_public_to_subscribers: boolean;
     is_web_public: boolean;
-} {
+} => {
     switch (selected_val) {
         case settings_config.stream_privacy_policy_values.public.code: {
             return {
@@ -291,4 +280,4 @@ export function get_request_data_for_stream_privacy(selected_val: string): {
             };
         }
     }
-}
+};

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -29,7 +29,7 @@ const meta = {
     loaded: false,
 };
 
-function can_delete_emoji(emoji: ServerEmoji): boolean {
+const can_delete_emoji = (emoji: ServerEmoji): boolean => {
     if (current_user.is_admin) {
         return true;
     }
@@ -41,9 +41,9 @@ function can_delete_emoji(emoji: ServerEmoji): boolean {
         return true;
     }
     return false;
-}
+};
 
-export function update_custom_emoji_ui(): void {
+export const update_custom_emoji_ui = (): void => {
     const rendered_tip = render_settings_emoji_settings_tip({
         realm_add_custom_emoji_policy: realm.realm_add_custom_emoji_policy,
         policy_values: settings_config.common_policy_values,
@@ -66,13 +66,13 @@ export function update_custom_emoji_ui(): void {
     }
 
     populate_emoji();
-}
+};
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-function sort_author_full_name(a: ServerEmoji, b: ServerEmoji): number {
+const sort_author_full_name = (a: ServerEmoji, b: ServerEmoji): number => {
     const author_a = a.author?.full_name;
     const author_b = b.author?.full_name;
 
@@ -86,15 +86,12 @@ function sort_author_full_name(a: ServerEmoji, b: ServerEmoji): number {
 
     // If one of the author is null, then we put the null author at the end.
     return author_a ? -1 : 1;
-}
+};
 
-function is_default_emoji(emoji_name: string): boolean {
-    // Spaces are replaced with `_` to match how the emoji name will
-    // actually be stored in the backend.
-    return emoji_codes.names.includes(emoji_name.replaceAll(" ", "_"));
-}
+const is_default_emoji = (emoji_name: string): boolean =>
+    emoji_codes.names.includes(emoji_name.replaceAll(" ", "_"));
 
-function is_custom_emoji(emoji_name: string): boolean {
+const is_custom_emoji = (emoji_name: string): boolean => {
     const emoji_data = emoji.get_server_realm_emoji_data();
     for (const emoji of Object.values(emoji_data)) {
         if (emoji.name === emoji_name && !emoji.deactivated) {
@@ -102,9 +99,9 @@ function is_custom_emoji(emoji_name: string): boolean {
         }
     }
     return false;
-}
+};
 
-export function populate_emoji(): void {
+export const populate_emoji = (): void => {
     if (!meta.loaded) {
         return;
     }
@@ -125,8 +122,8 @@ export function populate_emoji(): void {
     ListWidget.create<ServerEmoji>($emoji_table, active_emoji_data, {
         name: "emoji_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(item) {
-            return render_admin_emoji_list({
+        modifier_html: (item) =>
+            render_admin_emoji_list({
                 emoji: {
                     name: item.name,
                     display_name: item.name.replaceAll("_", " "),
@@ -134,16 +131,13 @@ export function populate_emoji(): void {
                     author: item.author ?? "",
                     can_delete_emoji: can_delete_emoji(item),
                 },
-            });
-        },
+            }),
         filter: {
             $element: $emoji_table
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
-            predicate(item, value) {
-                return item.name.toLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) => item.name.toLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar($emoji_table);
             },
         },
@@ -157,9 +151,9 @@ export function populate_emoji(): void {
     });
 
     loading.destroy_indicator($("#admin_page_emoji_loading_indicator"));
-}
+};
 
-export function add_custom_emoji_post_render(): void {
+export const add_custom_emoji_post_render = (): void => {
     $("#add-custom-emoji-modal .dialog_submit_button").prop("disabled", true);
 
     $("#add-custom-emoji-form").on("input", "input", () => {
@@ -169,9 +163,7 @@ export function add_custom_emoji_post_render(): void {
         );
     });
 
-    const get_file_input = function (): JQuery<HTMLInputElement> {
-        return $("#emoji_file_input");
-    };
+    const get_file_input = (): JQuery<HTMLInputElement> => $("#emoji_file_input");
 
     const $file_name_field = $("#emoji-file-name");
     const $input_error = $("#emoji_file_input_error");
@@ -209,18 +201,18 @@ export function add_custom_emoji_post_render(): void {
         $placeholder_icon.show();
         $preview_text.show();
     });
-}
+};
 
-function show_modal(): void {
+const show_modal = (): void => {
     const html_body = render_add_emoji({});
 
-    function add_custom_emoji(): void {
+    const add_custom_emoji = (): void => {
         dialog_widget.show_dialog_spinner();
 
         const $emoji_status = $("#dialog_error");
         const emoji: Record<string, string> = {};
 
-        function submit_custom_emoji_request(formData: FormData): void {
+        const submit_custom_emoji_request = (formData: FormData): void => {
             assert(emoji.name !== undefined);
             void channel.post({
                 url: "/json/realm/emoji/" + encodeURIComponent(emoji.name),
@@ -228,16 +220,16 @@ function show_modal(): void {
                 cache: false,
                 processData: false,
                 contentType: false,
-                success() {
+                success: () => {
                     dialog_widget.close();
                 },
-                error(xhr) {
+                error: (xhr) => {
                     $("#dialog_error").hide();
                     dialog_widget.hide_dialog_spinner();
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $emoji_status);
                 },
             });
-        }
+        };
 
         for (const obj of $("#add-custom-emoji-form").serializeArray()) {
             emoji[obj.name] = obj.value;
@@ -291,7 +283,7 @@ function show_modal(): void {
                 confirm_dialog.launch({
                     html_heading: $t_html({defaultMessage: "Override default emoji?"}),
                     html_body,
-                    on_click() {
+                    on_click: () => {
                         submit_custom_emoji_request(formData);
                     },
                 });
@@ -299,7 +291,7 @@ function show_modal(): void {
         } else {
             submit_custom_emoji_request(formData);
         }
-    }
+    };
     dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Add a new emoji"}),
         html_body,
@@ -310,7 +302,7 @@ function show_modal(): void {
         on_click: add_custom_emoji,
         post_render: add_custom_emoji_post_render,
     });
-}
+};
 
 export function set_up(): void {
     meta.loaded = true;
@@ -330,7 +322,7 @@ export function set_up(): void {
         const html_body = render_confirm_deactivate_custom_emoji({});
 
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 const $row = $btn.parents("tr");
                 $row.remove();
             },
@@ -340,7 +332,7 @@ export function set_up(): void {
             html_heading: $t_html({defaultMessage: "Deactivate custom emoji?"}),
             html_body,
             id: "confirm_deactivate_custom_emoji_modal",
-            on_click() {
+            on_click: () => {
                 dialog_widget.submit_api_request(channel.del, url, {}, opts);
             },
             loading_spinner: true,

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -30,11 +30,11 @@ const meta = {
     loaded: false,
 };
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-function sort_user(a: RealmExport, b: RealmExport): number {
+const sort_user = (a: RealmExport, b: RealmExport): number => {
     const a_name = people.get_full_name(a.acting_user_id).toLowerCase();
     const b_name = people.get_full_name(b.acting_user_id).toLowerCase();
     if (a_name > b_name) {
@@ -43,9 +43,9 @@ function sort_user(a: RealmExport, b: RealmExport): number {
         return 0;
     }
     return -1;
-}
+};
 
-export function populate_exports_table(exports: RealmExport[]): void {
+export const populate_exports_table = (exports: RealmExport[]): void => {
     if (!meta.loaded) {
         return;
     }
@@ -54,7 +54,7 @@ export function populate_exports_table(exports: RealmExport[]): void {
     ListWidget.create($exports_table, Object.values(exports), {
         name: "admin_exports_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(data) {
+        modifier_html: (data) => {
             let failed_timestamp = null;
             let deleted_timestamp = null;
 
@@ -89,10 +89,9 @@ export function populate_exports_table(exports: RealmExport[]): void {
             $element: $exports_table
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
-            predicate(item, value) {
-                return people.get_full_name(item.acting_user_id).toLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) =>
+                people.get_full_name(item.acting_user_id).toLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar($exports_table);
             },
         },
@@ -111,7 +110,7 @@ export function populate_exports_table(exports: RealmExport[]): void {
     } else {
         loading.destroy_indicator($spinner);
     }
-}
+};
 
 export function set_up(): void {
     meta.loaded = true;
@@ -123,14 +122,14 @@ export function set_up(): void {
 
         void channel.post({
             url: "/json/export/realm",
-            success() {
+            success: () => {
                 ui_report.success(
                     $t_html({defaultMessage: "Export started. Check back in a few minutes."}),
                     $export_status,
                     4000,
                 );
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error($t_html({defaultMessage: "Export failed"}), xhr, $export_status);
             },
         });
@@ -139,7 +138,7 @@ export function set_up(): void {
     // Do an initial population of the table
     void channel.get({
         url: "/json/export/realm",
-        success(raw_data) {
+        success: (raw_data) => {
             const data = z.object({exports: z.array(realm_export_schema)}).parse(raw_data);
             populate_exports_table(data.exports);
         },
@@ -155,7 +154,7 @@ export function set_up(): void {
         confirm_dialog.launch({
             html_heading: $t_html({defaultMessage: "Delete data export?"}),
             html_body,
-            on_click() {
+            on_click: () => {
                 dialog_widget.submit_api_request(channel.del, url, {});
             },
             loading_spinner: true,

--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -52,26 +52,26 @@ const meta = {
     loaded: false,
 };
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-function failed_listing_invites(xhr: JQuery.jqXHR): void {
+const failed_listing_invites = (xhr: JQuery.jqXHR): void => {
     loading.destroy_indicator($("#admin_page_invites_loading_indicator"));
     ui_report.error(
         $t_html({defaultMessage: "Error listing invites"}),
         xhr,
         $("#invites-field-status"),
     );
-}
+};
 
-function add_invited_as_text(invites: Invite[]): void {
+const add_invited_as_text = (invites: Invite[]): void => {
     for (const data of invites) {
         data.invited_as_text = settings_config.user_role_map.get(data.invited_as);
     }
-}
+};
 
-function sort_invitee(a: Invite, b: Invite): number {
+const sort_invitee = (a: Invite, b: Invite): number => {
     // multi-invite links don't have an email field,
     // so we set them to empty strings to let them
     // sort to the top
@@ -79,9 +79,9 @@ function sort_invitee(a: Invite, b: Invite): number {
     const str2 = b.is_multiuse ? "" : b.email.toUpperCase();
 
     return util.strcmp(str1, str2);
-}
+};
 
-function populate_invites(invites_data: {invites: Invite[]}): void {
+const populate_invites = (invites_data: {invites: Invite[]}): void => {
     if (!meta.loaded) {
         return;
     }
@@ -92,7 +92,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
     ListWidget.create($invites_table, invites_data.invites, {
         name: "admin_invites_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(item) {
+        modifier_html: (item) => {
             item.invited_absolute_time = timerender.absolute_time(item.invited * 1000);
             if (item.expiry_date !== null) {
                 item.expiry_date_absolute_time = timerender.absolute_time(item.expiry_date * 1000);
@@ -111,7 +111,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
             $element: $invites_table
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
-            predicate(item, value) {
+            predicate: (item, value) => {
                 const referrer = people.get_by_user_id(item.invited_by_user_id);
                 const referrer_email = referrer.email;
                 const referrer_name = referrer.full_name;
@@ -139,9 +139,9 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
     });
 
     loading.destroy_indicator($("#admin_page_invites_loading_indicator"));
-}
+};
 
-function do_revoke_invite({
+const do_revoke_invite = ({
     $row,
     invite_id,
     is_multiuse,
@@ -149,7 +149,7 @@ function do_revoke_invite({
     $row: JQuery;
     invite_id: string;
     is_multiuse: string;
-}): void {
+}): void => {
     const modal_invite_id = $(".dialog_submit_button").attr("data-invite-id");
     const modal_is_multiuse = $(".dialog_submit_button").attr("data-is-multiuse");
     const $revoke_button = $row.find("button.revoke");
@@ -172,16 +172,16 @@ function do_revoke_invite({
     }
     void channel.del({
         url,
-        error(xhr) {
+        error: (xhr) => {
             ui_report.generic_row_button_error(xhr, $revoke_button);
         },
-        success() {
+        success: () => {
             $row.remove();
         },
     });
-}
+};
 
-function do_resend_invite({$row, invite_id}: {$row: JQuery; invite_id: string}): void {
+const do_resend_invite = ({$row, invite_id}: {$row: JQuery; invite_id: string}): void => {
     const modal_invite_id = $(".dialog_submit_button").attr("data-invite-id");
     const $resend_button = $row.find("button.resend");
 
@@ -198,17 +198,17 @@ function do_resend_invite({$row, invite_id}: {$row: JQuery; invite_id: string}):
     $resend_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
     void channel.post({
         url: "/json/invites/" + invite_id + "/resend",
-        error(xhr) {
+        error: (xhr) => {
             ui_report.generic_row_button_error(xhr, $resend_button);
         },
-        success() {
+        success: () => {
             $resend_button.text($t({defaultMessage: "Sent!"}));
             $resend_button.removeClass("resend btn-warning").addClass("sea-green");
         },
     });
-}
+};
 
-export function set_up(initialize_event_handlers = true): void {
+export const set_up = (initialize_event_handlers = true): void => {
     meta.loaded = true;
 
     // create loading indicators
@@ -218,13 +218,13 @@ export function set_up(initialize_event_handlers = true): void {
     void channel.get({
         url: "/json/invites",
         timeout: 10 * 1000,
-        success(raw_data) {
+        success: (raw_data) => {
             const data = z.object({invites: z.array(invite_schema)}).parse(raw_data);
             on_load_success(data, initialize_event_handlers);
         },
         error: failed_listing_invites,
     });
-}
+};
 
 export function on_load_success(
     invites_data: {invites: Invite[]},
@@ -257,7 +257,7 @@ export function on_load_success(
                 ? $t_html({defaultMessage: "Revoke invitation link"})
                 : $t_html({defaultMessage: "Revoke invitation to {email}"}, {email}),
             html_body,
-            on_click() {
+            on_click: () => {
                 do_revoke_invite({$row, invite_id, is_multiuse});
             },
         });
@@ -280,7 +280,7 @@ export function on_load_success(
         confirm_dialog.launch({
             html_heading: $t_html({defaultMessage: "Resend invitation?"}),
             html_body,
-            on_click() {
+            on_click: () => {
                 do_resend_invite({$row, invite_id});
             },
         });
@@ -289,7 +289,7 @@ export function on_load_success(
     });
 }
 
-export function update_invite_users_setting_tip(): void {
+export const update_invite_users_setting_tip = (): void => {
     if (settings_data.user_can_invite_users_by_email() && !current_user.is_admin) {
         $(".invite-user-settings-tip").hide();
         return;
@@ -339,9 +339,9 @@ export function update_invite_users_setting_tip(): void {
     }
     $(".invite-user-settings-tip").show();
     $(".invite-user-settings-tip").text(tip_text);
-}
+};
 
-export function update_invite_user_panel(): void {
+export const update_invite_user_panel = (): void => {
     update_invite_users_setting_tip();
     if (
         !settings_data.user_can_invite_users_by_email() &&
@@ -351,4 +351,4 @@ export function update_invite_user_panel(): void {
     } else {
         $("#admin-invites-list .invite-user-link").show();
     }
-}
+};

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -28,17 +28,17 @@ const meta = {
     loaded: false,
 };
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-export function maybe_disable_widgets(): void {
+export const maybe_disable_widgets = (): void => {
     if (current_user.is_admin) {
         return;
     }
-}
+};
 
-function open_linkifier_edit_form(linkifier_id: number): void {
+const open_linkifier_edit_form = (linkifier_id: number): void => {
     const linkifiers_list = realm.realm_linkifiers;
     const linkifier = linkifiers_list.find((linkifier) => linkifier.id === linkifier_id);
     assert(linkifier !== undefined);
@@ -48,7 +48,7 @@ function open_linkifier_edit_form(linkifier_id: number): void {
         url_template: linkifier.url_template,
     });
 
-    function submit_linkifier_form(dialog_widget_id: string): void {
+    const submit_linkifier_form = (dialog_widget_id: string): void => {
         const $modal = $(`#${dialog_widget_id}`);
         const $change_linkifier_button = $modal.find(".dialog_submit_button");
         $change_linkifier_button.prop("disabled", true);
@@ -64,11 +64,11 @@ function open_linkifier_edit_form(linkifier_id: number): void {
         const $template_status = $modal.find("#edit-linkifier-template-status").expectOne();
         const $dialog_error_element = $modal.find("#dialog_error").expectOne();
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 $change_linkifier_button.prop("disabled", false);
                 dialog_widget.close();
             },
-            error_continuation(xhr: JQuery.jqXHR<unknown>) {
+            error_continuation: (xhr: JQuery.jqXHR<unknown>) => {
                 $change_linkifier_button.prop("disabled", false);
                 const parsed = z
                     .object({errors: z.record(z.array(z.string()).optional())})
@@ -99,16 +99,16 @@ function open_linkifier_edit_form(linkifier_id: number): void {
             $("#linkifier-field-status"),
             opts,
         );
-    }
+    };
 
     const dialog_widget_id = dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Edit linkfiers"}),
         html_body,
-        on_click() {
+        on_click: () => {
             submit_linkifier_form(dialog_widget_id);
         },
     });
-}
+};
 
 function update_linkifiers_order(): void {
     const order: number[] = [];
@@ -123,12 +123,12 @@ function update_linkifiers_order(): void {
     );
 }
 
-function handle_linkifier_api_error(
+const handle_linkifier_api_error = (
     errors: Record<string, string[] | undefined>,
     pattern_status: JQuery,
     template_status: JQuery,
     linkifier_status: JQuery,
-): void {
+): void => {
     // The endpoint uses the Django ValidationError system for error
     // handling, which returns somewhat complicated error
     // dictionaries. This logic parses them.
@@ -153,9 +153,9 @@ function handle_linkifier_api_error(
             linkifier_status,
         );
     }
-}
+};
 
-export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
+export const populate_linkifiers = (linkifiers_data: RealmLinkifiers): void => {
     if (!meta.loaded) {
         return;
     }
@@ -164,8 +164,8 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
     ListWidget.create($linkifiers_table, linkifiers_data, {
         name: "linkifiers_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(linkifier, filter_value) {
-            return render_admin_linkifier_list({
+        modifier_html: (linkifier, filter_value) =>
+            render_admin_linkifier_list({
                 linkifier: {
                     pattern: linkifier.pattern,
                     url_template: linkifier.url_template,
@@ -173,19 +173,15 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
                 },
                 can_modify: current_user.is_admin,
                 can_drag: filter_value.length === 0,
-            });
-        },
+            }),
         filter: {
             $element: $linkifiers_table
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
-            predicate(item, value) {
-                return (
-                    item.pattern.toLowerCase().includes(value) ||
-                    item.url_template.toLowerCase().includes(value)
-                );
-            },
-            onupdate() {
+            predicate: (item, value) =>
+                item.pattern.toLowerCase().includes(value) ||
+                item.url_template.toLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar($linkifiers_table);
             },
         },
@@ -201,12 +197,12 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
             preventOnFilter: false,
         });
     }
-}
+};
 
-export function set_up(): void {
+export const set_up = (): void => {
     build_page();
     maybe_disable_widgets();
-}
+};
 
 export function build_page(): void {
     meta.loaded = true;
@@ -225,7 +221,7 @@ export function build_page(): void {
             html_heading: $t_html({defaultMessage: "Delete linkifier?"}),
             html_body,
             id: "confirm_delete_linkifiers_modal",
-            on_click() {
+            on_click: () => {
                 dialog_widget.submit_api_request(channel.del, url, {});
             },
             loading_spinner: true,
@@ -263,7 +259,7 @@ export function build_page(): void {
             void channel.post({
                 url: "/json/realm/filters",
                 data: $(this).serialize(),
-                success(data) {
+                success: (data) => {
                     const clean_data = configure_linkifier_api_response_schema.parse(data);
                     $("#linkifier_pattern").val("");
                     $("#linkifier_template").val("");
@@ -274,7 +270,7 @@ export function build_page(): void {
                         $linkifier_status,
                     );
                 },
-                error(xhr) {
+                error: (xhr) => {
                     $add_linkifier_button.prop("disabled", false);
                     const parsed = z
                         .object({errors: z.record(z.array(z.string()).optional())})

--- a/web/src/settings_muted_users.ts
+++ b/web/src/settings_muted_users.ts
@@ -16,7 +16,7 @@ type MutedUserItem = {
     date_muted_str: string;
 };
 
-export function populate_list(): void {
+export const populate_list = (): void => {
     const all_muted_users = muted_users.get_muted_users().map((user) => {
         const muted_user = people.get_user_by_id_assert_valid(user.id);
         return {
@@ -33,15 +33,11 @@ export function populate_list(): void {
     ListWidget.create<MutedUserItem>($muted_users_table, all_muted_users, {
         name: "muted-users-list",
         get_item: ListWidget.default_get_item,
-        modifier_html(muted_user) {
-            return render_muted_user_ui_row({muted_user});
-        },
+        modifier_html: (muted_user) => render_muted_user_ui_row({muted_user}),
         filter: {
             $element: $search_input,
-            predicate(item, value) {
-                return item.user_name.toLocaleLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) => item.user_name.toLocaleLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar(
                     $muted_users_table.closest(".progressive-table-wrapper"),
                 );
@@ -54,7 +50,7 @@ export function populate_list(): void {
         $parent_container: $("#muted-user-settings"),
         $simplebar_container: $("#muted-user-settings .progressive-table-wrapper"),
     });
-}
+};
 
 export function set_up(): void {
     loaded = true;
@@ -69,6 +65,6 @@ export function set_up(): void {
     populate_list();
 }
 
-export function reset(): void {
+export const reset = (): void => {
     loaded = false;
-}
+};

--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -23,7 +23,7 @@ import {user_settings} from "./user_settings";
 
 export const user_settings_panel = {};
 
-function rerender_ui() {
+const rerender_ui = () => {
     const $unmatched_streams_table = $("#stream-specific-notify-table");
     if ($unmatched_streams_table.length === 0) {
         // If we haven't rendered "notification settings" yet, do nothing.
@@ -58,15 +58,15 @@ function rerender_ui() {
     } else {
         $unmatched_streams_table.css("display", "table-row-group");
     }
-}
+};
 
-function change_notification_setting(setting, value, $status_element) {
+const change_notification_setting = (setting, value, $status_element) => {
     const data = {};
     data[setting] = value;
     settings_ui.do_settings_change(channel.patch, "/json/settings", data, $status_element);
-}
+};
 
-function update_desktop_icon_count_display(settings_panel) {
+const update_desktop_icon_count_display = (settings_panel) => {
     const $container = $(settings_panel.container);
     const settings_object = settings_panel.settings_object;
     $container
@@ -75,9 +75,9 @@ function update_desktop_icon_count_display(settings_panel) {
     if (!settings_panel.for_realm_settings) {
         unread_ui.update_unread_counts();
     }
-}
+};
 
-export function set_notification_batching_ui($container, setting_seconds, force_custom) {
+export const set_notification_batching_ui = ($container, setting_seconds, force_custom) => {
     const $edit_elem = $container.find(".email_notification_batching_period_edit_minutes");
     const valid_period_values = settings_config.email_notifications_batching_period_values.map(
         (x) => x.value,
@@ -95,9 +95,9 @@ export function set_notification_batching_ui($container, setting_seconds, force_
         $edit_elem.attr("id"),
         show_edit_elem,
     );
-}
+};
 
-export function set_enable_digest_emails_visibility($container, for_realm_settings) {
+export const set_enable_digest_emails_visibility = ($container, for_realm_settings) => {
     if (realm.realm_digest_emails_enabled) {
         if (for_realm_settings) {
             $container.find(".other_email_notifications").show();
@@ -111,18 +111,18 @@ export function set_enable_digest_emails_visibility($container, for_realm_settin
         }
         $container.find(".enable_digest_emails_label").parent().hide();
     }
-}
+};
 
-export function set_enable_marketing_emails_visibility() {
+export const set_enable_marketing_emails_visibility = () => {
     const $container = $("#user-notification-settings");
     if (page_params.corporate_enabled) {
         $container.find(".enable_marketing_emails_label").parent().show();
     } else {
         $container.find(".enable_marketing_emails_label").parent().hide();
     }
-}
+};
 
-function stream_notification_setting_changed(e) {
+const stream_notification_setting_changed = (e) => {
     const $row = $(e.target).closest(".stream-notifications-row");
     const stream_id = Number.parseInt($row.attr("data-stream-id"), 10);
     if (!stream_id) {
@@ -147,7 +147,7 @@ function stream_notification_setting_changed(e) {
         {property: setting, value: e.target.checked},
         $status_element,
     );
-}
+};
 
 export function set_up(settings_panel) {
     const $container = $(settings_panel.container);
@@ -311,7 +311,7 @@ export function set_up(settings_panel) {
     rerender_ui();
 }
 
-export function update_page(settings_panel) {
+export const update_page = (settings_panel) => {
     const $container = $(settings_panel.container);
     const settings_object = settings_panel.settings_object;
     for (const setting of settings_config.all_notification_settings) {
@@ -351,9 +351,9 @@ export function update_page(settings_panel) {
         }
     }
     rerender_ui();
-}
+};
 
-export function update_muted_stream_state(sub) {
+export const update_muted_stream_state = (sub) => {
     const $row = $(
         `#stream-specific-notify-table .stream-notifications-row[data-stream-id='${CSS.escape(
             sub.stream_id,
@@ -369,9 +369,9 @@ export function update_muted_stream_state(sub) {
         "disabled",
         !realm.realm_push_notifications_enabled,
     );
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     user_settings_panel.container = "#user-notification-settings";
     user_settings_panel.settings_object = user_settings;
     user_settings_panel.notification_sound_elem = "#user-notification-sound-audio";
@@ -391,4 +391,4 @@ export function initialize() {
             $row.closest(".subsection-parent").find(".alert-notification"),
         );
     });
-}
+};

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -32,13 +32,13 @@ const meta = {
     loaded: false,
 };
 
-export function reset() {
+export const reset = () => {
     meta.loaded = false;
-}
+};
 
 const DISABLED_STATE_ID = -1;
 
-export function maybe_disable_widgets() {
+export const maybe_disable_widgets = () => {
     if (current_user.is_owner) {
         return;
     }
@@ -81,9 +81,9 @@ export function maybe_disable_widgets() {
     $(".organization-box [data-name='organization-permissions']")
         .find(".control-label-disabled")
         .addClass("enabled");
-}
+};
 
-export function get_organization_settings_options() {
+export const get_organization_settings_options = () => {
     const options = {};
     options.common_policy_values = settings_components.get_sorted_options_list(
         settings_config.common_policy_values,
@@ -108,15 +108,15 @@ export function get_organization_settings_options() {
             settings_config.move_messages_between_streams_policy_values,
         );
     return options;
-}
+};
 
-export function get_org_type_dropdown_options() {
+export const get_org_type_dropdown_options = () => {
     const current_org_type = realm.realm_org_type;
     if (current_org_type !== 0) {
         return settings_config.defined_org_type_values;
     }
     return settings_config.all_org_type_values;
-}
+};
 
 const simple_dropdown_properties = [
     "realm_create_private_stream_policy",
@@ -133,7 +133,7 @@ const simple_dropdown_properties = [
     "realm_org_type",
 ];
 
-function set_realm_waiting_period_setting() {
+const set_realm_waiting_period_setting = () => {
     const setting_value = realm.realm_waiting_period_threshold;
     const valid_limit_values = settings_config.waiting_period_threshold_dropdown_values.map(
         (x) => x.code,
@@ -150,9 +150,9 @@ function set_realm_waiting_period_setting() {
         "id_realm_waiting_period_threshold_custom_input",
         $("#id_realm_waiting_period_threshold").val() === "custom_period",
     );
-}
+};
 
-function update_jitsi_server_url_custom_input(dropdown_val) {
+const update_jitsi_server_url_custom_input = (dropdown_val) => {
     const custom_input = "id_realm_jitsi_server_url_custom_input";
     settings_components.change_element_block_display_property(
         custom_input,
@@ -165,9 +165,9 @@ function update_jitsi_server_url_custom_input(dropdown_val) {
 
     const $custom_input_elem = $(`#${CSS.escape(custom_input)}`);
     $custom_input_elem.val(realm.realm_jitsi_server_url);
-}
+};
 
-function set_jitsi_server_url_dropdown() {
+const set_jitsi_server_url_dropdown = () => {
     if (!settings_components.is_video_chat_provider_jitsi_meet()) {
         $("#realm_jitsi_server_url_setting").hide();
         return;
@@ -182,21 +182,21 @@ function set_jitsi_server_url_dropdown() {
 
     $("#id_realm_jitsi_server_url").val(dropdown_val);
     update_jitsi_server_url_custom_input(dropdown_val);
-}
+};
 
-function set_video_chat_provider_dropdown() {
+const set_video_chat_provider_dropdown = () => {
     const chat_provider_id = realm.realm_video_chat_provider;
     $("#id_realm_video_chat_provider").val(chat_provider_id);
 
     set_jitsi_server_url_dropdown();
-}
+};
 
-function set_giphy_rating_dropdown() {
+const set_giphy_rating_dropdown = () => {
     const rating_id = realm.realm_giphy_rating;
     $("#id_realm_giphy_rating").val(rating_id);
-}
+};
 
-function update_message_edit_sub_settings(is_checked) {
+const update_message_edit_sub_settings = (is_checked) => {
     settings_ui.disable_sub_setting_onchange(
         is_checked,
         "id_realm_message_content_edit_limit_seconds",
@@ -207,13 +207,13 @@ function update_message_edit_sub_settings(is_checked) {
         "id_realm_message_content_edit_limit_minutes",
         true,
     );
-}
+};
 
-function set_msg_edit_limit_dropdown() {
+const set_msg_edit_limit_dropdown = () => {
     settings_components.set_time_limit_setting("realm_message_content_edit_limit_seconds");
-}
+};
 
-function message_move_limit_setting_enabled(related_setting_name) {
+const message_move_limit_setting_enabled = (related_setting_name) => {
     const setting_value = Number.parseInt($(`#id_${CSS.escape(related_setting_name)}`).val(), 10);
 
     let settings_options;
@@ -236,17 +236,20 @@ function message_move_limit_setting_enabled(related_setting_name) {
     }
 
     return true;
-}
+};
 
-function enable_or_disable_related_message_move_time_limit_setting(setting_name, disable_setting) {
+const enable_or_disable_related_message_move_time_limit_setting = (
+    setting_name,
+    disable_setting,
+) => {
     const $setting_elem = $(`#id_${CSS.escape(setting_name)}`);
     const $custom_input_elem = $setting_elem.parent().find(".time-limit-custom-input");
 
     settings_ui.disable_sub_setting_onchange(disable_setting, $setting_elem.attr("id"), true);
     settings_ui.disable_sub_setting_onchange(disable_setting, $custom_input_elem.attr("id"), true);
-}
+};
 
-function set_msg_move_limit_setting(property_name) {
+const set_msg_move_limit_setting = (property_name) => {
     settings_components.set_time_limit_setting(property_name);
 
     let disable_setting;
@@ -258,9 +261,9 @@ function set_msg_move_limit_setting(property_name) {
         );
     }
     enable_or_disable_related_message_move_time_limit_setting(property_name, disable_setting);
-}
+};
 
-function message_delete_limit_setting_enabled(setting_value) {
+const message_delete_limit_setting_enabled = (setting_value) => {
     // This function is used to check whether the time-limit setting
     // should be enabled. The setting is disabled when delete_own_message_policy
     // is set to 'admins only' as admins can delete messages irrespective of
@@ -269,9 +272,9 @@ function message_delete_limit_setting_enabled(setting_value) {
         return false;
     }
     return true;
-}
+};
 
-function set_delete_own_message_policy_dropdown(setting_value) {
+const set_delete_own_message_policy_dropdown = (setting_value) => {
     $("#id_realm_delete_own_message_policy").val(setting_value);
     settings_ui.disable_sub_setting_onchange(
         message_delete_limit_setting_enabled(setting_value),
@@ -288,13 +291,13 @@ function set_delete_own_message_policy_dropdown(setting_value) {
             true,
         );
     }
-}
+};
 
-function set_msg_delete_limit_dropdown() {
+const set_msg_delete_limit_dropdown = () => {
     settings_components.set_time_limit_setting("realm_message_content_delete_limit_seconds");
-}
+};
 
-function get_dropdown_value_for_message_retention_setting(setting_value) {
+const get_dropdown_value_for_message_retention_setting = (setting_value) => {
     if (setting_value === settings_config.retain_message_forever) {
         return "unlimited";
     }
@@ -304,9 +307,9 @@ function get_dropdown_value_for_message_retention_setting(setting_value) {
     }
 
     return "custom_period";
-}
+};
 
-export function set_message_retention_setting_dropdown(sub) {
+export const set_message_retention_setting_dropdown = (sub) => {
     let property_name = "realm_message_retention_days";
     let setting_value;
     if (sub !== undefined) {
@@ -332,9 +335,9 @@ export function set_message_retention_setting_dropdown(sub) {
         $custom_input_elem.attr("id"),
         dropdown_val === "custom_period",
     );
-}
+};
 
-function set_org_join_restrictions_dropdown() {
+const set_org_join_restrictions_dropdown = () => {
     const value = settings_components.get_realm_settings_property_value(
         "realm_org_join_restrictions",
     );
@@ -343,32 +346,32 @@ function set_org_join_restrictions_dropdown() {
         "allowed_domains_label",
         value === "only_selected_domain",
     );
-}
+};
 
-function set_message_content_in_email_notifications_visibility() {
+const set_message_content_in_email_notifications_visibility = () => {
     settings_components.change_element_block_display_property(
         "message_content_in_email_notifications_label",
         realm.realm_message_content_allowed_in_email_notifications,
     );
-}
+};
 
-function set_digest_emails_weekday_visibility() {
+const set_digest_emails_weekday_visibility = () => {
     settings_components.change_element_block_display_property(
         "id_realm_digest_weekday",
         realm.realm_digest_emails_enabled,
     );
-}
+};
 
-function set_create_web_public_stream_dropdown_visibility() {
+const set_create_web_public_stream_dropdown_visibility = () => {
     settings_components.change_element_block_display_property(
         "id_realm_create_web_public_stream_policy",
         realm.server_web_public_streams_enabled &&
             realm.zulip_plan_is_not_limited &&
             realm.realm_enable_spectator_access,
     );
-}
+};
 
-export function populate_realm_domains_label(realm_domains) {
+export const populate_realm_domains_label = (realm_domains) => {
     if (!meta.loaded) {
         return;
     }
@@ -381,9 +384,9 @@ export function populate_realm_domains_label(realm_domains) {
         domains = $t({defaultMessage: "None"});
     }
     $("#allowed_domains_label").text($t({defaultMessage: "Allowed domains: {domains}"}, {domains}));
-}
+};
 
-function can_configure_auth_methods() {
+const can_configure_auth_methods = () => {
     if (settings_data.user_email_not_configured()) {
         return false;
     }
@@ -391,9 +394,9 @@ function can_configure_auth_methods() {
         return true;
     }
     return false;
-}
+};
 
-export function populate_auth_methods(auth_method_to_bool_map) {
+export const populate_auth_methods = (auth_method_to_bool_map) => {
     if (!meta.loaded) {
         return;
     }
@@ -432,9 +435,9 @@ export function populate_auth_methods(auth_method_to_bool_map) {
         rendered_auth_method_rows += render_settings_admin_auth_methods_list(render_args);
     }
     $auth_methods_list.html(rendered_auth_method_rows);
-}
+};
 
-function update_dependent_subsettings(property_name) {
+const update_dependent_subsettings = (property_name) => {
     if (simple_dropdown_properties.includes(property_name)) {
         settings_components.set_property_dropdown_value(property_name);
         return;
@@ -468,9 +471,9 @@ function update_dependent_subsettings(property_name) {
             set_create_web_public_stream_dropdown_visibility();
             break;
     }
-}
+};
 
-export function discard_realm_property_element_changes(elem) {
+export const discard_realm_property_element_changes = (elem) => {
     const $elem = $(elem);
     const property_name = settings_components.extract_property_name($elem);
     const property_value = settings_components.get_realm_settings_property_value(property_name);
@@ -538,9 +541,9 @@ export function discard_realm_property_element_changes(elem) {
             }
     }
     update_dependent_subsettings(property_name);
-}
+};
 
-export function discard_stream_property_element_changes(elem, sub) {
+export const discard_stream_property_element_changes = (elem, sub) => {
     const $elem = $(elem);
     const property_name = settings_components.extract_property_name($elem);
     const property_value = settings_components.get_stream_settings_property_value(
@@ -577,9 +580,9 @@ export function discard_stream_property_element_changes(elem, sub) {
             }
     }
     update_dependent_subsettings(property_name);
-}
+};
 
-export function discard_group_property_element_changes(elem, group) {
+export const discard_group_property_element_changes = (elem, group) => {
     const $elem = $(elem);
     const property_name = settings_components.extract_property_name($elem);
     const property_value = settings_components.get_group_property_value(property_name, group);
@@ -592,9 +595,9 @@ export function discard_group_property_element_changes(elem, group) {
         blueslip.error("Element refers to unknown property", {property_name});
     }
     update_dependent_subsettings(property_name);
-}
+};
 
-export function discard_realm_default_property_element_changes(elem) {
+export const discard_realm_default_property_element_changes = (elem) => {
     const $elem = $(elem);
     const property_name = settings_components.extract_property_name($elem, true);
     const property_value =
@@ -630,20 +633,20 @@ export function discard_realm_default_property_element_changes(elem) {
             }
     }
     update_dependent_subsettings(property_name);
-}
+};
 
-export function deactivate_organization(e) {
+export const deactivate_organization = (e) => {
     e.preventDefault();
     e.stopPropagation();
 
-    function do_deactivate_realm() {
+    const do_deactivate_realm = () => {
         channel.post({
             url: "/json/realm/deactivate",
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
             },
         });
-    }
+    };
 
     const html_body = render_settings_deactivate_realm_modal();
 
@@ -656,9 +659,9 @@ export function deactivate_organization(e) {
         focus_submit_on_open: true,
         html_submit_button: $t_html({defaultMessage: "Confirm"}),
     });
-}
+};
 
-export function sync_realm_settings(property) {
+export const sync_realm_settings = (property) => {
     if (!meta.loaded) {
         return;
     }
@@ -673,9 +676,9 @@ export function sync_realm_settings(property) {
     if ($element.length) {
         discard_realm_property_element_changes($element);
     }
-}
+};
 
-export function save_organization_settings(data, $save_button, patch_url) {
+export const save_organization_settings = (data, $save_button, patch_url) => {
     const $subsection_parent = $save_button.closest(".settings-subsection-parent");
     const $save_btn_container = $subsection_parent.find(".save-button-controls");
     const $failed_alert_elem = $subsection_parent.find(".subsection-failed-status p");
@@ -683,24 +686,24 @@ export function save_organization_settings(data, $save_button, patch_url) {
     channel.patch({
         url: patch_url,
         data,
-        success() {
+        success: () => {
             $failed_alert_elem.hide();
             settings_components.change_save_button_state($save_btn_container, "succeeded");
         },
-        error(xhr) {
+        error: (xhr) => {
             settings_components.change_save_button_state($save_btn_container, "failed");
             $save_button.hide();
             ui_report.error($t_html({defaultMessage: "Save failed"}), xhr, $failed_alert_elem);
         },
     });
-}
+};
 
-export function set_up() {
+export const set_up = () => {
     build_page();
     maybe_disable_widgets();
-}
+};
 
-export function init_dropdown_widgets() {
+export const init_dropdown_widgets = () => {
     const notification_stream_options = () => {
         const streams = stream_settings_data.get_streams_for_settings_page();
         const options = streams.map((stream) => ({
@@ -723,7 +726,7 @@ export function init_dropdown_widgets() {
         widget_name: "realm_new_stream_announcements_stream_id",
         get_options: notification_stream_options,
         $events_container: $("#settings_overlay_container #organization-settings"),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -748,7 +751,7 @@ export function init_dropdown_widgets() {
         widget_name: "realm_signup_announcements_stream_id",
         get_options: notification_stream_options,
         $events_container: $("#settings_overlay_container #organization-settings"),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -771,7 +774,7 @@ export function init_dropdown_widgets() {
         widget_name: "realm_zulip_update_announcements_stream_id",
         get_options: notification_stream_options,
         $events_container: $("#settings_overlay_container #organization-settings"),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -794,7 +797,7 @@ export function init_dropdown_widgets() {
 
     const default_code_language_widget = new dropdown_widget.DropdownWidget({
         widget_name: "realm_default_code_block_language",
-        get_options() {
+        get_options: () => {
             const options = Object.keys(pygments_data.langs).map((x) => ({
                 name: x,
                 unique_id: x,
@@ -815,7 +818,7 @@ export function init_dropdown_widgets() {
         tippy_props: {
             placement: "bottom-start",
         },
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -836,7 +839,7 @@ export function init_dropdown_widgets() {
                 "realm",
             ),
         $events_container: $("#settings_overlay_container #organization-permissions"),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -850,7 +853,7 @@ export function init_dropdown_widgets() {
         },
         default_id: realm.realm_create_multiuse_invite_group,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        on_mount_callback(dropdown) {
+        on_mount_callback: (dropdown) => {
             $(dropdown.popper).css("min-width", "300px");
         },
     });
@@ -867,7 +870,7 @@ export function init_dropdown_widgets() {
                 "realm",
             ),
         $events_container: $("#settings_overlay_container #organization-permissions"),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -881,19 +884,19 @@ export function init_dropdown_widgets() {
         },
         default_id: realm.realm_can_access_all_users_group,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        on_mount_callback(dropdown) {
+        on_mount_callback: (dropdown) => {
             $(dropdown.popper).css("min-width", "300px");
         },
     });
     settings_components.set_can_access_all_users_group_widget(can_access_all_users_group_widget);
     can_access_all_users_group_widget.setup();
-}
+};
 
-export function register_save_discard_widget_handlers(
+export const register_save_discard_widget_handlers = (
     $container,
     patch_url,
     for_realm_default_settings,
-) {
+) => {
     $container.on("change input", "input, select, textarea", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -963,7 +966,7 @@ export function register_save_discard_widget_handlers(
         }
         save_organization_settings(data, $save_button, patch_url);
     });
-}
+};
 
 export function build_page() {
     meta.loaded = true;
@@ -1116,19 +1119,19 @@ export function build_page() {
         settings_realm_domains.show_realm_domains_modal();
     });
 
-    function realm_icon_logo_upload_complete($spinner, $upload_text, $delete_button) {
+    const realm_icon_logo_upload_complete = ($spinner, $upload_text, $delete_button) => {
         $spinner.css({visibility: "hidden"});
         $upload_text.show();
         $delete_button.show();
-    }
+    };
 
-    function realm_icon_logo_upload_start($spinner, $upload_text, $delete_button) {
+    const realm_icon_logo_upload_start = ($spinner, $upload_text, $delete_button) => {
         $spinner.css({visibility: "visible"});
         $upload_text.hide();
         $delete_button.hide();
-    }
+    };
 
-    function upload_realm_logo_or_icon($file_input, night, icon) {
+    const upload_realm_logo_or_icon = ($file_input, night, icon) => {
         const form_data = new FormData();
         let widget;
         let url;
@@ -1161,15 +1164,15 @@ export function build_page() {
             cache: false,
             processData: false,
             contentType: false,
-            success() {
+            success: () => {
                 realm_icon_logo_upload_complete($spinner, $upload_text, $delete_button);
             },
-            error(xhr) {
+            error: (xhr) => {
                 realm_icon_logo_upload_complete($spinner, $upload_text, $delete_button);
                 ui_report.error("", xhr, $error_field);
             },
         });
-    }
+    };
 
     realm_icon.build_realm_icon_widget(upload_realm_logo_or_icon, null, true);
     if (realm.zulip_plan_is_not_limited) {

--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -11,17 +11,15 @@ import * as settings_sections from "./settings_sections";
 export let normal_settings;
 export let org_settings;
 
-export function mobile_deactivate_section() {
+export const mobile_deactivate_section = () => {
     const $settings_overlay_container = $("#settings_overlay_container");
     $settings_overlay_container.find(".right").removeClass("show");
     $settings_overlay_container.find(".settings-header.mobile").removeClass("slide-left");
-}
+};
 
-function two_column_mode() {
-    return $("#settings_overlay_container").css("--single-column") === undefined;
-}
+const two_column_mode = () => $("#settings_overlay_container").css("--single-column") === undefined;
 
-function set_settings_header(key) {
+const set_settings_header = (key) => {
     const selected_tab_key = $("#settings_page .tab-switcher .selected").data("tab-key");
     let header_prefix = $t_html({defaultMessage: "Personal settings"});
     if (selected_tab_key === "organization") {
@@ -42,7 +40,7 @@ function set_settings_header(key) {
                 " sidebar list. Please add it.",
         );
     }
-}
+};
 
 export class SettingsPanelMenu {
     constructor(opts) {
@@ -179,7 +177,7 @@ export class SettingsPanelMenu {
     }
 }
 
-export function initialize() {
+export const initialize = () => {
     normal_settings = new SettingsPanelMenu({
         $main_elem: $(".normal-settings-list"),
         hash_prefix: "settings/",
@@ -188,19 +186,19 @@ export function initialize() {
         $main_elem: $(".org-settings-list"),
         hash_prefix: "organization/",
     });
-}
+};
 
-export function show_normal_settings() {
+export const show_normal_settings = () => {
     org_settings.hide();
     normal_settings.show();
-}
+};
 
-export function show_org_settings() {
+export const show_org_settings = () => {
     normal_settings.hide();
     org_settings.show();
-}
+};
 
-export function set_key_handlers(toggler) {
+export const set_key_handlers = (toggler) => {
     normal_settings.set_key_handlers(toggler);
     org_settings.set_key_handlers(toggler);
-}
+};

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -24,17 +24,17 @@ const meta = {
     loaded: false,
 };
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-export function maybe_disable_widgets(): void {
+export const maybe_disable_widgets = (): void => {
     if (current_user.is_admin) {
         return;
     }
-}
+};
 
-export function populate_playgrounds(playgrounds_data: RealmPlayground[]): void {
+export const populate_playgrounds = (playgrounds_data: RealmPlayground[]): void => {
     if (!meta.loaded) {
         return;
     }
@@ -42,8 +42,8 @@ export function populate_playgrounds(playgrounds_data: RealmPlayground[]): void 
     ListWidget.create<RealmPlayground>($playgrounds_table, playgrounds_data, {
         name: "playgrounds_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(playground) {
-            return render_admin_playground_list({
+        modifier_html: (playground) =>
+            render_admin_playground_list({
                 playground: {
                     playground_name: playground.name,
                     pygments_language: playground.pygments_language,
@@ -51,19 +51,15 @@ export function populate_playgrounds(playgrounds_data: RealmPlayground[]): void 
                     id: playground.id,
                 },
                 can_modify: current_user.is_admin,
-            });
-        },
+            }),
         filter: {
             $element: $playgrounds_table
                 .closest(".settings-section")
                 .find<HTMLInputElement>("input.search"),
-            predicate(item, value) {
-                return (
-                    item.name.toLowerCase().includes(value) ||
-                    item.pygments_language.toLowerCase().includes(value)
-                );
-            },
-            onupdate() {
+            predicate: (item, value) =>
+                item.name.toLowerCase().includes(value) ||
+                item.pygments_language.toLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar($playgrounds_table);
             },
         },
@@ -78,12 +74,12 @@ export function populate_playgrounds(playgrounds_data: RealmPlayground[]): void 
         },
         $simplebar_container: $("#playground-settings .progressive-table-wrapper"),
     });
-}
+};
 
-export function set_up(): void {
+export const set_up = (): void => {
     build_page();
     maybe_disable_widgets();
-}
+};
 
 function build_page(): void {
     meta.loaded = true;
@@ -100,7 +96,7 @@ function build_page(): void {
             html_heading: $t_html({defaultMessage: "Delete code playground?"}),
             html_body,
             id: "confirm_delete_code_playgrounds_modal",
-            on_click() {
+            on_click: () => {
                 dialog_widget.submit_api_request(channel.del, url, {});
             },
             loading_spinner: true,
@@ -124,7 +120,7 @@ function build_page(): void {
             void channel.post({
                 url: "/json/realm/playgrounds",
                 data,
-                success() {
+                success: () => {
                     $("#playground_pygments_language").val("");
                     $("#playground_name").val("");
                     $("#playground_url_template").val("");
@@ -144,7 +140,7 @@ function build_page(): void {
                     // playgrounds. Since this isn't high priority right now, we can probably
                     // take this up later.
                 },
-                error(xhr) {
+                error: (xhr) => {
                     $add_playground_button.prop("disabled", false);
                     ui_report.error(
                         $t_html({defaultMessage: "Failed"}),
@@ -165,7 +161,7 @@ function build_page(): void {
     };
 
     pygments_typeahead = new Typeahead(bootstrap_typeahead_input, {
-        source(query: string): string[] {
+        source: (query: string): string[] => {
             language_labels = realm_playground.get_pygments_typeahead_list_for_settings(query);
             return [...language_labels.keys()];
         },
@@ -173,13 +169,12 @@ function build_page(): void {
         helpOnEmptyStrings: true,
         highlighter_html: (item: string): string =>
             render_typeahead_item({primary: language_labels.get(item)}),
-        matcher(item: string, query: string): boolean {
+        matcher: (item: string, query: string): boolean => {
             const q = query.trim().toLowerCase();
             return item.toLowerCase().startsWith(q);
         },
-        sorter(items: string[], query: string): string[] {
-            return bootstrap_typeahead.defaultSorter(items, query);
-        },
+        sorter: (items: string[], query: string): string[] =>
+            bootstrap_typeahead.defaultSorter(items, query),
     });
 
     $search_pygments_box.on("click", (e) => {

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -37,16 +37,16 @@ export let user_settings_panel: SettingsPanel;
 
 export let user_default_language_name: string | undefined;
 
-export function set_default_language_name(name: string | undefined): void {
+export const set_default_language_name = (name: string | undefined): void => {
     user_default_language_name = name;
-}
+};
 
-function change_display_setting(
+const change_display_setting = (
     data: Record<string, string | boolean | number>,
     $status_el: JQuery,
     success_msg_html?: string,
     sticky?: boolean,
-): void {
+): void => {
     const status_is_sticky = $status_el.attr("data-is_sticky") === "true";
     const display_message_html = status_is_sticky
         ? $status_el.attr("data-sticky_msg_html")
@@ -61,9 +61,9 @@ function change_display_setting(
         $status_el.attr("data-sticky_msg_html", success_msg_html);
     }
     settings_ui.do_settings_change(channel.patch, "/json/settings", data, $status_el, opts);
-}
+};
 
-function spectator_default_language_modal_post_render(): void {
+const spectator_default_language_modal_post_render = (): void => {
     $("#language_selection_modal")
         .find(".language")
         .on("click", (e) => {
@@ -80,9 +80,9 @@ function spectator_default_language_modal_post_render(): void {
             Cookies.set(page_params.language_cookie_name, $link.attr("data-code")!);
             window.location.reload();
         });
-}
+};
 
-function org_notification_default_language_modal_post_render(): void {
+const org_notification_default_language_modal_post_render = (): void => {
     $("#language_selection_modal")
         .find(".language")
         .on("click", (e) => {
@@ -104,9 +104,9 @@ function org_notification_default_language_modal_post_render(): void {
                 $("#org-notifications"),
             );
         });
-}
+};
 
-function user_default_language_modal_post_render(): void {
+const user_default_language_modal_post_render = (): void => {
     $("#language_selection_modal")
         .find(".language")
         .on("click", (e) => {
@@ -145,9 +145,9 @@ function user_default_language_modal_post_render(): void {
                 true,
             );
         });
-}
+};
 
-function default_language_modal_post_render(): void {
+const default_language_modal_post_render = (): void => {
     if (page_params.is_spectator) {
         spectator_default_language_modal_post_render();
     } else if (hash_parser.get_current_hash_category() === "organization") {
@@ -155,9 +155,9 @@ function default_language_modal_post_render(): void {
     } else {
         user_default_language_modal_post_render();
     }
-}
+};
 
-export function launch_default_language_setting_modal(): void {
+export const launch_default_language_setting_modal = (): void => {
     let selected_language = user_settings.default_language;
 
     if (hash_parser.get_current_hash_category() === "organization") {
@@ -177,12 +177,12 @@ export function launch_default_language_setting_modal(): void {
         focus_submit_on_open: true,
         single_footer_button: true,
         post_render: default_language_modal_post_render,
-        on_click() {
+        on_click: () => {
             // We perform no actions since the 'close_on_submit' field takes care
             // of closing the modal.
         },
     });
-}
+};
 
 export function set_up(settings_panel: SettingsPanel): void {
     meta.loaded = true;
@@ -252,11 +252,11 @@ export function set_up(settings_panel: SettingsPanel): void {
         void channel.patch({
             url: "/json/settings",
             data,
-            success() {
+            success: () => {
                 // We don't launch any success report, since it is currently handled
                 // by function report_emojiset_change.
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error(
                     settings_ui.strings.failure_html,
                     xhr,
@@ -278,11 +278,11 @@ export function set_up(settings_panel: SettingsPanel): void {
         void channel.patch({
             url: "/json/settings",
             data,
-            success() {
+            success: () => {
                 // We don't launch any success report, since it is
                 // currently handled by report_user_list_style_change.
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error(
                     settings_ui.strings.failure_html,
                     xhr,
@@ -293,7 +293,7 @@ export function set_up(settings_panel: SettingsPanel): void {
     });
 }
 
-export async function report_emojiset_change(settings_panel: SettingsPanel): Promise<void> {
+export const report_emojiset_change = async (settings_panel: SettingsPanel): Promise<void> => {
     // TODO: Clean up how this works so we can use
     // change_display_setting.  The challenge is that we don't want to
     // report success before the server_events request returns that
@@ -313,9 +313,9 @@ export async function report_emojiset_change(settings_panel: SettingsPanel): Pro
         $spinner.expectOne();
         settings_ui.display_checkmark($spinner);
     }
-}
+};
 
-export function report_user_list_style_change(settings_panel: SettingsPanel): void {
+export const report_user_list_style_change = (settings_panel: SettingsPanel): void => {
     // TODO: Clean up how this works so we can use
     // change_display_setting.  The challenge is that we don't want to
     // report success before the server_events request returns that
@@ -333,9 +333,9 @@ export function report_user_list_style_change(settings_panel: SettingsPanel): vo
         $spinner.expectOne();
         settings_ui.display_checkmark($spinner);
     }
-}
+};
 
-export function update_page(property: UserSettingsProperty): void {
+export const update_page = (property: UserSettingsProperty): void => {
     if (!overlays.settings_open()) {
         return;
     }
@@ -365,9 +365,9 @@ export function update_page(property: UserSettingsProperty): void {
 
     const $input_elem = $container.find(`[name=${CSS.escape(property)}]`);
     settings_components.set_input_element_value($input_elem, value);
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     const user_language_name = get_language_name(user_settings.default_language);
     set_default_language_name(user_language_name);
 
@@ -377,4 +377,4 @@ export function initialize(): void {
         for_realm_settings: false,
         notification_sound_elem: null,
     };
-}
+};

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -35,14 +35,14 @@ const meta: {
     loaded: false,
 };
 
-function display_success_status(): void {
+const display_success_status = (): void => {
     const $spinner = $("#admin-profile-field-status").expectOne();
     const success_msg_html = settings_ui.strings.success_html;
     ui_report.success(success_msg_html, $spinner, 1000);
     settings_ui.display_checkmark($spinner);
-}
+};
 
-export function maybe_disable_widgets(): void {
+export const maybe_disable_widgets = (): void => {
     if (current_user.is_admin) {
         return;
     }
@@ -50,12 +50,12 @@ export function maybe_disable_widgets(): void {
     $(".organization-box [data-name='profile-field-settings']")
         .find("input, button, select")
         .prop("disabled", true);
-}
+};
 
 let display_in_profile_summary_fields_limit_reached = false;
 let order: number[] = [];
 
-export function field_type_id_to_string(type_id: number): string | undefined {
+export const field_type_id_to_string = (type_id: number): string | undefined => {
     for (const field_type of Object.values(realm.custom_profile_field_types)) {
         if (field_type.id === type_id) {
             // Few necessary modifications in field-type-name for
@@ -69,16 +69,16 @@ export function field_type_id_to_string(type_id: number): string | undefined {
         }
     }
     return undefined;
-}
+};
 
 // Checking custom profile field type is valid for showing display on user card checkbox field.
-function is_valid_to_display_in_summary(field_type: number): boolean {
+const is_valid_to_display_in_summary = (field_type: number): boolean => {
     const field_types = realm.custom_profile_field_types;
     if (field_type === field_types.LONG_TEXT.id || field_type === field_types.USER.id) {
         return false;
     }
     return true;
-}
+};
 
 function delete_profile_field(this: HTMLElement, e: JQuery.ClickEvent): void {
     e.preventDefault();
@@ -101,15 +101,15 @@ function delete_profile_field(this: HTMLElement, e: JQuery.ClickEvent): void {
         count: users_using_deleting_profile_field,
     });
 
-    function request_delete(): void {
+    const request_delete = (): void => {
         const url = "/json/realm/profile_fields/" + profile_field_id;
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 display_success_status();
             },
         };
         dialog_widget.submit_api_request(channel.del, url, {}, opts);
-    }
+    };
 
     confirm_dialog.launch({
         html_body,
@@ -118,15 +118,15 @@ function delete_profile_field(this: HTMLElement, e: JQuery.ClickEvent): void {
     });
 }
 
-export function get_value_for_new_option(container: JQuery): number {
+export const get_value_for_new_option = (container: JQuery): number => {
     let value = 0;
     for (const row of $(container).find(".choice-row")) {
         value = Math.max(value, Number.parseInt($(row).attr("data-value")!, 10) + 1);
     }
     return value;
-}
+};
 
-function create_choice_row(container: JQuery): void {
+const create_choice_row = (container: JQuery): void => {
     const context = {
         text: "",
         value: get_value_for_new_option(container),
@@ -134,9 +134,9 @@ function create_choice_row(container: JQuery): void {
     };
     const row_html = render_settings_profile_field_choice(context);
     $(container).append($(row_html));
-}
+};
 
-function clear_form_data(): void {
+const clear_form_data = (): void => {
     const field_types = realm.custom_profile_field_types;
 
     $("#profile_field_name").val("").closest(".input-group").show();
@@ -156,9 +156,9 @@ function clear_form_data(): void {
             "select:not([multiple])#profile_field_external_accounts_type option:first-child",
         ).val()!,
     );
-}
+};
 
-function set_up_create_field_form(): void {
+const set_up_create_field_form = (): void => {
     const field_types = realm.custom_profile_field_types;
     // Hide error on field type change.
     $("#dialog_error").hide();
@@ -213,15 +213,15 @@ function set_up_create_field_form(): void {
         $("#profile_field_display_in_profile_summary").closest(".input-group").hide();
         $("#profile_field_display_in_profile_summary").prop("checked", false);
     }
-}
+};
 
-function open_custom_profile_field_form_modal(): void {
+const open_custom_profile_field_form_modal = (): void => {
     const html_body = render_add_new_custom_profile_field_form({
         realm_default_external_accounts: realm.realm_default_external_accounts,
         custom_profile_field_types: realm.custom_profile_field_types,
     });
 
-    function create_profile_field(): void {
+    const create_profile_field = (): void => {
         let field_data: FieldData | undefined = {};
         const field_type = $<HTMLSelectOneElement>(
             "select:not([multiple])#profile_field_type",
@@ -243,14 +243,14 @@ function open_custom_profile_field_form_modal(): void {
         };
         const url = "/json/realm/profile_fields";
         const opts = {
-            success_continuation() {
+            success_continuation: () => {
                 display_success_status();
             },
         };
         dialog_widget.submit_api_request(channel.post, url, data, opts);
-    }
+    };
 
-    function set_up_form_fields(): void {
+    const set_up_form_fields = (): void => {
         set_up_select_field();
         set_up_external_account_field();
         clear_form_data();
@@ -269,7 +269,7 @@ function open_custom_profile_field_form_modal(): void {
             "display_in_profile_summary_tooltip",
             display_in_profile_summary_fields_limit_reached,
         );
-    }
+    };
 
     dialog_widget.launch({
         form_id: "add-new-custom-profile-field-form",
@@ -281,7 +281,7 @@ function open_custom_profile_field_form_modal(): void {
         post_render: set_up_form_fields,
         loading_spinner: true,
     });
-}
+};
 
 function add_choice_row(this: HTMLElement, e: JQuery.TriggeredEvent): void {
     const $curr_choice_row = $(this).parent();
@@ -296,25 +296,25 @@ function add_choice_row(this: HTMLElement, e: JQuery.TriggeredEvent): void {
     create_choice_row($(choices_div));
 }
 
-function delete_choice_row(row: HTMLElement): void {
+const delete_choice_row = (row: HTMLElement): void => {
     const $row = $(row).parent();
     $row.remove();
-}
+};
 
-function delete_choice_row_for_edit(
+const delete_choice_row_for_edit = (
     row: HTMLElement,
     $profile_field_form: JQuery,
     field: CustomProfileField,
-): void {
+): void => {
     delete_choice_row(row);
     disable_submit_btn_if_no_property_changed($profile_field_form, field);
-}
+};
 
-function show_modal_for_deleting_options(
+const show_modal_for_deleting_options = (
     field: CustomProfileField,
     deleted_values: Record<string, string>,
     update_profile_field: () => void,
-): void {
+): void => {
     const active_user_ids = people.get_active_user_ids();
     let users_count_with_deleted_option_selected = 0;
     for (const user_id of active_user_ids) {
@@ -342,13 +342,12 @@ function show_modal_for_deleting_options(
         html_body,
         on_click: update_profile_field,
     });
-}
+};
 
-function get_profile_field(id: number): CustomProfileField | undefined {
-    return realm.custom_profile_fields.find((field) => field.id === id);
-}
+const get_profile_field = (id: number): CustomProfileField | undefined =>
+    realm.custom_profile_fields.find((field) => field.id === id);
 
-export function parse_field_choices_from_field_data(field_data: SelectFieldData): FieldChoice[] {
+export const parse_field_choices_from_field_data = (field_data: SelectFieldData): FieldChoice[] => {
     const choices: FieldChoice[] = [];
     for (const [value, choice] of Object.entries(field_data)) {
         choices.push({
@@ -359,12 +358,12 @@ export function parse_field_choices_from_field_data(field_data: SelectFieldData)
     }
     choices.sort((a, b) => Number.parseInt(a.order, 10) - Number.parseInt(b.order, 10));
     return choices;
-}
+};
 
-function set_up_external_account_field_edit_form(
+const set_up_external_account_field_edit_form = (
     $profile_field_form: JQuery,
     url_pattern_val: string,
-): void {
+): void => {
     if ($profile_field_form.find("select[name=external_acc_field_type]").val() === "custom") {
         $profile_field_form.find("input[name=url_pattern]").val(url_pattern_val);
         $profile_field_form.find(".custom_external_account_detail").show();
@@ -375,12 +374,12 @@ function set_up_external_account_field_edit_form(
         $profile_field_form.find("input[name=hint]").prop("disabled", true);
         $profile_field_form.find(".custom_external_account_detail").hide();
     }
-}
+};
 
-function disable_submit_btn_if_no_property_changed(
+const disable_submit_btn_if_no_property_changed = (
     $profile_field_form: JQuery,
     field: CustomProfileField,
-): void {
+): void => {
     const data = settings_components.populate_data_for_custom_profile_field_request(
         $profile_field_form,
         field,
@@ -393,12 +392,12 @@ function disable_submit_btn_if_no_property_changed(
         "disabled",
         save_changes_button_disabled,
     );
-}
+};
 
-function set_up_select_field_edit_form(
+const set_up_select_field_edit_form = (
     $profile_field_form: JQuery,
     field: CustomProfileField,
-): void {
+): void => {
     // Re-render field choices in edit form to load initial select data
     const $choice_list = $profile_field_form.find(".edit_profile_field_choices_container");
     $choice_list.off();
@@ -421,16 +420,16 @@ function set_up_select_field_edit_form(
     // Add blank choice at last
     create_choice_row($choice_list);
     SortableJS.create($choice_list[0]!, {
-        onUpdate() {
+        onUpdate: () => {
             // Do nothing on drag. We process the order on submission
         },
         filter: "input",
         preventOnFilter: false,
-        onSort() {
+        onSort: () => {
             disable_submit_btn_if_no_property_changed($profile_field_form, field);
         },
     });
-}
+};
 
 function open_edit_form_modal(this: HTMLElement): void {
     const field_types = realm.custom_profile_field_types;
@@ -516,7 +515,7 @@ function open_edit_form_modal(this: HTMLElement): void {
         });
     }
 
-    function submit_form(): void {
+    const submit_form = (): void => {
         const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
 
         const data = settings_components.populate_data_for_custom_profile_field_request(
@@ -524,15 +523,15 @@ function open_edit_form_modal(this: HTMLElement): void {
             field,
         );
 
-        function update_profile_field(): void {
+        const update_profile_field = (): void => {
             const url = "/json/realm/profile_fields/" + field_id;
             const opts = {
-                success_continuation() {
+                success_continuation: () => {
                     display_success_status();
                 },
             };
             dialog_widget.submit_api_request(channel.patch, url, data, opts);
-        }
+        };
 
         if (field.type === field_types.SELECT.id && data.field_data !== undefined) {
             const new_values = new Set(
@@ -561,7 +560,7 @@ function open_edit_form_modal(this: HTMLElement): void {
         }
 
         update_profile_field();
-    }
+    };
 
     const edit_custom_profile_field_form_id = "edit-custom-profile-field-form-" + field_id;
     dialog_widget.launch({
@@ -577,7 +576,7 @@ function open_edit_form_modal(this: HTMLElement): void {
 
 // If exceeds or equals the max limit, we are disabling option for
 // display custom profile field on user card and adding tooltip.
-function update_profile_fields_checkboxes(): void {
+const update_profile_fields_checkboxes = (): void => {
     // Disabling only uncheck checkboxes in table, so user should able uncheck checked checkboxes.
     $("#admin_profile_fields_table .display_in_profile_summary_checkbox_false").prop(
         "disabled",
@@ -587,7 +586,7 @@ function update_profile_fields_checkboxes(): void {
         "display_in_profile_summary_tooltip",
         display_in_profile_summary_fields_limit_reached,
     );
-}
+};
 
 function toggle_display_in_profile_summary_profile_field(this: HTMLInputElement): void {
     const field_id = Number.parseInt($(this).attr("data-profile-field-id")!, 10);
@@ -620,9 +619,9 @@ function toggle_required(this: HTMLInputElement): void {
         $profile_field_status,
     );
 }
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
 function update_field_order(this: HTMLElement): void {
     order = [];
@@ -637,16 +636,16 @@ function update_field_order(this: HTMLElement): void {
     );
 }
 
-export function populate_profile_fields(profile_fields_data: CustomProfileField[]): void {
+export const populate_profile_fields = (profile_fields_data: CustomProfileField[]): void => {
     if (!meta.loaded) {
         // If outside callers call us when we're not loaded, just
         // exit and we'll draw the widgets again during set_up().
         return;
     }
     do_populate_profile_fields(profile_fields_data);
-}
+};
 
-export function do_populate_profile_fields(profile_fields_data: CustomProfileField[]): void {
+export const do_populate_profile_fields = (profile_fields_data: CustomProfileField[]): void => {
     const field_types = realm.custom_profile_field_types;
 
     // We should only call this internally or from tests.
@@ -712,7 +711,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
 
     update_profile_fields_checkboxes();
     loading.destroy_indicator($("#admin_page_profile_fields_loading_indicator"));
-}
+};
 
 function set_up_select_field(): void {
     const field_types = realm.custom_profile_field_types;
@@ -722,7 +721,7 @@ function set_up_select_field(): void {
     if (current_user.is_admin) {
         const choice_list = $("#profile_field_choices")[0]!;
         SortableJS.create(choice_list, {
-            onUpdate() {
+            onUpdate: () => {
                 // Do nothing on drag. We process the order on submission
             },
             filter: "input",
@@ -755,7 +754,7 @@ function set_up_select_field(): void {
     });
 }
 
-function set_up_external_account_field(): void {
+const set_up_external_account_field = (): void => {
     $("#profile_field_type").on("change", () => {
         set_up_create_field_form();
     });
@@ -763,9 +762,9 @@ function set_up_external_account_field(): void {
     $("#profile_field_external_accounts_type").on("change", () => {
         set_up_create_field_form();
     });
-}
+};
 
-export function get_external_account_link(field: UserExternalAccountData): string {
+export const get_external_account_link = (field: UserExternalAccountData): string => {
     assert(field.field_data !== undefined);
     const field_subtype = field.field_data.subtype;
     let field_url_pattern: string;
@@ -779,14 +778,14 @@ export function get_external_account_link(field: UserExternalAccountData): strin
         field_url_pattern = external_account.url_pattern;
     }
     return field_url_pattern.replace("%(username)s", () => field.value);
-}
+};
 
-export function set_up(): void {
+export const set_up = (): void => {
     build_page();
     maybe_disable_widgets();
-}
+};
 
-export function build_page(): void {
+export const build_page = (): void => {
     // create loading indicators
     loading.make_indicator($("#admin_page_profile_fields_loading_indicator"));
     // Populate profile_fields table
@@ -802,4 +801,4 @@ export function build_page(): void {
         toggle_display_in_profile_summary_profile_field,
     );
     $("#admin_profile_fields_table").on("click", ".required-field-toggle", toggle_required);
-}
+};

--- a/web/src/settings_realm_domains.ts
+++ b/web/src/settings_realm_domains.ts
@@ -14,7 +14,7 @@ type RealmDomain = {
     allow_subdomains: boolean;
 };
 
-export function populate_realm_domains_table(realm_domains: RealmDomain[]): void {
+export const populate_realm_domains_table = (realm_domains: RealmDomain[]): void => {
     // Don't populate the table if the realm domains modal isn't open.
     if ($("#realm_domains_modal").length === 0) {
         return;
@@ -28,13 +28,13 @@ export function populate_realm_domains_table(realm_domains: RealmDomain[]): void
             $(render_settings_admin_realm_domains_list({realm_domain})),
         );
     }
-}
+};
 
-function fade_status_element($elem: JQuery): void {
+const fade_status_element = ($elem: JQuery): void => {
     setTimeout(() => {
         $elem.fadeOut(500);
     }, 3000);
-}
+};
 
 export function setup_realm_domains_modal_handlers(): void {
     $("#realm_domains_table").on("click", ".delete_realm_domain", function () {
@@ -44,14 +44,14 @@ export function setup_realm_domains_modal_handlers(): void {
 
         void channel.del({
             url,
-            success() {
+            success: () => {
                 ui_report.success(
                     $t_html({defaultMessage: "Deleted successfully!"}),
                     $realm_domains_info,
                 );
                 fade_status_element($realm_domains_info);
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $realm_domains_info);
                 fade_status_element($realm_domains_info);
             },
@@ -74,7 +74,7 @@ export function setup_realm_domains_modal_handlers(): void {
             void channel.patch({
                 url,
                 data,
-                success() {
+                success: () => {
                     if (allow_subdomains) {
                         ui_report.success(
                             $t_html(
@@ -100,7 +100,7 @@ export function setup_realm_domains_modal_handlers(): void {
                     }
                     fade_status_element($realm_domains_info);
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $realm_domains_info);
                     fade_status_element($realm_domains_info);
                 },
@@ -123,7 +123,7 @@ export function setup_realm_domains_modal_handlers(): void {
         void channel.post({
             url: "/json/realm/domains",
             data,
-            success() {
+            success: () => {
                 $("#add-realm-domain-widget .new-realm-domain").val("");
                 $("#add-realm-domain-widget .new-realm-domain-allow-subdomains").prop(
                     "checked",
@@ -135,7 +135,7 @@ export function setup_realm_domains_modal_handlers(): void {
                 );
                 fade_status_element($realm_domains_info);
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $realm_domains_info);
                 fade_status_element($realm_domains_info);
             },
@@ -143,7 +143,7 @@ export function setup_realm_domains_modal_handlers(): void {
     });
 }
 
-export function show_realm_domains_modal(): void {
+export const show_realm_domains_modal = (): void => {
     const realm_domains_table_body = render_realm_domains_modal();
 
     dialog_widget.launch({
@@ -151,15 +151,15 @@ export function show_realm_domains_modal(): void {
         html_body: realm_domains_table_body,
         html_submit_button: $t_html({defaultMessage: "Close"}),
         id: "realm_domains_modal",
-        on_click() {
+        on_click: () => {
             // This modal has no submit button.
         },
         close_on_submit: true,
         focus_submit_on_open: true,
         single_footer_button: true,
-        post_render() {
+        post_render: () => {
             setup_realm_domains_modal_handlers();
             populate_realm_domains_table(realm.realm_domains);
         },
     });
-}
+};

--- a/web/src/settings_realm_user_settings_defaults.js
+++ b/web/src/settings_realm_user_settings_defaults.js
@@ -11,7 +11,7 @@ import {current_user} from "./state_data";
 
 export const realm_default_settings_panel = {};
 
-export function maybe_disable_widgets() {
+export const maybe_disable_widgets = () => {
     if (!current_user.is_admin) {
         $(".organization-box [data-name='organization-level-user-defaults']")
             .find("input, select")
@@ -21,9 +21,9 @@ export function maybe_disable_widgets() {
             .find(".play_notification_sound")
             .addClass("control-label-disabled");
     }
-}
+};
 
-export function update_page(property) {
+export const update_page = (property) => {
     if (!overlays.settings_open()) {
         return;
     }
@@ -51,9 +51,9 @@ export function update_page(property) {
 
     const $input_elem = $container.find(`[name=${CSS.escape(property)}]`);
     settings_components.set_input_element_value($input_elem, value);
-}
+};
 
-export function set_up() {
+export const set_up = () => {
     const $container = $(realm_default_settings_panel.container);
     const $notification_sound_elem = $("audio#realm-default-notification-sound-audio");
     const $notification_sound_dropdown = $container.find(".setting_notification_sound");
@@ -83,12 +83,12 @@ export function set_up() {
     );
 
     maybe_disable_widgets();
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     realm_default_settings_panel.container = "#realm-user-default-settings";
     realm_default_settings_panel.settings_object = realm_user_settings_defaults;
     realm_default_settings_panel.notification_sound_elem =
         "#realm-default-notification-sound-audio";
     realm_default_settings_panel.for_realm_settings = true;
-}
+};

--- a/web/src/settings_sections.js
+++ b/web/src/settings_sections.js
@@ -21,7 +21,7 @@ import * as settings_users from "./settings_users";
 const load_func_dict = new Map(); // group -> function
 const loaded_groups = new Set();
 
-export function get_group(section) {
+export const get_group = (section) => {
     // Sometimes several sections all share the same code.
 
     switch (section) {
@@ -45,9 +45,9 @@ export function get_group(section) {
         default:
             return section;
     }
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     // personal
     load_func_dict.set("your-account", settings_account.set_up);
     load_func_dict.set("preferences", () => {
@@ -77,9 +77,9 @@ export function initialize() {
         "organization-level-user-defaults",
         settings_realm_user_settings_defaults.set_up,
     );
-}
+};
 
-export function load_settings_section(section) {
+export const load_settings_section = (section) => {
     const group = get_group(section);
 
     if (!load_func_dict.has(group)) {
@@ -98,9 +98,9 @@ export function load_settings_section(section) {
     // Do the real work here!
     load_func();
     loaded_groups.add(group);
-}
+};
 
-export function reset_sections() {
+export const reset_sections = () => {
     loaded_groups.clear();
     settings_emoji.reset();
     settings_exports.reset();
@@ -114,4 +114,4 @@ export function reset_sections() {
     settings_muted_users.reset();
     alert_words_ui.reset();
     // settings_users doesn't need a reset()
-}
+};

--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -19,16 +19,15 @@ import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
 
-function add_choice_row($widget: JQuery): void {
+const add_choice_row = ($widget: JQuery): void => {
     if ($widget.closest(".choice-row").next().hasClass("choice-row")) {
         return;
     }
     create_choice_row();
-}
+};
 
-function get_chosen_default_streams(): Set<number> {
-    // Return the set of stream id's of streams chosen in the default stream modal.
-    return new Set(
+const get_chosen_default_streams = (): Set<number> =>
+    new Set(
         // Note: We selectively map through the dropdown elements that contain the
         // `data-stream-id` attribute to avoid adding an element with undefined value
         //  into the returned `Set`.
@@ -36,9 +35,8 @@ function get_chosen_default_streams(): Set<number> {
             .map((_i, elem) => Number($(elem).attr("data-stream-id")))
             .get(),
     );
-}
 
-function create_choice_row(): void {
+const create_choice_row = (): void => {
     const $container = $("#default-stream-choices");
     const value = settings_profile_fields.get_value_for_new_option($container);
     const stream_dropdown_widget_name = `select_default_stream_${value}`;
@@ -46,15 +44,15 @@ function create_choice_row(): void {
     $container.append($(row_html));
 
     // List of non-default streams that are not yet selected.
-    function get_options(): {name: string; unique_id: number}[] {
+    const get_options = (): {name: string; unique_id: number}[] => {
         const chosen_default_streams = get_chosen_default_streams();
 
         return stream_data
             .get_non_default_stream_names()
             .filter((e) => !chosen_default_streams.has(e.unique_id));
-    }
+    };
 
-    function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance): void {
+    const item_click_callback = (event: JQuery.ClickEvent, dropdown: tippy.Instance): void => {
         const $selected_stream = $(event.currentTarget);
         const selected_stream_name = $selected_stream.attr("data-name")!;
         const selected_stream_id = Number.parseInt($selected_stream.attr("data-unique-id")!, 10);
@@ -69,7 +67,7 @@ function create_choice_row(): void {
         $("#add-default-stream-modal .dialog_submit_button").prop("disabled", false);
         event.stopPropagation();
         event.preventDefault();
-    }
+    };
 
     new dropdown_widget.DropdownWidget({
         widget_name: stream_dropdown_widget_name,
@@ -80,17 +78,17 @@ function create_choice_row(): void {
             placement: "bottom-start",
         },
     }).setup();
-}
+};
 
 const meta = {
     loaded: false,
 };
 
-export function reset(): void {
+export const reset = (): void => {
     meta.loaded = false;
-}
+};
 
-export function maybe_disable_widgets(): void {
+export const maybe_disable_widgets = (): void => {
     if (current_user.is_admin) {
         return;
     }
@@ -98,9 +96,9 @@ export function maybe_disable_widgets(): void {
     $(".organization-box [data-name='default-channels-list']")
         .find("input:not(.search), button, select")
         .prop("disabled", true);
-}
+};
 
-export function build_default_stream_table(): void {
+export const build_default_stream_table = (): void => {
     const $table = $("#admin_default_streams_table").expectOne();
 
     const stream_ids = stream_data.get_default_stream_ids();
@@ -109,18 +107,15 @@ export function build_default_stream_table(): void {
     ListWidget.create($table, subs, {
         name: "default_streams_list",
         get_item: ListWidget.default_get_item,
-        modifier_html(item) {
-            return render_admin_default_streams_list({
+        modifier_html: (item) =>
+            render_admin_default_streams_list({
                 stream: item,
                 can_modify: current_user.is_admin,
-            });
-        },
+            }),
         filter: {
             $element: $table.closest(".settings-section").find<HTMLInputElement>("input.search"),
-            predicate(item, query) {
-                return item.name.toLowerCase().includes(query.toLowerCase());
-            },
-            onupdate() {
+            predicate: (item, query) => item.name.toLowerCase().includes(query.toLowerCase()),
+            onupdate: () => {
                 scroll_util.reset_scrollbar($table);
             },
         },
@@ -133,32 +128,32 @@ export function build_default_stream_table(): void {
     });
 
     loading.destroy_indicator($("#admin_page_default_streams_loading_indicator"));
-}
+};
 
-export function update_default_streams_table(): void {
+export const update_default_streams_table = (): void => {
     if (["organization", "settings"].includes(hash_parser.get_current_hash_category())) {
         $("#admin_default_streams_table").expectOne().find("tr.default_stream_row").remove();
         build_default_stream_table();
     }
-}
+};
 
-export function delete_default_stream(
+export const delete_default_stream = (
     stream_id: number,
     $default_stream_row: JQuery,
     $alert_element: JQuery,
-): void {
+): void => {
     void channel.del({
         url: "/json/default_streams?" + $.param({stream_id}),
-        error(xhr) {
+        error: (xhr) => {
             ui_report.generic_row_button_error(xhr, $alert_element);
         },
-        success() {
+        success: () => {
             $default_stream_row.remove();
         },
     });
-}
+};
 
-function delete_choice_row(e: JQuery.ClickEvent): void {
+const delete_choice_row = (e: JQuery.ClickEvent): void => {
     const $row = $(e.currentTarget).parent();
     $row.remove();
 
@@ -167,12 +162,12 @@ function delete_choice_row(e: JQuery.ClickEvent): void {
         "disabled",
         $(".choice-row").length <= 1,
     );
-}
+};
 
-function show_add_default_streams_modal(): void {
+const show_add_default_streams_modal = (): void => {
     const html_body = render_add_default_streams();
 
-    function add_default_streams(e: JQuery.ClickEvent): void {
+    const add_default_streams = (e: JQuery.ClickEvent): void => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -181,19 +176,19 @@ function show_add_default_streams_modal(): void {
         let successful_requests = 0;
         const chosen_streams = get_chosen_default_streams();
 
-        function make_default_stream_request(stream_id: number): void {
+        const make_default_stream_request = (stream_id: number): void => {
             const data = {stream_id};
             void channel.post({
                 url: "/json/default_streams",
                 data,
-                success() {
+                success: () => {
                     successful_requests = successful_requests + 1;
 
                     if (successful_requests === chosen_streams.size) {
                         dialog_widget.close();
                     }
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error(
                         $t_html({defaultMessage: "Failed adding one or more channels."}),
                         xhr,
@@ -202,19 +197,19 @@ function show_add_default_streams_modal(): void {
                     dialog_widget.hide_dialog_spinner();
                 },
             });
-        }
+        };
 
         for (const chosen_stream of chosen_streams) {
             make_default_stream_request(chosen_stream);
         }
-    }
+    };
 
-    function default_stream_post_render(): void {
+    const default_stream_post_render = (): void => {
         $("#add-default-stream-modal .dialog_submit_button").prop("disabled", true);
 
         create_choice_row();
         $("#default-stream-choices").on("click", "button.delete-choice", delete_choice_row);
-    }
+    };
 
     dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Add default channels"}),
@@ -226,12 +221,12 @@ function show_add_default_streams_modal(): void {
         on_click: add_default_streams,
         post_render: default_stream_post_render,
     });
-}
+};
 
-export function set_up(): void {
+export const set_up = (): void => {
     build_page();
     maybe_disable_widgets();
-}
+};
 
 export function build_page(): void {
     meta.loaded = true;

--- a/web/src/settings_toggle.js
+++ b/web/src/settings_toggle.js
@@ -6,20 +6,20 @@ import * as settings_panel_menu from "./settings_panel_menu";
 
 let toggler;
 
-export function highlight_toggle(tab_name) {
+export const highlight_toggle = (tab_name) => {
     if (toggler) {
         toggler.goto(tab_name);
     }
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     toggler = components.toggle({
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "Personal"}), key: "settings"},
             {label: $t({defaultMessage: "Organization"}), key: "organization"},
         ],
-        callback(_name, key) {
+        callback: (_name, key) => {
             if (key === "organization") {
                 settings_panel_menu.show_org_settings();
             } else {
@@ -31,10 +31,10 @@ export function initialize() {
     settings_panel_menu.set_key_handlers(toggler);
 
     toggler.get().appendTo("#settings_overlay_container .tab-container");
-}
+};
 
 // Handles the collapse/reveal of some tabs in the org settings for non-admins.
-export function toggle_org_setting_collapse() {
+export const toggle_org_setting_collapse = () => {
     const is_collapsed = $(".collapse-org-settings").hasClass("hide-org-settings");
     const show_fewer_settings_text = $t({defaultMessage: "Show fewer"});
     const show_more_settings_text = $t({defaultMessage: "Show more"});
@@ -64,4 +64,4 @@ export function toggle_org_setting_collapse() {
     if ($current_tab.hasClass("hide-org-settings")) {
         $(location).attr("href", "/#organization/organization-profile");
     }
-}
+};

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -16,12 +16,12 @@ type RequestOpts = {
     $error_msg_element?: JQuery;
 };
 
-export function display_checkmark($elem: JQuery): void {
+export const display_checkmark = ($elem: JQuery): void => {
     const $check_mark = $("<img>");
     $check_mark.attr("src", checkbox_image);
     $check_mark.css("width", "13px");
     $elem.prepend($check_mark);
-}
+};
 
 export const strings = {
     success_html: $t_html({defaultMessage: "Saved"}),
@@ -31,7 +31,7 @@ export const strings = {
 // Generic function for informing users about changes to the settings
 // UI.  Intended to replace the old system that was built around
 // direct calls to `ui_report`.
-export function do_settings_change(
+export const do_settings_change = (
     request_method: AjaxRequestHandler,
     url: string,
     data: Omit<Parameters<AjaxRequestHandler>[0]["data"], "undefined">,
@@ -44,7 +44,7 @@ export function do_settings_change(
         sticky = false,
         $error_msg_element,
     }: RequestOpts = {},
-): void {
+): void => {
     const $spinner = $status_element.expectOne();
     $spinner.fadeTo(0, 1);
     loading.make_indicator($spinner, {text: strings.saving});
@@ -54,7 +54,7 @@ export function do_settings_change(
     void request_method({
         url,
         data,
-        success(response_data) {
+        success: (response_data) => {
             setTimeout(() => {
                 ui_report.success(success_msg_html, $spinner, remove_after);
                 display_checkmark($spinner);
@@ -63,7 +63,7 @@ export function do_settings_change(
                 success_continuation(response_data);
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             if ($error_msg_element) {
                 loading.destroy_indicator($spinner);
                 ui_report.error(failure_msg_html, xhr, $error_msg_element);
@@ -75,7 +75,7 @@ export function do_settings_change(
             }
         },
     });
-}
+};
 
 // This function is used to disable sub-setting when main setting is checked or unchecked
 // or two settings are inter-dependent on their values.
@@ -84,12 +84,12 @@ export function do_settings_change(
 //   string id of setting.
 // * disable_on_uncheck is boolean, true if sub setting should be disabled
 //   when main setting unchecked.
-export function disable_sub_setting_onchange(
+export const disable_sub_setting_onchange = (
     is_checked: boolean,
     sub_setting_id: string,
     disable_on_uncheck: boolean,
     include_label: boolean,
-): void {
+): void => {
     if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
         $(`#${CSS.escape(sub_setting_id)}`).prop("disabled", false);
         if (include_label) {
@@ -105,4 +105,4 @@ export function disable_sub_setting_onchange(
                 .addClass("control-label-disabled");
         }
     }
-}
+};

--- a/web/src/settings_user_topics.ts
+++ b/web/src/settings_user_topics.ts
@@ -11,7 +11,7 @@ import type {UserTopic} from "./user_topics";
 
 export let loaded = false;
 
-export function populate_list(): void {
+export const populate_list = (): void => {
     const all_user_topics = [];
     const visibility_policies = Object.values(user_topics.all_visibility_policies);
     for (const visibility_policy of visibility_policies) {
@@ -28,7 +28,7 @@ export function populate_list(): void {
     ListWidget.create<UserTopic>($user_topics_table, all_user_topics, {
         name: "user-topics-list",
         get_item: ListWidget.default_get_item,
-        modifier_html(user_topic) {
+        modifier_html: (user_topic) => {
             const context = {
                 user_topic,
                 user_topic_visibility_policy_values:
@@ -38,10 +38,8 @@ export function populate_list(): void {
         },
         filter: {
             $element: $search_input,
-            predicate(item, value) {
-                return item.topic.toLocaleLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) => item.topic.toLocaleLowerCase().includes(value),
+            onupdate: () => {
                 scroll_util.reset_scrollbar(
                     $user_topics_table.closest(".progressive-table-wrapper"),
                 );
@@ -56,7 +54,7 @@ export function populate_list(): void {
         $parent_container: $("#user-topic-settings"),
         $simplebar_container: $("#user-topic-settings .progressive-table-wrapper"),
     });
-}
+};
 
 export function set_up(): void {
     loaded = true;
@@ -89,6 +87,6 @@ export function set_up(): void {
     populate_list();
 }
 
-export function reset(): void {
+export const reset = (): void => {
     loaded = false;
-}
+};

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -45,43 +45,36 @@ const section = {
     bots: {},
 };
 
-function sort_bot_email(a, b) {
-    function email(bot) {
-        return (bot.display_email || "").toLowerCase();
-    }
+const sort_bot_email = (a, b) => {
+    const email = (bot) => (bot.display_email || "").toLowerCase();
 
     return user_sort.compare_a_b(email(a), email(b));
-}
+};
 
-function sort_bot_owner(a, b) {
-    function owner_name(bot) {
-        return (bot.bot_owner_full_name || "").toLowerCase();
-    }
+const sort_bot_owner = (a, b) => {
+    const owner_name = (bot) => (bot.bot_owner_full_name || "").toLowerCase();
 
     return user_sort.compare_a_b(owner_name(a), owner_name(b));
-}
+};
 
-function sort_last_active(a, b) {
-    return user_sort.compare_a_b(
+const sort_last_active = (a, b) =>
+    user_sort.compare_a_b(
         presence.last_active_date(a.user_id) || 0,
         presence.last_active_date(b.user_id) || 0,
     );
-}
 
-function get_user_info_row(user_id) {
-    return $(`tr.user_row[data-user-id='${CSS.escape(user_id)}']`);
-}
+const get_user_info_row = (user_id) => $(`tr.user_row[data-user-id='${CSS.escape(user_id)}']`);
 
-export function allow_sorting_deactivated_users_list_by_email() {
+export const allow_sorting_deactivated_users_list_by_email = () => {
     const deactivated_users = people.get_non_active_realm_users();
     const deactivated_humans_with_visible_email = deactivated_users.filter(
         (user) => !user.is_bot && user.delivery_email,
     );
 
     return deactivated_humans_with_visible_email.length !== 0;
-}
+};
 
-export function update_view_on_deactivate(user_id) {
+export const update_view_on_deactivate = (user_id) => {
     const $row = get_user_info_row(user_id);
     if ($row.length === 0) {
         return;
@@ -95,9 +88,9 @@ export function update_view_on_deactivate(user_id) {
     $button.empty().append($("<i>").addClass(["fa", "fa-user-plus"]).attr("aria-hidden", "true"));
     $row.removeClass("reactivated_user");
     $row.addClass("deactivated_user");
-}
+};
 
-function update_view_on_reactivate($row) {
+const update_view_on_reactivate = ($row) => {
     const $button = $row.find("button.reactivate");
     $row.find("i.deactivated-user-icon").hide();
     $button.addClass("btn-danger deactivate");
@@ -105,22 +98,22 @@ function update_view_on_reactivate($row) {
     $button.empty().append($("<i>").addClass(["fa", "fa-user-times"]).attr("aria-hidden", "true"));
     $row.removeClass("deactivated_user");
     $row.addClass("reactivated_user");
-}
+};
 
-function failed_listing_users() {
+const failed_listing_users = () => {
     loading.destroy_indicator($("#subs_page_loading_indicator"));
     const user_id = people.my_current_user_id();
     blueslip.error("Error while listing users for user_id", {user_id});
-}
+};
 
-function add_value_to_filters(section, key, value) {
+const add_value_to_filters = (section, key, value) => {
     section.filters[key] = value;
     // This hard_redraw will rerun the relevant predicate function
     // and in turn apply the new filters.
     section.list_widget.hard_redraw();
-}
+};
 
-function role_selected_handler(event, dropdown, widget) {
+const role_selected_handler = (event, dropdown, widget) => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -133,21 +126,19 @@ function role_selected_handler(event, dropdown, widget) {
 
     dropdown.hide();
     widget.render();
-}
+};
 
-function get_roles() {
-    return [
-        {unique_id: "0", name: $t({defaultMessage: "All roles"})},
-        ...Object.values(settings_config.user_role_values)
-            .map((user_role_value) => ({
-                unique_id: user_role_value.code.toString(),
-                name: user_role_value.description,
-            }))
-            .reverse(),
-    ];
-}
+const get_roles = () => [
+    {unique_id: "0", name: $t({defaultMessage: "All roles"})},
+    ...Object.values(settings_config.user_role_values)
+        .map((user_role_value) => ({
+            unique_id: user_role_value.code.toString(),
+            name: user_role_value.description,
+        }))
+        .reverse(),
+];
 
-function create_role_filter_dropdown($events_container, widget_name) {
+const create_role_filter_dropdown = ($events_container, widget_name) => {
     new dropdown_widget.DropdownWidget({
         widget_name,
         get_options: get_roles,
@@ -159,9 +150,9 @@ function create_role_filter_dropdown($events_container, widget_name) {
             offset: [0, 0],
         },
     }).setup();
-}
+};
 
-function populate_users() {
+const populate_users = () => {
     const active_user_ids = people.get_realm_active_human_user_ids();
     const deactivated_user_ids = people.get_non_active_human_ids();
 
@@ -176,15 +167,13 @@ function populate_users() {
         $("#admin-deactivated-users-list"),
         section.deactivated.dropdown_widget_name,
     );
-}
+};
 
-function reset_scrollbar($sel) {
-    return function () {
-        scroll_util.reset_scrollbar($sel);
-    };
-}
+const reset_scrollbar = ($sel) => () => {
+    scroll_util.reset_scrollbar($sel);
+};
 
-function bot_owner_full_name(owner_id) {
+const bot_owner_full_name = (owner_id) => {
     if (!owner_id) {
         return undefined;
     }
@@ -195,9 +184,9 @@ function bot_owner_full_name(owner_id) {
     }
 
     return bot_owner.full_name;
-}
+};
 
-function bot_info(bot_user_id) {
+const bot_info = (bot_user_id) => {
     const bot_user = people.maybe_get_user_by_id(bot_user_id);
 
     if (!bot_user) {
@@ -235,18 +224,18 @@ function bot_info(bot_user_id) {
     info.display_email = bot_user.email;
 
     return info;
-}
+};
 
-function get_last_active(user) {
+const get_last_active = (user) => {
     const last_active_date = presence.last_active_date(user.user_id);
 
     if (!last_active_date) {
         return $t({defaultMessage: "Unknown"});
     }
     return timerender.render_now(last_active_date).time_str;
-}
+};
 
-function human_info(person) {
+const human_info = (person) => {
     const info = {};
 
     info.is_bot = false;
@@ -269,7 +258,7 @@ function human_info(person) {
     }
 
     return info;
-}
+};
 
 let bot_list_widget;
 
@@ -288,7 +277,7 @@ section.bots.create_table = () => {
         html_selector: (item) => $(`tr[data-user-id='${CSS.escape(item.user_id)}']`),
         filter: {
             $element: $bots_table.closest(".settings-section").find(".search"),
-            predicate(item, value) {
+            predicate: (item, value) => {
                 if (!item) {
                     return false;
                 }
@@ -319,14 +308,13 @@ section.active.create_table = (active_users) => {
     section.active.list_widget = ListWidget.create($users_table, active_users, {
         name: "users_table_list",
         get_item: people.get_by_user_id,
-        modifier_html(item) {
+        modifier_html: (item) => {
             const info = human_info(item);
             return render_admin_user_list(info);
         },
         filter: {
-            predicate(person) {
-                return people.predicate_for_user_settings_filters(person, section.active.filters);
-            },
+            predicate: (person) =>
+                people.predicate_for_user_settings_filters(person, section.active.filters),
             onupdate: reset_scrollbar($users_table),
         },
         $parent_container: $("#admin-user-list").expectOne(),
@@ -353,17 +341,13 @@ section.deactivated.create_table = (deactivated_users) => {
         {
             name: "deactivated_users_table_list",
             get_item: people.get_by_user_id,
-            modifier_html(item) {
+            modifier_html: (item) => {
                 const info = human_info(item);
                 return render_admin_user_list(info);
             },
             filter: {
-                predicate(person) {
-                    return people.predicate_for_user_settings_filters(
-                        person,
-                        section.deactivated.filters,
-                    );
-                },
+                predicate: (person) =>
+                    people.predicate_for_user_settings_filters(person, section.deactivated.filters),
                 onupdate: reset_scrollbar($deactivated_users_table),
             },
             $parent_container: $("#admin-deactivated-users-list").expectOne(),
@@ -382,15 +366,15 @@ section.deactivated.create_table = (deactivated_users) => {
     $("#admin_deactivated_users_table").show();
 };
 
-export function update_bot_data(bot_user_id) {
+export const update_bot_data = (bot_user_id) => {
     if (!bot_list_widget) {
         return;
     }
 
     bot_list_widget.render_item(bot_info(bot_user_id));
-}
+};
 
-export function update_user_data(user_id, new_data) {
+export const update_user_data = (user_id, new_data) => {
     const $user_row = get_user_info_row(user_id);
 
     if ($user_row.length === 0) {
@@ -405,9 +389,9 @@ export function update_user_data(user_id, new_data) {
     if (new_data.role !== undefined) {
         $user_row.find(".user_role").text(people.get_user_type(user_id));
     }
-}
+};
 
-export function redraw_bots_list() {
+export const redraw_bots_list = () => {
     if (!bot_list_widget) {
         return;
     }
@@ -418,9 +402,9 @@ export function redraw_bots_list() {
     const bot_user_ids = people.get_bot_ids();
     bot_list_widget.replace_list_data(bot_user_ids);
     bot_list_widget.hard_redraw();
-}
+};
 
-function start_data_load() {
+const start_data_load = () => {
     loading.make_indicator($("#admin_page_users_loading_indicator"), {
         text: $t({defaultMessage: "Loading…"}),
     });
@@ -431,9 +415,9 @@ function start_data_load() {
     $("#admin_users_table").hide();
 
     populate_users();
-}
+};
 
-function handle_deactivation($tbody) {
+const handle_deactivation = ($tbody) => {
     $tbody.on("click", ".deactivate", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active` in `settings.js`.
@@ -443,7 +427,7 @@ function handle_deactivation($tbody) {
         const $row = $(e.target).closest(".user_row");
         const user_id = Number($row.attr("data-user-id"));
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/users/" + encodeURIComponent(user_id);
             let data = {};
             if ($(".send_email").is(":checked")) {
@@ -453,13 +437,13 @@ function handle_deactivation($tbody) {
             }
 
             dialog_widget.submit_api_request(channel.del, url, data);
-        }
+        };
 
         user_deactivation_ui.confirm_deactivation(user_id, handle_confirm, true);
     });
-}
+};
 
-function handle_bot_deactivation($tbody) {
+const handle_bot_deactivation = ($tbody) => {
     $tbody.on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -468,16 +452,16 @@ function handle_bot_deactivation($tbody) {
         const $row = $button_elem.closest(".user_row");
         const bot_id = Number.parseInt($row.attr("data-user-id"), 10);
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/bots/" + encodeURIComponent(bot_id);
             dialog_widget.submit_api_request(channel.del, url, {});
-        }
+        };
 
         user_deactivation_ui.confirm_bot_deactivation(bot_id, handle_confirm, true);
     });
-}
+};
 
-function handle_reactivation($tbody) {
+const handle_reactivation = ($tbody) => {
     $tbody.on("click", ".reactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -487,22 +471,22 @@ function handle_reactivation($tbody) {
         const $row = $button_elem.closest(".user_row");
         const user_id = Number.parseInt($row.attr("data-user-id"), 10);
 
-        function handle_confirm() {
+        const handle_confirm = () => {
             const $row = get_user_info_row(user_id);
             const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
             const opts = {
-                success_continuation() {
+                success_continuation: () => {
                     update_view_on_reactivate($row);
                 },
             };
             dialog_widget.submit_api_request(channel.post, url, {}, opts);
-        }
+        };
 
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
-}
+};
 
-function handle_edit_form($tbody) {
+const handle_edit_form = ($tbody) => {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -516,7 +500,7 @@ function handle_edit_form($tbody) {
         const user = people.get_by_user_id(user_id);
         user_profile.show_user_profile(user, "manage-profile-tab");
     });
-}
+};
 
 function handle_filter_change($tbody, section) {
     // This duplicates the built-in search filter live-update logic in
@@ -557,13 +541,13 @@ section.bots.handle_events = () => {
     handle_edit_form($tbody);
 };
 
-export function set_up_humans() {
+export const set_up_humans = () => {
     start_data_load();
     section.active.handle_events();
     section.deactivated.handle_events();
-}
+};
 
-export function set_up_bots() {
+export const set_up_bots = () => {
     section.bots.handle_events();
     section.bots.create_table();
 
@@ -572,4 +556,4 @@ export function set_up_bots() {
         e.stopPropagation();
         settings_bots.add_a_new_bot();
     });
-}
+};

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -17,12 +17,12 @@ import {user_settings} from "./user_settings";
 export let left_sidebar_expanded_as_overlay = false;
 export let right_sidebar_expanded_as_overlay = false;
 
-export function hide_userlist_sidebar(): void {
+export const hide_userlist_sidebar = (): void => {
     $(".app-main .column-right").removeClass("expanded");
     right_sidebar_expanded_as_overlay = false;
-}
+};
 
-export function show_userlist_sidebar(): void {
+export const show_userlist_sidebar = (): void => {
     const $userlist_sidebar = $(".app-main .column-right");
     if ($userlist_sidebar.css("display") !== "none") {
         // Return early if the right sidebar is already visible.
@@ -39,24 +39,23 @@ export function show_userlist_sidebar(): void {
     fix_invite_user_button_flicker();
     resize.resize_page_components();
     right_sidebar_expanded_as_overlay = true;
-}
+};
 
-export function show_streamlist_sidebar(): void {
+export const show_streamlist_sidebar = (): void => {
     $(".app-main .column-left").addClass("expanded");
     resize.resize_stream_filters_container();
     left_sidebar_expanded_as_overlay = true;
-}
+};
 
-export function hide_streamlist_sidebar(): void {
+export const hide_streamlist_sidebar = (): void => {
     $(".app-main .column-left").removeClass("expanded");
     left_sidebar_expanded_as_overlay = false;
-}
+};
 
-export function any_sidebar_expanded_as_overlay(): boolean {
-    return left_sidebar_expanded_as_overlay || right_sidebar_expanded_as_overlay;
-}
+export const any_sidebar_expanded_as_overlay = (): boolean =>
+    left_sidebar_expanded_as_overlay || right_sidebar_expanded_as_overlay;
 
-export function update_invite_user_option(): void {
+export const update_invite_user_option = (): void => {
     if (
         !settings_data.user_can_invite_users_by_email() &&
         !settings_data.user_can_create_multiuse_invite()
@@ -65,14 +64,14 @@ export function update_invite_user_option(): void {
     } else {
         $("#right-sidebar .invite-user-link").show();
     }
-}
+};
 
-export function hide_all(): void {
+export const hide_all = (): void => {
     hide_streamlist_sidebar();
     hide_userlist_sidebar();
-}
+};
 
-function fix_invite_user_button_flicker(): void {
+const fix_invite_user_button_flicker = (): void => {
     // Keep right sidebar hidden after browser renders it to avoid
     // flickering of "Invite more users" button. Since the user list
     // is a complex component browser takes time for it to render
@@ -82,9 +81,9 @@ function fix_invite_user_button_flicker(): void {
     setTimeout(() => {
         $("body").removeClass("hide-right-sidebar-by-visibility");
     }, 0);
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     $("body").on("click", ".login_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -172,9 +171,9 @@ export function initialize(): void {
         },
         {capture: true},
     );
-}
+};
 
-export function initialize_left_sidebar(): void {
+export const initialize_left_sidebar = (): void => {
     const rendered_sidebar = render_left_sidebar({
         is_guest: current_user.is_guest,
         development_environment: page_params.development_environment,
@@ -188,9 +187,9 @@ export function initialize_left_sidebar(): void {
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);
-}
+};
 
-export function initialize_right_sidebar(): void {
+export const initialize_right_sidebar = (): void => {
     const rendered_sidebar = render_right_sidebar({
         realm_rendered_description: page_params.realm_rendered_description,
     });
@@ -239,4 +238,4 @@ export function initialize_right_sidebar(): void {
         e.stopPropagation();
         buddy_list.toggle_other_users_section();
     });
-}
+};

--- a/web/src/spectators.ts
+++ b/web/src/spectators.ts
@@ -14,19 +14,18 @@ import * as browser_history from "./browser_history";
 import * as modals from "./modals";
 import {realm} from "./state_data";
 
-export function current_hash_as_next(): string {
-    return `next=/${encodeURIComponent(window.location.hash)}`;
-}
+export const current_hash_as_next = (): string =>
+    `next=/${encodeURIComponent(window.location.hash)}`;
 
-export function build_login_link(): string {
+export const build_login_link = (): string => {
     let login_link = "/login/?" + current_hash_as_next();
     if (page_params.development_environment) {
         login_link = "/devlogin/?" + current_hash_as_next();
     }
     return login_link;
-}
+};
 
-export function login_to_access(empty_narrow?: boolean): void {
+export const login_to_access = (empty_narrow?: boolean): void => {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
     const login_link = build_login_link();
@@ -45,8 +44,8 @@ export function login_to_access(empty_narrow?: boolean): void {
 
     modals.open("login_to_access_modal", {
         autoremove: true,
-        on_hide() {
+        on_hide: () => {
             browser_history.return_to_web_public_hash();
         },
     });
-}
+};

--- a/web/src/spoilers.ts
+++ b/web/src/spoilers.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-function collapse_spoiler($spoiler: JQuery): void {
+const collapse_spoiler = ($spoiler: JQuery): void => {
     const spoiler_height = $spoiler.height() ?? 0;
 
     // Set height to rendered height on next frame, then to zero on following
@@ -13,9 +13,9 @@ function collapse_spoiler($spoiler: JQuery): void {
             $spoiler.height("0px");
         });
     });
-}
+};
 
-function expand_spoiler($spoiler: JQuery): void {
+const expand_spoiler = ($spoiler: JQuery): void => {
     // Normally, the height of the spoiler block is not defined absolutely on
     // the `spoiler-content-open` class, but just set to `auto` (i.e. the height
     // of the content). CSS animations do not work with properties set to
@@ -33,7 +33,7 @@ function expand_spoiler($spoiler: JQuery): void {
         // This keeps things working if, e.g., the viewport is resized
         $spoiler.height("");
     });
-}
+};
 
 export const hide_spoilers_in_notification = ($content: JQuery): JQuery => {
     $content.find(".spoiler-block").each((_i, elem) => {

--- a/web/src/starred_messages.ts
+++ b/web/src/starred_messages.ts
@@ -2,35 +2,31 @@ import * as message_store from "./message_store";
 
 export const starred_ids = new Set<number>();
 
-export function initialize(starred_messages_params: {starred_messages: number[]}): void {
+export const initialize = (starred_messages_params: {starred_messages: number[]}): void => {
     starred_ids.clear();
 
     for (const id of starred_messages_params.starred_messages) {
         starred_ids.add(id);
     }
-}
+};
 
-export function add(ids: number[]): void {
+export const add = (ids: number[]): void => {
     for (const id of ids) {
         starred_ids.add(id);
     }
-}
+};
 
-export function remove(ids: number[]): void {
+export const remove = (ids: number[]): void => {
     for (const id of ids) {
         starred_ids.delete(id);
     }
-}
+};
 
-export function get_count(): number {
-    return starred_ids.size;
-}
+export const get_count = (): number => starred_ids.size;
 
-export function get_starred_msg_ids(): number[] {
-    return [...starred_ids];
-}
+export const get_starred_msg_ids = (): number[] => [...starred_ids];
 
-export function get_count_in_topic(stream_id?: number, topic?: string): number {
+export const get_count_in_topic = (stream_id?: number, topic?: string): number => {
     if (stream_id === undefined || topic === undefined) {
         return 0;
     }
@@ -60,4 +56,4 @@ export function get_count_in_topic(stream_id?: number, topic?: string): number {
     });
 
     return messages.length;
-}
+};

--- a/web/src/starred_messages_ui.ts
+++ b/web/src/starred_messages_ui.ts
@@ -14,7 +14,7 @@ import * as sub_store from "./sub_store";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
-export function toggle_starred_and_update_server(message: Message): void {
+export const toggle_starred_and_update_server = (message: Message): void => {
     if (message.locally_echoed) {
         // This is defensive code for when you hit the "*" key
         // before we get a server ack.  It's rare that somebody
@@ -41,11 +41,11 @@ export function toggle_starred_and_update_server(message: Message): void {
         starred_messages.remove([message.id]);
         rerender_ui();
     }
-}
+};
 
 // This updates the state of the starred flag in local data
 // structures, and triggers a UI rerender.
-export function update_starred_flag(message_id: number, updated_starred_flag: boolean): void {
+export const update_starred_flag = (message_id: number, updated_starred_flag: boolean): void => {
     const message = message_store.get(message_id);
     if (message === undefined) {
         // If we don't have the message locally, do nothing; if later
@@ -54,9 +54,9 @@ export function update_starred_flag(message_id: number, updated_starred_flag: bo
     }
     message.starred = updated_starred_flag;
     message_live_update.update_starred_view(message_id, updated_starred_flag);
-}
+};
 
-export function rerender_ui(): void {
+export const rerender_ui = (): void => {
     let count = starred_messages.get_count();
 
     if (!user_settings.starred_message_counts) {
@@ -67,9 +67,9 @@ export function rerender_ui(): void {
     popover_menus.get_topic_menu_popover()?.hide();
     popover_menus.get_starred_messages_popover()?.hide();
     left_sidebar_navigation_area.update_starred_count(count);
-}
+};
 
-export function confirm_unstar_all_messages(): void {
+export const confirm_unstar_all_messages = (): void => {
     const html_body = render_confirm_unstar_all_messages();
 
     confirm_dialog.launch({
@@ -77,12 +77,12 @@ export function confirm_unstar_all_messages(): void {
         html_body,
         on_click: message_flags.unstar_all_messages,
     });
-}
+};
 
-export function confirm_unstar_all_messages_in_topic(stream_id: number, topic: string): void {
-    function on_click(): void {
+export const confirm_unstar_all_messages_in_topic = (stream_id: number, topic: string): void => {
+    const on_click = (): void => {
         message_flags.unstar_all_messages_in_topic(stream_id, topic);
-    }
+    };
 
     const stream_name = sub_store.maybe_get_stream_name(stream_id);
     if (stream_name === undefined) {
@@ -99,8 +99,8 @@ export function confirm_unstar_all_messages_in_topic(stream_id: number, topic: s
         html_body,
         on_click,
     });
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     rerender_ui();
-}
+};

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -201,10 +201,12 @@ export const state_data_schema = current_user_schema
 export let current_user: z.infer<typeof current_user_schema>;
 export let realm: z.infer<typeof realm_schema>;
 
-export function set_current_user(initial_current_user: z.infer<typeof current_user_schema>): void {
+export const set_current_user = (
+    initial_current_user: z.infer<typeof current_user_schema>,
+): void => {
     current_user = initial_current_user;
-}
+};
 
-export function set_realm(initial_realm: z.infer<typeof realm_schema>): void {
+export const set_realm = (initial_realm: z.infer<typeof realm_schema>): void => {
     realm = initial_realm;
-}
+};

--- a/web/src/stats/stats.ts
+++ b/web/src/stats/stats.ts
@@ -57,12 +57,11 @@ const datum_schema: z.ZodType<Plotly.Datum> = z.any();
 // Define a schema factory function for the utility generic type
 // The inferred types from zod have to be used to type the return values
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function instantiate_type_DataByEveryoneUser<T extends z.ZodTypeAny>(schema: T) {
-    return z.object({
+const instantiate_type_DataByEveryoneUser = <T extends z.ZodTypeAny>(schema: T) =>
+    z.object({
         everyone: schema,
         user: schema,
     });
-}
 
 // Define zod schemas for incoming data from the server
 const common_data_schema = z.object({
@@ -120,9 +119,9 @@ const font_12pt = {
 
 let last_full_update = Number.POSITIVE_INFINITY;
 
-function handle_parse_server_stats_result<_, T>(
+const handle_parse_server_stats_result = <_, T>(
     result: z.SafeParseReturnType<_, T>,
-): T | undefined {
+): T | undefined => {
     if (!result.success) {
         blueslip.warn(
             "Server stats data cannot be parsed as expected.\n" +
@@ -134,10 +133,10 @@ function handle_parse_server_stats_result<_, T>(
         return undefined;
     }
     return result.data;
-}
+};
 
 // Copied from attachments_ui.js
-function bytes_to_size(bytes: number, kb_with_1024_bytes = false): string {
+const bytes_to_size = (bytes: number, kb_with_1024_bytes = false): string => {
     const kb_size = kb_with_1024_bytes ? 1024 : 1000;
     const sizes = ["B", "KB", "MB", "GB", "TB"];
     if (bytes === 0) {
@@ -149,32 +148,32 @@ function bytes_to_size(bytes: number, kb_with_1024_bytes = false): string {
         size = Math.round((bytes / Math.pow(kb_size, i)) * 10) / 10;
     }
     return `${size} ${sizes[i]}`;
-}
+};
 
 // TODO: should take a dict of arrays and do it for all keys
-function partial_sums(array: number[]): number[] {
+const partial_sums = (array: number[]): number[] => {
     let accumulator = 0;
     return array.map((o) => {
         accumulator += o;
         return accumulator;
     });
-}
+};
 
 // Assumes date is a round number of hours
-function floor_to_local_day(date: Date): Date {
+const floor_to_local_day = (date: Date): Date => {
     const date_copy = new Date(date.getTime());
     date_copy.setHours(0);
     return date_copy;
-}
+};
 
 // Assumes date is a round number of hours
-function floor_to_local_week(date: Date): Date {
+const floor_to_local_week = (date: Date): Date => {
     const date_copy = floor_to_local_day(date);
     date_copy.setHours(-24 * date.getDay());
     return date_copy;
-}
+};
 
-function format_date(date: Date, include_hour: boolean): string {
+const format_date = (date: Date, include_hour: boolean): string => {
     const months = [
         $t({defaultMessage: "January"}),
         $t({defaultMessage: "February"}),
@@ -200,9 +199,9 @@ function format_date(date: Date, include_hour: boolean): string {
         return `${month_str} ${day}, ${hour % 12}:00${str}`;
     }
     return `${month_str} ${day}, ${year}`;
-}
+};
 
-function update_last_full_update(end_times: number[]): void {
+const update_last_full_update = (end_times: number[]): void => {
     if (end_times.length === 0) {
         return;
     }
@@ -221,7 +220,7 @@ function update_last_full_update(end_times: number[]): void {
 
     $("#id_last_full_update").text(locale_time + " on " + locale_date);
     $("#id_last_full_update").closest(".last-update").show();
-}
+};
 
 $(() => {
     tippy.default(".last_update_tooltip", {
@@ -236,20 +235,18 @@ $(() => {
 });
 
 // Helper used in vertical bar charts
-function make_rangeselector(
+const make_rangeselector = (
     button1: Partial<Plotly.RangeSelectorButton>,
     button2: Partial<Plotly.RangeSelectorButton>,
-): Partial<Plotly.RangeSelector> {
-    return {
-        x: -0.045,
-        y: -0.62,
-        buttons: [
-            {stepmode: "backward", ...button1},
-            {stepmode: "backward", ...button2},
-            {step: "all", label: $t({defaultMessage: "All time"})},
-        ],
-    };
-}
+): Partial<Plotly.RangeSelector> => ({
+    x: -0.045,
+    y: -0.62,
+    buttons: [
+        {stepmode: "backward", ...button1},
+        {stepmode: "backward", ...button2},
+        {step: "all", label: $t({defaultMessage: "All time"})},
+    ],
+});
 
 type ActiveUserData = {
     _1day: Plotly.Datum[];
@@ -258,7 +255,7 @@ type ActiveUserData = {
 };
 
 // SUMMARY STATISTICS
-function get_user_summary_statistics(data: ActiveUserData): void {
+const get_user_summary_statistics = (data: ActiveUserData): void => {
     if (Object.keys(data).length === 0) {
         return;
     }
@@ -276,9 +273,9 @@ function get_user_summary_statistics(data: ActiveUserData): void {
 
     $("#id_active_fifteen_day_users").text(active_fifteen_day_users_string);
     $("#id_active_fifteen_day_users").closest("summary-stats").show();
-}
+};
 
-function get_total_messages_sent(data: DataByUserType<number[]>): void {
+const get_total_messages_sent = (data: DataByUserType<number[]>): void => {
     if (Object.keys(data).length === 0) {
         return;
     }
@@ -288,9 +285,9 @@ function get_total_messages_sent(data: DataByUserType<number[]>): void {
 
     $("#id_total_messages_sent").text(total_messages_string);
     $("#id_total_messages_sent").closest("summary-stats").show();
-}
+};
 
-function get_thirty_days_messages_sent(data: DataByUserType<number[]>): void {
+const get_thirty_days_messages_sent = (data: DataByUserType<number[]>): void => {
     if (Object.keys(data).length === 0) {
         return;
     }
@@ -307,9 +304,9 @@ function get_thirty_days_messages_sent(data: DataByUserType<number[]>): void {
 
     $("#id_thirty_days_messages_sent").text(thirty_days_messages_string);
     $("#id_thirty_days_messages_sent").closest("summary-stats").show();
-}
+};
 
-function set_storage_space_used_statistic(upload_space_used: number | null): void {
+const set_storage_space_used_statistic = (upload_space_used: number | null): void => {
     let space_used = "N/A";
     if (upload_space_used !== null) {
         space_used = bytes_to_size(upload_space_used, true);
@@ -317,9 +314,9 @@ function set_storage_space_used_statistic(upload_space_used: number | null): voi
 
     $("#id_storage_space_used").text(space_used);
     $("#id_storage_space_used").closest("summary-stats").show();
-}
+};
 
-function set_guest_users_statistic(guest_users: number | null): void {
+const set_guest_users_statistic = (guest_users: number | null): void => {
     let guest_users_string = "N/A";
     if (guest_users !== null) {
         guest_users_string = guest_users.toLocaleString();
@@ -327,7 +324,7 @@ function set_guest_users_statistic(guest_users: number | null): void {
 
     $("#id_guest_users_count").text(guest_users_string);
     $("#id_guest_users_count").closest("summary-stats").show();
-}
+};
 
 // PLOTLY CHARTS
 function populate_messages_sent_over_time(raw_data: unknown): void {
@@ -344,12 +341,12 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
     }
 
     // Helper functions
-    function make_traces(
+    const make_traces = (
         dates: Date[],
         values: DataByUserType<number[]>,
         type: Plotly.PlotType,
         date_formatter: DateFormatter,
-    ): DataByUserType<Partial<Plotly.PlotData>> {
+    ): DataByUserType<Partial<Plotly.PlotData>> => {
         const text = dates.map((date) => date_formatter(date));
         const common: Partial<Plotly.PlotData> = {
             x: dates,
@@ -380,7 +377,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
                 ...common,
             },
         };
-    }
+    };
 
     const layout: Partial<Plotly.Layout> = {
         barmode: "group",
@@ -413,7 +410,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
         {count: 6, label: $t({defaultMessage: "Last 6 months"}), step: "month"},
     );
 
-    function add_hover_handler(): void {
+    const add_hover_handler = (): void => {
         document
             .querySelector<Plotly.PlotlyHTMLElement>("#id_messages_sent_over_time")!
             .on("plotly_hover", (data) => {
@@ -446,7 +443,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
                     }
                 }
             });
-    }
+    };
 
     const start_dates = data.end_times.map(
         (timestamp: number) =>
@@ -454,23 +451,19 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
             new Date(timestamp * 1000 - 60 * 60 * 1000),
     );
 
-    function aggregate_data(
+    const aggregate_data = (
         data: SentData,
         aggregation: "day" | "week",
-    ): AggregatedData<DataByUserType<number[]>> {
+    ): AggregatedData<DataByUserType<number[]>> => {
         let start;
         let is_boundary;
         if (aggregation === "day") {
             start = floor_to_local_day(start_dates[0]!);
-            is_boundary = function (date: Date) {
-                return date.getHours() === 0;
-            };
+            is_boundary = (date: Date) => date.getHours() === 0;
         } else {
             assert(aggregation === "week");
             start = floor_to_local_week(start_dates[0]!);
-            is_boundary = function (date: Date) {
-                return date.getHours() === 0 && date.getDay() === 0;
-            };
+            is_boundary = (date: Date) => date.getHours() === 0 && date.getDay() === 0;
         }
         const dates = [start];
         const values: DataByUserType<number[]> = {human: [], bot: [], me: []};
@@ -506,26 +499,21 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
                 new Date(start_dates.at(-1)!.getTime() + 60 * 60 * 1000),
             ),
         };
-    }
+    };
 
     // Generate traces
-    let date_formatter = function (date: Date): string {
-        return format_date(date, true);
-    };
+    let date_formatter = (date: Date): string => format_date(date, true);
     let values = {me: data.user.human, human: data.everyone.human, bot: data.everyone.bot};
 
     let info = aggregate_data(data, "day");
-    date_formatter = function (date) {
-        return format_date(date, false);
-    };
+    date_formatter = (date) => format_date(date, false);
     const last_day_is_partial = info.last_value_is_partial;
     const daily_traces = make_traces(info.dates, info.values, "bar", date_formatter);
     get_thirty_days_messages_sent(info.values);
 
     info = aggregate_data(data, "week");
-    date_formatter = function (date) {
-        return $t({defaultMessage: "Week of {date}"}, {date: format_date(date, false)});
-    };
+    date_formatter = (date) =>
+        $t({defaultMessage: "Week of {date}"}, {date: format_date(date, false)});
     const last_week_is_partial = info.last_value_is_partial;
     const weekly_traces = make_traces(info.dates, info.values, "bar", date_formatter);
 
@@ -535,9 +523,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
         bot: partial_sums(data.everyone.bot),
         me: partial_sums(data.user.human),
     };
-    date_formatter = function (date) {
-        return format_date(date, true);
-    };
+    date_formatter = (date) => format_date(date, true);
     get_total_messages_sent(values);
     const cumulative_traces = make_traces(dates, values, "scatter", date_formatter);
 
@@ -547,12 +533,12 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
     // graph to any bar graph, since otherwise the rangeselector shows both (plotly bug)
     let clicked_cumulative = false;
 
-    function draw_or_update_plot(
+    const draw_or_update_plot = (
         rangeselector: Partial<Plotly.RangeSelector>,
         traces: DataByUserType<Partial<Plotly.PlotData>>,
         last_value_is_partial: boolean,
         initial_draw: boolean,
-    ): void {
+    ): void => {
         $("#daily_button, #weekly_button, #cumulative_button").removeClass("selected");
         $("#id_messages_sent_over_time > div").removeClass("spinner");
         if (initial_draw) {
@@ -592,7 +578,7 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
             "last_value_is_partial",
             last_value_is_partial.toString(),
         );
-    }
+    };
 
     // Click handlers for aggregation buttons
     $("#daily_button").on("click", function () {
@@ -624,8 +610,8 @@ function populate_messages_sent_over_time(raw_data: unknown): void {
     }
 }
 
-function round_to_percentages(values: number[], total: number): string[] {
-    return values.map((x) => {
+const round_to_percentages = (values: number[], total: number): string[] =>
+    values.map((x) => {
         if (x === total) {
             return "100%";
         }
@@ -644,10 +630,9 @@ function round_to_percentages(values: number[], total: number): string[] {
 
         return unrounded.toPrecision(precision) + "%";
     });
-}
 
 // Last label will turn into "Other" if time_series data has a label not in labels
-function compute_summary_chart_data(
+const compute_summary_chart_data = (
     time_series_data: Record<string, number[]>,
     num_steps: number,
     labels_: string[],
@@ -656,7 +641,7 @@ function compute_summary_chart_data(
     labels: string[];
     percentages: string[];
     total: number;
-} {
+} => {
     const data = new Map<string, number>();
     for (const [key, array] of Object.entries(time_series_data)) {
         if (array.length < num_steps) {
@@ -694,7 +679,7 @@ function compute_summary_chart_data(
         percentages: round_to_percentages(values, total),
         total,
     };
-}
+};
 
 function populate_messages_sent_by_client(raw_data: unknown): void {
     // Content rendered by this method is titled as "Messages sent by client" on the webpage
@@ -740,10 +725,10 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
         labels.push(item.label);
     }
 
-    function make_plot_data(
+    const make_plot_data = (
         time_series_data: Record<string, number[]>,
         num_steps: number,
-    ): PlotDataByMessageClient {
+    ): PlotDataByMessageClient => {
         const plot_data = compute_summary_chart_data(time_series_data, num_steps, labels);
         plot_data.values.reverse();
         plot_data.labels.reverse();
@@ -781,7 +766,7 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
                 text: annotations.text,
             },
         };
-    }
+    };
 
     const plot_data: DataByEveryoneUser<DataByTime<PlotDataByMessageClient>> = {
         everyone: {
@@ -818,7 +803,7 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
         }
     }
 
-    function draw_plot(): void {
+    const draw_plot = (): void => {
         $("#id_messages_sent_by_client > div").removeClass("spinner");
         const data_ = plot_data[user_button][time_button];
         layout.height = layout.margin!.b! + data_.trace.x.length * 30;
@@ -829,20 +814,20 @@ function populate_messages_sent_by_client(raw_data: unknown): void {
             layout,
             {displayModeBar: false, staticPlot: true},
         );
-    }
+    };
 
     draw_plot();
 
     // Click handlers
-    function set_user_button($button: JQuery): void {
+    const set_user_button = ($button: JQuery): void => {
         $("#pie_messages_sent_by_client button[data-user]").removeClass("selected");
         $button.addClass("selected");
-    }
+    };
 
-    function set_time_button($button: JQuery): void {
+    const set_time_button = ($button: JQuery): void => {
         $("#pie_messages_sent_by_client button[data-time]").removeClass("selected");
         $button.addClass("selected");
-    }
+    };
 
     $("#pie_messages_sent_by_client button").on("click", function () {
         if ($(this).attr("data-user")) {
@@ -882,11 +867,11 @@ function populate_messages_sent_by_message_type(raw_data: unknown): void {
         font: font_12pt,
     };
 
-    function make_plot_data(
+    const make_plot_data = (
         data: OrderedSentData,
         time_series_data: Record<string, number[]>,
         num_steps: number,
-    ): PlotDataByMessageType {
+    ): PlotDataByMessageType => {
         const plot_data = compute_summary_chart_data(
             time_series_data,
             num_steps,
@@ -918,7 +903,7 @@ function populate_messages_sent_by_message_type(raw_data: unknown): void {
                 {total_messages: total_string},
             ),
         };
-    }
+    };
 
     const plot_data: DataByEveryoneUser<DataByTime<PlotDataByMessageType>> = {
         everyone: {
@@ -956,7 +941,7 @@ function populate_messages_sent_by_message_type(raw_data: unknown): void {
         }
     }
 
-    function draw_plot(): void {
+    const draw_plot = (): void => {
         $("#id_messages_sent_by_message_type > div").removeClass("spinner");
         void Plotly.newPlot(
             "id_messages_sent_by_message_type",
@@ -965,20 +950,20 @@ function populate_messages_sent_by_message_type(raw_data: unknown): void {
             {displayModeBar: false},
         );
         totaldiv.innerHTML = plot_data[user_button][time_button].total_html;
-    }
+    };
 
     draw_plot();
 
     // Click handlers
-    function set_user_button($button: JQuery): void {
+    const set_user_button = ($button: JQuery): void => {
         $("#pie_messages_sent_by_type button[data-user]").removeClass("selected");
         $button.addClass("selected");
-    }
+    };
 
-    function set_time_button($button: JQuery): void {
+    const set_time_button = ($button: JQuery): void => {
         $("#pie_messages_sent_by_type button[data-time]").removeClass("selected");
         $button.addClass("selected");
-    }
+    };
 
     $("#pie_messages_sent_by_type button").on("click", function () {
         if ($(this).attr("data-user")) {
@@ -1026,19 +1011,20 @@ function populate_number_of_users(raw_data: unknown): void {
 
     const text = end_dates.map((date) => format_date(date, false));
 
-    function make_traces(values: Plotly.Datum[], type: Plotly.PlotType): Partial<Plotly.PlotData> {
-        return {
-            x: end_dates,
-            y: values,
-            type,
-            name: $t({defaultMessage: "Active users"}),
-            hoverinfo: "none",
-            text,
-            visible: true,
-        };
-    }
+    const make_traces = (
+        values: Plotly.Datum[],
+        type: Plotly.PlotType,
+    ): Partial<Plotly.PlotData> => ({
+        x: end_dates,
+        y: values,
+        type,
+        name: $t({defaultMessage: "Active users"}),
+        hoverinfo: "none",
+        text,
+        visible: true,
+    });
 
-    function add_hover_handler(): void {
+    const add_hover_handler = (): void => {
         document
             .querySelector<Plotly.PlotlyHTMLElement>("#id_number_of_users")!
             .on("plotly_hover", (data) => {
@@ -1065,7 +1051,7 @@ function populate_number_of_users(raw_data: unknown): void {
                     }
                 }
             });
-    }
+    };
 
     const _1day_trace = make_traces(data.everyone._1day, "bar");
     const _15day_trace = make_traces(data.everyone._15day, "scatter");
@@ -1075,13 +1061,13 @@ function populate_number_of_users(raw_data: unknown): void {
 
     // Redraw the plot every time for simplicity. If we have perf problems with this in the
     // future, we can copy the update behavior from populate_messages_sent_over_time
-    function draw_or_update_plot(trace: Plotly.Data): void {
+    const draw_or_update_plot = (trace: Plotly.Data): void => {
         $("#1day_actives_button, #15day_actives_button, #all_time_actives_button").removeClass(
             "selected",
         );
         void Plotly.newPlot("id_number_of_users", [trace], layout, {displayModeBar: false});
         add_hover_handler();
-    }
+    };
 
     $("#1day_actives_button").on("click", function () {
         draw_or_update_plot(_1day_trace);
@@ -1118,12 +1104,12 @@ function populate_messages_read_over_time(raw_data: unknown): void {
     }
 
     // Helper functions
-    function make_traces(
+    const make_traces = (
         dates: Date[],
         values: DataByEveryoneMe<number[]>,
         type: Plotly.PlotType,
         date_formatter: DateFormatter,
-    ): DataByEveryoneMe<Partial<Plotly.PlotData>> {
+    ): DataByEveryoneMe<Partial<Plotly.PlotData>> => {
         const text = dates.map((date) => date_formatter(date));
         const common: Partial<Plotly.PlotData> = {
             x: dates,
@@ -1146,7 +1132,7 @@ function populate_messages_read_over_time(raw_data: unknown): void {
                 ...common,
             },
         };
-    }
+    };
 
     const layout: Partial<Plotly.Layout> = {
         barmode: "group",
@@ -1179,7 +1165,7 @@ function populate_messages_read_over_time(raw_data: unknown): void {
         {count: 6, label: $t({defaultMessage: "Last 6 months"}), step: "month"},
     );
 
-    function add_hover_handler(): void {
+    const add_hover_handler = (): void => {
         document
             .querySelector<Plotly.PlotlyHTMLElement>("#id_messages_read_over_time")!
             .on("plotly_hover", (data) => {
@@ -1212,7 +1198,7 @@ function populate_messages_read_over_time(raw_data: unknown): void {
                     }
                 }
             });
-    }
+    };
 
     const start_dates = data.end_times.map(
         (timestamp: number) =>
@@ -1220,23 +1206,19 @@ function populate_messages_read_over_time(raw_data: unknown): void {
             new Date(timestamp * 1000 - 60 * 60 * 1000),
     );
 
-    function aggregate_data(
+    const aggregate_data = (
         data: ReadData,
         aggregation: "day" | "week",
-    ): AggregatedData<DataByEveryoneMe<number[]>> {
+    ): AggregatedData<DataByEveryoneMe<number[]>> => {
         let start;
         let is_boundary;
         if (aggregation === "day") {
             start = floor_to_local_day(start_dates[0]!);
-            is_boundary = function (date: Date) {
-                return date.getHours() === 0;
-            };
+            is_boundary = (date: Date) => date.getHours() === 0;
         } else {
             assert(aggregation === "week");
             start = floor_to_local_week(start_dates[0]!);
-            is_boundary = function (date: Date) {
-                return date.getHours() === 0 && date.getDay() === 0;
-            };
+            is_boundary = (date: Date) => date.getHours() === 0 && date.getDay() === 0;
         }
         const dates = [start];
         const values: DataByEveryoneMe<number[]> = {everyone: [], me: []};
@@ -1265,33 +1247,26 @@ function populate_messages_read_over_time(raw_data: unknown): void {
                 new Date(start_dates.at(-1)!.getTime() + 60 * 60 * 1000),
             ),
         };
-    }
+    };
 
     // Generate traces
-    let date_formatter = function (date: Date): string {
-        return format_date(date, true);
-    };
+    let date_formatter = (date: Date): string => format_date(date, true);
     let values = {me: data.user.read, everyone: data.everyone.read};
 
     let info = aggregate_data(data, "day");
-    date_formatter = function (date) {
-        return format_date(date, false);
-    };
+    date_formatter = (date) => format_date(date, false);
     const last_day_is_partial = info.last_value_is_partial;
     const daily_traces = make_traces(info.dates, info.values, "bar", date_formatter);
 
     info = aggregate_data(data, "week");
-    date_formatter = function (date) {
-        return $t({defaultMessage: "Week of {date}"}, {date: format_date(date, false)});
-    };
+    date_formatter = (date) =>
+        $t({defaultMessage: "Week of {date}"}, {date: format_date(date, false)});
     const last_week_is_partial = info.last_value_is_partial;
     const weekly_traces = make_traces(info.dates, info.values, "bar", date_formatter);
 
     const dates = data.end_times.map((timestamp: number) => new Date(timestamp * 1000));
     values = {everyone: partial_sums(data.everyone.read), me: partial_sums(data.user.read)};
-    date_formatter = function (date) {
-        return format_date(date, true);
-    };
+    date_formatter = (date) => format_date(date, true);
     const cumulative_traces = make_traces(dates, values, "scatter", date_formatter);
 
     // Functions to draw and interact with the plot
@@ -1300,12 +1275,12 @@ function populate_messages_read_over_time(raw_data: unknown): void {
     // graph to any bar graph, since otherwise the rangeselector shows both (plotly bug)
     let clicked_cumulative = false;
 
-    function draw_or_update_plot(
+    const draw_or_update_plot = (
         rangeselector: Partial<Plotly.RangeSelector>,
         traces: DataByEveryoneMe<Partial<Plotly.PlotData>>,
         last_value_is_partial: boolean,
         initial_draw: boolean,
-    ): void {
+    ): void => {
         $("#read_daily_button, #read_weekly_button, #read_cumulative_button").removeClass(
             "selected",
         );
@@ -1342,7 +1317,7 @@ function populate_messages_read_over_time(raw_data: unknown): void {
             "last_value_is_partial",
             last_value_is_partial.toString(),
         );
-    }
+    };
 
     // Click handlers for aggregation buttons
     $("#read_daily_button").on("click", function () {
@@ -1377,29 +1352,29 @@ function populate_messages_read_over_time(raw_data: unknown): void {
 // Above are helper functions that prepare the plot data
 // Below are main functions that render the plots
 
-function get_chart_data(
+const get_chart_data = (
     data: {
         chart_name: string;
         min_length: string;
     },
     callback: (data: unknown) => void,
-): void {
+): void => {
     void $.get({
         url: "/json/analytics/chart_data" + page_params.data_url_suffix,
         data,
-        success(data) {
+        success: (data) => {
             callback(data);
             const {end_times} = z.object({end_times: z.array(z.number())}).parse(data);
             update_last_full_update(end_times);
         },
-        error(xhr) {
+        error: (xhr) => {
             const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
             if (parsed.success) {
                 $("#id_stats_errors").show().text(parsed.data.msg);
             }
         },
     });
-}
+};
 
 get_chart_data(
     {chart_name: "messages_sent_over_time", min_length: "10"},

--- a/web/src/stream_color.ts
+++ b/web/src/stream_color.ts
@@ -12,7 +12,7 @@ import * as stream_settings_api from "./stream_settings_api";
 
 extend([lchPlugin, mixPlugin]);
 
-export function update_stream_recipient_color($stream_header: JQuery): void {
+export const update_stream_recipient_color = ($stream_header: JQuery): void => {
     if ($stream_header.length) {
         const stream_id = Number.parseInt($stream_header.attr("data-stream-id")!, 10);
         if (!stream_id) {
@@ -24,9 +24,9 @@ export function update_stream_recipient_color($stream_header: JQuery): void {
             .find(".message-header-contents")
             .css("background-color", recipient_bar_color);
     }
-}
+};
 
-export function get_corrected_color(hex_color: string): Colord {
+export const get_corrected_color = (hex_color: string): Colord => {
     // LCH stands for Lightness, Chroma, and Hue.
     // This function restricts Lightness of a color to be between 20 to 75.
     const color = colord(hex_color).toLch();
@@ -38,24 +38,24 @@ export function get_corrected_color(hex_color: string): Colord {
         color.l = max_color_l;
     }
     return colord(color);
-}
+};
 
-export function get_stream_privacy_icon_color(hex_color: string): string {
+export const get_stream_privacy_icon_color = (hex_color: string): string => {
     const corrected_color = get_corrected_color(hex_color);
     if (settings_data.using_dark_theme()) {
         return corrected_color.toHex();
     }
     return corrected_color.darken(0.12).toHex();
-}
+};
 
-export function get_recipient_bar_color(color: string): string {
+export const get_recipient_bar_color = (color: string): string => {
     // Mixes 50% of color to 40% of white (light theme) / black (dark theme).
     const using_dark_theme = settings_data.using_dark_theme();
     color = get_corrected_color(color).toHex();
     return colord(using_dark_theme ? "#000000" : "#f9f9f9")
         .mix(color, using_dark_theme ? 0.38 : 0.22)
         .toHex();
-}
+};
 
 const stream_color_palette = [
     ["a47462", "c2726a", "e4523d", "e7664d", "ee7e4a", "f4ae55"],
@@ -72,12 +72,12 @@ const subscriptions_table_colorpicker_options = {
     change: picker_do_change_color,
 };
 
-export function set_colorpicker_color($colorpicker: JQuery, color: string): void {
+export const set_colorpicker_color = ($colorpicker: JQuery, color: string): void => {
     $colorpicker.spectrum({
         ...subscriptions_table_colorpicker_options,
         color,
     });
-}
+};
 
 export const sidebar_popover_colorpicker_options_full = {
     clickoutFiresChange: false,

--- a/web/src/stream_color_events.ts
+++ b/web/src/stream_color_events.ts
@@ -8,11 +8,11 @@ import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import type {StreamSubscription} from "./sub_store";
 
-function update_table_message_recipient_stream_color(
+const update_table_message_recipient_stream_color = (
     table: JQuery,
     stream_name: string,
     recipient_bar_color: string,
-): void {
+): void => {
     const $stream_labels = table.find(".stream_label");
     for (const label of $stream_labels) {
         const $label = $(label);
@@ -22,16 +22,16 @@ function update_table_message_recipient_stream_color(
                 .css({background: recipient_bar_color});
         }
     }
-}
+};
 
-function update_stream_privacy_color(id: string, color: string): void {
+const update_stream_privacy_color = (id: string, color: string): void => {
     $(`.stream-privacy-original-color-${CSS.escape(id)}`).css("color", color);
     color = stream_color.get_stream_privacy_icon_color(color);
     // `modified-color` is only used in recipient bars.
     $(`.stream-privacy-modified-color-${CSS.escape(id)}`).css("color", color);
-}
+};
 
-function update_message_recipient_color(stream_name: string, color: string): void {
+const update_message_recipient_color = (stream_name: string, color: string): void => {
     const recipient_color = stream_color.get_recipient_bar_color(color);
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         update_table_message_recipient_stream_color(
@@ -54,9 +54,9 @@ function update_message_recipient_color(stream_name: string, color: string): voi
         const stream_id = stream_data.get_stream_id(stream_name);
         $(`#inbox-stream-header-${stream_id}`).css("background", recipient_color);
     }
-}
+};
 
-export function update_stream_color(sub: StreamSubscription, color: string): void {
+export const update_stream_color = (sub: StreamSubscription, color: string): void => {
     sub.color = color;
     const stream_id = sub.stream_id.toString();
     // The swatch in the subscription row header.
@@ -82,4 +82,4 @@ export function update_stream_color(sub: StreamSubscription, color: string): voi
     update_message_recipient_color(sub.name, color);
     update_stream_privacy_color(stream_id, color);
     message_view_header.colorize_message_view_header();
-}
+};

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -19,25 +19,22 @@ import * as ui_report from "./ui_report";
 
 let created_stream;
 
-export function reset_created_stream() {
+export const reset_created_stream = () => {
     created_stream = undefined;
-}
+};
 
-export function set_name(stream) {
+export const set_name = (stream) => {
     created_stream = stream;
-}
+};
 
-export function get_name() {
-    return created_stream;
-}
+export const get_name = () => created_stream;
 
-export function set_first_stream_created_modal_shown() {
+export const set_first_stream_created_modal_shown = () => {
     onboarding_steps.post_onboarding_step_as_read("first_stream_created_banner");
-}
+};
 
-export function should_show_first_stream_created_modal() {
-    return onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("first_stream_created_banner");
-}
+export const should_show_first_stream_created_modal = () =>
+    onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("first_stream_created_banner");
 
 class StreamSubscriptionError {
     report_no_subs_to_stream() {
@@ -126,7 +123,7 @@ const stream_name_error = new StreamNameError();
 let stream_announce_previous_value;
 
 // Within the new stream modal...
-function update_announce_stream_state() {
+const update_announce_stream_state = () => {
     // If there is no new_stream_announcements_stream, we simply hide the widget.
     if (stream_data.get_new_stream_announcements_stream() === "") {
         $("#announce-new-stream").hide();
@@ -163,9 +160,9 @@ function update_announce_stream_state() {
 
     $announce_stream_checkbox.prop("disabled", disable_it);
     $("#announce-new-stream").show();
-}
+};
 
-function create_stream() {
+const create_stream = () => {
     const data = {};
     const stream_name = $("#create_stream_name").val().trim();
     const description = $("#create_stream_description").val().trim();
@@ -276,7 +273,7 @@ function create_stream() {
     return channel.post({
         url: "/json/users/me/subscriptions",
         data,
-        success() {
+        success: () => {
             $("#create_stream_name").val("");
             $("#create_stream_description").val("");
             ui_report.success(
@@ -286,7 +283,7 @@ function create_stream() {
             loading.destroy_indicator($("#stream_creating_indicator"));
             // The rest of the work is done via the subscribe event we will get
         },
-        error(xhr) {
+        error: (xhr) => {
             if (xhr.responseJSON?.msg?.includes("access")) {
                 // If we can't access the stream, we can safely
                 // assume it's a duplicate stream that we are not invited to.
@@ -308,9 +305,9 @@ function create_stream() {
             loading.destroy_indicator($("#stream_creating_indicator"));
         },
     });
-}
+};
 
-export function new_stream_clicked(stream_name) {
+export const new_stream_clicked = (stream_name) => {
     // this changes the tab switcher (settings/preview) which isn't necessary
     // to a add new stream title.
     stream_settings_components.show_subs_pane.create_stream();
@@ -321,15 +318,15 @@ export function new_stream_clicked(stream_name) {
     }
     show_new_stream_modal();
     $("#create_stream_name").trigger("focus");
-}
+};
 
-function clear_error_display() {
+const clear_error_display = () => {
     stream_name_error.clear_errors();
     $(".stream_create_info").hide();
     stream_subscription_error.clear_errors();
-}
+};
 
-export function show_new_stream_modal() {
+export const show_new_stream_modal = () => {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
     stream_settings_components.hide_or_disable_stream_privacy_options_if_required(
@@ -384,9 +381,9 @@ export function show_new_stream_modal() {
     update_announce_stream_state();
     stream_ui_updates.update_default_stream_and_stream_privacy_state($("#stream-creation"));
     clear_error_display();
-}
+};
 
-export function set_up_handlers() {
+export const set_up_handlers = () => {
     stream_announce_previous_value =
         settings_data.user_can_create_public_streams() ||
         settings_data.user_can_create_web_public_streams();
@@ -435,7 +432,7 @@ export function set_up_handlers() {
             confirm_dialog.launch({
                 html_heading: $t_html({defaultMessage: "Large number of subscribers"}),
                 html_body,
-                on_click() {
+                on_click: () => {
                     create_stream();
                 },
             });
@@ -460,4 +457,4 @@ export function set_up_handlers() {
     });
 
     stream_settings_components.new_stream_can_remove_subscribers_group_widget.setup();
-}
+};

--- a/web/src/stream_create_subscribers.js
+++ b/web/src/stream_create_subscribers.js
@@ -13,37 +13,35 @@ import * as user_sort from "./user_sort";
 let pill_widget;
 let all_users_list_widget;
 
-export function get_principals() {
-    return stream_create_subscribers_data.get_principals();
-}
+export const get_principals = () => stream_create_subscribers_data.get_principals();
 
-function redraw_subscriber_list() {
+const redraw_subscriber_list = () => {
     all_users_list_widget.replace_list_data(stream_create_subscribers_data.sorted_user_ids());
-}
+};
 
-function add_user_ids(user_ids) {
+const add_user_ids = (user_ids) => {
     stream_create_subscribers_data.add_user_ids(user_ids);
     redraw_subscriber_list();
-}
+};
 
-function add_all_users() {
+const add_all_users = () => {
     const user_ids = stream_create_subscribers_data.get_all_user_ids();
     add_user_ids(user_ids);
-}
+};
 
-function remove_user_ids(user_ids) {
+const remove_user_ids = (user_ids) => {
     stream_create_subscribers_data.remove_user_ids(user_ids);
     redraw_subscriber_list();
-}
+};
 
-function build_pill_widget({$parent_container}) {
+const build_pill_widget = ({$parent_container}) => {
     const $pill_container = $parent_container.find(".pill-container");
     const get_potential_subscribers = stream_create_subscribers_data.get_potential_subscribers;
 
     pill_widget = add_subscribers_pill.create({$pill_container, get_potential_subscribers});
-}
+};
 
-export function create_handlers($container) {
+export const create_handlers = ($container) => {
     $container.on("click", ".add_all_users_to_stream", (e) => {
         e.preventDefault();
         add_all_users();
@@ -58,13 +56,13 @@ export function create_handlers($container) {
     });
 
     const button_selector = ".add_subscribers_container button.add-subscriber-button";
-    function add_users({pill_user_ids}) {
+    const add_users = ({pill_user_ids}) => {
         add_user_ids(pill_user_ids);
         // eslint-disable-next-line unicorn/no-array-callback-reference
         const $pill_widget_button = $container.find(button_selector);
         $pill_widget_button.prop("disabled", true);
         pill_widget.clear();
-    }
+    };
 
     add_subscribers_pill.set_up_handlers({
         get_pill_widget: () => pill_widget,
@@ -73,9 +71,9 @@ export function create_handlers($container) {
         button_selector,
         action: add_users,
     });
-}
+};
 
-export function build_widgets() {
+export const build_widgets = () => {
     const $add_people_container = $("#people_to_add");
     $add_people_container.html(render_new_stream_users({}));
 
@@ -90,7 +88,7 @@ export function build_widgets() {
         name: "new_stream_add_users",
         get_item: people.get_by_user_id,
         $parent_container: $add_people_container,
-        modifier_html(user) {
+        modifier_html: (user) => {
             const item = {
                 email: user.delivery_email,
                 user_id: user.user_id,
@@ -108,18 +106,14 @@ export function build_widgets() {
         },
         filter: {
             $element: $("#people_to_add .add-user-list-filter"),
-            predicate(user, search_term) {
-                return people.build_person_matcher(search_term)(user);
-            },
+            predicate: (user, search_term) => people.build_person_matcher(search_term)(user),
         },
         $simplebar_container,
-        html_selector(user) {
-            return $(`#${CSS.escape("user_checkbox_" + user.user_id)}`);
-        },
+        html_selector: (user) => $(`#${CSS.escape("user_checkbox_" + user.user_id)}`),
     });
-}
+};
 
-export function add_user_id_to_new_stream(user_id) {
+export const add_user_id_to_new_stream = (user_id) => {
     // This is only used by puppeteer tests.
     add_user_ids([user_id]);
-}
+};

--- a/web/src/stream_create_subscribers_data.ts
+++ b/web/src/stream_create_subscribers_data.ts
@@ -4,39 +4,35 @@ import {current_user} from "./state_data";
 
 let user_id_set: Set<number>;
 
-export function initialize_with_current_user(): void {
+export const initialize_with_current_user = (): void => {
     user_id_set = new Set([current_user.user_id]);
-}
+};
 
-export function sorted_user_ids(): number[] {
+export const sorted_user_ids = (): number[] => {
     const users = people.get_users_from_ids([...user_id_set]);
     people.sort_but_pin_current_user_on_top(users);
     return users.map((user) => user.user_id);
-}
+};
 
-export function get_all_user_ids(): number[] {
+export const get_all_user_ids = (): number[] => {
     const potential_subscribers = people.get_realm_users();
     const user_ids = potential_subscribers.map((user) => user.user_id);
     // sort for determinism
     user_ids.sort((a, b) => a - b);
     return user_ids;
-}
+};
 
-export function get_principals(): number[] {
-    // Return list of user ids which were selected by user.
-    return [...user_id_set];
-}
+export const get_principals = (): number[] => [...user_id_set];
 
-export function get_potential_subscribers(): User[] {
+export const get_potential_subscribers = (): User[] => {
     const potential_subscribers = people.get_realm_users();
     return potential_subscribers.filter((user) => !user_id_set.has(user.user_id));
-}
+};
 
-export function must_be_subscribed(user_id: number): boolean {
-    return !current_user.is_admin && user_id === current_user.user_id;
-}
+export const must_be_subscribed = (user_id: number): boolean =>
+    !current_user.is_admin && user_id === current_user.user_id;
 
-export function add_user_ids(user_ids: number[]): void {
+export const add_user_ids = (user_ids: number[]): void => {
     for (const user_id of user_ids) {
         if (!user_id_set.has(user_id)) {
             const user = people.maybe_get_user_by_id(user_id);
@@ -45,10 +41,10 @@ export function add_user_ids(user_ids: number[]): void {
             }
         }
     }
-}
+};
 
-export function remove_user_ids(user_ids: number[]): void {
+export const remove_user_ids = (user_ids: number[]): void => {
     for (const user_id of user_ids) {
         user_id_set.delete(user_id);
     }
-}
+};

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -130,16 +130,16 @@ const stream_ids_by_name = new FoldDict<number>();
 const stream_ids_by_old_names = new FoldDict<number>();
 const default_stream_ids = new Set<number>();
 
-export function clear_subscriptions(): void {
+export const clear_subscriptions = (): void => {
     // This function is only used once at page load, and then
     // it should only be used in tests.
     stream_info = new BinaryDict((sub) => sub.subscribed);
     sub_store.clear();
-}
+};
 
 clear_subscriptions();
 
-export function rename_sub(sub: StreamSubscription, new_name: string): void {
+export const rename_sub = (sub: StreamSubscription, new_name: string): void => {
     const old_name = sub.name;
     stream_ids_by_old_names.set(old_name, sub.stream_id);
 
@@ -147,55 +147,54 @@ export function rename_sub(sub: StreamSubscription, new_name: string): void {
     stream_info.set(sub.stream_id, sub);
     stream_ids_by_name.delete(old_name);
     stream_ids_by_name.set(new_name, sub.stream_id);
-}
+};
 
-export function subscribe_myself(sub: StreamSubscription): void {
+export const subscribe_myself = (sub: StreamSubscription): void => {
     const user_id = people.my_current_user_id();
     peer_data.add_subscriber(sub.stream_id, user_id);
     sub.subscribed = true;
     sub.newly_subscribed = true;
     stream_info.set_true(sub.stream_id, sub);
-}
+};
 
-export function unsubscribe_myself(sub: StreamSubscription): void {
+export const unsubscribe_myself = (sub: StreamSubscription): void => {
     // Remove user from subscriber's list
     const user_id = people.my_current_user_id();
     peer_data.remove_subscriber(sub.stream_id, user_id);
     sub.subscribed = false;
     sub.newly_subscribed = false;
     stream_info.set_false(sub.stream_id, sub);
-}
+};
 
-export function add_sub(sub: StreamSubscription): void {
+export const add_sub = (sub: StreamSubscription): void => {
     // This function is currently used only by tests.
     // We use create_sub_from_server_data at page load.
     // We use create_streams for new streams in live-update events.
     stream_info.set(sub.stream_id, sub);
     stream_ids_by_name.set(sub.name, sub.stream_id);
     sub_store.add_hydrated_sub(sub.stream_id, sub);
-}
+};
 
-export function get_sub(stream_name: string): StreamSubscription | undefined {
+export const get_sub = (stream_name: string): StreamSubscription | undefined => {
     const stream_id = stream_ids_by_name.get(stream_name);
     if (stream_id) {
         return stream_info.get(stream_id);
     }
     return undefined;
-}
+};
 
-export function get_sub_by_id(stream_id: number): StreamSubscription | undefined {
-    return stream_info.get(stream_id);
-}
+export const get_sub_by_id = (stream_id: number): StreamSubscription | undefined =>
+    stream_info.get(stream_id);
 
-export function maybe_get_creator_details(creator_id: number | null): User | undefined {
+export const maybe_get_creator_details = (creator_id: number | null): User | undefined => {
     if (creator_id === null) {
         return undefined;
     }
 
     return people.get_user_by_id_assert_valid(creator_id);
-}
+};
 
-export function get_stream_id(name: string): number | undefined {
+export const get_stream_id = (name: string): number | undefined => {
     // Note: Only use this function for situations where
     // you are comfortable with a user dealing with an
     // old name of a stream (from prior to a rename).
@@ -204,13 +203,12 @@ export function get_stream_id(name: string): number | undefined {
         stream_id = stream_ids_by_old_names.get(name);
     }
     return stream_id;
-}
+};
 
-export function get_stream_name_from_id(stream_id: number): string {
-    return get_sub_by_id(stream_id)?.name ?? "";
-}
+export const get_stream_name_from_id = (stream_id: number): string =>
+    get_sub_by_id(stream_id)?.name ?? "";
 
-export function get_sub_by_name(name: string): StreamSubscription | undefined {
+export const get_sub_by_name = (name: string): StreamSubscription | undefined => {
     // Note: Only use this function for situations where
     // you are comfortable with a user dealing with an
     // old name of a stream (from prior to a rename).
@@ -223,9 +221,9 @@ export function get_sub_by_name(name: string): StreamSubscription | undefined {
     }
 
     return sub_store.get(stream_id);
-}
+};
 
-export function name_to_slug(name: string): string {
+export const name_to_slug = (name: string): string => {
     const stream_id = get_stream_id(name);
 
     if (!stream_id) {
@@ -237,9 +235,9 @@ export function name_to_slug(name: string): string {
     name = name.replaceAll(" ", "-");
 
     return `${stream_id}-${name}`;
-}
+};
 
-export function slug_to_name(slug: string): string {
+export const slug_to_name = (slug: string): string => {
     /*
     Modern stream slugs look like this, where 42
     is a stream id:
@@ -285,18 +283,18 @@ export function slug_to_name(slug: string): string {
     stream id as a prefix.
     */
     return slug;
-}
+};
 
-export function delete_sub(stream_id: number): void {
+export const delete_sub = (stream_id: number): void => {
     if (!stream_info.get(stream_id)) {
         blueslip.warn("Failed to archive stream " + stream_id.toString());
         return;
     }
     sub_store.delete_sub(stream_id);
     stream_info.delete(stream_id);
-}
+};
 
-export function get_non_default_stream_names(): {name: string; unique_id: number}[] {
+export const get_non_default_stream_names = (): {name: string; unique_id: number}[] => {
     let subs = [...stream_info.values()];
     subs = subs.filter((sub) => !is_default_stream_id(sub.stream_id) && !sub.invite_only);
     const names = subs.map((sub) => ({
@@ -304,42 +302,31 @@ export function get_non_default_stream_names(): {name: string; unique_id: number
         unique_id: sub.stream_id,
     }));
     return names;
-}
+};
 
-export function get_unsorted_subs(): StreamSubscription[] {
-    return [...stream_info.values()];
-}
+export const get_unsorted_subs = (): StreamSubscription[] => [...stream_info.values()];
 
-export function num_subscribed_subs(): number {
-    return stream_info.num_true_items();
-}
+export const num_subscribed_subs = (): number => stream_info.num_true_items();
 
-export function subscribed_subs(): StreamSubscription[] {
-    return [...stream_info.true_values()];
-}
+export const subscribed_subs = (): StreamSubscription[] => [...stream_info.true_values()];
 
-export function unsubscribed_subs(): StreamSubscription[] {
-    return [...stream_info.false_values()];
-}
+export const unsubscribed_subs = (): StreamSubscription[] => [...stream_info.false_values()];
 
-export function subscribed_streams(): string[] {
-    return subscribed_subs().map((sub) => sub.name);
-}
+export const subscribed_streams = (): string[] => subscribed_subs().map((sub) => sub.name);
 
-export function subscribed_stream_ids(): number[] {
-    return subscribed_subs().map((sub) => sub.stream_id);
-}
+export const subscribed_stream_ids = (): number[] => subscribed_subs().map((sub) => sub.stream_id);
 
-export function muted_stream_ids(): number[] {
-    return subscribed_subs()
+export const muted_stream_ids = (): number[] =>
+    subscribed_subs()
         .filter((sub) => sub.is_muted)
         .map((sub) => sub.stream_id);
-}
 
-export function get_streams_for_user(user_id: number): {
+export const get_streams_for_user = (
+    user_id: number,
+): {
     subscribed: StreamSubscription[];
     can_subscribe: StreamSubscription[];
-} {
+} => {
     // Note that we only have access to subscribers of some streams
     // depending on our role.
     const all_subs = get_unsorted_subs();
@@ -363,18 +350,16 @@ export function get_streams_for_user(user_id: number): {
         subscribed: subscribed_subs,
         can_subscribe: can_subscribe_subs,
     };
-}
+};
 
-export function get_invite_stream_data(): InviteStreamData[] {
-    function get_data(sub: StreamSubscription): InviteStreamData {
-        return {
-            name: sub.name,
-            stream_id: sub.stream_id,
-            invite_only: sub.invite_only,
-            is_web_public: sub.is_web_public,
-            default_stream: default_stream_ids.has(sub.stream_id),
-        };
-    }
+export const get_invite_stream_data = (): InviteStreamData[] => {
+    const get_data = (sub: StreamSubscription): InviteStreamData => ({
+        name: sub.name,
+        stream_id: sub.stream_id,
+        invite_only: sub.invite_only,
+        is_web_public: sub.is_web_public,
+        default_stream: default_stream_ids.has(sub.stream_id),
+    });
 
     const streams = [];
 
@@ -392,54 +377,52 @@ export function get_invite_stream_data(): InviteStreamData[] {
     }
 
     return streams;
-}
+};
 
-export function get_colors(): string[] {
-    return subscribed_subs().map((sub) => sub.color);
-}
+export const get_colors = (): string[] => subscribed_subs().map((sub) => sub.color);
 
-export function update_stream_email_address(sub: StreamSubscription, email: string): void {
+export const update_stream_email_address = (sub: StreamSubscription, email: string): void => {
     sub.email_address = email;
-}
+};
 
-export function update_stream_post_policy(
+export const update_stream_post_policy = (
     sub: StreamSubscription,
     stream_post_policy: StreamPostPolicy,
-): void {
+): void => {
     sub.stream_post_policy = stream_post_policy;
-}
+};
 
-export function update_stream_privacy(
+export const update_stream_privacy = (
     sub: StreamSubscription,
     values: {
         invite_only: boolean;
         history_public_to_subscribers: boolean;
         is_web_public: boolean;
     },
-): void {
+): void => {
     sub.invite_only = values.invite_only;
     sub.history_public_to_subscribers = values.history_public_to_subscribers;
     sub.is_web_public = values.is_web_public;
-}
+};
 
-export function update_message_retention_setting(
+export const update_message_retention_setting = (
     sub: StreamSubscription,
     message_retention_days: number | null,
-): void {
+): void => {
     sub.message_retention_days = message_retention_days;
-}
+};
 
-export function update_can_remove_subscribers_group_id(
+export const update_can_remove_subscribers_group_id = (
     sub: StreamSubscription,
     can_remove_subscribers_group_id: number,
-): void {
+): void => {
     sub.can_remove_subscribers_group = can_remove_subscribers_group_id;
-}
+};
 
-export function receives_notifications(
+export const receives_notifications = (
     stream_id: number,
     notification_name: keyof StreamSpecificNotificationSettings,
-): boolean {
+): boolean => {
     const sub = sub_store.get(stream_id);
     if (sub === undefined) {
         return false;
@@ -448,22 +431,20 @@ export function receives_notifications(
         return sub[notification_name]!;
     }
     return user_settings[settings_config.generalize_stream_notification_setting[notification_name]];
-}
+};
 
-export function all_subscribed_streams_are_in_home_view(): boolean {
-    return subscribed_subs().every((sub) => !sub.is_muted);
-}
+export const all_subscribed_streams_are_in_home_view = (): boolean =>
+    subscribed_subs().every((sub) => !sub.is_muted);
 
-export function home_view_stream_names(): string[] {
+export const home_view_stream_names = (): string[] => {
     const home_view_subs = subscribed_subs().filter((sub) => !sub.is_muted);
     return home_view_subs.map((sub) => sub.name);
-}
+};
 
-export function canonicalized_name(stream_name: string): string {
-    return stream_name.toString().toLowerCase();
-}
+export const canonicalized_name = (stream_name: string): string =>
+    stream_name.toString().toLowerCase();
 
-export function get_color(stream_id: number | undefined): string {
+export const get_color = (stream_id: number | undefined): string => {
     if (stream_id === undefined) {
         return DEFAULT_COLOR;
     }
@@ -472,93 +453,62 @@ export function get_color(stream_id: number | undefined): string {
         return DEFAULT_COLOR;
     }
     return sub.color;
-}
+};
 
-export function is_muted(stream_id: number): boolean {
+export const is_muted = (stream_id: number): boolean => {
     const sub = sub_store.get(stream_id);
     // Return true for undefined streams
     if (sub === undefined) {
         return true;
     }
     return sub.is_muted;
-}
+};
 
-export function is_stream_muted_by_name(stream_name: string): boolean {
+export const is_stream_muted_by_name = (stream_name: string): boolean => {
     const sub = get_sub(stream_name);
     // Return true for undefined streams
     if (sub === undefined) {
         return true;
     }
     return sub.is_muted;
-}
+};
 
-export function is_new_stream_announcements_stream_muted(): boolean {
-    return is_muted(realm.realm_new_stream_announcements_stream_id);
-}
+export const is_new_stream_announcements_stream_muted = (): boolean =>
+    is_muted(realm.realm_new_stream_announcements_stream_id);
 
-export function can_toggle_subscription(sub: StreamSubscription): boolean {
-    // You can always remove your subscription if you're subscribed.
-    //
-    // One can only join a stream if it is public (!invite_only) and
-    // your role is Member or above (!is_guest).
-    // Spectators cannot subscribe to any streams.
-    //
-    // Note that the correctness of this logic relies on the fact that
-    // one cannot be subscribed to a deactivated stream, and
-    // deactivated streams are automatically made private during the
-    // archive stream process.
-    return (
-        (sub.subscribed || (!current_user.is_guest && !sub.invite_only)) &&
-        !page_params.is_spectator
-    );
-}
+export const can_toggle_subscription = (sub: StreamSubscription): boolean =>
+    (sub.subscribed || (!current_user.is_guest && !sub.invite_only)) && !page_params.is_spectator;
 
-export function can_access_stream_email(sub: StreamSubscription): boolean {
-    return (
-        (sub.subscribed || sub.is_web_public || (!current_user.is_guest && !sub.invite_only)) &&
-        !page_params.is_spectator
-    );
-}
+export const can_access_stream_email = (sub: StreamSubscription): boolean =>
+    (sub.subscribed || sub.is_web_public || (!current_user.is_guest && !sub.invite_only)) &&
+    !page_params.is_spectator;
 
-export function can_access_topic_history(sub: StreamSubscription): boolean {
-    // Anyone can access topic history for web-public streams and
-    // subscriptions; additionally, members can access history for
-    // public streams.
-    return sub.is_web_public || can_toggle_subscription(sub);
-}
+export const can_access_topic_history = (sub: StreamSubscription): boolean =>
+    sub.is_web_public || can_toggle_subscription(sub);
 
-export function can_preview(sub: StreamSubscription): boolean {
-    return sub.subscribed || !sub.invite_only || sub.previously_subscribed;
-}
+export const can_preview = (sub: StreamSubscription): boolean =>
+    sub.subscribed || !sub.invite_only || sub.previously_subscribed;
 
-export function can_change_permissions(sub: StreamSubscription): boolean {
-    return current_user.is_admin && (!sub.invite_only || sub.subscribed);
-}
+export const can_change_permissions = (sub: StreamSubscription): boolean =>
+    current_user.is_admin && (!sub.invite_only || sub.subscribed);
 
-export function can_view_subscribers(sub: StreamSubscription): boolean {
-    // Guest users can't access subscribers of any(public or private) non-subscribed streams.
-    return current_user.is_admin || sub.subscribed || (!current_user.is_guest && !sub.invite_only);
-}
+export const can_view_subscribers = (sub: StreamSubscription): boolean =>
+    current_user.is_admin || sub.subscribed || (!current_user.is_guest && !sub.invite_only);
 
-export function can_subscribe_others(sub: StreamSubscription): boolean {
-    // User can add other users to stream if stream is public or user is subscribed to stream
-    // and realm level setting allows user to add subscribers.
-    return (
-        !current_user.is_guest &&
-        (!sub.invite_only || sub.subscribed) &&
-        settings_data.user_can_subscribe_other_users()
-    );
-}
+export const can_subscribe_others = (sub: StreamSubscription): boolean =>
+    !current_user.is_guest &&
+    (!sub.invite_only || sub.subscribed) &&
+    settings_data.user_can_subscribe_other_users();
 
-export function can_subscribe_user(sub: StreamSubscription, user_id: number): boolean {
+export const can_subscribe_user = (sub: StreamSubscription, user_id: number): boolean => {
     if (people.is_my_user_id(user_id)) {
         return can_toggle_subscription(sub);
     }
 
     return can_subscribe_others(sub);
-}
+};
 
-export function can_unsubscribe_others(sub: StreamSubscription): boolean {
+export const can_unsubscribe_others = (sub: StreamSubscription): boolean => {
     // Whether the current user has permission to remove other users
     // from the stream. Organization administrators can remove users
     // from any stream; additionally, users who can access the stream
@@ -586,9 +536,9 @@ export function can_unsubscribe_others(sub: StreamSubscription): boolean {
         sub.can_remove_subscribers_group,
         people.my_current_user_id(),
     );
-}
+};
 
-export function can_post_messages_in_stream(stream: StreamSubscription): boolean {
+export const can_post_messages_in_stream = (stream: StreamSubscription): boolean => {
     if (page_params.is_spectator) {
         return false;
     }
@@ -628,19 +578,19 @@ export function can_post_messages_in_stream(stream: StreamSubscription): boolean
         return false;
     }
     return true;
-}
+};
 
-export function is_subscribed_by_name(stream_name: string): boolean {
+export const is_subscribed_by_name = (stream_name: string): boolean => {
     const sub = get_sub(stream_name);
     return sub ? sub.subscribed : false;
-}
+};
 
-export function is_subscribed(stream_id: number): boolean {
+export const is_subscribed = (stream_id: number): boolean => {
     const sub = sub_store.get(stream_id);
     return sub ? sub.subscribed : false;
-}
+};
 
-export function get_stream_privacy_policy(stream_id: number): string {
+export const get_stream_privacy_policy = (stream_id: number): string => {
     const sub = sub_store.get(stream_id)!;
 
     if (sub.is_web_public) {
@@ -653,46 +603,43 @@ export function get_stream_privacy_policy(stream_id: number): string {
         return settings_config.stream_privacy_policy_values.private.code;
     }
     return settings_config.stream_privacy_policy_values.private_with_public_history.code;
-}
+};
 
-export function is_web_public(stream_id: number): boolean {
+export const is_web_public = (stream_id: number): boolean => {
     const sub = sub_store.get(stream_id);
     return sub ? sub.is_web_public : false;
-}
+};
 
-export function is_invite_only_by_stream_id(stream_id: number): boolean {
+export const is_invite_only_by_stream_id = (stream_id: number): boolean => {
     const sub = get_sub_by_id(stream_id);
     if (sub === undefined) {
         return false;
     }
     return sub.invite_only;
-}
+};
 
-export function is_web_public_by_stream_name(stream_name: string): boolean {
+export const is_web_public_by_stream_name = (stream_name: string): boolean => {
     const sub = get_sub(stream_name);
     if (sub === undefined) {
         return false;
     }
     return sub.is_web_public;
-}
+};
 
-export function set_realm_default_streams(realm_default_streams: Stream[]): void {
+export const set_realm_default_streams = (realm_default_streams: Stream[]): void => {
     default_stream_ids.clear();
 
     for (const stream of realm_default_streams) {
         default_stream_ids.add(stream.stream_id);
     }
-}
+};
 
-export function get_default_stream_ids(): number[] {
-    return [...default_stream_ids];
-}
+export const get_default_stream_ids = (): number[] => [...default_stream_ids];
 
-export function is_default_stream_id(stream_id: number): boolean {
-    return default_stream_ids.has(stream_id);
-}
+export const is_default_stream_id = (stream_id: number): boolean =>
+    default_stream_ids.has(stream_id);
 
-export function get_name(stream_name: string): string {
+export const get_name = (stream_name: string): string => {
     // This returns the actual name of a stream if we are subscribed to
     // it (e.g. "Denmark" vs. "denmark"), while falling thru to
     // stream_name if we don't have a subscription.  (Stream names
@@ -706,9 +653,9 @@ export function get_name(stream_name: string): string {
         return stream_name;
     }
     return sub.name;
-}
+};
 
-export function is_user_subscribed(stream_id: number, user_id: number): boolean {
+export const is_user_subscribed = (stream_id: number, user_id: number): boolean => {
     const sub = sub_store.get(stream_id);
     if (sub === undefined || !can_view_subscribers(sub)) {
         // If we don't know about the stream, or we ourselves cannot access subscriber list,
@@ -724,9 +671,9 @@ export function is_user_subscribed(stream_id: number, user_id: number): boolean 
     }
 
     return peer_data.is_user_subscribed(stream_id, user_id);
-}
+};
 
-export function create_streams(streams: Stream[]): void {
+export const create_streams = (streams: Stream[]): void => {
     for (const stream of streams) {
         // We handle subscriber stuff in other events.
 
@@ -737,19 +684,19 @@ export function create_streams(streams: Stream[]): void {
         };
         create_sub_from_server_data(attrs, false, false);
     }
-}
+};
 
-export function clean_up_description(sub: StreamSubscription): void {
+export const clean_up_description = (sub: StreamSubscription): void => {
     if (sub.rendered_description !== undefined) {
         sub.rendered_description = sub.rendered_description.replace("<p>", "").replace("</p>", "");
     }
-}
+};
 
-export function create_sub_from_server_data(
+export const create_sub_from_server_data = (
     attrs: ApiGenericStreamSubscription,
     subscribed: boolean,
     previously_subscribed: boolean,
-): StreamSubscription {
+): StreamSubscription => {
     if (!attrs.stream_id) {
         // fail fast
         throw new Error("We cannot create a sub without a stream_id");
@@ -796,20 +743,19 @@ export function create_sub_from_server_data(
     sub_store.add_hydrated_sub(sub.stream_id, sub);
 
     return sub;
-}
+};
 
-export function get_streams_for_admin(): StreamSubscription[] {
+export const get_streams_for_admin = (): StreamSubscription[] => {
     // Sort and combine all our streams.
-    function by_name(a: StreamSubscription, b: StreamSubscription): number {
-        return util.strcmp(a.name, b.name);
-    }
+    const by_name = (a: StreamSubscription, b: StreamSubscription): number =>
+        util.strcmp(a.name, b.name);
 
     const subs = [...stream_info.values()];
 
     subs.sort(by_name);
 
     return subs;
-}
+};
 
 /*
   This module provides a common helper for finding the notification
@@ -817,11 +763,10 @@ export function get_streams_for_admin(): StreamSubscription[] {
   is the authoritative source of this data, and it will be updated by
   server_events_dispatch in case of changes.
 */
-export function realm_has_new_stream_announcements_stream(): boolean {
-    return realm.realm_new_stream_announcements_stream_id !== -1;
-}
+export const realm_has_new_stream_announcements_stream = (): boolean =>
+    realm.realm_new_stream_announcements_stream_id !== -1;
 
-export function get_new_stream_announcements_stream(): string {
+export const get_new_stream_announcements_stream = (): string => {
     const stream_id = realm.realm_new_stream_announcements_stream_id;
     if (stream_id !== -1) {
         const stream_obj = sub_store.get(stream_id);
@@ -832,9 +777,9 @@ export function get_new_stream_announcements_stream(): string {
         // stream the current user is not subscribed to.
     }
     return "";
-}
+};
 
-export function initialize(params: StreamInitParams): void {
+export const initialize = (params: StreamInitParams): void => {
     /*
         We get `params` data, which is data that we "own"
         and which has already been removed from `state_data`.
@@ -857,37 +802,36 @@ export function initialize(params: StreamInitParams): void {
 
     color_data.claim_colors(subscriptions);
 
-    function populate_subscriptions(
+    const populate_subscriptions = (
         subs: ApiStreamSubscription[] | NeverSubscribedStream[],
         subscribed: boolean,
         previously_subscribed: boolean,
-    ): void {
+    ): void => {
         for (const sub of subs) {
             create_sub_from_server_data(sub, subscribed, previously_subscribed);
         }
-    }
+    };
 
     set_realm_default_streams(realm_default_streams);
 
     populate_subscriptions(subscriptions, true, true);
     populate_subscriptions(unsubscribed, false, true);
     populate_subscriptions(never_subscribed, false, false);
-}
+};
 
-export function remove_default_stream(stream_id: number): void {
+export const remove_default_stream = (stream_id: number): void => {
     default_stream_ids.delete(stream_id);
-}
+};
 
-export function get_options_for_dropdown_widget(): {
+export const get_options_for_dropdown_widget = (): {
     name: string;
     unique_id: number;
     stream: StreamSubscription;
-}[] {
-    return subscribed_subs()
+}[] =>
+    subscribed_subs()
         .map((stream) => ({
             name: stream.name,
             unique_id: stream.stream_id,
             stream,
         }))
         .sort((a, b) => util.strcmp(a.name.toLowerCase(), b.name.toLowerCase()));
-}

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -39,7 +39,7 @@ import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
 
-export function setup_subscriptions_tab_hash(tab_key_value) {
+export const setup_subscriptions_tab_hash = (tab_key_value) => {
     if ($("#subscription_overlay .right").hasClass("show")) {
         return;
     }
@@ -60,9 +60,9 @@ export function setup_subscriptions_tab_hash(tab_key_value) {
             blueslip.debug("Unknown tab_key_value: " + tab_key_value);
         }
     }
-}
+};
 
-export function get_display_text_for_realm_message_retention_setting() {
+export const get_display_text_for_realm_message_retention_setting = () => {
     const realm_message_retention_days = realm.realm_message_retention_days;
     if (realm_message_retention_days === settings_config.retain_message_forever) {
         return $t({defaultMessage: "(forever)"});
@@ -71,16 +71,16 @@ export function get_display_text_for_realm_message_retention_setting() {
         {defaultMessage: "({message_retention_days} days)"},
         {message_retention_days: realm_message_retention_days},
     );
-}
+};
 
-function get_stream_id(target) {
+const get_stream_id = (target) => {
     const $row = $(target).closest(
         ".stream-row, .stream_settings_header, .subscription_settings, .save-button",
     );
     return Number.parseInt($row.attr("data-stream-id"), 10);
-}
+};
 
-function get_sub_for_target(target) {
+const get_sub_for_target = (target) => {
     const stream_id = get_stream_id(target);
     if (!stream_id) {
         blueslip.error("Cannot find stream id for target");
@@ -93,30 +93,30 @@ function get_sub_for_target(target) {
         return undefined;
     }
     return sub;
-}
+};
 
-export function open_edit_panel_for_row(stream_row) {
+export const open_edit_panel_for_row = (stream_row) => {
     const sub = get_sub_for_target(stream_row);
 
     $(".stream-row.active").removeClass("active");
     stream_settings_components.show_subs_pane.settings(sub);
     $(stream_row).addClass("active");
     setup_stream_settings(stream_row);
-}
+};
 
-export function empty_right_panel() {
+export const empty_right_panel = () => {
     $(".stream-row.active").removeClass("active");
     $("#subscription_overlay .right").removeClass("show");
     stream_settings_components.show_subs_pane.nothing_selected();
-}
+};
 
-export function open_edit_panel_empty() {
+export const open_edit_panel_empty = () => {
     const tab_key = stream_settings_components.get_active_data().$tabs.first().attr("data-tab-key");
     empty_right_panel();
     setup_subscriptions_tab_hash(tab_key);
-}
+};
 
-export function update_stream_name(sub, new_name) {
+export const update_stream_name = (sub, new_name) => {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
     $edit_container.find(".email-address").text(sub.email_address);
     $edit_container.find(".sub-stream-name").text(new_name);
@@ -125,18 +125,18 @@ export function update_stream_name(sub, new_name) {
     if (active_data.id === sub.stream_id) {
         stream_settings_components.set_right_panel_title(sub);
     }
-}
+};
 
-export function update_stream_description(sub) {
+export const update_stream_description = (sub) => {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
     $edit_container.find("input.description").val(sub.description);
     const html = render_stream_description({
         rendered_description: util.clean_user_content_links(sub.rendered_description),
     });
     $edit_container.find(".stream-description").html(html);
-}
+};
 
-function show_subscription_settings(sub) {
+const show_subscription_settings = (sub) => {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
 
     const $colorpicker = $edit_container.find(".colorpicker");
@@ -164,22 +164,21 @@ function show_subscription_settings(sub) {
         sub,
         $parent_container: $subscriber_container,
     });
-}
+};
 
-function has_global_notification_setting(setting_label) {
+const has_global_notification_setting = (setting_label) => {
     if (setting_label.includes("_notifications")) {
         return true;
     } else if (setting_label.includes("_notify")) {
         return true;
     }
     return false;
-}
+};
 
-function is_notification_setting(setting_label) {
-    return has_global_notification_setting(setting_label) || setting_label === "is_muted";
-}
+const is_notification_setting = (setting_label) =>
+    has_global_notification_setting(setting_label) || setting_label === "is_muted";
 
-export function stream_settings(sub) {
+export const stream_settings = (sub) => {
     const settings_labels = settings_config.general_notifications_table_labels.stream;
     const check_realm_setting =
         settings_config.all_notifications(user_settings).show_push_notifications_tooltip;
@@ -206,9 +205,9 @@ export function stream_settings(sub) {
         return ret;
     });
     return settings;
-}
+};
 
-function setup_dropdown(sub, slim_sub) {
+const setup_dropdown = (sub, slim_sub) => {
     const can_remove_subscribers_group_widget = new dropdown_widget.DropdownWidget({
         widget_name: "can_remove_subscribers_group",
         get_options: () =>
@@ -216,7 +215,7 @@ function setup_dropdown(sub, slim_sub) {
                 "can_remove_subscribers_group",
                 "stream",
             ),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -232,7 +231,7 @@ function setup_dropdown(sub, slim_sub) {
         },
         default_id: sub.can_remove_subscribers_group,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        on_mount_callback(dropdown) {
+        on_mount_callback: (dropdown) => {
             $(dropdown.popper).css("min-width", "300px");
         },
     });
@@ -240,9 +239,9 @@ function setup_dropdown(sub, slim_sub) {
         can_remove_subscribers_group_widget,
     );
     can_remove_subscribers_group_widget.setup();
-}
+};
 
-export function show_settings_for(node) {
+export const show_settings_for = (node) => {
     const stream_id = get_stream_id(node);
     const slim_sub = sub_store.get(stream_id);
     stream_data.clean_up_description(slim_sub);
@@ -299,22 +298,22 @@ export function show_settings_for(node) {
             $(e.target).parent().remove();
         },
     );
-}
+};
 
-export function setup_stream_settings(node) {
+export const setup_stream_settings = (node) => {
     stream_edit_toggler.setup_toggler();
     show_settings_for(node);
-}
+};
 
-export function update_muting_rendering(sub) {
+export const update_muting_rendering = (sub) => {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
     const $is_muted_checkbox = $edit_container.find("#sub_is_muted_setting .sub_setting_control");
 
     $is_muted_checkbox.prop("checked", sub.is_muted);
     $edit_container.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
-}
+};
 
-function stream_notification_reset(e) {
+const stream_notification_reset = (e) => {
     const sub = get_sub_for_target(e.target);
     const data = [{stream_id: sub.stream_id, property: "is_muted", value: false}];
     for (const [per_stream_setting_name, global_setting_name] of Object.entries(
@@ -331,9 +330,9 @@ function stream_notification_reset(e) {
         data,
         $(e.target).closest(".subsection-parent").find(".alert-notification"),
     );
-}
+};
 
-function stream_setting_changed(e) {
+const stream_setting_changed = (e) => {
     const sub = get_sub_for_target(e.target);
     const $status_element = $(e.target).closest(".subsection-parent").find(".alert-notification");
     const setting = e.target.name;
@@ -350,21 +349,21 @@ function stream_setting_changed(e) {
         {property: setting, value: e.target.checked},
         $status_element,
     );
-}
+};
 
-export function archive_stream(stream_id, $alert_element, $stream_row) {
+export const archive_stream = (stream_id, $alert_element, $stream_row) => {
     channel.del({
         url: "/json/streams/" + stream_id,
-        error(xhr) {
+        error: (xhr) => {
             ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $alert_element);
         },
-        success() {
+        success: () => {
             $stream_row.remove();
         },
     });
-}
+};
 
-export function get_stream_email_address(flags, address) {
+export const get_stream_email_address = (flags, address) => {
     const clean_address = address
         .replace(".show-sender", "")
         .replace(".include-footer", "")
@@ -374,7 +373,7 @@ export function get_stream_email_address(flags, address) {
     const flag_string = flags.map((flag) => "." + flag).join("");
 
     return clean_address.replace("@", flag_string + "@");
-}
+};
 
 function show_stream_email_address_modal(address) {
     const copy_email_address_modal_html = render_copy_email_address_modal({
@@ -410,15 +409,13 @@ function show_stream_email_address_modal(address) {
         html_submit_button: $t_html({defaultMessage: "Copy address"}),
         html_exit_button: $t_html({defaultMessage: "Close"}),
         help_link: "/help/message-a-channel-by-email#configuration-options",
-        on_click() {},
+        on_click: () => {},
         close_on_submit: false,
     });
     $("#show-sender").prop("checked", true);
 
     const clipboard = new ClipboardJS("#copy_email_address_modal .dialog_submit_button", {
-        text() {
-            return address;
-        },
+        text: () => address,
     });
 
     // Show a tippy tooltip when the stream email address copied
@@ -475,7 +472,7 @@ export function initialize() {
             id: "change_stream_info_modal",
             loading_spinner: true,
             on_click: save_stream_info,
-            post_render() {
+            post_render: () => {
                 $("#change_stream_info_modal .dialog_submit_button")
                     .addClass("save-button")
                     .attr("data-stream-id", stream_id);
@@ -523,7 +520,7 @@ export function initialize() {
         },
     );
 
-    function save_stream_info(e) {
+    const save_stream_info = (e) => {
         const sub = get_sub_for_target(e.currentTarget);
 
         const url = `/json/streams/${sub.stream_id}`;
@@ -539,7 +536,7 @@ export function initialize() {
         }
 
         dialog_widget.submit_api_request(channel.patch, url, data);
-    }
+    };
 
     $("#channels_overlay_container").on("click", ".copy_email_button", (e) => {
         e.preventDefault();
@@ -549,11 +546,11 @@ export function initialize() {
 
         channel.get({
             url: "/json/streams/" + stream_id + "/email_address",
-            success(data) {
+            success: (data) => {
                 const address = data.email;
                 show_stream_email_address_modal(address);
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error(
                     $t_html({defaultMessage: "Failed"}),
                     xhr,
@@ -614,7 +611,7 @@ export function initialize() {
             return;
         }
 
-        function do_archive_stream() {
+        const do_archive_stream = () => {
             const stream_id = Number($(".dialog_submit_button").attr("data-stream-id"));
             if (!stream_id) {
                 ui_report.client_error(
@@ -625,7 +622,7 @@ export function initialize() {
             }
             const $row = $(".stream-row.active");
             archive_stream(stream_id, $(".stream_change_property_info"), $row);
-        }
+        };
 
         const stream = sub_store.get(stream_id);
 
@@ -730,7 +727,7 @@ export function initialize() {
                 html_body: render_confirm_stream_privacy_change_modal,
                 id: "confirm_stream_privacy_change",
                 html_submit_button: $t_html({defaultMessage: "Confirm"}),
-                on_click() {
+                on_click: () => {
                     settings_org.save_organization_settings(data, $save_button, url);
                 },
                 close_on_submit: true,

--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -9,11 +9,11 @@ import * as sub_store from "./sub_store";
 export let toggler: components.Toggle;
 export let select_tab = "personal";
 
-export function set_select_tab(right_side_tab: string): void {
+export const set_select_tab = (right_side_tab: string): void => {
     select_tab = right_side_tab;
-}
+};
 
-export function setup_toggler(): void {
+export const setup_toggler = (): void => {
     toggler = components.toggle({
         child_wants_focus: true,
         values: [
@@ -21,7 +21,7 @@ export function setup_toggler(): void {
             {label: $t({defaultMessage: "Personal"}), key: "personal"},
             {label: $t({defaultMessage: "Subscribers"}), key: "subscribers"},
         ],
-        callback(_name, key) {
+        callback: (_name, key) => {
             $(".stream_section").hide();
             $(`[data-stream-section="${CSS.escape(key)}"]`).show();
             select_tab = key;
@@ -34,4 +34,4 @@ export function setup_toggler(): void {
             }
         },
     });
-}
+};

--- a/web/src/stream_events.js
+++ b/web/src/stream_events.js
@@ -27,13 +27,13 @@ import * as user_profile from "./user_profile";
 // however, they are only called after a manual override, so
 // doing so is unnecessary with the current code.  Ideally, we'd do a
 // refactor to address that, however.
-function update_stream_setting(sub, value, setting) {
+const update_stream_setting = (sub, value, setting) => {
     const $setting_checkbox = $(`#${CSS.escape(setting)}_${CSS.escape(sub.stream_id)}`);
     $setting_checkbox.prop("checked", value);
     sub[setting] = value;
-}
+};
 
-export function update_property(stream_id, property, value, other_values) {
+export const update_property = (stream_id, property, value, other_values) => {
     const sub = sub_store.get(stream_id);
     if (sub === undefined) {
         // This isn't a stream we know about, so ignore it.
@@ -107,12 +107,12 @@ export function update_property(stream_id, property, value, other_values) {
                 value,
             });
     }
-}
+};
 
 // Add yourself to a stream we already know about client-side.
 // It's likely we should be passing in the full sub object from the caller/backend,
 // but for now we just pass in the subscribers and color (things likely to be different).
-export function mark_subscribed(sub, subscribers, color) {
+export const mark_subscribed = (sub, subscribers, color) => {
     if (sub === undefined) {
         blueslip.error("Undefined sub passed to mark_subscribed");
         return;
@@ -159,9 +159,9 @@ export function mark_subscribed(sub, subscribers, color) {
     stream_list.add_sidebar_row(sub);
     stream_list.update_subscribe_to_more_streams_link();
     user_profile.update_user_profile_streams_list_for_users([people.my_current_user_id()]);
-}
+};
 
-export function mark_unsubscribed(sub) {
+export const mark_unsubscribed = (sub) => {
     if (sub === undefined) {
         // We don't know about this stream
         return;
@@ -197,9 +197,9 @@ export function mark_unsubscribed(sub) {
     stream_list.remove_sidebar_row(sub.stream_id);
     stream_list.update_subscribe_to_more_streams_link();
     user_profile.update_user_profile_streams_list_for_users([people.my_current_user_id()]);
-}
+};
 
-export function remove_deactivated_user_from_all_streams(user_id) {
+export const remove_deactivated_user_from_all_streams = (user_id) => {
     const all_subs = stream_data.get_unsorted_subs();
 
     for (const sub of all_subs) {
@@ -208,9 +208,9 @@ export function remove_deactivated_user_from_all_streams(user_id) {
             stream_settings_ui.update_subscribers_ui(sub);
         }
     }
-}
+};
 
-export function process_subscriber_update(user_ids, stream_ids) {
+export const process_subscriber_update = (user_ids, stream_ids) => {
     for (const stream_id of stream_ids) {
         const sub = sub_store.get(stream_id);
         stream_settings_ui.update_subscribers_ui(sub);
@@ -219,4 +219,4 @@ export function process_subscriber_update(user_ids, stream_ids) {
     if (stream_ids.includes(narrow_state.stream_id())) {
         activity_ui.build_user_sidebar();
     }
-}
+};

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -38,11 +38,9 @@ export let stream_cursor: ListCursor<number>;
 
 let has_scrolled = false;
 
-export function is_zoomed_in(): boolean {
-    return zoomed_in;
-}
+export const is_zoomed_in = (): boolean => zoomed_in;
 
-function zoom_in(): void {
+const zoom_in = (): void => {
     const stream_id = topic_list.active_stream_id();
 
     popovers.hide_all();
@@ -53,13 +51,13 @@ function zoom_in(): void {
     });
 
     zoomed_in = true;
-}
+};
 
-export function set_pending_stream_list_rerender(value: boolean): void {
+export const set_pending_stream_list_rerender = (value: boolean): void => {
     pending_stream_list_rerender = value;
-}
+};
 
-export function zoom_out(): void {
+export const zoom_out = (): void => {
     if (pending_stream_list_rerender) {
         update_streams_sidebar(true);
     }
@@ -74,9 +72,9 @@ export function zoom_out(): void {
     }
 
     zoomed_in = false;
-}
+};
 
-export function clear_topics(): void {
+export const clear_topics = (): void => {
     const $stream_li = topic_list.get_stream_li();
 
     topic_list.close();
@@ -90,15 +88,15 @@ export function clear_topics(): void {
     }
 
     zoomed_in = false;
-}
+};
 
-export function update_count_in_dom(
+export const update_count_in_dom = (
     $stream_li: JQuery,
     stream_counts: StreamCountInfo,
     stream_has_any_unread_mention_messages: boolean,
     stream_has_any_unmuted_unread_mention: boolean,
     stream_has_only_muted_unread_mention: boolean,
-): void {
+): void => {
     // The subscription_block properly excludes the topic list,
     // and it also has sensitive margins related to whether the
     // count is there or not.
@@ -171,7 +169,7 @@ export function update_count_in_dom(
         $subscription_block.removeClass("has-only-muted-unreads");
         $subscription_block.removeClass("stream-with-count");
     }
-}
+};
 
 class StreamSidebar {
     rows = new Map<number, StreamSidebarRow>(); // stream id -> row widget
@@ -200,25 +198,25 @@ class StreamSidebar {
 }
 export const stream_sidebar = new StreamSidebar();
 
-function get_search_term(): string {
+const get_search_term = (): string => {
     const $search_box = $<HTMLInputElement>("input.stream-list-filter").expectOne();
     const search_term = $search_box.val();
     assert(search_term !== undefined);
     return search_term.trim();
-}
+};
 
-export function add_sidebar_row(sub: StreamSubscription): void {
+export const add_sidebar_row = (sub: StreamSubscription): void => {
     create_sidebar_row(sub);
     update_streams_sidebar();
-}
+};
 
-export function remove_sidebar_row(stream_id: number): void {
+export const remove_sidebar_row = (stream_id: number): void => {
     stream_sidebar.remove_row(stream_id);
     const force_rerender = stream_id === topic_list.active_stream_id();
     update_streams_sidebar(force_rerender);
-}
+};
 
-export function create_initial_sidebar_rows(): void {
+export const create_initial_sidebar_rows = (): void => {
     // This code is slightly opaque, but it ends up building
     // up list items and attaching them to the "sub" data
     // structures that are kept in stream_data.js.
@@ -227,9 +225,9 @@ export function create_initial_sidebar_rows(): void {
     for (const sub of subs) {
         create_sidebar_row(sub);
     }
-}
+};
 
-export function build_stream_list(force_rerender: boolean): void {
+export const build_stream_list = (force_rerender: boolean): void => {
     // The stream list in the left sidebar contains 3 sections:
     // pinned, normal, and dormant streams, with headings above them
     // as appropriate.
@@ -253,12 +251,12 @@ export function build_stream_list(force_rerender: boolean): void {
 
     const elems = [];
 
-    function add_sidebar_li(stream_id: number): void {
+    const add_sidebar_li = (stream_id: number): void => {
         const sidebar_row = stream_sidebar.get_row(stream_id);
         assert(sidebar_row !== undefined);
         sidebar_row.update_whether_active();
         elems.push(sidebar_row.get_li());
-    }
+    };
 
     clear_topics();
     $parent.empty();
@@ -332,9 +330,9 @@ export function build_stream_list(force_rerender: boolean): void {
     }
 
     $parent.append(elems); // eslint-disable-line no-jquery/no-append-html
-}
+};
 
-export function get_stream_li(stream_id: number): JQuery | undefined {
+export const get_stream_li = (stream_id: number): JQuery | undefined => {
     const row = stream_sidebar.get_row(stream_id);
     if (!row) {
         // Not all streams are in the sidebar, so we don't report
@@ -355,9 +353,9 @@ export function get_stream_li(stream_id: number): JQuery | undefined {
     }
 
     return $li;
-}
+};
 
-export function update_subscribe_to_more_streams_link(): void {
+export const update_subscribe_to_more_streams_link = (): void => {
     const can_subscribe_stream_count = stream_data
         .unsubscribed_subs()
         .filter((sub) => stream_data.can_toggle_subscription(sub)).length;
@@ -374,13 +372,13 @@ export function update_subscribe_to_more_streams_link(): void {
             exactly_one_unsubscribed_stream: can_subscribe_stream_count === 1,
         }),
     );
-}
+};
 
-function stream_id_for_elt($elt: JQuery): number {
+const stream_id_for_elt = ($elt: JQuery): number => {
     const stream_id_string = $elt.attr("data-stream-id");
     assert(stream_id_string !== undefined);
     return Number.parseInt(stream_id_string, 10);
-}
+};
 
 export function zoom_in_topics(options: {stream_id: number | undefined}): void {
     // This only does stream-related tasks related to zooming
@@ -428,7 +426,7 @@ export function zoom_out_topics(): void {
     $(".filter-topics").remove();
 }
 
-export function set_in_home_view(stream_id: number, in_home: boolean): void {
+export const set_in_home_view = (stream_id: number, in_home: boolean): void => {
     const $li = get_stream_li(stream_id);
     if (!$li) {
         blueslip.error("passed in bad stream id", {stream_id});
@@ -440,9 +438,9 @@ export function set_in_home_view(stream_id: number, in_home: boolean): void {
     } else {
         $li.addClass("out_of_home_view");
     }
-}
+};
 
-function build_stream_sidebar_li(sub: StreamSubscription): JQuery {
+const build_stream_sidebar_li = (sub: StreamSubscription): JQuery => {
     const name = sub.name;
     const is_muted = stream_data.is_muted(sub.stream_id);
     const args = {
@@ -458,7 +456,7 @@ function build_stream_sidebar_li(sub: StreamSubscription): JQuery {
     };
     const $list_item = $(render_stream_sidebar_row(args));
     return $list_item;
-}
+};
 
 class StreamSidebarRow {
     sub: StreamSubscription;
@@ -508,20 +506,20 @@ class StreamSidebarRow {
     }
 }
 
-function build_stream_sidebar_row(sub: StreamSubscription): void {
+const build_stream_sidebar_row = (sub: StreamSubscription): void => {
     stream_sidebar.set_row(sub.stream_id, new StreamSidebarRow(sub));
-}
+};
 
-export function create_sidebar_row(sub: StreamSubscription): void {
+export const create_sidebar_row = (sub: StreamSubscription): void => {
     if (stream_sidebar.has_row_for(sub.stream_id)) {
         // already exists
         blueslip.warn("Dup try to build sidebar row for stream", {stream_id: sub.stream_id});
         return;
     }
     build_stream_sidebar_row(sub);
-}
+};
 
-export function redraw_stream_privacy(sub: StreamSubscription): void {
+export const redraw_stream_privacy = (sub: StreamSubscription): void => {
     const $li = get_stream_li(sub.stream_id);
     if (!$li) {
         // We don't want to raise error here, if we can't find stream in subscription
@@ -539,15 +537,15 @@ export function redraw_stream_privacy(sub: StreamSubscription): void {
 
     const html = render_stream_privacy(args);
     $div.html(html);
-}
+};
 
-function set_stream_unread_count(
+const set_stream_unread_count = (
     stream_id: number,
     count: StreamCountInfo,
     stream_has_any_unread_mention_messages: boolean,
     stream_has_any_unmuted_unread_mention: boolean,
     stream_has_only_muted_unread_mentions: boolean,
-): void {
+): void => {
     const $stream_li = get_stream_li(stream_id);
     if (!$stream_li) {
         // This can happen for legitimate reasons, but we warn
@@ -562,9 +560,9 @@ function set_stream_unread_count(
         stream_has_any_unmuted_unread_mention,
         stream_has_only_muted_unread_mentions,
     );
-}
+};
 
-export function update_streams_sidebar(force_rerender = false): void {
+export const update_streams_sidebar = (force_rerender = false): void => {
     if (!force_rerender && is_zoomed_in()) {
         // We do our best to update topics that are displayed
         // in case user zoomed in. Streams list will be updated,
@@ -588,9 +586,9 @@ export function update_streams_sidebar(force_rerender = false): void {
     }
 
     update_stream_sidebar_for_narrow(filter);
-}
+};
 
-export function update_dom_with_unread_counts(counts: FullUnreadCountsData): void {
+export const update_dom_with_unread_counts = (counts: FullUnreadCountsData): void => {
     // counts.stream_count maps streams to counts
     for (const [stream_id, count] of counts.stream_count) {
         const stream_has_any_unread_mention_messages =
@@ -611,9 +609,9 @@ export function update_dom_with_unread_counts(counts: FullUnreadCountsData): voi
             stream_has_only_muted_unread_mentions,
         );
     }
-}
+};
 
-export function update_dom_unread_counts_visibility(): void {
+export const update_dom_unread_counts_visibility = (): void => {
     const $streams_header = $("#streams_header");
     if (settings_data.should_mask_unread_count(false)) {
         $streams_header.addClass("hide_unread_counts");
@@ -632,15 +630,15 @@ export function update_dom_unread_counts_visibility(): void {
             $subscription_block.removeClass("hide_unread_counts");
         }
     }
-}
+};
 
-export function rename_stream(sub: StreamSubscription): void {
+export const rename_stream = (sub: StreamSubscription): void => {
     // The sub object is expected to already have the updated name
     build_stream_sidebar_row(sub);
     update_streams_sidebar(true); // big hammer
-}
+};
 
-export function refresh_pinned_or_unpinned_stream(sub: StreamSubscription): void {
+export const refresh_pinned_or_unpinned_stream = (sub: StreamSubscription): void => {
     // Pinned/unpinned streams require re-ordering.
     // We use kind of brute force now, which is probably fine.
     build_stream_sidebar_row(sub);
@@ -657,17 +655,19 @@ export function refresh_pinned_or_unpinned_stream(sub: StreamSubscription): void
         }
         scroll_stream_into_view($stream_li);
     }
-}
+};
 
-export function refresh_muted_or_unmuted_stream(sub: StreamSubscription): void {
+export const refresh_muted_or_unmuted_stream = (sub: StreamSubscription): void => {
     build_stream_sidebar_row(sub);
     update_streams_sidebar();
-}
+};
 
-export function get_sidebar_stream_topic_info(filter: Filter): {
+export const get_sidebar_stream_topic_info = (
+    filter: Filter,
+): {
     stream_id: number | undefined;
     topic_selected: boolean;
-} {
+} => {
     const result: {
         stream_id: number | undefined;
         topic_selected: boolean;
@@ -698,13 +698,13 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
     result.topic_selected = op_topic.length === 1;
 
     return result;
-}
+};
 
-function deselect_stream_items(): void {
+const deselect_stream_items = (): void => {
     $("ul#stream_filters li").removeClass("active-filter stream-expanded");
-}
+};
 
-export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undefined {
+export const update_stream_sidebar_for_narrow = (filter: Filter): JQuery | undefined => {
     const info = get_sidebar_stream_topic_info(filter);
 
     deselect_stream_items();
@@ -745,13 +745,13 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     topic_list.rebuild($stream_li, stream_id);
 
     return $stream_li;
-}
+};
 
-export function handle_narrow_activated(
+export const handle_narrow_activated = (
     filter: Filter,
     change_hash: boolean,
     show_more_topics: boolean,
-): void {
+): void => {
     const $stream_li = update_stream_sidebar_for_narrow(filter);
     if ($stream_li) {
         scroll_stream_into_view($stream_li);
@@ -763,32 +763,32 @@ export function handle_narrow_activated(
             }
         }
     }
-}
+};
 
-export function handle_message_view_deactivated(): void {
+export const handle_message_view_deactivated = (): void => {
     deselect_stream_items();
     clear_topics();
-}
+};
 
-function focus_stream_filter(e: JQuery.ClickEvent): void {
+const focus_stream_filter = (e: JQuery.ClickEvent): void => {
     stream_cursor.reset();
     e.stopPropagation();
-}
+};
 
-function actually_update_streams_for_search(): void {
+const actually_update_streams_for_search = (): void => {
     update_streams_sidebar();
     resize.resize_page_components();
     stream_cursor.reset();
-}
+};
 
 const update_streams_for_search = _.throttle(actually_update_streams_for_search, 50);
 
 // Exported for tests only.
-export function initialize_stream_cursor(): void {
+export const initialize_stream_cursor = (): void => {
     stream_cursor = new ListCursor({
         list: {
             scroll_container_selector: "#left_sidebar_scroll_container",
-            find_li(opts) {
+            find_li: (opts) => {
                 const stream_id = opts.key;
                 const $li = get_stream_li(stream_id);
                 return $li;
@@ -799,13 +799,13 @@ export function initialize_stream_cursor(): void {
         },
         highlight_class: "highlighted_stream",
     });
-}
+};
 
-export function initialize({
+export const initialize = ({
     on_stream_click,
 }: {
     on_stream_click: (stream_id: number, trigger: string) => void;
-}): void {
+}): void => {
     create_initial_sidebar_rows();
 
     // We build the stream_list now.  It may get re-built again very shortly
@@ -830,13 +830,13 @@ export function initialize({
         e.preventDefault();
         e.stopPropagation();
     });
-}
+};
 
-export function set_event_handlers({
+export const set_event_handlers = ({
     on_stream_click,
 }: {
     on_stream_click: (stream_id: number, trigger: string) => void;
-}): void {
+}): void => {
     $("#stream_filters").on("click", "li .subscription_block", (e) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;
@@ -862,7 +862,7 @@ export function set_event_handlers({
             toggle_filter_displayed(e);
         });
 
-    function toggle_pm_header_icon(): void {
+    const toggle_pm_header_icon = (): void => {
         if (pm_list.is_private_messages_collapsed()) {
             return;
         }
@@ -880,7 +880,7 @@ export function set_event_handlers({
             $("#toggle_private_messages_section_icon").addClass("fa-caret-down");
             $("#toggle_private_messages_section_icon").removeClass("fa-caret-right");
         }
-    }
+    };
 
     // check for user scrolls on streams list for first time
     scroll_util.get_scroll_element($("#left_sidebar_scroll_container")).on("scroll", () => {
@@ -890,7 +890,7 @@ export function set_event_handlers({
 
     const $search_input = $(".stream-list-filter").expectOne();
 
-    function keydown_enter_key(): void {
+    const keydown_enter_key = (): void => {
         const stream_id = stream_cursor.get_key();
 
         if (stream_id === undefined) {
@@ -900,20 +900,20 @@ export function set_event_handlers({
 
         clear_and_hide_search();
         on_stream_click(stream_id, "sidebar enter key");
-    }
+    };
 
     keydown_util.handle({
         $elem: $search_input,
         handlers: {
-            Enter() {
+            Enter: () => {
                 keydown_enter_key();
                 return true;
             },
-            ArrowUp() {
+            ArrowUp: () => {
                 stream_cursor.prev();
                 return true;
             },
-            ArrowDown() {
+            ArrowDown: () => {
                 stream_cursor.next();
                 return true;
             },
@@ -925,13 +925,11 @@ export function set_event_handlers({
         stream_cursor.clear();
     });
     $search_input.on("input", update_streams_for_search);
-}
+};
 
-export function searching(): boolean {
-    return $(".stream-list-filter").expectOne().is(":focus");
-}
+export const searching = (): boolean => $(".stream-list-filter").expectOne().is(":focus");
 
-export function clear_search(e: JQuery.ClickEvent): void {
+export const clear_search = (e: JQuery.ClickEvent): void => {
     e.stopPropagation();
     const $filter = $(".stream-list-filter").expectOne();
     if ($filter.val() === "") {
@@ -941,21 +939,21 @@ export function clear_search(e: JQuery.ClickEvent): void {
     $filter.val("");
     $filter.trigger("blur");
     update_streams_for_search();
-}
+};
 
-export function show_search_section(): void {
+export const show_search_section = (): void => {
     $("#streams_header").addClass("showing-stream-search-section");
     $(".stream_search_section").expectOne().removeClass("notdisplayed");
     resize.resize_stream_filters_container();
-}
+};
 
-export function hide_search_section(): void {
+export const hide_search_section = (): void => {
     $("#streams_header").removeClass("showing-stream-search-section");
     $(".stream_search_section").expectOne().addClass("notdisplayed");
     resize.resize_stream_filters_container();
-}
+};
 
-export function initiate_search(): void {
+export const initiate_search = (): void => {
     popovers.hide_all();
     show_search_section();
 
@@ -972,9 +970,9 @@ export function initiate_search(): void {
     $filter.trigger("focus");
 
     stream_cursor.reset();
-}
+};
 
-export function clear_and_hide_search(): void {
+export const clear_and_hide_search = (): void => {
     const $filter = $(".stream-list-filter").expectOne();
     if ($filter.val() !== "") {
         $filter.val("");
@@ -984,18 +982,18 @@ export function clear_and_hide_search(): void {
     $filter.trigger("blur");
 
     hide_search_section();
-}
+};
 
-export function toggle_filter_displayed(e: JQuery.ClickEvent): void {
+export const toggle_filter_displayed = (e: JQuery.ClickEvent): void => {
     if ($(".stream_search_section.notdisplayed").length === 0) {
         clear_and_hide_search();
     } else {
         initiate_search();
     }
     e.preventDefault();
-}
+};
 
-export function scroll_stream_into_view($stream_li: JQuery): void {
+export const scroll_stream_into_view = ($stream_li: JQuery): void => {
     const $container = $("#left_sidebar_scroll_container");
 
     if ($stream_li.length !== 1) {
@@ -1004,9 +1002,9 @@ export function scroll_stream_into_view($stream_li: JQuery): void {
     }
     const stream_header_height = $("#streams_header").outerHeight();
     scroll_util.scroll_element_into_container($stream_li, $container, stream_header_height);
-}
+};
 
-export function maybe_scroll_narrow_into_view(): void {
+export const maybe_scroll_narrow_into_view = (): void => {
     // we don't want to interfere with user scrolling once the page loads
     if (has_scrolled) {
         return;
@@ -1016,9 +1014,9 @@ export function maybe_scroll_narrow_into_view(): void {
     if ($stream_li) {
         scroll_stream_into_view($stream_li);
     }
-}
+};
 
-export function get_current_stream_li(): JQuery | undefined {
+export const get_current_stream_li = (): JQuery | undefined => {
     const stream_id = topic_list.active_stream_id();
 
     if (!stream_id) {
@@ -1035,4 +1033,4 @@ export function get_current_stream_li(): JQuery | undefined {
     }
 
     return $stream_li;
-}
+};

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -23,14 +23,13 @@ let all_streams: number[] = [];
 // to avoid making left sidebar rendering a quadratic operation.
 let filter_out_inactives = false;
 
-export function get_streams(): string[] {
-    return all_streams.flatMap((stream_id) => {
+export const get_streams = (): string[] =>
+    all_streams.flatMap((stream_id) => {
         const stream_name = sub_store.maybe_get_stream_name(stream_id);
         return stream_name === undefined ? [] : [stream_name];
     });
-}
 
-function compare_function(a: number, b: number): number {
+const compare_function = (a: number, b: number): number => {
     const stream_a = sub_store.get(a);
     const stream_b = sub_store.get(b);
 
@@ -38,9 +37,9 @@ function compare_function(a: number, b: number): number {
     const stream_name_b = stream_b ? stream_b.name : "";
 
     return util.strcmp(stream_name_a, stream_name_b);
-}
+};
 
-export function set_filter_out_inactives(): void {
+export const set_filter_out_inactives = (): void => {
     if (
         user_settings.demote_inactive_streams ===
         settings_config.demote_inactive_streams_values.automatic.code
@@ -54,14 +53,12 @@ export function set_filter_out_inactives(): void {
     } else {
         filter_out_inactives = false;
     }
-}
+};
 
 // Exported for access by unit tests.
-export function is_filtering_inactives(): boolean {
-    return filter_out_inactives;
-}
+export const is_filtering_inactives = (): boolean => filter_out_inactives;
 
-export function has_recent_activity(sub: StreamSubscription): boolean {
+export const has_recent_activity = (sub: StreamSubscription): boolean => {
     if (!filter_out_inactives || sub.pin_to_top) {
         // If users don't want to filter inactive streams
         // to the bottom, we respect that setting and don't
@@ -73,11 +70,10 @@ export function has_recent_activity(sub: StreamSubscription): boolean {
         return true;
     }
     return stream_topic_history.stream_has_topics(sub.stream_id) || sub.newly_subscribed;
-}
+};
 
-export function has_recent_activity_but_muted(sub: StreamSubscription): boolean {
-    return has_recent_activity(sub) && sub.is_muted;
-}
+export const has_recent_activity_but_muted = (sub: StreamSubscription): boolean =>
+    has_recent_activity(sub) && sub.is_muted;
 
 type StreamListSortResult = {
     same_as_before: boolean;
@@ -88,7 +84,7 @@ type StreamListSortResult = {
     muted_active_streams: number[];
 };
 
-export function sort_groups(stream_ids: number[], search_term: string): StreamListSortResult {
+export const sort_groups = (stream_ids: number[], search_term: string): StreamListSortResult => {
     const stream_id_to_name = (stream_id: number): string => sub_store.get(stream_id)!.name;
     // Use -, _, : and / as word separators apart from the default space character
     const word_separator_regex = /[\s/:_-]/;
@@ -99,9 +95,7 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
         word_separator_regex,
     );
 
-    function is_normal(sub: StreamSubscription): boolean {
-        return has_recent_activity(sub);
-    }
+    const is_normal = (sub: StreamSubscription): boolean => has_recent_activity(sub);
 
     const pinned_streams = [];
     const normal_streams = [];
@@ -169,21 +163,19 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
         muted_pinned_streams,
         muted_active_streams,
     };
-}
+};
 
-function maybe_get_stream_id(i: number): number | undefined {
+const maybe_get_stream_id = (i: number): number | undefined => {
     if (i < 0 || i >= all_streams.length) {
         return undefined;
     }
 
     return all_streams[i];
-}
+};
 
-export function first_stream_id(): number | undefined {
-    return maybe_get_stream_id(0);
-}
+export const first_stream_id = (): number | undefined => maybe_get_stream_id(0);
 
-export function prev_stream_id(stream_id: number): number | undefined {
+export const prev_stream_id = (stream_id: number): number | undefined => {
     const i = all_streams.indexOf(stream_id);
 
     if (i < 0) {
@@ -191,9 +183,9 @@ export function prev_stream_id(stream_id: number): number | undefined {
     }
 
     return maybe_get_stream_id(i - 1);
-}
+};
 
-export function next_stream_id(stream_id: number): number | undefined {
+export const next_stream_id = (stream_id: number): number | undefined => {
     const i = all_streams.indexOf(stream_id);
 
     if (i < 0) {
@@ -201,8 +193,8 @@ export function next_stream_id(stream_id: number): number | undefined {
     }
 
     return maybe_get_stream_id(i + 1);
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     set_filter_out_inactives();
-}
+};

--- a/web/src/stream_muting.js
+++ b/web/src/stream_muting.js
@@ -4,7 +4,7 @@ import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
 import * as unread_ui from "./unread_ui";
 
-export function update_is_muted(sub, value) {
+export const update_is_muted = (sub, value) => {
     sub.is_muted = value;
 
     for (const msg_list of message_lists.all_rendered_message_lists()) {
@@ -23,4 +23,4 @@ export function update_is_muted(sub, value) {
     settings_notifications.update_muted_stream_state(sub);
     stream_edit.update_muting_rendering(sub);
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
-}
+};

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -14,15 +14,15 @@ type StreamPillWidget = InputPillContainer<StreamPill>;
 
 export type StreamPillData = StreamSubscription & {type: "stream"};
 
-function display_pill(sub: StreamSubscription): string {
+const display_pill = (sub: StreamSubscription): string => {
     const sub_count = peer_data.get_subscriber_count(sub.stream_id);
     return "#" + sub.name + ": " + sub_count + " users";
-}
+};
 
-export function create_item_from_stream_name(
+export const create_item_from_stream_name = (
     stream_name: string,
     current_items: CombinedPillItem[],
-): InputPillItem<StreamPill> | undefined {
+): InputPillItem<StreamPill> | undefined => {
     stream_name = stream_name.trim();
     if (!stream_name.startsWith("#")) {
         return undefined;
@@ -44,13 +44,12 @@ export function create_item_from_stream_name(
         stream_id: sub.stream_id,
         stream_name: sub.name,
     };
-}
+};
 
-export function get_stream_name_from_item(item: InputPillItem<StreamPill>): string {
-    return item.stream_name;
-}
+export const get_stream_name_from_item = (item: InputPillItem<StreamPill>): string =>
+    item.stream_name;
 
-export function get_user_ids(pill_widget: StreamPillWidget | CombinedPillContainer): number[] {
+export const get_user_ids = (pill_widget: StreamPillWidget | CombinedPillContainer): number[] => {
     let user_ids = pill_widget
         .items()
         .flatMap((item) =>
@@ -59,12 +58,12 @@ export function get_user_ids(pill_widget: StreamPillWidget | CombinedPillContain
     user_ids = [...new Set(user_ids)];
     user_ids.sort((a, b) => a - b);
     return user_ids;
-}
+};
 
-export function append_stream(
+export const append_stream = (
     stream: StreamSubscription,
     pill_widget: CombinedPillContainer,
-): void {
+): void => {
     pill_widget.appendValidatedData({
         type: "stream",
         display_value: display_pill(stream),
@@ -72,26 +71,26 @@ export function append_stream(
         stream_name: stream.name,
     });
     pill_widget.clear_text();
-}
+};
 
-export function get_stream_ids(pill_widget: CombinedPillContainer): number[] {
+export const get_stream_ids = (pill_widget: CombinedPillContainer): number[] => {
     const items = pill_widget.items();
     return items.flatMap((item) => (item.type === "stream" ? item.stream_id : []));
-}
+};
 
-export function filter_taken_streams(
+export const filter_taken_streams = (
     items: StreamSubscription[],
     pill_widget: CombinedPillContainer,
-): StreamSubscription[] {
+): StreamSubscription[] => {
     const taken_stream_ids = get_stream_ids(pill_widget);
     items = items.filter((item) => !taken_stream_ids.includes(item.stream_id));
     return items;
-}
+};
 
-export function typeahead_source(pill_widget: CombinedPillContainer): StreamPillData[] {
+export const typeahead_source = (pill_widget: CombinedPillContainer): StreamPillData[] => {
     const potential_streams = stream_data.get_unsorted_subs();
     return filter_taken_streams(potential_streams, pill_widget).map((stream) => ({
         ...stream,
         type: "stream",
     }));
-}
+};

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -34,7 +34,7 @@ let stream_popover_instance = null;
 let stream_widget_value;
 let move_topic_to_stream_topic_typeahead;
 
-function get_popover_menu_items(sidebar_elem) {
+const get_popover_menu_items = (sidebar_elem) => {
     if (!sidebar_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
         return undefined;
@@ -47,14 +47,14 @@ function get_popover_menu_items(sidebar_elem) {
     }
 
     return $("li:not(.divider):visible > a", $popover);
-}
+};
 
-export function stream_sidebar_menu_handle_keyboard(key) {
+export const stream_sidebar_menu_handle_keyboard = (key) => {
     const items = get_popover_menu_items(stream_popover_instance);
     popover_menus.popover_items_handle_keyboard(key, items);
-}
+};
 
-export function elem_to_stream_id($elem) {
+export const elem_to_stream_id = ($elem) => {
     const stream_id = Number.parseInt($elem.attr("data-stream-id"), 10);
 
     if (stream_id === undefined) {
@@ -62,21 +62,19 @@ export function elem_to_stream_id($elem) {
     }
 
     return stream_id;
-}
+};
 
-export function is_open() {
-    return Boolean(stream_popover_instance);
-}
+export const is_open = () => Boolean(stream_popover_instance);
 
-export function hide_stream_popover() {
+export const hide_stream_popover = () => {
     if (is_open()) {
         ui_util.hide_left_sidebar_menu_icon();
         stream_popover_instance.destroy();
         stream_popover_instance = null;
     }
-}
+};
 
-function stream_popover_sub(e) {
+const stream_popover_sub = (e) => {
     const $elem = $(e.currentTarget).parents("ul");
     const stream_id = elem_to_stream_id($elem);
     const sub = sub_store.get(stream_id);
@@ -85,9 +83,9 @@ function stream_popover_sub(e) {
         return undefined;
     }
     return sub;
-}
+};
 
-function build_stream_popover(opts) {
+const build_stream_popover = (opts) => {
     const {elt, stream_id} = opts;
 
     // This will allow the user to close the popover by clicking
@@ -107,13 +105,13 @@ function build_stream_popover(opts) {
         delay: [100, 0],
         theme: "popover-menu",
         ...left_sidebar_tippy_options,
-        onCreate(instance) {
+        onCreate: (instance) => {
             stream_popover_instance = instance;
             const $popover = $(instance.popper);
             $popover.addClass("stream-popover-root");
             instance.setContent(ui_util.parse_html(content));
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             ui_util.show_left_sidebar_menu_icon(elt);
 
@@ -194,18 +192,18 @@ function build_stream_popover(opts) {
                 e.stopPropagation();
             });
         },
-        onHidden() {
+        onHidden: () => {
             hide_stream_popover();
         },
     });
-}
+};
 
-async function get_message_placement_from_server(
+const get_message_placement_from_server = async (
     current_stream_id,
     topic_name,
     current_message_id,
-) {
-    return new Promise((resolve) => {
+) =>
+    new Promise((resolve) => {
         message_edit.is_message_oldest_or_newest(
             current_stream_id,
             topic_name,
@@ -221,13 +219,12 @@ async function get_message_placement_from_server(
             },
         );
     });
-}
 
-async function get_message_placement_in_conversation(
+const get_message_placement_in_conversation = async (
     current_stream_id,
     topic_name,
     current_message_id,
-) {
+) => {
     assert(message_lists.current !== undefined);
     // First we check if the placement of the message can be determined
     // in the current message list. This allows us to avoid a server call
@@ -311,14 +308,14 @@ async function get_message_placement_in_conversation(
         topic_name,
         current_message_id,
     );
-}
+};
 
-export async function build_move_topic_to_stream_popover(
+export const build_move_topic_to_stream_popover = async (
     current_stream_id,
     topic_name,
     only_topic_edit,
     message,
-) {
+) => {
     const current_stream_name = sub_store.maybe_get_stream_name(current_stream_id);
     const args = {
         topic_name,
@@ -373,15 +370,14 @@ export async function build_move_topic_to_stream_popover(
         );
     }
 
-    function get_params_from_form() {
-        return Object.fromEntries(
+    const get_params_from_form = () =>
+        Object.fromEntries(
             $("#move_topic_form")
                 .serializeArray()
                 .map(({name, value}) => [name, value]),
         );
-    }
 
-    function update_submit_button_disabled_state(select_stream_id) {
+    const update_submit_button_disabled_state = (select_stream_id) => {
         const {current_stream_id, new_topic_name, old_topic_name} = get_params_from_form();
 
         // Unlike most topic comparisons in Zulip, we intentionally do
@@ -394,9 +390,9 @@ export async function build_move_topic_to_stream_popover(
         $("#move_topic_modal .dialog_submit_button")[0].disabled =
             Number.parseInt(current_stream_id, 10) === Number.parseInt(select_stream_id, 10) &&
             (new_topic_name === undefined || new_topic_name.trim() === old_topic_name.trim());
-    }
+    };
 
-    function move_topic() {
+    const move_topic = () => {
         const params = get_params_from_form();
 
         const old_topic_name = params.old_topic_name.trim();
@@ -484,9 +480,9 @@ export async function build_move_topic_to_stream_popover(
                 );
             },
         );
-    }
+    };
 
-    function set_stream_topic_typeahead() {
+    const set_stream_topic_typeahead = () => {
         const $topic_input = $("#move_topic_form .move_messages_edit_topic");
         const new_stream_id = Number(stream_widget_value, 10);
         const new_stream_name = sub_store.get(new_stream_id).name;
@@ -496,9 +492,9 @@ export async function build_move_topic_to_stream_popover(
             new_stream_name,
             false,
         );
-    }
+    };
 
-    function render_selected_stream() {
+    const render_selected_stream = () => {
         const stream_id = Number.parseInt(stream_widget_value, 10);
         const stream = stream_data.get_sub_by_id(stream_id);
         if (stream === undefined) {
@@ -510,9 +506,9 @@ export async function build_move_topic_to_stream_popover(
                 render_inline_decorated_stream_name({stream, show_colored_icon: true}),
             );
         }
-    }
+    };
 
-    function move_topic_on_update(event, dropdown) {
+    const move_topic_on_update = (event, dropdown) => {
         stream_widget_value = $(event.currentTarget).attr("data-unique-id");
 
         update_submit_button_disabled_state(stream_widget_value);
@@ -522,9 +518,9 @@ export async function build_move_topic_to_stream_popover(
         dropdown.hide();
         event.preventDefault();
         event.stopPropagation();
-    }
+    };
 
-    function move_topic_post_render() {
+    const move_topic_post_render = () => {
         $("#move_topic_modal .dialog_submit_button").prop("disabled", true);
 
         const $topic_input = $("#move_topic_form .move_messages_edit_topic");
@@ -570,13 +566,13 @@ export async function build_move_topic_to_stream_popover(
         $("#move_topic_modal .move_messages_edit_topic").on("input", () => {
             update_submit_button_disabled_state(stream_widget_value);
         });
-    }
+    };
 
-    function focus_on_move_modal_render() {
+    const focus_on_move_modal_render = () => {
         if (!args.disable_topic_input) {
             ui_util.place_caret_at_end($(".move_messages_edit_topic")[0]);
         }
-    }
+    };
 
     dialog_widget.launch({
         html_heading: modal_heading,
@@ -586,14 +582,14 @@ export async function build_move_topic_to_stream_popover(
         on_click: move_topic,
         loading_spinner: true,
         on_shown: focus_on_move_modal_render,
-        on_hidden() {
+        on_hidden: () => {
             move_topic_to_stream_topic_typeahead = undefined;
         },
         post_render: move_topic_post_render,
     });
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $("#stream_filters").on("click", ".stream-sidebar-menu-icon", (e) => {
         const elt = e.currentTarget;
         const $stream_li = $(elt).parents("li");
@@ -618,4 +614,4 @@ export function initialize() {
 
         e.stopPropagation();
     });
-}
+};

--- a/web/src/stream_settings_api.ts
+++ b/web/src/stream_settings_api.ts
@@ -5,7 +5,7 @@ import * as settings_ui from "./settings_ui";
 import type {StreamProperties, StreamSubscription} from "./sub_store";
 import * as sub_store from "./sub_store";
 
-export function bulk_set_stream_property(
+export const bulk_set_stream_property = (
     sub_data: {
         [Property in keyof StreamProperties]: {
             stream_id: number;
@@ -14,7 +14,7 @@ export function bulk_set_stream_property(
         };
     }[keyof StreamProperties][],
     $status_element?: JQuery,
-): void {
+): void => {
     const url = "/json/users/me/subscriptions/properties";
     const data = {subscription_data: JSON.stringify(sub_data)};
     if (!$status_element) {
@@ -27,9 +27,9 @@ export function bulk_set_stream_property(
 
     settings_ui.do_settings_change(channel.post, url, data, $status_element);
     return undefined;
-}
+};
 
-export function set_stream_property(
+export const set_stream_property = (
     sub: StreamSubscription,
     data: {
         [Property in keyof StreamProperties]: {
@@ -38,13 +38,13 @@ export function set_stream_property(
         };
     }[keyof StreamProperties],
     $status_element?: JQuery,
-): void {
+): void => {
     const sub_data = {stream_id: sub.stream_id, ...data};
     bulk_set_stream_property([sub_data], $status_element);
-}
+};
 
-export function set_color(stream_id: number, color: string): void {
+export const set_color = (stream_id: number, color: string): void => {
     const sub = sub_store.get(stream_id);
     assert(sub !== undefined);
     set_stream_property(sub, {property: "color", value: color});
-}
+};

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -20,7 +20,7 @@ import * as stream_ui_updates from "./stream_ui_updates";
 import * as ui_report from "./ui_report";
 import * as user_groups from "./user_groups";
 
-export function set_right_panel_title(sub) {
+export const set_right_panel_title = (sub) => {
     let title_icon_color = "#333333";
     if (settings_data.using_dark_theme()) {
         title_icon_color = "#dddeee";
@@ -30,29 +30,29 @@ export function set_right_panel_title(sub) {
     $("#subscription_overlay .stream-info-title").html(
         render_selected_stream_title({sub, title_icon_color, preview_url}),
     );
-}
+};
 
 export const show_subs_pane = {
-    nothing_selected() {
+    nothing_selected: () => {
         $(".settings, #stream-creation").hide();
         $(".nothing-selected").show();
         $("#subscription_overlay .stream-info-title").text(
             $t({defaultMessage: "Channel settings"}),
         );
     },
-    settings(sub) {
+    settings: (sub) => {
         $(".settings, #stream-creation").hide();
         $(".settings").show();
         set_right_panel_title(sub);
     },
-    create_stream() {
+    create_stream: () => {
         $(".nothing-selected, .settings, #stream-creation").hide();
         $("#stream-creation").show();
         $("#subscription_overlay .stream-info-title").text($t({defaultMessage: "Create channel"}));
     },
 };
 
-export function get_active_data() {
+export const get_active_data = () => {
     const $active_row = $("div.stream-row.active");
     const valid_active_id = Number.parseInt($active_row.attr("data-stream-id"), 10);
     const $active_tabs = $(".subscriptions-container").find("div.ind-tab.selected");
@@ -61,11 +61,11 @@ export function get_active_data() {
         id: valid_active_id,
         $tabs: $active_tabs,
     };
-}
+};
 
 export let new_stream_can_remove_subscribers_group_widget = null;
 
-export function dropdown_setup() {
+export const dropdown_setup = () => {
     new_stream_can_remove_subscribers_group_widget = new dropdown_widget.DropdownWidget({
         widget_name: "new_stream_can_remove_subscribers_group",
         get_options: () =>
@@ -73,7 +73,7 @@ export function dropdown_setup() {
                 "can_remove_subscribers_group",
                 "stream",
             ),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -83,17 +83,17 @@ export function dropdown_setup() {
         tippy_props: {
             placement: "bottom-start",
         },
-        on_mount_callback(dropdown) {
+        on_mount_callback: (dropdown) => {
             $(dropdown.popper).css("min-width", "300px");
         },
         default_text: $t({defaultMessage: "No user groups"}),
         default_id: user_groups.get_user_group_from_name("role:administrators").id,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
     });
-}
+};
 
 /* For the given stream_row, remove the tick and replace by a spinner. */
-function display_subscribe_toggle_spinner(stream_row) {
+const display_subscribe_toggle_spinner = (stream_row) => {
     /* Prevent sending multiple requests by removing the button class. */
     $(stream_row).find(".check").removeClass("sub_unsub_button");
 
@@ -105,10 +105,10 @@ function display_subscribe_toggle_spinner(stream_row) {
     const $spinner = $(stream_row).find(".sub_unsub_status").expectOne();
     $spinner.show();
     loading.make_indicator($spinner);
-}
+};
 
 /* For the given stream_row, add the tick and delete the spinner. */
-function hide_subscribe_toggle_spinner(stream_row) {
+const hide_subscribe_toggle_spinner = (stream_row) => {
     /* Re-enable the button to handle requests. */
     $(stream_row).find(".check").addClass("sub_unsub_button");
 
@@ -119,9 +119,9 @@ function hide_subscribe_toggle_spinner(stream_row) {
     /* Destroy the spinner. */
     const $spinner = $(stream_row).find(".sub_unsub_status").expectOne();
     loading.destroy_indicator($spinner);
-}
+};
 
-export function ajaxSubscribe(stream, color, $stream_row) {
+export const ajaxSubscribe = (stream, color, $stream_row) => {
     // Subscribe yourself to a single stream.
     let true_stream_name;
 
@@ -131,7 +131,7 @@ export function ajaxSubscribe(stream, color, $stream_row) {
     return channel.post({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([{name: stream, color}])},
-        success(_resp, _statusText, xhr) {
+        success: (_resp, _statusText, xhr) => {
             if (overlays.streams_open()) {
                 $("#create_stream_name").val("");
             }
@@ -154,7 +154,7 @@ export function ajaxSubscribe(stream, color, $stream_row) {
                 hide_subscribe_toggle_spinner($stream_row);
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             if ($stream_row !== undefined) {
                 hide_subscribe_toggle_spinner($stream_row);
             }
@@ -165,9 +165,9 @@ export function ajaxSubscribe(stream, color, $stream_row) {
             );
         },
     });
-}
+};
 
-function ajaxUnsubscribe(sub, $stream_row) {
+const ajaxUnsubscribe = (sub, $stream_row) => {
     // TODO: use stream_id when backend supports it
     if ($stream_row !== undefined) {
         display_subscribe_toggle_spinner($stream_row);
@@ -175,7 +175,7 @@ function ajaxUnsubscribe(sub, $stream_row) {
     return channel.del({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([sub.name])},
-        success() {
+        success: () => {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get
 
@@ -183,7 +183,7 @@ function ajaxUnsubscribe(sub, $stream_row) {
                 hide_subscribe_toggle_spinner($stream_row);
             }
         },
-        error(xhr) {
+        error: (xhr) => {
             if ($stream_row !== undefined) {
                 hide_subscribe_toggle_spinner($stream_row);
             }
@@ -194,9 +194,9 @@ function ajaxUnsubscribe(sub, $stream_row) {
             );
         },
     });
-}
+};
 
-export function unsubscribe_from_private_stream(sub) {
+export const unsubscribe_from_private_stream = (sub) => {
     const invite_only = sub.invite_only;
     const sub_count = peer_data.get_subscriber_count(sub.stream_id);
     const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({stream: sub});
@@ -206,7 +206,7 @@ export function unsubscribe_from_private_stream(sub) {
         display_stream_archive_warning: sub_count === 1 && invite_only,
     });
 
-    function unsubscribe_from_stream() {
+    const unsubscribe_from_stream = () => {
         let $stream_row;
         if (overlays.streams_open()) {
             $stream_row = $(
@@ -217,7 +217,7 @@ export function unsubscribe_from_private_stream(sub) {
         }
 
         ajaxUnsubscribe(sub, $stream_row);
-    }
+    };
 
     confirm_dialog.launch({
         html_heading: $t_html(
@@ -227,9 +227,9 @@ export function unsubscribe_from_private_stream(sub) {
         html_body,
         on_click: unsubscribe_from_stream,
     });
-}
+};
 
-export function sub_or_unsub(sub, $stream_row) {
+export const sub_or_unsub = (sub, $stream_row) => {
     if (sub.subscribed) {
         // TODO: This next line should allow guests to access web-public streams.
         if (sub.invite_only || current_user.is_guest) {
@@ -240,19 +240,19 @@ export function sub_or_unsub(sub, $stream_row) {
     } else {
         ajaxSubscribe(sub.name, sub.color, $stream_row);
     }
-}
+};
 
-export function update_public_stream_privacy_option_state($container) {
+export const update_public_stream_privacy_option_state = ($container) => {
     const $public_stream_elem = $container.find(
         `input[value='${CSS.escape(settings_config.stream_privacy_policy_values.public.code)}']`,
     );
     $public_stream_elem.prop("disabled", !settings_data.user_can_create_public_streams());
-}
+};
 
-export function hide_or_disable_stream_privacy_options_if_required($container) {
+export const hide_or_disable_stream_privacy_options_if_required = ($container) => {
     stream_ui_updates.update_web_public_stream_privacy_option_state($container);
 
     update_public_stream_privacy_option_state($container);
 
     stream_ui_updates.update_private_stream_privacy_option_state($container);
-}
+};

--- a/web/src/stream_settings_containers.ts
+++ b/web/src/stream_settings_containers.ts
@@ -3,11 +3,11 @@ import assert from "minimalistic-assert";
 
 import type {StreamSubscription} from "./sub_store";
 
-export function get_edit_container(sub: StreamSubscription): JQuery {
+export const get_edit_container = (sub: StreamSubscription): JQuery => {
     assert(sub !== undefined, "Stream subscription is undefined.");
     return $(
         `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
             sub.stream_id.toString(),
         )}']`,
     );
-}
+};

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -43,11 +43,10 @@ import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
 import * as util from "./util";
 
-export function is_sub_already_present(sub) {
-    return stream_ui_updates.row_for_stream_id(sub.stream_id).length > 0;
-}
+export const is_sub_already_present = (sub) =>
+    stream_ui_updates.row_for_stream_id(sub.stream_id).length > 0;
 
-export function update_left_panel_row(sub) {
+export const update_left_panel_row = (sub) => {
     const $row = stream_ui_updates.row_for_stream_id(sub.stream_id);
 
     if ($row.length === 0) {
@@ -70,9 +69,9 @@ export function update_left_panel_row(sub) {
     }
 
     $row.replaceWith($new_row);
-}
+};
 
-function get_row_data($row) {
+const get_row_data = ($row) => {
     const row_id = Number.parseInt($row.attr("data-stream-id"), 10);
     if (row_id) {
         const row_object = sub_store.get(row_id);
@@ -82,26 +81,24 @@ function get_row_data($row) {
         };
     }
     return undefined;
-}
+};
 
-function selectText(element) {
+const selectText = (element) => {
     const sel = window.getSelection();
     const range = document.createRange();
     range.selectNodeContents(element);
 
     sel.removeAllRanges();
     sel.addRange(range);
-}
+};
 
-function should_list_all_streams() {
-    return !realm.realm_is_zephyr_mirror_realm;
-}
+const should_list_all_streams = () => !realm.realm_is_zephyr_mirror_realm;
 
-export function toggle_pin_to_top_stream(sub) {
+export const toggle_pin_to_top_stream = (sub) => {
     stream_settings_api.set_stream_property(sub, {property: "pin_to_top", value: !sub.pin_to_top});
-}
+};
 
-export function update_stream_name(sub, new_name) {
+export const update_stream_name = (sub, new_name) => {
     // Rename the stream internally.
     stream_data.rename_sub(sub, new_name);
     const stream_id = sub.stream_id;
@@ -126,9 +123,9 @@ export function update_stream_name(sub, new_name) {
 
     // Update navbar if needed
     message_view_header.maybe_rerender_title_area_for_stream(sub);
-}
+};
 
-export function update_stream_description(sub, description, rendered_description) {
+export const update_stream_description = (sub, description, rendered_description) => {
     sub.description = description;
     sub.rendered_description = rendered_description;
     stream_data.clean_up_description(sub);
@@ -142,9 +139,9 @@ export function update_stream_description(sub, description, rendered_description
 
     // Update navbar if needed
     message_view_header.maybe_rerender_title_area_for_stream(sub);
-}
+};
 
-export function update_stream_privacy(slim_sub, values) {
+export const update_stream_privacy = (slim_sub, values) => {
     stream_data.update_stream_privacy(slim_sub, values);
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
 
@@ -167,39 +164,39 @@ export function update_stream_privacy(slim_sub, values) {
 
     // Update navbar if needed
     message_view_header.maybe_rerender_title_area_for_stream(sub);
-}
+};
 
-export function update_stream_post_policy(sub, new_value) {
+export const update_stream_post_policy = (sub, new_value) => {
     stream_data.update_stream_post_policy(sub, new_value);
     stream_ui_updates.update_setting_element(sub, "stream_post_policy");
-}
+};
 
-export function update_message_retention_setting(sub, new_value) {
+export const update_message_retention_setting = (sub, new_value) => {
     stream_data.update_message_retention_setting(sub, new_value);
     stream_ui_updates.update_setting_element(sub, "message_retention_days");
-}
+};
 
-export function update_can_remove_subscribers_group_id(sub, new_value) {
+export const update_can_remove_subscribers_group_id = (sub, new_value) => {
     stream_data.update_can_remove_subscribers_group_id(sub, new_value);
     stream_ui_updates.update_setting_element(sub, "can_remove_subscribers_group");
     stream_edit_subscribers.rerender_subscribers_list(sub);
-}
+};
 
-export function update_is_default_stream() {
+export const update_is_default_stream = () => {
     const active_stream_id = stream_settings_components.get_active_data().id;
     if (active_stream_id) {
         const sub = sub_store.get(active_stream_id);
         stream_ui_updates.update_setting_element(sub, "is_default_stream");
     }
-}
+};
 
-export function update_subscribers_ui(sub) {
+export const update_subscribers_ui = (sub) => {
     update_left_panel_row(sub);
     stream_edit_subscribers.update_subscribers_list(sub);
     message_view_header.maybe_rerender_title_area_for_stream(sub);
-}
+};
 
-export function add_sub_to_table(sub) {
+export const add_sub_to_table = (sub) => {
     if (is_sub_already_present(sub)) {
         // If a stream is already listed/added in subscription modal,
         // display stream in `Subscribed` tab and return.
@@ -255,8 +252,8 @@ export function add_sub_to_table(sub) {
         }
     }
     update_empty_left_panel_message();
-}
-function show_first_stream_created_modal(stream) {
+};
+const show_first_stream_created_modal = (stream) => {
     dialog_widget.launch({
         html_heading: $t_html(
             {defaultMessage: "Channel <b><z-stream></z-stream></b> created!"},
@@ -266,14 +263,14 @@ function show_first_stream_created_modal(stream) {
         ),
         html_body: render_first_stream_created_modal({stream}),
         id: "first_stream_created_modal",
-        on_click() {},
+        on_click: () => {},
         html_submit_button: $t({defaultMessage: "Continue"}),
         close_on_submit: true,
         single_footer_button: true,
     });
-}
+};
 
-export function remove_stream(stream_id) {
+export const remove_stream = (stream_id) => {
     // It is possible that row is empty when we deactivate a
     // stream, but we let jQuery silently handle that.
     const $row = stream_ui_updates.row_for_stream_id(stream_id);
@@ -282,9 +279,9 @@ export function remove_stream(stream_id) {
     if (hash_parser.is_editing_stream(stream_id)) {
         stream_edit.open_edit_panel_empty();
     }
-}
+};
 
-export function update_settings_for_subscribed(slim_sub) {
+export const update_settings_for_subscribed = (slim_sub) => {
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
     stream_ui_updates.update_add_subscriptions_elements(sub);
     $(
@@ -311,18 +308,18 @@ export function update_settings_for_subscribed(slim_sub) {
 
     // Update whether there's any streams shown or not.
     update_empty_left_panel_message();
-}
+};
 
-export function show_active_stream_in_left_panel() {
+export const show_active_stream_in_left_panel = () => {
     const selected_row = hash_parser.get_current_hash_section();
 
     if (Number.parseFloat(selected_row)) {
         const $sub_row = stream_ui_updates.row_for_stream_id(selected_row);
         $sub_row.addClass("active");
     }
-}
+};
 
-export function update_settings_for_unsubscribed(slim_sub) {
+export const update_settings_for_unsubscribed = (slim_sub) => {
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
     update_left_panel_row(sub);
     stream_edit_subscribers.update_subscribers_list(sub);
@@ -345,9 +342,9 @@ export function update_settings_for_unsubscribed(slim_sub) {
     stream_ui_updates.update_permissions_banner(sub);
 
     update_empty_left_panel_message();
-}
+};
 
-function triage_stream(left_panel_params, sub) {
+const triage_stream = (left_panel_params, sub) => {
     if (left_panel_params.show_subscribed && !sub.subscribed) {
         // reject non-subscribed streams
         return "rejected";
@@ -360,14 +357,14 @@ function triage_stream(left_panel_params, sub) {
 
     const search_terms = search_util.get_search_terms(left_panel_params.input);
 
-    function match(attr) {
+    const match = (attr) => {
         const val = sub[attr];
 
         return search_util.vanilla_match({
             val,
             search_terms,
         });
-    }
+    };
 
     if (match("name")) {
         return "name_match";
@@ -378,9 +375,9 @@ function triage_stream(left_panel_params, sub) {
     }
 
     return "rejected";
-}
+};
 
-function get_stream_id_buckets(stream_ids, left_panel_params) {
+const get_stream_id_buckets = (stream_ids, left_panel_params) => {
     // When we simplify the settings UI, we can get
     // rid of the "others" bucket.
 
@@ -407,9 +404,9 @@ function get_stream_id_buckets(stream_ids, left_panel_params) {
     stream_settings_data.sort_for_stream_settings(buckets.desc, left_panel_params.sort_order);
 
     return buckets;
-}
+};
 
-export function render_left_panel_superset() {
+export const render_left_panel_superset = () => {
     // For annoying legacy reasons we render all the subs we are
     // allowed to know about and put them in the DOM, then we do
     // a second pass where we filter/sort them.
@@ -418,9 +415,9 @@ export function render_left_panel_superset() {
     });
 
     scroll_util.get_content_element($("#channels_overlay_container .streams-list")).html(html);
-}
+};
 
-export function update_empty_left_panel_message() {
+export const update_empty_left_panel_message = () => {
     // Check if we have any streams in panel to decide whether to
     // display a notice.
     let has_streams;
@@ -451,17 +448,15 @@ export function update_empty_left_panel_message() {
         $(".all_streams_tab_empty_text").show();
     }
     $(".no-streams-to-show").show();
-}
+};
 
 // LeftPanelParams { input: String, show_subscribed: Boolean, sort_order: String }
-export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
+export const redraw_left_panel = (left_panel_params = get_left_panel_params()) => {
     // We only get left_panel_params passed in from tests.  Real
     // code calls get_left_panel_params().
     show_active_stream_in_left_panel();
 
-    function stream_id_for_row(row) {
-        return Number.parseInt($(row).attr("data-stream-id"), 10);
-    }
+    const stream_id_for_row = (row) => Number.parseInt($(row).attr("data-stream-id"), 10);
 
     const widgets = new Map();
 
@@ -508,11 +503,11 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
 
     // return this for test convenience
     return [...buckets.name, ...buckets.desc];
-}
+};
 
 let sort_order = "by-stream-name";
 
-export function get_left_panel_params() {
+export const get_left_panel_params = () => {
     const $search_box = $("#stream_filter input[type='text']");
     const input = $search_box.expectOne().val().trim();
     const params = {
@@ -522,12 +517,12 @@ export function get_left_panel_params() {
         sort_order,
     };
     return params;
-}
+};
 
 // Make it explicit that our toggler is not created right away.
 export let toggler;
 
-export function switch_stream_tab(tab_name) {
+export const switch_stream_tab = (tab_name) => {
     /*
         This switches the stream tab, but it doesn't update
         the toggler widget.  You may instead want to
@@ -558,9 +553,9 @@ export function switch_stream_tab(tab_name) {
         stream_edit.empty_right_panel();
     }
     stream_edit.setup_subscriptions_tab_hash(tab_name);
-}
+};
 
-export function switch_stream_sort(tab_name) {
+export const switch_stream_sort = (tab_name) => {
     if (
         tab_name === "by-stream-name" ||
         tab_name === "by-subscriber-count" ||
@@ -571,9 +566,9 @@ export function switch_stream_sort(tab_name) {
         sort_order = "by-stream-name";
     }
     redraw_left_panel();
-}
+};
 
-export function setup_page(callback) {
+export const setup_page = (callback) => {
     // We should strongly consider only setting up the page once,
     // but I am writing these comments write before a big release,
     // so it's too risky a change for now.
@@ -587,7 +582,7 @@ export function setup_page(callback) {
     // For now, every time we go back into the widget we'll
     // continue the strategy that we re-render everything from scratch.
     // Also, we'll always go back to the "Subscribed" tab.
-    function initialize_components() {
+    const initialize_components = () => {
         // Sort by name by default when opening "Stream settings".
         sort_order = "by-stream-name";
         const sort_toggler = components.toggle({
@@ -612,7 +607,7 @@ export function setup_page(callback) {
                 },
             ],
             html_class: "stream_sorter_toggle",
-            callback(_value, key) {
+            callback: (_value, key) => {
                 switch_stream_sort(key);
             },
         });
@@ -629,7 +624,7 @@ export function setup_page(callback) {
                 {label: $t({defaultMessage: "Not subscribed"}), key: "not-subscribed"},
                 {label: $t({defaultMessage: "All channels"}), key: "all-streams"},
             ],
-            callback(_value, key) {
+            callback: (_value, key) => {
                 switch_stream_tab(key);
             },
         });
@@ -645,9 +640,9 @@ export function setup_page(callback) {
 
         // show the "Stream settings" header by default.
         $(".display-type #stream_settings_title").show();
-    }
+    };
 
-    function populate_and_fill() {
+    const populate_and_fill = () => {
         $("#channels_overlay_container").empty();
 
         // TODO: Ideally we'd indicate in some way what stream types
@@ -729,16 +724,16 @@ export function setup_page(callback) {
         if (callback) {
             callback();
         }
-    }
+    };
 
     populate_and_fill();
 
     if (!should_list_all_streams()) {
         $(".create_stream_button").val($t({defaultMessage: "Subscribe"}));
     }
-}
+};
 
-export function switch_to_stream_row(stream_id) {
+export const switch_to_stream_row = (stream_id) => {
     const $stream_row = stream_ui_updates.row_for_stream_id(stream_id);
     const $container = $(".streams-list");
 
@@ -748,15 +743,15 @@ export function switch_to_stream_row(stream_id) {
     scroll_util.scroll_element_into_container($stream_row, $container);
 
     stream_edit.open_edit_panel_for_row($stream_row);
-}
+};
 
-function show_right_section() {
+const show_right_section = () => {
     $(".right").addClass("show");
     $(".subscriptions-header").addClass("slide-left");
     resize.resize_stream_subscribers_list();
-}
+};
 
-export function change_state(section, left_side_tab, right_side_tab) {
+export const change_state = (section, left_side_tab, right_side_tab) => {
     // if in #channels/new form.
     if (section === "new") {
         do_open_create_stream();
@@ -801,14 +796,14 @@ export function change_state(section, left_side_tab, right_side_tab) {
 
     toggler.goto("subscribed");
     stream_edit.empty_right_panel();
-}
+};
 
-export function launch(section, left_side_tab, right_side_tab) {
+export const launch = (section, left_side_tab, right_side_tab) => {
     setup_page(() => {
         overlays.open_overlay({
             name: "subscriptions",
             $overlay: $("#subscription_overlay"),
-            on_close() {
+            on_close: () => {
                 browser_history.exit_overlay();
                 $(".colorpicker").spectrum("destroy");
             },
@@ -822,9 +817,9 @@ export function launch(section, left_side_tab, right_side_tab) {
             $("#search_stream_name").trigger("focus");
         }
     }
-}
+};
 
-export function switch_rows(event) {
+export const switch_rows = (event) => {
     const active_data = stream_settings_components.get_active_data();
     const $add_subscriber_pill_input = $(".add_subscribers_container .input");
     let $switch_row;
@@ -863,17 +858,17 @@ export function switch_rows(event) {
         $("#search_stream_name").trigger("focus");
     }
     return true;
-}
+};
 
-export function keyboard_sub() {
+export const keyboard_sub = () => {
     const active_data = stream_settings_components.get_active_data();
     const row_data = get_row_data(active_data.$row);
     if (row_data) {
         stream_settings_components.sub_or_unsub(row_data.object);
     }
-}
+};
 
-export function toggle_view(event) {
+export const toggle_view = (event) => {
     const active_data = stream_settings_components.get_active_data();
     const stream_filter_tab = active_data.$tabs.first().text();
 
@@ -899,9 +894,9 @@ export function toggle_view(event) {
             }
             break;
     }
-}
+};
 
-export function view_stream() {
+export const view_stream = () => {
     const active_data = stream_settings_components.get_active_data();
     const row_data = get_row_data(active_data.$row);
     if (row_data) {
@@ -909,9 +904,9 @@ export function view_stream() {
             "#narrow/stream/" + hash_util.encode_stream_name(row_data.object.name);
         browser_history.go_to_location(stream_narrow_hash);
     }
-}
+};
 
-export function do_open_create_stream() {
+export const do_open_create_stream = () => {
     // Only call this directly for hash changes.
     // Prefer open_create_stream().
 
@@ -925,14 +920,14 @@ export function do_open_create_stream() {
     }
 
     stream_create.new_stream_clicked(stream);
-}
+};
 
-export function open_create_stream() {
+export const open_create_stream = () => {
     do_open_create_stream();
     browser_history.update("#channels/new");
-}
+};
 
-export function update_stream_privacy_choices(policy) {
+export const update_stream_privacy_choices = (policy) => {
     if (!overlays.streams_open()) {
         return;
     }
@@ -956,7 +951,7 @@ export function update_stream_privacy_choices(policy) {
     if (policy === "create_web_public_stream_policy") {
         stream_ui_updates.update_web_public_stream_privacy_option_state($container);
     }
-}
+};
 
 export function initialize() {
     $("#channels_overlay_container").on("click", ".create_stream_button", (e) => {

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -12,7 +12,7 @@ const stream_dict = new Map<number, PerStreamHistory>();
 const fetched_stream_ids = new Set<number>();
 const request_pending_stream_ids = new Set<number>();
 
-export function all_topics_in_cache(sub: StreamSubscription): boolean {
+export const all_topics_in_cache = (sub: StreamSubscription): boolean => {
     // Checks whether this browser's cache of contiguous messages
     // (used to locally render narrows) in all_messages_data has all
     // messages from a given stream, and thus all historical topics
@@ -43,9 +43,9 @@ export function all_topics_in_cache(sub: StreamSubscription): boolean {
     // cache.
     const first_cached_message = all_messages_data.first();
     return first_cached_message!.id <= sub.first_message_id;
-}
+};
 
-export function is_complete_for_stream_id(stream_id: number): boolean {
+export const is_complete_for_stream_id = (stream_id: number): boolean => {
     if (fetched_stream_ids.has(stream_id)) {
         return true;
     }
@@ -65,9 +65,9 @@ export function is_complete_for_stream_id(stream_id: number): boolean {
     }
 
     return in_cache;
-}
+};
 
-export function stream_has_topics(stream_id: number): boolean {
+export const stream_has_topics = (stream_id: number): boolean => {
     if (!stream_dict.has(stream_id)) {
         return false;
     }
@@ -76,7 +76,7 @@ export function stream_has_topics(stream_id: number): boolean {
     assert(history !== undefined);
 
     return history.has_topics();
-}
+};
 
 export type TopicHistoryEntry =
     | {
@@ -246,12 +246,12 @@ export class PerStreamHistory {
     }
 }
 
-export function remove_messages(opts: {
+export const remove_messages = (opts: {
     stream_id: number;
     topic_name: string;
     num_messages: number;
     max_removed_msg_id: number;
-}): void {
+}): void => {
     const stream_id = opts.stream_id;
     const topic_name = opts.topic_name;
     const num_messages = opts.num_messages;
@@ -289,9 +289,9 @@ export function remove_messages(opts: {
     if (history.max_message_id <= max_removed_msg_id) {
         history.max_message_id = message_util.get_max_message_id_in_stream(stream_id);
     }
-}
+};
 
-export function find_or_create(stream_id: number): PerStreamHistory {
+export const find_or_create = (stream_id: number): PerStreamHistory => {
     let history = stream_dict.get(stream_id);
 
     if (!history) {
@@ -300,13 +300,13 @@ export function find_or_create(stream_id: number): PerStreamHistory {
     }
 
     return history;
-}
+};
 
-export function add_message(opts: {
+export const add_message = (opts: {
     stream_id: number;
     message_id: number;
     topic_name: string;
-}): void {
+}): void => {
     const stream_id = opts.stream_id;
     const message_id = opts.message_id;
     const topic_name = opts.topic_name;
@@ -314,45 +314,42 @@ export function add_message(opts: {
     const history = find_or_create(stream_id);
 
     history.add_or_update(topic_name, message_id);
-}
+};
 
-export function add_history(stream_id: number, server_history: ServerTopicHistoryEntry[]): void {
+export const add_history = (stream_id: number, server_history: ServerTopicHistoryEntry[]): void => {
     const history = find_or_create(stream_id);
     history.add_history(server_history);
     fetched_stream_ids.add(stream_id);
-}
+};
 
-export function has_history_for(stream_id: number): boolean {
-    return fetched_stream_ids.has(stream_id);
-}
+export const has_history_for = (stream_id: number): boolean => fetched_stream_ids.has(stream_id);
 
-export function get_recent_topic_names(stream_id: number): string[] {
+export const get_recent_topic_names = (stream_id: number): string[] => {
     const history = find_or_create(stream_id);
 
     return history.get_recent_topic_names();
-}
+};
 
-export function get_max_message_id(stream_id: number): number {
+export const get_max_message_id = (stream_id: number): number => {
     const history = find_or_create(stream_id);
 
     return history.get_max_message_id();
-}
+};
 
-export function reset(): void {
+export const reset = (): void => {
     // This is only used by tests.
     stream_dict.clear();
     fetched_stream_ids.clear();
     request_pending_stream_ids.clear();
-}
+};
 
-export function is_request_pending_for(stream_id: number): boolean {
-    return request_pending_stream_ids.has(stream_id);
-}
+export const is_request_pending_for = (stream_id: number): boolean =>
+    request_pending_stream_ids.has(stream_id);
 
-export function add_request_pending_for(stream_id: number): void {
+export const add_request_pending_for = (stream_id: number): void => {
     request_pending_stream_ids.add(stream_id);
-}
+};
 
-export function remove_request_pending_for(stream_id: number): void {
+export const remove_request_pending_for = (stream_id: number): void => {
     request_pending_stream_ids.delete(stream_id);
-}
+};

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -12,7 +12,7 @@ const stream_topic_history_response_schema = z.object({
     ),
 });
 
-export function get_server_history(stream_id: number, on_success: () => void): void {
+export const get_server_history = (stream_id: number, on_success: () => void): void => {
     if (stream_topic_history.has_history_for(stream_id)) {
         on_success();
         return;
@@ -27,15 +27,15 @@ export function get_server_history(stream_id: number, on_success: () => void): v
     void channel.get({
         url,
         data: {},
-        success(data) {
+        success: (data) => {
             const clean_data = stream_topic_history_response_schema.parse(data);
             const server_history = clean_data.topics;
             stream_topic_history.add_history(stream_id, server_history);
             stream_topic_history.remove_request_pending_for(stream_id);
             on_success();
         },
-        error() {
+        error: () => {
             stream_topic_history.remove_request_pending_for(stream_id);
         },
     });
-}
+};

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -16,42 +16,28 @@ import * as stream_edit_toggler from "./stream_edit_toggler";
 import * as stream_settings_containers from "./stream_settings_containers";
 import * as sub_store from "./sub_store";
 
-export function row_for_stream_id(stream_id) {
-    return $(`.stream-row[data-stream-id='${CSS.escape(stream_id)}']`);
-}
+export const row_for_stream_id = (stream_id) =>
+    $(`.stream-row[data-stream-id='${CSS.escape(stream_id)}']`);
 
-function settings_button_for_sub(sub) {
-    // We don't do expectOne() here, because this button is only
-    // visible if the user has that stream selected in the streams UI.
-    return $(
-        `.stream_settings_header[data-stream-id='${CSS.escape(sub.stream_id)}'] .subscribe-button`,
-    );
-}
+const settings_button_for_sub = (sub) =>
+    $(`.stream_settings_header[data-stream-id='${CSS.escape(sub.stream_id)}'] .subscribe-button`);
 
 export let show_subscribed = true;
 export let show_not_subscribed = false;
 
-export function is_subscribed_stream_tab_active() {
-    // Returns true if "Subscribed" tab in stream settings is open
-    // otherwise false.
-    return show_subscribed;
-}
+export const is_subscribed_stream_tab_active = () => show_subscribed;
 
-export function is_not_subscribed_stream_tab_active() {
-    // Returns true if "not-subscribed" tab in stream settings is open
-    // otherwise false.
-    return show_not_subscribed;
-}
+export const is_not_subscribed_stream_tab_active = () => show_not_subscribed;
 
-export function set_show_subscribed(value) {
+export const set_show_subscribed = (value) => {
     show_subscribed = value;
-}
+};
 
-export function set_show_not_subscribed(value) {
+export const set_show_not_subscribed = (value) => {
     show_not_subscribed = value;
-}
+};
 
-export function update_web_public_stream_privacy_option_state($container) {
+export const update_web_public_stream_privacy_option_state = ($container) => {
     const $web_public_stream_elem = $container.find(
         `input[value='${CSS.escape(
             settings_config.stream_privacy_policy_values.web_public.code,
@@ -98,9 +84,12 @@ export function update_web_public_stream_privacy_option_state($container) {
             !settings_data.user_can_create_web_public_streams(),
         );
     }
-}
+};
 
-export function update_private_stream_privacy_option_state($container, is_default_stream = false) {
+export const update_private_stream_privacy_option_state = (
+    $container,
+    is_default_stream = false,
+) => {
     // Disable both "Private, shared history" and "Private, protected history" options.
     const $private_stream_elem = $container.find(
         `input[value='${CSS.escape(settings_config.stream_privacy_policy_values.private.code)}']`,
@@ -123,14 +112,14 @@ export function update_private_stream_privacy_option_state($container, is_defaul
     $private_with_public_history_elem
         .closest("div")
         .toggleClass("default_stream_private_tooltip", is_default_stream);
-}
+};
 
-export function initialize_cant_subscribe_popover() {
+export const initialize_cant_subscribe_popover = () => {
     const $button_wrapper = $(".settings .stream_settings_header .sub_unsub_button_wrapper");
     settings_components.initialize_disable_btn_hint_popover($button_wrapper);
-}
+};
 
-export function set_up_right_panel_section(sub) {
+export const set_up_right_panel_section = (sub) => {
     if (sub.subscribed) {
         stream_edit_toggler.toggler.enable_tab("personal");
         stream_edit_toggler.toggler.goto(stream_edit_toggler.select_tab);
@@ -146,17 +135,17 @@ export function set_up_right_panel_section(sub) {
         stream_edit_toggler.toggler.disable_tab("personal");
     }
     enable_or_disable_subscribers_tab(sub);
-}
+};
 
-export function update_toggler_for_sub(sub) {
+export const update_toggler_for_sub = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
 
     set_up_right_panel_section(sub);
-}
+};
 
-export function enable_or_disable_subscribers_tab(sub) {
+export const enable_or_disable_subscribers_tab = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
@@ -170,9 +159,9 @@ export function enable_or_disable_subscribers_tab(sub) {
     }
 
     stream_edit_toggler.toggler.enable_tab("subscribers");
-}
+};
 
-export function update_settings_button_for_sub(sub) {
+export const update_settings_button_for_sub = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
@@ -201,9 +190,9 @@ export function update_settings_button_for_sub(sub) {
         $settings_button.prop("disabled", true);
         $settings_button.removeClass("toggle-subscription-tooltip");
     }
-}
+};
 
-export function update_regular_sub_settings(sub) {
+export const update_regular_sub_settings = (sub) => {
     // These are in the right panel.
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
@@ -214,9 +203,9 @@ export function update_regular_sub_settings(sub) {
     } else {
         $settings.find(".stream-email-box").hide();
     }
-}
+};
 
-export function update_default_stream_and_stream_privacy_state($container) {
+export const update_default_stream_and_stream_privacy_state = ($container) => {
     const $default_stream = $container.find(".default-stream");
     const is_stream_creation = $container.attr("id") === "stream-creation";
 
@@ -241,9 +230,9 @@ export function update_default_stream_and_stream_privacy_state($container) {
     // If the default stream option is checked, the private stream options are disabled.
     const is_default_stream = $default_stream.find("input").prop("checked");
     update_private_stream_privacy_option_state($container, is_default_stream);
-}
+};
 
-export function enable_or_disable_permission_settings_in_edit_panel(sub) {
+export const enable_or_disable_permission_settings_in_edit_panel = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
@@ -271,9 +260,9 @@ export function enable_or_disable_permission_settings_in_edit_panel(sub) {
         .prop("disabled", disable_message_retention_setting);
 
     update_web_public_stream_privacy_option_state($("#stream_permission_settings"));
-}
+};
 
-export function update_announce_stream_option() {
+export const update_announce_stream_option = () => {
     if (!hash_parser.is_create_new_stream_narrow()) {
         return;
     }
@@ -291,9 +280,9 @@ export function update_announce_stream_option() {
         new_stream_announcements_stream_sub,
     });
     $("#announce-new-stream").expectOne().html(rendered_announce_stream);
-}
+};
 
-export function update_stream_privacy_icon_in_settings(sub) {
+export const update_stream_privacy_icon_in_settings = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
@@ -309,16 +298,16 @@ export function update_stream_privacy_icon_in_settings(sub) {
             }),
         ),
     );
-}
+};
 
-export function update_permissions_banner(sub) {
+export const update_permissions_banner = (sub) => {
     const $settings = $(`.subscription_settings[data-stream-id='${CSS.escape(sub.stream_id)}']`);
 
     const rendered_tip = render_stream_settings_tip(sub);
     $settings.find(".stream-settings-tip-container").html(rendered_tip);
-}
+};
 
-export function update_notification_setting_checkbox(notification_name) {
+export const update_notification_setting_checkbox = (notification_name) => {
     // This is in the right panel (Personal settings).
     const $stream_row = $("#channels_overlay_container .stream-row.active");
     if (!$stream_row.length) {
@@ -329,9 +318,9 @@ export function update_notification_setting_checkbox(notification_name) {
         "checked",
         stream_data.receives_notifications(stream_id, notification_name),
     );
-}
+};
 
-export function update_stream_row_in_settings_tab(sub) {
+export const update_stream_row_in_settings_tab = (sub) => {
     // This is in the left panel.
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.
@@ -351,9 +340,9 @@ export function update_stream_row_in_settings_tab(sub) {
             $row.addClass("notdisplayed");
         }
     }
-}
+};
 
-export function update_add_subscriptions_elements(sub) {
+export const update_add_subscriptions_elements = (sub) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
@@ -390,22 +379,22 @@ export function update_add_subscriptions_elements(sub) {
             tooltip_message,
         );
     }
-}
+};
 
-export function update_setting_element(sub, setting_name) {
+export const update_setting_element = (sub, setting_name) => {
     if (!hash_parser.is_editing_stream(sub.stream_id)) {
         return;
     }
 
     const $elem = $(`#id_${CSS.escape(setting_name)}`);
     settings_org.discard_stream_property_element_changes($elem, sub);
-}
+};
 
-export function enable_or_disable_add_subscribers_elements(
+export const enable_or_disable_add_subscribers_elements = (
     $container_elem,
     enable_elem,
     stream_creation = false,
-) {
+) => {
     const $input_element = $container_elem.find(".input").expectOne();
     const $add_subscribers_button = $container_elem
         .find('button[name="add_subscriber"]')
@@ -437,4 +426,4 @@ export function enable_or_disable_add_subscribers_elements(
                 .addClass("add_subscribers_disabled");
         }
     }
-}
+};

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -70,11 +70,10 @@ export type StreamSubscription = PartialBy<
 
 const subs_by_stream_id = new Map<number, StreamSubscription>();
 
-export function get(stream_id: number): StreamSubscription | undefined {
-    return subs_by_stream_id.get(stream_id);
-}
+export const get = (stream_id: number): StreamSubscription | undefined =>
+    subs_by_stream_id.get(stream_id);
 
-export function validate_stream_ids(stream_ids: number[]): number[] {
+export const validate_stream_ids = (stream_ids: number[]): number[] => {
     const good_ids = [];
     const bad_ids = [];
 
@@ -91,23 +90,23 @@ export function validate_stream_ids(stream_ids: number[]): number[] {
     }
 
     return good_ids;
-}
+};
 
-export function clear(): void {
+export const clear = (): void => {
     subs_by_stream_id.clear();
-}
+};
 
-export function delete_sub(stream_id: number): void {
+export const delete_sub = (stream_id: number): void => {
     subs_by_stream_id.delete(stream_id);
-}
+};
 
-export function add_hydrated_sub(stream_id: number, sub: StreamSubscription): void {
+export const add_hydrated_sub = (stream_id: number, sub: StreamSubscription): void => {
     // The only code that should call this directly is
     // in stream_data.js. Grep there to find callers.
     subs_by_stream_id.set(stream_id, sub);
-}
+};
 
-export function maybe_get_stream_name(stream_id: number): string | undefined {
+export const maybe_get_stream_name = (stream_id: number): string | undefined => {
     if (!stream_id) {
         return undefined;
     }
@@ -118,4 +117,4 @@ export function maybe_get_stream_name(stream_id: number): string | undefined {
     }
 
     return stream.name;
-}
+};

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -72,7 +72,7 @@ const submessages_event_schema = z
 
 type SubmessageEvents = z.infer<typeof submessages_event_schema>;
 
-export function get_message_events(message: Message): SubmessageEvents | undefined {
+export const get_message_events = (message: Message): SubmessageEvents | undefined => {
     if (message.locally_echoed) {
         return undefined;
     }
@@ -93,18 +93,18 @@ export function get_message_events(message: Message): SubmessageEvents | undefin
     }));
     const clean_events = submessages_event_schema.parse(events);
     return clean_events;
-}
+};
 
-export function process_widget_rows_in_list(list: MessageList | undefined): void {
+export const process_widget_rows_in_list = (list: MessageList | undefined): void => {
     for (const message_id of widgetize.widget_event_handlers.keys()) {
         const $row = list?.get_row(message_id);
         if ($row && $row.length !== 0) {
             process_submessages({message_id, $row});
         }
     }
-}
+};
 
-export function process_submessages(in_opts: {$row: JQuery; message_id: number}): void {
+export const process_submessages = (in_opts: {$row: JQuery; message_id: number}): void => {
     // This happens in our rendering path, so we try to limit any
     // damage that may be triggered by one rogue message.
     try {
@@ -114,9 +114,9 @@ export function process_submessages(in_opts: {$row: JQuery; message_id: number})
         blueslip.error("Failed to do_process_submessages", undefined, error);
         return;
     }
-}
+};
 
-export function do_process_submessages(in_opts: {$row: JQuery; message_id: number}): void {
+export const do_process_submessages = (in_opts: {$row: JQuery; message_id: number}): void => {
     const message_id = in_opts.message_id;
     const message = message_store.get(message_id);
 
@@ -162,9 +162,9 @@ export function do_process_submessages(in_opts: {$row: JQuery; message_id: numbe
         message,
         post_to_server,
     });
-}
+};
 
-export function update_message(submsg: Submessage): void {
+export const update_message = (submsg: Submessage): void => {
     const message = message_store.get(submsg.message_id);
 
     if (message === undefined) {
@@ -187,9 +187,9 @@ export function update_message(submsg: Submessage): void {
     }
 
     message.submessages.push(submsg);
-}
+};
 
-export function handle_event(submsg: Submessage): void {
+export const handle_event = (submsg: Submessage): void => {
     // Update message.submessages in case we haven't actually
     // activated the widget yet, so that when the message does
     // come in view, the data will be complete.
@@ -217,12 +217,11 @@ export function handle_event(submsg: Submessage): void {
         message_id: submsg.message_id,
         data,
     });
-}
+};
 
-export function make_server_callback(
-    message_id: number,
-): (opts: {msg_type: string; data: string}) => void {
-    return function (opts: {msg_type: string; data: string}) {
+export const make_server_callback =
+    (message_id: number): ((opts: {msg_type: string; data: string}) => void) =>
+    (opts: {msg_type: string; data: string}) => {
         const url = "/json/submessage";
 
         void channel.post({
@@ -234,4 +233,3 @@ export function make_server_callback(
             },
         });
     };
-}

--- a/web/src/subscriber_api.ts
+++ b/web/src/subscriber_api.ts
@@ -9,12 +9,12 @@ import type {StreamSubscription} from "./sub_store";
     nor how to JSON.stringify things, nor the URL scheme.
 */
 
-export function add_user_ids_to_stream(
+export const add_user_ids_to_stream = (
     user_ids: number[],
     sub: StreamSubscription,
     success: () => void,
     failure: (xhr: JQuery.jqXHR<unknown>) => void,
-): JQuery.jqXHR<unknown> | undefined {
+): JQuery.jqXHR<unknown> | undefined => {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
     if (user_ids.length === 1 && people.is_my_user_id(Number(user_ids[0]))) {
@@ -36,14 +36,14 @@ export function add_user_ids_to_stream(
         success,
         error: failure,
     });
-}
+};
 
-export function remove_user_id_from_stream(
+export const remove_user_id_from_stream = (
     user_id: number[],
     sub: StreamSubscription,
     success: () => void,
     failure: (xhr: JQuery.jqXHR<unknown>) => void,
-): JQuery.jqXHR<unknown> | undefined {
+): JQuery.jqXHR<unknown> | undefined => {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
     return channel.del({
@@ -52,4 +52,4 @@ export function remove_user_id_from_stream(
         success,
         error: failure,
     });
-}
+};

--- a/web/src/templates.js
+++ b/web/src/templates.js
@@ -17,10 +17,8 @@ import * as util from "./util";
 // other DOM-ready callbacks that attempt to render templates.
 
 Handlebars.registerHelper({
-    eq(a, b) {
-        return a === b;
-    },
-    and(...args) {
+    eq: (a, b) => a === b,
+    and: (...args) => {
         args.pop(); // Handlebars options
         if (args.length === 0) {
             return true;
@@ -33,7 +31,7 @@ Handlebars.registerHelper({
         }
         return last;
     },
-    or(...args) {
+    or: (...args) => {
         args.pop(); // Handlebars options
         if (args.length === 0) {
             return false;
@@ -46,9 +44,7 @@ Handlebars.registerHelper({
         }
         return last;
     },
-    not(a) {
-        return !a || Handlebars.Utils.isEmpty(a);
-    },
+    not: (a) => !a || Handlebars.Utils.isEmpty(a),
 });
 
 Handlebars.registerHelper("t", function (message) {

--- a/web/src/time_zone_util.ts
+++ b/web/src/time_zone_util.ts
@@ -1,6 +1,6 @@
 const parsable_formats = new Map<string, Intl.DateTimeFormat>();
 
-function get_parsable_format(time_zone: string): Intl.DateTimeFormat {
+const get_parsable_format = (time_zone: string): Intl.DateTimeFormat => {
     let format = parsable_formats.get(time_zone);
     if (format === undefined) {
         format = new Intl.DateTimeFormat("en-US", {
@@ -16,10 +16,10 @@ function get_parsable_format(time_zone: string): Intl.DateTimeFormat {
         parsable_formats.set(time_zone, format);
     }
     return format;
-}
+};
 
 /** Get the given time zone's offset in milliseconds at the given date. */
-export function get_offset(date: number | Date, time_zone: string): number {
+export const get_offset = (date: number | Date, time_zone: string): number => {
     const parts = Object.fromEntries(
         get_parsable_format(time_zone)
             .formatToParts(date)
@@ -36,30 +36,31 @@ export function get_offset(date: number | Date, time_zone: string): number {
         ) -
         (Number(date) - (Number(date) % 1000))
     );
-}
+};
 
 /** Get the start of the day for the given date in the given time zone. */
-export function start_of_day(date: number | Date, time_zone: string): Date {
+export const start_of_day = (date: number | Date, time_zone: string): Date => {
     const offset = get_offset(date, time_zone);
     let t = Number(date) + offset;
     t -= t % 86400000;
     return new Date(t - get_offset(new Date(t - offset), time_zone));
-}
+};
 
 /** Get the number of calendar days between the given dates (ignoring times) in
  * the given time zone. */
-export function difference_in_calendar_days(
+export const difference_in_calendar_days = (
     left: number | Date,
     right: number | Date,
     time_zone: string,
-): number {
-    return Math.round(
+): number =>
+    Math.round(
         (start_of_day(left, time_zone).getTime() - start_of_day(right, time_zone).getTime()) /
             86400000,
     );
-}
 
 /** Are the given dates in the same day in the given time zone? */
-export function is_same_day(left: number | Date, right: number | Date, time_zone: string): boolean {
-    return start_of_day(left, time_zone).getTime() === start_of_day(right, time_zone).getTime();
-}
+export const is_same_day = (
+    left: number | Date,
+    right: number | Date,
+    time_zone: string,
+): boolean => start_of_day(left, time_zone).getTime() === start_of_day(right, time_zone).getTime();

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -21,15 +21,15 @@ export let display_time_zone = new Intl.DateTimeFormat().resolvedOptions().timeZ
 
 const formatter_map = new Map<string, Intl.DateTimeFormat>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     next_timerender_id = 0;
-}
+};
 
 // Exported for testing only; we do not support live-updating the time zone.
-export function set_display_time_zone(time_zone: string): void {
+export const set_display_time_zone = (time_zone: string): void => {
     display_time_zone = time_zone;
     formatter_map.clear();
-}
+};
 
 type DateFormat = "weekday" | "dayofyear" | "weekday_dayofyear_year" | "dayofyear_year";
 type DateWithTimeFormat =
@@ -51,10 +51,10 @@ type DateOrTimeFormat = DateFormat | TimeFormat | DateWithTimeFormat;
 // for any formats that display the name for a month/weekday, but
 // possibly in more subtle ways for languages with different
 // punctuation schemes for date and times.
-export function get_format_options_for_type(
+export const get_format_options_for_type = (
     type: DateOrTimeFormat,
     is_twenty_four_hour_time: boolean,
-): Intl.DateTimeFormatOptions {
+): Intl.DateTimeFormatOptions => {
     const time_format_options: Intl.DateTimeFormatOptions = is_twenty_four_hour_time
         ? {hourCycle: "h23", hour: "2-digit", minute: "2-digit"}
         : {
@@ -105,17 +105,17 @@ export function get_format_options_for_type(
         default:
             throw new Error("Wrong format provided.");
     }
-}
+};
 
 // Common function for all date/time rendering in the project. Handles
 // localization using the user's configured locale and the
 // twenty_four_hour_time setting.
 //
 // See get_format_options_for_type for details on the supported formats.
-export function get_localized_date_or_time_for_format(
+export const get_localized_date_or_time_for_format = (
     date: Date | number,
     format: DateOrTimeFormat,
-): string {
+): string => {
     const is_twenty_four_hour_time = user_settings.twenty_four_hour_time;
     const format_key = `${user_settings.default_language}:${is_twenty_four_hour_time}:${format}`;
 
@@ -129,10 +129,10 @@ export function get_localized_date_or_time_for_format(
         );
     }
     return formatter_map.get(format_key)!.format(date);
-}
+};
 
 // Exported for tests only.
-export function get_tz_with_UTC_offset(time: number | Date): string {
+export const get_tz_with_UTC_offset = (time: number | Date): string => {
     let timezone = new Intl.DateTimeFormat(user_settings.default_language, {
         timeZone: display_time_zone,
         timeZoneName: "short",
@@ -158,7 +158,7 @@ export function get_tz_with_UTC_offset(time: number | Date): string {
         return timezone + " " + tz_UTC_offset;
     }
     return tz_UTC_offset;
-}
+};
 
 // Given a Date object 'time', returns an object:
 // {
@@ -174,7 +174,7 @@ export type TimeRender = {
     needs_update: boolean;
 };
 
-export function render_now(time: Date, today = new Date()): TimeRender {
+export const render_now = (time: Date, today = new Date()): TimeRender => {
     let time_str = "";
     let needs_update = false;
     // render formal time to be used for tippy tooltip
@@ -209,10 +209,10 @@ export function render_now(time: Date, today = new Date()): TimeRender {
         formal_time_str,
         needs_update,
     };
-}
+};
 
 // Relative time rendering for use in most screens like Recent conversations.
-export function relative_time_string_from_date(date: Date): string {
+export const relative_time_string_from_date = (date: Date): string => {
     const current_date = new Date();
     const minutes = differenceInMinutes(current_date, date);
     if (minutes <= 2) {
@@ -247,7 +247,7 @@ export function relative_time_string_from_date(date: Date): string {
         return get_localized_date_or_time_for_format(date, "dayofyear");
     }
     return get_localized_date_or_time_for_format(date, "dayofyear_year");
-}
+};
 
 // Relative time logic variant use in the buddy list, where every
 // string has "Active" init. This is hard to deduplicate with
@@ -255,7 +255,7 @@ export function relative_time_string_from_date(date: Date): string {
 // word order.
 //
 // Current date is passed as an argument for unit testing
-export function last_seen_status_from_date(last_active_date: Date): string {
+export const last_seen_status_from_date = (last_active_date: Date): string => {
     const current_date = new Date();
     const minutes = differenceInMinutes(current_date, last_active_date);
     if (minutes < 60) {
@@ -303,7 +303,7 @@ export function last_seen_status_from_date(last_active_date: Date): string {
             ),
         },
     );
-}
+};
 
 // List of the dates that need to be updated when the day changes.
 // Each timestamp is represented as a list of length 2:
@@ -319,7 +319,7 @@ let update_list: UpdateEntry[] = [];
 // Represented as a Date with hour, minute, second, millisecond 0.
 let last_update: Date;
 
-export function initialize(): void {
+export const initialize = (): void => {
     if (
         display_time_zone === undefined || // https://bugs.chromium.org/p/chromium/issues/detail?id=1487920
         display_time_zone === "Etc/Unknown" // https://bugs.chromium.org/p/chromium/issues/detail?id=1473422
@@ -333,18 +333,18 @@ export function initialize(): void {
     }
 
     last_update = start_of_day(new Date(), display_time_zone);
-}
+};
 
-function maybe_add_update_list_entry(entry: UpdateEntry): void {
+const maybe_add_update_list_entry = (entry: UpdateEntry): void => {
     if (entry.needs_update) {
         update_list.push(entry);
     }
-}
+};
 
-function render_date_span($elem: JQuery, rendered_time: TimeRender): JQuery {
+const render_date_span = ($elem: JQuery, rendered_time: TimeRender): JQuery => {
     $elem.text(rendered_time.time_str);
     return $elem.attr("data-tippy-content", rendered_time.formal_time_str);
-}
+};
 
 // Given an Date object 'time', return a DOM node that initially
 // displays the human-formatted date, and is updated automatically as
@@ -353,7 +353,7 @@ function render_date_span($elem: JQuery, rendered_time: TimeRender): JQuery {
 // (What's actually spliced into the message template is the contents
 // of this DOM node as HTML, so effectively a copy of the node. That's
 // okay since to update the time later we look up the node by its id.)
-export function render_date(time: Date): JQuery {
+export const render_date = (time: Date): JQuery => {
     const className = `timerender${next_timerender_id}`;
     next_timerender_id += 1;
     const rendered_time = render_now(time);
@@ -365,25 +365,24 @@ export function render_date(time: Date): JQuery {
         time,
     });
     return $node;
-}
+};
 
 // Renders the timestamp returned by the <time:> Markdown syntax.
-export function format_markdown_time(time: number | Date): string {
-    return get_localized_date_or_time_for_format(time, "weekday_dayofyear_year_time");
-}
+export const format_markdown_time = (time: number | Date): string =>
+    get_localized_date_or_time_for_format(time, "weekday_dayofyear_year_time");
 
-export function get_markdown_time_tooltip(reference: HTMLElement): DocumentFragment | string {
+export const get_markdown_time_tooltip = (reference: HTMLElement): DocumentFragment | string => {
     if (reference instanceof HTMLTimeElement) {
         const time = parseISO(reference.dateTime);
         const tz_offset_str = get_tz_with_UTC_offset(time);
         return parse_html(render_markdown_time_tooltip({tz_offset_str}));
     }
     return "";
-}
+};
 
 // This isn't expected to be called externally except manually for
 // testing purposes.
-export function update_timestamps(): void {
+export const update_timestamps = (): void => {
     const today = start_of_day(new Date(), display_time_zone);
     if (!isEqual(today, last_update)) {
         const to_process = update_list;
@@ -411,23 +410,21 @@ export function update_timestamps(): void {
 
         last_update = today;
     }
-}
+};
 
 setInterval(update_timestamps, 60 * 1000);
 
 // Transform a Unix timestamp into a ISO 8601 formatted date string.
 //   Example: 1978-10-31T13:37:42Z
-export function get_full_time(timestamp: number): string {
-    return formatISO(timestamp * 1000);
-}
+export const get_full_time = (timestamp: number): string => formatISO(timestamp * 1000);
 
-function get_current_time_to_hour(): Date {
+const get_current_time_to_hour = (): Date => {
     const timestamp = new Date();
     timestamp.setMinutes(0, 0);
     return timestamp;
-}
+};
 
-export function get_timestamp_for_flatpickr(timestring?: string): Date {
+export const get_timestamp_for_flatpickr = (timestring?: string): Date => {
     let timestamp;
 
     // timestring is undefined when first opening the picker from the
@@ -447,13 +444,12 @@ export function get_timestamp_for_flatpickr(timestring?: string): Date {
         }
     }
     return timestamp;
-}
+};
 
-export function stringify_time(time: number | Date): string {
-    return get_localized_date_or_time_for_format(time, "time");
-}
+export const stringify_time = (time: number | Date): string =>
+    get_localized_date_or_time_for_format(time, "time");
 
-export function format_time_modern(time: number | Date, today = new Date()): string {
+export const format_time_modern = (time: number | Date, today = new Date()): string => {
     const hours = differenceInHours(today, time);
     const days_old = difference_in_calendar_days(today, time, display_time_zone);
 
@@ -471,11 +467,11 @@ export function format_time_modern(time: number | Date, today = new Date()): str
     }
 
     return get_localized_date_or_time_for_format(time, "dayofyear_year");
-}
+};
 
 // this is for rendering absolute time based off the preferences for twenty-four
 // hour time in the format of "%mmm %d, %h:%m %p".
-export function absolute_time(timestamp: number): string {
+export const absolute_time = (timestamp: number): string => {
     const today = new Date();
     const date = new Date(timestamp);
     const is_older_year = today.getFullYear() - date.getFullYear() > 0;
@@ -484,22 +480,22 @@ export function absolute_time(timestamp: number): string {
         date,
         is_older_year ? "dayofyear_year_time" : "dayofyear_time",
     );
-}
+};
 
 // Pass time_format="time" to not include seconds in the time format.
-export function get_full_datetime(time: Date, time_format: TimeFormat = "time_sec"): string {
+export const get_full_datetime = (time: Date, time_format: TimeFormat = "time_sec"): string => {
     const date_string = get_localized_date_or_time_for_format(time, "dayofyear_year");
     const time_string = get_localized_date_or_time_for_format(time, time_format);
     return $t({defaultMessage: "{date} at {time}"}, {date: date_string, time: time_string});
-}
+};
 
 // Preferred variant for displaying a full datetime to users in
 // contexts like tooltips, where the time was already displayed to the
 // user in a less precise format.
-export function get_full_datetime_clarification(
+export const get_full_datetime_clarification = (
     time: Date,
     time_format: TimeFormat = "time_sec",
-): string {
+): string => {
     const date_string = time.toLocaleDateString(user_settings.default_language, {
         timeZone: display_time_zone,
     });
@@ -510,16 +506,16 @@ export function get_full_datetime_clarification(
     time_string = time_string + " " + tz_offset_str;
 
     return $t({defaultMessage: "{date} at {time}"}, {date: date_string, time: time_string});
-}
+};
 
 type TimeLimitSetting = {
     value: number;
     unit: string;
 };
 
-export function get_time_limit_setting_in_appropriate_unit(
+export const get_time_limit_setting_in_appropriate_unit = (
     time_limit_in_seconds: number,
-): TimeLimitSetting {
+): TimeLimitSetting => {
     const time_limit_in_minutes = Math.floor(time_limit_in_seconds / 60);
     if (time_limit_in_minutes < 60) {
         return {value: time_limit_in_minutes, unit: "minute"};
@@ -532,9 +528,9 @@ export function get_time_limit_setting_in_appropriate_unit(
 
     const time_limit_in_days = Math.floor(time_limit_in_hours / 24);
     return {value: time_limit_in_days, unit: "day"};
-}
+};
 
-export function should_display_profile_incomplete_alert(timestamp: number): boolean {
+export const should_display_profile_incomplete_alert = (timestamp: number): boolean => {
     const today = new Date(Date.now());
     const time = new Date(timestamp);
     const days_old = difference_in_calendar_days(today, time, display_time_zone);
@@ -543,4 +539,4 @@ export function should_display_profile_incomplete_alert(timestamp: number): bool
         return true;
     }
     return false;
-}
+};

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -15,7 +15,7 @@ import {user_settings} from "./user_settings";
 
 // For tooltips without data-tippy-content, we use the HTML content of
 // a <template> whose id is given by data-tooltip-template-id.
-function get_tooltip_content(reference: Element): string | Element | DocumentFragment {
+const get_tooltip_content = (reference: Element): string | Element | DocumentFragment => {
     if (reference instanceof HTMLElement && reference.dataset.tooltipTemplateId !== undefined) {
         const template = document.querySelector<HTMLTemplateElement>(
             `template#${CSS.escape(reference.dataset.tooltipTemplateId)}`,
@@ -27,7 +27,7 @@ function get_tooltip_content(reference: Element): string | Element | DocumentFra
         }
     }
     return "";
-}
+};
 
 // We use different delay settings for tooltips. The default "instant"
 // version has just a tiny bit of delay to create a natural feeling
@@ -162,13 +162,13 @@ export function initialize(): void {
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const $container = $(instance.popper).find(".views-tooltip-container");
             if ($container.data("view-code") === user_settings.web_home_view) {
                 $container.find(".views-tooltip-home-view-note").removeClass("hide");
             }
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
         popperOptions: {
@@ -192,7 +192,7 @@ export function initialize(): void {
         target: ".draft-selection-tooltip",
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             let content = $t({defaultMessage: "Select draft"});
             const $elem = $(instance.reference);
             if ($($elem).parent().find(".draft-selection-checkbox").hasClass("fa-check-square")) {
@@ -205,7 +205,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".delete-selected-drafts-button-container",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             let content = $t({defaultMessage: "Delete all selected drafts"});
             const $elem = $(instance.reference);
             if ($($elem).find(".delete-selected-drafts-button").is(":disabled")) {
@@ -218,7 +218,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: "#add-poll-modal .dialog_submit_button_container",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const content = $t({defaultMessage: "Please enter a question."});
             const $elem = $(instance.reference);
             // Show tooltip to enter question only if submit button is disabled
@@ -264,7 +264,7 @@ export function initialize(): void {
         ].join(","),
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -272,7 +272,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".media-info-wrapper > .media-description > .title",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const title = $(instance.reference).attr("aria-label");
             if (title === undefined) {
                 return false;
@@ -288,7 +288,7 @@ export function initialize(): void {
             instance.setContent($markup[0]!);
             return undefined;
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -321,7 +321,7 @@ export function initialize(): void {
             defaultMessage: "Only 2 custom profile fields can be displayed on the user card.",
         }),
         appendTo: () => document.body,
-        onTrigger(instance) {
+        onTrigger: (instance) => {
             // Sometimes just removing class is not enough to destroy/remove tooltip, especially in
             // "Add a new custom profile field" form, so here we are manually calling `destroy()`.
             if (!instance.reference.classList.contains("display_in_profile_summary_tooltip")) {
@@ -337,7 +337,7 @@ export function initialize(): void {
                 "Name changes are disabled in this organization. Contact an administrator to change your name.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -346,7 +346,7 @@ export function initialize(): void {
         target: "#change_email_button_container.disabled_setting_tooltip",
         content: $t({defaultMessage: "Email address changes are disabled in this organization."}),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -361,7 +361,7 @@ export function initialize(): void {
                 "Because you are the only organization owner, you cannot deactivate your account.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -372,7 +372,7 @@ export function initialize(): void {
             defaultMessage: "Only organization owners may deactivate an organization.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -383,7 +383,7 @@ export function initialize(): void {
             defaultMessage: "Default channels for new users cannot be made private.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -397,7 +397,7 @@ export function initialize(): void {
             defaultMessage: "You can only view channels that you are subscribed to.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -408,7 +408,7 @@ export function initialize(): void {
             defaultMessage: "Private channels cannot be default channels for new users.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -420,7 +420,7 @@ export function initialize(): void {
                 "You do not have permissions to create invite links in this organization.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -434,7 +434,7 @@ export function initialize(): void {
             defaultMessage: "You must configure your email to access this feature.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -446,14 +446,14 @@ export function initialize(): void {
                 "You do not have permissions to send invite emails in this organization.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
 
     tippy.delegate("body", {
         target: ".views-tooltip-target",
-        onShow(instance) {
+        onShow: (instance) => {
             if ($("#toggle-top-left-navigation-area-icon").hasClass("fa-caret-down")) {
                 instance.setContent(
                     $t({
@@ -470,7 +470,7 @@ export function initialize(): void {
 
     tippy.delegate("body", {
         target: ".dm-tooltip-target",
-        onShow(instance) {
+        onShow: (instance) => {
             if ($(".direct-messages-container").hasClass("zoom-in")) {
                 return false;
             }
@@ -497,7 +497,7 @@ export function initialize(): void {
                 "You do not have permission to add other users to channels in this organization.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -505,7 +505,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".user_row .actions button",
         trigger: "mouseenter",
-        onShow(instance) {
+        onShow: (instance) => {
             if ($(instance.reference).hasClass("deactivate")) {
                 instance.setContent($t({defaultMessage: "Deactivate"}));
                 return undefined;
@@ -538,11 +538,11 @@ export function initialize(): void {
             those regions.
         */
 
-        onShow() {
+        onShow: () => {
             popovers.hide_all();
         },
 
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -564,7 +564,7 @@ export function initialize(): void {
 
     tippy.delegate("body", {
         target: "#move_topic_to_stream_widget_wrapper",
-        onShow(instance) {
+        onShow: (instance) => {
             if ($("#move_topic_to_stream_widget").prop("disabled")) {
                 instance.setContent(
                     $t({
@@ -583,7 +583,7 @@ export function initialize(): void {
         target: "#userlist-header",
         placement: "top",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const total_user_count = people.get_active_human_count();
             instance.setContent(
                 ui_util.parse_html(render_buddy_list_title_tooltip({total_user_count})),
@@ -596,7 +596,7 @@ export function initialize(): void {
         delay: LONG_HOVER_DELAY,
         placement: "bottom",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             let template = "show-userlist-tooltip-template";
             if ($("#right-sidebar-container").is(":visible")) {
                 template = "hide-userlist-tooltip-template";
@@ -604,7 +604,7 @@ export function initialize(): void {
             $(instance.reference).attr("data-tooltip-template-id", template);
             instance.setContent(get_tooltip_content(instance.reference));
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -613,7 +613,7 @@ export function initialize(): void {
         target: "#realm-logo",
         placement: "right",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const escape_navigates_to_home_view = user_settings.web_escape_navigates_to_home_view;
             const home_view =
                 settings_config.web_home_view_values[user_settings.web_home_view].description;
@@ -631,7 +631,7 @@ export function initialize(): void {
             defaultMessage: "This profile field is required.",
         }),
         appendTo: () => document.body,
-        onHidden(instance) {
+        onHidden: (instance) => {
             instance.destroy();
         },
     });
@@ -641,7 +641,7 @@ export function initialize(): void {
         trigger: "mouseenter",
         placement: "top",
         appendTo: () => document.body,
-        onShow(instance) {
+        onShow: (instance) => {
             const hotkey_hints = $(instance.reference).attr("data-hotkey-hints");
             if (hotkey_hints) {
                 instance.setContent(hotkey_hints.replace("⇧", "Shift").replaceAll(",", " + "));

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -220,7 +220,7 @@ export class TaskData {
     }
 }
 
-export function activate({$elem, callback, extra_data, message}) {
+export const activate = ({$elem, callback, extra_data, message}) => {
     const parse_result = todo_widget_extra_data_schema.safeParse(extra_data);
     if (!parse_result.success) {
         blueslip.warn("invalid todo extra data", parse_result.error.issues);
@@ -238,12 +238,12 @@ export function activate({$elem, callback, extra_data, message}) {
         report_error_function: blueslip.warn,
     });
 
-    function update_edit_controls() {
+    const update_edit_controls = () => {
         const has_title = $elem.find("input.todo-task-list-title").val().trim() !== "";
         $elem.find("button.todo-task-list-title-check").toggle(has_title);
-    }
+    };
 
-    function render_task_list_title() {
+    const render_task_list_title = () => {
         const task_list_title = task_data.get_task_list_title();
         const input_mode = task_data.get_input_mode();
         const can_edit = is_my_task_list && !input_mode;
@@ -254,23 +254,23 @@ export function activate({$elem, callback, extra_data, message}) {
         update_edit_controls();
 
         $elem.find(".todo-task-list-title-bar").toggle(input_mode);
-    }
+    };
 
-    function start_editing() {
+    const start_editing = () => {
         task_data.set_input_mode();
 
         const task_list_title = task_data.get_task_list_title();
         $elem.find("input.todo-task-list-title").val(task_list_title);
         render_task_list_title();
         $elem.find("input.todo-task-list-title").trigger("focus");
-    }
+    };
 
-    function abort_edit() {
+    const abort_edit = () => {
         task_data.clear_input_mode();
         render_task_list_title();
-    }
+    };
 
-    function submit_task_list_title() {
+    const submit_task_list_title = () => {
         const $task_list_title_input = $elem.find("input.todo-task-list-title");
         let new_task_list_title = $task_list_title_input.val().trim();
         const old_task_list_title = task_data.get_task_list_title();
@@ -293,9 +293,9 @@ export function activate({$elem, callback, extra_data, message}) {
         // Broadcast the new task list title to our peers.
         const data = task_data.handle.new_task_list_title.outbound(new_task_list_title);
         callback(data);
-    }
+    };
 
-    function build_widget() {
+    const build_widget = () => {
         const html = render_widgets_todo_widget();
         $elem.html(html);
 
@@ -355,9 +355,9 @@ export function activate({$elem, callback, extra_data, message}) {
             const data = task_data.handle.new_task.outbound(task, desc);
             callback(data);
         });
-    }
+    };
 
-    function render_results() {
+    const render_results = () => {
         const widget_data = task_data.get_widget_data();
         const html = render_widgets_todo_widget_tasks(widget_data);
         $elem.find("ul.todo-widget").html(html);
@@ -381,9 +381,9 @@ export function activate({$elem, callback, extra_data, message}) {
             const data = task_data.handle.strike.outbound(key);
             callback(data);
         });
-    }
+    };
 
-    const handle_events = function (events) {
+    const handle_events = (events) => {
         for (const event of events) {
             task_data.handle_event(event.sender_id, event.data);
         }
@@ -397,4 +397,4 @@ export function activate({$elem, callback, extra_data, message}) {
     render_results();
 
     return handle_events;
-}
+};

--- a/web/src/topic_generator.ts
+++ b/web/src/topic_generator.ts
@@ -9,13 +9,13 @@ import * as stream_topic_history from "./stream_topic_history";
 import * as unread from "./unread";
 import * as user_topics from "./user_topics";
 
-export function next_topic(
+export const next_topic = (
     streams: string[],
     get_topics: (stream_name: string) => string[],
     has_unread_messages: (stream_name: string, topic: string) => boolean,
     curr_stream: string,
     curr_topic: string,
-): {stream: string; topic: string} | undefined {
+): {stream: string; topic: string} | undefined => {
     const curr_stream_index = streams.indexOf(curr_stream); // -1 if not found
 
     if (curr_stream_index >= 0) {
@@ -57,13 +57,13 @@ export function next_topic(
     }
 
     return undefined;
-}
+};
 
-export function get_next_topic(
+export const get_next_topic = (
     curr_stream: string,
     curr_topic: string,
     only_followed_topics: boolean,
-): {stream: string; topic: string} | undefined {
+): {stream: string; topic: string} | undefined => {
     let my_streams = stream_list_sort.get_streams();
 
     my_streams = my_streams.filter((stream_name) => {
@@ -89,7 +89,7 @@ export function get_next_topic(
         return topics.some((topic) => user_topics.is_topic_unmuted_or_followed(stream_id, topic));
     });
 
-    function get_unmuted_topics(stream_name: string): string[] {
+    const get_unmuted_topics = (stream_name: string): string[] => {
         const stream_id = stream_data.get_stream_id(stream_name);
         const narrowed_steam_id = narrow_state.stream_id();
         assert(stream_id !== undefined);
@@ -116,21 +116,21 @@ export function get_next_topic(
             );
         }
         return topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
-    }
+    };
 
-    function get_followed_topics(stream_name: string): string[] {
+    const get_followed_topics = (stream_name: string): string[] => {
         const stream_id = stream_data.get_stream_id(stream_name);
         assert(stream_id !== undefined);
         let topics = stream_topic_history.get_recent_topic_names(stream_id);
         topics = topics.filter((topic) => user_topics.is_topic_followed(stream_id, topic));
         return topics;
-    }
+    };
 
-    function has_unread_messages(stream_name: string, topic: string): boolean {
+    const has_unread_messages = (stream_name: string, topic: string): boolean => {
         const stream_id = stream_data.get_stream_id(stream_name);
         assert(stream_id !== undefined);
         return unread.topic_has_any_unread(stream_id, topic);
-    }
+    };
 
     if (only_followed_topics) {
         return next_topic(
@@ -143,9 +143,9 @@ export function get_next_topic(
     }
 
     return next_topic(my_streams, get_unmuted_topics, has_unread_messages, curr_stream, curr_topic);
-}
+};
 
-export function get_next_unread_pm_string(curr_pm: string): string | undefined {
+export const get_next_unread_pm_string = (curr_pm: string): string | undefined => {
     const my_pm_strings = pm_conversations.recent.get_strings();
     const curr_pm_index = my_pm_strings.indexOf(curr_pm); // -1 if not found
 
@@ -162,9 +162,9 @@ export function get_next_unread_pm_string(curr_pm: string): string | undefined {
     }
 
     return undefined;
-}
+};
 
-export function get_next_stream(curr_stream: string): string | undefined {
+export const get_next_stream = (curr_stream: string): string | undefined => {
     const my_streams = stream_list_sort.get_streams();
     const curr_stream_index = my_streams.indexOf(curr_stream);
     return my_streams[
@@ -172,10 +172,10 @@ export function get_next_stream(curr_stream: string): string | undefined {
             ? 0
             : curr_stream_index + 1
     ];
-}
+};
 
-export function get_prev_stream(curr_stream: string): string | undefined {
+export const get_prev_stream = (curr_stream: string): string | undefined => {
     const my_streams = stream_list_sort.get_streams();
     const curr_stream_index = my_streams.indexOf(curr_stream);
     return my_streams[curr_stream_index <= 0 ? my_streams.length - 1 : curr_stream_index - 1];
-}
+};

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -28,13 +28,13 @@ const active_widgets = new Map<number, TopicListWidget>();
 // We know whether we're zoomed or not.
 let zoomed = false;
 
-export function update(): void {
+export const update = (): void => {
     for (const widget of active_widgets.values()) {
         widget.build();
     }
-}
+};
 
-export function clear(): void {
+export const clear = (): void => {
     popover_menus.get_topic_menu_popover()?.hide();
 
     for (const widget of active_widgets.values()) {
@@ -42,14 +42,14 @@ export function clear(): void {
     }
 
     active_widgets.clear();
-}
+};
 
-export function close(): void {
+export const close = (): void => {
     zoomed = false;
     clear();
-}
+};
 
-export function zoom_out(): void {
+export const zoom_out = (): void => {
     zoomed = false;
 
     const stream_ids = [...active_widgets.keys()];
@@ -65,7 +65,7 @@ export function zoom_out(): void {
     const parent_widget = widget.get_parent();
 
     rebuild(parent_widget, stream_id);
-}
+};
 
 type ListInfoNodeOptions =
     | {
@@ -82,7 +82,7 @@ type ListInfoNodeOptions =
 
 type ListInfoNode = vdom.Node<ListInfoNodeOptions>;
 
-export function keyed_topic_li(conversation: TopicInfo): ListInfoNode {
+export const keyed_topic_li = (conversation: TopicInfo): ListInfoNode => {
     const render = (): string => render_topic_list_item(conversation);
 
     const eq = (other: ListInfoNode): boolean =>
@@ -97,13 +97,13 @@ export function keyed_topic_li(conversation: TopicInfo): ListInfoNode {
         conversation,
         eq,
     };
-}
+};
 
-export function more_li(
+export const more_li = (
     more_topics_unreads: number,
     more_topics_have_unread_mention_messages: boolean,
     more_topics_unread_count_muted: boolean,
-): ListInfoNode {
+): ListInfoNode => {
     const render = (): string =>
         render_more_topics({
             more_topics_unreads,
@@ -123,9 +123,9 @@ export function more_li(
         render,
         eq,
     };
-}
+};
 
-export function spinner_li(): ListInfoNode {
+export const spinner_li = (): ListInfoNode => {
     const render = (): string => render_more_topics_spinner();
 
     const eq = (other: ListInfoNode): boolean => other.type === "spinner";
@@ -138,7 +138,7 @@ export function spinner_li(): ListInfoNode {
         render,
         eq,
     };
-}
+};
 
 export class TopicListWidget {
     prior_dom: vdom.Tag<ListInfoNodeOptions> | undefined = undefined;
@@ -225,7 +225,7 @@ export class TopicListWidget {
     }
 }
 
-export function clear_topic_search(e: JQuery.Event): void {
+export const clear_topic_search = (e: JQuery.Event): void => {
     e.stopPropagation();
     const $input = $("#filter-topic-input");
     if ($input.length) {
@@ -244,9 +244,9 @@ export function clear_topic_search(e: JQuery.Event): void {
 
         rebuild(parent_widget, stream_id);
     }
-}
+};
 
-export function active_stream_id(): number | undefined {
+export const active_stream_id = (): number | undefined => {
     const stream_ids = [...active_widgets.keys()];
 
     if (stream_ids.length !== 1) {
@@ -254,9 +254,9 @@ export function active_stream_id(): number | undefined {
     }
 
     return stream_ids[0];
-}
+};
 
-export function get_stream_li(): JQuery | undefined {
+export const get_stream_li = (): JQuery | undefined => {
     const widgets = [...active_widgets.values()];
 
     if (widgets.length !== 1 || widgets[0] === undefined) {
@@ -265,9 +265,9 @@ export function get_stream_li(): JQuery | undefined {
 
     const $stream_li = widgets[0].get_parent();
     return $stream_li;
-}
+};
 
-export function rebuild($stream_li: JQuery, stream_id: number): void {
+export const rebuild = ($stream_li: JQuery, stream_id: number): void => {
     const active_widget = active_widgets.get(stream_id);
 
     if (active_widget) {
@@ -280,11 +280,11 @@ export function rebuild($stream_li: JQuery, stream_id: number): void {
     widget.build();
 
     active_widgets.set(stream_id, widget);
-}
+};
 
 // For zooming, we only do topic-list stuff here...let stream_list
 // handle hiding/showing the non-narrowed streams
-export function zoom_in(): void {
+export const zoom_in = (): void => {
     zoomed = true;
 
     const stream_id = active_stream_id();
@@ -296,8 +296,8 @@ export function zoom_in(): void {
     const active_widget = active_widgets.get(stream_id);
     assert(active_widget !== undefined);
 
-    function on_success(): void {
-        if (!active_widgets.has(stream_id!)) {
+    const on_success = (): void => {
+        if (!active_widgets.has(stream_id)) {
             blueslip.warn("User re-narrowed before topic history was returned.");
             return;
         }
@@ -311,8 +311,8 @@ export function zoom_in(): void {
             return;
         }
 
-        active_widget!.build();
-    }
+        active_widget.build();
+    };
 
     scroll_util.get_scroll_element($("#left_sidebar_scroll_container")).scrollTop(0);
 
@@ -320,22 +320,22 @@ export function zoom_in(): void {
     active_widget.build(spinner);
 
     stream_topic_history_util.get_server_history(stream_id, on_success);
-}
+};
 
-export function get_topic_search_term(): string {
+export const get_topic_search_term = (): string => {
     const $filter = $<HTMLInputElement>("input#filter-topic-input");
     const filter_val = $filter.val();
     if (filter_val === undefined) {
         return "";
     }
     return filter_val.trim();
-}
+};
 
-export function initialize({
+export const initialize = ({
     on_topic_click,
 }: {
     on_topic_click: (stream_id: number, topic?: string) => void;
-}): void {
+}): void => {
     $("#stream_filters").on(
         "click",
         ".sidebar-topic-check, .sidebar-topic-name, .topic-markers-and-controls",
@@ -363,4 +363,4 @@ export function initialize({
         assert(stream_id !== undefined);
         active_widgets.get(stream_id)?.build();
     });
-}
+};

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -38,12 +38,12 @@ type TopicChoiceState = {
     items: TopicInfo[];
 };
 
-function choose_topics(
+const choose_topics = (
     stream_id: number,
     topic_names: string[],
     zoomed: boolean,
     topic_choice_state: TopicChoiceState,
-): void {
+): void => {
     for (const [idx, topic_name] of topic_names.entries()) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
@@ -61,7 +61,7 @@ function choose_topics(
         );
 
         if (!zoomed) {
-            function should_show_topic(topics_selected: number): boolean {
+            const should_show_topic = (topics_selected: number): boolean => {
                 // This function exists just for readability, to
                 // avoid long chained conditionals to determine
                 // which topics to include.
@@ -100,7 +100,7 @@ function choose_topics(
                 // unzoomed view.  We might display its unread
                 // count in "show all topics" if it is not muted.
                 return false;
-            }
+            };
 
             const show_topic = should_show_topic(topic_choice_state.topics_selected);
             if (!show_topic) {
@@ -138,7 +138,7 @@ function choose_topics(
 
         topic_choice_state.items.push(topic_info);
     }
-}
+};
 
 type TopicListInfo = {
     items: TopicInfo[];
@@ -148,11 +148,11 @@ type TopicListInfo = {
     more_topics_unread_count_muted: boolean;
 };
 
-export function get_list_info(
+export const get_list_info = (
     stream_id: number,
     zoomed: boolean,
     search_term: string,
-): TopicListInfo {
+): TopicListInfo => {
     const narrowed_topic = narrow_state.topic();
     const topic_choice_state: TopicChoiceState = {
         items: [],
@@ -225,4 +225,4 @@ export function get_list_info(
             topic_choice_state.more_topics_have_muted_unread_mention_messages,
         more_topics_unread_count_muted: false,
     };
-}
+};

--- a/web/src/topic_popover.js
+++ b/web/src/topic_popover.js
@@ -17,13 +17,13 @@ import * as unread_ops from "./unread_ops";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
 
-export function initialize() {
+export const initialize = () => {
     popover_menus.register_popover_menu(
         "#stream_filters .topic-sidebar-menu-icon, .inbox-row .inbox-topic-menu",
         {
             theme: "popover-menu",
             ...popover_menus.left_sidebar_tippy_options,
-            onShow(instance) {
+            onShow: (instance) => {
                 popover_menus.popover_instances.topics_menu = instance;
                 ui_util.show_left_sidebar_menu_icon(instance.reference);
                 popover_menus.on_show_prep(instance);
@@ -55,7 +55,7 @@ export function initialize() {
                     ui_util.parse_html(render_left_sidebar_topic_actions_popover(instance.context)),
                 );
             },
-            onMount(instance) {
+            onMount: (instance) => {
                 const $popper = $(instance.popper);
                 const {stream_id, topic_name} = instance.context;
 
@@ -133,7 +133,7 @@ export function initialize() {
                         html_heading: $t_html({defaultMessage: "Delete topic"}),
                         help_link: "/help/delete-a-topic",
                         html_body,
-                        on_click() {
+                        on_click: () => {
                             message_edit.delete_topic(stream_id, topic_name);
                         },
                     });
@@ -166,11 +166,11 @@ export function initialize() {
                     },
                 );
             },
-            onHidden(instance) {
+            onHidden: (instance) => {
                 instance.destroy();
                 popover_menus.popover_instances.topics_menu = undefined;
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
     );
-}
+};

--- a/web/src/transmit.js
+++ b/web/src/transmit.js
@@ -10,7 +10,7 @@ import * as server_events from "./server_events";
 import {current_user} from "./state_data";
 import * as stream_data from "./stream_data";
 
-export function send_message(request, on_success, error) {
+export const send_message = (request, on_success, error) => {
     if (!request.resend) {
         sent_messages.start_tracking_message({
             local_id: request.local_id,
@@ -24,7 +24,7 @@ export function send_message(request, on_success, error) {
         channel.post({
             url: "/json/messages",
             data: request,
-            success: function success(data) {
+            success: (data) => {
                 // Call back to our callers to do things like closing the compose
                 // box, turning off spinners, reifying locally echoed messages and
                 // displaying visibility policy related compose banners.
@@ -57,7 +57,7 @@ export function send_message(request, on_success, error) {
                     }, 5000);
                 }
             },
-            error(xhr, error_type) {
+            error: (xhr, error_type) => {
                 if (error_type !== "timeout" && reload_state.is_pending()) {
                     // The error might be due to the server changing
                     reload.initiate({
@@ -75,9 +75,9 @@ export function send_message(request, on_success, error) {
     } finally {
         Sentry.getCurrentHub().popScope();
     }
-}
+};
 
-export function reply_message(opts) {
+export const reply_message = (opts) => {
     // This code does an application-triggered reply to a message (as
     // opposed to the user themselves doing it).  Its only use case
     // for now is experimental widget-aware bots, so treat this as
@@ -88,19 +88,19 @@ export function reply_message(opts) {
     const message = opts.message;
     let content = opts.content;
 
-    function success() {
+    const success = () => {
         // TODO: If server response comes back before the message event,
         //       we could show it earlier, although that creates some
         //       complexity.  For now do nothing.  (Note that send_message
         //       already handles things like reporting times to the server.)
-    }
+    };
 
-    function error(_response, _server_error_code) {
+    const error = (_response, _server_error_code) => {
         // TODO: In our current use case, which is widgets, to meaningfully
         //       handle errors, we would want the widget to provide some
         //       kind of callback to us so it can do some appropriate UI.
         //       For now do nothing.
-    }
+    };
 
     const locally_echoed = false;
     const local_id = sent_messages.get_new_local_id();
@@ -144,4 +144,4 @@ export function reply_message(opts) {
     }
 
     blueslip.error("unknown message type", {message, content});
-}
+};

--- a/web/src/tutorial.js
+++ b/web/src/tutorial.js
@@ -2,15 +2,14 @@ import * as channel from "./channel";
 import * as message_view from "./message_view";
 import {page_params} from "./page_params";
 
-function set_tutorial_status(status, callback) {
-    return channel.post({
+const set_tutorial_status = (status, callback) =>
+    channel.post({
         url: "/json/users/me/tutorial_status",
         data: {status},
         success: callback,
     });
-}
 
-export function initialize() {
+export const initialize = () => {
     if (page_params.needs_tutorial) {
         set_tutorial_status("started");
         message_view.show(
@@ -23,4 +22,4 @@ export function initialize() {
             {trigger: "sidebar"},
         );
     }
-}
+};

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -40,12 +40,12 @@ export type CombinedPillItem =
     | InputPillItem<UserGroupPill>
     | InputPillItem<StreamPill>;
 
-export function build_highlight_regex(query: string): RegExp {
+export const build_highlight_regex = (query: string): RegExp => {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");
     return regex;
-}
+};
 
-export function highlight_with_escaping_and_regex(regex: RegExp, item: string): string {
+export const highlight_with_escaping_and_regex = (regex: RegExp, item: string): string => {
     // if regex is empty return entire item highlighted and escaped
     if (regex.source === "()") {
         return "<strong>" + Handlebars.Utils.escapeExpression(item) + "</strong>";
@@ -70,17 +70,15 @@ export function highlight_with_escaping_and_regex(regex: RegExp, item: string): 
     }
 
     return result;
-}
+};
 
-export function make_query_highlighter(query: string): (phrase: string) => string {
+export const make_query_highlighter = (query: string): ((phrase: string) => string) => {
     query = query.toLowerCase();
 
     const regex = build_highlight_regex(query);
 
-    return function (phrase) {
-        return highlight_with_escaping_and_regex(regex, phrase);
-    };
-}
+    return (phrase) => highlight_with_escaping_and_regex(regex, phrase);
+};
 
 type StreamData = {
     invite_only: boolean;
@@ -91,7 +89,7 @@ type StreamData = {
     subscribed: boolean;
 };
 
-export function render_typeahead_item(args: {
+export const render_typeahead_item = (args: {
     primary?: string | undefined;
     is_person?: boolean;
     img_src?: string;
@@ -102,7 +100,7 @@ export function render_typeahead_item(args: {
     stream?: StreamData;
     is_unsubscribed?: boolean;
     emoji_code?: string | undefined;
-}): string {
+}): string => {
     const has_image = args.img_src !== undefined;
     const has_status = args.status_emoji_info !== undefined;
     const has_secondary = args.secondary !== undefined;
@@ -114,9 +112,9 @@ export function render_typeahead_item(args: {
         has_secondary,
         has_pronouns,
     });
-}
+};
 
-export function render_person(person: UserPillData | UserOrMentionPillData): string {
+export const render_person = (person: UserPillData | UserOrMentionPillData): string => {
     if (person.type === "broadcast") {
         return render_typeahead_item({
             primary: person.user.special_item_text,
@@ -148,27 +146,26 @@ export function render_person(person: UserPillData | UserOrMentionPillData): str
     };
 
     return render_typeahead_item(typeahead_arguments);
-}
+};
 
-export function render_user_group(user_group: {name: string; description: string}): string {
-    return render_typeahead_item({
+export const render_user_group = (user_group: {name: string; description: string}): string =>
+    render_typeahead_item({
         primary: user_group.name,
         secondary: user_group.description,
         is_user_group: true,
     });
-}
 
-export function render_person_or_user_group(
+export const render_person_or_user_group = (
     item: UserGroupPillData | UserPillData | UserOrMentionPillData,
-): string {
+): string => {
     if (item.type === "user_group") {
         return render_user_group(item);
     }
 
     return render_person(item);
-}
+};
 
-export function render_stream(stream: StreamData): string {
+export const render_stream = (stream: StreamData): string => {
     let desc = stream.description;
     const short_desc = desc.slice(0, 35);
 
@@ -181,9 +178,9 @@ export function render_stream(stream: StreamData): string {
         stream,
         is_unsubscribed: !stream.subscribed,
     });
-}
+};
 
-export function render_emoji(item: EmojiSuggestion): string {
+export const render_emoji = (item: EmojiSuggestion): string => {
     const args = {
         is_emoji: true,
         primary: item.emoji_name.replaceAll("_", " "),
@@ -199,14 +196,14 @@ export function render_emoji(item: EmojiSuggestion): string {
         ...args,
         emoji_code: item.emoji_code,
     });
-}
+};
 
-export function sorter<T>(query: string, objs: T[], get_item: (x: T) => string): T[] {
+export const sorter = <T>(query: string, objs: T[], get_item: (x: T) => string): T[] => {
     const results = typeahead.triage(query, objs, get_item);
     return [...results.matches, ...results.rest];
-}
+};
 
-export function compare_by_pms(user_a: User, user_b: User): number {
+export const compare_by_pms = (user_a: User, user_b: User): number => {
     const count_a = people.get_recipient_count(user_a);
     const count_b = people.get_recipient_count(user_b);
 
@@ -243,14 +240,14 @@ export function compare_by_pms(user_a: User, user_b: User): number {
         return 0;
     }
     return 1;
-}
+};
 
-export function compare_people_for_relevance(
+export const compare_people_for_relevance = (
     person_a: UserOrMentionPillData | UserPillData,
     person_b: UserOrMentionPillData | UserPillData,
     compare_by_current_conversation?: (user_a: User, user_b: User) => number,
     current_stream_id?: number,
-): number {
+): number => {
     // give preference to "all", "everyone" or "stream"
     if (compose_state.get_message_type() !== "private") {
         if (person_a.type === "broadcast") {
@@ -293,13 +290,13 @@ export function compare_people_for_relevance(
     }
 
     return compare_by_pms(person_a.user, person_b.user);
-}
+};
 
-export function sort_people_for_relevance<UserType extends UserOrMentionPillData | UserPillData>(
+export const sort_people_for_relevance = <UserType extends UserOrMentionPillData | UserPillData>(
     objs: UserType[],
     current_stream_id?: number,
     current_topic?: string,
-): UserType[] {
+): UserType[] => {
     // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
     const current_stream =
         current_stream_id !== undefined ? stream_data.get_sub_by_id(current_stream_id) : undefined;
@@ -325,9 +322,9 @@ export function sort_people_for_relevance<UserType extends UserOrMentionPillData
     }
 
     return objs;
-}
+};
 
-function compare_language_by_popularity(lang_a: string, lang_b: string): number {
+const compare_language_by_popularity = (lang_a: string, lang_b: string): number => {
     const lang_a_data = pygments_data.langs[lang_a];
     const lang_b_data = pygments_data.langs[lang_b];
 
@@ -372,11 +369,11 @@ function compare_language_by_popularity(lang_a: string, lang_b: string): number 
     }
 
     return lang_b_data.priority - lang_a_data.priority;
-}
+};
 
 // This function compares two languages first by their popularity, then if
 // there is a tie on popularity, then compare alphabetically to break the tie.
-export function compare_language(lang_a: string, lang_b: string): number {
+export const compare_language = (lang_a: string, lang_b: string): number => {
     let diff = compare_language_by_popularity(lang_a, lang_b);
 
     // Check to see if there is a tie. If there is, then use alphabetical order
@@ -386,9 +383,9 @@ export function compare_language(lang_a: string, lang_b: string): number {
     }
 
     return diff;
-}
+};
 
-function retain_unique_language_aliases(matches: string[]): string[] {
+const retain_unique_language_aliases = (matches: string[]): string[] => {
     // We make the typeahead a little more nicer but only showing one alias per language.
     // For example if the user searches for prefix "j", then the typeahead list should contain
     // "javascript" only, and not "js" and "javascript".
@@ -404,9 +401,12 @@ function retain_unique_language_aliases(matches: string[]): string[] {
         }
     }
     return unique_aliases;
-}
+};
 
-export function sort_languages(matches: LanguageSuggestion[], query: string): LanguageSuggestion[] {
+export const sort_languages = (
+    matches: LanguageSuggestion[],
+    query: string,
+): LanguageSuggestion[] => {
     const languages = matches.map((object) => object.language);
     const results = typeahead.triage(query, languages, (x) => x, compare_language);
     const unique_languages = retain_unique_language_aliases([...results.matches, ...results.rest]);
@@ -414,9 +414,9 @@ export function sort_languages(matches: LanguageSuggestion[], query: string): La
         language,
         type: "syntax",
     }));
-}
+};
 
-export function sort_recipients<UserType extends UserOrMentionPillData | UserPillData>({
+export const sort_recipients = <UserType extends UserOrMentionPillData | UserPillData>({
     users,
     query,
     current_stream_id,
@@ -430,10 +430,9 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
     current_topic?: string | undefined;
     groups?: UserGroupPillData[];
     max_num_items?: number | undefined;
-}): (UserType | UserGroupPillData)[] {
-    function sort_relevance(items: UserType[]): UserType[] {
-        return sort_people_for_relevance(items, current_stream_id, current_topic);
-    }
+}): (UserType | UserGroupPillData)[] => {
+    const sort_relevance = (items: UserType[]): UserType[] =>
+        sort_people_for_relevance(items, current_stream_id, current_topic);
 
     const users_name_results = typeahead.triage_raw(query, users, (p) => p.user.full_name);
     const users_name_good_matches = [
@@ -512,7 +511,7 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
     const recipients: (UserType | UserGroupPillData)[] = [];
     let stream_wildcard_mention_included = false;
 
-    function add_user_recipients(items: UserType[]): void {
+    const add_user_recipients = (items: UserType[]): void => {
         for (const item of items) {
             if (
                 item.type !== "broadcast" ||
@@ -525,13 +524,13 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
                 }
             }
         }
-    }
+    };
 
-    function add_group_recipients(items: UserGroupPillData[]): void {
+    const add_group_recipients = (items: UserGroupPillData[]): void => {
         for (const item of items) {
             recipients.push(item);
         }
-    }
+    };
 
     for (const getter of getters) {
         /*
@@ -557,16 +556,16 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
     // FirstName, which we don't want to artificially prioritize over the
     // the lone active user whose name is FirstName LastName.
     return recipients.slice(0, max_num_items);
-}
+};
 
 type SlashCommand = {
     name: string;
 };
 
-function slash_command_comparator(
+const slash_command_comparator = (
     slash_command_a: SlashCommand,
     slash_command_b: SlashCommand,
-): number {
+): number => {
     if (slash_command_a.name < slash_command_b.name) {
         return -1;
     } else if (slash_command_a.name > slash_command_b.name) {
@@ -574,20 +573,20 @@ function slash_command_comparator(
     }
     /* istanbul ignore next */
     return 0;
-}
+};
 
-export function sort_slash_commands(
+export const sort_slash_commands = (
     matches: SlashCommandSuggestion[],
     query: string,
-): SlashCommandSuggestion[] {
+): SlashCommandSuggestion[] => {
     // We will likely want to in the future make this sort the
     // just-`/` commands by something approximating usefulness.
     const results = typeahead.triage(query, matches, (x) => x.name, slash_command_comparator);
 
     return [...results.matches, ...results.rest];
-}
+};
 
-function activity_score(sub: StreamSubscription): number {
+const activity_score = (sub: StreamSubscription): number => {
     // We assign the highest score to the stream being composed
     // to, and the lowest score to unsubscribed streams. For others,
     // we prioritise pinned unmuted streams > unpinned unmuted streams
@@ -611,15 +610,15 @@ function activity_score(sub: StreamSubscription): number {
         stream_score += 1;
     }
     return stream_score;
-}
+};
 
 // Sort streams by ranking them by activity. If activity is equal,
 // as defined bv activity_score, decide based on our weekly traffic
 // stats.
-export function compare_by_activity(
+export const compare_by_activity = (
     stream_a: StreamSubscription,
     stream_b: StreamSubscription,
-): number {
+): number => {
     let diff = activity_score(stream_b) - activity_score(stream_a);
     if (diff !== 0) {
         return diff;
@@ -629,9 +628,9 @@ export function compare_by_activity(
         return diff;
     }
     return util.strcmp(stream_a.name, stream_b.name);
-}
+};
 
-export function sort_streams(matches: StreamPillData[], query: string): StreamPillData[] {
+export const sort_streams = (matches: StreamPillData[], query: string): StreamPillData[] => {
     const name_results = typeahead.triage(query, matches, (x) => x.name, compare_by_activity);
     const desc_results = typeahead.triage(
         query,
@@ -641,12 +640,12 @@ export function sort_streams(matches: StreamPillData[], query: string): StreamPi
     );
 
     return [...name_results.matches, ...desc_results.matches, ...desc_results.rest];
-}
+};
 
-export function query_matches_person(
+export const query_matches_person = (
     query: string,
     person: UserPillData | UserOrMentionPillData,
-): boolean {
+): boolean => {
     if (typeahead.query_matches_string_in_order(query, person.user.full_name, " ")) {
         return true;
     }
@@ -658,11 +657,9 @@ export function query_matches_person(
         );
     }
     return false;
-}
+};
 
-export function query_matches_name(
+export const query_matches_name = (
     query: string,
     user_group_or_stream: UserGroupPillData | StreamPillData,
-): boolean {
-    return typeahead.query_matches_string_in_order(query, user_group_or_stream.name, " ");
-}
+): boolean => typeahead.query_matches_string_in_order(query, user_group_or_stream.name, " ");

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -29,35 +29,35 @@ type TypingAPIRequest = {op: "start" | "stop"} & (
 // when we are typing.  For the inbound side see typing_events.ts.
 // See docs/subsystems/typing-indicators.md for more details.
 
-function send_typing_notification_ajax(data: TypingAPIRequest): void {
+const send_typing_notification_ajax = (data: TypingAPIRequest): void => {
     void channel.post({
         url: "/json/typing",
         data,
-        error(xhr) {
+        error: (xhr) => {
             if (xhr.readyState !== 0) {
                 blueslip.warn("Failed to send typing event: " + xhr.responseText);
             }
         },
     });
-}
+};
 
-function send_direct_message_typing_notification(
+const send_direct_message_typing_notification = (
     user_ids_array: number[],
     operation: "start" | "stop",
-): void {
+): void => {
     const data = {
         to: JSON.stringify(user_ids_array),
         type: "direct",
         op: operation,
     };
     send_typing_notification_ajax(data);
-}
+};
 
-function send_stream_typing_notification(
+const send_stream_typing_notification = (
     stream_id: number,
     topic: string,
     operation: "start" | "stop",
-): void {
+): void => {
     const data = {
         type: "stream",
         stream_id: JSON.stringify(stream_id),
@@ -65,50 +65,48 @@ function send_stream_typing_notification(
         op: operation,
     };
     send_typing_notification_ajax(data);
-}
+};
 
-function send_typing_notification_based_on_message_type(
+const send_typing_notification_based_on_message_type = (
     to: Recipient,
     operation: "start" | "stop",
-): void {
+): void => {
     if (to.message_type === "direct" && user_settings.send_private_typing_notifications) {
         send_direct_message_typing_notification(to.ids, operation);
     } else if (to.message_type === "stream" && user_settings.send_stream_typing_notifications) {
         send_stream_typing_notification(to.stream_id, to.topic, operation);
     }
-}
+};
 
-function get_user_ids_array(): number[] | null {
+const get_user_ids_array = (): number[] | null => {
     const user_ids_string = compose_pm_pill.get_user_ids_string();
     if (user_ids_string === "") {
         return null;
     }
 
     return people.user_ids_string_to_ids_array(user_ids_string);
-}
+};
 
-function is_valid_conversation(): boolean {
+const is_valid_conversation = (): boolean => {
     const compose_empty = !compose_state.has_message_content();
     if (compose_empty) {
         return false;
     }
 
     return true;
-}
+};
 
-function get_current_time(): number {
-    return Date.now();
-}
+const get_current_time = (): number => Date.now();
 
-function notify_server_start(to: Recipient): void {
+const notify_server_start = (to: Recipient): void => {
     send_typing_notification_based_on_message_type(to, "start");
-}
+};
 
-function notify_server_stop(to: Recipient): void {
+const notify_server_stop = (to: Recipient): void => {
     send_typing_notification_based_on_message_type(to, "stop");
-}
+};
 
-export function get_recipient(): Recipient | null {
+export const get_recipient = (): Recipient | null => {
     const message_type = compose_state.get_message_type();
     if (message_type === "private") {
         return {
@@ -133,9 +131,9 @@ export function get_recipient(): Recipient | null {
         };
     }
     return null;
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     const worker = {
         get_current_time,
         notify_server_start,
@@ -164,4 +162,4 @@ export function initialize(): void {
             realm.server_typing_stopped_wait_period_milliseconds,
         );
     });
-}
+};

--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -6,30 +6,30 @@ import * as util from "./util";
 const typists_dict = new Map<string, number[]>();
 const inbound_timer_dict = new Map<string, ReturnType<typeof setInterval> | undefined>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     typists_dict.clear();
     inbound_timer_dict.clear();
-}
+};
 
-export function get_direct_message_conversation_key(group: number[]): string {
+export const get_direct_message_conversation_key = (group: number[]): string => {
     const ids = util.sorted_ids(group);
     return "direct:" + ids.join(",");
-}
+};
 
-export function get_topic_key(stream_id: number, topic: string): string {
+export const get_topic_key = (stream_id: number, topic: string): string => {
     topic = topic.toLowerCase(); // Topics are case-insensitive
     return "topic:" + JSON.stringify({stream_id, topic});
-}
+};
 
-export function add_typist(key: string, typist: number): void {
+export const add_typist = (key: string, typist: number): void => {
     const current = typists_dict.get(key) ?? [];
     if (!current.includes(typist)) {
         current.push(typist);
     }
     typists_dict.set(key, util.sorted_ids(current));
-}
+};
 
-export function remove_typist(key: string, typist: number): boolean {
+export const remove_typist = (key: string, typist: number): boolean => {
     let current = typists_dict.get(key) ?? [];
 
     if (!current.includes(typist)) {
@@ -40,15 +40,15 @@ export function remove_typist(key: string, typist: number): boolean {
 
     typists_dict.set(key, current);
     return true;
-}
+};
 
-export function get_group_typists(group: number[]): number[] {
+export const get_group_typists = (group: number[]): number[] => {
     const key = get_direct_message_conversation_key(group);
     const user_ids = typists_dict.get(key) ?? [];
     return muted_users.filter_muted_user_ids(user_ids);
-}
+};
 
-export function get_all_direct_message_typists(): number[] {
+export const get_all_direct_message_typists = (): number[] => {
     let typists: number[] = [];
     for (const [key, value] of typists_dict) {
         if (key.startsWith("direct:")) {
@@ -57,33 +57,33 @@ export function get_all_direct_message_typists(): number[] {
     }
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);
-}
+};
 
-export function get_topic_typists(stream_id: number, topic: string): number[] {
+export const get_topic_typists = (stream_id: number, topic: string): number[] => {
     const typists = typists_dict.get(get_topic_key(stream_id, topic)) ?? [];
     return muted_users.filter_muted_user_ids(typists);
-}
+};
 
-export function clear_typing_data(): void {
+export const clear_typing_data = (): void => {
     for (const [, timer] of inbound_timer_dict.entries()) {
         clearTimeout(timer);
     }
     inbound_timer_dict.clear();
     typists_dict.clear();
-}
+};
 
 // The next functions aren't pure data, but it is easy
 // enough to mock the setTimeout/clearTimeout functions.
-export function clear_inbound_timer(key: string): void {
+export const clear_inbound_timer = (key: string): void => {
     const timer = inbound_timer_dict.get(key);
     if (timer) {
         clearTimeout(timer);
         inbound_timer_dict.set(key, undefined);
     }
-}
+};
 
-export function kickstart_inbound_timer(key: string, delay: number, callback: () => void): void {
+export const kickstart_inbound_timer = (key: string, delay: number, callback: () => void): void => {
     clear_inbound_timer(key);
     const timer = setTimeout(callback, delay);
     inbound_timer_dict.set(key, timer);
-}
+};

--- a/web/src/typing_events.ts
+++ b/web/src/typing_events.ts
@@ -46,7 +46,7 @@ type TypingEvent = {
       }
 );
 
-function get_users_typing_for_narrow(): number[] {
+const get_users_typing_for_narrow = (): number[] => {
     if (narrow_state.narrowed_by_topic_reply()) {
         const current_stream_id = narrow_state.stream_id();
         const current_topic = narrow_state.topic();
@@ -85,9 +85,9 @@ function get_users_typing_for_narrow(): number[] {
     }
     // Get all users typing (in all direct message conversations with current user)
     return typing_data.get_all_direct_message_typists();
-}
+};
 
-export function render_notifications_for_narrow(): void {
+export const render_notifications_for_narrow = (): void => {
     const user_ids = get_users_typing_for_narrow();
     const users_typing = user_ids
         .map((user_id) => people.get_user_by_id_assert_valid(user_id))
@@ -105,9 +105,9 @@ export function render_notifications_for_narrow(): void {
         );
         $("#typing_notifications").show();
     }
-}
+};
 
-function get_key(event: TypingEvent): string {
+const get_key = (event: TypingEvent): string => {
     if (event.message_type === "stream") {
         return typing_data.get_topic_key(event.stream_id, event.topic);
     }
@@ -117,9 +117,9 @@ function get_key(event: TypingEvent): string {
         return typing_data.get_direct_message_conversation_key(recipients);
     }
     throw new Error("Invalid typing notification type", event);
-}
+};
 
-export function hide_notification(event: TypingEvent): void {
+export const hide_notification = (event: TypingEvent): void => {
     const key = get_key(event);
     typing_data.clear_inbound_timer(key);
 
@@ -128,9 +128,9 @@ export function hide_notification(event: TypingEvent): void {
     if (removed) {
         render_notifications_for_narrow();
     }
-}
+};
 
-export function display_notification(event: TypingEvent): void {
+export const display_notification = (event: TypingEvent): void => {
     const sender_id = event.sender.user_id;
 
     const key = get_key(event);
@@ -145,9 +145,9 @@ export function display_notification(event: TypingEvent): void {
             hide_notification(event);
         },
     );
-}
+};
 
-export function disable_typing_notification(): void {
+export const disable_typing_notification = (): void => {
     typing_data.clear_typing_data();
     render_notifications_for_narrow();
-}
+};

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -158,20 +158,20 @@ import * as widgets from "./widgets";
    because we want to reserve space for the email address.  This avoids
    things jumping around slightly when the email address is shown. */
 
-function initialize_bottom_whitespace() {
+const initialize_bottom_whitespace = () => {
     $("#bottom_whitespace").html(render_message_feed_bottom_whitespace());
-}
+};
 
-function initialize_navbar() {
+const initialize_navbar = () => {
     const rendered_navbar = render_navbar({
         embedded: page_params.narrow_stream !== undefined,
         user_avatar: current_user.avatar_url_medium,
     });
 
     $("#header-container").html(rendered_navbar);
-}
+};
 
-function initialize_compose_box() {
+const initialize_compose_box = () => {
     $("#compose-container").append(
         $(
             render_compose({
@@ -186,11 +186,11 @@ function initialize_compose_box() {
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();
     common.adjust_mac_kbd_tags(".open_enter_sends_dialog kbd");
-}
+};
 
-function initialize_message_feed_errors() {
+const initialize_message_feed_errors = () => {
     $("#message_feed_errors_container").html(render_message_feed_errors());
-}
+};
 
 export function initialize_kitchen_sink_stuff() {
     // TODO:
@@ -358,7 +358,7 @@ export function initialize_kitchen_sink_stuff() {
     }
 }
 
-function initialize_unread_ui() {
+const initialize_unread_ui = () => {
     unread_ui.register_update_unread_counts_hook((counts) =>
         activity_ui.update_dom_with_unread_counts(counts),
     );
@@ -378,9 +378,9 @@ function initialize_unread_ui() {
     unread_ui.register_update_unread_counts_hook(inbox_ui.update);
 
     unread_ui.initialize({notify_server_messages_read: unread_ops.notify_server_messages_read});
-}
+};
 
-export function initialize_everything(state_data) {
+export const initialize_everything = (state_data) => {
     /*
         When we initialize our various modules, a lot
         of them will consume data from the server
@@ -459,7 +459,7 @@ export function initialize_everything(state_data) {
               `stream_data` in `state_data` itself
     */
 
-    function pop_fields(...fields) {
+    const pop_fields = (...fields) => {
         const result = {};
 
         for (const field of fields) {
@@ -468,7 +468,7 @@ export function initialize_everything(state_data) {
         }
 
         return result;
-    }
+    };
 
     const alert_words_params = pop_fields("alert_words");
 
@@ -729,13 +729,13 @@ export function initialize_everything(state_data) {
     realm_logo.initialize();
     message_lists.initialize();
     recent_view_ui.initialize({
-        on_click_participant(avatar_element, participant_user_id) {
+        on_click_participant: (avatar_element, participant_user_id) => {
             const user = people.get_by_user_id(participant_user_id);
             user_card_popover.toggle_user_card_popover(avatar_element, user);
         },
         on_mark_pm_as_read: unread_ops.mark_pm_as_read,
         on_mark_topic_as_read: unread_ops.mark_topic_as_read,
-        maybe_load_older_messages(first_unread_message_id) {
+        maybe_load_older_messages: (first_unread_message_id) => {
             recent_view_ui.set_backfill_in_progress(true);
             message_fetch.maybe_load_older_messages({
                 msg_list_data: all_messages_data,
@@ -770,7 +770,7 @@ export function initialize_everything(state_data) {
     stream_settings_ui.initialize();
     left_sidebar_navigation_area.initialize();
     stream_list.initialize({
-        on_stream_click(stream_id, trigger) {
+        on_stream_click: (stream_id, trigger) => {
             const sub = sub_store.get(stream_id);
             sidebar_ui.hide_all();
             popovers.hide_all();
@@ -838,7 +838,7 @@ export function initialize_everything(state_data) {
     audible_notifications.initialize();
     compose_notifications.initialize({
         on_click_scroll_to_selected: message_viewport.scroll_to_selected,
-        on_narrow_to_recipient(message_id) {
+        on_narrow_to_recipient: (message_id) => {
             message_view.narrow_by_topic(message_id, {trigger: "compose_notification"});
         },
     });
@@ -858,7 +858,7 @@ export function initialize_everything(state_data) {
     initialize_unread_ui();
     activity.initialize();
     activity_ui.initialize({
-        narrow_by_email(email) {
+        narrow_by_email: (email) => {
             message_view.show(
                 [
                     {
@@ -884,7 +884,7 @@ export function initialize_everything(state_data) {
     personal_menu_popover.initialize();
     pm_list.initialize();
     topic_list.initialize({
-        on_topic_click(stream_id, topic) {
+        on_topic_click: (stream_id, topic) => {
             const sub = sub_store.get(stream_id);
             message_view.show(
                 [
@@ -907,7 +907,7 @@ export function initialize_everything(state_data) {
     desktop_integration.initialize();
 
     $("#app-loading").addClass("loaded");
-}
+};
 
 $(async () => {
     if (page_params.is_spectator) {
@@ -926,11 +926,11 @@ $(async () => {
         channel.post({
             url: "/json/register",
             data,
-            success(response_data) {
+            success: (response_data) => {
                 const state_data = state_data_schema.parse(response_data);
                 initialize_everything(state_data);
             },
-            error() {
+            error: () => {
                 $("#app-loading-middle-content").hide();
                 $("#app-loading-bottom-content").hide();
                 $(".app").hide();

--- a/web/src/ui_report.ts
+++ b/web/src/ui_report.ts
@@ -11,12 +11,12 @@ import {$t} from "./i18n";
    cls- class that we want to add/remove to/from the status_box
 */
 
-export function message(
+export const message = (
     response_html: string,
     $status_box: JQuery,
     cls = "alert",
     remove_after?: number,
-): void {
+): void => {
     // Note we use html() below, since we can rely on our callers escaping HTML
     // via $t_html when interpolating data.
     $status_box
@@ -31,31 +31,35 @@ export function message(
         }, remove_after);
     }
     $status_box.addClass("show");
-}
+};
 
-export function error(
+export const error = (
     response_html: string,
     xhr: JQuery.jqXHR | undefined,
     status_box: JQuery,
     remove_after?: number,
-): void {
+): void => {
     const msg = xhr ? channel.xhr_error_message(response_html, xhr) : response_html;
     message(msg, status_box, "alert-error", remove_after);
-}
+};
 
-export function client_error(
+export const client_error = (
     response_html: string,
     status_box: JQuery,
     remove_after?: number,
-): void {
+): void => {
     message(response_html, status_box, "alert-error", remove_after);
-}
+};
 
-export function success(response_html: string, $status_box: JQuery, remove_after?: number): void {
+export const success = (
+    response_html: string,
+    $status_box: JQuery,
+    remove_after?: number,
+): void => {
     message(response_html, $status_box, "alert-success", remove_after);
-}
+};
 
-export function generic_embed_error(error_html: string, remove_after?: number): void {
+export const generic_embed_error = (error_html: string, remove_after?: number): void => {
     const $alert = $("<div>").addClass(["alert", "home-error-bar", "show"]);
     const $exit = $("<div>").addClass("exit");
 
@@ -66,9 +70,9 @@ export function generic_embed_error(error_html: string, remove_after?: number): 
             $alert.fadeOut(400);
         }, remove_after);
     }
-}
+};
 
-export function generic_row_button_error(xhr: JQuery.jqXHR, $btn: JQuery): void {
+export const generic_row_button_error = (xhr: JQuery.jqXHR, $btn: JQuery): void => {
     let parsed;
     if (
         xhr.status >= 400 &&
@@ -80,24 +84,24 @@ export function generic_row_button_error(xhr: JQuery.jqXHR, $btn: JQuery): void 
     } else {
         $btn.text($t({defaultMessage: "Failed!"}));
     }
-}
+};
 
-export function hide_error($target: JQuery): void {
+export const hide_error = ($target: JQuery): void => {
     $target.addClass("fade-out");
     setTimeout(() => {
         $target.removeClass("show fade-out");
     }, 300);
-}
+};
 
-export function show_error($target: JQuery): void {
+export const show_error = ($target: JQuery): void => {
     $target.addClass("show");
-}
+};
 
-export function loading(
+export const loading = (
     response_html: string,
     $status_box: JQuery,
     successfully_loaded = false,
-): void {
+): void => {
     $status_box.find(".alert-content").html(response_html);
     if (!successfully_loaded) {
         $status_box.removeClass(common.status_classes).addClass("alert-loading").stop(true);
@@ -109,4 +113,4 @@ export function loading(
     }
 
     $status_box.addClass("show");
-}
+};

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -8,7 +8,7 @@ import * as keydown_util from "./keydown_util";
 // dependencies other than jQuery.
 
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
-export function place_caret_at_end(el: HTMLElement): void {
+export const place_caret_at_end = (el: HTMLElement): void => {
     el.focus();
     if (el instanceof HTMLInputElement) {
         el.setSelectionRange(el.value.length, el.value.length);
@@ -20,7 +20,7 @@ export function place_caret_at_end(el: HTMLElement): void {
         sel?.removeAllRanges();
         sel?.addRange(range);
     }
-}
+};
 
 export function replace_emoji_with_text($element: JQuery): void {
     $element
@@ -49,7 +49,7 @@ export function change_katex_to_raw_latex($element: JQuery): void {
     });
 }
 
-export function is_user_said_paragraph($element: JQuery): boolean {
+export const is_user_said_paragraph = ($element: JQuery): boolean => {
     // Irrespective of language, the user said paragraph has these exact elements:
     // 1. A user mention
     // 2. A same server message link ("said")
@@ -70,15 +70,14 @@ export function is_user_said_paragraph($element: JQuery): boolean {
         .replace($user_mention.text(), "")
         .replace($message_link.text(), "");
     return remaining_text.trim() === ":";
-}
+};
 
-export function get_collapsible_status_array($elements: JQuery): boolean[] {
-    return [...$elements].map(
+export const get_collapsible_status_array = ($elements: JQuery): boolean[] =>
+    [...$elements].map(
         (element) => $(element).is("blockquote") || is_user_said_paragraph($(element)),
     );
-}
 
-export function potentially_collapse_quotes($element: JQuery): boolean {
+export const potentially_collapse_quotes = ($element: JQuery): boolean => {
     const $children = $element.children();
     const collapsible_status = get_collapsible_status_array($children);
 
@@ -101,24 +100,24 @@ export function potentially_collapse_quotes($element: JQuery): boolean {
         }
     }
     return true;
-}
+};
 
-export function blur_active_element(): void {
+export const blur_active_element = (): void => {
     // this blurs anything that may perhaps be actively focused on.
     if (document.activeElement instanceof HTMLElement) {
         document.activeElement.blur();
     }
-}
+};
 
-export function convert_enter_to_click(e: JQuery.KeyDownEvent): void {
+export const convert_enter_to_click = (e: JQuery.KeyDownEvent): void => {
     if (keydown_util.is_enter_event(e)) {
         e.preventDefault();
         e.stopPropagation();
         $(e.currentTarget).trigger("click");
     }
-}
+};
 
-export function update_unread_count_in_dom($unread_count_elem: JQuery, count: number): void {
+export const update_unread_count_in_dom = ($unread_count_elem: JQuery, count: number): void => {
     // This function is used to update unread count in top left corner
     // elements.
     const $unread_count_span = $unread_count_elem.find(".unread_count");
@@ -131,12 +130,12 @@ export function update_unread_count_in_dom($unread_count_elem: JQuery, count: nu
 
     $unread_count_span.removeClass("hide");
     $unread_count_span.text(count);
-}
+};
 
-export function update_unread_mention_info_in_dom(
+export const update_unread_mention_info_in_dom = (
     $unread_mention_info_elem: JQuery,
     stream_has_any_unread_mention_messages: boolean,
-): void {
+): void => {
     const $unread_mention_info_span = $unread_mention_info_elem.find(".unread_mention_info");
     if (!stream_has_any_unread_mention_messages) {
         $unread_mention_info_span.hide();
@@ -146,7 +145,7 @@ export function update_unread_mention_info_in_dom(
 
     $unread_mention_info_span.show();
     $unread_mention_info_span.text("@");
-}
+};
 
 /**
  * Parse HTML and return a DocumentFragment.
@@ -156,11 +155,11 @@ export function update_unread_mention_info_in_dom(
  * templates; violating this expectation will introduce bugs that are
  * likely to be security vulnerabilities.
  */
-export function parse_html(html: string): DocumentFragment {
+export const parse_html = (html: string): DocumentFragment => {
     const template = document.createElement("template");
     template.innerHTML = html;
     return template.content;
-}
+};
 
 /*
  * Handle permission denied to play audio by the browser.
@@ -169,7 +168,7 @@ export function parse_html(html: string): DocumentFragment {
  * any interactive trigger like a button. See
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play for more details.
  */
-export async function play_audio(elem: HTMLVideoElement): Promise<void> {
+export const play_audio = async (elem: HTMLVideoElement): Promise<void> => {
     try {
         await elem.play();
     } catch (error) {
@@ -178,9 +177,9 @@ export async function play_audio(elem: HTMLVideoElement): Promise<void> {
         }
         blueslip.debug(`Unable to play audio. ${error.name}: ${error.message}`);
     }
-}
+};
 
-export function listener_for_preferred_color_scheme_change(callback: () => void): void {
+export const listener_for_preferred_color_scheme_change = (callback: () => void): void => {
     const media_query_list = window.matchMedia("(prefers-color-scheme: dark)");
     // MediaQueryList.addEventListener is missing in Safari < 14
     const listener = (): void => {
@@ -193,14 +192,14 @@ export function listener_for_preferred_color_scheme_change(callback: () => void)
     } else {
         media_query_list.addListener(listener);
     }
-}
+};
 
 // Keep the menu icon over which the popover is based off visible.
-export function show_left_sidebar_menu_icon(element: HTMLElement): void {
+export const show_left_sidebar_menu_icon = (element: HTMLElement): void => {
     $(element).closest(".sidebar-menu-icon").addClass("left_sidebar_menu_icon_visible");
-}
+};
 
 // Remove the class from element when popover is closed
-export function hide_left_sidebar_menu_icon(): void {
+export const hide_left_sidebar_menu_icon = (): void => {
     $(".left_sidebar_menu_icon_visible").removeClass("left_sidebar_menu_icon_visible");
-}
+};

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -30,9 +30,9 @@ export let old_unreads_missing = false;
 // it is simpler and we as a client are not expected to.
 export let first_unread_unmuted_message_id = Number.POSITIVE_INFINITY;
 
-export function clear_old_unreads_missing(): void {
+export const clear_old_unreads_missing = (): void => {
     old_unreads_missing = false;
-}
+};
 
 export const unread_mentions_counter = new Set<number>();
 export const direct_message_with_mention_count = new Set();
@@ -597,7 +597,7 @@ class UnreadTopicCounter {
 }
 const unread_topic_counter = new UnreadTopicCounter();
 
-function add_message_to_unread_mention_topics(message_id: number): void {
+const add_message_to_unread_mention_topics = (message_id: number): void => {
     const message = message_store.get(message_id);
     if (message?.type !== "stream") {
         return;
@@ -609,9 +609,9 @@ function add_message_to_unread_mention_topics(message_id: number): void {
     } else {
         unread_mention_topics.set(topic_key, new Set([message_id]));
     }
-}
+};
 
-function remove_message_from_unread_mention_topics(message_id: number): void {
+const remove_message_from_unread_mention_topics = (message_id: number): void => {
     const stream_topic = unread_topic_counter.reverse_lookup.get(message_id);
     if (!stream_topic) {
         // Direct messages and messages that were already not unread
@@ -621,9 +621,9 @@ function remove_message_from_unread_mention_topics(message_id: number): void {
     const {stream_id, topic} = stream_topic;
     const topic_key = recent_view_util.get_topic_key(stream_id, topic);
     unread_mention_topics.get(topic_key)?.delete(message_id);
-}
+};
 
-export function clear_and_populate_unread_mention_topics(): void {
+export const clear_and_populate_unread_mention_topics = (): void => {
     // The unread_mention_topics is an important data structure for
     // efficiently querying whether a given stream/topic pair contains
     // unread mentions.
@@ -655,35 +655,30 @@ export function clear_and_populate_unread_mention_topics(): void {
             unread_mention_topics.set(topic_key, new Set([message_id]));
         }
     }
-}
+};
 
-export function message_unread(message: Message): boolean {
+export const message_unread = (message: Message): boolean => {
     if (message === undefined) {
         return false;
     }
     return message.unread;
-}
+};
 
-export function get_read_message_ids(message_ids: number[]): number[] {
-    return message_ids.filter((message_id) => !unread_messages.has(message_id));
-}
+export const get_read_message_ids = (message_ids: number[]): number[] =>
+    message_ids.filter((message_id) => !unread_messages.has(message_id));
 
-export function get_unread_message_ids(message_ids: number[]): number[] {
-    return message_ids.filter((message_id) => unread_messages.has(message_id));
-}
+export const get_unread_message_ids = (message_ids: number[]): number[] =>
+    message_ids.filter((message_id) => unread_messages.has(message_id));
 
-export function get_unread_messages(messages: Message[]): Message[] {
-    return messages.filter((message) => unread_messages.has(message.id));
-}
+export const get_unread_messages = (messages: Message[]): Message[] =>
+    messages.filter((message) => unread_messages.has(message.id));
 
-export function get_unread_message_count(): number {
-    return unread_messages.size;
-}
+export const get_unread_message_count = (): number => unread_messages.size;
 
-export function update_unread_topics(
+export const update_unread_topics = (
     msg: Message & {type: "stream"},
     event: UpdateMessageEvent,
-): void {
+): void => {
     const new_topic = util.get_edit_event_topic(event);
     const {new_stream_id} = event;
 
@@ -702,12 +697,12 @@ export function update_unread_topics(
         stream_id: new_stream_id ?? msg.stream_id,
         topic: new_topic ?? msg.topic,
     });
-}
+};
 
-export function process_loaded_messages(
+export const process_loaded_messages = (
     messages: Message[],
     expect_no_new_unreads = false,
-): boolean {
+): boolean => {
     // Process a set of messages that we have full copies of from the
     // server for whether any are unread but not tracked as such by
     // our data structures. This can occur due to old_unreads_missing,
@@ -758,7 +753,7 @@ export function process_loaded_messages(
     }
 
     return any_untracked_unread_messages;
-}
+};
 
 type UnreadMessageData = {
     id: number;
@@ -777,7 +772,7 @@ type UnreadMessageData = {
       }
 );
 
-export function process_unread_message(message: UnreadMessageData): void {
+export const process_unread_message = (message: UnreadMessageData): void => {
     // The `message` here just needs to require certain fields. For example,
     // the "message" may actually be constructed from a Zulip event that doesn't
     // include fields like "content".  The caller must verify that the message
@@ -800,12 +795,12 @@ export function process_unread_message(message: UnreadMessageData): void {
     }
 
     update_message_for_mention(message);
-}
+};
 
-export function update_message_for_mention(
+export const update_message_for_mention = (
     message: UnreadMessageData,
     content_edited = false,
-): boolean {
+): boolean => {
     // Returns true if this is a stream message whose content was
     // changed, and thus the caller might need to trigger a rerender
     // of UI elements displaying whether the message's topic contains
@@ -845,9 +840,9 @@ export function update_message_for_mention(
         return true;
     }
     return false;
-}
+};
 
-export function mark_as_read(message_id: number): void {
+export const mark_as_read = (message_id: number): void => {
     // We don't need to check anything about the message, since all
     // the following methods are cheap and work fine even if message_id
     // was never set to unread.
@@ -866,9 +861,9 @@ export function mark_as_read(message_id: number): void {
     if (message) {
         message.unread = false;
     }
-}
+};
 
-export function declare_bankruptcy(): void {
+export const declare_bankruptcy = (): void => {
     // Only used in tests.
     unread_direct_message_counter.clear();
     unread_topic_counter.clear();
@@ -876,15 +871,13 @@ export function declare_bankruptcy(): void {
     direct_message_with_mention_count.clear();
     unread_messages.clear();
     unread_mention_topics.clear();
-}
+};
 
-export function get_unread_pm(): DirectMessageCountInfoWithLatestMsgId {
-    return unread_direct_message_counter.get_counts_with_latest_msg_id();
-}
+export const get_unread_pm = (): DirectMessageCountInfoWithLatestMsgId =>
+    unread_direct_message_counter.get_counts_with_latest_msg_id();
 
-export function get_unread_topics(): UnreadTopicCounts {
-    return unread_topic_counter.get_counts_per_topic();
-}
+export const get_unread_topics = (): UnreadTopicCounts =>
+    unread_topic_counter.get_counts_per_topic();
 
 export type FullUnreadCountsData = {
     direct_message_count: number;
@@ -903,7 +896,7 @@ export type FullUnreadCountsData = {
 // Return a data structure with various counts.  This function should be
 // pretty cheap, even if you don't care about all the counts, and you
 // should strive to keep it free of side effects on globals or DOM.
-export function get_counts(): FullUnreadCountsData {
+export const get_counts = (): FullUnreadCountsData => {
     const update_first_unmuted_message_id = true;
     // Reset the first_unread_unmuted_message_id, to ensure it is always capture the
     // minimum of current unread messages between topics and DMs.
@@ -927,10 +920,10 @@ export function get_counts(): FullUnreadCountsData {
         pm_count: pm_res.pm_dict,
         home_unread_messages: topic_res.stream_unread_messages + pm_res.total_count,
     };
-}
+};
 
 // Saves us from calling to get_counts() when we can avoid it.
-export function calculate_notifiable_count(res: FullUnreadCountsData): number {
+export const calculate_notifiable_count = (res: FullUnreadCountsData): number => {
     let new_message_count = 0;
 
     const only_show_dm_mention =
@@ -968,96 +961,78 @@ export function calculate_notifiable_count(res: FullUnreadCountsData): number {
         new_message_count = res.home_unread_messages;
     }
     return new_message_count;
-}
+};
 
-export function get_notifiable_count(): number {
+export const get_notifiable_count = (): number => {
     const res = get_counts();
     return calculate_notifiable_count(res);
-}
+};
 
-export function unread_count_info_for_stream(stream_id: number): StreamCountInfo {
-    return unread_topic_counter.get_stream_count_info(stream_id);
-}
+export const unread_count_info_for_stream = (stream_id: number): StreamCountInfo =>
+    unread_topic_counter.get_stream_count_info(stream_id);
 
-export function num_unread_for_topic(stream_id: number, topic_name: string): number {
-    return unread_topic_counter.get(stream_id, topic_name);
-}
+export const num_unread_for_topic = (stream_id: number, topic_name: string): number =>
+    unread_topic_counter.get(stream_id, topic_name);
 
-export function stream_has_any_unread_mentions(stream_id: number): boolean {
+export const stream_has_any_unread_mentions = (stream_id: number): boolean => {
     // This function is somewhat inefficient and thus should not be
     // called in loops, since runs in O(total unread mentions) time.
     const streams_with_mentions = unread_topic_counter.get_streams_with_unread_mentions();
     return streams_with_mentions.has(stream_id);
-}
+};
 
-export function stream_has_any_unmuted_mentions(stream_id: number): boolean {
+export const stream_has_any_unmuted_mentions = (stream_id: number): boolean => {
     // This function is somewhat inefficient and thus should not be
     // called in loops, since runs in O(total unread mentions) time.
     const streams_with_mentions = unread_topic_counter.get_streams_with_unmuted_mentions();
     return streams_with_mentions.has(stream_id);
-}
+};
 
-export function topic_has_any_unread_mentions(stream_id: number, topic: string): boolean {
+export const topic_has_any_unread_mentions = (stream_id: number, topic: string): boolean => {
     // Because this function is called in a loop for every displayed
     // Recent Conversations row, it's important for it to run in O(1) time.
     const topic_key = stream_id + ":" + topic.toLowerCase();
     return (unread_mention_topics.get(topic_key)?.size ?? 0) > 0;
-}
+};
 
-export function topic_has_any_unread(stream_id: number, topic: string): boolean {
-    return unread_topic_counter.topic_has_any_unread(stream_id, topic);
-}
+export const topic_has_any_unread = (stream_id: number, topic: string): boolean =>
+    unread_topic_counter.topic_has_any_unread(stream_id, topic);
 
-export function get_topics_with_unread_mentions(stream_id: number): Set<string> {
-    return unread_topic_counter.get_topics_with_unread_mentions(stream_id);
-}
+export const get_topics_with_unread_mentions = (stream_id: number): Set<string> =>
+    unread_topic_counter.get_topics_with_unread_mentions(stream_id);
 
-export function num_unread_for_user_ids_string(user_ids_string: string): number {
-    return unread_direct_message_counter.num_unread(user_ids_string);
-}
+export const num_unread_for_user_ids_string = (user_ids_string: string): number =>
+    unread_direct_message_counter.num_unread(user_ids_string);
 
-export function get_msg_ids_for_stream(stream_id: number): number[] {
-    return unread_topic_counter.get_msg_ids_for_stream(stream_id);
-}
+export const get_msg_ids_for_stream = (stream_id: number): number[] =>
+    unread_topic_counter.get_msg_ids_for_stream(stream_id);
 
-export function get_msg_ids_for_topic(stream_id: number, topic_name: string): number[] {
-    return unread_topic_counter.get_msg_ids_for_topic(stream_id, topic_name);
-}
+export const get_msg_ids_for_topic = (stream_id: number, topic_name: string): number[] =>
+    unread_topic_counter.get_msg_ids_for_topic(stream_id, topic_name);
 
-export function get_msg_ids_for_user_ids_string(user_ids_string: string): number[] {
-    return unread_direct_message_counter.get_msg_ids_for_user_ids_string(user_ids_string);
-}
+export const get_msg_ids_for_user_ids_string = (user_ids_string: string): number[] =>
+    unread_direct_message_counter.get_msg_ids_for_user_ids_string(user_ids_string);
 
-export function get_msg_ids_for_private(): number[] {
-    return unread_direct_message_counter.get_msg_ids();
-}
+export const get_msg_ids_for_private = (): number[] => unread_direct_message_counter.get_msg_ids();
 
-export function get_msg_ids_for_mentions(): number[] {
+export const get_msg_ids_for_mentions = (): number[] => {
     const ids = [...unread_mentions_counter];
 
     return util.sorted_ids(ids);
-}
+};
 
-export function get_all_msg_ids(): number[] {
+export const get_all_msg_ids = (): number[] => {
     const ids = [...unread_messages];
 
     return util.sorted_ids(ids);
-}
+};
 
-export function get_missing_topics(opts: {
+export const get_missing_topics = (opts: {
     stream_id: number;
     topic_dict: FoldDict<TopicHistoryEntry>;
-}): {pretty_name: string; message_id: number}[] {
-    return unread_topic_counter.get_missing_topics(opts);
-}
+}): {pretty_name: string; message_id: number}[] => unread_topic_counter.get_missing_topics(opts);
 
-export function get_msg_ids_for_starred(): number[] {
-    // This is here for API consistency sake--we never
-    // have unread starred messages.  (Some day we may ironically
-    // want to make starring the same as mark-as-unread, but
-    // for now starring === reading.)
-    return [];
-}
+export const get_msg_ids_for_starred = (): number[] => [];
 
 type UnreadStreamInfo = {
     stream_id: number;
@@ -1088,7 +1063,7 @@ type UnreadMessagesParams = {
     };
 };
 
-export function initialize(params: UnreadMessagesParams): void {
+export const initialize = (params: UnreadMessagesParams): void => {
     const unread_msgs = params.unread_msgs;
 
     old_unreads_missing = unread_msgs.old_unreads_missing;
@@ -1124,4 +1099,4 @@ export function initialize(params: UnreadMessagesParams): void {
     for (const message_id of unread_msgs.mentions) {
         unread_messages.add(message_id);
     }
-}
+};

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -19,11 +19,11 @@ let user_closed_unread_banner = false;
 type UpdateUnreadCountsHook = (counts: FullUnreadCountsData, skip_animations: boolean) => void;
 const update_unread_counts_hooks: UpdateUnreadCountsHook[] = [];
 
-export function register_update_unread_counts_hook(f: UpdateUnreadCountsHook): void {
+export const register_update_unread_counts_hook = (f: UpdateUnreadCountsHook): void => {
     update_unread_counts_hooks.push(f);
-}
+};
 
-export function update_unread_banner(): void {
+export const update_unread_banner = (): void => {
     if (message_lists.current === undefined) {
         return;
     }
@@ -49,33 +49,33 @@ export function update_unread_banner(): void {
             hide_unread_banner();
         }
     }
-}
+};
 
-export function hide_unread_banner(): void {
+export const hide_unread_banner = (): void => {
     // Use visibility instead of hide() to prevent messages on the screen from
     // shifting vertically.
     $("#mark_read_on_scroll_state_banner").toggleClass("invisible", true);
-}
+};
 
-export function reset_unread_banner(): void {
+export const reset_unread_banner = (): void => {
     hide_unread_banner();
     user_closed_unread_banner = false;
-}
+};
 
-export function notify_messages_remain_unread(): void {
+export const notify_messages_remain_unread = (): void => {
     if (!user_closed_unread_banner) {
         $("#mark_read_on_scroll_state_banner").toggleClass("invisible", false);
     }
-}
+};
 
-export function set_count_toggle_button($elem: JQuery, count: number): JQuery {
+export const set_count_toggle_button = ($elem: JQuery, count: number): JQuery => {
     if (count === 0) {
         return $elem.hide();
     }
     return $elem.show();
-}
+};
 
-export function update_unread_counts(skip_animations = false): void {
+export const update_unread_counts = (skip_animations = false): void => {
     // Pure computation:
     const res = unread.get_counts();
 
@@ -89,9 +89,9 @@ export function update_unread_counts(skip_animations = false): void {
 
     // Set the unread indicator on the toggle for the left sidebar
     set_count_toggle_button($("#streamlist-toggle-unreadcount"), res.home_unread_messages);
-}
+};
 
-export function should_display_bankruptcy_banner(): boolean {
+export const should_display_bankruptcy_banner = (): boolean => {
     // Until we've handled possibly declaring bankruptcy, don't show
     // unread counts since they only consider messages that are loaded
     // client side and may be different from the numbers reported by
@@ -112,13 +112,13 @@ export function should_display_bankruptcy_banner(): boolean {
     }
 
     return false;
-}
+};
 
-export function initialize({
+export const initialize = ({
     notify_server_messages_read,
 }: {
     notify_server_messages_read: (unread_messages: Message[]) => void;
-}): void {
+}): void => {
     const skip_animations = true;
     update_unread_counts(skip_animations);
     $("body").on("click", "#mark_view_read", () => {
@@ -148,4 +148,4 @@ export function initialize({
     // the banner, to avoid scroll position jumps when it is shown/hidden.
     update_unread_banner();
     hide_unread_banner();
-}
+};

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -24,19 +24,17 @@ let drag_drop_img: HTMLElement | null = null;
 let compose_upload_object: Uppy;
 const upload_objects_by_message_edit_row = new Map<number, Uppy>();
 
-export function compose_upload_cancel(): void {
+export const compose_upload_cancel = (): void => {
     compose_upload_object.cancelAll();
-}
+};
 
-export function feature_check(): XMLHttpRequestUpload {
-    // Show the upload button only if the browser supports it.
-    return window.XMLHttpRequest && new window.XMLHttpRequest().upload;
-}
+export const feature_check = (): XMLHttpRequestUpload =>
+    window.XMLHttpRequest && new window.XMLHttpRequest().upload;
 
-export function get_translated_status(file: File | UppyFile): string {
+export const get_translated_status = (file: File | UppyFile): string => {
     const status = $t({defaultMessage: "Uploading {filename}…"}, {filename: file.name});
     return "[" + status + "]()";
-}
+};
 
 type Config = ({mode: "compose"} | {mode: "edit"; row: number}) & {
     textarea: () => JQuery<HTMLTextAreaElement>;
@@ -81,52 +79,48 @@ export const compose_config: Config = {
     markdown_preview_hide_button: () => $("#compose .undo_markdown_preview"),
 };
 
-export function edit_config(row: number): Config {
-    return {
-        mode: "edit",
-        row,
-        textarea: () =>
-            $<HTMLTextAreaElement>(
-                `#edit_form_${CSS.escape(`${row}`)} textarea.message_edit_content`,
-            ),
-        send_button: () => $(`#edit_form_${CSS.escape(`${row}`)}`).find(".message_edit_save"),
-        banner_container: () => $(`#edit_form_${CSS.escape(`${row}`)} .edit_form_banners`),
-        upload_banner_identifier: (file_id) =>
-            `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(file_id)}`,
-        upload_banner: (file_id) =>
-            $(`#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(file_id)}`),
-        upload_banner_cancel_button: (file_id) =>
-            $(
-                `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
-                    file_id,
-                )} .upload_banner_cancel_button`,
-            ),
-        upload_banner_hide_button: (file_id) =>
-            $(
-                `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
-                    file_id,
-                )} .main-view-banner-close-button`,
-            ),
-        upload_banner_message: (file_id) =>
-            $(
-                `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
-                    file_id,
-                )} .upload_msg`,
-            ),
-        file_input_identifier: () => `#edit_form_${CSS.escape(`${row}`)} input.file_input`,
-        source: () => "message-edit-file-input",
-        drag_drop_container() {
-            assert(message_lists.current !== undefined);
-            return $(
-                `#message-row-${message_lists.current.id}-${CSS.escape(`${row}`)} .message_edit_form`,
-            );
-        },
-        markdown_preview_hide_button: () =>
-            $(`#edit_form_${CSS.escape(`${row}`)} .undo_markdown_preview`),
-    };
-}
+export const edit_config = (row: number): Config => ({
+    mode: "edit",
+    row,
+    textarea: () =>
+        $<HTMLTextAreaElement>(`#edit_form_${CSS.escape(`${row}`)} textarea.message_edit_content`),
+    send_button: () => $(`#edit_form_${CSS.escape(`${row}`)}`).find(".message_edit_save"),
+    banner_container: () => $(`#edit_form_${CSS.escape(`${row}`)} .edit_form_banners`),
+    upload_banner_identifier: (file_id) =>
+        `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(file_id)}`,
+    upload_banner: (file_id) =>
+        $(`#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(file_id)}`),
+    upload_banner_cancel_button: (file_id) =>
+        $(
+            `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
+                file_id,
+            )} .upload_banner_cancel_button`,
+        ),
+    upload_banner_hide_button: (file_id) =>
+        $(
+            `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
+                file_id,
+            )} .main-view-banner-close-button`,
+        ),
+    upload_banner_message: (file_id) =>
+        $(
+            `#edit_form_${CSS.escape(`${row}`)} .upload_banner.file_${CSS.escape(
+                file_id,
+            )} .upload_msg`,
+        ),
+    file_input_identifier: () => `#edit_form_${CSS.escape(`${row}`)} input.file_input`,
+    source: () => "message-edit-file-input",
+    drag_drop_container: () => {
+        assert(message_lists.current !== undefined);
+        return $(
+            `#message-row-${message_lists.current.id}-${CSS.escape(`${row}`)} .message_edit_form`,
+        );
+    },
+    markdown_preview_hide_button: () =>
+        $(`#edit_form_${CSS.escape(`${row}`)} .undo_markdown_preview`),
+});
 
-export function hide_upload_banner(uppy: Uppy, config: Config, file_id: string): void {
+export const hide_upload_banner = (uppy: Uppy, config: Config, file_id: string): void => {
     config.upload_banner(file_id).remove();
     if (uppy.getFiles().length === 0) {
         if (config.mode === "compose") {
@@ -135,15 +129,15 @@ export function hide_upload_banner(uppy: Uppy, config: Config, file_id: string):
             config.send_button().prop("disabled", false);
         }
     }
-}
+};
 
-function add_upload_banner(
+const add_upload_banner = (
     config: Config,
     banner_type: string,
     banner_text: string,
     file_id: string,
     is_upload_process_tracker = false,
-): void {
+): void => {
     const new_banner_html = render_upload_banner({
         banner_type,
         is_upload_process_tracker,
@@ -154,13 +148,13 @@ function add_upload_banner(
         $(new_banner_html),
         config.banner_container(),
     );
-}
+};
 
-export function show_error_message(
+export const show_error_message = (
     config: Config,
     message = $t({defaultMessage: "An unknown error occurred."}),
     file_id: string | null = null,
-): void {
+): void => {
     if (file_id) {
         $(`${config.upload_banner_identifier(file_id)} .moving_bar`).hide();
         config.upload_banner(file_id).removeClass("info").addClass("error");
@@ -171,9 +165,9 @@ export function show_error_message(
         // with files. This is notably relevant for the close click handler.
         add_upload_banner(config, "error", message, "generic_error");
     }
-}
+};
 
-export function upload_files(uppy: Uppy, config: Config, files: File[] | FileList): void {
+export const upload_files = (uppy: Uppy, config: Config, files: File[] | FileList): void => {
     if (files.length === 0) {
         return;
     }
@@ -243,9 +237,9 @@ export function upload_files(uppy: Uppy, config: Config, files: File[] | FileLis
             hide_upload_banner(uppy, config, file_id);
         });
     }
-}
+};
 
-export function setup_upload(config: Config): Uppy {
+export const setup_upload = (config: Config): Uppy => {
     const uppy = new Uppy({
         debug: false,
         autoProceed: true,
@@ -455,9 +449,9 @@ export function setup_upload(config: Config): Uppy {
     });
 
     return uppy;
-}
+};
 
-export function deactivate_upload(config: Config): void {
+export const deactivate_upload = (config: Config): void => {
     // Remove event listeners added for handling uploads.
     $(config.file_input_identifier()).off("change");
     config.banner_container().off("click");
@@ -489,9 +483,9 @@ export function deactivate_upload(config: Config): void {
         // now remove the corresponding upload object from the store.
         upload_objects_by_message_edit_row.delete(config.row);
     }
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     compose_upload_object = setup_upload(compose_config);
 
     $(".app, #navbar-fixed-container").on("dragstart", (event) => {
@@ -562,4 +556,4 @@ export function initialize(): void {
             upload_files(compose_upload_object, compose_config, files);
         }
     });
-}
+};

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -15,30 +15,25 @@ const default_max_file_size = 5;
 
 const supported_types = ["image/jpeg", "image/png", "image/gif", "image/tiff"];
 
-function is_image_format(file: File): boolean {
+const is_image_format = (file: File): boolean => {
     const type = file.type;
     if (!type) {
         return false;
     }
     return supported_types.includes(type);
-}
+};
 
-export function build_widget(
-    // function returns a jQuery file input object
+export const build_widget = (
     get_file_input: () => JQuery<HTMLInputElement>,
-    // jQuery object to show file name
     $file_name_field: JQuery,
-    // jQuery object for error text
     $input_error: JQuery,
-    // jQuery button to clear last upload choice
     $clear_button: JQuery,
-    // jQuery button to open file dialog
     $upload_button: JQuery,
     $preview_text?: JQuery,
     $preview_image?: JQuery,
     max_file_upload_size = default_max_file_size,
-): UploadWidget {
-    function accept(file: File): void {
+): UploadWidget => {
+    const accept = (file: File): void => {
         $file_name_field.text(file.name);
         $input_error.hide();
         $clear_button.show();
@@ -49,9 +44,9 @@ export function build_widget(
             $preview_image.addClass("upload_widget_image_preview");
             $preview_text.show();
         }
-    }
+    };
 
-    function clear(): void {
+    const clear = (): void => {
         const $control = get_file_input();
         $control.val("");
         $file_name_field.text("");
@@ -60,7 +55,7 @@ export function build_widget(
         if ($preview_text !== undefined) {
             $preview_text.hide();
         }
-    }
+    };
 
     $clear_button.on("click", (e) => {
         clear();
@@ -109,13 +104,13 @@ export function build_widget(
         e.preventDefault();
     });
 
-    function close(): void {
+    const close = (): void => {
         clear();
         $clear_button.off("click");
         $upload_button.off("drop");
         get_file_input().off("change");
         $upload_button.off("click");
-    }
+    };
 
     return {
         // Call back to clear() in situations like adding bots, when
@@ -125,20 +120,17 @@ export function build_widget(
         // so you can release handlers.
         close,
     };
-}
+};
 
-export function build_direct_upload_widget(
-    // function returns a jQuery file input object
+export const build_direct_upload_widget = (
     get_file_input: () => JQuery<HTMLInputElement>,
-    // jQuery object for error text
     $input_error: JQuery,
-    // jQuery button to open file dialog
     $upload_button: JQuery,
     upload_function: UploadFunction,
     max_file_upload_size: number,
-): void {
+): void => {
     // default value of max uploaded file size
-    function accept(): void {
+    const accept = (): void => {
         $input_error.hide();
         const $realm_logo_section = $upload_button.closest(".image_upload_widget");
         if ($realm_logo_section.attr("id") === "realm-night-logo-upload-widget") {
@@ -148,12 +140,12 @@ export function build_direct_upload_widget(
         } else {
             upload_function(get_file_input(), null, true);
         }
-    }
+    };
 
-    function clear(): void {
+    const clear = (): void => {
         const $control = get_file_input();
         $control.val("");
-    }
+    };
 
     $upload_button.on("drop", (e) => {
         const files = e.originalEvent?.dataTransfer?.files;
@@ -196,4 +188,4 @@ export function build_direct_upload_widget(
         get_file_input().trigger("click");
         e.preventDefault();
     });
-}
+};

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -46,10 +46,10 @@ import * as user_status_ui from "./user_status_ui";
 
 let current_user_sidebar_user_id;
 
-export function confirm_mute_user(user_id) {
-    function on_click() {
+export const confirm_mute_user = (user_id) => {
+    const on_click = () => {
         muted_users.mute_user(user_id);
-    }
+    };
 
     const html_body = render_confirm_mute_user({
         user_name: people.get_full_name(user_id),
@@ -61,7 +61,7 @@ export function confirm_mute_user(user_id) {
         html_body,
         on_click,
     });
-}
+};
 
 class PopoverMenu {
     constructor() {
@@ -102,7 +102,7 @@ export const user_sidebar = new PopoverMenu();
 export const message_user_card = new PopoverMenu();
 export const user_card = new PopoverMenu();
 
-function popover_items_handle_keyboard_with_overrides(key, $items) {
+const popover_items_handle_keyboard_with_overrides = (key, $items) => {
     /* Variant of popover_items_handle_keyboard with somewhat hacky
      * logic for opening the manage menu. */
     if (!$items) {
@@ -124,7 +124,7 @@ function popover_items_handle_keyboard_with_overrides(key, $items) {
 
             const previously_defined_on_mount = manage_menu.instance.props.onMount;
             manage_menu.instance.setProps({
-                onMount() {
+                onMount: () => {
                     // We're monkey patching the onMount method here to ensure we start
                     // focusing on the item after the popover is mounted to the DOM;
                     // otherwise, it won't work correctly.
@@ -155,9 +155,9 @@ function popover_items_handle_keyboard_with_overrides(key, $items) {
 
     /* Otherwise, use the base implementation */
     popover_menus.popover_items_handle_keyboard(key, $items);
-}
+};
 
-function get_popover_classname(popover) {
+const get_popover_classname = (popover) => {
     const popovers = {
         user_sidebar: "user-sidebar-popover-root",
         message_user_card: "message-user-card-popover-root",
@@ -165,7 +165,7 @@ function get_popover_classname(popover) {
     };
 
     return popovers[popover];
-}
+};
 
 user_sidebar.hide = function () {
     PopoverMenu.prototype.hide.call(this);
@@ -179,41 +179,34 @@ const user_card_popovers = {
     user_card,
 };
 
-export function any_active() {
-    return Object.values(user_card_popovers).some((instance) => instance.is_open());
-}
+export const any_active = () =>
+    Object.values(user_card_popovers).some((instance) => instance.is_open());
 
-export function hide_all_instances() {
+export const hide_all_instances = () => {
     for (const key in user_card_popovers) {
         if (user_card_popovers[key].hide) {
             user_card_popovers[key].hide();
         }
     }
-}
+};
 
-export function hide_all_user_card_popovers() {
+export const hide_all_user_card_popovers = () => {
     hide_all_instances();
-}
+};
 
-export function clear_for_testing() {
+export const clear_for_testing = () => {
     message_user_card.instance = undefined;
     user_card.instance = undefined;
     manage_menu.instance = undefined;
-}
+};
 
-function elem_to_user_id($elem) {
-    return Number.parseInt($elem.attr("data-user-id"), 10);
-}
+const elem_to_user_id = ($elem) => Number.parseInt($elem.attr("data-user-id"), 10);
 
-function clipboard_enable(arg) {
-    // arg is a selector or element
-    // We extract this function for testing purpose.
-    return new ClipboardJS(arg);
-}
+const clipboard_enable = (arg) => new ClipboardJS(arg);
 
 // Functions related to user card popover.
 
-export function toggle_user_card_popover(element, user) {
+export const toggle_user_card_popover = (element, user) => {
     show_user_card_popover(
         user,
         $(element),
@@ -223,14 +216,14 @@ export function toggle_user_card_popover(element, user) {
         "user_card",
         "right",
     );
-}
+};
 
-function get_user_card_popover_data(
+const get_user_card_popover_data = (
     user,
     has_message_context,
     is_sender_popover,
     private_msg_class,
-) {
+) => {
     const is_me = people.is_my_user_id(user.user_id);
 
     let invisible_mode = false;
@@ -307,9 +300,9 @@ function get_user_card_popover_data(
     }
 
     return args;
-}
+};
 
-function show_user_card_popover(
+const show_user_card_popover = (
     user,
     $popover_element,
     is_sender_popover,
@@ -318,7 +311,7 @@ function show_user_card_popover(
     template_class,
     popover_placement,
     on_mount,
-) {
+) => {
     let popover_html;
     let args;
     if (user.is_inaccessible_user) {
@@ -343,7 +336,7 @@ function show_user_card_popover(
         {
             placement: popover_placement,
             arrow: false,
-            onCreate(instance) {
+            onCreate: (instance) => {
                 instance.setContent(ui_util.parse_html(popover_html));
                 user_card_popovers[template_class].instance = instance;
 
@@ -361,10 +354,10 @@ function show_user_card_popover(
                     ),
                 );
             },
-            onHidden() {
+            onHidden: () => {
                 user_card_popovers[template_class].hide();
             },
-            onMount(instance) {
+            onMount: (instance) => {
                 if (on_mount) {
                     on_mount(instance);
                 }
@@ -400,9 +393,9 @@ function show_user_card_popover(
             show_as_overlay_on_mobile: true,
         },
     );
-}
+};
 
-function copy_email_handler(e) {
+const copy_email_handler = (e) => {
     const $email_el = $(e.trigger.parentElement);
     const $copy_icon = $email_el.find("i");
 
@@ -418,7 +411,7 @@ function copy_email_handler(e) {
         email_textnode.nodeValue = $copy_icon.attr("data-clipboard-text");
     }, 1500);
     e.clearSelection();
-}
+};
 
 function init_email_clipboard() {
     /*
@@ -476,7 +469,7 @@ function load_medium_avatar(user, $elt) {
 
 // Functions related to manage menu popover.
 
-function toggle_user_card_popover_manage_menu(element, user) {
+const toggle_user_card_popover_manage_menu = (element, user) => {
     const is_me = people.is_my_user_id(user.user_id);
     const is_muted = muted_users.is_user_muted(user.user_id);
     const is_system_bot = user.is_system_bot;
@@ -493,19 +486,19 @@ function toggle_user_card_popover_manage_menu(element, user) {
 
     popover_menus.toggle_popover_menu(element, {
         placement: "bottom",
-        onCreate(instance) {
+        onCreate: (instance) => {
             manage_menu.instance = instance;
             const $popover = $(instance.popper);
             $popover.addClass("manage-menu-popover-root");
             instance.setContent(ui_util.parse_html(render_user_card_popover_manage_menu(args)));
         },
-        onHidden() {
+        onHidden: () => {
             manage_menu.hide();
         },
     });
-}
+};
 
-export function get_user_card_popover_manage_menu_items() {
+export const get_user_card_popover_manage_menu_items = () => {
     if (!manage_menu.is_open()) {
         blueslip.error("Trying to get menu items when manage menu popover is closed.");
         return undefined;
@@ -518,14 +511,14 @@ export function get_user_card_popover_manage_menu_items() {
     }
 
     return $(".user-card-popover-manage-menu li:not(.divider):visible a", $popover);
-}
+};
 
 // Functions related to message user card popover.
 
 // element is the target element to pop off of
 // user is the user whose profile to show
 // message is the message containing it, which should be selected
-function toggle_user_card_popover_for_message(element, user, message, on_mount) {
+const toggle_user_card_popover_for_message = (element, user, message, on_mount) => {
     const $elt = $(element);
     if (!message_user_card.is_open()) {
         if (user === undefined) {
@@ -551,11 +544,11 @@ function toggle_user_card_popover_for_message(element, user, message, on_mount) 
             on_mount,
         );
     }
-}
+};
 
 // This function serves as the entry point for toggling
 // the user card popover via keyboard shortcut.
-export function toggle_sender_info() {
+export const toggle_sender_info = () => {
     if (message_user_card.is_open()) {
         // We need to call the hide method here because
         // the event wasn't triggered by the mouse.
@@ -580,9 +573,9 @@ export function toggle_sender_info() {
             focus_user_card_popover_item();
         }
     });
-}
+};
 
-function focus_user_card_popover_item() {
+const focus_user_card_popover_item = () => {
     // For now I recommend only calling this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_user_card_popover_for_message_items();
@@ -592,9 +585,9 @@ function focus_user_card_popover_item() {
     } else {
         popover_menus.focus_first_popover_item($items);
     }
-}
+};
 
-function get_user_card_popover_for_message_items() {
+const get_user_card_popover_for_message_items = () => {
     if (!message_user_card.is_open()) {
         blueslip.error("Trying to get menu items when message user card popover is closed.");
         return undefined;
@@ -607,11 +600,11 @@ function get_user_card_popover_for_message_items() {
     }
 
     return $("li:not(.divider):visible a", $popover);
-}
+};
 
 // Functions related to the user card popover in the user sidebar.
 
-function toggle_sidebar_user_card_popover($target) {
+const toggle_sidebar_user_card_popover = ($target) => {
     const user_id = elem_to_user_id($target.find("a"));
     const user = people.get_by_user_id(user_id);
 
@@ -642,7 +635,7 @@ function toggle_sidebar_user_card_popover($target) {
     );
 
     current_user_sidebar_user_id = user.user_id;
-}
+};
 
 function register_click_handlers() {
     $("#main_div").on("click", ".sender_name, .inline_profile_picture", function (e) {
@@ -733,7 +726,7 @@ function register_click_handlers() {
             status_text: "",
             emoji_name: "",
             emoji_code: "",
-            success() {
+            success: () => {
                 $(".user-card-popover-actions #status_message").empty();
             },
         });
@@ -744,19 +737,19 @@ function register_click_handlers() {
         hide_all();
         e.stopPropagation();
         e.preventDefault();
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
             channel.post({
                 url,
-                success() {
+                success: () => {
                     dialog_widget.close();
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
                     dialog_widget.hide_dialog_spinner();
                 },
             });
-        }
+        };
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
 
@@ -827,14 +820,14 @@ function register_click_handlers() {
         e.preventDefault();
     });
 
-    function open_user_status_modal(e) {
+    const open_user_status_modal = (e) => {
         hide_all();
 
         user_status_ui.open_user_status_modal();
 
         e.stopPropagation();
         e.preventDefault();
-    }
+    };
 
     $("body").on("click", ".update_status_text", open_user_status_modal);
 
@@ -905,18 +898,17 @@ function register_click_handlers() {
         toggle_user_card_popover_manage_menu(e.target, user);
     });
     new ClipboardJS(".copy-custom-field-url", {
-        text(trigger) {
-            return $(trigger)
+        text: (trigger) =>
+            $(trigger)
                 .closest(".custom-user-url-field")
                 .find(".custom-profile-fields-link")
-                .attr("href");
-        },
+                .attr("href"),
     }).on("success", (e) => {
         show_copied_confirmation(e.trigger);
     });
 }
 
-export function initialize() {
+export const initialize = () => {
     register_click_handlers();
     clipboard_enable(".copy_mention_syntax");
-}
+};

--- a/web/src/user_deactivation_ui.ts
+++ b/web/src/user_deactivation_ui.ts
@@ -15,18 +15,18 @@ import * as people from "./people";
 import {invite_schema} from "./settings_invites";
 import {realm} from "./state_data";
 
-export function confirm_deactivation(
+export const confirm_deactivation = (
     user_id: number,
     handle_confirm: () => void,
     loading_spinner: boolean,
-): void {
+): void => {
     // Knowing the number of invites requires making this request. If the request fails,
     // we won't have the accurate number of invites. So, we don't show the modal if the
     // request fails.
     void channel.get({
         url: "/json/invites",
         timeout: 10 * 1000,
-        success(raw_data) {
+        success: (raw_data) => {
             const data = z.object({invites: z.array(invite_schema)}).parse(raw_data);
 
             let number_of_invites_by_user = 0;
@@ -51,7 +51,7 @@ export function confirm_deactivation(
             };
             const html_body = render_settings_deactivation_user_modal(opts);
 
-            function set_email_field_visibility(dialog_widget_id: string): void {
+            const set_email_field_visibility = (dialog_widget_id: string): void => {
                 const $modal = $(`#${dialog_widget_id}`);
                 const $send_email_checkbox = $modal.find(".send_email");
                 const $email_field = $modal.find(".email_field");
@@ -64,7 +64,7 @@ export function confirm_deactivation(
                         $email_field.hide();
                     }
                 });
-            }
+            };
 
             dialog_widget.launch({
                 html_heading: $t_html(
@@ -81,13 +81,13 @@ export function confirm_deactivation(
             });
         },
     });
-}
+};
 
-export function confirm_bot_deactivation(
+export const confirm_bot_deactivation = (
     bot_id: number,
     handle_confirm: () => void,
     loading_spinner: boolean,
-): void {
+): void => {
     const bot = people.get_by_user_id(bot_id);
     const html_body = render_settings_deactivation_bot_modal();
 
@@ -99,13 +99,13 @@ export function confirm_bot_deactivation(
         on_click: handle_confirm,
         loading_spinner,
     });
-}
+};
 
-export function confirm_reactivation(
+export const confirm_reactivation = (
     user_id: number,
     handle_confirm: () => void,
     loading_spinner: boolean,
-): void {
+): void => {
     const user = people.get_by_user_id(user_id);
     const opts: {
         username: string;
@@ -136,4 +136,4 @@ export function confirm_reactivation(
         on_click: handle_confirm,
         loading_spinner,
     });
-}
+};

--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -26,7 +26,7 @@ import {current_user, realm} from "./state_data";
 import * as stream_events from "./stream_events";
 import * as user_profile from "./user_profile";
 
-export const update_person = function update(person) {
+export const update_person = (person) => {
     const person_obj = people.maybe_get_user_by_id(person.user_id);
 
     if (!person_obj) {

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -5,7 +5,7 @@ import * as settings_components from "./settings_components";
 import * as user_groups from "./user_groups";
 import type {UserGroup} from "./user_groups";
 
-export function setup_permissions_dropdown(group: UserGroup, for_group_creation: boolean): void {
+export const setup_permissions_dropdown = (group: UserGroup, for_group_creation: boolean): void => {
     let widget_name: string;
     let default_id: number;
     if (for_group_creation) {
@@ -23,7 +23,7 @@ export function setup_permissions_dropdown(group: UserGroup, for_group_creation:
                 "can_mention_group",
                 "group",
             ),
-        item_click_callback(event, dropdown) {
+        item_click_callback: (event, dropdown) => {
             dropdown.hide();
             event.preventDefault();
             event.stopPropagation();
@@ -41,7 +41,7 @@ export function setup_permissions_dropdown(group: UserGroup, for_group_creation:
         },
         default_id,
         unique_id_type: dropdown_widget.DataTypes.NUMBER,
-        on_mount_callback(dropdown) {
+        on_mount_callback: (dropdown) => {
             $(dropdown.popper).css("min-width", "300px");
         },
     });
@@ -51,4 +51,4 @@ export function setup_permissions_dropdown(group: UserGroup, for_group_creation:
         settings_components.set_can_mention_group_widget(can_mention_group_widget);
     }
     can_mention_group_widget.setup();
-}
+};

--- a/web/src/user_group_create.js
+++ b/web/src/user_group_create.js
@@ -13,17 +13,15 @@ import * as user_groups from "./user_groups";
 
 let created_group_name;
 
-export function reset_name() {
+export const reset_name = () => {
     created_group_name = undefined;
-}
+};
 
-export function set_name(group_name) {
+export const set_name = (group_name) => {
     created_group_name = group_name;
-}
+};
 
-export function get_name() {
-    return created_group_name;
-}
+export const get_name = () => created_group_name;
 
 class UserGroupMembershipError {
     report_no_members_to_user_group() {
@@ -89,22 +87,22 @@ class UserGroupNameError {
 }
 const user_group_name_error = new UserGroupNameError();
 
-function clear_error_display() {
+const clear_error_display = () => {
     user_group_name_error.clear_errors();
     $(".user_group_create_info").hide();
     user_group_membership_error.clear_errors();
-}
+};
 
-export function show_new_user_group_modal() {
+export const show_new_user_group_modal = () => {
     $("#user-group-creation").removeClass("hide");
     $(".right .settings").hide();
 
     user_group_create_members.build_widgets();
 
     clear_error_display();
-}
+};
 
-function create_user_group() {
+const create_user_group = () => {
     const data = {};
     const group_name = $("#create_user_group_name").val().trim();
     const description = $("#create_user_group_description").val().trim();
@@ -137,14 +135,14 @@ function create_user_group() {
     return channel.post({
         url: "/json/user_groups/create",
         data,
-        success() {
+        success: () => {
             $("#create_user_group_name").val("");
             $("#create_user_group_description").val("");
             user_group_create_members.clear_member_list();
             loading.destroy_indicator($("#user_group_creating_indicator"));
             // TODO: The rest of the work should be done via the create event we will get for user group.
         },
-        error(xhr) {
+        error: (xhr) => {
             ui_report.error(
                 $t_html({defaultMessage: "Error creating user group."}),
                 xhr,
@@ -154,9 +152,9 @@ function create_user_group() {
             loading.destroy_indicator($("#user_group_creating_indicator"));
         },
     });
-}
+};
 
-export function set_up_handlers() {
+export const set_up_handlers = () => {
     const $people_to_add_holder = $("#people_to_add_in_group").expectOne();
     user_group_create_members.create_handlers($people_to_add_holder);
 
@@ -198,4 +196,4 @@ export function set_up_handlers() {
     });
 
     user_group_components.setup_permissions_dropdown(undefined, true);
-}
+};

--- a/web/src/user_group_create_members.js
+++ b/web/src/user_group_create_members.js
@@ -13,35 +13,33 @@ import * as user_sort from "./user_sort";
 let pill_widget;
 let all_users_list_widget;
 
-export function get_principals() {
-    return user_group_create_members_data.get_principals();
-}
+export const get_principals = () => user_group_create_members_data.get_principals();
 
-function redraw_member_list() {
+const redraw_member_list = () => {
     all_users_list_widget.replace_list_data(user_group_create_members_data.sorted_user_ids());
-}
+};
 
-function add_user_ids(user_ids) {
+const add_user_ids = (user_ids) => {
     user_group_create_members_data.add_user_ids(user_ids);
     redraw_member_list();
-}
+};
 
-function add_all_users() {
+const add_all_users = () => {
     const user_ids = user_group_create_members_data.get_all_user_ids();
     add_user_ids(user_ids);
-}
+};
 
-function remove_user_ids(user_ids) {
+const remove_user_ids = (user_ids) => {
     user_group_create_members_data.remove_user_ids(user_ids);
     redraw_member_list();
-}
+};
 
-export function clear_member_list() {
+export const clear_member_list = () => {
     user_group_create_members_data.initialize_with_current_user();
     redraw_member_list();
-}
+};
 
-function build_pill_widget({$parent_container}) {
+const build_pill_widget = ({$parent_container}) => {
     const $pill_container = $parent_container.find(".pill-container");
     const get_potential_members = user_group_create_members_data.get_potential_members;
 
@@ -49,9 +47,9 @@ function build_pill_widget({$parent_container}) {
         $pill_container,
         get_potential_subscribers: get_potential_members,
     });
-}
+};
 
-export function create_handlers($container) {
+export const create_handlers = ($container) => {
     $container.on("click", ".add_all_users_to_user_group", (e) => {
         e.preventDefault();
         add_all_users();
@@ -65,10 +63,10 @@ export function create_handlers($container) {
         remove_user_ids([user_id]);
     });
 
-    function add_users({pill_user_ids}) {
+    const add_users = ({pill_user_ids}) => {
         add_user_ids(pill_user_ids);
         pill_widget.clear();
-    }
+    };
 
     add_subscribers_pill.set_up_handlers({
         get_pill_widget: () => pill_widget,
@@ -77,9 +75,9 @@ export function create_handlers($container) {
         button_selector: ".add_members_container button.add-member-button",
         action: add_users,
     });
-}
+};
 
-export function build_widgets() {
+export const build_widgets = () => {
     const $add_people_container = $("#people_to_add_in_group");
     $add_people_container.html(render_new_user_group_users({}));
 
@@ -99,7 +97,7 @@ export function build_widgets() {
             id: user_sort.sort_user_id,
             ...ListWidget.generic_sort_functions("alphabetic", ["full_name"]),
         },
-        modifier_html(user) {
+        modifier_html: (user) => {
             const item = {
                 email: user.delivery_email,
                 user_id: user.user_id,
@@ -111,13 +109,9 @@ export function build_widgets() {
         },
         filter: {
             $element: $("#people_to_add_in_group .add-user-list-filter"),
-            predicate(user, search_term) {
-                return people.build_person_matcher(search_term)(user);
-            },
+            predicate: (user, search_term) => people.build_person_matcher(search_term)(user),
         },
         $simplebar_container,
-        html_selector(user) {
-            return $(`#${CSS.escape("user_checkbox_" + user.user_id)}`);
-        },
+        html_selector: (user) => $(`#${CSS.escape("user_checkbox_" + user.user_id)}`),
     });
-}
+};

--- a/web/src/user_group_create_members_data.ts
+++ b/web/src/user_group_create_members_data.ts
@@ -4,35 +4,32 @@ import {current_user} from "./state_data";
 
 let user_id_set: Set<number>;
 
-export function initialize_with_current_user(): void {
+export const initialize_with_current_user = (): void => {
     user_id_set = new Set([current_user.user_id]);
-}
+};
 
-export function sorted_user_ids(): number[] {
+export const sorted_user_ids = (): number[] => {
     const users = people.get_users_from_ids([...user_id_set]);
     people.sort_but_pin_current_user_on_top(users);
     return users.map((user) => user.user_id);
-}
+};
 
-export function get_all_user_ids(): number[] {
+export const get_all_user_ids = (): number[] => {
     const potential_members = people.get_realm_users();
     const user_ids = potential_members.map((user) => user.user_id);
     // sort for determinism
     user_ids.sort((a, b) => a - b);
     return user_ids;
-}
+};
 
-export function get_principals(): number[] {
-    // Return list of user ids which were selected by user.
-    return [...user_id_set];
-}
+export const get_principals = (): number[] => [...user_id_set];
 
-export function get_potential_members(): User[] {
+export const get_potential_members = (): User[] => {
     const potential_members = people.get_realm_users();
     return potential_members.filter((user) => !user_id_set.has(user.user_id));
-}
+};
 
-export function add_user_ids(user_ids: number[]): void {
+export const add_user_ids = (user_ids: number[]): void => {
     for (const user_id of user_ids) {
         if (!user_id_set.has(user_id)) {
             const user = people.maybe_get_user_by_id(user_id);
@@ -41,10 +38,10 @@ export function add_user_ids(user_ids: number[]): void {
             }
         }
     }
-}
+};
 
-export function remove_user_ids(user_ids: number[]): void {
+export const remove_user_ids = (user_ids: number[]): void => {
     for (const user_id of user_ids) {
         user_id_set.delete(user_id);
     }
-}
+};

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -37,14 +37,14 @@ let group_list_widget;
 let group_list_toggler;
 let active_group_id;
 
-function get_user_group_id(target) {
+const get_user_group_id = (target) => {
     const $row = $(target).closest(
         ".group-row, .user_group_settings_wrapper, .save-button, .group_settings_header",
     );
     return Number.parseInt($row.attr("data-group-id"), 10);
-}
+};
 
-function get_user_group_for_target(target) {
+const get_user_group_for_target = (target) => {
     const user_group_id = get_user_group_id(target);
     if (!user_group_id) {
         blueslip.error("Cannot find user group id for target");
@@ -57,15 +57,12 @@ function get_user_group_for_target(target) {
         return undefined;
     }
     return group;
-}
+};
 
-export function get_edit_container(group) {
-    return $(
-        `#groups_overlay .user_group_settings_wrapper[data-group-id='${CSS.escape(group.id)}']`,
-    );
-}
+export const get_edit_container = (group) =>
+    $(`#groups_overlay .user_group_settings_wrapper[data-group-id='${CSS.escape(group.id)}']`);
 
-function update_add_members_elements(group) {
+const update_add_members_elements = (group) => {
     if (!is_editing_group(group.id)) {
         return;
     }
@@ -100,9 +97,9 @@ function update_add_members_elements(group) {
             $t({defaultMessage: "Only group members can add users to a group."}),
         );
     }
-}
+};
 
-function show_membership_settings(group) {
+const show_membership_settings = (group) => {
     const $edit_container = get_edit_container(group);
     update_add_members_elements(group);
 
@@ -111,9 +108,9 @@ function show_membership_settings(group) {
         group,
         $parent_container: $member_container,
     });
-}
+};
 
-function enable_group_edit_settings(group) {
+const enable_group_edit_settings = (group) => {
     if (!is_editing_group(group.id)) {
         return;
     }
@@ -121,9 +118,9 @@ function enable_group_edit_settings(group) {
     $edit_container.find(".group-header .button-group").show();
     $edit_container.find(".member-list .actions").show();
     update_add_members_elements(group);
-}
+};
 
-function disable_group_edit_settings(group) {
+const disable_group_edit_settings = (group) => {
     if (!is_editing_group(group.id)) {
         return;
     }
@@ -131,13 +128,12 @@ function disable_group_edit_settings(group) {
     $edit_container.find(".group-header .button-group").hide();
     $edit_container.find(".member-list .user-remove-actions").hide();
     update_add_members_elements(group);
-}
+};
 
-function group_membership_button(group_id) {
-    return $(`.group_settings_header[data-group-id='${CSS.escape(group_id)}'] .join_leave_button`);
-}
+const group_membership_button = (group_id) =>
+    $(`.group_settings_header[data-group-id='${CSS.escape(group_id)}'] .join_leave_button`);
 
-function initialize_tooltip_for_membership_button(group_id) {
+const initialize_tooltip_for_membership_button = (group_id) => {
     const $tooltip_wrapper = group_membership_button(group_id).closest(
         ".join_leave_button_wrapper",
     );
@@ -149,9 +145,9 @@ function initialize_tooltip_for_membership_button(group_id) {
         tooltip_message = $t({defaultMessage: "You do not have permission to join this group."});
     }
     settings_components.initialize_disable_btn_hint_popover($tooltip_wrapper, tooltip_message);
-}
+};
 
-function update_group_membership_button(group_id) {
+const update_group_membership_button = (group_id) => {
     const $group_settings_button = group_membership_button(group_id);
 
     if (!$group_settings_button.length) {
@@ -172,9 +168,9 @@ function update_group_membership_button(group_id) {
         $group_settings_button.prop("disabled", true);
         initialize_tooltip_for_membership_button(group_id);
     }
-}
+};
 
-export function handle_member_edit_event(group_id, user_ids) {
+export const handle_member_edit_event = (group_id, user_ids) => {
     if (!overlays.groups_open()) {
         return;
     }
@@ -244,21 +240,21 @@ export function handle_member_edit_event(group_id, user_ids) {
     } else {
         disable_group_edit_settings(group);
     }
-}
+};
 
-export function update_settings_pane(group) {
+export const update_settings_pane = (group) => {
     const $edit_container = get_edit_container(group);
     $edit_container.find(".group-name").text(group.name);
     $edit_container.find(".group-description").text(group.description);
 
     settings_org.discard_group_property_element_changes($("#id_can_mention_group"), group);
-}
+};
 
-function update_toggler_for_group_setting() {
+const update_toggler_for_group_setting = () => {
     toggler.goto(select_tab);
-}
+};
 
-export function show_settings_for(group) {
+export const show_settings_for = (group) => {
     const html = render_user_group_settings({
         group,
         can_edit: settings_data.can_edit_user_group(group.id),
@@ -279,16 +275,16 @@ export function show_settings_for(group) {
     $edit_container.show();
     show_membership_settings(group);
     user_group_components.setup_permissions_dropdown(group, false);
-}
+};
 
-export function setup_group_settings(group) {
+export const setup_group_settings = (group) => {
     toggler = components.toggle({
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "General"}), key: "general"},
             {label: $t({defaultMessage: "Members"}), key: "members"},
         ],
-        callback(_name, key) {
+        callback: (_name, key) => {
             $(".group_setting_section").hide();
             $(`[data-group-section="${CSS.escape(key)}"]`).show();
             select_tab = key;
@@ -298,9 +294,9 @@ export function setup_group_settings(group) {
     });
 
     show_settings_for(group);
-}
+};
 
-export function setup_group_list_tab_hash(tab_key_value) {
+export const setup_group_list_tab_hash = (tab_key_value) => {
     /*
         We do not update the hash based on tab switches if
         a group is currently being edited.
@@ -316,9 +312,9 @@ export function setup_group_list_tab_hash(tab_key_value) {
     } else {
         blueslip.debug(`Unknown tab_key_value: ${tab_key_value} for groups overlay.`);
     }
-}
+};
 
-function display_membership_toggle_spinner(group_row) {
+const display_membership_toggle_spinner = (group_row) => {
     /* Prevent sending multiple requests by removing the button class. */
     $(group_row).find(".check").removeClass("join_leave_button");
 
@@ -330,9 +326,9 @@ function display_membership_toggle_spinner(group_row) {
     const $spinner = $(group_row).find(".join_leave_status").expectOne();
     $spinner.show();
     loading.make_indicator($spinner);
-}
+};
 
-function hide_membership_toggle_spinner(group_row) {
+const hide_membership_toggle_spinner = (group_row) => {
     /* Re-enable the button to handle requests. */
     $(group_row).find(".check").addClass("join_leave_button");
 
@@ -343,10 +339,10 @@ function hide_membership_toggle_spinner(group_row) {
     /* Destroy the spinner. */
     const $spinner = $(group_row).find(".join_leave_status").expectOne();
     loading.destroy_indicator($spinner);
-}
+};
 
 export const show_user_group_settings_pane = {
-    nothing_selected() {
+    nothing_selected: () => {
         $("#groups_overlay .settings, #user-group-creation").hide();
         reset_active_group_id();
         $("#groups_overlay .nothing-selected").show();
@@ -354,13 +350,13 @@ export const show_user_group_settings_pane = {
             $t({defaultMessage: "User group settings"}),
         );
     },
-    settings(group) {
+    settings: (group) => {
         $("#groups_overlay .nothing-selected, #user-group-creation").hide();
         $("#groups_overlay .settings").show();
         set_active_group_id(group.id);
         $("#groups_overlay .user-group-info-title").text(group.name);
     },
-    create_user_group() {
+    create_user_group: () => {
         $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
         reset_active_group_id();
         $("#user-group-creation").show();
@@ -368,28 +364,28 @@ export const show_user_group_settings_pane = {
     },
 };
 
-function empty_right_panel() {
+const empty_right_panel = () => {
     $(".group-row.active").removeClass("active");
     show_user_group_settings_pane.nothing_selected();
-}
+};
 
-function open_right_panel_empty() {
+const open_right_panel_empty = () => {
     empty_right_panel();
     const tab_key = $(".user-groups-container")
         .find("div.ind-tab.selected")
         .first()
         .attr("data-tab-key");
     setup_group_list_tab_hash(tab_key);
-}
+};
 
-export function is_editing_group(desired_group_id) {
+export const is_editing_group = (desired_group_id) => {
     if (!overlays.groups_open()) {
         return false;
     }
     return get_active_data().id === desired_group_id;
-}
+};
 
-export function handle_deleted_group(group_id) {
+export const handle_deleted_group = (group_id) => {
     if (!overlays.groups_open()) {
         return;
     }
@@ -398,34 +394,34 @@ export function handle_deleted_group(group_id) {
         open_right_panel_empty();
     }
     redraw_user_group_list();
-}
+};
 
-export function show_group_settings(group) {
+export const show_group_settings = (group) => {
     $(".group-row.active").removeClass("active");
     show_user_group_settings_pane.settings(group);
     row_for_group_id(group.id).addClass("active");
     setup_group_settings(group);
-}
+};
 
-export function open_group_edit_panel_for_row(group_row) {
+export const open_group_edit_panel_for_row = (group_row) => {
     const group = get_user_group_for_target(group_row);
     show_group_settings(group);
-}
+};
 
-export function set_active_group_id(group_id) {
+export const set_active_group_id = (group_id) => {
     active_group_id = group_id;
-}
+};
 
-export function reset_active_group_id() {
+export const reset_active_group_id = () => {
     active_group_id = undefined;
-}
+};
 
 // Ideally this should be included in page params.
 // Like we have realm.max_stream_name_length` and
 // `realm.max_stream_description_length` for streams.
 export const max_user_group_name_length = 100;
 
-export function set_up_click_handlers() {
+export const set_up_click_handlers = () => {
     $("#groups_overlay").on("click", ".left #clear_search_group_name", (e) => {
         const $input = $("#groups_overlay .left #search_group_name");
         $input.val("");
@@ -437,9 +433,9 @@ export function set_up_click_handlers() {
         e.stopPropagation();
         e.preventDefault();
     });
-}
+};
 
-function create_user_group_clicked() {
+const create_user_group_clicked = () => {
     // this changes the tab switcher (settings/preview) which isn't necessary
     // to a add new stream title.
     show_user_group_settings_pane.create_user_group();
@@ -447,38 +443,35 @@ function create_user_group_clicked() {
 
     user_group_create.show_new_user_group_modal();
     $("#create_user_group_name").trigger("focus");
-}
+};
 
-export function do_open_create_user_group() {
+export const do_open_create_user_group = () => {
     // Only call this directly for hash changes.
     // Prefer open_create_user_group().
     show_right_section();
     create_user_group_clicked();
-}
+};
 
-export function open_create_user_group() {
+export const open_create_user_group = () => {
     do_open_create_user_group();
     browser_history.update("#groups/new");
-}
+};
 
-export function row_for_group_id(group_id) {
-    return $(`.group-row[data-group-id='${CSS.escape(group_id)}']`);
-}
+export const row_for_group_id = (group_id) =>
+    $(`.group-row[data-group-id='${CSS.escape(group_id)}']`);
 
-export function is_group_already_present(group) {
-    return row_for_group_id(group.id).length > 0;
-}
+export const is_group_already_present = (group) => row_for_group_id(group.id).length > 0;
 
-export function get_active_data() {
+export const get_active_data = () => {
     const $active_tabs = $(".user-groups-container").find("div.ind-tab.selected");
     return {
         $row: row_for_group_id(active_group_id),
         id: active_group_id,
         $tabs: $active_tabs,
     };
-}
+};
 
-export function switch_to_group_row(group) {
+export const switch_to_group_row = (group) => {
     if (is_group_already_present(group)) {
         /*
             It is possible that this function may be called at times
@@ -501,14 +494,14 @@ export function switch_to_group_row(group) {
     }
 
     show_group_settings(group);
-}
+};
 
-function show_right_section() {
+const show_right_section = () => {
     $(".right").addClass("show");
     $(".user-groups-header").addClass("slide-left");
-}
+};
 
-export function add_group_to_table(group) {
+export const add_group_to_table = (group) => {
     if (is_group_already_present(group)) {
         // If a group is already listed/added in groups modal,
         // then we simply return.
@@ -529,9 +522,9 @@ export function add_group_to_table(group) {
         show_group_settings(group);
         user_group_create.reset_name();
     }
-}
+};
 
-export function update_group(group_id) {
+export const update_group = (group_id) => {
     if (!overlays.groups_open()) {
         return;
     }
@@ -547,9 +540,9 @@ export function update_group(group_id) {
         // update settings title
         $("#groups_overlay .user-group-info-title").text(group.name);
     }
-}
+};
 
-export function change_state(section, left_side_tab, right_side_tab) {
+export const change_state = (section, left_side_tab, right_side_tab) => {
     if (section === "new") {
         do_open_create_user_group();
         redraw_user_group_list();
@@ -589,13 +582,11 @@ export function change_state(section, left_side_tab, right_side_tab) {
 
     group_list_toggler.goto("your-groups");
     empty_right_panel();
-}
+};
 
-function compare_by_name(a, b) {
-    return util.strcmp(a.name, b.name);
-}
+const compare_by_name = (a, b) => util.strcmp(a.name, b.name);
 
-function redraw_left_panel(tab_name) {
+const redraw_left_panel = (tab_name) => {
     let groups_list_data;
     if (tab_name === "all-groups") {
         groups_list_data = user_groups.get_realm_user_groups();
@@ -606,14 +597,14 @@ function redraw_left_panel(tab_name) {
     group_list_widget.replace_list_data(groups_list_data);
     update_empty_left_panel_message();
     maybe_reset_right_panel(groups_list_data);
-}
+};
 
-export function redraw_user_group_list() {
+export const redraw_user_group_list = () => {
     const tab_name = get_active_data().$tabs.first().attr("data-tab-key");
     redraw_left_panel(tab_name);
-}
+};
 
-export function switch_group_tab(tab_name) {
+export const switch_group_tab = (tab_name) => {
     /*
         This switches the groups list tab, but it doesn't update
         the group_list_toggler widget.  You may instead want to
@@ -621,21 +612,21 @@ export function switch_group_tab(tab_name) {
     */
     redraw_left_panel(tab_name);
     setup_group_list_tab_hash(tab_name);
-}
+};
 
-export function add_or_remove_from_group(group, group_row) {
+export const add_or_remove_from_group = (group, group_row) => {
     const user_id = people.my_current_user_id();
-    function success_callback() {
+    const success_callback = () => {
         if (group_row.length) {
             hide_membership_toggle_spinner(group_row);
         }
-    }
+    };
 
-    function error_callback() {
+    const error_callback = () => {
         if (group_row.length) {
             hide_membership_toggle_spinner(group_row);
         }
-    }
+    };
 
     if (group_row.length) {
         display_membership_toggle_spinner(group_row);
@@ -655,9 +646,9 @@ export function add_or_remove_from_group(group, group_row) {
             error_callback,
         });
     }
-}
+};
 
-export function maybe_reset_right_panel(groups_list_data) {
+export const maybe_reset_right_panel = (groups_list_data) => {
     if (active_group_id === undefined) {
         return;
     }
@@ -666,9 +657,9 @@ export function maybe_reset_right_panel(groups_list_data) {
     if (!group_ids.has(active_group_id)) {
         show_user_group_settings_pane.nothing_selected();
     }
-}
+};
 
-export function update_empty_left_panel_message() {
+export const update_empty_left_panel_message = () => {
     // Check if we have any groups in panel to decide whether to
     // display a notice.
     let has_groups;
@@ -691,25 +682,25 @@ export function update_empty_left_panel_message() {
         $(".all_groups_tab_empty_text").show();
     }
     $(".no-groups-to-show").show();
-}
+};
 
-export function setup_page(callback) {
-    function initialize_components() {
+export const setup_page = (callback) => {
+    const initialize_components = () => {
         group_list_toggler = components.toggle({
             child_wants_focus: true,
             values: [
                 {label: $t({defaultMessage: "Your groups"}), key: "your-groups"},
                 {label: $t({defaultMessage: "All groups"}), key: "all-groups"},
             ],
-            callback(_label, key) {
+            callback: (_label, key) => {
                 switch_group_tab(key);
             },
         });
 
         group_list_toggler.get().prependTo("#groups_overlay_container .list-toggler-container");
-    }
+    };
 
-    function populate_and_fill() {
+    const populate_and_fill = () => {
         const template_data = {
             can_create_or_edit_user_groups: settings_data.user_can_edit_user_groups(),
             max_user_group_name_length,
@@ -738,7 +729,7 @@ export function setup_page(callback) {
         group_list_widget = ListWidget.create($container, [], {
             name: "user-groups-overlay",
             get_item: ListWidget.default_get_item,
-            modifier_html(item) {
+            modifier_html: (item) => {
                 item.is_member = user_groups.is_direct_member_of(
                     people.my_current_user_id(),
                     item.id,
@@ -748,14 +739,11 @@ export function setup_page(callback) {
             },
             filter: {
                 $element: $("#groups_overlay_container .left #search_group_name"),
-                predicate(item, value) {
-                    return (
-                        item &&
-                        (item.name.toLocaleLowerCase().includes(value) ||
-                            item.description.toLocaleLowerCase().includes(value))
-                    );
-                },
-                onupdate() {
+                predicate: (item, value) =>
+                    item &&
+                    (item.name.toLocaleLowerCase().includes(value) ||
+                        item.description.toLocaleLowerCase().includes(value)),
+                onupdate: () => {
                     if (active_group_id !== undefined) {
                         const active_group = user_groups.get_user_group_from_id(active_group_id);
                         if (is_group_already_present(active_group)) {
@@ -779,10 +767,10 @@ export function setup_page(callback) {
         if (callback) {
             callback();
         }
-    }
+    };
 
     populate_and_fill();
-}
+};
 
 export function initialize() {
     $("#groups_overlay_container").on("click", ".group-row", function (e) {
@@ -811,7 +799,7 @@ export function initialize() {
             id: "change_group_info_modal",
             loading_spinner: true,
             on_click: save_group_info,
-            post_render() {
+            post_render: () => {
                 $("#change_group_info_modal .dialog_submit_button")
                     .addClass("save-button")
                     .attr("data-group-id", user_group_id);
@@ -828,16 +816,16 @@ export function initialize() {
         if (!user_group || !settings_data.can_edit_user_group(group_id)) {
             return;
         }
-        function delete_user_group() {
+        const delete_user_group = () => {
             channel.del({
                 url: "/json/user_groups/" + group_id,
                 data: {
                     id: group_id,
                 },
-                success() {
+                success: () => {
                     active_group_data.$row.remove();
                 },
-                error(xhr) {
+                error: (xhr) => {
                     ui_report.error(
                         $t_html({defaultMessage: "Failed"}),
                         xhr,
@@ -845,7 +833,7 @@ export function initialize() {
                     );
                 },
             });
-        }
+        };
 
         const html_body = render_confirm_delete_user({
             group_name: user_group.name,
@@ -860,7 +848,7 @@ export function initialize() {
         });
     });
 
-    function save_group_info(e) {
+    const save_group_info = (e) => {
         const group = get_user_group_for_target(e.currentTarget);
 
         const url = `/json/user_groups/${group.id}`;
@@ -876,7 +864,7 @@ export function initialize() {
         }
 
         dialog_widget.submit_api_request(channel.patch, url, data);
-    }
+    };
 
     $("#groups_overlay_container").on("click", ".create_user_group_button", (e) => {
         e.preventDefault();
@@ -953,12 +941,12 @@ export function initialize() {
     );
 }
 
-export function launch(section, left_side_tab, right_side_tab) {
+export const launch = (section, left_side_tab, right_side_tab) => {
     setup_page(() => {
         overlays.open_overlay({
             name: "group_subscriptions",
             $overlay: $("#groups_overlay"),
-            on_close() {
+            on_close: () => {
                 browser_history.exit_overlay();
             },
         });
@@ -971,4 +959,4 @@ export function launch(section, left_side_tab, right_side_tab) {
             $("#search_group_name").trigger("focus");
         }
     }
-}
+};

--- a/web/src/user_group_edit_members.js
+++ b/web/src/user_group_edit_members.js
@@ -22,35 +22,35 @@ export let pill_widget;
 let current_group_id;
 let member_list_widget;
 
-function get_potential_members() {
+const get_potential_members = () => {
     const group = user_groups.get_user_group_from_id(current_group_id);
-    function is_potential_member(person) {
+    const is_potential_member = (person) => {
         // user  verbose style filter to have room
         // to add more potential checks easily.
         if (group.members.has(person.user_id)) {
             return false;
         }
         return true;
-    }
+    };
 
     return people.filter_all_users(is_potential_member);
-}
+};
 
-function get_user_group_members(group) {
+const get_user_group_members = (group) => {
     const member_ids = [...group.members];
     const active_member_ids = member_ids.filter((user_id) => people.is_person_active(user_id));
     return people.get_users_from_ids(active_member_ids);
-}
+};
 
-export function update_member_list_widget(group) {
+export const update_member_list_widget = (group) => {
     assert(group.id === current_group_id, "Unexpected group rerendering members list");
     const users = get_user_group_members(group);
     people.sort_but_pin_current_user_on_top(users);
     member_list_widget.replace_list_data(users);
-}
+};
 
-function format_member_list_elem(person) {
-    return render_user_group_member_list_entry({
+const format_member_list_elem = (person) =>
+    render_user_group_member_list_entry({
         name: person.full_name,
         user_id: person.user_id,
         is_current_user: person.user_id === current_user.user_id,
@@ -59,9 +59,8 @@ function format_member_list_elem(person) {
         for_user_group_members: true,
         img_src: people.small_avatar_url_for_person(person),
     });
-}
 
-function make_list_widget({$parent_container, name, users}) {
+const make_list_widget = ({$parent_container, name, users}) => {
     people.sort_but_pin_current_user_on_top(users);
 
     const $list_container = $parent_container.find(".member_table");
@@ -78,12 +77,10 @@ function make_list_widget({$parent_container, name, users}) {
             id: user_sort.sort_user_id,
             ...ListWidget.generic_sort_functions("alphabetic", ["full_name"]),
         },
-        modifier_html(item) {
-            return format_member_list_elem(item);
-        },
+        modifier_html: (item) => format_member_list_elem(item),
         filter: {
             $element: $parent_container.find(".search"),
-            predicate(person, value) {
+            predicate: (person, value) => {
                 const matcher = people.build_person_matcher(value);
                 const match = matcher(person);
 
@@ -92,9 +89,9 @@ function make_list_widget({$parent_container, name, users}) {
         },
         $simplebar_container,
     });
-}
+};
 
-export function enable_member_management({group, $parent_container}) {
+export const enable_member_management = ({group, $parent_container}) => {
     const group_id = group.id;
 
     const $pill_container = $parent_container.find(".pill-container");
@@ -116,15 +113,15 @@ export function enable_member_management({group, $parent_container}) {
         name: "user_group_members",
         users: get_user_group_members(group),
     });
-}
+};
 
-function show_user_group_membership_request_result({
+const show_user_group_membership_request_result = ({
     message,
     add_class,
     remove_class,
     already_added_users,
     ignored_deactivated_users,
-}) {
+}) => {
     const $user_group_subscription_req_result_elem = $(
         ".user_group_subscription_request_result",
     ).expectOne();
@@ -140,9 +137,9 @@ function show_user_group_membership_request_result({
     if (remove_class) {
         $user_group_subscription_req_result_elem.removeClass(remove_class);
     }
-}
+};
 
-export function edit_user_group_membership({group, added = [], removed = [], success, error}) {
+export const edit_user_group_membership = ({group, added = [], removed = [], success, error}) => {
     channel.post({
         url: "/json/user_groups/" + group.id + "/members",
         data: {
@@ -152,9 +149,9 @@ export function edit_user_group_membership({group, added = [], removed = [], suc
         success,
         error,
     });
-}
+};
 
-function add_new_members({pill_user_ids}) {
+const add_new_members = ({pill_user_ids}) => {
     const group = user_groups.get_user_group_from_id(current_group_id);
     if (!group) {
         return;
@@ -218,7 +215,7 @@ function add_new_members({pill_user_ids}) {
     }
     const user_ids = [...user_id_set];
 
-    function invite_success() {
+    const invite_success = () => {
         pill_widget.clear();
         show_user_group_membership_request_result({
             message: $t({defaultMessage: "Added successfully."}),
@@ -227,9 +224,9 @@ function add_new_members({pill_user_ids}) {
             already_added_users: ignored_already_added_users,
             ignored_deactivated_users,
         });
-    }
+    };
 
-    function invite_failure(xhr) {
+    const invite_failure = (xhr) => {
         let message = "Failed to add user!";
         if (xhr.responseJSON?.msg) {
             message = xhr.responseJSON.msg;
@@ -239,7 +236,7 @@ function add_new_members({pill_user_ids}) {
             add_class: "text-error",
             remove_class: "text-success",
         });
-    }
+    };
 
     edit_user_group_membership({
         group,
@@ -247,15 +244,15 @@ function add_new_members({pill_user_ids}) {
         success: invite_success,
         error: invite_failure,
     });
-}
+};
 
-function remove_member({group_id, target_user_id, $list_entry}) {
+const remove_member = ({group_id, target_user_id, $list_entry}) => {
     const group = user_groups.get_user_group_from_id(current_group_id);
     if (!group) {
         return;
     }
 
-    function removal_success() {
+    const removal_success = () => {
         if (group_id !== current_group_id) {
             blueslip.info("Response for subscription removal came too late.");
             return;
@@ -268,24 +265,24 @@ function remove_member({group_id, target_user_id, $list_entry}) {
             add_class: "text-success",
             remove_class: "text-remove",
         });
-    }
+    };
 
-    function removal_failure() {
+    const removal_failure = () => {
         show_user_group_membership_request_result({
             message: $t({defaultMessage: "Error removing user from this group."}),
             add_class: "text-error",
             remove_class: "text-success",
         });
-    }
+    };
 
-    function do_remove_user_from_group() {
+    const do_remove_user_from_group = () => {
         edit_user_group_membership({
             group,
             removed: [target_user_id],
             success: removal_success,
             error: removal_failure,
         });
-    }
+    };
 
     if (people.is_my_user_id(target_user_id) && !current_user.is_admin) {
         const html_body = render_leave_user_group_modal({
@@ -303,9 +300,9 @@ function remove_member({group_id, target_user_id, $list_entry}) {
     }
 
     do_remove_user_from_group();
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     add_subscribers_pill.set_up_handlers({
         get_pill_widget: () => pill_widget,
         $parent_container: $("#groups_overlay_container"),
@@ -327,4 +324,4 @@ export function initialize() {
             remove_member({group_id, target_user_id, $list_entry});
         },
     );
-}
+};

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -16,14 +16,12 @@ export type UserGroupPillData = UserGroup & {
     is_silent?: boolean;
 };
 
-function display_pill(group: UserGroup): string {
-    return `${group.name}: ${group.members.size} users`;
-}
+const display_pill = (group: UserGroup): string => `${group.name}: ${group.members.size} users`;
 
-export function create_item_from_group_name(
+export const create_item_from_group_name = (
     group_name: string,
     current_items: CombinedPillItem[],
-): InputPillItem<UserGroupPill> | undefined {
+): InputPillItem<UserGroupPill> | undefined => {
     group_name = group_name.trim();
     const group = user_groups.get_user_group_from_name(group_name);
     if (!group) {
@@ -40,13 +38,14 @@ export function create_item_from_group_name(
         group_id: group.id,
         group_name: group.name,
     };
-}
+};
 
-export function get_group_name_from_item(item: InputPillItem<UserGroupPill>): string {
-    return item.group_name;
-}
+export const get_group_name_from_item = (item: InputPillItem<UserGroupPill>): string =>
+    item.group_name;
 
-export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillContainer): number[] {
+export const get_user_ids = (
+    pill_widget: UserGroupPillWidget | CombinedPillContainer,
+): number[] => {
     let user_ids = pill_widget
         .items()
         .flatMap((item) =>
@@ -59,9 +58,9 @@ export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillCont
 
     user_ids = user_ids.filter(Boolean);
     return user_ids;
-}
+};
 
-export function append_user_group(group: UserGroup, pill_widget: CombinedPillContainer): void {
+export const append_user_group = (group: UserGroup, pill_widget: CombinedPillContainer): void => {
     pill_widget.appendValidatedData({
         type: "user_group",
         display_value: display_pill(group),
@@ -69,26 +68,26 @@ export function append_user_group(group: UserGroup, pill_widget: CombinedPillCon
         group_name: group.name,
     });
     pill_widget.clear_text();
-}
+};
 
-export function get_group_ids(pill_widget: CombinedPillContainer): number[] {
+export const get_group_ids = (pill_widget: CombinedPillContainer): number[] => {
     const items = pill_widget.items();
     return items.flatMap((item) => (item.type === "user_group" ? item.group_id : []));
-}
+};
 
-export function filter_taken_groups(
+export const filter_taken_groups = (
     items: UserGroup[],
     pill_widget: CombinedPillContainer,
-): UserGroup[] {
+): UserGroup[] => {
     const taken_group_ids = get_group_ids(pill_widget);
     items = items.filter((item) => !taken_group_ids.includes(item.id));
     return items;
-}
+};
 
-export function typeahead_source(pill_widget: CombinedPillContainer): UserGroupPillData[] {
+export const typeahead_source = (pill_widget: CombinedPillContainer): UserGroupPillData[] => {
     const groups = user_groups.get_realm_user_groups();
     return filter_taken_groups(groups, pill_widget).map((user_group) => ({
         ...user_group,
         type: "user_group",
     }));
-}
+};

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -21,18 +21,16 @@ let user_group_popover_instance: tippy.Instance | undefined;
 
 type PopoverGroupMember = User & {user_circle_class: string; user_last_seen_time_status: string};
 
-export function hide(): void {
+export const hide = (): void => {
     if (user_group_popover_instance !== undefined) {
         user_group_popover_instance.destroy();
         user_group_popover_instance = undefined;
     }
-}
+};
 
-export function is_open(): boolean {
-    return Boolean(user_group_popover_instance);
-}
+export const is_open = (): boolean => Boolean(user_group_popover_instance);
 
-function get_user_group_popover_items(): JQuery | undefined {
+const get_user_group_popover_items = (): JQuery | undefined => {
     if (user_group_popover_instance === undefined) {
         blueslip.error("Trying to get menu items when user group popover is closed.");
         return undefined;
@@ -45,21 +43,21 @@ function get_user_group_popover_items(): JQuery | undefined {
     }
 
     return $("li:not(.divider):visible a", $popover);
-}
+};
 
-export function handle_keyboard(key: string): void {
+export const handle_keyboard = (key: string): void => {
     const $items = get_user_group_popover_items();
     popover_menus.popover_items_handle_keyboard(key, $items);
-}
+};
 
 // element is the target element to pop off of;
 // the element could be user group pill or mentions in a message;
 // in case of message, message_id is the message id containing it;
 // in case of user group pill, message_id is not used;
-export function toggle_user_group_info_popover(
+export const toggle_user_group_info_popover = (
     element: tippy.ReferenceElement,
     message_id: number | undefined,
-): void {
+): void => {
     if (is_open()) {
         hide();
         return;
@@ -86,7 +84,7 @@ export function toggle_user_group_info_popover(
                     },
                 ],
             },
-            onCreate(instance) {
+            onCreate: (instance) => {
                 if (message_id) {
                     assert(message_lists.current !== undefined);
                     message_lists.current.select_id(message_id);
@@ -103,7 +101,7 @@ export function toggle_user_group_info_popover(
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
             },
-            onHidden() {
+            onHidden: () => {
                 hide();
             },
         },
@@ -111,7 +109,7 @@ export function toggle_user_group_info_popover(
             show_as_overlay_on_mobile: true,
         },
     );
-}
+};
 
 export function register_click_handlers(): void {
     $("#main_div").on("click", ".user-group-mention", function (this: HTMLElement, e) {
@@ -144,35 +142,29 @@ export function register_click_handlers(): void {
     );
 }
 
-function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {
-    return (
-        member_ids
-            .map((m: number) => people.get_user_by_id_assert_valid(m))
-            // We need to include inaccessible users here separately, since
-            // we do not include them in active_user_dict, but we want to
-            // show them in the popover as "Unknown user".
-            .filter(
-                (m: User) => people.is_active_user_for_popover(m.user_id) || m.is_inaccessible_user,
-            )
-            .map((p: User) => ({
-                ...p,
-                user_circle_class: buddy_data.get_user_circle_class(p.user_id),
-                user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
-            }))
-    );
-}
+const fetch_group_members = (member_ids: number[]): PopoverGroupMember[] =>
+    member_ids
+        .map((m: number) => people.get_user_by_id_assert_valid(m))
+        // We need to include inaccessible users here separately, since
+        // we do not include them in active_user_dict, but we want to
+        // show them in the popover as "Unknown user".
+        .filter((m: User) => people.is_active_user_for_popover(m.user_id) || m.is_inaccessible_user)
+        .map((p: User) => ({
+            ...p,
+            user_circle_class: buddy_data.get_user_circle_class(p.user_id),
+            user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
+        }));
 
-function sort_group_members(members: PopoverGroupMember[]): PopoverGroupMember[] {
-    return members.sort((a: PopoverGroupMember, b: PopoverGroupMember) =>
+const sort_group_members = (members: PopoverGroupMember[]): PopoverGroupMember[] =>
+    members.sort((a: PopoverGroupMember, b: PopoverGroupMember) =>
         util.strcmp(a.full_name, b.full_name),
     );
-}
 
 // exporting these functions for testing purposes
 export const _test_fetch_group_members = fetch_group_members;
 
 export const _test_sort_group_members = sort_group_members;
 
-export function initialize(): void {
+export const initialize = (): void => {
     register_click_handlers();
-}
+};

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -30,15 +30,15 @@ let user_group_by_id_dict: Map<number, UserGroup>;
 
 // We have an init() function so that our automated tests
 // can easily clear data.
-export function init(): void {
+export const init = (): void => {
     user_group_name_dict = new FoldDict();
     user_group_by_id_dict = new Map<number, UserGroup>();
-}
+};
 
 // WE INITIALIZE DATA STRUCTURES HERE!
 init();
 
-export function add(user_group_raw: UserGroupRaw): void {
+export const add = (user_group_raw: UserGroupRaw): void => {
     // Reformat the user group members structure to be a set.
     const user_group = {
         description: user_group_raw.description,
@@ -52,26 +52,25 @@ export function add(user_group_raw: UserGroupRaw): void {
 
     user_group_name_dict.set(user_group.name, user_group);
     user_group_by_id_dict.set(user_group.id, user_group);
-}
+};
 
-export function remove(user_group: UserGroup): void {
+export const remove = (user_group: UserGroup): void => {
     user_group_name_dict.delete(user_group.name);
     user_group_by_id_dict.delete(user_group.id);
-}
+};
 
-export function get_user_group_from_id(group_id: number): UserGroup {
+export const get_user_group_from_id = (group_id: number): UserGroup => {
     const user_group = user_group_by_id_dict.get(group_id);
     if (!user_group) {
         throw new Error(`Unknown group_id in get_user_group_from_id: ${group_id}`);
     }
     return user_group;
-}
+};
 
-export function maybe_get_user_group_from_id(group_id: number): UserGroup | undefined {
-    return user_group_by_id_dict.get(group_id);
-}
+export const maybe_get_user_group_from_id = (group_id: number): UserGroup | undefined =>
+    user_group_by_id_dict.get(group_id);
 
-export function update(event: UserGroupUpdateEvent): void {
+export const update = (event: UserGroupUpdateEvent): void => {
     const group = get_user_group_from_id(event.group_id);
     if (event.data.name !== undefined) {
         user_group_name_dict.delete(group.name);
@@ -89,35 +88,34 @@ export function update(event: UserGroupUpdateEvent): void {
         user_group_name_dict.delete(group.name);
         user_group_name_dict.set(group.name, group);
     }
-}
+};
 
-export function get_user_group_from_name(name: string): UserGroup | undefined {
-    return user_group_name_dict.get(name);
-}
+export const get_user_group_from_name = (name: string): UserGroup | undefined =>
+    user_group_name_dict.get(name);
 
-export function get_realm_user_groups(): UserGroup[] {
+export const get_realm_user_groups = (): UserGroup[] => {
     const user_groups = [...user_group_by_id_dict.values()].sort((a, b) => a.id - b.id);
     return user_groups.filter((group) => !group.is_system_group);
-}
+};
 
-export function get_user_groups_allowed_to_mention(): UserGroup[] {
+export const get_user_groups_allowed_to_mention = (): UserGroup[] => {
     const user_groups = get_realm_user_groups();
     return user_groups.filter((group) => {
         const can_mention_group_id = group.can_mention_group;
         return is_user_in_group(can_mention_group_id, current_user.user_id);
     });
-}
+};
 
-export function is_direct_member_of(user_id: number, user_group_id: number): boolean {
+export const is_direct_member_of = (user_id: number, user_group_id: number): boolean => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
         return false;
     }
     return user_group.members.has(user_id);
-}
+};
 
-export function add_members(user_group_id: number, user_ids: number[]): void {
+export const add_members = (user_group_id: number, user_ids: number[]): void => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
@@ -127,9 +125,9 @@ export function add_members(user_group_id: number, user_ids: number[]): void {
     for (const user_id of user_ids) {
         user_group.members.add(user_id);
     }
-}
+};
 
-export function remove_members(user_group_id: number, user_ids: number[]): void {
+export const remove_members = (user_group_id: number, user_ids: number[]): void => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
@@ -139,9 +137,9 @@ export function remove_members(user_group_id: number, user_ids: number[]): void 
     for (const user_id of user_ids) {
         user_group.members.delete(user_id);
     }
-}
+};
 
-export function add_subgroups(user_group_id: number, subgroup_ids: number[]): void {
+export const add_subgroups = (user_group_id: number, subgroup_ids: number[]): void => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
@@ -151,9 +149,9 @@ export function add_subgroups(user_group_id: number, subgroup_ids: number[]): vo
     for (const subgroup_id of subgroup_ids) {
         user_group.direct_subgroup_ids.add(subgroup_id);
     }
-}
+};
 
-export function remove_subgroups(user_group_id: number, subgroup_ids: number[]): void {
+export const remove_subgroups = (user_group_id: number, subgroup_ids: number[]): void => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
@@ -163,29 +161,27 @@ export function remove_subgroups(user_group_id: number, subgroup_ids: number[]):
     for (const subgroup_id of subgroup_ids) {
         user_group.direct_subgroup_ids.delete(subgroup_id);
     }
-}
+};
 
-export function initialize(params: {realm_user_groups: UserGroupRaw[]}): void {
+export const initialize = (params: {realm_user_groups: UserGroupRaw[]}): void => {
     for (const user_group of params.realm_user_groups) {
         add(user_group);
     }
-}
+};
 
-export function is_user_group(
+export const is_user_group = (
     item: (UserOrMention & {members: undefined}) | UserGroup,
-): item is UserGroup {
-    return item.members !== undefined;
-}
+): item is UserGroup => item.members !== undefined;
 
-export function get_user_groups_of_user(user_id: number): UserGroup[] {
+export const get_user_groups_of_user = (user_id: number): UserGroup[] => {
     const user_groups_realm = get_realm_user_groups();
     const groups_of_user = user_groups_realm.filter((group) =>
         is_direct_member_of(user_id, group.id),
     );
     return groups_of_user;
-}
+};
 
-export function get_recursive_subgroups(target_user_group: UserGroup): Set<number> | undefined {
+export const get_recursive_subgroups = (target_user_group: UserGroup): Set<number> | undefined => {
     // Correctness of this algorithm relying on the ES6 Set
     // implementation having the property that a `for of` loop will
     // visit all items that are added to the set during the loop.
@@ -202,9 +198,9 @@ export function get_recursive_subgroups(target_user_group: UserGroup): Set<numbe
         }
     }
     return subgroup_ids;
-}
+};
 
-export function is_user_in_group(user_group_id: number, user_id: number): boolean {
+export const is_user_in_group = (user_group_id: number, user_id: number): boolean => {
     const user_group = user_group_by_id_dict.get(user_group_id);
     if (user_group === undefined) {
         blueslip.error("Could not find user group", {user_group_id});
@@ -225,12 +221,12 @@ export function is_user_in_group(user_group_id: number, user_id: number): boolea
         }
     }
     return false;
-}
+};
 
-export function get_realm_user_groups_for_dropdown_list_widget(
+export const get_realm_user_groups_for_dropdown_list_widget = (
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
-): UserGroupForDropdownListWidget[] {
+): UserGroupForDropdownListWidget[] => {
     const group_setting_config = group_permission_settings.get_group_permission_setting_config(
         setting_name,
         setting_type,
@@ -294,4 +290,4 @@ export function get_realm_user_groups_for_dropdown_list_widget(
     }));
 
     return [...system_user_groups, ...user_groups_excluding_system_groups];
-}
+};

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -20,11 +20,11 @@ export type UserPillWidget = InputPillContainer<UserPill>;
 
 export type UserPillData = {type: "user"; user: User};
 
-export function create_item_from_email(
+export const create_item_from_email = (
     email: string,
     current_items: CombinedPillItem[],
     pill_config?: InputPillConfig | undefined,
-): InputPillItem<UserPill> | undefined {
+): InputPillItem<UserPill> | undefined => {
     // For normal Zulip use, we need to validate the email for our realm.
     const user = people.get_by_email(email);
 
@@ -84,16 +84,14 @@ export function create_item_from_email(
     }
 
     return item;
-}
+};
 
-export function get_email_from_item(item: InputPillItem<UserPill>): string {
-    return item.email;
-}
+export const get_email_from_item = (item: InputPillItem<UserPill>): string => item.email;
 
-export function append_person(opts: {
+export const append_person = (opts: {
     person: User;
     pill_widget: UserPillWidget | CombinedPillContainer;
-}): void {
+}): void => {
     const person = opts.person;
     const pill_widget = opts.pill_widget;
     const avatar_url = people.small_avatar_url_for_person(person);
@@ -111,14 +109,14 @@ export function append_person(opts: {
 
     pill_widget.appendValidatedData(pill_data);
     pill_widget.clear_text();
-}
+};
 
-export function get_user_ids(pill_widget: UserPillWidget | CombinedPillContainer): number[] {
+export const get_user_ids = (pill_widget: UserPillWidget | CombinedPillContainer): number[] => {
     const items = pill_widget.items();
     return items.flatMap((item) => (item.type === "user" ? item.user_id ?? [] : [])); // be defensive about undefined users
-}
+};
 
-export function has_unconverted_data(pill_widget: UserPillWidget): boolean {
+export const has_unconverted_data = (pill_widget: UserPillWidget): boolean => {
     // This returns true if we either have text that hasn't been
     // turned into pills or email-only pills (for Zephyr).
     if (pill_widget.is_pending()) {
@@ -129,26 +127,26 @@ export function has_unconverted_data(pill_widget: UserPillWidget): boolean {
     const has_unknown_items = items.some((item) => item.user_id === undefined);
 
     return has_unknown_items;
-}
+};
 
-export function typeahead_source(
+export const typeahead_source = (
     pill_widget: UserPillWidget | CombinedPillContainer,
     exclude_bots?: boolean,
-): UserPillData[] {
+): UserPillData[] => {
     const users = exclude_bots ? people.get_realm_active_human_users() : people.get_realm_users();
     return filter_taken_users(users, pill_widget).map((user) => ({type: "user", user}));
-}
+};
 
-export function filter_taken_users(
+export const filter_taken_users = (
     items: User[],
     pill_widget: UserPillWidget | CombinedPillContainer,
-): User[] {
+): User[] => {
     const taken_user_ids = get_user_ids(pill_widget);
     items = items.filter((item) => !taken_user_ids.includes(item.user_id));
     return items;
-}
+};
 
-export function append_user(user: User, pills: UserPillWidget | CombinedPillContainer): void {
+export const append_user = (user: User, pills: UserPillWidget | CombinedPillContainer): void => {
     if (user) {
         append_person({
             pill_widget: pills,
@@ -157,12 +155,12 @@ export function append_user(user: User, pills: UserPillWidget | CombinedPillCont
     } else {
         blueslip.warn("Undefined user in function append_user");
     }
-}
+};
 
-export function create_pills(
+export const create_pills = (
     $pill_container: JQuery,
     pill_config?: InputPillConfig | undefined,
-): input_pill.InputPillContainer<UserPill> {
+): input_pill.InputPillContainer<UserPill> => {
     const pills = input_pill.create({
         $container: $pill_container,
         pill_config,
@@ -170,4 +168,4 @@ export function create_pills(
         get_text_from_item: get_email_from_item,
     });
     return pills;
-}
+};

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -58,7 +58,7 @@ const INCOMING_WEBHOOK_BOT_TYPE = 2;
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const EMBEDDED_BOT_TYPE = "4";
 
-export function show_button_spinner($button) {
+export const show_button_spinner = ($button) => {
     const $spinner = $button.find(".modal__spinner");
     const dialog_submit_button_span_width = $button.find("span").width();
     const dialog_submit_button_span_height = $button.find("span").height();
@@ -68,37 +68,35 @@ export function show_button_spinner($button) {
         width: dialog_submit_button_span_width,
         height: dialog_submit_button_span_height,
     });
-}
+};
 
-export function hide_button_spinner($button) {
+export const hide_button_spinner = ($button) => {
     const $spinner = $button.find(".modal__spinner");
     $button.prop("disabled", false);
     $button.find("span").show();
     loading.destroy_indicator($spinner);
-}
+};
 
-function compare_by_name(a, b) {
-    return util.strcmp(a.name, b.name);
-}
+const compare_by_name = (a, b) => util.strcmp(a.name, b.name);
 
-export function get_user_id_if_user_profile_modal_open() {
+export const get_user_id_if_user_profile_modal_open = () => {
     if (modals.any_active() && modals.active_modal() === "#user-profile-modal") {
         const user_id = Number($("#user-profile-modal").attr("data-user-id"));
         return user_id;
     }
     return undefined;
-}
+};
 
-export function update_user_profile_streams_list_for_users(user_ids) {
+export const update_user_profile_streams_list_for_users = (user_ids) => {
     const user_id = get_user_id_if_user_profile_modal_open();
     if (user_id && user_ids.includes(user_id) && user_streams_list_widget !== undefined) {
         const user_streams = stream_data.get_streams_for_user(user_id).subscribed;
         user_streams.sort(compare_by_name);
         user_streams_list_widget.replace_list_data(user_streams);
     }
-}
+};
 
-export function update_profile_modal_ui(user, new_data) {
+export const update_profile_modal_ui = (user, new_data) => {
     if (!(modals.any_active() && modals.active_modal() === "#user-profile-modal")) {
         return;
     }
@@ -127,9 +125,9 @@ export function update_profile_modal_ui(user, new_data) {
         };
         $("#name .user-profile-name").html(render_user_full_name(user_type));
     }
-}
+};
 
-function initialize_bot_owner(element_id, bot_id) {
+const initialize_bot_owner = (element_id, bot_id) => {
     const user_pills = new Map();
     const bot = people.get_by_user_id(bot_id);
     const bot_owner = people.get_bot_owner_user(bot);
@@ -148,9 +146,9 @@ function initialize_bot_owner(element_id, bot_id) {
         user_pills.set(bot_owner.user_id, pills);
     }
     return user_pills;
-}
+};
 
-function render_user_profile_subscribe_widget() {
+const render_user_profile_subscribe_widget = () => {
     const opts = {
         widget_name: "user_profile_subscribe",
         get_options: get_user_unsub_streams,
@@ -163,9 +161,9 @@ function render_user_profile_subscribe_widget() {
     user_profile_subscribe_widget =
         user_profile_subscribe_widget || new dropdown_widget.DropdownWidget(opts);
     user_profile_subscribe_widget.setup();
-}
+};
 
-function change_state_of_subscribe_button(event, dropdown) {
+const change_state_of_subscribe_button = (event, dropdown) => {
     dropdown.hide();
     event.preventDefault();
     event.stopPropagation();
@@ -173,9 +171,9 @@ function change_state_of_subscribe_button(event, dropdown) {
     const $subscribe_button = $("#user-profile-modal .add-subscription-button");
     $subscribe_button.parent()[0]._tippy?.destroy();
     $subscribe_button.prop("disabled", false);
-}
+};
 
-function reset_subscribe_widget() {
+const reset_subscribe_widget = () => {
     $("#user-profile-modal .add-subscription-button").prop("disabled", true);
     settings_components.initialize_disable_btn_hint_popover(
         $("#user-profile-modal .add-subscription-button-wrapper"),
@@ -193,9 +191,9 @@ function reset_subscribe_widget() {
     if (user_profile_subscribe_widget) {
         user_profile_subscribe_widget.current_value = null;
     }
-}
+};
 
-export function get_user_unsub_streams() {
+export const get_user_unsub_streams = () => {
     const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
     return stream_data
         .get_streams_for_user(target_user_id)
@@ -213,9 +211,9 @@ export function get_user_unsub_streams() {
             }
             return 0;
         });
-}
+};
 
-function format_user_stream_list_item_html(stream, user) {
+const format_user_stream_list_item_html = (stream, user) => {
     const show_unsubscribe_button =
         people.can_admin_user(user) || stream_data.can_unsubscribe_others(stream);
     const show_private_stream_unsub_tooltip =
@@ -233,36 +231,31 @@ function format_user_stream_list_item_html(stream, user) {
         show_last_user_in_private_stream_unsub_tooltip,
         stream_edit_url: hash_util.channels_settings_edit_url(stream, "general"),
     });
-}
+};
 
-function format_user_group_list_item_html(group) {
-    return render_user_group_list_item({
+const format_user_group_list_item_html = (group) =>
+    render_user_group_list_item({
         group_id: group.id,
         name: group.name,
         group_edit_url: hash_util.group_edit_url(group),
         is_guest: current_user.is_guest,
     });
-}
 
-function render_user_stream_list(streams, user) {
+const render_user_stream_list = (streams, user) => {
     streams.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-stream-list");
     $container.empty();
     user_streams_list_widget = ListWidget.create($container, streams, {
         name: `user-${user.user_id}-stream-list`,
         get_item: ListWidget.default_get_item,
-        modifier_html(item) {
-            return format_user_stream_list_item_html(item, user);
-        },
-        callback_after_render() {
+        modifier_html: (item) => format_user_stream_list_item_html(item, user),
+        callback_after_render: () => {
             $container.parent().removeClass("empty-list");
         },
         filter: {
             $element: $("#user-profile-streams-tab .stream-search"),
-            predicate(item, value) {
-                return item && item.name.toLocaleLowerCase().includes(value);
-            },
-            onupdate() {
+            predicate: (item, value) => item && item.name.toLocaleLowerCase().includes(value),
+            onupdate: () => {
                 if ($container.find(".empty-table-message").length) {
                     $container.parent().addClass("empty-list");
                 }
@@ -270,26 +263,24 @@ function render_user_stream_list(streams, user) {
         },
         $simplebar_container: $("#user-profile-modal .modal__body"),
     });
-}
+};
 
-function render_user_group_list(groups, user) {
+const render_user_group_list = (groups, user) => {
     groups.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-group-list");
     $container.empty();
     ListWidget.create($container, groups, {
         name: `user-${user.user_id}-group-list`,
         get_item: ListWidget.default_get_item,
-        callback_after_render() {
+        callback_after_render: () => {
             $container.parent().removeClass("empty-list");
         },
-        modifier_html(item) {
-            return format_user_group_list_item_html(item);
-        },
+        modifier_html: (item) => format_user_group_list_item_html(item),
         $simplebar_container: $("#user-profile-modal .modal__body"),
     });
-}
+};
 
-function render_manage_profile_content(user) {
+const render_manage_profile_content = (user) => {
     // Since we want the height of the profile modal to remain consistent when switching tabs,
     // we need to restrict the height of the main body. This will ensure that the footer of
     // the "Manage User" tab can adjust within the provided height without expanding the modal.
@@ -302,9 +293,9 @@ function render_manage_profile_content(user) {
     } else {
         show_edit_user_info_modal(user.user_id, $container);
     }
-}
+};
 
-export function get_custom_profile_field_data(user, field, field_types) {
+export const get_custom_profile_field_data = (user, field, field_types) => {
     const field_value = people.get_custom_profile_data(user.user_id, field.id);
     const field_type = field.type;
     const profile_field = {};
@@ -355,9 +346,9 @@ export function get_custom_profile_field_data(user, field, field_types) {
             profile_field.value = field_value.value;
     }
     return profile_field;
-}
+};
 
-export function update_user_custom_profile_fields(user) {
+export const update_user_custom_profile_fields = (user) => {
     if (!(modals.any_active() && modals.active_modal() === "#user-profile-modal")) {
         return;
     }
@@ -379,23 +370,23 @@ export function update_user_custom_profile_fields(user) {
         user.user_id,
         false,
     );
-}
+};
 
-export function hide_user_profile() {
+export const hide_user_profile = () => {
     modals.close_if_open("user-profile-modal");
-}
+};
 
-function on_user_profile_hide() {
+const on_user_profile_hide = () => {
     user_streams_list_widget = undefined;
     user_profile_subscribe_widget = undefined;
     browser_history.exit_overlay();
-}
+};
 
-function show_manage_user_tab(target) {
+const show_manage_user_tab = (target) => {
     toggler.goto(target);
-}
+};
 
-function initialize_user_type_fields(user) {
+const initialize_user_type_fields = (user) => {
     // Avoid duplicate pill fields, by removing existing ones.
     $("#user-profile-modal .pill").remove();
     if (!user.is_bot) {
@@ -407,21 +398,21 @@ function initialize_user_type_fields(user) {
     } else {
         initialize_bot_owner("#user-profile-modal #content", user.user_id);
     }
-}
+};
 
-export function show_user_profile_access_error_modal() {
+export const show_user_profile_access_error_modal = () => {
     $("body").append($(render_profile_access_error_model()));
 
     // This opens the model, referencing it by it's ID('profile_access_error_model)
     modals.open("profile_access_error_modal", {
         autoremove: true,
-        on_hide() {
+        on_hide: () => {
             browser_history.exit_overlay();
         },
     });
-}
+};
 
-export function show_user_profile(user, default_tab_key = "profile-tab") {
+export const show_user_profile = (user, default_tab_key = "profile-tab") => {
     const field_types = realm.custom_profile_field_types;
     const profile_data = realm.custom_profile_fields
         .map((f) => get_custom_profile_field_data(user, f, field_types))
@@ -498,7 +489,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
             {label: $t({defaultMessage: "Channels"}), key: "user-profile-streams-tab"},
             {label: $t({defaultMessage: "User groups"}), key: "user-profile-groups-tab"},
         ],
-        callback(_name, key) {
+        callback: (_name, key) => {
             $(".tabcontent").hide();
             $(`#${CSS.escape(key)}`).show();
             $("#user-profile-modal .modal__footer").hide();
@@ -553,9 +544,9 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     if (show_user_subscribe_widget) {
         reset_subscribe_widget();
     }
-}
+};
 
-function handle_remove_stream_subscription(target_user_id, sub, success, failure) {
+const handle_remove_stream_subscription = (target_user_id, sub, success, failure) => {
     if (people.is_my_user_id(target_user_id)) {
         // Self unsubscribe.
         channel.del({
@@ -567,7 +558,7 @@ function handle_remove_stream_subscription(target_user_id, sub, success, failure
     } else {
         subscriber_api.remove_user_id_from_stream(target_user_id, sub, success, failure);
     }
-}
+};
 
 export function show_edit_bot_info_modal(user_id, $container) {
     const bot = people.maybe_get_user_by_id(user_id);
@@ -644,7 +635,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
             data: formData,
             processData: false,
             contentType: false,
-            success() {
+            success: () => {
                 avatar_widget.clear();
                 hide_button_spinner($submit_btn);
                 original_values = get_current_values($("#bot-edit-form"));
@@ -656,7 +647,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
                 );
                 $cancel_btn.prop("disabled", false);
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error(
                     $t_html({defaultMessage: "Failed"}),
                     xhr,
@@ -672,25 +663,25 @@ export function show_edit_bot_info_modal(user_id, $container) {
         });
     });
 
-    function edit_bot_post_render() {
+    const edit_bot_post_render = () => {
         $("#edit_bot_modal .dialog_submit_button").prop("disabled", true);
 
-        function get_options() {
+        const get_options = () => {
             const user_ids = people.get_realm_active_human_user_ids();
             return user_ids.map((user_id) => ({
                 name: people.get_full_name(user_id),
                 unique_id: user_id,
             }));
-        }
+        };
 
-        function item_click_callback(event, dropdown) {
+        const item_click_callback = (event, dropdown) => {
             bot_owner_dropdown_widget.render();
             // Let dialog_widget know that there was a change in value.
             $(bot_owner_dropdown_widget.widget_selector).trigger("input");
             dropdown.hide();
             event.stopPropagation();
             event.preventDefault();
-        }
+        };
 
         bot_owner_dropdown_widget = new dropdown_widget.DropdownWidget({
             widget_name: "edit_bot_owner",
@@ -749,10 +740,10 @@ export function show_edit_bot_info_modal(user_id, $container) {
             e.preventDefault();
             e.stopPropagation();
             const bot_id = Number($("#bot-edit-form").attr("data-user-id"));
-            function handle_confirm() {
+            const handle_confirm = () => {
                 const url = "/json/bots/" + encodeURIComponent(bot_id);
                 dialog_widget.submit_api_request(channel.del, url, {});
-            }
+            };
             user_deactivation_ui.confirm_bot_deactivation(bot_id, handle_confirm, true);
         });
 
@@ -761,10 +752,10 @@ export function show_edit_bot_info_modal(user_id, $container) {
             e.preventDefault();
             e.stopPropagation();
             const user_id = Number($("#bot-edit-form").attr("data-user-id"));
-            function handle_confirm() {
+            const handle_confirm = () => {
                 const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
                 dialog_widget.submit_api_request(channel.post, url, {});
-            }
+            };
             user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
         });
 
@@ -774,7 +765,7 @@ export function show_edit_bot_info_modal(user_id, $container) {
             const current_bot_data = bot_data.get(bot.user_id);
             integration_url_modal.show_generate_integration_url_modal(current_bot_data.api_key);
         });
-    }
+    };
 }
 
 function get_human_profile_data(fields_user_pills) {
@@ -813,14 +804,14 @@ function get_human_profile_data(fields_user_pills) {
     return new_profile_data;
 }
 
-function get_current_values($edit_form) {
+const get_current_values = ($edit_form) => {
     const current_values = dialog_widget.get_current_values(
         $edit_form.find("input, select, textarea, button, .pill-container"),
     );
     return current_values;
-}
+};
 
-function toggle_submit_button($edit_form) {
+const toggle_submit_button = ($edit_form) => {
     const current_values = get_current_values($edit_form);
     const $submit_btn = $("#user-profile-modal .dialog_submit_button");
     if (!_.isEqual(original_values, current_values)) {
@@ -828,9 +819,9 @@ function toggle_submit_button($edit_form) {
     } else {
         $submit_btn.prop("disabled", true);
     }
-}
+};
 
-export function show_edit_user_info_modal(user_id, $container) {
+export const show_edit_user_info_modal = (user_id, $container) => {
     const person = people.maybe_get_user_by_id(user_id);
     const is_active = people.is_person_active(user_id);
 
@@ -882,10 +873,10 @@ export function show_edit_user_info_modal(user_id, $container) {
         e.preventDefault();
         e.stopPropagation();
         const user_id = Number($("#edit-user-form").attr("data-user-id"));
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/users/" + encodeURIComponent(user_id);
             dialog_widget.submit_api_request(channel.del, url, {});
-        }
+        };
         user_deactivation_ui.confirm_deactivation(user_id, handle_confirm, true);
     });
 
@@ -894,10 +885,10 @@ export function show_edit_user_info_modal(user_id, $container) {
         e.preventDefault();
         e.stopPropagation();
         const user_id = Number($("#edit-user-form").attr("data-user-id"));
-        function handle_confirm() {
+        const handle_confirm = () => {
             const url = "/json/users/" + encodeURIComponent(user_id) + "/reactivate";
             dialog_widget.submit_api_request(channel.post, url, {});
-        }
+        };
         user_deactivation_ui.confirm_reactivation(user_id, handle_confirm, true);
     });
 
@@ -926,7 +917,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         channel.patch({
             url,
             data,
-            success() {
+            success: () => {
                 hide_button_spinner($submit_btn);
                 original_values = get_current_values($("#edit-user-form"));
                 toggle_submit_button($("#edit-user-form"));
@@ -937,7 +928,7 @@ export function show_edit_user_info_modal(user_id, $container) {
                 );
                 $cancel_btn.prop("disabled", false);
             },
-            error(xhr) {
+            error: (xhr) => {
                 ui_report.error(
                     $t_html({defaultMessage: "Failed"}),
                     xhr,
@@ -952,16 +943,16 @@ export function show_edit_user_info_modal(user_id, $container) {
             },
         });
     });
-}
+};
 
-export function initialize() {
+export const initialize = () => {
     $("body").on("click", "#user-profile-modal .add-subscription-button", (e) => {
         e.preventDefault();
         const stream_id = Number.parseInt(user_profile_subscribe_widget.value(), 10);
         const sub = sub_store.get(stream_id);
         const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
-        function addition_success(data) {
+        const addition_success = (data) => {
             if (Object.keys(data.subscribed).length > 0) {
                 reset_subscribe_widget();
                 ui_report.success(
@@ -976,10 +967,10 @@ export function initialize() {
                     1200,
                 );
             }
-        }
-        function addition_failure(xhr) {
+        };
+        const addition_failure = (xhr) => {
             ui_report.error("", xhr, $alert_box, 1200);
-        }
+        };
         subscriber_api.add_user_ids_to_stream(
             [target_user_id],
             sub,
@@ -996,7 +987,7 @@ export function initialize() {
         const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
 
-        function removal_success(data) {
+        const removal_success = (data) => {
             if (data.removed.length > 0) {
                 ui_report.success(
                     $t_html({defaultMessage: "Unsubscribed successfully!"}),
@@ -1010,9 +1001,9 @@ export function initialize() {
                     1200,
                 );
             }
-        }
+        };
 
-        function removal_failure() {
+        const removal_failure = () => {
             let error_message;
             if (people.is_my_user_id(target_user_id)) {
                 error_message = $t(
@@ -1027,7 +1018,7 @@ export function initialize() {
             }
 
             ui_report.client_error(error_message, $alert_box, 1200);
-        }
+        };
 
         if (
             sub.invite_only &&
@@ -1091,7 +1082,7 @@ export function initialize() {
     });
 
     new ClipboardJS(".copy-link-to-user-profile", {
-        text(trigger) {
+        text: (trigger) => {
             const user_id = $(trigger).attr("data-user-id");
             const user_profile_link = window.location.origin + "/#user/" + user_id;
 
@@ -1100,4 +1091,4 @@ export function initialize() {
     }).on("success", (e) => {
         show_copied_confirmation(e.trigger);
     });
-}
+};

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -67,6 +67,6 @@ export type UserSettings = (StreamNotificationSettings &
 
 export let user_settings: UserSettings;
 
-export function initialize_user_settings(params: {user_settings: UserSettings}): void {
+export const initialize_user_settings = (params: {user_settings: UserSettings}): void => {
     user_settings = params.user_settings;
-}
+};

--- a/web/src/user_sort.ts
+++ b/web/src/user_sort.ts
@@ -1,15 +1,15 @@
 import type {User} from "./people";
 
-export function compare_a_b(a: number | string, b: number | string): number {
+export const compare_a_b = (a: number | string, b: number | string): number => {
     if (a > b) {
         return 1;
     } else if (a === b) {
         return 0;
     }
     return -1;
-}
+};
 
-export function sort_email(a: User, b: User): number {
+export const sort_email = (a: User, b: User): number => {
     const email_a = a.delivery_email;
     const email_b = b.delivery_email;
 
@@ -27,12 +27,8 @@ export function sort_email(a: User, b: User): number {
         return -1;
     }
     return compare_a_b(email_a.toLowerCase(), email_b.toLowerCase());
-}
+};
 
-export function sort_role(a: User, b: User): number {
-    return compare_a_b(a.role, b.role);
-}
+export const sort_role = (a: User, b: User): number => compare_a_b(a.role, b.role);
 
-export function sort_user_id(a: User, b: User): number {
-    return compare_a_b(a.user_id, b.user_id);
-}
+export const sort_user_id = (a: User, b: User): number => compare_a_b(a.user_id, b.user_id);

--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -43,13 +43,13 @@ const user_status_param_schema = z.record(z.string(), user_status_schema);
 const user_info = new Map<number, string>();
 const user_status_emoji_info = new Map<number, UserStatusEmojiInfo>();
 
-export function server_update_status(opts: {
+export const server_update_status = (opts: {
     status_text: string;
     emoji_name: string;
     emoji_code: string;
     reaction_type?: string;
     success?: () => void;
-}): void {
+}): void => {
     void channel.post({
         url: "/json/users/me/status",
         data: {
@@ -58,50 +58,47 @@ export function server_update_status(opts: {
             emoji_code: opts.emoji_code,
             reaction_type: opts.reaction_type,
         },
-        success() {
+        success: () => {
             if (opts.success) {
                 opts.success();
             }
         },
     });
-}
+};
 
-export function server_invisible_mode_on(): void {
+export const server_invisible_mode_on = (): void => {
     void channel.patch({
         url: "/json/settings",
         data: {
             presence_enabled: false,
         },
     });
-}
+};
 
-export function server_invisible_mode_off(): void {
+export const server_invisible_mode_off = (): void => {
     void channel.patch({
         url: "/json/settings",
         data: {
             presence_enabled: true,
         },
     });
-}
+};
 
-export function get_status_text(user_id: number): string | undefined {
-    return user_info.get(user_id);
-}
+export const get_status_text = (user_id: number): string | undefined => user_info.get(user_id);
 
-export function set_status_text(opts: {user_id: number; status_text: string}): void {
+export const set_status_text = (opts: {user_id: number; status_text: string}): void => {
     if (!opts.status_text) {
         user_info.delete(opts.user_id);
         return;
     }
 
     user_info.set(opts.user_id, opts.status_text);
-}
+};
 
-export function get_status_emoji(user_id: number): UserStatusEmojiInfo | undefined {
-    return user_status_emoji_info.get(user_id);
-}
+export const get_status_emoji = (user_id: number): UserStatusEmojiInfo | undefined =>
+    user_status_emoji_info.get(user_id);
 
-export function set_status_emoji(event: UserStatusEvent): void {
+export const set_status_emoji = (event: UserStatusEvent): void => {
     const opts = user_status_event_schema.parse(event);
 
     if (!opts.emoji_name) {
@@ -117,9 +114,9 @@ export function set_status_emoji(event: UserStatusEvent): void {
             reaction_type: opts.reaction_type,
         }),
     });
-}
+};
 
-export function initialize(params: {user_status: unknown}): void {
+export const initialize = (params: {user_status: unknown}): void => {
     user_info.clear();
 
     const user_status = user_status_param_schema.parse(params.user_status);
@@ -139,4 +136,4 @@ export function initialize(params: {user_status: unknown}): void {
             });
         }
     }
-}
+};

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -15,19 +15,16 @@ import type {UserStatusEmojiInfo} from "./user_status";
 let selected_emoji_info: Partial<UserStatusEmojiInfo> = {};
 let default_status_messages_and_emoji_info: {status_text: string; emoji: EmojiRenderingDetails}[];
 
-export function set_selected_emoji_info(emoji_info: Partial<UserStatusEmojiInfo>): void {
+export const set_selected_emoji_info = (emoji_info: Partial<UserStatusEmojiInfo>): void => {
     selected_emoji_info = {...emoji_info};
     rebuild_status_emoji_selector_ui(selected_emoji_info);
-}
-export function input_field(): JQuery<HTMLInputElement> {
-    return $<HTMLInputElement>("#set-user-status-modal input.user-status");
-}
+};
+export const input_field = (): JQuery<HTMLInputElement> =>
+    $<HTMLInputElement>("#set-user-status-modal input.user-status");
 
-export function submit_button(): JQuery {
-    return $("#set-user-status-modal .dialog_submit_button");
-}
+export const submit_button = (): JQuery => $("#set-user-status-modal .dialog_submit_button");
 
-export function open_user_status_modal(): void {
+export const open_user_status_modal = (): void => {
     const user_id = people.my_current_user_id();
     const selected_emoji_info = user_status.get_status_emoji(user_id) ?? {};
     const rendered_set_status_overlay = render_set_status_overlay({
@@ -42,13 +39,13 @@ export function open_user_status_modal(): void {
         id: "set-user-status-modal",
         on_click: submit_new_status,
         post_render: user_status_post_render,
-        on_shown() {
+        on_shown: () => {
             input_field().trigger("focus");
         },
     });
-}
+};
 
-export function submit_new_status(): void {
+export const submit_new_status = (): void => {
     const user_id = people.my_current_user_id();
     let old_status_text = user_status.get_status_text(user_id) ?? "";
     old_status_text = old_status_text.trim();
@@ -68,13 +65,13 @@ export function submit_new_status(): void {
         emoji_name: selected_emoji_info.emoji_name ?? "",
         emoji_code: selected_emoji_info.emoji_code ?? "",
         reaction_type: selected_emoji_info.reaction_type ?? "",
-        success() {
+        success: () => {
             dialog_widget.close();
         },
     });
-}
+};
 
-export function update_button(): void {
+export const update_button = (): void => {
     const user_id = people.my_current_user_id();
     let old_status_text = user_status.get_status_text(user_id) ?? "";
     old_status_text = old_status_text.trim();
@@ -90,30 +87,28 @@ export function update_button(): void {
     } else {
         $button.prop("disabled", false);
     }
-}
+};
 
-export function toggle_clear_message_button(): void {
+export const toggle_clear_message_button = (): void => {
     if (input_field().val() !== "" || selected_emoji_info.emoji_name) {
         $("#clear_status_message_button").prop("disabled", false);
     } else {
         $("#clear_status_message_button").prop("disabled", true);
     }
-}
+};
 
-export function clear_message(): void {
+export const clear_message = (): void => {
     const $field = input_field();
     $field.val("");
     $("#clear_status_message_button").prop("disabled", true);
-}
+};
 
-export function user_status_picker_open(): boolean {
-    return $("#set-user-status-modal").length !== 0;
-}
+export const user_status_picker_open = (): boolean => $("#set-user-status-modal").length !== 0;
 
-function emoji_status_fields_changed(
+const emoji_status_fields_changed = (
     selected_emoji_info: Partial<UserStatusEmojiInfo>,
     old_emoji_info?: UserStatusEmojiInfo,
-): boolean {
+): boolean => {
     if (old_emoji_info === undefined && Object.keys(selected_emoji_info).length === 0) {
         return false;
     } else if (
@@ -126,18 +121,20 @@ function emoji_status_fields_changed(
     }
 
     return true;
-}
+};
 
-function rebuild_status_emoji_selector_ui(selected_emoji_info: Partial<UserStatusEmojiInfo>): void {
+const rebuild_status_emoji_selector_ui = (
+    selected_emoji_info: Partial<UserStatusEmojiInfo>,
+): void => {
     let selected_emoji = null;
     if (selected_emoji_info && Object.keys(selected_emoji_info).length) {
         selected_emoji = selected_emoji_info;
     }
     const rendered_status_emoji_selector = render_status_emoji_selector({selected_emoji});
     $("#set-user-status-modal .status-emoji-wrapper").html(rendered_status_emoji_selector);
-}
+};
 
-function user_status_post_render(): void {
+const user_status_post_render = (): void => {
     const user_id = people.my_current_user_id();
     const old_status_text = user_status.get_status_text(user_id) ?? "";
     const old_emoji_info = user_status.get_status_emoji(user_id) ?? {};
@@ -181,9 +178,9 @@ function user_status_post_render(): void {
         set_selected_emoji_info({});
         update_button();
     });
-}
+};
 
-export function initialize(): void {
+export const initialize = (): void => {
     default_status_messages_and_emoji_info = [
         {
             status_text: $t({defaultMessage: "Busy"}),
@@ -214,4 +211,4 @@ export function initialize(): void {
             emoji: emoji.get_emoji_details_by_name("office"),
         },
     ];
-}
+};

--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -8,7 +8,7 @@ import {parse_html} from "./ui_util";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
 
-export function initialize() {
+export const initialize = () => {
     popover_menus.register_popover_menu(".change_visibility_policy", {
         placement: "bottom",
         popperOptions: {
@@ -23,7 +23,7 @@ export function initialize() {
                 },
             ],
         },
-        onShow(instance) {
+        onShow: (instance) => {
             popover_menus.popover_instances.change_visibility_policy = instance;
             popover_menus.on_show_prep(instance);
             const $elt = $(instance.reference).closest(".change_visibility_policy").expectOne();
@@ -40,7 +40,7 @@ export function initialize() {
                 parse_html(render_change_visibility_policy_popover(instance.context)),
             );
         },
-        onMount(instance) {
+        onMount: (instance) => {
             const $popper = $(instance.popper);
             const {stream_id, topic_name} = instance.context;
 
@@ -94,7 +94,7 @@ export function initialize() {
                 );
             });
         },
-        onHidden(instance) {
+        onHidden: (instance) => {
             $(instance.reference)
                 .closest(".change_visibility_policy")
                 .expectOne()
@@ -103,4 +103,4 @@ export function initialize() {
             popover_menus.popover_instances.change_visibility_policy = undefined;
         },
     });
-}
+};

--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -50,13 +50,13 @@ export const all_visibility_policies = {
     FOLLOWED: 3,
 };
 
-export function update_user_topics(
+export const update_user_topics = (
     stream_id: number,
     stream_name: string,
     topic: string,
     visibility_policy: number,
     date_updated: number,
-): void {
+): void => {
     let sub_dict = all_user_topics.get(stream_id);
     if (visibility_policy === all_visibility_policies.INHERIT && sub_dict) {
         sub_dict.delete(topic);
@@ -68,33 +68,29 @@ export function update_user_topics(
         const time = get_time_from_date_muted(date_updated);
         sub_dict.set(topic, {date_updated: time, visibility_policy, stream_name});
     }
-}
+};
 
-export function get_topic_visibility_policy(stream_id: number, topic: string): number | false {
+export const get_topic_visibility_policy = (stream_id: number, topic: string): number | false => {
     if (stream_id === undefined) {
         return false;
     }
     const sub_dict = all_user_topics.get(stream_id);
     return sub_dict?.get(topic)?.visibility_policy ?? all_visibility_policies.INHERIT;
-}
+};
 
-export function is_topic_followed(stream_id: number, topic: string): boolean {
-    return get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.FOLLOWED;
-}
+export const is_topic_followed = (stream_id: number, topic: string): boolean =>
+    get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.FOLLOWED;
 
-export function is_topic_unmuted(stream_id: number, topic: string): boolean {
-    return get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.UNMUTED;
-}
+export const is_topic_unmuted = (stream_id: number, topic: string): boolean =>
+    get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.UNMUTED;
 
-export function is_topic_muted(stream_id: number, topic: string): boolean {
-    return get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.MUTED;
-}
+export const is_topic_muted = (stream_id: number, topic: string): boolean =>
+    get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.MUTED;
 
-export function is_topic_unmuted_or_followed(stream_id: number, topic: string): boolean {
-    return is_topic_unmuted(stream_id, topic) || is_topic_followed(stream_id, topic);
-}
+export const is_topic_unmuted_or_followed = (stream_id: number, topic: string): boolean =>
+    is_topic_unmuted(stream_id, topic) || is_topic_followed(stream_id, topic);
 
-export function get_user_topics_for_visibility_policy(visibility_policy: number): UserTopic[] {
+export const get_user_topics_for_visibility_policy = (visibility_policy: number): UserTopic[] => {
     const topics: UserTopic[] = [];
     for (const [stream_id, sub_dict] of all_user_topics) {
         for (const topic of sub_dict.keys()) {
@@ -114,9 +110,9 @@ export function get_user_topics_for_visibility_policy(visibility_policy: number)
         }
     }
     return topics;
-}
+};
 
-export function set_user_topic_visibility_policy(
+export const set_user_topic_visibility_policy = (
     stream_id: number,
     topic: string,
     visibility_policy: number,
@@ -125,7 +121,7 @@ export function set_user_topic_visibility_policy(
     $status_element?: JQuery,
     success_cb?: () => void,
     error_cb?: () => void,
-): void {
+): void => {
     const data = {
         stream_id,
         topic,
@@ -142,7 +138,7 @@ export function set_user_topic_visibility_policy(
     void channel.post({
         url: "/json/user_topics",
         data,
-        success() {
+        success: () => {
             if (success_cb) {
                 success_cb();
             }
@@ -179,13 +175,13 @@ export function set_user_topic_visibility_policy(
             if (visibility_policy === all_visibility_policies.MUTED) {
                 const stream_name = sub_store.maybe_get_stream_name(stream_id);
                 feedback_widget.show({
-                    populate($container) {
+                    populate: ($container) => {
                         const rendered_html = render_topic_muted({});
                         $container.html(rendered_html);
                         $container.find(".stream").text(stream_name ?? "");
                         $container.find(".topic").text(topic);
                     },
-                    on_undo() {
+                    on_undo: () => {
                         set_user_topic_visibility_policy(
                             stream_id,
                             topic,
@@ -197,21 +193,24 @@ export function set_user_topic_visibility_policy(
                 });
             }
         },
-        error() {
+        error: () => {
             if (error_cb) {
                 error_cb();
             }
         },
     });
-}
+};
 
-export function set_visibility_policy_for_element($elt: JQuery, visibility_policy: number): void {
+export const set_visibility_policy_for_element = (
+    $elt: JQuery,
+    visibility_policy: number,
+): void => {
     const stream_id = Number.parseInt($elt.attr("data-stream-id")!, 10);
     const topic = $elt.attr("data-topic-name")!;
     set_user_topic_visibility_policy(stream_id, topic, visibility_policy);
-}
+};
 
-export function set_user_topic(user_topic: ServerUserTopic): void {
+export const set_user_topic = (user_topic: ServerUserTopic): void => {
     const stream_id = user_topic.stream_id;
     const topic = user_topic.topic_name;
     const date_updated = user_topic.last_updated;
@@ -224,18 +223,18 @@ export function set_user_topic(user_topic: ServerUserTopic): void {
     }
 
     update_user_topics(stream_id, stream_name, topic, user_topic.visibility_policy, date_updated);
-}
+};
 
-export function set_user_topics(user_topics: ServerUserTopic[]): void {
+export const set_user_topics = (user_topics: ServerUserTopic[]): void => {
     all_user_topics.clear();
 
     for (const user_topic of user_topics) {
         set_user_topic(user_topic);
     }
-}
+};
 
-export function initialize(params: {user_topics: ServerUserTopic[]}): void {
+export const initialize = (params: {user_topics: ServerUserTopic[]}): void => {
     const user_topics = user_topic_schema.array().parse(params.user_topics);
 
     set_user_topics(user_topics);
-}
+};

--- a/web/src/user_topics_ui.ts
+++ b/web/src/user_topics_ui.ts
@@ -14,7 +14,7 @@ import * as unread_ui from "./unread_ui";
 import * as user_topics from "./user_topics";
 import type {ServerUserTopic} from "./user_topics";
 
-function should_add_topic_update_delay(visibility_policy: number): boolean | undefined {
+const should_add_topic_update_delay = (visibility_policy: number): boolean | undefined => {
     // If topic visibility related popovers are active, add a delay to all methods that
     // hide the topic on mute. This allows the switching animations to complete before the
     // popover is force closed due to the reference element being removed from view.
@@ -29,9 +29,9 @@ function should_add_topic_update_delay(visibility_policy: number): boolean | und
     const is_topic_narrow = narrow_state.narrowed_by_topic_reply();
 
     return is_topic_muted && is_relevant_popover_open && !is_inbox_view && !is_topic_narrow;
-}
+};
 
-export function handle_topic_updates(user_topic_event: ServerUserTopic): void {
+export const handle_topic_updates = (user_topic_event: ServerUserTopic): void => {
     // Update the UI after changes in topic visibility policies.
     user_topics.set_user_topic(user_topic_event);
 
@@ -79,9 +79,9 @@ export function handle_topic_updates(user_topic_event: ServerUserTopic): void {
             }
         }
     }, 0);
-}
+};
 
-export function toggle_topic_visibility_policy(message: Message): void {
+export const toggle_topic_visibility_policy = (message: Message): void => {
     if (message.type !== "stream") {
         return;
     }
@@ -115,4 +115,4 @@ export function toggle_topic_visibility_policy(message: Message): void {
             );
         }
     }
-}
+};

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -7,9 +7,8 @@ import type {UpdateMessageEvent} from "./types";
 import {user_settings} from "./user_settings";
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
-export function random_int(min: number, max: number): number {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-}
+export const random_int = (min: number, max: number): number =>
+    Math.floor(Math.random() * (max - min + 1)) + min;
 
 // Like C++'s std::lower_bound.  Returns the first index at which
 // `value` could be inserted without changing the ordering.  Assumes
@@ -21,11 +20,11 @@ export function random_int(min: number, max: number): number {
 // for some i and false otherwise.
 //
 // Usage: lower_bound(array, value, less)
-export function lower_bound<T1, T2>(
+export const lower_bound = <T1, T2>(
     array: T1[],
     value: T2,
     less: (item: T1, value: T2, middle: number) => boolean,
-): number {
+): number => {
     let first = 0;
     const last = array.length;
 
@@ -44,9 +43,9 @@ export function lower_bound<T1, T2>(
         }
     }
     return first;
-}
+};
 
-export const lower_same = function lower_same(a?: string, b?: string): boolean {
+export const lower_same = (a?: string, b?: string): boolean => {
     if (a === undefined || b === undefined) {
         blueslip.error("Cannot compare strings; at least one value is undefined", {a, b});
         return false;
@@ -59,17 +58,11 @@ export type StreamTopic = {
     topic: string;
 };
 
-export const same_stream_and_topic = function util_same_stream_and_topic(
-    a: StreamTopic,
-    b: StreamTopic,
-): boolean {
-    // Streams and topics are case-insensitive.
-    return a.stream_id === b.stream_id && lower_same(a.topic, b.topic);
-};
+export const same_stream_and_topic = (a: StreamTopic, b: StreamTopic): boolean =>
+    a.stream_id === b.stream_id && lower_same(a.topic, b.topic);
 
-export function extract_pm_recipients(recipients: string): string[] {
-    return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
-}
+export const extract_pm_recipients = (recipients: string): string[] =>
+    recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
 
 // When the type is "private", properties from to_user_ids might be undefined.
 // See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
@@ -77,7 +70,7 @@ export type Recipient =
     | {type: "private"; to_user_ids?: string | undefined; reply_to: string}
     | ({type: "stream"} & StreamTopic);
 
-export const same_recipient = function util_same_recipient(a?: Recipient, b?: Recipient): boolean {
+export const same_recipient = (a?: Recipient, b?: Recipient): boolean => {
     if (a === undefined || b === undefined) {
         return false;
     }
@@ -94,31 +87,24 @@ export const same_recipient = function util_same_recipient(a?: Recipient, b?: Re
     return false;
 };
 
-export const same_sender = function util_same_sender(a: RawMessage, b: RawMessage): boolean {
-    return (
-        a !== undefined &&
-        b !== undefined &&
-        a.sender_email.toLowerCase() === b.sender_email.toLowerCase()
-    );
-};
+export const same_sender = (a: RawMessage, b: RawMessage): boolean =>
+    a !== undefined &&
+    b !== undefined &&
+    a.sender_email.toLowerCase() === b.sender_email.toLowerCase();
 
-export function normalize_recipients(recipients: string): string {
-    // Converts a string listing emails of message recipients
-    // into a canonical formatting: emails sorted ASCIIbetically
-    // with exactly one comma and no spaces between each.
-    return recipients
+export const normalize_recipients = (recipients: string): string =>
+    recipients
         .split(",")
         .map((s) => s.trim().toLowerCase())
         .filter((s) => s.length > 0)
         .sort()
         .join(",");
-}
 
 // Avoid URI decode errors by removing characters from the end
 // one by one until the decode succeeds.  This makes sense if
 // we are decoding input that the user is in the middle of
 // typing.
-export function robust_url_decode(str: string): string {
+export const robust_url_decode = (str: string): string => {
     let end = str.length;
     while (end > 0) {
         try {
@@ -131,13 +117,13 @@ export function robust_url_decode(str: string): string {
         }
     }
     return "";
-}
+};
 
 // If we can, use a locale-aware sorter.  However, if the browser
 // doesn't support the ECMAScript Internationalization API
 // Specification, do a dumb string comparison because
 // String.localeCompare is really slow.
-export function make_strcmp(): (x: string, y: string) => number {
+export const make_strcmp = (): ((x: string, y: string) => number) => {
     try {
         const collator = new Intl.Collator();
         return collator.compare.bind(collator);
@@ -145,14 +131,12 @@ export function make_strcmp(): (x: string, y: string) => number {
         // continue regardless of error
     }
 
-    return function util_strcmp(a: string, b: string): number {
-        return a < b ? -1 : a > b ? 1 : 0;
-    };
-}
+    return (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+};
 
 export const strcmp = make_strcmp();
 
-export const array_compare = function util_array_compare<T>(a: T[], b: T[]): boolean {
+export const array_compare = <T>(a: T[], b: T[]): boolean => {
     if (a.length !== b.length) {
         return false;
     }
@@ -194,7 +178,7 @@ export class CachedValue<T> {
     }
 }
 
-export function find_stream_wildcard_mentions(message_content: string): string | null {
+export const find_stream_wildcard_mentions = (message_content: string): string | null => {
     // We cannot use the exact same regex as the server side uses (in zerver/lib/mention.py)
     // because Safari < 16.4 does not support look-behind assertions.  Reframe the lookbehind of a
     // negative character class as a start-of-string or positive character class.
@@ -205,12 +189,9 @@ export function find_stream_wildcard_mentions(message_content: string): string |
         return null;
     }
     return mention[2]!;
-}
+};
 
-export const move_array_elements_to_front = function util_move_array_elements_to_front<T>(
-    array: T[],
-    selected: T[],
-): T[] {
+export const move_array_elements_to_front = <T>(array: T[], selected: T[]): T[] => {
     const selected_hash = new Set(selected);
     const selected_elements: T[] = [];
     const unselected_elements: T[] = [];
@@ -221,37 +202,29 @@ export const move_array_elements_to_front = function util_move_array_elements_to
 };
 
 // check by the userAgent string if a user's client is likely mobile.
-export function is_mobile(): boolean {
-    return /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(
+export const is_mobile = (): boolean =>
+    /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(
         window.navigator.userAgent,
     );
-}
 
-export function is_client_safari(): boolean {
-    // Since GestureEvent is only supported on Safari, we can use it
-    // to detect if the browser is Safari including Safari on iOS.
-    // https://developer.mozilla.org/en-US/docs/Web/API/GestureEvent
-    return "GestureEvent" in window;
-}
+export const is_client_safari = (): boolean => "GestureEvent" in window;
 
-export function sorted_ids(ids: number[]): number[] {
+export const sorted_ids = (ids: number[]): number[] => {
     // This makes sure we don't mutate the list.
     const id_list = [...new Set(ids)];
     id_list.sort((a, b) => a - b);
 
     return id_list;
-}
+};
 
-export function set_match_data(target: Message, source: MatchedMessage): void {
+export const set_match_data = (target: Message, source: MatchedMessage): void => {
     target.match_subject = source.match_subject;
     target.match_content = source.match_content;
-}
+};
 
-export function get_match_topic(obj: Message | RawMessage): string | undefined {
-    return obj.match_subject;
-}
+export const get_match_topic = (obj: Message | RawMessage): string | undefined => obj.match_subject;
 
-export function get_edit_event_topic(obj: UpdateMessageEvent): string | undefined {
+export const get_edit_event_topic = (obj: UpdateMessageEvent): string | undefined => {
     if (obj.topic === undefined) {
         return obj.subject;
     }
@@ -259,30 +232,23 @@ export function get_edit_event_topic(obj: UpdateMessageEvent): string | undefine
     // This code won't be reachable till we fix the
     // server, but we use it now in tests.
     return obj.topic;
-}
+};
 
-export function get_edit_event_orig_topic(obj: UpdateMessageEvent): string | undefined {
-    return obj.orig_subject;
-}
+export const get_edit_event_orig_topic = (obj: UpdateMessageEvent): string | undefined =>
+    obj.orig_subject;
 
-export function is_topic_synonym(operator: string): boolean {
-    return operator === "subject";
-}
+export const is_topic_synonym = (operator: string): boolean => operator === "subject";
 
 // TODO: When "stream" is renamed to "channel", update these stream
 // synonym helper functions for the reverse logic.
-export function is_stream_synonym(text: string): boolean {
-    return text === "channel";
-}
+export const is_stream_synonym = (text: string): boolean => text === "channel";
 
-export function is_streams_synonym(text: string): boolean {
-    return text === "channels";
-}
+export const is_streams_synonym = (text: string): boolean => text === "channels";
 
 // For parts of the codebase that have been converted to use
 // channel/channels internally, this is used to convert those
 // back into stream/streams for external presentation.
-export function canonicalize_stream_synonyms(text: string): string {
+export const canonicalize_stream_synonyms = (text: string): string => {
     if (is_stream_synonym(text.toLowerCase())) {
         return "stream";
     }
@@ -290,11 +256,11 @@ export function canonicalize_stream_synonyms(text: string): string {
         return "streams";
     }
     return text;
-}
+};
 
 let inertDocument: Document | undefined;
 
-export function clean_user_content_links(html: string): string {
+export const clean_user_content_links = (html: string): string => {
     if (inertDocument === undefined) {
         inertDocument = new DOMParser().parseFromString("", "text/html");
     }
@@ -377,14 +343,14 @@ export function clean_user_content_links(html: string): string {
         }
     }
     return template.innerHTML;
-}
+};
 
-export function filter_by_word_prefix_match<T>(
+export const filter_by_word_prefix_match = <T>(
     items: T[],
     search_term: string,
     item_to_text: (item: T) => string,
     word_separator_regex = /\s/,
-): T[] {
+): T[] => {
     if (search_term === "") {
         return items;
     }
@@ -407,16 +373,16 @@ export function filter_by_word_prefix_match<T>(
     );
 
     return filtered_items;
-}
+};
 
-export function get_time_from_date_muted(date_muted: number | undefined): number {
+export const get_time_from_date_muted = (date_muted: number | undefined): number => {
     if (date_muted === undefined) {
         return Date.now();
     }
     return date_muted * 1000;
-}
+};
 
-export function call_function_periodically(callback: () => void, delay: number): void {
+export const call_function_periodically = (callback: () => void, delay: number): void => {
     // We previously used setInterval for this purpose, but
     // empirically observed that after unsuspend, Chrome can end
     // up trying to "catch up" by doing dozens of these requests
@@ -438,9 +404,9 @@ export function call_function_periodically(callback: () => void, delay: number):
         // exception.
         callback();
     }, delay);
-}
+};
 
-export function get_string_diff(string1: string, string2: string): [number, number, number] {
+export const get_string_diff = (string1: string, string2: string): [number, number, number] => {
     // This function specifies the single minimal diff between 2 strings. For
     // example, the diff between "#ann is for updates" and "#**announce** is
     // for updates" is from index 1, till 4 in the 1st string and 13 in the
@@ -477,9 +443,9 @@ export function get_string_diff(string1: string, string2: string): [number, numb
     }
 
     return [diff_start_index, diff_end_1_index, diff_end_2_index];
-}
+};
 
-export function try_parse_as_truthy<T>(val: (T | undefined)[]): T[] | undefined {
+export const try_parse_as_truthy = <T>(val: (T | undefined)[]): T[] | undefined => {
     // This is a typesafe helper to narrow an array from containing
     // possibly falsy values into an array containing non-undefined
     // items or undefined when any of the items is falsy.
@@ -496,9 +462,9 @@ export function try_parse_as_truthy<T>(val: (T | undefined)[]): T[] | undefined 
         result.push(x);
     }
     return result;
-}
+};
 
-export function is_valid_url(url: string, require_absolute = false): boolean {
+export const is_valid_url = (url: string, require_absolute = false): boolean => {
     try {
         let base_url;
         if (!require_absolute) {
@@ -514,14 +480,14 @@ export function is_valid_url(url: string, require_absolute = false): boolean {
         return false;
     }
     return true;
-}
+};
 
 // Formats an array of strings as a Internationalized list using the specified language.
-export function format_array_as_list(
+export const format_array_as_list = (
     array: string[],
     style: Intl.ListFormatStyle,
     type: Intl.ListFormatType,
-): string {
+): string => {
     // If Intl.ListFormat is not supported
     if (Intl.ListFormat === undefined) {
         return array.join(", ");
@@ -532,9 +498,8 @@ export function format_array_as_list(
 
     // Return the formatted string.
     return list_formatter.format(array);
-}
+};
 
 // Returns the remaining time in milliseconds from the start_time and duration.
-export function get_remaining_time(start_time: number, duration: number): number {
-    return Math.max(0, start_time + duration - Date.now());
-}
+export const get_remaining_time = (start_time: number, duration: number): number =>
+    Math.max(0, start_time + duration - Date.now());

--- a/web/src/vdom.ts
+++ b/web/src/vdom.ts
@@ -19,11 +19,11 @@ export type Tag<T> = {
     opts: Options<T>;
 };
 
-export function eq_array<T>(
+export const eq_array = <T>(
     a: T[] | undefined,
     b: T[] | undefined,
     eq: (a_item: T, b_item: T) => boolean,
-): boolean {
+): boolean => {
     if (a === b) {
         // either both are undefined, or they
         // are referentially equal
@@ -39,16 +39,14 @@ export function eq_array<T>(
     }
 
     return a.every((item, i) => eq(item, b[i]!));
-}
+};
 
-export function ul<T>(opts: Options<T>): Tag<T> {
-    return {
-        tag_name: "ul",
-        opts,
-    };
-}
+export const ul = <T>(opts: Options<T>): Tag<T> => ({
+    tag_name: "ul",
+    opts,
+});
 
-export function render_tag<T>(tag: Tag<T>): string {
+export const render_tag = <T>(tag: Tag<T>): string => {
     /*
         This renders a tag into a string.  It will
         automatically escape attributes, but it's your
@@ -69,13 +67,13 @@ export function render_tag<T>(tag: Tag<T>): string {
 
     const innards = opts.keyed_nodes.map((node) => node.render()).join("\n");
     return start_tag + "\n" + innards + "\n" + end_tag;
-}
+};
 
-export function update_attrs(
+export const update_attrs = (
     $elem: JQuery,
     new_attrs: Iterable<[string, string]>,
     old_attrs: Iterable<[string, string]>,
-): void {
+): void => {
     const new_dict = new Map(new_attrs);
     const old_dict = new Map(old_attrs);
 
@@ -90,14 +88,14 @@ export function update_attrs(
             $elem.removeAttr(k);
         }
     }
-}
+};
 
-export function update<T>(
+export const update = <T>(
     replace_content: (html: string) => void,
     find: () => JQuery,
     new_dom: Tag<T>,
     old_dom: Tag<T> | undefined,
-): void {
+): void => {
     /*
         The update method allows you to continually
         update a "virtual" representation of your DOM,
@@ -149,10 +147,10 @@ export function update<T>(
         For examples of creating vdom objects, look at
         `pm_list_dom.ts`.
     */
-    function do_full_update(): void {
+    const do_full_update = (): void => {
         const rendered_dom = render_tag(new_dom);
         replace_content(rendered_dom);
-    }
+    };
 
     if (old_dom === undefined) {
         do_full_update();
@@ -207,4 +205,4 @@ export function update<T>(
     }
 
     update_attrs(find(), new_opts.attrs, old_opts.attrs);
-}
+};

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -27,15 +27,6 @@ const TIPPY_PROPS: Partial<tippy.Props> = {
     offset: [0, 2],
 };
 
-export const COMMON_DROPDOWN_WIDGET_PARAMS = {
-    get_options: filters_dropdown_options,
-    tippy_props: TIPPY_PROPS,
-    unique_id_type: dropdown_widget.DataTypes.STRING,
-    hide_search_box: true,
-    bold_current_selection: true,
-    disable_for_spectators: true,
-};
-
 export function filters_dropdown_options(current_value: string | number | undefined): {
     unique_id: string;
     name: string;
@@ -65,6 +56,15 @@ export function filters_dropdown_options(current_value: string | number | undefi
         },
     ];
 }
+
+export const COMMON_DROPDOWN_WIDGET_PARAMS = {
+    get_options: filters_dropdown_options,
+    tippy_props: TIPPY_PROPS,
+    unique_id_type: dropdown_widget.DataTypes.STRING,
+    hide_search_box: true,
+    bold_current_selection: true,
+    disable_for_spectators: true,
+};
 
 export function show(opts: {
     highlight_view_in_left_sidebar: () => void;

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -27,35 +27,35 @@ const TIPPY_PROPS: Partial<tippy.Props> = {
     offset: [0, 2],
 };
 
-export function filters_dropdown_options(current_value: string | number | undefined): {
+export const filters_dropdown_options = (
+    current_value: string | number | undefined,
+): {
     unique_id: string;
     name: string;
     description: string;
     bold_current_selection: boolean;
-}[] {
-    return [
-        {
-            unique_id: FILTERS.FOLLOWED_TOPICS,
-            name: $t({defaultMessage: "Followed topics"}),
-            description: $t({defaultMessage: "Only topics you follow"}),
-            bold_current_selection: current_value === FILTERS.FOLLOWED_TOPICS,
-        },
-        {
-            unique_id: FILTERS.UNMUTED_TOPICS,
-            name: $t({defaultMessage: "Standard view"}),
-            description: $t({defaultMessage: "All unmuted topics"}),
-            bold_current_selection: current_value === FILTERS.UNMUTED_TOPICS,
-        },
-        {
-            unique_id: FILTERS.ALL_TOPICS,
-            name: $t({defaultMessage: "All topics"}),
-            description: $t({
-                defaultMessage: "Includes muted channels and topics",
-            }),
-            bold_current_selection: current_value === FILTERS.ALL_TOPICS,
-        },
-    ];
-}
+}[] => [
+    {
+        unique_id: FILTERS.FOLLOWED_TOPICS,
+        name: $t({defaultMessage: "Followed topics"}),
+        description: $t({defaultMessage: "Only topics you follow"}),
+        bold_current_selection: current_value === FILTERS.FOLLOWED_TOPICS,
+    },
+    {
+        unique_id: FILTERS.UNMUTED_TOPICS,
+        name: $t({defaultMessage: "Standard view"}),
+        description: $t({defaultMessage: "All unmuted topics"}),
+        bold_current_selection: current_value === FILTERS.UNMUTED_TOPICS,
+    },
+    {
+        unique_id: FILTERS.ALL_TOPICS,
+        name: $t({defaultMessage: "All topics"}),
+        description: $t({
+            defaultMessage: "Includes muted channels and topics",
+        }),
+        bold_current_selection: current_value === FILTERS.ALL_TOPICS,
+    },
+];
 
 export const COMMON_DROPDOWN_WIDGET_PARAMS = {
     get_options: filters_dropdown_options,
@@ -66,7 +66,7 @@ export const COMMON_DROPDOWN_WIDGET_PARAMS = {
     disable_for_spectators: true,
 };
 
-export function show(opts: {
+export const show = (opts: {
     highlight_view_in_left_sidebar: () => void;
     $view: JQuery;
     update_compose: () => void;
@@ -74,7 +74,7 @@ export function show(opts: {
     set_visible: (value: boolean) => void;
     complete_rerender: () => void;
     is_recent_view?: boolean;
-}): void {
+}): void => {
     if (opts.is_visible()) {
         // If we're already visible, E.g. because the user hit Esc
         // while already in the view, do nothing.
@@ -109,9 +109,9 @@ export function show(opts: {
     if (opts.is_recent_view) {
         resize.update_recent_view_filters_height();
     }
-}
+};
 
-export function hide(opts: {$view: JQuery; set_visible: (value: boolean) => void}): void {
+export const hide = (opts: {$view: JQuery; set_visible: (value: boolean) => void}): void => {
     const active_element = document.activeElement;
     if (active_element !== null && opts.$view.has(active_element)) {
         $(active_element).trigger("blur");
@@ -133,4 +133,4 @@ export function hide(opts: {$view: JQuery; set_visible: (value: boolean) => void
     // This makes sure user lands on the selected message
     // and not always at the top of the narrow.
     message_viewport.plan_scroll_to_selected();
-}
+};

--- a/web/src/watchdog.ts
+++ b/web/src/watchdog.ts
@@ -9,13 +9,11 @@ let watchdog_time = Date.now();
 // system when coming back from unsuspend.
 let suspect_offline = false;
 
-export function set_suspect_offline(suspected: boolean): void {
+export const set_suspect_offline = (suspected: boolean): void => {
     suspect_offline = suspected;
-}
+};
 
-export function suspects_user_is_offline(): boolean {
-    return suspect_offline;
-}
+export const suspects_user_is_offline = (): boolean => suspect_offline;
 
 /*
     Our watchdog code checks every 5 seconds to make sure that we
@@ -27,7 +25,7 @@ export function suspects_user_is_offline(): boolean {
     to reset ourselves accordingly.
 */
 
-export function check_for_unsuspend(): void {
+export const check_for_unsuspend = (): void => {
     const new_time = Date.now();
     if (new_time - watchdog_time > 20000) {
         // 20 seconds.
@@ -51,10 +49,10 @@ export function check_for_unsuspend(): void {
         }
     }
     watchdog_time = new_time;
-}
+};
 
-export function on_unsuspend(f: () => void): void {
+export const on_unsuspend = (f: () => void): void => {
     unsuspend_callbacks.push(f);
-}
+};
 
 setInterval(check_for_unsuspend, 5000);

--- a/web/src/widgetize.ts
+++ b/web/src/widgetize.ts
@@ -41,16 +41,16 @@ type WidgetValue = Record<string, unknown> & {
 export const widgets = new Map<string, WidgetValue>();
 export const widget_event_handlers = new Map<number, (events: Event[]) => void>();
 
-export function clear_for_testing(): void {
+export const clear_for_testing = (): void => {
     widget_event_handlers.clear();
-}
+};
 
-function set_widget_in_message($row: JQuery, $widget_elem: JQuery): void {
+const set_widget_in_message = ($row: JQuery, $widget_elem: JQuery): void => {
     const $content_holder = $row.find(".message_content");
     $content_holder.empty().append($widget_elem);
-}
+};
 
-export function activate(in_opts: WidgetOptions): void {
+export const activate = (in_opts: WidgetOptions): void => {
     const widget_type = in_opts.widget_type;
     const extra_data = in_opts.extra_data;
     const events = in_opts.events;
@@ -66,7 +66,7 @@ export function activate(in_opts: WidgetOptions): void {
         return;
     }
 
-    const callback = function (data: string): void {
+    const callback = (data: string): void => {
         post_to_server({
             msg_type: "widget",
             data,
@@ -98,9 +98,9 @@ export function activate(in_opts: WidgetOptions): void {
     if (events.length > 0) {
         event_handler(events);
     }
-}
+};
 
-export function handle_event(widget_event: Event & {message_id: number}): void {
+export const handle_event = (widget_event: Event & {message_id: number}): void => {
     const event_handler = widget_event_handlers.get(widget_event.message_id);
 
     if (!event_handler || message_lists.current?.get_row(widget_event.message_id).length === 0) {
@@ -113,4 +113,4 @@ export function handle_event(widget_event: Event & {message_id: number}): void {
     const events = [widget_event];
 
     event_handler(events);
-}
+};

--- a/web/src/widgets.js
+++ b/web/src/widgets.js
@@ -3,8 +3,8 @@ import * as todo_widget from "./todo_widget";
 import * as widgetize from "./widgetize";
 import * as zform from "./zform";
 
-export function initialize() {
+export const initialize = () => {
     widgetize.widgets.set("poll", poll_widget);
     widgetize.widgets.set("todo", todo_widget);
     widgetize.widgets.set("zform", zform);
-}
+};

--- a/web/src/zcommand.ts
+++ b/web/src/zcommand.ts
@@ -31,7 +31,7 @@ const data_schema = z.object({
     msg: z.string(),
 });
 
-export function send(opts: {command: string; on_success?: (data: unknown) => void}): void {
+export const send = (opts: {command: string; on_success?: (data: unknown) => void}): void => {
     const command = opts.command;
     const on_success = opts.on_success;
     const data = {
@@ -41,18 +41,18 @@ export function send(opts: {command: string; on_success?: (data: unknown) => voi
     void channel.post({
         url: "/json/zcommand",
         data,
-        success(data) {
+        success: (data) => {
             if (on_success) {
                 on_success(data);
             }
         },
-        error() {
+        error: () => {
             tell_user("server did not respond");
         },
     });
-}
+};
 
-export function tell_user(msg: string): void {
+export const tell_user = (msg: string): void => {
     // This is a bit hacky, but we don't have a super easy API now
     // for just telling users stuff.
     compose_banner.show_error_message(
@@ -60,23 +60,23 @@ export function tell_user(msg: string): void {
         compose_banner.CLASSNAMES.generic_compose_error,
         $("#compose_banners"),
     );
-}
+};
 
-export function switch_to_light_theme(): void {
+export const switch_to_light_theme = (): void => {
     send({
         command: "/day",
-        on_success(data) {
+        on_success: (data) => {
             const clean_data = data_schema.parse(data);
             requestAnimationFrame(() => {
                 dark_theme.disable();
                 message_lists.update_recipient_bar_background_color();
             });
             feedback_widget.show({
-                populate($container) {
+                populate: ($container) => {
                     const rendered_msg = markdown.parse_non_message(clean_data.msg);
                     $container.html(rendered_msg);
                 },
-                on_undo() {
+                on_undo: () => {
                     send({
                         command: "/night",
                     });
@@ -86,23 +86,23 @@ export function switch_to_light_theme(): void {
             });
         },
     });
-}
+};
 
-export function switch_to_dark_theme(): void {
+export const switch_to_dark_theme = (): void => {
     send({
         command: "/night",
-        on_success(data) {
+        on_success: (data) => {
             const clean_data = data_schema.parse(data);
             requestAnimationFrame(() => {
                 dark_theme.enable();
                 message_lists.update_recipient_bar_background_color();
             });
             feedback_widget.show({
-                populate($container) {
+                populate: ($container) => {
                     const rendered_msg = markdown.parse_non_message(clean_data.msg);
                     $container.html(rendered_msg);
                 },
-                on_undo() {
+                on_undo: () => {
                     send({
                         command: "/day",
                     });
@@ -112,9 +112,9 @@ export function switch_to_dark_theme(): void {
             });
         },
     });
-}
+};
 
-export function process(message_content: string): boolean {
+export const process = (message_content: string): boolean => {
     const content = message_content.trim();
 
     if (content === "/ping") {
@@ -122,7 +122,7 @@ export function process(message_content: string): boolean {
 
         send({
             command: content,
-            on_success() {
+            on_success: () => {
                 const end_time = new Date();
                 let diff = end_time.getTime() - start_time.getTime();
                 diff = Math.round(diff);
@@ -149,4 +149,4 @@ export function process(message_content: string): boolean {
     // if we don't see an actual zcommand, so that compose.js
     // knows this is a normal message.
     return false;
-}
+};

--- a/web/src/zform.js
+++ b/web/src/zform.js
@@ -6,7 +6,7 @@ import * as blueslip from "./blueslip";
 import {zform_widget_extra_data_schema} from "./submessage";
 import * as transmit from "./transmit";
 
-export function activate(opts) {
+export const activate = (opts) => {
     const self = {};
 
     const $outer_elem = opts.$elem;
@@ -18,7 +18,7 @@ export function activate(opts) {
     }
     const {data} = parse_result;
 
-    function make_choices(data) {
+    const make_choices = (data) => {
         // Assign idx values to each of our choices so that
         // our template can create data-idx values for our
         // JS code to use later.
@@ -46,18 +46,18 @@ export function activate(opts) {
         });
 
         return $elem;
-    }
+    };
 
-    function render() {
+    const render = () => {
         let rendered_widget;
 
         if (data.type === "choices") {
             rendered_widget = make_choices(data);
             $outer_elem.html(rendered_widget);
         }
-    }
+    };
 
-    self.handle_events = function (events) {
+    self.handle_events = (events) => {
         if (events) {
             blueslip.info("unexpected");
         }
@@ -67,4 +67,4 @@ export function activate(opts) {
     render();
 
     return self;
-}
+};

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -20,9 +20,7 @@ set_global("to_$", () => $window_stub);
 $(window).idle = noop;
 
 const _document = {
-    hasFocus() {
-        return true;
-    },
+    hasFocus: () => true,
 };
 
 const channel = mock_esm("../src/channel");
@@ -103,7 +101,7 @@ const $alice_stub = $.create("alice stub");
 const $fred_stub = $.create("fred stub");
 
 const rome_sub = {name: "Rome", subscribed: true, stream_id: 1001};
-function add_sub_and_set_as_current_narrow(sub) {
+const add_sub_and_set_as_current_narrow = (sub) => {
     stream_data.add_sub(sub);
     const filter = new Filter([{operator: "stream", operand: sub.name}]);
     message_lists.set_current({
@@ -111,9 +109,9 @@ function add_sub_and_set_as_current_narrow(sub) {
             filter,
         },
     });
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         user_settings.presence_enabled = true;
         // Simulate a small window by having the
@@ -148,7 +146,7 @@ function test(label, f) {
 
         presence.clear_internal_data();
     });
-}
+};
 
 run_test("reload_defaults", () => {
     activity.clear_for_testing();
@@ -258,12 +256,12 @@ test("presence_list_full_update", ({override, mock_template}) => {
     assert.equal(presence_rows[0].user_id, me.user_id);
 });
 
-function simulate_right_column_buddy_list() {
+const simulate_right_column_buddy_list = () => {
     $("input.user-list-filter").closest = (selector) => {
         assert.equal(selector, ".app-main [class^='column-']");
         return $.create("right-sidebar").addClass("column-right");
     };
-}
+};
 
 test("direct_message_update_dom_counts", () => {
     const $count = $.create("alice-unread-count");
@@ -322,12 +320,12 @@ test("handlers", ({override, override_rewire, mock_template}) => {
 
     let narrowed;
 
-    function narrow_by_email(email) {
+    const narrow_by_email = (email) => {
         assert.equal(email, "alice@zulip.com");
         narrowed = true;
-    }
+    };
 
-    function init() {
+    const init = () => {
         $.clear_all_elements();
         stub_buddy_list_elements();
 
@@ -339,26 +337,26 @@ test("handlers", ({override, override_rewire, mock_template}) => {
         buddy_list.populate({
             all_user_ids: [me.user_id, alice.user_id, fred.user_id],
         });
-    }
+    };
 
-    (function test_filter_keys() {
+    (() => {
         init();
         activity_ui.user_cursor.go_to(alice.user_id);
         filter_key_handlers.ArrowDown();
         filter_key_handlers.ArrowUp();
     })();
 
-    (function test_click_filter() {
+    (() => {
         init();
         const e = {
-            stopPropagation() {},
+            stopPropagation: () => {},
         };
 
         const handler = $("input.user-list-filter").get_on_handler("focus");
         handler(e);
     })();
 
-    (function test_click_header_filter() {
+    (() => {
         init();
         const e = {};
         const handler = $("#userlist-header").get_on_handler("click");
@@ -370,7 +368,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
         handler(e);
     })();
 
-    (function test_enter_key() {
+    (() => {
         init();
 
         $("input.user-list-filter").val("al");
@@ -384,7 +382,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
         filter_key_handlers.Enter();
     })();
 
-    (function test_click_handler() {
+    (() => {
         init();
         // We wire up the click handler in click_handlers.js,
         // so this just tests the called function.
@@ -393,7 +391,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
         assert.ok(narrowed);
     })();
 
-    (function test_blur_filter() {
+    (() => {
         init();
         const e = {};
         const handler = $("input.user-list-filter").get_on_handler("blur");
@@ -486,10 +484,10 @@ test("render_empty_user_list_message", ({override, mock_template}) => {
 
     let $appended_data;
     override(buddy_list, "$container", {
-        append($data) {
+        append: ($data) => {
             $appended_data = $data;
         },
-        attr(name) {
+        attr: (name) => {
             assert.equal(name, "data-search-results-empty");
             return empty_list_message;
         },
@@ -764,7 +762,7 @@ test("initialize", ({override, mock_template}) => {
         }
     });
 
-    function clear() {
+    const clear = () => {
         $.clear_all_elements();
         buddy_list.$users_matching_view_container = $("#buddy-list-users-matching-view");
         buddy_list.$users_matching_view_container.append = noop;
@@ -774,7 +772,7 @@ test("initialize", ({override, mock_template}) => {
         mock_template("empty_list_widget_for_list.hbs", false, () => "<empty-list-stub>");
         clear_buddy_list(buddy_list);
         page_params.presences = {};
-    }
+    };
 
     clear();
 
@@ -798,7 +796,7 @@ test("initialize", ({override, mock_template}) => {
     });
 
     activity.initialize();
-    activity_ui.initialize({narrow_by_email() {}});
+    activity_ui.initialize({narrow_by_email: () => {}});
     payload.success({
         zephyr_mirror_active: true,
         presences: {},
@@ -823,7 +821,7 @@ test("initialize", ({override, mock_template}) => {
 
     $(window).off("focus");
     activity.initialize();
-    activity_ui.initialize({narrow_by_email() {}});
+    activity_ui.initialize({narrow_by_email: () => {}});
     payload.success({
         zephyr_mirror_active: false,
         presences: {},
@@ -847,14 +845,14 @@ test("initialize", ({override, mock_template}) => {
 test("electron_bridge", ({override_rewire}) => {
     override_rewire(activity, "send_presence_to_server", noop);
 
-    function with_bridge_idle(bridge_idle, f) {
+    const with_bridge_idle = (bridge_idle, f) => {
         with_overrides(({override}) => {
             override(window, "electron_bridge", {
                 get_idle_on_system: () => bridge_idle,
             });
             return f();
         });
-    }
+    };
 
     with_bridge_idle(true, () => {
         activity.mark_client_idle();

--- a/web/tests/alert_words.test.js
+++ b/web/tests/alert_words.test.js
@@ -136,11 +136,11 @@ run_test("munging", () => {
     alert_words.process_message(alertwordboundary_message);
     assert.equal(alertwordboundary_message.content, saved_content);
 
-    function assert_transform(message, expected_new_content) {
+    const assert_transform = (message, expected_new_content) => {
         const msg = {...message};
         alert_words.process_message(msg);
         assert.equal(msg.content, expected_new_content);
-    }
+    };
 
     assert_transform(
         other_message,

--- a/web/tests/alert_words_ui.test.js
+++ b/web/tests/alert_words_ui.test.js
@@ -21,7 +21,7 @@ run_test("rerender_alert_words_ui", ({mock_template}) => {
     alert_words_ui.reset();
     const ListWidget = mock_esm("../src/list_widget", {
         modifier_html: noop,
-        create(_container, words, opts) {
+        create: (_container, words, opts) => {
             const alert_words = [];
             ListWidget.modifier_html = opts.modifier_html;
             for (const word of words) {
@@ -107,7 +107,7 @@ run_test("close_status_message", ({override_rewire}) => {
     $alert.show();
 
     const event = {
-        preventDefault() {},
+        preventDefault: () => {},
         currentTarget: ".close-alert-word-status",
     };
 

--- a/web/tests/bot_data.test.js
+++ b/web/tests/bot_data.test.js
@@ -60,7 +60,7 @@ const bot_data_params = {
     ],
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
@@ -70,7 +70,7 @@ function test(label, f) {
         assert.equal(bot_data.get(314).full_name, "Outgoing webhook");
         f({override});
     });
-}
+};
 
 test("test_basics", () => {
     people.add_active_user(fred);
@@ -116,7 +116,7 @@ test("test_basics", () => {
         extra: "This field should be ignored",
     };
 
-    (function test_add() {
+    (() => {
         bot_data.add(test_bot);
         const bot = bot_data.get(43);
         const services = bot_data.get_services(43);
@@ -137,7 +137,7 @@ test("test_basics", () => {
         assert.equal(undefined, bot.extra);
     })();
 
-    (function test_update() {
+    (() => {
         bot_data.add(test_bot);
 
         let bot = bot_data.get(43);
@@ -169,7 +169,7 @@ test("test_basics", () => {
         assert.ok(bot_data.get(43).is_active);
     })();
 
-    (function test_embedded_bot_update() {
+    (() => {
         bot_data.add(test_embedded_bot);
         const bot_id = 143;
         const services = bot_data.get_services(bot_id);
@@ -182,13 +182,13 @@ test("test_basics", () => {
         assert.equal("embedded bot service", services[0].service_name);
     })();
 
-    (function test_all_user_ids() {
+    (() => {
         const all_ids = bot_data.all_user_ids();
         all_ids.sort();
         assert.deepEqual(all_ids, [143, 314, 42, 43]);
     })();
 
-    (function test_delete() {
+    (() => {
         let bot;
 
         bot_data.add({...test_bot, is_active: true});
@@ -201,7 +201,7 @@ test("test_basics", () => {
         assert.equal(bot, undefined);
     })();
 
-    (function test_get_editable() {
+    (() => {
         bot_data.add({...test_bot, user_id: 44, owner_id: me.user_id, is_active: true});
         bot_data.add({
             ...test_bot,
@@ -222,7 +222,7 @@ test("test_basics", () => {
         assert.deepEqual(["bot1@zulip.com", "bot2@zulip.com"], editable_bots);
     })();
 
-    (function test_get_all_bots_for_current_user() {
+    (() => {
         const bots = bot_data.get_all_bots_for_current_user();
 
         assert.equal(bots.length, 2);
@@ -230,7 +230,7 @@ test("test_basics", () => {
         assert.equal(bots[1].email, "bot2@zulip.com");
     })();
 
-    (function test_get_number_of_bots_owned_by_user() {
+    (() => {
         const bots_owned_by_user = bot_data.get_all_bots_owned_by_user(3);
 
         assert.equal(bots_owned_by_user[0].email, "bot3@zulip.com");

--- a/web/tests/browser_history.test.js
+++ b/web/tests/browser_history.test.js
@@ -12,14 +12,14 @@ window.location.hash = "#bogus";
 
 const browser_history = zrequire("browser_history");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (...args) => {
         user_settings.web_home_view = "recent";
         window.location.hash = "#bogus";
         browser_history.clear_for_testing();
         f(...args);
     });
-}
+};
 
 test("basics", () => {
     const hash1 = "#settings/profile";

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -83,7 +83,7 @@ const bot_with_owner = {
     bot_owner_full_name: "Human Myself",
 };
 
-function add_canned_users() {
+const add_canned_users = () => {
     people.add_active_user(alice);
     people.add_active_user(bot);
     people.add_active_user(bot_with_owner);
@@ -92,9 +92,9 @@ function add_canned_users() {
     people.add_active_user(mark);
     people.add_active_user(old_user);
     people.add_active_user(selma);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         user_settings.presence_enabled = true;
         compose_fade_helper.clear_focused_recipient();
@@ -111,14 +111,14 @@ function test(label, f) {
 
         presence.clear_internal_data();
     });
-}
+};
 
-function set_presence(user_id, status) {
+const set_presence = (user_id, status) => {
     presence.presence_info.set(user_id, {
         status,
         last_active: 9999,
     });
-}
+};
 
 test("user_circle, level", () => {
     add_canned_users();

--- a/web/tests/buddy_list.test.js
+++ b/web/tests/buddy_list.test.js
@@ -23,7 +23,7 @@ const buddy_data = zrequire("buddy_data");
 const {BuddyList} = zrequire("buddy_list");
 const people = zrequire("people");
 
-function init_simulated_scrolling() {
+const init_simulated_scrolling = () => {
     const elem = {
         dataset: {},
         scrollTop: 0,
@@ -35,7 +35,7 @@ function init_simulated_scrolling() {
     $("#buddy_list_wrapper_padding").set_height(0);
 
     return elem;
-}
+};
 
 const alice = {
     email: "alice@zulip.com",

--- a/web/tests/channel.test.js
+++ b/web/tests/channel.test.js
@@ -14,14 +14,14 @@ const xhr_401 = {
 
 let login_to_access_shown = false;
 mock_esm("../src/spectators", {
-    login_to_access() {
+    login_to_access: () => {
         login_to_access_shown = true;
     },
 });
 
 set_global("window", {
     location: {
-        replace() {},
+        replace: () => {},
         href: "http://example.com",
     },
 });
@@ -33,7 +33,7 @@ const default_stub_xhr = {"default-stub-xhr": 0};
 
 const $ = mock_jquery({});
 
-function test_with_mock_ajax(test_params) {
+const test_with_mock_ajax = (test_params) => {
     const {xhr = default_stub_xhr, run_code, check_ajax_options} = test_params;
 
     let ajax_called;
@@ -57,22 +57,22 @@ function test_with_mock_ajax(test_params) {
     run_code();
     assert.ok(ajax_called);
     check_ajax_options(ajax_options);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         reload_state.clear_for_testing();
         f({override});
     });
-}
+};
 
 test("post", () => {
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "POST");
             assert.equal(options.dataType, "json");
 
@@ -85,11 +85,11 @@ test("post", () => {
 
 test("patch", () => {
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.patch({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "POST");
             assert.equal(options.data.method, "PATCH");
             assert.equal(options.dataType, "json");
@@ -103,11 +103,11 @@ test("patch", () => {
 
 test("put", () => {
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.put({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "PUT");
             assert.equal(options.dataType, "json");
 
@@ -120,11 +120,11 @@ test("put", () => {
 
 test("delete", () => {
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.del({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "DELETE");
             assert.equal(options.dataType, "json");
 
@@ -137,11 +137,11 @@ test("delete", () => {
 
 test("get", () => {
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.get({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "GET");
             assert.equal(options.dataType, "json");
 
@@ -166,23 +166,23 @@ test("normal_post", () => {
     test_with_mock_ajax({
         xhr: stub_xhr,
 
-        run_code() {
+        run_code: () => {
             channel.post({
                 data,
                 url: "/json/endpoint",
-                success(data, text_status, xhr) {
+                success: (data, text_status, xhr) => {
                     orig_success_called = true;
                     assert.equal(data, "response data");
                     assert.equal(text_status, "success");
                     assert.equal(xhr, stub_xhr);
                 },
-                error() {
+                error: () => {
                     orig_error_called = true;
                 },
             });
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "POST");
             assert.equal(options.dataType, "json");
             assert.deepEqual(options.data, data);
@@ -201,7 +201,7 @@ test("patch_with_form_data", () => {
     let appended;
 
     const data = {
-        append(k, v) {
+        append: (k, v) => {
             assert.equal(k, "method");
             assert.equal(v, "PATCH");
             appended = true;
@@ -209,7 +209,7 @@ test("patch_with_form_data", () => {
     };
 
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.patch({
                 data,
                 url: "/json/endpoint",
@@ -218,7 +218,7 @@ test("patch_with_form_data", () => {
             assert.ok(appended);
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             assert.equal(options.type, "POST");
             assert.equal(options.dataType, "json");
 
@@ -232,12 +232,12 @@ test("patch_with_form_data", () => {
 test("authentication_error_401_is_spectator", () => {
     test_with_mock_ajax({
         xhr: xhr_401,
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
         // is_spectator = true
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             page_params.page_type = "home";
             page_params.is_spectator = true;
 
@@ -252,13 +252,13 @@ test("authentication_error_401_is_spectator", () => {
 test("authentication_error_401_password_change_in_progress", () => {
     test_with_mock_ajax({
         xhr: xhr_401,
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
         // is_spectator = true
         // password_change_in_progress = true
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             page_params.page_type = "home";
             page_params.is_spectator = true;
             channel.set_password_change_in_progress(true);
@@ -276,12 +276,12 @@ test("authentication_error_401_password_change_in_progress", () => {
 test("authentication_error_401_not_spectator", () => {
     test_with_mock_ajax({
         xhr: xhr_401,
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
         // is_spectator = false
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             page_params.page_type = "home";
             page_params.is_spectator = false;
 
@@ -300,11 +300,11 @@ test("reload_on_403_error", () => {
             responseJSON: {msg: "CSRF Fehler: etwas", code: "CSRF_FAILED"},
         },
 
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             let handler_called = false;
             reload_state.set_csrf_failed_handler(() => {
                 handler_called = true;
@@ -324,11 +324,11 @@ test("unexpected_403_response", () => {
             responseText: "unexpected",
         },
 
-        run_code() {
+        run_code: () => {
             channel.post({url: "/json/endpoint"});
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             blueslip.expect("error", "Unexpected 403 response from server");
             options.simulate_error();
         },
@@ -361,22 +361,20 @@ test("while_reloading", () => {
     assert.equal(channel.get({ignore_reload: false}), undefined);
 
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.del({
                 url: "/json/endpoint",
                 ignore_reload: true,
-                /* istanbul ignore next */
-                success() {
+                success: /* istanbul ignore next */ () => {
                     throw new Error("unexpected success");
                 },
-                /* istanbul ignore next */
-                error() {
+                error: /* istanbul ignore next */ () => {
                     throw new Error("unexpected error");
                 },
             });
         },
 
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             blueslip.expect("log", "Ignoring DELETE /json/endpoint response while reloading");
             options.simulate_success();
 
@@ -391,20 +389,20 @@ test("error in callback", () => {
     let error_called = false;
     let raised_error = false;
     test_with_mock_ajax({
-        run_code() {
+        run_code: () => {
             channel.get({
                 url: "/json/endpoint",
-                success() {
+                success: () => {
                     success_called = true;
                     throw new Error("success");
                 },
-                error() {
+                error: () => {
                     error_called = true;
                     throw new Error("failure");
                 },
             });
         },
-        check_ajax_options(options) {
+        check_ajax_options: (options) => {
             try {
                 options.simulate_success();
             } catch (error) {

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -7,7 +7,7 @@ const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 mock_esm("tippy.js", {
-    default(arg) {
+    default: (arg) => {
         arg._tippy = {setContent: noop};
         return arg._tippy;
     },
@@ -181,25 +181,25 @@ run_test("show password", () => {
 
     $(password_selector)[0] = noop;
 
-    function set_attribute(type) {
+    const set_attribute = (type) => {
         $("#id_password").attr("type", type);
-    }
+    };
 
-    function check_assertion(type, present_class, absent_class) {
+    const check_assertion = (type, present_class, absent_class) => {
         assert.equal($("#id_password").attr("type"), type);
         assert.ok($(password_selector).hasClass(present_class));
         assert.ok(!$(password_selector).hasClass(absent_class));
-    }
+    };
 
     const click_ev = {
-        preventDefault() {},
-        stopPropagation() {},
+        preventDefault: () => {},
+        stopPropagation: () => {},
     };
 
     const key_ev = {
         key: "Enter",
-        preventDefault() {},
-        stopPropagation() {},
+        preventDefault: () => {},
+        stopPropagation: () => {},
     };
 
     set_attribute("password");

--- a/web/tests/components.test.js
+++ b/web/tests/components.test.js
@@ -9,7 +9,7 @@ const blueslip = require("./lib/zblueslip");
 
 let env;
 
-function make_tab(i) {
+const make_tab = (i) => {
     const $self = {};
 
     assert.equal(env.tabs.length, i);
@@ -58,9 +58,9 @@ function make_tab(i) {
     env.tabs.push($self);
 
     return $self;
-}
+};
 
-const ind_tab = (function () {
+const ind_tab = (() => {
     const $self = {};
 
     $self.stub = true;
@@ -84,7 +84,7 @@ const ind_tab = (function () {
     return $self;
 })();
 
-function make_switcher() {
+const make_switcher = () => {
     const $self = {};
 
     $self.stub = true;
@@ -113,7 +113,7 @@ function make_switcher() {
     };
 
     return $self;
-}
+};
 
 mock_jquery((sel) => {
     if (sel.stub) {
@@ -124,14 +124,14 @@ mock_jquery((sel) => {
     switch (sel) {
         case "<div>":
             return {
-                addClass(className) {
+                addClass: (className) => {
                     if (className === "tab-switcher") {
                         return env.switcher;
                     }
 
                     assert.equal(className, "ind-tab");
                     return {
-                        attr(attributes) {
+                        attr: (attributes) => {
                             const tab_id = attributes["data-tab-id"];
                             assert.deepEqual(
                                 attributes,
@@ -190,7 +190,7 @@ run_test("basics", () => {
             {label: $t({defaultMessage: "Search filters"}), key: "search-operators"},
         ],
         html_class: "stream_sorter_toggle",
-        callback(name, key) {
+        callback: (name, key) => {
             assert.equal(callback_args, undefined);
             callback_args = [name, key];
 

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -14,7 +14,7 @@ const {current_user, page_params, realm, user_settings} = require("./lib/zpage_p
 const settings_config = zrequire("settings_config");
 
 set_global("document", {
-    querySelector() {},
+    querySelector: () => {},
 });
 set_global("navigator", {});
 set_global(
@@ -61,10 +61,10 @@ const echo = zrequire("echo");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 
-function reset_jquery() {
+const reset_jquery = () => {
     // Avoid leaks.
     $.clear_all_elements();
-}
+};
 
 const new_user = {
     email: "new_user@example.com",
@@ -115,30 +115,30 @@ const social = {
 };
 stream_data.add_sub(social);
 
-function test_ui(label, f) {
+const test_ui = (label, f) => {
     // TODO: initialize data more aggressively.
     run_test(label, f);
-}
+};
 
-function initialize_handlers({override}) {
+const initialize_handlers = ({override}) => {
     override(realm, "realm_available_video_chat_providers", {disabled: {id: 0}});
     override(realm, "realm_video_chat_provider", 0);
     override(resize, "watch_manual_resize", noop);
     compose_setup.initialize();
-}
+};
 
 test_ui("send_message_success", ({override, override_rewire}) => {
     mock_banners();
 
     let draft_deleted;
     let reify_message_id_checked;
-    function reset() {
+    const reset = () => {
         $("textarea#compose-textarea").val("foobarfoobar");
         $("textarea#compose-textarea").trigger("blur");
         $(".compose-submit-button .loader").show();
         draft_deleted = false;
         reify_message_id_checked = false;
-    }
+    };
 
     reset();
 
@@ -217,13 +217,13 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
     // This is the common setup stuff for all of the four tests.
     let stub_state;
-    function initialize_state_stub_dict() {
+    const initialize_state_stub_dict = () => {
         stub_state = {};
         stub_state.send_msg_called = 0;
         stub_state.get_events_running_called = 0;
         stub_state.reify_message_id_checked = 0;
         return stub_state;
-    }
+    };
 
     const $container = $(".top_left_drafts");
     const $child = $(".unread_count");
@@ -241,7 +241,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     });
 
     // Tests start here.
-    (function test_message_send_success_codepath() {
+    (() => {
         stub_state = initialize_state_stub_dict();
         compose_state.topic("");
         compose_state.set_message_type("private");
@@ -323,7 +323,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     });
 
     // Tests start here.
-    (function test_param_error_function_passed_from_send_message() {
+    (() => {
         stub_state = initialize_state_stub_dict();
 
         compose.send_message();
@@ -337,7 +337,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.ok(echo_error_msg_checked);
     })();
 
-    (function test_error_codepath_local_id_undefined() {
+    (() => {
         let banner_rendered = false;
         mock_template("compose_banner/compose_banner.hbs", false, (data) => {
             assert.equal(data.classname, "generic_compose_error");
@@ -432,7 +432,7 @@ test_ui("finish", ({override, override_rewire}) => {
         show_button_spinner_called = true;
     });
 
-    (function test_when_compose_validation_fails() {
+    (() => {
         $("textarea#compose-textarea").toggleClass = (classname, value) => {
             assert.equal(classname, "invalid");
             assert.equal(value, true);
@@ -451,7 +451,7 @@ test_ui("finish", ({override, override_rewire}) => {
         assert.ok(show_button_spinner_called);
     })();
 
-    (function test_when_compose_validation_succeed() {
+    (() => {
         // Testing successfully sending of a message.
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
@@ -515,15 +515,15 @@ test_ui("initialize", ({override}) => {
 
     assert.ok(resize_watch_manual_resize_checked);
 
-    function set_up_compose_start_mock(expected_opts) {
+    const set_up_compose_start_mock = (expected_opts) => {
         compose_actions_start_checked = false;
         compose_actions_expected_opts = {
             ...expected_opts,
             message_type: "stream",
         };
-    }
+    };
 
-    (function test_page_params_narrow_path() {
+    (() => {
         page_params.narrow = true;
 
         reset_jquery();
@@ -534,7 +534,7 @@ test_ui("initialize", ({override}) => {
         assert.ok(compose_actions_start_checked);
     })();
 
-    (function test_page_params_narrow_topic() {
+    (() => {
         page_params.narrow_topic = "testing";
 
         reset_jquery();
@@ -545,7 +545,7 @@ test_ui("initialize", ({override}) => {
         assert.ok(compose_actions_start_checked);
     })();
 
-    (function test_abort_xhr() {
+    (() => {
         reset_jquery();
         compose_setup.initialize();
 
@@ -599,7 +599,7 @@ test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {
     let prevent_default_checked = false;
     let compose_finish_checked = false;
     const e = {
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_checked = true;
         },
     };
@@ -620,7 +620,7 @@ test_ui("on_events", ({override, override_rewire}) => {
 
     override(rendered_markdown, "update_elements", noop);
 
-    (function test_attach_files_compose_clicked() {
+    (() => {
         const handler = $("#compose").get_on_handler("click", ".compose_upload_file");
         let compose_file_input_clicked = false;
         $("#compose .file_input").on("click", () => {
@@ -636,53 +636,53 @@ test_ui("on_events", ({override, override_rewire}) => {
         assert.ok(compose_file_input_clicked);
     })();
 
-    (function test_markdown_preview_compose_clicked() {
+    (() => {
         // Tests setup
-        function setup_visibilities() {
+        const setup_visibilities = () => {
             $("textarea#compose-textarea").show();
             $("#compose .markdown_preview").show();
             $("#compose .undo_markdown_preview").hide();
             $("#compose .preview_message_area").hide();
             $("#compose").removeClass("preview_mode");
-        }
+        };
 
-        function assert_visibilities() {
+        const assert_visibilities = () => {
             assert.ok(!$("textarea#compose-textarea").visible());
             assert.ok(!$("#compose .markdown_preview").visible());
             assert.ok($("#compose .undo_markdown_preview").visible());
             assert.ok($("#compose .preview_message_area").visible());
             assert.ok($("#compose").hasClass("preview_mode"));
-        }
+        };
 
-        function setup_mock_markdown_contains_backend_only_syntax(msg_content, return_val) {
+        const setup_mock_markdown_contains_backend_only_syntax = (msg_content, return_val) => {
             override(markdown, "contains_backend_only_syntax", (msg) => {
                 assert.equal(msg, msg_content);
                 return return_val;
             });
-        }
+        };
 
-        function setup_mock_markdown_is_status_message(msg_content, return_val) {
+        const setup_mock_markdown_is_status_message = (msg_content, return_val) => {
             override(markdown, "is_status_message", (content) => {
                 assert.equal(content, msg_content);
                 return return_val;
             });
-        }
+        };
 
-        function test_post_success(success_callback) {
+        const test_post_success = (success_callback) => {
             const resp = {
                 rendered: "Server: foobarfoobar",
             };
             success_callback(resp);
             assert.equal($("#compose .preview_content").html(), "Server: foobarfoobar");
-        }
+        };
 
-        function test_post_error(error_callback) {
+        const test_post_error = (error_callback) => {
             error_callback();
             assert.equal(
                 $("#compose .preview_content").html(),
                 "translated HTML: Failed to generate preview",
             );
-        }
+        };
 
         let current_message;
 
@@ -691,7 +691,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             assert.ok(payload.data);
             assert.deepEqual(payload.data.content, current_message);
 
-            function test(func, param) {
+            const test = (func, param) => {
                 let destroy_indicator_called = false;
                 override(loading, "destroy_indicator", ($spinner) => {
                     assert.equal($spinner, $("#compose .markdown_preview_spinner"));
@@ -702,7 +702,7 @@ test_ui("on_events", ({override, override_rewire}) => {
                 func(param);
 
                 assert.ok(destroy_indicator_called);
-            }
+            };
 
             test(test_post_error, payload.error);
             test(test_post_success, payload.success);
@@ -762,7 +762,7 @@ test_ui("on_events", ({override, override_rewire}) => {
         assert.equal($("#compose .preview_content").html(), "Server: foobarfoobar");
     })();
 
-    (function test_undo_markdown_preview_clicked() {
+    (() => {
         const handler = $("#compose").get_on_handler("click", ".undo_markdown_preview");
 
         $("textarea#compose-textarea").hide();

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -78,23 +78,23 @@ const respond_to_message = compose_reply.respond_to_message;
 const reply_with_mention = compose_reply.reply_with_mention;
 const quote_and_reply = compose_reply.quote_and_reply;
 
-function assert_visible(sel) {
+const assert_visible = (sel) => {
     assert.ok($(sel).visible());
-}
+};
 
-function assert_hidden(sel) {
+const assert_hidden = (sel) => {
     assert.ok(!$(sel).visible());
-}
+};
 
-function override_private_message_recipient({override}) {
+const override_private_message_recipient = ({override}) => {
     let recipient;
     override(compose_pm_pill, "set_from_emails", (value) => {
         recipient = value;
     });
     override(compose_pm_pill, "get_emails", () => recipient, {unused: false});
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         // We don't test the css calls; we just skip over them.
         $("#compose").css = noop;
@@ -104,7 +104,7 @@ function test(label, f) {
         compose_state.set_message_type(undefined);
         f(helpers);
     });
-}
+};
 
 test("initial_state", () => {
     assert.equal(compose_state.composing(), false);

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -28,7 +28,7 @@ const {Filter} = zrequire("filter");
 const {MessageList} = zrequire("message_list");
 
 // Helper test function
-function test_reply_label(expected_label) {
+const test_reply_label = (expected_label) => {
     const label = $("#left_bar_compose_reply_button_big").text();
     const prepend_text_length = "translated: Message ".length;
     assert.equal(
@@ -37,7 +37,7 @@ function test_reply_label(expected_label) {
         "'" + label.slice(prepend_text_length),
         Number("' did not match '") + expected_label + "'",
     );
-}
+};
 
 run_test("reply_label", () => {
     // Mocking up a test message list

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -4,19 +4,19 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
-const {run_test, noop} = require("./lib/test");
+const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 // Mocking and stubbing things
 set_global("document", "document-stub");
 const message_lists = mock_esm("../src/message_lists");
-function MessageListView() {
-    return {
-        maybe_rerender: noop,
-        append: noop,
-        prepend: noop,
-        is_current_message_list: () => true,
-    };
+class MessageListView {
+    maybe_rerender() {}
+    append() {}
+    prepend() {}
+    is_current_message_list() {
+        return true;
+    }
 }
 mock_esm("../src/message_list_view", {
     MessageListView,

--- a/web/tests/compose_fade.test.js
+++ b/web/tests/compose_fade.test.js
@@ -9,9 +9,7 @@ mock_jquery((selector) => {
     switch (selector) {
         case "input#stream_message_recipient_topic":
             return {
-                val() {
-                    return "lunch";
-                },
+                val: () => "lunch",
             };
         /* istanbul ignore next */
         default:

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -101,14 +101,14 @@ run_test("pills", ({override, override_rewire}) => {
         }
     });
 
-    function test_create_item(handler) {
-        (function test_rejection_path() {
+    const test_create_item = (handler) => {
+        (() => {
             const item = handler(othello.email, pills.items());
             assert.ok(get_by_email_called);
             assert.equal(item, undefined);
         })();
 
-        (function test_success_path() {
+        (() => {
             get_by_email_called = false;
             const res = handler(iago.email, pills.items());
             assert.ok(get_by_email_called);
@@ -117,7 +117,7 @@ run_test("pills", ({override, override_rewire}) => {
             assert.equal(res.display_value, iago.full_name);
         })();
 
-        (function test_deactivated_pill() {
+        (() => {
             people.deactivate(iago);
             get_by_email_called = false;
             const res = handler(iago.email, pills.items());
@@ -128,14 +128,14 @@ run_test("pills", ({override, override_rewire}) => {
             assert.ok(res.deactivated);
             people.add_active_user(iago);
         })();
-    }
+    };
 
-    function input_pill_stub(opts) {
+    const input_pill_stub = (opts) => {
         assert.equal(opts.$container, pill_container_stub);
         create_item_handler = opts.create_item_from_text;
         assert.ok(create_item_handler);
         return pills;
-    }
+    };
 
     override(input_pill, "create", input_pill_stub);
 
@@ -149,7 +149,7 @@ run_test("pills", ({override, override_rewire}) => {
 
     let on_pill_create_or_remove_call_count = 0;
     compose_pm_pill.initialize({
-        on_pill_create_or_remove() {
+        on_pill_create_or_remove: () => {
             on_pill_create_or_remove_call_count += 1;
         },
     });

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -115,12 +115,12 @@ run_test("insert_syntax_and_focus", ({override}) => {
 run_test("smart_insert", ({override}) => {
     let $textbox = make_textbox("abc");
     $textbox.caret(4);
-    function override_with_expected_syntax(expected_syntax) {
+    const override_with_expected_syntax = (expected_syntax) => {
         override(text_field_edit, "insertTextIntoField", (elt, syntax) => {
             assert.equal(elt, "textarea");
             assert.equal(syntax, expected_syntax);
         });
-    }
+    };
     override_with_expected_syntax(" :smile: ");
     compose_ui.smart_insert_inline($textbox, ":smile:");
 
@@ -295,9 +295,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     let textarea_val = "";
     let textarea_caret_pos;
 
-    $("textarea#compose-textarea").val = function () {
-        return textarea_val;
-    };
+    $("textarea#compose-textarea").val = () => textarea_val;
 
     $("textarea#compose-textarea").caret = function (arg) {
         if (arg === undefined) {
@@ -332,15 +330,15 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         assert.equal(syntax, "\n\ntranslated: [Quoting…]\n\n");
     });
 
-    function set_compose_content_with_caret(content) {
+    const set_compose_content_with_caret = (content) => {
         const caret_position = content.indexOf("%");
         content = content.slice(0, caret_position) + content.slice(caret_position + 1); // remove the "%"
         textarea_val = content;
         textarea_caret_pos = caret_position;
         $("textarea#compose-textarea").trigger("focus");
-    }
+    };
 
-    function reset_test_state() {
+    const reset_test_state = () => {
         // Reset `raw_content` property of `selected_message`.
         delete selected_message.raw_content;
 
@@ -348,9 +346,9 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         textarea_val = "";
         textarea_caret_pos = 0;
         $("textarea#compose-textarea").trigger("blur");
-    }
+    };
 
-    function override_with_quote_text(quote_text) {
+    const override_with_quote_text = (quote_text) => {
         override(text_field_edit, "replaceFieldText", (elt, old_syntax, new_syntax) => {
             assert.equal(elt, "compose-textarea");
             assert.equal(old_syntax, "translated: [Quoting…]");
@@ -362,7 +360,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
                     "```",
             );
         });
-    }
+    };
     let quote_text = "Testing caret position";
     override_with_quote_text(quote_text);
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
@@ -501,7 +499,7 @@ run_test("test_compose_height_changes", ({override, override_rewire}) => {
 
 const $textarea = $("textarea#compose-textarea");
 $textarea.get = () => ({
-    setSelectionRange(start, end) {
+    setSelectionRange: (start, end) => {
         $textarea.range = () => ({
             start,
             end,
@@ -509,7 +507,7 @@ $textarea.get = () => ({
             length: end - start,
         });
     },
-    click() {},
+    click: () => {},
 });
 
 // The argument `text_representation` is a string representing the text
@@ -517,7 +515,7 @@ $textarea.get = () => ({
 // selection, and `|` represents the cursor when there is no selection.
 // To work as expected, the string must contain either a `|`, or a `<`
 // followed by a `>` with some text in between.
-function init_textarea_state(text_representation) {
+const init_textarea_state = (text_representation) => {
     $textarea.val = () => text_representation.replaceAll(/[<>|]/g, "");
     $textarea.range = text_representation.includes("|")
         ? () => ({
@@ -535,16 +533,16 @@ function init_textarea_state(text_representation) {
               ),
               length: text_representation.indexOf(">") - text_representation.indexOf("<") - 1,
           });
-}
+};
 
 // Returns a string representing the text in the compose box, of the same
 // style as the argument `text_representation` of the above function.
-function get_textarea_state() {
+const get_textarea_state = () => {
     const before_text = $textarea.val().slice(0, $textarea.range().start);
     const selected_text = $textarea.range().text ? "<" + $textarea.range().text + ">" : "|";
     const after_text = $textarea.val().slice($textarea.range().end);
     return before_text + selected_text + after_text;
-}
+};
 
 run_test("format_text - bold and italic", ({override, override_rewire}) => {
     override_rewire(
@@ -1150,7 +1148,7 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
         preventDefault: noop,
     };
 
-    function all_markdown_test(isCtrl, isCmd) {
+    const all_markdown_test = (isCtrl, isCmd) => {
         // Test bold:
         // Mac env = Cmd+b
         // Windows/Linux = Ctrl+b
@@ -1179,13 +1177,13 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
         compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
         assert.equal(format_text_type, "link");
         format_text_type = undefined;
-    }
+    };
 
     // This function cross tests the Cmd/Ctrl + Markdown shortcuts in
     // Mac and Linux/Windows environments.  So in short, this tests
     // that e.g. Cmd+B should be ignored on Linux/Windows and Ctrl+B
     // should be ignored on Mac.
-    function os_specific_markdown_test(isCtrl, isCmd) {
+    const os_specific_markdown_test = (isCtrl, isCmd) => {
         event.ctrlKey = isCtrl;
         event.metaKey = isCmd;
 
@@ -1202,7 +1200,7 @@ run_test("markdown_shortcuts", ({override_rewire}) => {
         event.shiftKey = true;
         compose_ui.handle_keydown(event, $("textarea#compose-textarea"));
         assert.equal(format_text_type, undefined);
-    }
+    };
 
     // These keyboard shortcuts differ as to what key one should use
     // on MacOS vs. other platforms: Cmd (Mac) vs. Ctrl (non-Mac).

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -64,22 +64,22 @@ const welcome_bot = {
 
 people.add_cross_realm_user(welcome_bot);
 
-function test_ui(label, f) {
+const test_ui = (label, f) => {
     // The sloppy_$ flag lets us reuse setup from prior tests.
     run_test(label, (helpers) => {
         $("textarea#compose-textarea").val("some message");
         f(helpers);
     });
-}
+};
 
-function stub_message_row($textarea) {
+const stub_message_row = ($textarea) => {
     const $stub = $.create("message_row_stub");
     $textarea.closest = (selector) => {
         assert.equal(selector, ".message_row");
         $stub.length = 0;
         return $stub;
     };
-}
+};
 
 test_ui("validate_stream_message_address_info", ({mock_template}) => {
     mock_banners();
@@ -113,7 +113,7 @@ test_ui("validate_stream_message_address_info", ({mock_template}) => {
 });
 
 test_ui("validate", ({mock_template}) => {
-    function initialize_pm_pill() {
+    const initialize_pm_pill = () => {
         $.clear_all_elements();
 
         $("#compose-send-button").prop("disabled", false);
@@ -135,11 +135,11 @@ test_ui("validate", ({mock_template}) => {
         mock_template("input_pill.hbs", false, () => "<div>pill-html</div>");
 
         mock_banners();
-    }
+    };
 
-    function add_content_to_compose_box() {
+    const add_content_to_compose_box = () => {
         $("textarea#compose-textarea").val("foobarfoobar");
-    }
+    };
 
     // test validating direct messages
     compose_state.set_message_type("private");
@@ -614,13 +614,13 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
         return "<banner-stub>";
     });
 
-    function test_noop_case(invite_only) {
+    const test_noop_case = (invite_only) => {
         banner_rendered = false;
         compose_state.set_message_type("stream");
         denmark.invite_only = invite_only;
         compose_validate.warn_if_private_stream_is_linked(denmark, $textarea);
         assert.ok(!banner_rendered);
-    }
+    };
 
     test_noop_case(false);
     // invite_only=true and current compose stream subscribers are a subset
@@ -681,7 +681,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
         return "<banner-stub>";
     });
 
-    function test_noop_case(is_private, is_zephyr_mirror, type) {
+    const test_noop_case = (is_private, is_zephyr_mirror, type) => {
         new_banner_rendered = false;
         const msg_type = is_private ? "private" : "stream";
         compose_state.set_message_type(msg_type);
@@ -689,7 +689,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
         mentioned_details.type = type;
         compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
         assert.ok(!new_banner_rendered);
-    }
+    };
 
     test_noop_case(true, false, "user");
     test_noop_case(false, true, "user");

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -12,10 +12,10 @@ const channel = mock_esm("../src/channel");
 const compose_closed_ui = mock_esm("../src/compose_closed_ui");
 const compose_ui = mock_esm("../src/compose_ui");
 mock_esm("../src/resize", {
-    watch_manual_resize() {},
+    watch_manual_resize: () => {},
 });
 set_global("document", {
-    querySelector() {},
+    querySelector: () => {},
 });
 set_global("navigator", {});
 set_global(
@@ -28,7 +28,7 @@ set_global(
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose_setup = zrequire("compose_setup");
 
-function stub_out_video_calls() {
+const stub_out_video_calls = () => {
     const $elem = $(".compose-control-buttons-container .video_link");
     $elem.toggle = (show) => {
         /* istanbul ignore if */
@@ -38,7 +38,7 @@ function stub_out_video_calls() {
             $elem.hide();
         }
     };
-}
+};
 
 const realm_available_video_chat_providers = {
     disabled: {
@@ -59,12 +59,12 @@ const realm_available_video_chat_providers = {
     },
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         realm.realm_available_video_chat_providers = realm_available_video_chat_providers;
         f(helpers);
     });
-}
+};
 
 test("videos", ({override}) => {
     realm.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
@@ -73,13 +73,13 @@ test("videos", ({override}) => {
 
     compose_setup.initialize();
 
-    (function test_no_provider_video_link_compose_clicked() {
+    (() => {
         const $textarea = $.create("target-stub");
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault() {},
-            stopPropagation() {},
+            preventDefault: () => {},
+            stopPropagation: () => {},
         };
 
         const handler = $("body").get_on_handler("click", ".video_link");
@@ -91,7 +91,7 @@ test("videos", ({override}) => {
         });
     })();
 
-    (function test_jitsi_video_link_compose_clicked() {
+    (() => {
         let syntax_to_insert;
         let called = false;
 
@@ -99,8 +99,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault() {},
-            stopPropagation() {},
+            preventDefault: () => {},
+            stopPropagation: () => {},
             target: {
                 to_$: () => $textarea,
             },
@@ -147,7 +147,7 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, video_link_regex);
     })();
 
-    (function test_zoom_video_and_audio_links_compose_clicked() {
+    (() => {
         let syntax_to_insert;
         let called = false;
 
@@ -155,8 +155,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault() {},
-            stopPropagation() {},
+            preventDefault: () => {},
+            stopPropagation: () => {},
             target: {
                 to_$: () => $textarea,
             },
@@ -185,7 +185,7 @@ test("videos", ({override}) => {
                 msg: "",
                 url: "example.zoom.com",
             });
-            return {abort() {}};
+            return {abort: () => {}};
         };
 
         $("textarea#compose-textarea").val("");
@@ -203,7 +203,7 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, audio_link_regex);
     })();
 
-    (function test_bbb_video_link_compose_clicked() {
+    (() => {
         let syntax_to_insert;
         let called = false;
 
@@ -211,8 +211,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault() {},
-            stopPropagation() {},
+            preventDefault: () => {},
+            stopPropagation: () => {},
             target: {
                 to_$: () => $textarea,
             },

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -12,7 +12,7 @@ let autosize_called;
 
 const bootstrap_typeahead = mock_esm("../src/bootstrap_typeahead");
 const compose_ui = mock_esm("../src/compose_ui", {
-    autosize_textarea() {
+    autosize_textarea: () => {
         autosize_called = true;
     },
     cursor_inside_code_block: () => false,
@@ -61,41 +61,29 @@ const ct = composebox_typeahead;
 // broadcast-mentions/persons/groups.
 ct.__Rewire__("max_num_items", 15);
 
-function user_item(user) {
-    return {type: "user", user};
-}
+const user_item = (user) => ({type: "user", user});
 
-function broadcast_item(user) {
-    return {type: "broadcast", user};
-}
+const broadcast_item = (user) => ({type: "broadcast", user});
 
-function slash_item(slash) {
-    return {
-        ...slash,
-        type: "slash",
-    };
-}
+const slash_item = (slash) => ({
+    ...slash,
+    type: "slash",
+});
 
-function stream_item(stream) {
-    return {
-        ...stream,
-        type: "stream",
-    };
-}
+const stream_item = (stream) => ({
+    ...stream,
+    type: "stream",
+});
 
-function user_group_item(item) {
-    return {
-        ...item,
-        type: "user_group",
-    };
-}
+const user_group_item = (item) => ({
+    ...item,
+    type: "user_group",
+});
 
-function language_item(language) {
-    return {
-        language,
-        type: "syntax",
-    };
-}
+const language_item = (language) => ({
+    language,
+    type: "syntax",
+});
 
 run_test("verify wildcard mentions typeahead for stream message", () => {
     compose_state.set_message_type("stream");
@@ -321,9 +309,8 @@ const emoji_list = composebox_typeahead.emoji_collection.map((emoji) => ({
     type: "emoji",
 }));
 const emoji_list_by_name = new Map(emoji_list.map((emoji) => [emoji.emoji_name, emoji]));
-function emoji_objects(emoji_names) {
-    return emoji_names.map((emoji_name) => emoji_list_by_name.get(emoji_name));
-}
+const emoji_objects = (emoji_names) =>
+    emoji_names.map((emoji_name) => emoji_list_by_name.get(emoji_name));
 
 const ali = {
     email: "ali@zulip.com",
@@ -474,7 +461,7 @@ const sorted_user_list = [
     othello_item,
 ];
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         people.init();
         user_groups.init();
@@ -502,7 +489,7 @@ function test(label, f) {
 
         f(helpers);
     });
-}
+};
 
 test("topics_seen_for", ({override, override_rewire}) => {
     override_rewire(stream_topic_history, "get_recent_topic_names", (stream_id) => {
@@ -827,9 +814,7 @@ test("content_typeahead_selected", ({override}) => {
     assert.ok(warned_for_stream_link);
 });
 
-function sorted_names_from(subs) {
-    return subs.map((sub) => sub.name).sort();
-}
+const sorted_names_from = (subs) => subs.map((sub) => sub.name).sort();
 
 const sweden_topics_to_show = ["<&>", "even more ice", "furniture", "ice", "kronor", "more ice"];
 
@@ -840,13 +825,13 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     let cleared = false;
     let appended_names = [];
     override(input_pill, "create", () => ({
-        clear_text() {
+        clear_text: () => {
             cleared = true;
         },
         items: () => pill_items,
-        onPillCreate() {},
-        onPillRemove() {},
-        appendValidatedData(item) {
+        onPillCreate: () => {},
+        onPillRemove: () => {},
+        appendValidatedData: (item) => {
             appended_names.push(item.display_value);
         },
     }));
@@ -965,10 +950,10 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ];
                 assert.deepEqual(actual_value, expected_value);
 
-                function matcher(query, person) {
+                const matcher = (query, person) => {
                     query = typeahead.clean_query_lowercase(query);
                     return typeahead_helper.query_matches_person(query, person);
-                }
+                };
 
                 let query;
                 query = "el"; // Matches both "othELlo" and "cordELia"
@@ -1013,14 +998,13 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 deactivated_user.delivery_email = "other@zulip.com";
                 assert.equal(matcher(query, deactivated_user_item), true);
 
-                function sorter(query, people) {
-                    return typeahead_helper.sort_recipients({
+                const sorter = (query, people) =>
+                    typeahead_helper.sort_recipients({
                         users: people,
                         query,
                         current_stream_id: compose_state.stream_id(),
                         current_topic: compose_state.topic(),
                     });
-                }
 
                 // The sorter's output has the items that match the query from the
                 // beginning first, and then the rest of them in REVERSE order of
@@ -1253,9 +1237,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
     user_settings.enter_sends = false;
     let compose_finish_called = false;
-    function finish() {
+    const finish = () => {
         compose_finish_called = true;
-    }
+    };
 
     ct.initialize({
         on_enter_send: finish,
@@ -1419,14 +1403,14 @@ test("begins_typeahead", ({override, override_rewire}) => {
         type: "input",
     };
 
-    function get_values(input, rest) {
+    const get_values = (input, rest) => {
         // Stub out split_at_cursor that uses $(':focus')
         override_rewire(ct, "split_at_cursor", () => [input, rest]);
         const values = ct.get_candidates(input, input_element);
         return values;
-    }
+    };
 
-    function assert_typeahead_equals(input, rest, reference) {
+    const assert_typeahead_equals = (input, rest, reference) => {
         // Usage:
         // assert_typeahead_equals('#some', reference); => '#some|'
         // assert_typeahead_equals('#some', 'thing', reference) => '#some|thing'
@@ -1437,9 +1421,9 @@ test("begins_typeahead", ({override, override_rewire}) => {
         }
         const values = get_values(input, rest);
         assert.deepEqual(values, reference);
-    }
+    };
 
-    function assert_typeahead_starts_with(input, rest, reference) {
+    const assert_typeahead_starts_with = (input, rest, reference) => {
         if (reference === undefined) {
             reference = rest;
             rest = "";
@@ -1447,7 +1431,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
         const values = get_values(input, rest);
         assert.ok(reference.length > 0);
         assert.deepEqual(values.slice(0, reference.length), reference);
-    }
+    };
 
     assert_typeahead_equals("test", []);
     assert_typeahead_equals("test one two", []);
@@ -1459,9 +1443,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     // Make sure that the last token is the one we read.
     assert_typeahead_equals("~~~ @zulip", []); // zulip isn't set up as a user group
     assert_typeahead_equals("@zulip :ta", emoji_objects(["tada", "stadium"]));
-    function language_objects(languages) {
-        return languages.map((language) => language_item(language));
-    }
+    const language_objects = (languages) => languages.map((language) => language_item(language));
     assert_typeahead_equals(
         "#foo\n~~~py",
         language_objects([
@@ -1498,12 +1480,11 @@ test("begins_typeahead", ({override, override_rewire}) => {
         call_center, // "folks working in support"
     ];
     const mention_everyone = broadcast_item(ct.broadcast_mentions()[1]);
-    function mentions_with_silent_marker(mentions, is_silent) {
-        return mentions.map((item) => ({
+    const mentions_with_silent_marker = (mentions, is_silent) =>
+        mentions.map((item) => ({
             ...item,
             is_silent,
         }));
-    }
     assert_typeahead_equals("@", mentions_with_silent_marker(users_and_all_mention, false));
     // The user we're testing for is only allowed to do silent mentions of groups
     assert_typeahead_equals("@", mentions_with_silent_marker(users_and_all_mention, false));
@@ -1782,12 +1763,11 @@ test("begins_typeahead", ({override, override_rewire}) => {
 
     // topic_list
     // includes "more ice"
-    function typed_topics(topics) {
-        return topics.map((topic) => ({
+    const typed_topics = (topics) =>
+        topics.map((topic) => ({
             type: "topic_list",
             topic,
         }));
-    }
     assert_typeahead_equals("#**Sweden>more ice", typed_topics(["more ice", "even more ice"]));
     assert_typeahead_equals("#**Sweden>totally new topic", typed_topics(["totally new topic"]));
 
@@ -1919,12 +1899,11 @@ test("content_highlighter_html", ({override_rewire}) => {
     assert.ok(th_render_slash_command_called);
 });
 
-function possibly_silent_list(list, is_silent) {
-    return list.map((item) => ({
+const possibly_silent_list = (list, is_silent) =>
+    list.map((item) => ({
         ...item,
         is_silent,
     }));
-}
 
 test("filter_and_sort_mentions (normal)", () => {
     compose_state.set_message_type("stream");
@@ -1988,28 +1967,28 @@ test("typeahead_results", () => {
         mobile_stream,
     ];
 
-    function assert_emoji_matches(input, expected) {
+    const assert_emoji_matches = (input, expected) => {
         const matcher = typeahead.get_emoji_matcher(input);
         const returned = emoji_list.filter((item) => matcher(item));
         assert.deepEqual(returned, expected);
-    }
+    };
 
-    function assert_mentions_matches(input, expected) {
+    const assert_mentions_matches = (input, expected) => {
         const is_silent = false;
         const returned = ct.filter_and_sort_mentions(is_silent, input);
         assert.deepEqual(returned, expected);
-    }
-    function assert_stream_matches(input, expected) {
+    };
+    const assert_stream_matches = (input, expected) => {
         const matcher = ct.get_stream_or_user_group_matcher(input);
         const returned = stream_list.filter((item) => matcher(item));
         assert.deepEqual(returned, expected);
-    }
+    };
 
-    function assert_slash_matches(input, expected) {
+    const assert_slash_matches = (input, expected) => {
         const matcher = ct.get_slash_matcher(input);
         const returned = composebox_typeahead.all_slash_commands.filter((item) => matcher(item));
         assert.deepEqual(returned, expected);
-    }
+    };
     assert_emoji_matches("da", [
         {
             emoji_name: "panda_face",
@@ -2067,12 +2046,10 @@ test("typeahead_results", () => {
     assert_emoji_matches("notaemoji", []);
 
     // Autocomplete user mentions by user name.
-    function not_silent(item) {
-        return {
-            ...item,
-            is_silent: false,
-        };
-    }
+    const not_silent = (item) => ({
+        ...item,
+        is_silent: false,
+    });
     assert_mentions_matches("cordelia", [not_silent(cordelia_item)]);
     assert_mentions_matches("cordelia, le", [not_silent(cordelia_item)]);
     assert_mentions_matches("cordelia, le ", []);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -42,7 +42,7 @@ const narrow_title = mock_esm("../src/narrow_title");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
 const pm_list = mock_esm("../src/pm_list");
 const reactions = mock_esm("../src/reactions", {
-    generate_clean_reactions() {},
+    generate_clean_reactions: () => {},
 });
 const realm_icon = mock_esm("../src/realm_icon");
 const realm_logo = mock_esm("../src/realm_logo");
@@ -77,13 +77,13 @@ const stream_settings_ui = mock_esm("../src/stream_settings_ui");
 const stream_list_sort = mock_esm("../src/stream_list_sort");
 const stream_topic_history = mock_esm("../src/stream_topic_history");
 const stream_ui_updates = mock_esm("../src/stream_ui_updates", {
-    update_announce_stream_option() {},
+    update_announce_stream_option: () => {},
 });
 const submessage = mock_esm("../src/submessage");
 mock_esm("../src/left_sidebar_navigation_area", {
-    update_starred_count() {},
-    update_scheduled_messages_row() {},
-    handle_home_view_changed() {},
+    update_starred_count: () => {},
+    update_scheduled_messages_row: () => {},
+    handle_home_view_changed: () => {},
 });
 const typing_events = mock_esm("../src/typing_events");
 const unread_ops = mock_esm("../src/unread_ops");
@@ -131,9 +131,9 @@ const onboarding_steps = zrequire("onboarding_steps");
 
 const server_events_dispatch = zrequire("server_events_dispatch");
 
-function dispatch(ev) {
+const dispatch = (ev) => {
     server_events_dispatch.dispatch_normal_event(ev);
-}
+};
 
 const me = {
     email: "me@example.com",
@@ -154,12 +154,12 @@ const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 
 emoji.initialize({realm_emoji, emoji_codes});
 
-function assert_same(actual, expected) {
+const assert_same = (actual, expected) => {
     // This helper prevents us from getting false positives
     // where actual and expected are both undefined.
     assert.notEqual(expected, undefined);
     assert.deepEqual(actual, expected);
-}
+};
 
 run_test("alert_words", ({override}) => {
     alert_words.initialize({alert_words: []});
@@ -449,15 +449,15 @@ run_test("realm settings", ({override}) => {
     override(navbar_alerts, "check_profile_incomplete", noop);
     override(navbar_alerts, "show_profile_incomplete", noop);
 
-    function test_electron_dispatch(event, fake_send_event) {
+    const test_electron_dispatch = (event, fake_send_event) => {
         with_overrides(({override}) => {
             override(electron_bridge, "send_event", fake_send_event);
             dispatch(event);
         });
-    }
+    };
 
     // realm
-    function test_realm_boolean(event, parameter_name) {
+    const test_realm_boolean = (event, parameter_name) => {
         realm[parameter_name] = true;
         event = {...event};
         event.value = false;
@@ -467,9 +467,9 @@ run_test("realm settings", ({override}) => {
         event.value = true;
         dispatch(event);
         assert.equal(realm[parameter_name], true);
-    }
+    };
 
-    function test_realm_integer(event, parameter_name) {
+    const test_realm_integer = (event, parameter_name) => {
         realm[parameter_name] = 1;
         event = {...event};
         event.value = 2;
@@ -485,7 +485,7 @@ run_test("realm settings", ({override}) => {
         event.value = 1;
         dispatch(event);
         assert.equal(realm[parameter_name], 1);
-    }
+    };
 
     let update_called = false;
     let event = event_fixtures.realm__update__create_private_stream_policy;

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -42,12 +42,12 @@ people.initialize_current_user(me.user_id);
 
 const dispatch = server_events_dispatch.dispatch_normal_event;
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         f(helpers);
     });
-}
+};
 
 test("add", ({override}) => {
     const event = event_fixtures.subscription__add;

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -42,15 +42,15 @@ let tippy_args;
 let tippy_show_called;
 let tippy_destroy_called;
 mock_esm("tippy.js", {
-    default(sel, opts) {
+    default: (sel, opts) => {
         assert.equal(sel, tippy_sel);
         assert.deepEqual(opts, tippy_args);
         return [
             {
-                show() {
+                show: () => {
                     tippy_show_called = true;
                 },
-                destroy() {
+                destroy: () => {
                     tippy_destroy_called = true;
                 },
             },
@@ -95,13 +95,13 @@ const short_msg = {
     drafts_version: 1,
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         $("#draft_overlay").css = noop;
         window.localStorage.clear();
         f(helpers);
     });
-}
+};
 
 // There were some buggy drafts that had their topics
 // renamed to `undefined` in #23238.
@@ -205,7 +205,7 @@ test("snapshot_message", ({override, override_rewire}) => {
 
     let curr_draft;
 
-    function set_compose_state() {
+    const set_compose_state = () => {
         compose_state.set_message_type(curr_draft.type);
         compose_state.message_content(curr_draft.content);
         if (curr_draft.type === "private") {
@@ -215,7 +215,7 @@ test("snapshot_message", ({override, override_rewire}) => {
         }
         compose_state.topic(curr_draft.topic);
         compose_state.private_message_recipient(curr_draft.private_message_recipient);
-    }
+    };
 
     const stream = {
         stream_id: draft_1.stream_id,
@@ -407,11 +407,11 @@ test("rename_stream_recipient", ({override_rewire}) => {
     ls.set("drafts", data);
 
     const draft_model = drafts.draft_model;
-    function assert_draft(draft_id, stream_id, topic_name) {
+    const assert_draft = (draft_id, stream_id, topic_name) => {
         const draft = draft_model.getDraft(draft_id);
         assert.equal(draft.topic, topic_name);
         assert.equal(draft.stream_id, stream_id);
-    }
+    };
 
     // There are no drafts in B>b, so moving messages from there doesn't change drafts
     drafts.rename_stream_recipient(stream_B.stream_id, "b", undefined, "c");
@@ -459,13 +459,9 @@ test("delete_all_drafts", ({override_rewire}) => {
 
 test("format_drafts", ({override, override_rewire, mock_template}) => {
     override_rewire(stream_data, "get_color", () => "#FFFFFF");
-    function feb12() {
-        return new Date(1549958107000); // 2/12/2019 07:55:07 AM (UTC+0)
-    }
+    const feb12 = () => new Date(1549958107000);
 
-    function date(offset) {
-        return feb12().setDate(offset);
-    }
+    const date = (offset) => feb12().setDate(offset);
 
     const draft_1 = {
         topic: "topic",
@@ -626,13 +622,9 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
 
 test("filter_drafts", ({override, override_rewire, mock_template}) => {
     override_rewire(stream_data, "get_color", () => "#FFFFFF");
-    function feb12() {
-        return new Date(1549958107000); // 2/12/2019 07:55:07 AM (UTC+0)
-    }
+    const feb12 = () => new Date(1549958107000);
 
-    function date(offset) {
-        return feb12().setDate(offset);
-    }
+    const date = (offset) => feb12().setDate(offset);
 
     const stream_draft_1 = {
         topic: "topic",

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -16,22 +16,22 @@ const message_lists = mock_esm("../src/message_lists");
 let disparities = [];
 
 mock_esm("../src/message_live_update", {
-    update_message_in_all_views() {},
+    update_message_in_all_views: () => {},
 });
 
 mock_esm("../src/sent_messages", {
-    mark_disparity(local_id) {
+    mark_disparity: (local_id) => {
         disparities.push(local_id);
     },
-    report_event_received() {},
+    report_event_received: () => {},
 });
 
 const message_store = mock_esm("../src/message_store", {
     get: () => ({failed_request: true}),
 
-    update_booleans() {},
+    update_booleans: () => {},
 
-    convert_raw_message_to_message_with_booleans() {},
+    convert_raw_message_to_message_with_booleans: () => {},
 });
 
 message_lists.current = {

--- a/web/tests/emoji_picker.test.js
+++ b/web/tests/emoji_picker.test.js
@@ -27,21 +27,21 @@ run_test("initialize", () => {
 
     let total_emoji_in_categories = 0;
 
-    function assert_emoji_category(ele, icon, num) {
+    const assert_emoji_category = (ele, icon, num) => {
         assert.equal(ele.icon, icon);
         assert.equal(ele.emojis.length, num);
-        function check_emojis(val) {
+        const check_emojis = (val) => {
             for (const this_emoji of ele.emojis) {
                 assert.equal(this_emoji.is_realm_emoji, val);
             }
-        }
+        };
         if (ele.name === "Custom") {
             check_emojis(true);
         } else {
             check_emojis(false);
             total_emoji_in_categories += ele.emojis.length;
         }
-    }
+    };
     const popular_emoji_count = 6;
     const zulip_emoji_count = 1;
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-car", 195);

--- a/web/tests/example5.test.js
+++ b/web/tests/example5.test.js
@@ -32,9 +32,7 @@ const unread_ui = mock_esm("../src/unread_ui");
 message_lists.current = {
     data: {
         filter: {
-            can_apply_locally() {
-                return true;
-            },
+            can_apply_locally: () => true,
         },
     },
 };
@@ -66,18 +64,18 @@ people.add_active_user(isaac);
 
 */
 
-function test_helper({override}) {
+const test_helper = ({override}) => {
     const events = [];
 
     return {
-        redirect(module, func_name) {
+        redirect: (module, func_name) => {
             override(module, func_name, () => {
                 events.push([module, func_name]);
             });
         },
         events,
     };
-}
+};
 
 run_test("insert_message", ({override}) => {
     message_store.clear_for_testing();

--- a/web/tests/example6.test.js
+++ b/web/tests/example6.test.js
@@ -17,14 +17,12 @@ run_test("explore make_stub", ({override}) => {
     // Let's say you have to test the following code.
 
     const app = {
-        /* istanbul ignore next */
-        notify_server_of_deposit(deposit_amount) {
+        notify_server_of_deposit: /* istanbul ignore next */ (deposit_amount) => {
             // simulate difficulty
             throw new Error(`We cannot report this value without wifi: ${deposit_amount}`);
         },
 
-        /* istanbul ignore next */
-        pop_up_fancy_confirmation_screen(deposit_amount, label) {
+        pop_up_fancy_confirmation_screen: /* istanbul ignore next */ (deposit_amount, label) => {
             // simulate difficulty
             throw new Error(`We cannot make a ${label} dialog for amount ${deposit_amount}`);
         },
@@ -32,11 +30,11 @@ run_test("explore make_stub", ({override}) => {
 
     let balance = 40;
 
-    function deposit_paycheck(paycheck_amount) {
+    const deposit_paycheck = (paycheck_amount) => {
         balance += paycheck_amount;
         app.notify_server_of_deposit(paycheck_amount);
         app.pop_up_fancy_confirmation_screen(paycheck_amount, "paycheck");
-    }
+    };
 
     // Our deposit_paycheck should be easy to unit test for its
     // core functionality (updating your balance), but the side

--- a/web/tests/fetch_status.test.js
+++ b/web/tests/fetch_status.test.js
@@ -6,60 +6,60 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
 mock_esm("../src/message_feed_loading", {
-    hide_loading_older() {},
+    hide_loading_older: () => {},
 
-    show_loading_older() {},
-    hide_loading_newer() {},
-    show_loading_newer() {},
+    show_loading_older: () => {},
+    hide_loading_newer: () => {},
+    show_loading_newer: () => {},
 });
 
 const {FetchStatus} = zrequire("fetch_status");
 
 let fetch_status = new FetchStatus();
 
-function reset() {
+const reset = () => {
     fetch_status = new FetchStatus();
-}
+};
 
-function can_load_newer() {
+const can_load_newer = () => {
     assert.equal(fetch_status.can_load_newer_messages(), true);
-}
+};
 
-function blocked_newer() {
+const blocked_newer = () => {
     assert.equal(fetch_status.can_load_newer_messages(), false);
-}
+};
 
-function can_load_older() {
+const can_load_older = () => {
     assert.equal(fetch_status.can_load_older_messages(), true);
-}
+};
 
-function blocked_older() {
+const blocked_older = () => {
     assert.equal(fetch_status.can_load_older_messages(), false);
-}
+};
 
-function has_found_oldest() {
+const has_found_oldest = () => {
     assert.equal(fetch_status.has_found_oldest(), true);
-}
+};
 
-function has_not_found_oldest() {
+const has_not_found_oldest = () => {
     assert.equal(fetch_status.has_found_oldest(), false);
-}
+};
 
-function has_found_newest() {
+const has_found_newest = () => {
     assert.equal(fetch_status.has_found_newest(), true);
-}
+};
 
-function has_not_found_newest() {
+const has_not_found_newest = () => {
     assert.equal(fetch_status.has_found_newest(), false);
-}
+};
 
-function can_load_history() {
+const can_load_history = () => {
     assert.equal(fetch_status.history_limited(), false);
-}
+};
 
-function blocked_history() {
+const blocked_history = () => {
     assert.equal(fetch_status.history_limited(), true);
-}
+};
 
 run_test("basics", () => {
     reset();

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -52,35 +52,35 @@ people.add_active_user(steve);
 people.add_active_user(alice);
 people.initialize_current_user(me.user_id);
 
-function assert_same_terms(result, terms) {
+const assert_same_terms = (result, terms) => {
     // If negated flag is undefined, we explicitly
     // set it to false.
     terms = terms.map(({negated = false, operator, operand}) => ({negated, operator, operand}));
     assert.deepEqual(result, terms);
-}
+};
 
-function get_predicate(raw_terms) {
+const get_predicate = (raw_terms) => {
     const terms = raw_terms.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));
     return new Filter(terms).predicate();
-}
+};
 
-function make_sub(name, stream_id) {
+const make_sub = (name, stream_id) => {
     const sub = {
         name,
         stream_id,
     };
     stream_data.add_sub(sub);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         f(helpers);
     });
-}
+};
 
 test("basics", () => {
     let terms = [
@@ -395,7 +395,7 @@ test("basics", () => {
     assert.ok(filter.is_conversation_view());
 });
 
-function assert_not_mark_read_with_has_operands(additional_terms_to_test) {
+const assert_not_mark_read_with_has_operands = (additional_terms_to_test) => {
     additional_terms_to_test = additional_terms_to_test || [];
     let has_link_term = [{operator: "has", operand: "link"}];
     let filter = new Filter([...additional_terms_to_test, ...has_link_term]);
@@ -420,8 +420,8 @@ function assert_not_mark_read_with_has_operands(additional_terms_to_test) {
     has_link_term = [{operator: "has", operand: "attachment"}];
     filter = new Filter([...additional_terms_to_test, ...has_link_term]);
     assert.ok(!filter.can_mark_messages_read());
-}
-function assert_not_mark_read_with_is_operands(additional_terms_to_test) {
+};
+const assert_not_mark_read_with_is_operands = (additional_terms_to_test) => {
     additional_terms_to_test = additional_terms_to_test || [];
     let is_operator = [{operator: "is", operand: "starred"}];
     let filter = new Filter([...additional_terms_to_test, ...is_operator]);
@@ -466,9 +466,9 @@ function assert_not_mark_read_with_is_operands(additional_terms_to_test) {
     is_operator = [{operator: "is", operand: "resolved", negated: true}];
     filter = new Filter([...additional_terms_to_test, ...is_operator]);
     assert.ok(!filter.can_mark_messages_read());
-}
+};
 
-function assert_not_mark_read_when_searching(additional_terms_to_test) {
+const assert_not_mark_read_when_searching = (additional_terms_to_test) => {
     additional_terms_to_test = additional_terms_to_test || [];
     let search_op = [{operator: "search", operand: "keyword"}];
     let filter = new Filter([...additional_terms_to_test, ...search_op]);
@@ -477,7 +477,7 @@ function assert_not_mark_read_when_searching(additional_terms_to_test) {
     search_op = [{operator: "search", operand: "keyword", negated: true}];
     filter = new Filter([...additional_terms_to_test, ...search_op]);
     assert.ok(!filter.can_mark_messages_read());
-}
+};
 
 test("can_mark_messages_read", () => {
     assert_not_mark_read_with_has_operands();
@@ -984,9 +984,9 @@ test("predicate_basics", ({override}) => {
     // HTML content of message is used to determine if image have link, image or attachment.
     // We are using jquery to parse the html and find existence of relevant tags/elements.
     // In tests we need to stub the calls to jquery so using zjquery's .set_find_results method.
-    function set_find_results_for_msg_content(msg, jquery_selector, results) {
+    const set_find_results_for_msg_content = (msg, jquery_selector, results) => {
         $(`<div>${msg.content}</div>`).set_find_results(jquery_selector, results);
-    }
+    };
 
     const has_link = get_predicate([["has", "link"]]);
     set_find_results_for_msg_content(img_msg, "a", ["stub"]);
@@ -1036,7 +1036,7 @@ test("negated_predicates", () => {
     assert.ok(predicate({}));
 });
 
-function test_mit_exceptions() {
+const test_mit_exceptions = () => {
     const foo_stream_id = 555;
     make_sub("Foo", foo_stream_id);
     let predicate = get_predicate([
@@ -1071,7 +1071,7 @@ function test_mit_exceptions() {
     ];
     predicate = new Filter(terms).predicate();
     assert.ok(!predicate({type: stream_message, stream_id: foo_stream_id, topic: "bar"}));
-}
+};
 
 test("mit_exceptions", ({override}) => {
     override(realm, "realm_is_zephyr_mirror_realm", true);
@@ -1114,10 +1114,10 @@ test("parse", () => {
     let string;
     let terms;
 
-    function _test() {
+    const _test = () => {
         const result = Filter.parse(string);
         assert_same_terms(result, terms);
-    }
+    };
 
     string = "channel:Foo topic:Bar yo";
     terms = [
@@ -1492,17 +1492,15 @@ test("can_bucket_by", () => {
 });
 
 test("term_type", () => {
-    function assert_term_type(term, expected_term_type) {
+    const assert_term_type = (term, expected_term_type) => {
         assert.equal(Filter.term_type(term), expected_term_type);
-    }
+    };
 
-    function term(operator, operand, negated) {
-        return {
-            operator,
-            operand,
-            negated,
-        };
-    }
+    const term = (operator, operand, negated) => ({
+        operator,
+        operand,
+        negated,
+    });
 
     assert_term_type(term("channels", "public"), "channels-public");
     assert_term_type(term("channel", "whatever"), "channel");
@@ -1513,10 +1511,10 @@ test("term_type", () => {
     assert_term_type(term("has", "link"), "has-link");
     assert_term_type(term("has", "attachment", true), "not-has-attachment");
 
-    function assert_term_sort(in_terms, expected) {
+    const assert_term_sort = (in_terms, expected) => {
         const sorted_terms = Filter.sorted_term_types(in_terms);
         assert.deepEqual(sorted_terms, expected);
-    }
+    };
 
     assert_term_sort(["topic", "channel", "sender"], ["channel", "topic", "sender"]);
 
@@ -1597,62 +1595,62 @@ test("update_email", () => {
     assert.deepEqual(filter.operands("channel"), ["steve@foo.com"]);
 });
 
-function make_private_sub(name, stream_id) {
+const make_private_sub = (name, stream_id) => {
     const sub = {
         name,
         stream_id,
         invite_only: true,
     };
     stream_data.add_sub(sub);
-}
+};
 
-function make_web_public_sub(name, stream_id) {
+const make_web_public_sub = (name, stream_id) => {
     const sub = {
         name,
         stream_id,
         is_web_public: true,
     };
     stream_data.add_sub(sub);
-}
+};
 
 test("navbar_helpers", () => {
     const stream_id = 43;
     make_sub("Foo", stream_id);
 
     // make sure title has names separated with correct delimiters
-    function properly_separated_names(names) {
+    const properly_separated_names = (names) => {
         const names_internationalized = new Intl.ListFormat("en", {
             style: "long",
             type: "conjunction",
         }).format(names);
         return names_internationalized;
-    }
+    };
 
-    function test_redirect_url_with_search(test_case) {
+    const test_redirect_url_with_search = (test_case) => {
         const terms = [...test_case.terms, {operator: "search", operand: "fizzbuzz"}];
         const filter = new Filter(terms);
         assert.equal(filter.generate_redirect_url(), test_case.redirect_url_with_search);
-    }
+    };
 
-    function test_common_narrow(test_case) {
+    const test_common_narrow = (test_case) => {
         const filter = new Filter(test_case.terms);
         assert.equal(filter.is_common_narrow(), test_case.is_common_narrow);
-    }
+    };
 
-    function test_add_icon_data(test_case) {
+    const test_add_icon_data = (test_case) => {
         const filter = new Filter(test_case.terms);
         let context = {};
         context = filter.add_icon_data(context);
         assert.equal(context.icon, test_case.icon);
         assert.equal(context.zulip_icon, test_case.zulip_icon);
-    }
+    };
 
-    function test_get_title(test_case) {
+    const test_get_title = (test_case) => {
         const filter = new Filter(test_case.terms);
         assert.deepEqual(filter.get_title(), test_case.title);
-    }
+    };
 
-    function test_get_description(test_case) {
+    const test_get_description = (test_case) => {
         const filter = new Filter(test_case.terms);
         const description = filter.get_description();
 
@@ -1664,16 +1662,16 @@ test("navbar_helpers", () => {
         } else {
             assert.strictEqual(description, undefined);
         }
-    }
+    };
 
-    function test_helpers(test_case) {
+    const test_helpers = (test_case) => {
         // debugging tip: add a `console.log(test_case)` here
         test_common_narrow(test_case);
         test_add_icon_data(test_case);
         test_get_title(test_case);
         test_get_description(test_case);
         test_redirect_url_with_search(test_case);
-    }
+    };
 
     const sender = [{operator: "sender", operand: joe.email}];
     const guest_sender = [{operator: "sender", operand: alice.email}];

--- a/web/tests/fold_dict.test.js
+++ b/web/tests/fold_dict.test.js
@@ -74,12 +74,12 @@ run_test("case insensitivity", () => {
 run_test("clear", () => {
     const d = new FoldDict();
 
-    function populate() {
+    const populate = () => {
         d.set("fOO", 1);
         assert.equal(d.get("foo"), 1);
         d.set("bAR", 2);
         assert.equal(d.get("bar"), 2);
-    }
+    };
 
     populate();
     assert.equal(d.size, 2);

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -28,13 +28,13 @@ stream_data.add_sub(frontend);
 
 run_test("hash_util", () => {
     // Test encode_operand and decode_operand
-    function encode_decode_operand(operator, operand, expected_val) {
+    const encode_decode_operand = (operator, operand, expected_val) => {
         const encode_result = hash_util.encode_operand(operator, operand);
         assert.equal(encode_result, expected_val);
         const new_operand = encode_result;
         const decode_result = hash_util.decode_operand(operator, new_operand);
         assert.equal(decode_result, operand);
-    }
+    };
 
     let operator = "sender";
     let operand = hamlet.email;
@@ -257,9 +257,7 @@ run_test("test_by_conversation_and_time_url", () => {
 });
 
 run_test("test_search_public_streams_notice_url", () => {
-    function get_terms(url) {
-        return hash_util.parse_narrow(url.split("/"));
-    }
+    const get_terms = (url) => hash_util.parse_narrow(url.split("/"));
 
     assert.equal(
         hash_util.search_public_streams_notice_url(get_terms("#narrow/search/abc")),

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -159,15 +159,15 @@ run_test("people_slugs", () => {
     assert.deepEqual(narrow, [{operator: "pm-with", operand: "alice@example.com", negated: false}]);
 });
 
-function test_helper({override, override_rewire, change_tab}) {
+const test_helper = ({override, override_rewire, change_tab}) => {
     let events = [];
     let narrow_terms;
 
-    function stub(module, func_name) {
+    const stub = (module, func_name) => {
         module[func_name] = () => {
             events.push([module, func_name]);
         };
-    }
+    };
 
     stub(admin, "launch");
     stub(admin, "build_page");
@@ -192,15 +192,15 @@ function test_helper({override, override_rewire, change_tab}) {
     }
 
     return {
-        clear_events() {
+        clear_events: () => {
             events = [];
         },
-        assert_events(expected_events) {
+        assert_events: (expected_events) => {
             assert.deepEqual(events, expected_events);
         },
         get_narrow_terms: () => narrow_terms,
     };
-}
+};
 
 run_test("hash_interactions", ({override, override_rewire}) => {
     $window_stub = $.create("window-stub");

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -41,7 +41,7 @@ const condense = mock_esm("../src/condense");
 const drafts_overlay_ui = mock_esm("../src/drafts_overlay_ui");
 const emoji_picker = mock_esm("../src/emoji_picker", {
     is_open: () => false,
-    toggle_emoji_popover() {},
+    toggle_emoji_popover: () => {},
 });
 const gear_menu = mock_esm("../src/gear_menu");
 const lightbox = mock_esm("../src/lightbox");
@@ -97,27 +97,19 @@ const stream_popover = mock_esm("../src/stream_popover", {
 });
 
 message_lists.current = {
-    visibly_empty() {
-        return false;
-    },
-    selected_id() {
-        return 42;
-    },
-    selected_row() {
+    visibly_empty: () => false,
+    selected_id: () => 42,
+    selected_row: () => {
         const $row = $.create("selected-row-stub");
         $row.set_find_results(".message-actions-menu-button", []);
         $row.set_find_results(".emoji-message-control-button-container", {is: () => false});
         return $row;
     },
-    selected_message() {
-        return {
-            sent_by_me: true,
-            flags: ["read", "starred"],
-        };
-    },
-    get_row() {
-        return 101;
-    },
+    selected_message: () => ({
+        sent_by_me: true,
+        flags: ["read", "starred"],
+    }),
+    get_row: () => 101,
 };
 
 const emoji = zrequire("emoji");
@@ -129,34 +121,32 @@ emoji.initialize({
     emoji_codes,
 });
 
-function stubbing(module, func_name_to_stub, test_function) {
+const stubbing = (module, func_name_to_stub, test_function) => {
     with_overrides(({override}) => {
         const stub = make_stub();
         override(module, func_name_to_stub, stub.f);
         test_function(stub);
     });
-}
+};
 
 // Set up defaults for most tests.
 hotkey.__Rewire__("processing_text", () => false);
 
 run_test("mappings", () => {
-    function map_press(which, shiftKey) {
-        return hotkey.get_keypress_hotkey({
+    const map_press = (which, shiftKey) =>
+        hotkey.get_keypress_hotkey({
             which,
             shiftKey,
         });
-    }
 
-    function map_down(which, shiftKey, ctrlKey, metaKey, altKey) {
-        return hotkey.get_keydown_hotkey({
+    const map_down = (which, shiftKey, ctrlKey, metaKey, altKey) =>
+        hotkey.get_keydown_hotkey({
             which,
             shiftKey,
             ctrlKey,
             metaKey,
             altKey,
         });
-    }
 
     // The next assertion protects against an iOS bug where we
     // treat "!" as a hotkey, because iOS sends the wrong code.
@@ -226,7 +216,7 @@ run_test("mappings", () => {
     navigator.platform = "";
 });
 
-function process(s, shiftKey, keydown = false) {
+const process = (s, shiftKey, keydown = false) => {
     const e = {
         which: s.codePointAt(0),
         shiftKey,
@@ -244,28 +234,28 @@ function process(s, shiftKey, keydown = false) {
         console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
         throw error;
     }
-}
+};
 
-function assert_mapping(c, module, func_name, shiftKey, keydown) {
+const assert_mapping = (c, module, func_name, shiftKey, keydown) => {
     stubbing(module, func_name, (stub) => {
         assert.ok(process(c, shiftKey, keydown));
         assert.equal(stub.num_calls, 1);
     });
-}
+};
 
-function assert_unmapped(s) {
+const assert_unmapped = (s) => {
     for (const c of s) {
         assert.equal(process(c), false);
     }
-}
+};
 
-function test_normal_typing() {
+const test_normal_typing = () => {
     assert_unmapped("abcdefghijklmnopqrsuvwxyz");
     assert_unmapped(" ");
     assert_unmapped("[]\\.,;");
     assert_unmapped("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
     assert_unmapped('~!@#$%^*()_+{}:"<>');
-}
+};
 
 run_test("allow normal typing when processing text", ({override, override_rewire}) => {
     // Unmapped keys should immediately return false, without
@@ -458,7 +448,7 @@ run_test("motion_keys", () => {
         "+": 187,
     };
 
-    function process(name) {
+    const process = (name) => {
         const e = {
             which: codes[name],
         };
@@ -473,18 +463,18 @@ run_test("motion_keys", () => {
             console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
             throw error;
         }
-    }
+    };
 
-    function assert_unmapped(name) {
+    const assert_unmapped = (name) => {
         assert.equal(process(name), false);
-    }
+    };
 
-    function assert_mapping(key_name, module, func_name) {
+    const assert_mapping = (key_name, module, func_name) => {
         stubbing(module, func_name, (stub) => {
             assert.ok(process(key_name));
             assert.equal(stub.num_calls, 1);
         });
-    }
+    };
 
     list_util.inside_list = () => false;
     message_lists.current.visibly_empty = () => true;

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -23,7 +23,7 @@ set_global("getSelection", () => ({
 
 const input_pill = zrequire("input_pill");
 
-function pill_html(value, img_src, status_emoji_info) {
+const pill_html = (value, img_src, status_emoji_info) => {
     const has_image = img_src !== undefined;
     const has_status = status_emoji_info !== undefined;
 
@@ -42,7 +42,7 @@ function pill_html(value, img_src, status_emoji_info) {
     }
 
     return require("../templates/input_pill.hbs")(opts);
-}
+};
 
 run_test("basics", ({mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
@@ -88,7 +88,7 @@ run_test("basics", ({mock_template}) => {
     assert.deepEqual(widget.items(), [item]);
 });
 
-function set_up() {
+const set_up = () => {
     const items = {
         blue: {
             display_value: "BLUE",
@@ -132,7 +132,7 @@ function set_up() {
         items,
         $container,
     };
-}
+};
 
 run_test("copy from pill", ({mock_template}) => {
     mock_template("input_pill.hbs", true, (data, html) => {
@@ -156,7 +156,7 @@ run_test("copy from pill", ({mock_template}) => {
 
     const originalEvent = new ClipboardEvent();
     originalEvent.clipboardData = {
-        setData(format, text) {
+        setData: (format, text) => {
             assert.equal(format, "text/plain");
             copied_text = text;
         },
@@ -190,7 +190,7 @@ run_test("paste to input", ({mock_template}) => {
 
     const originalEvent = new ClipboardEvent();
     originalEvent.clipboardData = {
-        getData(format) {
+        getData: (format) => {
             assert.equal(format, "text/plain");
             return paste_text;
         },
@@ -233,25 +233,25 @@ run_test("arrows on pills", ({mock_template}) => {
 
     const key_handler = $container.get_on_handler("keydown", ".pill");
 
-    function test_key(c) {
+    const test_key = (c) => {
         key_handler({
             key: c,
         });
-    }
+    };
 
     let prev_focused = false;
     let next_focused = false;
 
     const $pill_stub = {
         prev: () => ({
-            trigger(type) {
+            trigger: (type) => {
                 if (type === "focus") {
                     prev_focused = true;
                 }
             },
         }),
         next: () => ({
-            trigger(type) {
+            trigger: (type) => {
                 if (type === "focus") {
                     next_focused = true;
                 }
@@ -290,7 +290,7 @@ run_test("left arrow on input", ({mock_template}) => {
 
     $container.set_find_results(".pill", {
         last: () => ({
-            trigger(type) {
+            trigger: (type) => {
                 if (type === "focus") {
                     last_pill_focused = true;
                 }
@@ -429,11 +429,9 @@ run_test("insert_remove", ({mock_template}) => {
     assert.equal(widget.is_pending(), false);
 
     let color_removed;
-    function set_colored_removed_func(color) {
-        return () => {
-            color_removed = color;
-        };
-    }
+    const set_colored_removed_func = (color) => () => {
+        color_removed = color;
+    };
 
     const pills = widget._get_pills_for_testing();
     for (const pill of pills) {
@@ -460,7 +458,7 @@ run_test("insert_remove", ({mock_template}) => {
     let next_pill_focused = false;
 
     const $next_pill_stub = {
-        trigger(type) {
+        trigger: (type) => {
             if (type === "focus") {
                 next_pill_focused = true;
             }
@@ -511,7 +509,7 @@ run_test("exit button on pill", ({mock_template}) => {
     let next_pill_focused = false;
 
     const $next_pill_stub = {
-        trigger(type) {
+        trigger: (type) => {
             if (type === "focus") {
                 next_pill_focused = true;
             }
@@ -525,7 +523,7 @@ run_test("exit button on pill", ({mock_template}) => {
 
     const exit_button_stub = {
         to_$: () => ({
-            closest(sel) {
+            closest: (sel) => {
                 assert.equal(sel, ".pill");
                 return $curr_pill_stub;
             },
@@ -560,7 +558,7 @@ run_test("misc things", () => {
 
     const input_stub = {
         to_$: () => ({
-            removeClass(cls) {
+            removeClass: (cls) => {
                 assert.equal(cls, "shake");
                 shake_class_removed = true;
             },

--- a/web/tests/keydown_util.test.js
+++ b/web/tests/keydown_util.test.js
@@ -13,8 +13,7 @@ run_test("test_early_returns", () => {
     const opts = {
         $elem: $stub,
         handlers: {
-            /* istanbul ignore next */
-            ArrowLeft() {
+            ArrowLeft: /* istanbul ignore next */ () => {
                 throw new Error("do not dispatch this with alt key");
             },
         },

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -7,7 +7,7 @@ const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 mock_esm("../src/resize", {
-    resize_stream_filters_container() {},
+    resize_stream_filters_container: () => {},
 });
 
 const scheduled_messages = mock_esm("../src/scheduled_messages");
@@ -70,13 +70,13 @@ run_test("narrowing", () => {
 });
 
 run_test("update_count_in_dom", () => {
-    function make_elem($elem, count_selector) {
+    const make_elem = ($elem, count_selector) => {
         const $count = $(count_selector);
         $elem.set_find_results(".unread_count", $count);
         $count.set_parent($elem);
 
         return $elem;
-    }
+    };
 
     const counts = {
         mentioned_message_count: 222,

--- a/web/tests/lib/handlebars.js
+++ b/web/tests/lib/handlebars.js
@@ -22,7 +22,7 @@ class ZJavaScriptCompiler extends hb.JavaScriptCompiler {
 ZJavaScriptCompiler.prototype.compiler = ZJavaScriptCompiler;
 hb.JavaScriptCompiler = ZJavaScriptCompiler;
 
-function compile_hbs(module, filename) {
+const compile_hbs = (module, filename) => {
     const code = fs.readFileSync(filename, "utf8");
     const pc = hb.precompile(code, {preventIndent: true, srcName: filename, strict: true});
     const node = new SourceNode();
@@ -39,7 +39,7 @@ function compile_hbs(module, filename) {
             Buffer.from(out.map.toString()).toString("base64"),
         filename,
     );
-}
+};
 
 exports.hook_require = () => {
     require.extensions[".hbs"] = compile_hbs;

--- a/web/tests/lib/index.js
+++ b/web/tests/lib/index.js
@@ -47,9 +47,7 @@ require("@babel/register")({
 Sentry.addTracingExtensions();
 
 // Create a helper function to avoid sneaky delays in tests.
-function immediate(f) {
-    return () => f();
-}
+const immediate = (f) => () => f();
 
 // Find the files we need to run.
 const files = process.argv.slice(2);
@@ -57,7 +55,7 @@ assert.notEqual(files.length, 0, "No tests found");
 
 // Set up our namespace helpers.
 const window = new Proxy(global, {
-    set(_obj, prop, value) {
+    set: (_obj, prop, value) => {
         namespace.set_global(prop, value);
         return true;
     },
@@ -65,17 +63,14 @@ const window = new Proxy(global, {
 
 const ls_container = new Map();
 const localStorage = {
-    getItem(key) {
-        return ls_container.get(key);
-    },
-    setItem(key, val) {
+    getItem: (key) => ls_container.get(key),
+    setItem: (key, val) => {
         ls_container.set(key, val);
     },
-    /* istanbul ignore next */
-    removeItem(key) {
+    removeItem: /* istanbul ignore next */ (key) => {
         ls_container.delete(key);
     },
-    clear() {
+    clear: () => {
         ls_container.clear();
     },
 };
@@ -83,11 +78,11 @@ const localStorage = {
 // Set up Handlebars
 handlebars.hook_require();
 
-const noop = function () {};
+const noop = () => {};
 
 require("../../src/templates"); // register Zulip extensions
 
-async function run_one_module(file) {
+const run_one_module = async (file) => {
     zjquery.clear_initialize_function();
     zjquery.clear_all_elements();
     console.info("running test " + path.basename(file, ".test.js"));
@@ -98,7 +93,7 @@ async function run_one_module(file) {
         await f();
     }
     namespace.complain_about_unused_mocks();
-}
+};
 
 test.set_verbose(files.length === 1);
 

--- a/web/tests/lib/markdown_assert.js
+++ b/web/tests/lib/markdown_assert.js
@@ -37,11 +37,8 @@ class MarkdownComparer {
         this._output_formatter =
             output_formatter ||
             /* istanbul ignore next */
-            function (actual, expected) {
-                return ["Actual and expected output do not match.", actual, "!=", expected].join(
-                    "\n",
-                );
-            };
+            ((actual, expected) =>
+                ["Actual and expected output do not match.", actual, "!=", expected].join("\n"));
         this._document = new JSDOM().window.document;
     }
 
@@ -177,7 +174,7 @@ class MarkdownComparer {
     }
 }
 
-function returnComparer() {
+const returnComparer = () => {
     if (!_markdownComparerInstance) {
         _markdownComparerInstance = new MarkdownComparer(
             /* istanbul ignore next */
@@ -189,19 +186,18 @@ function returnComparer() {
         );
     }
     return _markdownComparerInstance;
-}
+};
 
 module.exports = {
-    equal(expected, actual, message) {
+    equal: (expected, actual, message) => {
         returnComparer().assertEqual(actual, expected, message);
     },
 
-    notEqual(expected, actual, message) {
+    notEqual: (expected, actual, message) => {
         returnComparer().assertNotEqual(actual, expected, message);
     },
 
-    /* istanbul ignore next */
-    setFormatter(output_formatter) {
+    setFormatter: /* istanbul ignore next */ (output_formatter) => {
         returnComparer().setFormatter(output_formatter);
     },
 };

--- a/web/tests/lib/mdiff.js
+++ b/web/tests/lib/mdiff.js
@@ -15,7 +15,7 @@
 
 const difflib = require("difflib");
 
-function apply_color(input_string, changes) {
+const apply_color = (input_string, changes) => {
     let previous_index = 0;
     let processed_string = input_string.slice(0, 2);
     input_string = input_string.slice(2);
@@ -37,7 +37,7 @@ function apply_color(input_string, changes) {
 
     processed_string += input_string.slice(previous_index);
     return processed_string;
-}
+};
 
 /**
  * The library difflib produces diffs that look as follows:
@@ -51,7 +51,7 @@ function apply_color(input_string, changes) {
  * colored versions, where the question-mark lines are removed, replaced with
  * directions to add appropriate color to the lines that they annotate.
  */
-function parse_questionmark_line(questionmark_line) {
+const parse_questionmark_line = (questionmark_line) => {
     let current_sequence = ""; // Either "^", "-", "+", or ""
     let beginning_index = 0;
     let index = 0;
@@ -93,9 +93,9 @@ function parse_questionmark_line(questionmark_line) {
     add_change();
 
     return changes_list;
-}
+};
 
-function diff_strings(string_0, string_1) {
+const diff_strings = (string_0, string_1) => {
     let output_lines = [];
     let ndiff_output = "";
     let changes_list = [];
@@ -120,7 +120,7 @@ function diff_strings(string_0, string_1) {
     );
 
     return output_lines.join("\n");
-}
+};
 
 module.exports = {diff_strings};
 

--- a/web/tests/lib/namespace.js
+++ b/web/tests/lib/namespace.js
@@ -26,7 +26,7 @@ let jquery_function;
 const template_path = path.resolve(__dirname, "../../templates");
 
 /* istanbul ignore next */
-function need_to_mock_template_error(filename) {
+const need_to_mock_template_error = (filename) => {
     const fn = path.relative(template_path, filename);
 
     return `
@@ -63,9 +63,9 @@ function need_to_mock_template_error(filename) {
             });
         });
     `;
-}
+};
 
-function load(request, parent, isMain) {
+const load = (request, parent, isMain) => {
     let module;
 
     const filename = Module._resolveFilename(request, parent, isMain);
@@ -87,9 +87,9 @@ function load(request, parent, isMain) {
         "__Rewire__" in module
     ) {
         /* istanbul ignore next */
-        function error_immutable() {
+        const error_immutable = () => {
             throw new Error(`${filename} is an immutable ES module`);
-        }
+        };
         return new Proxy(module, {
             defineProperty: error_immutable,
             deleteProperty: error_immutable,
@@ -100,10 +100,11 @@ function load(request, parent, isMain) {
     }
 
     return module;
-}
+};
 
-function template_stub({filename, actual_render}) {
-    return function render(...args) {
+const template_stub =
+    ({filename, actual_render}) =>
+    (...args) => {
         // If our template is being rendered as a partial, always
         // use the actual implementation.
         if (in_mid_render) {
@@ -136,7 +137,6 @@ function template_stub({filename, actual_render}) {
 
         return f(data);
     };
-}
 
 exports.start = () => {
     assert.equal(actual_load, undefined, "namespace.start was called twice in a row.");
@@ -245,7 +245,7 @@ exports.unmock_module = (module_path, {callsite = callsites()[1]} = {}) => {
     used_module_mocks.delete(filename);
 };
 
-exports.set_global = function (name, val) {
+exports.set_global = (name, val) => {
     assert.notEqual(val, null, `We try to avoid using null in our codebase.`);
 
     if (!(name in old_globals)) {
@@ -258,7 +258,7 @@ exports.set_global = function (name, val) {
     return val;
 };
 
-exports.zrequire = function (short_fn) {
+exports.zrequire = (short_fn) => {
     assert.notEqual(
         short_fn,
         "templates",
@@ -276,7 +276,7 @@ exports.zrequire = function (short_fn) {
 const webPath = path.resolve(__dirname, "../..") + path.sep;
 const testsLibPath = __dirname + path.sep;
 
-exports.complain_about_unused_mocks = function () {
+exports.complain_about_unused_mocks = () => {
     for (const filename of module_mocks.keys()) {
         /* istanbul ignore if */
         if (!used_module_mocks.has(filename)) {
@@ -285,7 +285,7 @@ exports.complain_about_unused_mocks = function () {
     }
 };
 
-exports.finish = function () {
+exports.finish = () => {
     /*
         Handle cleanup tasks after we've run one module.
 
@@ -380,7 +380,7 @@ exports.with_overrides = function (test_function) {
         });
     };
 
-    const disallow = function (obj, prop) {
+    const disallow = (obj, prop) => {
         override(
             obj,
             prop,
@@ -433,7 +433,7 @@ exports.with_overrides = function (test_function) {
         });
     };
 
-    const disallow_rewire = function (obj, prop) {
+    const disallow_rewire = (obj, prop) => {
         // This is deprecated because it relies on the slow
         // babel-plugin-rewire-ts plugin.
 

--- a/web/tests/lib/stub.js
+++ b/web/tests/lib/stub.js
@@ -7,17 +7,17 @@ const {strict: assert} = require("assert");
 // to it.  To use stubs as something more like "spies," use something
 // like set_global() to override your namespace.
 
-exports.make_stub = function () {
+exports.make_stub = () => {
     const self = {};
     self.num_calls = 0;
 
-    self.f = function (...args) {
+    self.f = (...args) => {
         self.last_call_args = args;
         self.num_calls += 1;
         return true;
     };
 
-    self.get_args = function (...param_names) {
+    self.get_args = (...param_names) => {
         const result = {};
 
         for (const [i, name] of param_names.entries()) {
@@ -30,7 +30,7 @@ exports.make_stub = function () {
     return self;
 };
 
-(function test_ourselves() {
+(() => {
     const stub = exports.make_stub();
     stub.f("blue", 42);
     assert.equal(stub.num_calls, 1);

--- a/web/tests/lib/test.js
+++ b/web/tests/lib/test.js
@@ -21,7 +21,7 @@ exports.noop = () => {};
 
 exports.suite = [];
 
-async function execute_test(label, f, opts) {
+const execute_test = async (label, f, opts) => {
     const {sloppy_$} = opts || {};
 
     /* istanbul ignore if */
@@ -52,7 +52,7 @@ async function execute_test(label, f, opts) {
     }
     // defensively reset blueslip after each test.
     zblueslip.reset();
-}
+};
 
 exports.run_test = (label, f, opts) => {
     exports.suite.push(() => execute_test(label, f, opts));

--- a/web/tests/lib/zblueslip.js
+++ b/web/tests/lib/zblueslip.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-function make_zblueslip() {
+const make_zblueslip = () => {
     const lib = {};
 
     const opts = {
@@ -85,12 +85,12 @@ function make_zblueslip() {
     for (const name of names) {
         if (!opts[name]) {
             // should just log the message.
-            lib[name] = function (message, more_info, cause) {
+            lib[name] = (message, more_info, cause) => {
                 lib.test_logs[name].push({message, more_info, cause});
             };
             continue;
         }
-        lib[name] = function (message, more_info, cause) {
+        lib[name] = (message, more_info, cause) => {
             /* istanbul ignore if */
             if (typeof message !== "string") {
                 // We may catch exceptions in blueslip, and if
@@ -117,6 +117,6 @@ function make_zblueslip() {
     }
 
     return lib;
-}
+};
 
 module.exports = make_zblueslip();

--- a/web/tests/lib/zjquery_element.js
+++ b/web/tests/lib/zjquery_element.js
@@ -4,10 +4,10 @@ const {strict: assert} = require("assert");
 
 const FakeEvent = require("./zjquery_event");
 
-const noop = function () {};
+const noop = () => {};
 
 // TODO: convert this to a true class
-function FakeElement(selector, opts) {
+const FakeElement = (selector, opts) => {
     let html = "never-been-set";
     let text = "never-been-set";
     let value;
@@ -29,52 +29,45 @@ function FakeElement(selector, opts) {
                 yield $self[i];
             }
         },
-        addClass(class_name) {
+        addClass: (class_name) => {
             classes.set(class_name, true);
             return $self;
         },
-        append(arg) {
+        append: (arg) => {
             html = html + arg;
             return $self;
         },
-        attr(name, val) {
+        attr: (name, val) => {
             if (val === undefined) {
                 return attrs.get(name);
             }
             attrs.set(name, val);
             return $self;
         },
-        data(name, val) {
+        data: (name, val) => {
             if (val === undefined) {
                 return attrs.get("data-" + name);
             }
             attrs.set("data-" + name, val);
             return $self;
         },
-        delay() {
-            return $self;
-        },
+        delay: () => $self,
         /* istanbul ignore next */
-        debug() {
-            return {
-                value,
-                shown,
-                selector,
-            };
-        },
-        empty(arg) {
+        debug: () => ({
+            value,
+            shown,
+            selector,
+        }),
+        empty: (arg) => {
             if (arg === undefined) {
                 find_results.clear();
                 html = "";
             }
             return $self;
         },
-        expectOne() {
-            // silently do nothing
-            return $self;
-        },
+        expectOne: () => $self,
         fadeTo: noop,
-        find(child_selector) {
+        find: (child_selector) => {
             const $child = find_results.get(child_selector);
             if ($child) {
                 return $child;
@@ -99,28 +92,24 @@ function FakeElement(selector, opts) {
 
                 `);
         },
-        get_on_handler(name, child_selector) {
-            return event_store.get_on_handler(name, child_selector);
-        },
-        hasClass(class_name) {
-            return classes.has(class_name);
-        },
-        height() {
+        get_on_handler: (name, child_selector) => event_store.get_on_handler(name, child_selector),
+        hasClass: (class_name) => classes.has(class_name),
+        height: () => {
             assert.notEqual(height, undefined, `Please call $("${selector}").set_height`);
             return height;
         },
-        hide() {
+        hide: () => {
             shown = false;
             return $self;
         },
-        html(arg) {
+        html: (arg) => {
             if (arg !== undefined) {
                 html = arg;
                 return $self;
             }
             return html;
         },
-        is(arg) {
+        is: (arg) => {
             switch (arg) {
                 case ":visible":
                     return shown;
@@ -131,34 +120,26 @@ function FakeElement(selector, opts) {
                     throw new Error("zjquery does not support this is() call");
             }
         },
-        is_focused() {
-            // is_focused is not a jQuery thing; this is
-            // for our testing
-            return event_store.is_focused();
-        },
-        off(...args) {
+        is_focused: () => event_store.is_focused(),
+        off: (...args) => {
             event_store.off(...args);
             return $self;
         },
-        offset() {
-            return {
-                top: 0,
-                left: 0,
-            };
-        },
-        on(...args) {
+        offset: () => ({
+            top: 0,
+            left: 0,
+        }),
+        on: (...args) => {
             event_store.on(...args);
             return $self;
         },
         /* istanbul ignore next */
-        one(...args) {
+        one: (...args) => {
             event_store.one(...args);
             return $self;
         },
-        parent() {
-            return $my_parent;
-        },
-        parents(parents_selector) {
+        parent: () => $my_parent,
+        parents: (parents_selector) => {
             const $result = parents_result.get(parents_selector);
             assert.ok(
                 $result,
@@ -166,22 +147,22 @@ function FakeElement(selector, opts) {
             );
             return $result;
         },
-        prepend(arg) {
+        prepend: (arg) => {
             html = arg + html;
             return $self;
         },
-        prop(name, val) {
+        prop: (name, val) => {
             if (val === undefined) {
                 return properties.get(name);
             }
             properties.set(name, val);
             return $self;
         },
-        removeAttr(name) {
+        removeAttr: (name) => {
             attrs.delete(name);
             return $self;
         },
-        removeClass(class_names) {
+        removeClass: (class_names) => {
             class_names = class_names.split(" ");
             for (const class_name of class_names) {
                 classes.delete(class_name);
@@ -189,7 +170,7 @@ function FakeElement(selector, opts) {
             return $self;
         },
         /* istanbul ignore next */
-        remove() {
+        remove: () => {
             throw new Error(`
                 We don't support remove in zjquery.
 
@@ -200,7 +181,7 @@ function FakeElement(selector, opts) {
             `);
         },
         removeData: noop,
-        set_find_results(find_selector, $jquery_object) {
+        set_find_results: (find_selector, $jquery_object) => {
             assert.notEqual(
                 $jquery_object,
                 undefined,
@@ -208,20 +189,20 @@ function FakeElement(selector, opts) {
             );
             find_results.set(find_selector, $jquery_object);
         },
-        set_height(fake_height) {
+        set_height: (fake_height) => {
             height = fake_height;
         },
-        set_parent($parent_elem) {
+        set_parent: ($parent_elem) => {
             $my_parent = $parent_elem;
         },
-        set_parents_result(selector, $result) {
+        set_parents_result: (selector, $result) => {
             parents_result.set(selector, $result);
         },
-        show() {
+        show: () => {
             shown = true;
             return $self;
         },
-        text(...args) {
+        text: (...args) => {
             if (args.length !== 0) {
                 if (args[0] !== undefined) {
                     text = args[0].toString();
@@ -230,12 +211,12 @@ function FakeElement(selector, opts) {
             }
             return text;
         },
-        toggle(show) {
+        toggle: (show) => {
             assert.ok([true, false].includes(show));
             shown = show;
             return $self;
         },
-        toggleClass(class_name, add) {
+        toggleClass: (class_name, add) => {
             if (add) {
                 classes.set(class_name, true);
             } else {
@@ -243,20 +224,18 @@ function FakeElement(selector, opts) {
             }
             return $self;
         },
-        trigger(ev) {
+        trigger: (ev) => {
             event_store.trigger($self, ev);
             return $self;
         },
-        val(...args) {
+        val: (...args) => {
             if (args.length === 0) {
                 return value || "";
             }
             [value] = args;
             return $self;
         },
-        visible() {
-            return shown;
-        },
+        visible: () => shown,
     };
 
     if (opts.children) {
@@ -284,7 +263,7 @@ function FakeElement(selector, opts) {
     $self.__zjquery = true;
 
     return $self;
-}
+};
 
 function make_event_store(selector) {
     /*
@@ -303,7 +282,7 @@ function make_event_store(selector) {
     let focused = false;
 
     const self = {
-        get_on_handler(name, child_selector) {
+        get_on_handler: (name, child_selector) => {
             let handler;
 
             if (child_selector === undefined) {
@@ -322,7 +301,7 @@ function make_event_store(selector) {
             return handler;
         },
 
-        off(event_name, ...args) {
+        off: (event_name, ...args) => {
             if (args.length === 0) {
                 on_functions.delete(event_name);
                 return;
@@ -336,7 +315,7 @@ function make_event_store(selector) {
             throw new Error("zjquery does not support this call sequence");
         },
 
-        on(event_name, ...args) {
+        on: (event_name, ...args) => {
             // parameters will either be
             //    (event_name, handler) or
             //    (event_name, sel, handler)
@@ -381,7 +360,7 @@ function make_event_store(selector) {
             });
         },
 
-        trigger($element, ev, data) {
+        trigger: ($element, ev, data) => {
             if (typeof ev === "string") {
                 ev = new FakeEvent(ev);
             }
@@ -407,9 +386,7 @@ function make_event_store(selector) {
             }
         },
 
-        is_focused() {
-            return focused;
-        },
+        is_focused: () => focused,
     };
 
     return self;

--- a/web/tests/linkifiers.test.js
+++ b/web/tests/linkifiers.test.js
@@ -10,9 +10,7 @@ const linkifiers = zrequire("linkifiers");
 
 linkifiers.initialize([]);
 
-function get_linkifier_regexes() {
-    return [...linkifiers.get_linkifier_map().keys()];
-}
+const get_linkifier_regexes = () => [...linkifiers.get_linkifier_map().keys()];
 
 run_test("python_to_js_linkifier", () => {
     // The only way to reach python_to_js_linkifier is indirectly, hence the call

--- a/web/tests/list_cursor.test.js
+++ b/web/tests/list_cursor.test.js
@@ -9,10 +9,10 @@ const $ = require("./lib/zjquery");
 
 const {ListCursor} = zrequire("list_cursor");
 
-function basic_conf({first_key, prev_key, next_key}) {
+const basic_conf = ({first_key, prev_key, next_key}) => {
     const list = {
         scroll_container_selector: "whatever",
-        find_li() {},
+        find_li: () => {},
         first_key,
         prev_key,
         next_key,
@@ -24,7 +24,7 @@ function basic_conf({first_key, prev_key, next_key}) {
     };
 
     return conf;
-}
+};
 
 run_test("misc errors", ({override}) => {
     const conf = basic_conf({
@@ -67,7 +67,7 @@ run_test("single item list", ({override}) => {
 
     const $li_stub = {
         length: 1,
-        addClass() {},
+        addClass: () => {},
     };
 
     override(conf.list, "find_li", () => $li_stub);
@@ -93,9 +93,7 @@ run_test("multiple item list", ({override}) => {
     const cursor = new ListCursor(conf);
     override(cursor, "adjust_scroll", noop);
 
-    function li(key) {
-        return $.create(`item-${key}`, {children: ["stub"]});
-    }
+    const li = (key) => $.create(`item-${key}`, {children: ["stub"]});
 
     const list_items = {
         1: li(1),

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -26,7 +26,7 @@ mock_jquery((arg) => {
         addClass() {
             return this;
         },
-        replace(regex, string) {
+        replace: (regex, string) => {
             arg = arg.replace(regex, string);
         },
         html: () => arg,
@@ -43,7 +43,7 @@ const ListWidget = zrequire("list_widget");
 // it.  This is a good time to read set_up_event_handlers
 // in the real code.
 
-function make_container() {
+const make_container = () => {
     const $container = {};
     $container.attr = noop;
     $container.empty = noop;
@@ -56,9 +56,9 @@ function make_container() {
     };
 
     return $container;
-}
+};
 
-function make_scroll_container() {
+const make_scroll_container = () => {
     const $scroll_container = {};
     $scroll_container[0] = {};
 
@@ -80,9 +80,9 @@ function make_scroll_container() {
     $scroll_container.is = () => false;
 
     return $scroll_container;
-}
+};
 
-function make_sort_container() {
+const make_sort_container = () => {
     const $sort_container = {};
 
     $sort_container.cleared = false;
@@ -99,9 +99,9 @@ function make_sort_container() {
     };
 
     return $sort_container;
-}
+};
 
-function make_filter_element() {
+const make_filter_element = () => {
     const $element = {};
 
     $element.cleared = false;
@@ -117,9 +117,9 @@ function make_filter_element() {
     };
 
     return $element;
-}
+};
 
-function make_search_input() {
+const make_search_input = () => {
     const $element = {};
 
     // Allow ourselves to be wrapped by $(...) and
@@ -138,11 +138,9 @@ function make_search_input() {
     };
 
     return $element;
-}
+};
 
-function div(item) {
-    return "<div>" + item + "</div>";
-}
+const div = (item) => "<div>" + item + "</div>";
 
 run_test("scrolling", () => {
     const $container = make_container();
@@ -250,7 +248,7 @@ run_test("filtering", () => {
             $element: $search_input,
             predicate: (item, value) => item.includes(value),
         },
-        modifier_html(item, filter_value) {
+        modifier_html: (item, filter_value) => {
             last_filter_value = filter_value;
             return div(item);
         },
@@ -298,7 +296,7 @@ run_test("no filtering", () => {
     const opts = {
         modifier_html: (item) => div(item),
         $simplebar_container: $scroll_container,
-        callback_after_render() {
+        callback_after_render: () => {
             callback_called = true;
         },
         get_item: (item) => item,
@@ -311,13 +309,13 @@ run_test("no filtering", () => {
     assert.deepEqual($container.$appended_data.html(), expected_html);
 });
 
-function sort_button(opts) {
+const sort_button = (opts) => {
     // The complications here are due to needing to find
     // the list via complicated HTML assumptions. Also, we
     // don't have any abstraction for the button and its
     // siblings other than direct jQuery actions.
 
-    function attr(name) {
+    const attr = (name) => {
         switch (name) {
             case "data-sort":
                 return opts.sort_type;
@@ -327,14 +325,12 @@ function sort_button(opts) {
             default:
                 throw new Error("unknown attribute: " + name);
         }
-    }
+    };
 
-    function lookup(sel, value) {
-        return (selector) => {
-            assert.equal(sel, selector);
-            return value;
-        };
-    }
+    const lookup = (sel, value) => (selector) => {
+        assert.equal(sel, selector);
+        return value;
+    };
 
     const classList = new Set();
 
@@ -343,15 +339,15 @@ function sort_button(opts) {
         closest: lookup(".progressive-table-wrapper", {
             data: lookup("list-widget", opts.list_name),
         }),
-        addClass(cls) {
+        addClass: (cls) => {
             classList.add(cls);
         },
         hasClass: (cls) => classList.has(cls),
-        removeClass(cls) {
+        removeClass: (cls) => {
             classList.delete(cls);
         },
         siblings: lookup(".active", {
-            removeClass(cls) {
+            removeClass: (cls) => {
                 assert.equal(cls, "active");
                 $button.siblings_deactivated = true;
             },
@@ -361,7 +357,7 @@ function sort_button(opts) {
     };
 
     return $button;
-}
+};
 
 run_test("wire up filter element", () => {
     const lst = ["alice", "JESSE", "moses", "scott", "Sean", "Xavier"];
@@ -418,9 +414,7 @@ run_test("sorting", () => {
         $simplebar_container: $scroll_container,
     };
 
-    function html_for(people) {
-        return people.map((item) => opts.modifier_html(item)).join("");
-    }
+    const html_for = (people) => people.map((item) => opts.modifier_html(item)).join("");
 
     ListWidget.create($container, list, opts);
 
@@ -501,13 +495,9 @@ run_test("custom sort", () => {
 
     const list = [n42, n43, n44];
 
-    function sort_by_x(a, b) {
-        return a.x - b.x;
-    }
+    const sort_by_x = (a, b) => a.x - b.x;
 
-    function sort_by_product(a, b) {
-        return a.x * a.y - b.x * b.y;
-    }
+    const sort_by_product = (a, b) => a.x * a.y - b.x * b.y;
 
     const widget = ListWidget.create($container, list, {
         name: "custom-sort-list",
@@ -527,9 +517,7 @@ run_test("custom sort", () => {
     assert.deepEqual($container.$appended_data.html(), "(1, 43)(4, 11)(6, 7)");
 
     // We can sort without registering the function, too.
-    function sort_by_y(a, b) {
-        return a.y - b.y;
-    }
+    const sort_by_y = (a, b) => a.y - b.y;
 
     widget.sort(sort_by_y);
     assert.deepEqual($container.$appended_data.html(), "(6, 7)(4, 11)(1, 43)");
@@ -547,8 +535,8 @@ run_test("clear_event_handlers", () => {
     const opts = {
         name: "list-we-create-twice",
         $parent_container: $sort_container,
-        modifier_html() {},
-        get_item() {},
+        modifier_html: () => {},
+        get_item: () => {},
         filter: {
             $element: $filter_element,
             predicate: /* istanbul ignore next */ () => true,
@@ -604,7 +592,7 @@ run_test("replace_list_data w/filter update", () => {
         get_item: (item) => item,
         filter: {
             predicate: (n) => n % 2 === 0,
-            onupdate() {
+            onupdate: () => {
                 num_updates += 1;
             },
         },
@@ -689,7 +677,7 @@ run_test("render item", () => {
             // Return a JQuery stub for the original HTML.
             // We want this to be called when we replace
             // the existing HTML with newly rendered HTML.
-            replaceWith($element) {
+            replaceWith: ($element) => {
                 assert.equal(new_html, $element.html());
                 called = true;
                 $container.$appended_data.replace(regex, new_html);
@@ -743,7 +731,7 @@ run_test("render item", () => {
     const widget_2 = ListWidget.create($container, list, {
         name: "replace-list",
         modifier_html: (item) => `<tr data-item=${item.value}>${item.text}</tr>\n`,
-        get_item(item) {
+        get_item: (item) => {
             get_item_called = true;
             return item;
         },
@@ -785,24 +773,22 @@ run_test("Multiselect dropdown retain_selected_items", () => {
     // We essentially create fake jQuery functions
     // whose return value are stored in objects so that
     // they can be later asserted with expected values.
-    function DropdownItem(element) {
+    const DropdownItem = (element) => {
         const temp = {};
 
-        function length() {
+        const length = () => {
             if (element) {
                 return true;
             }
             /* istanbul ignore next */
             return false;
-        }
+        };
 
-        function find(tag) {
-            return ListItem(tag, temp);
-        }
+        const find = (tag) => ListItem(tag, temp);
 
-        function addClass(cls) {
+        const addClass = (cls) => {
             temp.appended_class = cls;
-        }
+        };
 
         temp.element = element;
         return {
@@ -810,23 +796,23 @@ run_test("Multiselect dropdown retain_selected_items", () => {
             find,
             addClass,
         };
-    }
+    };
 
-    function ListItem(element, temp) {
-        function expectOne() {
+    const ListItem = (element, temp) => {
+        const expectOne = () => {
             data_rendered.push(temp);
             return ListItem(element, temp);
-        }
+        };
 
-        function prepend($data) {
+        const prepend = ($data) => {
             temp.prepended_data = $data.html();
-        }
+        };
 
         return {
             expectOne,
             prepend,
         };
-    }
+    };
 
     const widget = ListWidget.create($container, list, {
         name: "replace-list",

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -199,13 +199,13 @@ stream_data.add_sub(amp_stream);
 markdown.initialize(markdown_config.get_helpers());
 linkifiers.initialize(example_realm_linkifiers);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         page_params.realm_users = [];
         linkifiers.update_linkifier_rules(example_realm_linkifiers);
         f(helpers);
     });
-}
+};
 
 test("markdown_detection", () => {
     const no_markup = [
@@ -957,9 +957,8 @@ test("backend_only_linkifiers", () => {
 test("translate_emoticons_to_names", () => {
     const get_emoticon_translations = emoji.get_emoticon_translations;
 
-    function translate_emoticons_to_names(src) {
-        return markdown.translate_emoticons_to_names({src, get_emoticon_translations});
-    }
+    const translate_emoticons_to_names = (src) =>
+        markdown.translate_emoticons_to_names({src, get_emoticon_translations});
 
     // Simple test
     const test_text = "Testing :)";
@@ -1039,7 +1038,7 @@ test("missing unicode emojis", ({override}) => {
 test("katex_throws_unexpected_exceptions", ({override_rewire}) => {
     const message = {raw_content: "$$a$$"};
     override_rewire(markdown, "katex", {
-        renderToString() {
+        renderToString: () => {
             throw new Error("some-exception");
         },
     });

--- a/web/tests/markdown_parse.test.js
+++ b/web/tests/markdown_parse.test.js
@@ -16,11 +16,9 @@ const user_map = new Map();
 user_map.set(my_id, "Me Myself");
 user_map.set(105, "greg");
 
-function get_actual_name_from_user_id(user_id) {
-    return user_map.get(user_id);
-}
+const get_actual_name_from_user_id = (user_id) => user_map.get(user_id);
 
-function get_user_id_from_name(name) {
+const get_user_id_from_name = (name) => {
     for (const [user_id, _name] of user_map.entries()) {
         if (name === _name) {
             return user_id;
@@ -29,19 +27,14 @@ function get_user_id_from_name(name) {
 
     /* istanbul ignore next */
     throw new Error(`unexpected name ${name}`);
-}
+};
 
-function is_valid_full_name_and_user_id(name, user_id) {
-    return user_map.has(user_id) && user_map.get(user_id) === name;
-}
+const is_valid_full_name_and_user_id = (name, user_id) =>
+    user_map.has(user_id) && user_map.get(user_id) === name;
 
-function my_user_id() {
-    return my_id;
-}
+const my_user_id = () => my_id;
 
-function is_valid_user_id(user_id) {
-    return user_map.has(user_id);
-}
+const is_valid_user_id = (user_id) => user_map.has(user_id);
 
 const staff_group = {
     id: 201,
@@ -51,15 +44,13 @@ const staff_group = {
 const user_group_map = new Map();
 user_group_map.set(staff_group.name, staff_group);
 
-function get_user_group_from_name(name) {
-    return user_group_map.get(name);
-}
+const get_user_group_from_name = (name) => user_group_map.get(name);
 
-function is_member_of_user_group(user_id, user_group_id) {
+const is_member_of_user_group = (user_id, user_group_id) => {
     assert.equal(user_group_id, staff_group.id);
     assert.equal(user_id, my_id);
     return true;
-}
+};
 
 const social = {
     stream_id: 301,
@@ -69,34 +60,24 @@ const social = {
 const sub_map = new Map();
 sub_map.set(social.name, social);
 
-function get_stream_by_name(name) {
-    return sub_map.get(name);
-}
+const get_stream_by_name = (name) => sub_map.get(name);
 
-function stream_hash(stream_id) {
-    return `stream-${stream_id}`;
-}
+const stream_hash = (stream_id) => `stream-${stream_id}`;
 
-function stream_topic_hash(stream_id, topic) {
-    return `stream-${stream_id}-topic-${topic}`;
-}
+const stream_topic_hash = (stream_id, topic) => `stream-${stream_id}-topic-${topic}`;
 
-function get_emoticon_translations() {
-    return [
-        {regex: /(:\))/g, replacement_text: ":smile:"},
-        {regex: /(<3)/g, replacement_text: ":heart:"},
-    ];
-}
+const get_emoticon_translations = () => [
+    {regex: /(:\))/g, replacement_text: ":smile:"},
+    {regex: /(<3)/g, replacement_text: ":heart:"},
+];
 
 const emoji_map = new Map();
 emoji_map.set("smile", "1f642");
 emoji_map.set("alien", "1f47d");
 
-function get_emoji_codepoint(emoji_name) {
-    return emoji_map.get(emoji_name);
-}
+const get_emoji_codepoint = (emoji_name) => emoji_map.get(emoji_name);
 
-function get_emoji_name(codepoint) {
+const get_emoji_name = (codepoint) => {
     for (const [emoji_name, _codepoint] of emoji_map.entries()) {
         if (codepoint === _codepoint) {
             return emoji_name;
@@ -105,14 +86,12 @@ function get_emoji_name(codepoint) {
 
     /* istanbul ignore next */
     throw new Error(`unexpected codepoint ${codepoint}`);
-}
+};
 
 const realm_emoji_map = new Map();
 realm_emoji_map.set("heart", "/images/emoji/heart.bmp");
 
-function get_realm_emoji_url(emoji_name) {
-    return realm_emoji_map.get(emoji_name);
-}
+const get_realm_emoji_url = (emoji_name) => realm_emoji_map.get(emoji_name);
 
 const regex = /#foo(\d+)(?!\w)/g;
 const linkifier_map = new Map();
@@ -121,9 +100,7 @@ linkifier_map.set(regex, {
     group_number_to_name: {1: "id"},
 });
 
-function get_linkifier_map() {
-    return linkifier_map;
-}
+const get_linkifier_map = () => linkifier_map;
 
 const helper_config = {
     // user stuff
@@ -155,10 +132,10 @@ const helper_config = {
     get_linkifier_map,
 };
 
-function assert_parse(raw_content, expected_content) {
+const assert_parse = (raw_content, expected_content) => {
     const {content} = markdown.parse({raw_content, helper_config});
     assert.equal(content, expected_content);
-}
+};
 
 run_test("basics", () => {
     assert_parse("boring", "<p>boring</p>");
@@ -222,10 +199,10 @@ run_test("linkifiers", () => {
     );
 });
 
-function assert_topic_links(topic, expected_links) {
+const assert_topic_links = (topic, expected_links) => {
     const topic_links = markdown.get_topic_links(topic);
     assert.deepEqual(topic_links, expected_links);
-}
+};
 
 run_test("topic links", () => {
     linkifiers.initialize([{pattern: "#foo(?P<id>\\d+)", url_template: "http://foo.com/{id}"}]);

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -38,7 +38,7 @@ const denmark = {
 };
 stream_data.add_sub(denmark);
 
-function test_helper(side_effects) {
+const test_helper = (side_effects) => {
     const events = [];
 
     for (const [module, field] of side_effects) {
@@ -54,7 +54,7 @@ function test_helper(side_effects) {
     };
 
     return self;
-}
+};
 
 run_test("update_messages", () => {
     const raw_message = {

--- a/web/tests/message_flags.test.js
+++ b/web/tests/message_flags.test.js
@@ -11,13 +11,13 @@ const message_live_update = mock_esm("../src/message_live_update");
 set_global("document", {hasFocus: () => true});
 
 mock_esm("../src/starred_messages", {
-    add() {},
+    add: () => {},
     get_count: () => 5,
     get_starred_msg_ids: () => [1, 2, 3, 4, 5],
-    remove() {},
+    remove: () => {},
 });
 mock_esm("../src/left_sidebar_navigation_area", {
-    update_starred_count() {},
+    update_starred_count: () => {},
 });
 
 const message_flags = zrequire("message_flags");
@@ -157,12 +157,12 @@ run_test("read", ({override}) => {
     });
 
     // For testing purpose limit the batch size value to 5 instead of 1000
-    function send_read(messages) {
+    const send_read = (messages) => {
         with_overrides(({override_rewire}) => {
             override_rewire(message_flags, "_unread_batch_size", 5);
             message_flags.send_read(messages);
         });
-    }
+    };
 
     let msgs_to_flag_read = [
         {locally_echoed: false, id: 1},
@@ -229,12 +229,12 @@ run_test("read", ({override}) => {
     // Messages still not acked yet
     const events = {};
     const stub_delay = 100;
-    function set_timeout(f, delay) {
+    const set_timeout = (f, delay) => {
         assert.equal(delay, stub_delay);
         events.f = f;
         events.timer_set = true;
         return;
-    }
+    };
     set_global("setTimeout", set_timeout);
     // Mock successful flagging of ids
     success_response_data = {
@@ -284,12 +284,12 @@ run_test("read_empty_data", ({override}) => {
     });
 
     // For testing purpose limit the batch size value to 5 instead of 1000
-    function send_read(messages) {
+    const send_read = (messages) => {
         with_overrides(({override_rewire}) => {
             override_rewire(message_flags, "_unread_batch_size", 5);
             message_flags.send_read(messages);
         });
-    }
+    };
 
     // send read to obtain success callback
     send_read([{locally_echoed: false, id: 1}]);

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -13,14 +13,12 @@ const {current_user} = require("./lib/zpage_params");
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.
 
-const noop = function () {};
+const noop = () => {};
 
 set_global("document", {
-    to_$() {
-        return {
-            trigger() {},
-        };
-    },
+    to_$: () => ({
+        trigger: () => {},
+    }),
 });
 
 const narrow_state = mock_esm("../src/narrow_state");
@@ -98,7 +96,7 @@ run_test("basics", ({override}) => {
 
     // Make sure not rerendered when reselected
     let num_renders = 0;
-    list.rerender = function () {
+    list.rerender = () => {
         num_renders += 1;
     };
     list.reselect_selected_id();
@@ -125,7 +123,7 @@ run_test("basics", ({override}) => {
     list.append(new_messages, true);
     assert.equal(list.last().id, 90);
 
-    list.view.clear_table = function () {};
+    list.view.clear_table = () => {};
 
     list.remove_and_rerender([60]);
     const removed = list.all_messages().filter((msg) => msg.id !== 60);

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -27,14 +27,14 @@ const narrow_state = mock_esm("../src/narrow_state");
 const stream_data = mock_esm("../src/stream_data");
 
 const {MessageList} = zrequire("message_list");
-function MessageListView() {
-    return {
-        maybe_rerender: noop,
-        append: noop,
-        prepend: noop,
-        clear_rendering_state: noop,
-        is_current_message_list: () => true,
-    };
+class MessageListView {
+    maybe_rerender() {}
+    append() {}
+    prepend() {}
+    clear_rendering_state() {}
+    is_current_message_list() {
+        return true;
+    }
 }
 mock_esm("../src/message_list_view", {
     MessageListView,

--- a/web/tests/message_list_data.test.js
+++ b/web/tests/message_list_data.test.js
@@ -11,30 +11,26 @@ const muted_users = zrequire("muted_users");
 const {MessageListData} = zrequire("../src/message_list_data");
 const {Filter} = zrequire("filter");
 
-function make_msg(msg_id) {
-    return {
-        id: msg_id,
-        type: "stream",
-        unread: true,
-        topic: "whatever",
-    };
-}
+const make_msg = (msg_id) => ({
+    id: msg_id,
+    type: "stream",
+    unread: true,
+    topic: "whatever",
+});
 
-function make_msgs(msg_ids) {
-    return msg_ids.map((msg_id) => make_msg(msg_id));
-}
+const make_msgs = (msg_ids) => msg_ids.map((msg_id) => make_msg(msg_id));
 
-function assert_contents(mld, msg_ids) {
+const assert_contents = (mld, msg_ids) => {
     const msgs = mld.all_messages();
     assert.deepEqual(msgs, make_msgs(msg_ids));
-}
+};
 
-function assert_msg_ids(messages, msg_ids) {
+const assert_msg_ids = (messages, msg_ids) => {
     assert.deepEqual(
         msg_ids,
         messages.map((message) => message.id),
     );
-}
+};
 
 run_test("basics", () => {
     const mld = new MessageListData({

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -12,12 +12,8 @@ set_global("document", "document-stub");
 
 // timerender calls setInterval when imported
 mock_esm("../src/timerender", {
-    render_date(time) {
-        return [{outerHTML: String(time.getTime())}];
-    },
-    stringify_time(time) {
-        return time.toString("h:mm TT");
-    },
+    render_date: (time) => [{outerHTML: String(time.getTime())}],
+    stringify_time: (time) => time.toString("h:mm TT"),
 });
 
 mock_esm("../src/people", {
@@ -34,20 +30,20 @@ const muted_users = zrequire("muted_users");
 
 let next_timestamp = 1500000000;
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override, mock_template}) => {
         muted_users.set_muted_users([]);
         mock_template("message_list.hbs", false, () => "<message-list-stub>");
         f({override, mock_template});
     });
-}
+};
 
 test("msg_moved_var", () => {
     // This is a test to verify that when the stream or topic is changed
     // (and the content is not), the message says "MOVED" rather than "EDITED."
     // See the end of the test for the list of cases verified.
 
-    function build_message_context(message = {}, message_context = {}) {
+    const build_message_context = (message = {}, message_context = {}) => {
         message_context = {
             ...message_context,
         };
@@ -62,13 +58,11 @@ test("msg_moved_var", () => {
             };
         }
         return message_context;
-    }
+    };
 
-    function build_message_group(messages) {
-        return {message_containers: messages};
-    }
+    const build_message_group = (messages) => ({message_containers: messages});
 
-    function build_list(message_groups) {
+    const build_list = (message_groups) => {
         const list = new MessageListView(
             {
                 id: 1,
@@ -78,19 +72,19 @@ test("msg_moved_var", () => {
         );
         list._message_groups = message_groups;
         return list;
-    }
+    };
 
-    function assert_moved_true(message_container) {
+    const assert_moved_true = (message_container) => {
         assert.equal(message_container.moved, true);
-    }
-    function assert_moved_false(message_container) {
+    };
+    const assert_moved_false = (message_container) => {
         assert.equal(message_container.moved, false);
-    }
-    function assert_moved_undefined(message_container) {
+    };
+    const assert_moved_undefined = (message_container) => {
         assert.equal(message_container.moved, undefined);
-    }
+    };
 
-    (function test_msg_moved_var() {
+    (() => {
         const messages = [
             // no edit history: NO LABEL
             build_message_context({}),
@@ -206,7 +200,7 @@ test("msg_edited_vars", () => {
     //   * message that includes sender
     //   * message without sender
 
-    function build_message_context(message = {}, message_context = {}) {
+    const build_message_context = (message = {}, message_context = {}) => {
         message_context = {
             include_sender: true,
             ...message_context,
@@ -218,13 +212,11 @@ test("msg_edited_vars", () => {
             ...message,
         };
         return message_context;
-    }
+    };
 
-    function build_message_group(messages) {
-        return {message_containers: messages};
-    }
+    const build_message_group = (messages) => ({message_containers: messages});
 
-    function build_list(message_groups) {
+    const build_list = (message_groups) => {
         const list = new MessageListView(
             {
                 id: 1,
@@ -234,30 +226,30 @@ test("msg_edited_vars", () => {
         );
         list._message_groups = message_groups;
         return list;
-    }
+    };
 
-    function assert_left_col(message_container) {
+    const assert_left_col = (message_container) => {
         assert.equal(message_container.modified, true);
         assert.equal(message_container.message_edit_notices_in_left_col, true);
         assert.equal(message_container.message_edit_notices_alongside_sender, false);
         assert.equal(message_container.message_edit_notices_for_status_message, false);
-    }
+    };
 
-    function assert_alongside_sender(message_container) {
+    const assert_alongside_sender = (message_container) => {
         assert.equal(message_container.modified, true);
         assert.equal(message_container.message_edit_notices_in_left_col, false);
         assert.equal(message_container.message_edit_notices_alongside_sender, true);
         assert.equal(message_container.message_edit_notices_for_status_message, false);
-    }
+    };
 
-    function assert_status_msg(message_container) {
+    const assert_status_msg = (message_container) => {
         assert.equal(message_container.modified, true);
         assert.equal(message_container.message_edit_notices_in_left_col, false);
         assert.equal(message_container.message_edit_notices_alongside_sender, false);
         assert.equal(message_container.message_edit_notices_for_status_message, true);
-    }
+    };
 
-    function set_edited_notice_locations(message_container) {
+    const set_edited_notice_locations = (message_container) => {
         const include_sender = message_container.include_sender;
         const is_hidden = message_container.is_hidden;
         const status_message = Boolean(message_container.status_message);
@@ -265,9 +257,9 @@ test("msg_edited_vars", () => {
         message_container.message_edit_notices_alongside_sender = include_sender && !status_message;
         message_container.message_edit_notices_for_status_message =
             include_sender && status_message;
-    }
+    };
 
-    (function test_msg_edited_vars() {
+    (() => {
         const messages = [
             build_message_context(),
             build_message_context({}, {include_sender: false}),
@@ -298,7 +290,7 @@ test("muted_message_vars", () => {
     // This verifies that the variables for muted/hidden messages are set
     // correctly.
 
-    function build_message_context(message = {}, message_context = {}) {
+    const build_message_context = (message = {}, message_context = {}) => {
         message_context = {
             ...message_context,
         };
@@ -306,13 +298,11 @@ test("muted_message_vars", () => {
             ...message,
         };
         return message_context;
-    }
+    };
 
-    function build_message_group(messages) {
-        return {message_containers: messages};
-    }
+    const build_message_group = (messages) => ({message_containers: messages});
 
-    function build_list(message_groups) {
+    const build_list = (message_groups) => {
         const list = new MessageListView(
             {
                 id: 1,
@@ -322,16 +312,16 @@ test("muted_message_vars", () => {
         );
         list._message_groups = message_groups;
         return list;
-    }
+    };
 
-    function calculate_variables(list, messages, is_revealed) {
+    const calculate_variables = (list, messages, is_revealed) => {
         list.set_calculated_message_container_variables(messages[0], is_revealed);
         list.set_calculated_message_container_variables(messages[1], is_revealed);
         list.set_calculated_message_container_variables(messages[2], is_revealed);
         return list._message_groups[0].message_containers;
-    }
+    };
 
-    (function test_hidden_message_variables() {
+    (() => {
         // We want to have no search results, which apparently works like this.
         // See https://chat.zulip.org/#narrow/stream/6-frontend/topic/set_find_results.20with.20no.20results/near/1414799
         const empty_list_stub = $.create("empty-stub", {children: []});
@@ -434,7 +424,7 @@ test("merge_message_groups", ({mock_template}) => {
     // MessageListView has lots of DOM code, so we are going to test the message
     // group merging logic on its own.
 
-    function build_message_context(message = {}, message_context = {}) {
+    const build_message_context = (message = {}, message_context = {}) => {
         message_context = {
             include_sender: true,
             ...message_context,
@@ -450,16 +440,14 @@ test("merge_message_groups", ({mock_template}) => {
             ...message,
         };
         return message_context;
-    }
+    };
 
-    function build_message_group(messages) {
-        return {
-            message_containers: messages,
-            message_group_id: _.uniqueId("test_message_group_"),
-        };
-    }
+    const build_message_group = (messages) => ({
+        message_containers: messages,
+        message_group_id: _.uniqueId("test_message_group_"),
+    });
 
-    function build_list(message_groups) {
+    const build_list = (message_groups) => {
         const filter = new Filter([{operator: "stream", operand: "foo"}]);
 
         const list = new message_list.MessageList({
@@ -472,31 +460,27 @@ test("merge_message_groups", ({mock_template}) => {
         view.list.unsubscribed_bookend_content = noop;
         view.list.subscribed_bookend_content = noop;
         return view;
-    }
+    };
 
-    function extract_message_ids(lst) {
-        return lst.map((item) => item.msg.id);
-    }
+    const extract_message_ids = (lst) => lst.map((item) => item.msg.id);
 
-    function assert_message_list_equal(list1, list2) {
+    const assert_message_list_equal = (list1, list2) => {
         const ids1 = extract_message_ids(list1);
         const ids2 = extract_message_ids(list2);
         assert.ok(ids1.length);
         assert.deepEqual(ids1, ids2);
-    }
+    };
 
-    function extract_group(group) {
-        return extract_message_ids(group.message_containers);
-    }
+    const extract_group = (group) => extract_message_ids(group.message_containers);
 
-    function assert_message_groups_list_equal(list1, list2) {
+    const assert_message_groups_list_equal = (list1, list2) => {
         const ids1 = list1.map((group) => extract_group(group));
         const ids2 = list2.map((group) => extract_group(group));
         assert.ok(ids1.length);
         assert.deepEqual(ids1, ids2);
-    }
+    };
 
-    (function test_empty_list_bottom() {
+    (() => {
         const list = build_list([]);
         const message_group = build_message_group([build_message_context()]);
 
@@ -509,7 +493,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_append_message_same_topic() {
+    (() => {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -528,7 +512,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert_message_list_equal(result.append_messages, [message2]);
     })();
 
-    (function test_append_message_different_topic() {
+    (() => {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -546,7 +530,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_append_message_different_topic_and_days() {
+    (() => {
         const message1 = build_message_context({timestamp: 1000});
         const message_group1 = build_message_group([message1]);
 
@@ -564,7 +548,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.equal(message_group2.date_unchanged, false);
     })();
 
-    (function test_append_message_different_day() {
+    (() => {
         const message1 = build_message_context({timestamp: 1000});
         const message_group1 = build_message_group([message1]);
 
@@ -582,7 +566,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.ok(list._message_groups[0].message_containers[1].want_date_divider);
     })();
 
-    (function test_append_message_historical() {
+    (() => {
         const message1 = build_message_context({historical: false});
         const message_group1 = build_message_group([message1]);
 
@@ -600,7 +584,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_append_message_same_topic_me_message() {
+    (() => {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -620,7 +604,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert_message_list_equal(result.append_messages, [message2]);
     })();
 
-    (function test_prepend_message_same_topic() {
+    (() => {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -641,7 +625,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_prepend_message_different_topic() {
+    (() => {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -658,7 +642,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_prepend_message_different_topic_and_day() {
+    (() => {
         const message1 = build_message_context({timestamp: 900000});
         const message_group1 = build_message_group([message1]);
 
@@ -676,7 +660,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_prepend_message_different_day() {
+    (() => {
         const message1 = build_message_context({timestamp: 900000});
         const message_group1 = build_message_group([message1]);
 
@@ -694,7 +678,7 @@ test("merge_message_groups", ({mock_template}) => {
         assert.deepEqual(result.append_messages, []);
     })();
 
-    (function test_prepend_message_historical() {
+    (() => {
         const message1 = build_message_context({historical: false});
         const message_group1 = build_message_group([message1]);
 
@@ -720,7 +704,7 @@ test("render_windows", ({mock_template}) => {
     // start/end) when the pointer moves outside of the window or close
     // to the edges.
 
-    const view = (function make_view() {
+    const view = (() => {
         const filter = new Filter([]);
 
         const list = new message_list.MessageList({
@@ -744,7 +728,7 @@ test("render_windows", ({mock_template}) => {
 
     const list = view.list;
 
-    (function test_with_empty_list() {
+    (() => {
         // The function should early exit here.
         const rendered = view.maybe_rerender();
         assert.equal(rendered, false);
@@ -752,7 +736,7 @@ test("render_windows", ({mock_template}) => {
 
     let messages;
 
-    function reset_list(opts) {
+    const reset_list = (opts) => {
         messages = _.range(opts.count).map((i) => ({
             id: i,
         }));
@@ -761,9 +745,9 @@ test("render_windows", ({mock_template}) => {
         list.clear();
 
         list.add_messages(messages, {});
-    }
+    };
 
-    function verify_no_move_range(start, end) {
+    const verify_no_move_range = (start, end) => {
         // In our render window, there are up to 300 positions in
         // the list where we can move the pointer without forcing
         // a re-render.  The code avoids hasty re-renders for
@@ -773,9 +757,9 @@ test("render_windows", ({mock_template}) => {
             const rendered = view.maybe_rerender();
             assert.equal(rendered, false);
         }
-    }
+    };
 
-    function verify_move(idx, range) {
+    const verify_move = (idx, range) => {
         const start = range[0];
         const end = range[1];
 
@@ -784,7 +768,7 @@ test("render_windows", ({mock_template}) => {
         assert.equal(rendered, true);
         assert.equal(view._render_win_start, start);
         assert.equal(view._render_win_end, end);
-    }
+    };
 
     reset_list({count: 51});
     verify_no_move_range(0, 51);

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -77,22 +77,20 @@ people.add_active_user(denise);
 
 people.initialize_current_user(me.user_id);
 
-function convert_recipients(people) {
-    // Display_recipient uses `id` for user_ids.
-    return people.map((p) => ({
+const convert_recipients = (people) =>
+    people.map((p) => ({
         email: p.email,
         id: p.user_id,
         full_name: p.full_name,
     }));
-}
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         message_store.clear_for_testing();
         message_user_ids.clear_for_testing();
         f(helpers);
     });
-}
+};
 
 test("process_new_message", () => {
     let message = {

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -22,23 +22,23 @@ const inbox_util = zrequire("inbox_util");
 const message_lists = zrequire("message_lists");
 
 mock_esm("../src/compose_banner", {
-    clear_search_view_banner() {},
+    clear_search_view_banner: () => {},
 });
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 mock_esm("../src/spectators", {
-    login_to_access() {},
+    login_to_access: () => {},
 });
 
-function empty_narrow_html(title, html, search_data) {
+const empty_narrow_html = (title, html, search_data) => {
     const opts = {
         title,
         html,
         search_data,
     };
     return require("../templates/empty_feed_notice.hbs")(opts);
-}
+};
 
-function set_filter(terms) {
+const set_filter = (terms) => {
     terms = terms.map((op) => ({
         operator: op[0],
         operand: op[1],
@@ -48,7 +48,7 @@ function set_filter(terms) {
             filter: new Filter(terms),
         },
     });
-}
+};
 
 const me = {
     email: "me@example.com",

--- a/web/tests/muted_users.test.js
+++ b/web/tests/muted_users.test.js
@@ -7,12 +7,12 @@ const {run_test} = require("./lib/test");
 
 const muted_users = zrequire("muted_users");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         muted_users.set_muted_users([]);
         f({override});
     });
-}
+};
 
 test("edge_cases", () => {
     // invalid user

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -8,7 +8,7 @@ const $ = require("./lib/zjquery");
 
 set_global("history", {});
 mock_esm("../src/resize", {
-    resize_stream_filters_container() {},
+    resize_stream_filters_container: () => {},
 });
 const {Filter} = zrequire("../src/filter");
 const all_messages_data = mock_esm("../src/all_messages_data");
@@ -34,12 +34,10 @@ const message_lists = mock_esm("../src/message_lists", {
             filter: new Filter([{operator: "in", operand: "all"}]),
         },
     },
-    update_current_message_list(msg_list) {
+    update_current_message_list: (msg_list) => {
         message_lists.current = msg_list;
     },
-    all_rendered_message_lists() {
-        return [message_lists.current];
-    },
+    all_rendered_message_lists: () => [message_lists.current],
 });
 const message_feed_top_notices = mock_esm("../src/message_feed_top_notices");
 const message_feed_loading = mock_esm("../src/message_feed_loading");
@@ -52,11 +50,11 @@ const left_sidebar_navigation_area = mock_esm("../src/left_sidebar_navigation_ar
 const typing_events = mock_esm("../src/typing_events");
 const unread_ops = mock_esm("../src/unread_ops");
 mock_esm("../src/pm_list", {
-    handle_narrow_activated() {},
+    handle_narrow_activated: () => {},
 });
 mock_esm("../src/unread_ui", {
-    reset_unread_banner() {},
-    update_unread_banner() {},
+    reset_unread_banner: () => {},
+    update_unread_banner: () => {},
 });
 
 //
@@ -87,14 +85,14 @@ const denmark = {
 };
 stream_data.add_sub(denmark);
 
-function test_helper({override}) {
+const test_helper = ({override}) => {
     const events = [];
 
-    function stub(module, func_name) {
+    const stub = (module, func_name) => {
         override(module, func_name, () => {
             events.push([module, func_name]);
         });
-    }
+    };
 
     stub(browser_history, "set_hash");
     stub(compose_banner, "clear_message_sent_banners");
@@ -117,11 +115,11 @@ function test_helper({override}) {
     $("#mark_read_on_scroll_state_banner").toggleClass = noop;
 
     return {
-        assert_events(expected_events) {
+        assert_events: (expected_events) => {
             assert.deepEqual(events, expected_events);
         },
     };
-}
+};
 
 function stub_message_list() {
     message_list.MessageList = class MessageList {

--- a/web/tests/narrow_local.test.js
+++ b/web/tests/narrow_local.test.js
@@ -14,7 +14,7 @@ const message_view = zrequire("message_view");
 const message_lists = zrequire("message_lists");
 const resolved_topic = zrequire("../shared/src/resolved_topic");
 
-function test_with(fixture) {
+const test_with = (fixture) => {
     const filter = new Filter(fixture.filter_terms);
     message_lists.set_current({
         data: {
@@ -49,15 +49,15 @@ function test_with(fixture) {
             has_found_newest: () => fixture.has_found_newest,
         },
         visibly_empty: () => fixture.visibly_empty,
-        all_messages() {
+        all_messages: () => {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages;
         },
-        first() {
+        first: () => {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages[0];
         },
-        last() {
+        last: () => {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages.at(-1);
         },
@@ -75,7 +75,7 @@ function test_with(fixture) {
     const msgs = msg_data.all_messages();
     const msg_ids = msgs.map((message) => message.id);
     assert.deepEqual(msg_ids, fixture.expected_msg_ids);
-}
+};
 
 run_test("near after unreads", () => {
     // Current near: behavior is to ignore the unreads and take you

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -12,7 +12,7 @@ const stream_data = zrequire("stream_data");
 const narrow_state = zrequire("narrow_state");
 const message_lists = zrequire("message_lists");
 
-function set_filter(raw_terms) {
+const set_filter = (raw_terms) => {
     const terms = raw_terms.map((op) => ({
         operator: op[0],
         operand: op[1],
@@ -25,15 +25,15 @@ function set_filter(raw_terms) {
     });
 
     return filter;
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         message_lists.set_current(undefined);
         stream_data.clear_subscriptions();
         f({override});
     });
-}
+};
 
 test("stream", () => {
     assert.equal(narrow_state.public_search_terms(), undefined);

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -28,25 +28,23 @@ const alice = {
 people.init();
 people.add_active_user(alice);
 
-function set_filter(terms) {
+const set_filter = (terms) => {
     const filter = new Filter(terms);
     message_lists.set_current({
         data: {
             filter,
         },
     });
-}
+};
 
-function assert_unread_info(expected) {
+const assert_unread_info = (expected) => {
     assert.deepEqual(
         narrow_state.get_first_unread_info(message_lists.current?.data.filter),
         expected,
     );
-}
+};
 
-function candidate_ids() {
-    return narrow_state._possible_unread_message_ids();
-}
+const candidate_ids = () => narrow_state._possible_unread_message_ids();
 
 run_test("get_unread_ids", () => {
     unread.declare_bankruptcy();

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -17,12 +17,12 @@ const timerender = mock_esm("../src/timerender");
 const {localstorage} = zrequire("localstorage");
 const navbar_alerts = zrequire("navbar_alerts");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         window.localStorage.clear();
         f(helpers);
     });
-}
+};
 
 test("allow_notification_alert", ({disallow, override}) => {
     const ls = localstorage();

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -7,7 +7,7 @@ const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {current_user, page_params, user_settings} = require("./lib/zpage_params");
 
-mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
+mock_esm("../src/spoilers", {hide_spoilers_in_notification: () => {}});
 
 const user_topics = zrequire("user_topics");
 const stream_data = zrequire("stream_data");
@@ -50,7 +50,7 @@ user_topics.update_user_topics(
     user_topics.all_visibility_policies.FOLLOWED,
 );
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         current_user.is_admin = false;
         page_params.realm_users = [];
@@ -63,7 +63,7 @@ function test(label, f) {
         user_settings.notification_sound = "ding";
         f(helpers);
     });
-}
+};
 
 test("message_is_notifiable", () => {
     // A notification is sent if both message_is_notifiable(message)
@@ -341,8 +341,8 @@ test("message_is_notifiable", () => {
 });
 
 test("basic_notifications", () => {
-    $("<div>").set_find_results(".emoji", {text: () => ({contents: () => ({unwrap() {}})})});
-    $("<div>").set_find_results("span.katex", {each() {}});
+    $("<div>").set_find_results(".emoji", {text: () => ({contents: () => ({unwrap: () => {}})})});
+    $("<div>").set_find_results("span.katex", {each: () => {}});
     $("<div>").children = () => [];
 
     let n; // Object for storing all notification data for assertions.

--- a/web/tests/password.test.js
+++ b/web/tests/password.test.js
@@ -7,7 +7,7 @@ const {run_test} = require("./lib/test");
 
 const {password_quality, password_warning} = zrequire("password_quality");
 
-function password_field(min_length, min_guesses) {
+const password_field = (min_length, min_guesses) => {
     const self = {};
 
     self.attr = (name) => {
@@ -23,14 +23,14 @@ function password_field(min_length, min_guesses) {
     };
 
     return self;
-}
+};
 
 run_test("basics w/progress bar", () => {
     let accepted;
     let password;
     let warning;
 
-    const $bar = (function () {
+    const $bar = (() => {
         const $self = {};
 
         $self.width = (width) => {

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -44,11 +44,9 @@ const george = {
     user_id: 103,
 };
 
-function contains_sub(subs, sub) {
-    return subs.some((s) => s.name === sub.name);
-}
+const contains_sub = (subs, sub) => subs.some((s) => s.name === sub.name);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         peer_data.clear_for_testing();
         stream_data.clear_subscriptions();
@@ -59,7 +57,7 @@ function test(label, f) {
 
         f({override});
     });
-}
+};
 
 test("unsubscribe", () => {
     const devel = {name: "devel", subscribed: false, stream_id: 1};
@@ -100,10 +98,10 @@ test("subscribers", () => {
 
     const stream_id = sub.stream_id;
 
-    function potential_subscriber_ids() {
+    const potential_subscriber_ids = () => {
         const users = peer_data.potential_subscribers(stream_id);
         return users.map((u) => u.user_id).sort();
-    }
+    };
 
     assert.deepEqual(potential_subscriber_ids(), [
         me.user_id,
@@ -250,7 +248,7 @@ test("get_subscriber_count", () => {
 });
 
 test("is_subscriber_subset", () => {
-    function make_sub(stream_id, user_ids) {
+    const make_sub = (stream_id, user_ids) => {
         const sub = {
             stream_id,
             name: `stream ${stream_id}`,
@@ -258,7 +256,7 @@ test("is_subscriber_subset", () => {
         stream_data.add_sub(sub);
         peer_data.set_subscribers(sub.stream_id, user_ids);
         return sub;
-    }
+    };
 
     const sub_a = make_sub(301, [1, 2]);
     const sub_b = make_sub(302, [2, 3]);

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -50,21 +50,21 @@ const isaac = {
 
 const unknown_user = people.make_user(1500, "unknown@example.com", "Unknown user");
 
-function initialize() {
+const initialize = () => {
     people.init();
     people.add_active_user({...me});
     people.initialize_current_user(me.user_id);
     muted_users.set_muted_users([]);
 
     people._add_user(unknown_user);
-}
+};
 
-function test_people(label, f) {
+const test_people = (label, f) => {
     run_test(label, (helpers) => {
         initialize();
         f(helpers);
     });
-}
+};
 
 /*
     TEST SETUP NOTES:
@@ -272,9 +272,7 @@ const invalid_user = {
     unknown_local_echo_user: true,
 };
 
-function get_all_persons() {
-    return people.filter_all_persons(() => true);
-}
+const get_all_persons = () => people.filter_all_persons(() => true);
 
 test_people("basics", ({override}) => {
     const persons = get_all_persons();
@@ -1363,12 +1361,11 @@ test_people("get_active_message_people", () => {
 test_people("huddle_string", () => {
     assert.equal(people.huddle_string({type: "stream"}), undefined);
 
-    function huddle(user_ids) {
-        return people.huddle_string({
+    const huddle = (user_ids) =>
+        people.huddle_string({
             type: "private",
             display_recipient: user_ids.map((id) => ({id})),
         });
-    }
 
     people.add_active_user(maria);
     people.add_active_user(bob);

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -7,7 +7,7 @@ const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
-const noop = function () {};
+const noop = () => {};
 
 const bootstrap_typeahead = mock_esm("../src/bootstrap_typeahead");
 
@@ -26,7 +26,7 @@ const $fake_rendered_person = $.create("fake-rendered-person");
 const $fake_rendered_stream = $.create("fake-rendered-stream");
 const $fake_rendered_group = $.create("fake-rendered-group");
 
-function override_typeahead_helper(override_rewire) {
+const override_typeahead_helper = (override_rewire) => {
     override_rewire(typeahead_helper, "render_person", () => $fake_rendered_person);
     override_rewire(typeahead_helper, "render_user_group", () => $fake_rendered_group);
     override_rewire(typeahead_helper, "render_stream", () => $fake_rendered_stream);
@@ -37,11 +37,9 @@ function override_typeahead_helper(override_rewire) {
         sort_recipients_called = true;
         return users;
     });
-}
+};
 
-function user_item(user) {
-    return {type: "user", user};
-}
+const user_item = (user) => ({type: "user", user});
 
 const jill = {
     email: "jill@zulip.com",
@@ -74,12 +72,10 @@ for (const person of persons) {
 }
 const person_items = persons.map((person) => user_item(person));
 
-function user_group_item(user_group) {
-    return {
-        ...user_group,
-        type: "user_group",
-    };
-}
+const user_group_item = (user_group) => ({
+    ...user_group,
+    type: "user_group",
+});
 
 const admins = {
     name: "Admins",
@@ -102,12 +98,10 @@ for (const group of groups) {
 }
 const group_items = [admins_item, testers_item];
 
-function stream_item(stream) {
-    return {
-        ...stream,
-        type: "stream",
-    };
-}
+const stream_item = (stream) => ({
+    ...stream,
+    type: "stream",
+});
 
 const denmark = {
     stream_id: 1,
@@ -156,9 +150,9 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
     });
 
     let update_func_called = false;
-    function update_func() {
+    const update_func = () => {
         update_func_called = true;
-    }
+    };
 
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
@@ -175,11 +169,11 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         // test queries
         const person_query = "me";
 
-        (function test_highlighter() {
+        (() => {
             assert.equal(config.highlighter_html(me_item, person_query), $fake_rendered_person);
         })();
 
-        (function test_matcher() {
+        (() => {
             let result;
             result = config.matcher(me_item, person_query);
             assert.ok(result);
@@ -187,13 +181,13 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
             assert.ok(!result);
         })();
 
-        (function test_sorter() {
+        (() => {
             sort_recipients_called = false;
             config.sorter([me_item], person_query);
             assert.ok(sort_recipients_called);
         })();
 
-        (function test_source() {
+        (() => {
             let expected_result = [];
             let actual_result = [];
             const result = config.source(person_query);
@@ -203,11 +197,11 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
             assert.deepEqual(actual_result, expected_result);
         })();
 
-        (function test_updater() {
-            function number_of_pills() {
+        (() => {
+            const number_of_pills = () => {
                 const pills = $pill_widget.items();
                 return pills.length;
-            }
+            };
             assert.equal(number_of_pills(), 0);
             config.updater(me_item, person_query);
             assert.equal(number_of_pills(), 1);
@@ -245,9 +239,9 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
     });
 
     let update_func_called = false;
-    function update_func() {
+    const update_func = () => {
         update_func_called = true;
-    }
+    };
 
     let opts = {};
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
@@ -267,7 +261,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         const person_query = "me";
         const group_query = "test";
 
-        (function test_highlighter() {
+        (() => {
             if (opts.stream) {
                 // Test stream highlighter_html for widgets that allow stream pills.
                 assert.equal(
@@ -295,7 +289,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
             }
         })();
 
-        (function test_matcher() {
+        (() => {
             let result;
             if (opts.stream) {
                 result = config.matcher(denmark_item, stream_query);
@@ -335,7 +329,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
             }
         })();
 
-        (function test_sorter() {
+        (() => {
             if (opts.stream) {
                 sort_streams_called = false;
                 config.sorter([denmark_item], stream_query);
@@ -353,7 +347,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
             }
         })();
 
-        (function test_source() {
+        (() => {
             let result;
             if (opts.stream) {
                 result = config.source(stream_query);
@@ -364,9 +358,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
 
             let expected_result = [];
             let actual_result = [];
-            function is_group(item) {
-                return item.members;
-            }
+            const is_group = (item) => item.members;
             result = config.source(person_query);
             actual_result = result
                 .map((item) => {
@@ -397,7 +389,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
             assert.deepEqual(actual_result, expected_result);
         })();
 
-        (function test_updater() {
+        (() => {
             if (opts.user && opts.user_group && opts.stream) {
                 // Test it only for the case when all types of pills
                 // are allowed, as it would be difficult to keep track
@@ -405,10 +397,10 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 // times in this test. So this case checks all possible cases handled by
                 // updater in pill_typeahead.
 
-                function number_of_pills() {
+                const number_of_pills = () => {
                     const pills = $pill_widget.items();
                     return pills.length;
-                }
+                };
                 assert.equal(number_of_pills(), 0);
                 config.updater(denmark_item, stream_query);
                 assert.equal(number_of_pills(), 1);
@@ -426,10 +418,10 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         input_pill_typeahead_called = true;
     });
 
-    function test_pill_typeahead(opts) {
+    const test_pill_typeahead = (opts) => {
         pill_typeahead.set_up_combined($fake_input, $pill_widget, opts);
         assert.ok(input_pill_typeahead_called);
-    }
+    };
 
     const all_possible_opts = [
         // These are various possible cases of opts that

--- a/web/tests/pm_conversations.test.js
+++ b/web/tests/pm_conversations.test.js
@@ -20,7 +20,7 @@ const params = {
     ],
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         pmc.clear_for_testing();
         user_topics.set_user_topics([]);
@@ -28,7 +28,7 @@ function test(label, f) {
         people.initialize_current_user(15);
         f({override});
     });
-}
+};
 
 test("partners", () => {
     const user1_id = 1;

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -66,31 +66,31 @@ people.add_active_user(iago);
 people.add_active_user(bot_test);
 people.initialize_current_user(me.user_id);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         message_lists.set_current(undefined);
         pm_conversations.clear_for_testing();
         f(helpers);
     });
-}
+};
 
-function set_pm_with_filter(emails) {
+const set_pm_with_filter = (emails) => {
     const active_filter = new Filter([{operator: "dm", operand: emails}]);
     message_lists.set_current({
         data: {
             filter: active_filter,
         },
     });
-}
+};
 
-function check_list_info(list, length, more_unread, recipients_array) {
+const check_list_info = (list, length, more_unread, recipients_array) => {
     assert.deepEqual(list.conversations_to_be_shown.length, length);
     assert.deepEqual(list.more_conversations_unread_count, more_unread);
     assert.deepEqual(
         list.conversations_to_be_shown.map((conversation) => conversation.recipients),
         recipients_array,
     );
-}
+};
 
 test("get_conversations", ({override}) => {
     pm_conversations.recent.insert([alice.user_id, bob.user_id], 1);

--- a/web/tests/poll_widget.test.js
+++ b/web/tests/poll_widget.test.js
@@ -364,14 +364,14 @@ run_test("activate own poll", ({mock_template}) => {
 
     set_widget_find_result("button.poll-question-remove");
 
-    function assert_visibility() {
+    const assert_visibility = () => {
         assert.ok($poll_option_container.visible());
         assert.ok($poll_question_header.visible());
         assert.ok(!$poll_question_container.visible());
         assert.ok($poll_edit_question.visible());
         assert.ok(!$poll_please_wait.visible());
         assert.ok(!$poll_author_help.visible());
-    }
+    };
 
     poll_widget.activate(opts);
 

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -15,7 +15,7 @@ const popover_menus_data = zrequire("popover_menus_data");
 const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 
-const noop = function () {};
+const noop = () => {};
 
 // Define MessageList stuff
 class MessageListView {
@@ -71,7 +71,7 @@ const me = {
 };
 
 // Helper functions:
-function add_initialize_users() {
+const add_initialize_users = () => {
     // Initialize people
     people.init();
 
@@ -82,9 +82,9 @@ function add_initialize_users() {
 
     // Initialize current user
     people.initialize_current_user(me.user_id);
-}
+};
 
-function init_message_list() {
+const init_message_list = () => {
     const filter = new Filter([]);
     const list = new MessageList({
         filter,
@@ -93,21 +93,21 @@ function init_message_list() {
     assert.equal(list.empty(), true);
 
     return list;
-}
+};
 
 // Append message to message_list, also add container to message_lists
-function add_message_with_view(list, messages) {
+const add_message_with_view = (list, messages) => {
     list.append(messages, true);
     for (const message of messages) {
         message_lists.current.view.message_containers.set(message.id, {
             is_hidden: message.is_hidden,
         });
     }
-}
+};
 
 // Function sets page parameters with no time constraints on editing the message.
 // User is assumed to not be an admin.
-function set_page_params_no_edit_restrictions() {
+const set_page_params_no_edit_restrictions = () => {
     page_params.is_spectator = false;
     realm.realm_allow_message_editing = true;
     realm.realm_message_content_edit_limit_seconds = null;
@@ -117,10 +117,10 @@ function set_page_params_no_edit_restrictions() {
     realm.realm_enable_read_receipts = true;
     realm.realm_edit_topic_policy = 5;
     realm.realm_move_messages_within_stream_limit_seconds = null;
-}
+};
 
 // Test init function
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         // Stubs for calculate_timestamp_widths()
         $("<div>").css = noop;
@@ -133,7 +133,7 @@ function test(label, f) {
         message_lists.initialize();
         f(helpers);
     });
-}
+};
 
 // Test functions
 test("my_message_all_actions", () => {

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -18,19 +18,19 @@ const compose_state = zrequire("compose_state");
 const noop = function () {};
 
 // Define MessageList stuff
-function MessageListView() {
-    return {
-        maybe_rerender: noop,
-        append: noop,
-        prepend: noop,
-        clear_rendering_state: noop,
-        get_row: () => ({
+class MessageListView {
+    maybe_rerender() {}
+    append() {}
+    prepend() {}
+    clear_rendering_state() {}
+    get_row() {
+        return {
             find: () => ({
                 is: () => false,
             }),
-        }),
-        message_containers: new Map(),
-    };
+        };
+    }
+    message_containers = new Map();
 }
 mock_esm("../src/message_list_view", {
     MessageListView,

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -75,14 +75,14 @@ inaccessible_user.is_inaccessible_user = true;
 
 people.initialize_current_user(me.user_id);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         realm.server_presence_offline_threshold_seconds = OFFLINE_THRESHOLD_SECS;
         user_settings.presence_enabled = true;
         presence.clear_internal_data();
         f(helpers);
     });
-}
+};
 
 test("my user", () => {
     assert.equal(presence.get_status(me.user_id), "active");

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -42,7 +42,7 @@ const channel = mock_esm("../src/channel");
 const message_store = mock_esm("../src/message_store");
 const settings_data = mock_esm("../src/settings_data");
 const spectators = mock_esm("../src/spectators", {
-    login_to_access() {},
+    login_to_access: () => {},
 });
 const message_lists = mock_esm("../src/message_lists", {
     current: {
@@ -106,23 +106,23 @@ people.add_active_user(bob);
 people.add_active_user(cali);
 people.add_active_user(alexus);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         current_user.user_id = alice_user_id;
         f(helpers);
     });
-}
+};
 
-function sample_message_with_clean_reactions() {
+const sample_message_with_clean_reactions = () => {
     const message = {...sample_message};
     convert_reactions_to_clean_reactions(message);
     return message;
-}
+};
 
-function convert_reactions_to_clean_reactions(message) {
+const convert_reactions_to_clean_reactions = (message) => {
     message.clean_reactions = reactions.generate_clean_reactions(message);
     delete message.reactions;
-}
+};
 
 test("basics", () => {
     settings_data.user_can_access_all_other_users = () => true;
@@ -425,22 +425,22 @@ test("prevent_simultaneous_requests_updating_reaction", ({override_rewire}) => {
     assert.equal(stub.num_calls, 1);
 });
 
-function stub_reactions(message_id) {
+const stub_reactions = (message_id) => {
     const $message_reactions = $.create("reactions-stub");
     const $message_row = $.create(`#message-row-1-${CSS.escape(message_id)}`);
     message_lists.all_rendered_row_for_message_id = () => $message_row;
     $message_row.set_find_results(".message_reactions", $message_reactions);
     return $message_reactions;
-}
+};
 
-function stub_reaction(message_id, local_id) {
+const stub_reaction = (message_id, local_id) => {
     const $reaction = $.create("reaction-stub");
     stub_reactions(message_id).set_find_results(
         `[data-reaction-id='${CSS.escape(local_id)}']`,
         $reaction,
     );
     return $reaction;
-}
+};
 
 test("get_vote_text (more than 3 reactions)", () => {
     const user_ids = [5, 6, 7];
@@ -619,7 +619,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         },
     );
 
-    function test_function_calls(test_params) {
+    const test_function_calls = (test_params) => {
         function_calls = [];
 
         test_params.run_code();
@@ -629,7 +629,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
             new Set(reactions.get_emojis_used_by_user_for_message_id(message.message_id)),
             new Set(test_params.alice_emojis),
         );
-    }
+    };
 
     const alice_8ball_event = {
         message_id: 2001,
@@ -669,7 +669,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         vote_text: "translated: You",
     };
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.add_reaction(alice_8ball_event);
         },
         expected_function_calls: [
@@ -692,7 +692,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
 
     // Add redundant reaction.
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.add_reaction(alice_8ball_event);
         },
         expected_function_calls: [],
@@ -713,7 +713,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         vote_text: "translated: You, Bob van Roberts",
     };
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.add_reaction(bob_8ball_event);
         },
         expected_function_calls: [
@@ -748,7 +748,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         vote_text: "Cali",
     };
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.add_reaction(cali_airplane_event);
         },
         expected_function_calls: [
@@ -771,7 +771,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
     });
 
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.remove_reaction(bob_8ball_event);
         },
         expected_function_calls: [
@@ -794,7 +794,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
     });
 
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.remove_reaction(alice_8ball_event);
         },
         expected_function_calls: [
@@ -829,7 +829,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
 
     // Test redundant remove.
     test_function_calls({
-        run_code() {
+        run_code: () => {
             reactions.remove_reaction(alice_8ball_event);
         },
         expected_function_calls: [],
@@ -1221,12 +1221,12 @@ test("remove last user", ({override, override_rewire}) => {
     override(message_store, "get", () => message);
     override_rewire(reactions, "remove_reaction_from_view", noop);
 
-    function assert_names(names) {
+    const assert_names = (names) => {
         assert.deepEqual(
             reactions.get_message_reactions(message).map((r) => r.emoji_name),
             names,
         );
-    }
+    };
 
     assert_names(["smile", "frown", "tada", "rocket", "wave", "inactive_realm_emoji"]);
 

--- a/web/tests/recent_senders.test.js
+++ b/web/tests/recent_senders.test.js
@@ -8,7 +8,7 @@ const {run_test} = require("./lib/test");
 let next_id = 0;
 const messages = new Map();
 
-function make_stream_message({stream_id, topic, sender_id}) {
+const make_stream_message = ({stream_id, topic, sender_id}) => {
     next_id += 1;
 
     const message = {
@@ -21,7 +21,7 @@ function make_stream_message({stream_id, topic, sender_id}) {
     messages.set(message.id, message);
 
     return message;
-}
+};
 
 mock_esm("../src/message_store", {
     get: (message_id) => messages.get(message_id),
@@ -31,22 +31,22 @@ people.initialize_current_user(1);
 const rs = zrequire("recent_senders");
 zrequire("message_util.ts");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         messages.clear();
         next_id = 0;
         rs.clear_for_testing();
         f({override});
     });
-}
+};
 
 test("IdTracker", () => {
     const id_tracker = new rs.IdTracker();
 
-    function test_add(id, expected_max_id) {
+    const test_add = (id, expected_max_id) => {
         id_tracker.add(id);
         assert.equal(id_tracker.max_id(), expected_max_id);
-    }
+    };
 
     test_add(5, 5);
     test_add(7, 7);
@@ -55,10 +55,10 @@ test("IdTracker", () => {
     test_add(12, 12);
     test_add(11, 12);
 
-    function test_remove(id, expected_max_id) {
+    const test_remove = (id, expected_max_id) => {
         id_tracker.remove(id);
         assert.equal(id_tracker.max_id(), expected_max_id);
-    }
+    };
 
     test_remove(10, 12);
     test_remove(999999, 12); // bogus id has no effect

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -54,7 +54,7 @@ let expected_data_to_replace_in_list_widget;
 const ListWidget = mock_esm("../src/list_widget", {
     modifier_html: noop,
     generic_sort_functions: noop,
-    create(_container, mapped_topic_values, opts) {
+    create: (_container, mapped_topic_values, opts) => {
         const formatted_topics = [];
         ListWidget.modifier_html = opts.modifier_html;
         for (const item of mapped_topic_values) {
@@ -76,7 +76,7 @@ const ListWidget = mock_esm("../src/list_widget", {
 
     hard_redraw: noop,
     filter_and_sort: noop,
-    replace_list_data(data) {
+    replace_list_data: (data) => {
         assert.notEqual(
             expected_data_to_replace_in_list_widget,
             undefined,
@@ -100,7 +100,7 @@ mock_esm("../src/message_list_data", {
     MessageListData: class {},
 });
 mock_esm("../src/message_store", {
-    get(msg_id) {
+    get: (msg_id) => {
         if (msg_id < 15) {
             return messages[msg_id - 1];
         }
@@ -111,19 +111,19 @@ mock_esm("../src/message_view_header", {
     render_title_area: noop,
 });
 mock_esm("../src/user_topics", {
-    is_topic_muted(stream_id, topic) {
+    is_topic_muted: (stream_id, topic) => {
         if (stream_id === stream1 && topic === topic7) {
             return true;
         }
         return false;
     },
-    is_topic_unmuted_or_followed(stream_id, topic) {
+    is_topic_unmuted_or_followed: (stream_id, topic) => {
         if (stream_id === stream6 && (topic === topic11 || topic === topic12)) {
             return true;
         }
         return false;
     },
-    get_topic_visibility_policy(stream_id, topic) {
+    get_topic_visibility_policy: (stream_id, topic) => {
         if (stream_id === stream1 && topic === topic7) {
             return all_visibility_policies.MUTED;
         } else if (stream_id === stream6 && topic === topic11) {
@@ -136,7 +136,7 @@ mock_esm("../src/user_topics", {
     all_visibility_policies,
 });
 mock_esm("../src/narrow_title", {
-    update_narrow_title() {},
+    update_narrow_title: () => {},
 });
 mock_esm("../src/pm_list", {
     update_private_messages: noop,
@@ -144,16 +144,12 @@ mock_esm("../src/pm_list", {
 });
 mock_esm("../src/recent_senders", {
     get_topic_recent_senders: () => [2, 1],
-    get_pm_recent_senders(user_ids_string) {
-        return {
-            participants: user_ids_string.split(",").map((user_id) => Number.parseInt(user_id, 10)),
-        };
-    },
+    get_pm_recent_senders: (user_ids_string) => ({
+        participants: user_ids_string.split(",").map((user_id) => Number.parseInt(user_id, 10)),
+    }),
 });
 mock_esm("../src/stream_data", {
-    is_muted(stream_id) {
-        return stream_id === stream6;
-    },
+    is_muted: (stream_id) => stream_id === stream6,
     get_stream_name_from_id: () => "stream_name",
 });
 mock_esm("../src/stream_list", {
@@ -167,15 +163,13 @@ mock_esm("../src/left_sidebar_navigation_area", {
     highlight_recent_view: noop,
 });
 mock_esm("../src/unread", {
-    num_unread_for_topic(stream_id, topic) {
+    num_unread_for_topic: (stream_id, topic) => {
         if (stream_id === 1 && topic === "topic-1") {
             return 0;
         }
         return 1;
     },
-    num_unread_for_user_ids_string() {
-        return 0;
-    },
+    num_unread_for_user_ids_string: () => 0,
     topic_has_any_unread_mentions: () => false,
 });
 mock_esm("../src/resize", {
@@ -377,11 +371,9 @@ private_messages[2] = {
     pm_with_url: test_url(),
 };
 
-function get_topic_key(stream_id, topic) {
-    return stream_id + ":" + topic.toLowerCase();
-}
+const get_topic_key = (stream_id, topic) => stream_id + ":" + topic.toLowerCase();
 
-function generate_topic_data(topic_info_array) {
+const generate_topic_data = (topic_info_array) => {
     // Since most of the fields are common, this function helps generate fixtures
     // with non-common fields.
     $.clear_all_elements();
@@ -413,17 +405,17 @@ function generate_topic_data(topic_info_array) {
         });
     }
     return data;
-}
+};
 
-function verify_topic_data(all_topics, stream, topic, last_msg_id, participated) {
+const verify_topic_data = (all_topics, stream, topic, last_msg_id, participated) => {
     const topic_data = all_topics.get(stream + ":" + topic);
     assert.equal(topic_data.last_msg_id, last_msg_id);
     assert.equal(topic_data.participated, participated);
-}
+};
 
 rt.set_default_focus();
 
-function stub_out_filter_buttons() {
+const stub_out_filter_buttons = () => {
     // TODO: We probably want more direct tests that make sure
     //       the widgets get updated correctly, but the stubs here
     //       should accurately simulate toggling the filters.
@@ -435,9 +427,9 @@ function stub_out_filter_buttons() {
         const selector = `[data-filter="${filter}"]`;
         $("#recent_view_filter_buttons").set_find_results(selector, $stub);
     }
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         $(".header").css = noop;
         page_params.development_environment = true;
@@ -445,7 +437,7 @@ function test(label, f) {
         messages = sample_messages.map((message) => ({...message}));
         f(helpers);
     });
-}
+};
 
 test("test_recent_view_show", ({override, mock_template}) => {
     // Note: unread count and urls are fake,

--- a/web/tests/reload_state.test.js
+++ b/web/tests/reload_state.test.js
@@ -7,12 +7,12 @@ const {run_test} = require("./lib/test");
 
 const reload_state = zrequire("reload_state");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         reload_state.clear_for_testing();
         f({override});
     });
-}
+};
 
 test("set_state_to_pending", () => {
     assert.ok(!reload_state.is_pending());

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -91,7 +91,7 @@ const $array = (array) => {
     return {each};
 };
 
-function set_message_for_message_content($content, value) {
+const set_message_for_message_content = ($content, value) => {
     // no message row found
     if (value === undefined) {
         $content.closest = (closest_opts) => {
@@ -120,7 +120,7 @@ function set_message_for_message_content($content, value) {
         assert.equal(message_id_opt, message_id);
         return value;
     };
-}
+};
 
 const get_content_element = () => {
     const $content = $.create("content-stub");
@@ -140,7 +140,7 @@ const get_content_element = () => {
     // Fend off dumb security bugs by forcing devs to be
     // intentional about HTML manipulation.
     /* istanbul ignore next */
-    function security_violation() {
+    const security_violation = () => {
         throw new Error(`
             Be super careful about HTML manipulation.
 
@@ -148,7 +148,7 @@ const get_content_element = () => {
             functions to validate that calls to html/prepend/append
             use trusted values.
         `);
-    }
+    };
     $content.html = security_violation;
     $content.prepend = security_violation;
     $content.append = security_violation;
@@ -472,7 +472,7 @@ run_test("emoji", () => {
         const text = f.call($emoji);
         assert.equal(":tada:", text);
         called = true;
-        return {contents: () => ({unwrap() {}})};
+        return {contents: () => ({unwrap: () => {}})};
     };
     $content.set_find_results(".emoji", $emoji);
     user_settings.emojiset = "text";
@@ -525,12 +525,12 @@ run_test("spoiler-header-empty-fill", () => {
     assert.equal($appended[1].selector, toggle_button_html);
 });
 
-function assert_clipboard_setup() {
+const assert_clipboard_setup = () => {
     assert.equal(clipboard_args[0], "copy-code-stub");
     const text = clipboard_args[1].text({
         to_$: () => ({
             parent: () => ({
-                siblings(arg) {
+                siblings: (arg) => {
                     assert.equal(arg, "code");
                     return {
                         text: () => "text",
@@ -540,9 +540,9 @@ function assert_clipboard_setup() {
         }),
     });
     assert.equal(text, "text");
-}
+};
 
-function test_code_playground(mock_template, viewing_code) {
+const test_code_playground = (mock_template, viewing_code) => {
     const $content = get_content_element();
     const $hilite = $.create("div.codehilite");
     const $pre = $.create("hilite-pre");
@@ -590,7 +590,7 @@ function test_code_playground(mock_template, viewing_code) {
         $copy_code: $copy_code_button,
         $view_code: $view_code_in_playground,
     };
-}
+};
 
 run_test("code playground none", ({override, mock_template}) => {
     override(realm_playground, "get_playground_info_for_languages", (language) => {

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -53,7 +53,7 @@ const per_day_stamps = {
     },
 };
 
-function get_expected_send_opts(day, expecteds) {
+const get_expected_send_opts = (day, expecteds) => {
     const modal_opts = {
         send_later_tomorrow: {
             tomorrow_nine_am: {
@@ -103,7 +103,7 @@ function get_expected_send_opts(day, expecteds) {
     }
 
     return modal_opts;
-}
+};
 
 run_test("scheduled_modal_opts", () => {
     // Sunday thru Saturday
@@ -148,13 +148,13 @@ run_test("should_update_send_later_options", () => {
     start_of_the_day.setHours(0, 0);
     assert.ok(compose_send_menu_popover.should_update_send_later_options(start_of_the_day));
 
-    function get_minutes_to_hour(minutes) {
+    const get_minutes_to_hour = (minutes) => {
         const date = new Date();
         date.setHours(4);
         date.setMinutes(minutes);
         date.setSeconds(0);
         return date;
-    }
+    };
 
     // We should rerender if it is 5 minutes before the hour
     for (let minute = 0; minute < 60; minute += 1) {

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -210,14 +210,14 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             $search_query_box.off("blur");
         }
         return {
-            lookup() {
+            lookup: () => {
                 typeahead_forced_open = true;
             },
         };
     });
 
     search.initialize({
-        on_narrow_search(raw_terms, options) {
+        on_narrow_search: (raw_terms, options) => {
             assert.deepEqual(raw_terms, terms);
             assert.deepEqual(options, {trigger: "search"});
         },
@@ -235,7 +235,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
     let ev = {
         type: "keydown",
         which: 15,
-        preventDefault() {
+        preventDefault: () => {
             default_prevented = true;
         },
     };

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -51,7 +51,7 @@ const jeff = {
 
 const example_avatar_url = "http://example.com/example.png";
 
-function init() {
+const init = () => {
     current_user.is_admin = true;
 
     people.init();
@@ -66,18 +66,16 @@ function init() {
     stream_topic_history.reset();
     huddle_data.clear_for_testing();
     stream_data.clear_subscriptions();
-}
+};
 
-function get_suggestions(query) {
-    return search.get_suggestions(query);
-}
+const get_suggestions = (query) => search.get_suggestions(query);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         init();
         f(helpers);
     });
-}
+};
 
 test("basic_get_suggestions", ({override}) => {
     const query = "fred";
@@ -353,15 +351,13 @@ test("group_suggestions", ({mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    function message(user_ids, timestamp) {
-        return {
-            type: "private",
-            display_recipient: user_ids.map((id) => ({
-                id,
-            })),
-            timestamp,
-        };
-    }
+    const message = (user_ids, timestamp) => ({
+        type: "private",
+        display_recipient: user_ids.map((id) => ({
+            id,
+        })),
+        timestamp,
+    });
 
     huddle_data.process_loaded_messages([
         message([bob.user_id, ted.user_id], 99),
@@ -436,9 +432,7 @@ test("empty_query_suggestions", () => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
-    }
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
@@ -465,9 +459,7 @@ test("has_suggestions", ({override, mock_template}) => {
     let expected = ["h", "has:link", "has:image", "has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
-    }
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
 
     assert.equal(describe("has:link"), "Messages that contain links");
     assert.equal(describe("has:image"), "Messages that contain images");
@@ -537,9 +529,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
-    }
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
 
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
@@ -717,9 +707,7 @@ test("topic_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
-    }
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
     assert.equal(describe("te"), "Search for <strong>te</strong>");
     assert.equal(describe("channel:office topic:team"), "Channel office > team");
 
@@ -761,12 +749,12 @@ test("topic_suggestions", ({override, mock_template}) => {
 test("topic_suggestions (limits)", () => {
     let candidate_topics = [];
 
-    function assert_result(guess, expected_topics) {
+    const assert_result = (guess, expected_topics) => {
         assert.deepEqual(
             search.get_topic_suggestions_from_candidates({candidate_topics, guess}),
             expected_topics,
         );
-    }
+    };
 
     assert_result("", []);
     assert_result("zzz", []);
@@ -918,48 +906,38 @@ test("people_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    function is_person(q) {
-        return suggestions.lookup_table.get(q).is_person;
-    }
+    const is_person = (q) => suggestions.lookup_table.get(q).is_person;
     assert.equal(is_person("dm:ted@zulip.com"), true);
     assert.equal(is_person("sender:ted@zulip.com"), true);
     assert.equal(is_person("dm-including:ted@zulip.com"), true);
 
-    function has_image(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.has_image;
-    }
+    const has_image = (q) => suggestions.lookup_table.get(q).user_pill_context.has_image;
     assert.equal(has_image("dm:bob@zulip.com"), true);
     assert.equal(has_image("sender:bob@zulip.com"), true);
     assert.equal(has_image("dm-including:bob@zulip.com"), true);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
-    }
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
     assert.equal(describe("dm:ted@zulip.com"), "Direct messages with");
     assert.equal(describe("sender:ted@zulip.com"), "Sent by");
     assert.equal(describe("dm-including:ted@zulip.com"), "Direct messages including");
 
     let expectedString = "<strong>Te</strong>d Smith";
 
-    function get_full_name(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.display_value.string;
-    }
+    const get_full_name = (q) =>
+        suggestions.lookup_table.get(q).user_pill_context.display_value.string;
     assert.equal(get_full_name("sender:ted@zulip.com"), expectedString);
     assert.equal(get_full_name("dm:ted@zulip.com"), expectedString);
     assert.equal(get_full_name("dm-including:ted@zulip.com"), expectedString);
 
     expectedString = example_avatar_url + "?s=50";
 
-    function get_avatar_url(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.img_src;
-    }
+    const get_avatar_url = (q) => suggestions.lookup_table.get(q).user_pill_context.img_src;
     assert.equal(get_avatar_url("dm:bob@zulip.com"), expectedString);
     assert.equal(get_avatar_url("sender:bob@zulip.com"), expectedString);
     assert.equal(get_avatar_url("dm-including:bob@zulip.com"), expectedString);
 
-    function get_should_add_guest_user_indicator(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.should_add_guest_user_indicator;
-    }
+    const get_should_add_guest_user_indicator = (q) =>
+        suggestions.lookup_table.get(q).user_pill_context.should_add_guest_user_indicator;
 
     realm.realm_enable_guest_user_indicator = true;
     suggestions = get_suggestions(query);

--- a/web/tests/server_events.test.js
+++ b/web/tests/server_events.test.js
@@ -14,9 +14,7 @@ set_global("addEventListener", noop);
 
 const channel = mock_esm("../src/channel");
 mock_esm("../src/reload_state", {
-    is_in_progress() {
-        return false;
-    },
+    is_in_progress: () => false,
 });
 page_params.test_suite = false;
 
@@ -24,27 +22,25 @@ page_params.test_suite = false;
 set_global("pointer", {});
 
 mock_esm("../src/ui_report", {
-    hide_error() {
-        return false;
-    },
+    hide_error: () => false,
 });
 
 mock_esm("../src/stream_events", {
-    update_property() {
+    update_property: () => {
         throw new Error("subs update error");
     },
 });
 
 mock_esm("../src/sent_messages", {
-    report_event_received() {},
+    report_event_received: () => {},
     messages: new Map(),
 });
 
 const message_events = mock_esm("../src/message_events", {
-    insert_new_messages() {
+    insert_new_messages: () => {
         throw new Error("insert error");
     },
-    update_messages() {
+    update_messages: () => {
         throw new Error("update error");
     },
 });

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -32,7 +32,7 @@ const settings_bots = zrequire("settings_bots");
 
 bot_data.initialize(bot_data_params);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         realm.realm_url = "https://chat.example.com";
         realm.realm_embedded_bots = [
@@ -43,7 +43,7 @@ function test(label, f) {
 
         f({override});
     });
-}
+};
 
 test("generate_zuliprc_url", () => {
     const url = settings_bots.generate_zuliprc_url(1);

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -98,7 +98,7 @@ run_test("user_can_change_logo", () => {
     assert.equal(can_change_logo(), false);
 });
 
-function test_policy(label, policy, validation_func) {
+const test_policy = (label, policy, validation_func) => {
     run_test(label, () => {
         current_user.is_admin = true;
         realm[policy] = settings_config.common_policy_values.by_admins_only.code;
@@ -139,7 +139,7 @@ function test_policy(label, policy, validation_func) {
         settings_data.initialize(isaac.date_joined);
         assert.equal(validation_func(), true);
     });
-}
+};
 
 test_policy(
     "user_can_create_private_streams",
@@ -177,7 +177,7 @@ test_policy(
     settings_data.user_can_add_custom_emoji,
 );
 
-function test_message_policy(label, policy, validation_func) {
+const test_message_policy = (label, policy, validation_func) => {
     run_test(label, () => {
         current_user.is_admin = true;
         realm[policy] = settings_config.common_message_policy_values.by_admins_only.code;
@@ -214,7 +214,7 @@ function test_message_policy(label, policy, validation_func) {
         settings_data.initialize(isaac.date_joined);
         assert.equal(validation_func(), true);
     });
-}
+};
 
 test_message_policy(
     "user_can_move_messages_to_another_topic",

--- a/web/tests/settings_muted_users.test.js
+++ b/web/tests/settings_muted_users.test.js
@@ -75,7 +75,7 @@ run_test("settings", ({override}) => {
     channel.del = (payload) => {
         assert.equal(payload.url, "/json/users/me/muted_users/5");
         unmute_user_called = true;
-        return {abort() {}};
+        return {abort: () => {}};
     };
 
     unmute_click_handler.call($unmute_button, event);
@@ -86,7 +86,7 @@ run_test("settings", ({override}) => {
     channel.post = (payload) => {
         assert.equal(payload.url, "/json/users/me/muted_users/5");
         mute_user_called = true;
-        return {abort() {}};
+        return {abort: () => {}};
     };
     muted_users.mute_user(5);
     assert.ok(mute_user_called);

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -28,7 +28,7 @@ const settings_components = zrequire("settings_components");
 const settings_org = zrequire("settings_org");
 const dropdown_widget = zrequire("dropdown_widget");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         $("#realm-icon-upload-widget .upload-spinner-background").css = noop;
         current_user.is_admin = false;
@@ -40,7 +40,7 @@ function test(label, f) {
         settings_org.reset();
         f(helpers);
     });
-}
+};
 
 test("unloaded", () => {
     // This test mostly gets us line coverage, and makes
@@ -51,7 +51,7 @@ test("unloaded", () => {
     settings_org.populate_auth_methods();
 });
 
-function createSaveButtons(subsection) {
+const createSaveButtons = (subsection) => {
     const $stub_save_button_header = $(`#org-${CSS.escape(subsection)}`);
     const $save_button_controls = $(".save-button-controls");
     const $stub_save_button = $(".save-discard-widget-button.save-button");
@@ -91,9 +91,9 @@ function createSaveButtons(subsection) {
         $save_button_controls,
         $save_button_text: $stub_save_button_text,
     };
-}
+};
 
-function test_submit_settings_form(override, submit_form) {
+const test_submit_settings_form = (override, submit_form) => {
     Object.assign(realm, {
         realm_bot_creation_policy: settings_bots.bot_creation_policy_values.restricted.code,
         realm_add_custom_emoji_policy: settings_config.common_policy_values.by_admins_only.code,
@@ -212,9 +212,9 @@ function test_submit_settings_form(override, submit_form) {
     assert.equal(stubs.props.hidden, true);
     assert.equal($save_button.attr("data-status"), "saved");
     assert.equal(stubs.$save_button_text.text(), "translated: Saved");
-}
+};
 
-function test_change_save_button_state() {
+const test_change_save_button_state = () => {
     const {
         $save_button_controls,
         $save_button_text,
@@ -261,9 +261,9 @@ function test_change_save_button_state() {
         assert.equal($save_button.attr("data-status"), "failed");
         assert.equal($save_button_text.text(), "translated: Save changes");
     }
-}
+};
 
-function test_upload_realm_icon(override, upload_realm_logo_or_icon) {
+const test_upload_realm_icon = (override, upload_realm_logo_or_icon) => {
     const file_input = [{files: ["image1.png", "image2.png"]}];
 
     let posted;
@@ -277,9 +277,9 @@ function test_upload_realm_icon(override, upload_realm_logo_or_icon) {
 
     upload_realm_logo_or_icon(file_input, null, true);
     assert.ok(posted);
-}
+};
 
-function test_extract_property_name() {
+const test_extract_property_name = () => {
     $("#id_realm_allow_message_editing").attr("id", "id_realm_allow_message_editing");
     assert.equal(
         settings_components.extract_property_name($("#id_realm_allow_message_editing")),
@@ -302,9 +302,9 @@ function test_extract_property_name() {
         settings_components.extract_property_name($("#id-realm-allow-message-deleting")),
         "realm_allow_message_deleting",
     );
-}
+};
 
-function test_sync_realm_settings() {
+const test_sync_realm_settings = () => {
     {
         /* Test invalid settings property sync */
         const $property_elem = $("#id_realm_invalid_settings_property");
@@ -315,7 +315,7 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("invalid_settings_property");
     }
 
-    function test_common_policy(property_name) {
+    const test_common_policy = (property_name) => {
         const $property_elem = $(`#id_realm_${CSS.escape(property_name)}`);
         $property_elem.length = 1;
         $property_elem.attr("id", `id_realm_${CSS.escape(property_name)}`);
@@ -332,7 +332,7 @@ function test_sync_realm_settings() {
             settings_org.sync_realm_settings(property_name);
             assert.equal($property_elem.val(), policy_value.code);
         }
-    }
+    };
 
     test_common_policy("create_private_stream_policy");
     test_common_policy("create_public_stream_policy");
@@ -387,9 +387,9 @@ function test_sync_realm_settings() {
         settings_org.sync_realm_settings("emails_restricted_to_domains");
         assert.equal($("#id_realm_org_join_restrictions").val(), "no_restriction");
     }
-}
+};
 
-function test_parse_time_limit() {
+const test_parse_time_limit = () => {
     const $elem = $("#id_realm_message_content_edit_limit_minutes");
     const test_function = (value, expected_value = value) => {
         $elem.val(value);
@@ -419,9 +419,9 @@ function test_parse_time_limit() {
     test_function("201.1");
     test_function("501.15", "501.1");
     test_function("501.34", "501.3");
-}
+};
 
-function test_discard_changes_button(discard_changes) {
+const test_discard_changes_button = (discard_changes) => {
     const ev = {
         preventDefault: noop,
         stopPropagation: noop,
@@ -486,7 +486,7 @@ function test_discard_changes_button(discard_changes) {
     assert.equal($msg_delete_limit_setting.val(), "120");
     assert.equal($message_content_delete_limit_minutes.val(), "2");
     assert.ok(props.hidden);
-}
+};
 
 test("set_up", ({override, override_rewire}) => {
     realm.realm_available_video_chat_providers = {

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -51,7 +51,7 @@ mock_esm("sortablejs", {default: Sortable});
 
 const settings_profile_fields = zrequire("settings_profile_fields");
 
-function test_populate(opts, template_data) {
+const test_populate = (opts, template_data) => {
     const fields_data = opts.fields_data;
 
     realm.custom_profile_field_types = custom_profile_field_types;
@@ -78,7 +78,7 @@ function test_populate(opts, template_data) {
 
     assert.deepEqual(template_data, opts.expected_template_data);
     assert.equal(num_appends, fields_data.length);
-}
+};
 
 run_test("populate_profile_fields", ({mock_template}) => {
     realm.custom_profile_fields = {};

--- a/web/tests/settings_realm_domains.test.js
+++ b/web/tests/settings_realm_domains.test.js
@@ -8,18 +8,18 @@ const $ = require("./lib/zjquery");
 
 const channel = mock_esm("../src/channel");
 mock_esm("../src/ui_report", {
-    success(msg, elem) {
+    success: (msg, elem) => {
         elem.val(msg);
     },
 
-    error(msg, _xhr, elem) {
+    error: (msg, _xhr, elem) => {
         elem.val(msg);
     },
 });
 
 const settings_realm_domains = zrequire("settings_realm_domains");
 
-function test_realms_domain_modal(override, add_realm_domain) {
+const test_realms_domain_modal = (override, add_realm_domain) => {
     const $info = $(".realm_domains_info");
 
     $("#add-realm-domain-widget").set_find_results(
@@ -52,9 +52,9 @@ function test_realms_domain_modal(override, add_realm_domain) {
 
     error_callback({});
     assert.equal($info.val(), "translated HTML: Failed");
-}
+};
 
-function test_change_allow_subdomains(change_allow_subdomains) {
+const test_change_allow_subdomains = (change_allow_subdomains) => {
     const ev = {
         stopPropagation: noop,
     };
@@ -103,7 +103,7 @@ function test_change_allow_subdomains(change_allow_subdomains) {
         $info.val(),
         "translated HTML: Update successful: Subdomains no longer allowed for example.com",
     );
-}
+};
 
 run_test("test_realm_domains_table", ({override}) => {
     settings_realm_domains.setup_realm_domains_modal_handlers();

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -8,7 +8,7 @@ const {run_test} = require("./lib/test");
 const {user_settings} = require("./lib/zpage_params");
 
 const left_sidebar_navigation_area = mock_esm("../src/left_sidebar_navigation_area", {
-    update_starred_count() {},
+    update_starred_count: () => {},
 });
 const message_store = zrequire("message_store");
 const starred_messages = zrequire("starred_messages");

--- a/web/tests/stream_create_subscribers_data.test.js
+++ b/web/tests/stream_create_subscribers_data.test.js
@@ -33,7 +33,7 @@ const test_user103 = {
     user_id: 103,
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         current_user.is_admin = false;
         people.init();
@@ -45,7 +45,7 @@ function test(label, f) {
         people.initialize_current_user(me.user_id);
         f(helpers);
     });
-}
+};
 
 test("basics", () => {
     stream_create_subscribers_data.initialize_with_current_user();

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -49,7 +49,7 @@ const moderators_group = {
     direct_subgroup_ids: new Set([1]),
 };
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         current_user.is_admin = false;
         page_params.realm_users = [];
@@ -61,7 +61,7 @@ function test(label, f) {
         user_groups.initialize({realm_user_groups: [admins_group, moderators_group]});
         f(helpers);
     });
-}
+};
 
 test("basics", () => {
     const denmark = {
@@ -317,7 +317,7 @@ test("renames", () => {
 });
 
 test("admin_options", () => {
-    function make_sub() {
+    const make_sub = () => {
         const sub = {
             subscribed: false,
             color: "blue",
@@ -331,15 +331,12 @@ test("admin_options", () => {
         };
         stream_data.add_sub(sub);
         return sub;
-    }
+    };
 
-    function is_realm_admin(sub) {
-        return stream_settings_data.get_sub_for_settings(sub).is_realm_admin;
-    }
+    const is_realm_admin = (sub) => stream_settings_data.get_sub_for_settings(sub).is_realm_admin;
 
-    function can_change_stream_permissions(sub) {
-        return stream_settings_data.get_sub_for_settings(sub).can_change_stream_permissions;
-    }
+    const can_change_stream_permissions = (sub) =>
+        stream_settings_data.get_sub_for_settings(sub).can_change_stream_permissions;
 
     // non-admins can't do anything
     current_user.is_admin = false;
@@ -838,7 +835,7 @@ test("creator_id", () => {
 });
 
 test("initialize", () => {
-    function get_params() {
+    const get_params = () => {
         const params = {};
 
         params.subscriptions = [
@@ -865,11 +862,11 @@ test("initialize", () => {
         params.realm_default_streams = [];
 
         return params;
-    }
+    };
 
-    function initialize() {
+    const initialize = () => {
         stream_data.initialize(get_params());
-    }
+    };
 
     realm.realm_new_stream_announcements_stream_id = -1;
 

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -23,13 +23,13 @@ const message_lists = mock_esm("../src/message_lists", {
     current: undefined,
 });
 const message_view_header = mock_esm("../src/message_view_header", {
-    maybe_rerender_title_area_for_stream() {},
+    maybe_rerender_title_area_for_stream: () => {},
 });
 mock_esm("../src/recent_view_ui", {
-    complete_rerender() {},
+    complete_rerender: () => {},
 });
 mock_esm("../src/settings_notifications", {
-    update_page() {},
+    update_page: () => {},
 });
 mock_esm("../src/overlays", {
     streams_open: () => true,
@@ -78,21 +78,21 @@ const frontend = {
     invite_only: false,
 };
 
-function narrow_to_frontend() {
+const narrow_to_frontend = () => {
     const filter = new Filter([{operator: "stream", operand: "frontend"}]);
     message_lists.current = {
         data: {
             filter,
         },
     };
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         f(helpers);
     });
-}
+};
 
 test("update_property", ({override}) => {
     override(compose_recipient, "possibly_update_stream_name_in_compose", noop);
@@ -142,9 +142,7 @@ test("update_property", ({override}) => {
         assert.equal(args.val, true);
     }
 
-    function checkbox_for(property) {
-        return $(`#${CSS.escape(property)}_${CSS.escape(stream_id)}`);
-    }
+    const checkbox_for = (property) => $(`#${CSS.escape(property)}_${CSS.escape(stream_id)}`);
 
     // Test desktop notifications
     stream_events.update_property(stream_id, "desktop_notifications", true);

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -18,7 +18,7 @@ let stream_has_any_unread_mentions;
 
 const topic_list = mock_esm("../src/topic_list");
 const scroll_util = mock_esm("../src/scroll_util", {
-    scroll_element_into_container() {},
+    scroll_element_into_container: () => {},
     get_scroll_element: ($element) => $element,
 });
 mock_esm("../src/unread", {
@@ -56,7 +56,7 @@ let pinned_subheader_flag = false;
 let active_subheader_flag = false;
 let inactive_subheader_flag = false;
 
-function create_devel_sidebar_row({mock_template}) {
+const create_devel_sidebar_row = ({mock_template}) => {
     const $devel_count = $.create("devel-count");
     const $subscription_block = $.create("devel-block");
     const $devel_unread_mention_info = $.create("devel-unread-mention-info");
@@ -77,9 +77,9 @@ function create_devel_sidebar_row({mock_template}) {
     stream_list.create_sidebar_row(devel);
     assert.equal($devel_count.text(), "42");
     assert.equal($devel_unread_mention_info.text(), "");
-}
+};
 
-function create_social_sidebar_row({mock_template}) {
+const create_social_sidebar_row = ({mock_template}) => {
     const $social_count = $.create("social-count");
     const $subscription_block = $.create("social-block");
     const $social_unread_mention_info = $.create("social-unread-mention-info");
@@ -100,9 +100,9 @@ function create_social_sidebar_row({mock_template}) {
     stream_list.create_sidebar_row(social);
     assert.equal($social_count.text(), "99");
     assert.equal($social_unread_mention_info.text(), "@");
-}
+};
 
-function create_stream_subheader({mock_template}) {
+const create_stream_subheader = ({mock_template}) => {
     mock_template("streams_subheader.hbs", false, (data) => {
         if (data.subheader_name === "translated: Pinned") {
             pinned_subheader_flag = true;
@@ -116,15 +116,15 @@ function create_stream_subheader({mock_template}) {
         inactive_subheader_flag = true;
         return "<inactive-subheader-stub>";
     });
-}
+};
 
-function test_ui(label, f) {
+const test_ui = (label, f) => {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         stream_list.stream_sidebar.rows.clear();
         f(helpers);
     });
-}
+};
 
 test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
     // Make a couple calls to create_sidebar_row() and make sure they
@@ -249,11 +249,11 @@ test_ui("pinned_streams_never_inactive", ({override_rewire, mock_template}) => {
     assert.ok(!$devel_sidebar.hasClass("inactive_stream"));
 });
 
-function add_row(sub) {
+const add_row = (sub) => {
     stream_data.add_sub(sub);
     const row = {
-        update_whether_active() {},
-        get_li() {
+        update_whether_active: () => {},
+        get_li: () => {
             const html = "<" + sub.name + "-sidebar-row-stub>";
             const $obj = $(html);
 
@@ -263,9 +263,9 @@ function add_row(sub) {
         },
     };
     stream_list.stream_sidebar.set_row(sub.stream_id, row);
-}
+};
 
-function initialize_stream_data() {
+const initialize_stream_data = () => {
     // pinned streams
     const develSub = {
         name: "devel",
@@ -323,11 +323,9 @@ function initialize_stream_data() {
     add_row(carSub);
 
     stream_list.build_stream_list();
-}
+};
 
-function elem($obj) {
-    return {to_$: () => $obj};
-}
+const elem = ($obj) => ({to_$: () => $obj});
 
 test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     const $label1 = $.create("label1 stub");
@@ -355,12 +353,10 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     const $stream_li1 = $.create("stream1 stub");
     const $stream_li2 = $.create("stream2 stub");
 
-    function make_attr(arg) {
-        return (sel) => {
-            assert.equal(sel, "data-stream-id");
-            return arg;
-        };
-    }
+    const make_attr = (arg) => (sel) => {
+        assert.equal(sel, "data-stream-id");
+        return arg;
+    };
 
     $stream_li1.attr = make_attr("42");
     $stream_li1.hide();
@@ -378,7 +374,7 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     mock_template("filter_topics.hbs", false, () => "<filter-topics-stub>");
     let filter_topics_appended = false;
     $stream_li1.children = () => ({
-        append($element) {
+        append: ($element) => {
             assert.equal($element.selector, "<filter-topics-stub>");
             filter_topics_appended = true;
         },
@@ -460,20 +456,20 @@ test_ui("narrowing", ({mock_template}) => {
 });
 
 test_ui("focusout_user_filter", () => {
-    stream_list.set_event_handlers({narrow_on_stream_click() {}});
+    stream_list.set_event_handlers({narrow_on_stream_click: () => {}});
     const e = {};
     const click_handler = $(".stream-list-filter").get_on_handler("focusout");
     click_handler(e);
 });
 
 test_ui("focus_user_filter", () => {
-    stream_list.set_event_handlers({narrow_on_stream_click() {}});
+    stream_list.set_event_handlers({narrow_on_stream_click: () => {}});
 
     initialize_stream_data();
     stream_list.build_stream_list();
 
     const e = {
-        stopPropagation() {},
+        stopPropagation: () => {},
     };
     const click_handler = $(".stream-list-filter").get_on_handler("click");
     click_handler(e);

--- a/web/tests/stream_list_sort.test.js
+++ b/web/tests/stream_list_sort.test.js
@@ -14,9 +14,7 @@ const stream_topic_history = zrequire("stream_topic_history");
 const stream_list_sort = zrequire("stream_list_sort");
 const settings_config = zrequire("settings_config");
 
-function contains_sub(subs, sub) {
-    return subs.some((s) => s.name === sub.name);
-}
+const contains_sub = (subs, sub) => subs.some((s) => s.name === sub.name);
 
 const me = {
     email: "me@zulip.com",
@@ -75,17 +73,17 @@ const muted_pinned = {
     is_muted: true,
 };
 
-function sort_groups(query) {
+const sort_groups = (query) => {
     const streams = stream_data.subscribed_stream_ids();
     return stream_list_sort.sort_groups(streams, query);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         f(helpers);
     });
-}
+};
 
 test("no_subscribed_streams", () => {
     const sorted = sort_groups("");

--- a/web/tests/stream_pill.test.js
+++ b/web/tests/stream_pill.test.js
@@ -42,10 +42,10 @@ for (const sub of subs) {
 }
 
 run_test("create_item", () => {
-    function test_create_item(stream_name, current_items, expected_item) {
+    const test_create_item = (stream_name, current_items, expected_item) => {
         const item = stream_pill.create_item_from_stream_name(stream_name, current_items);
         assert.deepEqual(item, expected_item);
-    }
+    };
 
     test_create_item("sweden", [], undefined);
     test_create_item("#sweden", [sweden_pill], undefined);

--- a/web/tests/stream_search.test.js
+++ b/web/tests/stream_search.test.js
@@ -22,18 +22,18 @@ const sidebar_ui = mock_esm("../src/sidebar_ui");
 
 const stream_list = zrequire("stream_list");
 
-function expand_sidebar() {
+const expand_sidebar = () => {
     $(".app-main .column-left").addClass("expanded");
-}
+};
 
-function make_cursor_helper() {
+const make_cursor_helper = () => {
     const events = [];
 
     stream_list.__Rewire__("stream_cursor", {
-        reset() {
+        reset: () => {
             events.push("reset");
         },
-        clear() {
+        clear: () => {
             events.push("clear");
         },
     });
@@ -41,26 +41,26 @@ function make_cursor_helper() {
     return {
         events,
     };
-}
+};
 
-function simulate_search_expanded() {
+const simulate_search_expanded = () => {
     // The way we check if the search widget is expanded
     // is kind of awkward.
 
     $(".stream_search_section.notdisplayed").length = 0;
-}
+};
 
-function simulate_search_collapsed() {
+const simulate_search_collapsed = () => {
     $(".stream_search_section.notdisplayed").length = 1;
-}
+};
 
-function toggle_filter() {
+const toggle_filter = () => {
     stream_list.toggle_filter_displayed({preventDefault: noop});
-}
+};
 
-function clear_search_input() {
+const clear_search_input = () => {
     stream_list.clear_search({stopPropagation: noop});
-}
+};
 
 run_test("basics", ({override_rewire}) => {
     let cursor_helper;
@@ -72,24 +72,24 @@ run_test("basics", ({override_rewire}) => {
 
     cursor_helper = make_cursor_helper();
 
-    function verify_expanded() {
+    const verify_expanded = () => {
         assert.ok(!$section.hasClass("notdisplayed"));
         simulate_search_expanded();
-    }
+    };
 
-    function verify_focused() {
+    const verify_focused = () => {
         assert.ok(stream_list.searching());
         assert.ok($input.is_focused());
-    }
+    };
 
-    function verify_collapsed() {
+    const verify_collapsed = () => {
         assert.ok($section.hasClass("notdisplayed"));
         assert.ok(!$input.is_focused());
         assert.ok(!stream_list.searching());
         simulate_search_collapsed();
-    }
+    };
 
-    function verify_list_updated(f) {
+    const verify_list_updated = (f) => {
         let updated;
         override_rewire(stream_list, "update_streams_sidebar", () => {
             updated = true;
@@ -97,7 +97,7 @@ run_test("basics", ({override_rewire}) => {
 
         f();
         assert.ok(updated);
-    }
+    };
 
     // Initiate search (so expand widget).
     stream_list.initiate_search();
@@ -119,7 +119,7 @@ run_test("basics", ({override_rewire}) => {
     verify_expanded();
     verify_focused();
 
-    (function add_some_text_and_collapse() {
+    (() => {
         cursor_helper = make_cursor_helper();
         $input.val("foo");
         verify_list_updated(() => {

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -13,11 +13,11 @@ const scroll_util = mock_esm("../src/scroll_util", {
 });
 
 mock_esm("../src/hash_util", {
-    by_stream_url() {},
+    by_stream_url: () => {},
 });
 
 mock_esm("../src/browser_history", {
-    update() {},
+    update: () => {},
 });
 
 mock_esm("../src/hash_parser", {
@@ -183,14 +183,14 @@ run_test("redraw_left_panel", ({mock_template}) => {
     // sanity check it's not set to active
     assert.ok(!$denmark_row.hasClass("active"));
 
-    function test_filter(params, expected_streams) {
+    const test_filter = (params, expected_streams) => {
         $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
         const stream_ids = stream_settings_ui.redraw_left_panel(params);
         assert.deepEqual(
             stream_ids,
             expected_streams.map((sub) => sub.stream_id),
         );
-    }
+    };
 
     // Search with single keyword
     test_filter({input: "Po", show_subscribed: false, show_not_subscribed: false}, [

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -15,13 +15,13 @@ const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const stream_topic_history_util = zrequire("stream_topic_history_util");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         unread.declare_bankruptcy();
         stream_topic_history.reset();
         f(helpers);
     });
-}
+};
 
 test("basics", () => {
     const stream_id = 55;
@@ -170,13 +170,13 @@ test("server_history", () => {
         topic_name: "local",
     });
 
-    function add_server_history() {
+    const add_server_history = () => {
         stream_topic_history.add_history(stream_id, [
             {name: "local", max_id: 501},
             {name: "hist2", max_id: 31},
             {name: "hist1", max_id: 30},
         ]);
-    }
+    };
 
     add_server_history();
 

--- a/web/tests/support.test.js
+++ b/web/tests/support.test.js
@@ -34,12 +34,12 @@ run_test("scrub_realm", () => {
     let submit_form_called = false;
     const fake_this = {to_$: () => $fake_this};
     fake_this.form = {
-        submit() {
+        submit: () => {
             submit_form_called = true;
         },
     };
     const event = {
-        preventDefault() {},
+        preventDefault: () => {},
     };
 
     window.prompt = () => "zulip";

--- a/web/tests/time_zone_util.test.js
+++ b/web/tests/time_zone_util.test.js
@@ -8,9 +8,7 @@ const {run_test} = require("./lib/test");
 const {get_offset, start_of_day, is_same_day, difference_in_calendar_days} =
     zrequire("time_zone_util");
 
-function pre(date) {
-    return new Date(date.getTime() - 1);
-}
+const pre = (date) => new Date(date.getTime() - 1);
 
 const ny = "America/New_York";
 const ny_new_year = new Date("2023-01-01T05:00Z");

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -15,12 +15,12 @@ user_settings.twenty_four_hour_time = true;
 
 const timerender = zrequire("timerender");
 
-function get_date(time_ISO, DOW) {
+const get_date = (time_ISO, DOW) => {
     const time = new Date(time_ISO);
     // DOW helps the test reader to know the DOW of the current date being tested.
     assert.equal(new Intl.DateTimeFormat("en-US", {weekday: "long"}).format(time), DOW);
     return time;
-}
+};
 
 const date_2017 = get_date("2017-05-18T07:12:53.000Z", "Thursday");
 
@@ -500,11 +500,11 @@ run_test("last_seen_status_from_date", () => {
     let base_date = new Date(2016, 2, 1, 0, 30);
     MockDate.set(base_date.getTime());
 
-    function assert_same(duration, expected_status) {
+    const assert_same = (duration, expected_status) => {
         const past_date = add(base_date, duration);
         const actual_status = timerender.last_seen_status_from_date(past_date, base_date);
         assert.equal(actual_status, expected_status);
-    }
+    };
 
     assert_same({minutes: -30}, $t({defaultMessage: "Active 30 minutes ago"}));
 
@@ -554,11 +554,11 @@ run_test("relative_time_string_from_date", () => {
     let base_date = new Date(2016, 2, 1, 0, 30);
     MockDate.set(base_date.getTime());
 
-    function assert_same(duration, expected_status) {
+    const assert_same = (duration, expected_status) => {
         const past_date = add(base_date, duration);
         const actual_status = timerender.relative_time_string_from_date(past_date);
         assert.equal(actual_status, expected_status);
-    }
+    };
 
     assert_same({seconds: -20}, $t({defaultMessage: "Just now"}));
 

--- a/web/tests/topic_generator.test.js
+++ b/web/tests/topic_generator.test.js
@@ -17,10 +17,10 @@ const user_topics = mock_esm("../src/user_topics");
 const tg = zrequire("topic_generator");
 
 run_test("streams", ({override}) => {
-    function assert_next_stream(curr_stream, expected) {
+    const assert_next_stream = (curr_stream, expected) => {
         const actual = tg.get_next_stream(curr_stream);
         assert.equal(actual, expected);
-    }
+    };
 
     override(stream_list_sort, "get_streams", () => ["announce", "muted", "devel", "test here"]);
 
@@ -30,10 +30,10 @@ run_test("streams", ({override}) => {
     assert_next_stream("announce", "muted");
     assert_next_stream("test here", "announce");
 
-    function assert_prev_stream(curr_stream, expected) {
+    const assert_prev_stream = (curr_stream, expected) => {
         const actual = tg.get_prev_stream(curr_stream);
         assert.equal(actual, expected);
-    }
+    };
 
     assert_prev_stream(undefined, "test here");
     assert_prev_stream("test here", "devel");
@@ -49,17 +49,12 @@ run_test("topics", ({override}) => {
         ["stream4", ["4a"]],
     ]);
 
-    function has_unread_messages(_stream, topic) {
-        return topic !== "read";
-    }
+    const has_unread_messages = (_stream, topic) => topic !== "read";
 
-    function get_topics(stream) {
-        return topics.get(stream);
-    }
+    const get_topics = (stream) => topics.get(stream);
 
-    function next_topic(curr_stream, curr_topic) {
-        return tg.next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic);
-    }
+    const next_topic = (curr_stream, curr_topic) =>
+        tg.next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic);
 
     assert.deepEqual(next_topic("stream1", "1a"), {stream: "stream1", topic: "1b"});
     assert.deepEqual(next_topic("stream1", undefined), {stream: "stream1", topic: "1a"});
@@ -109,9 +104,9 @@ run_test("topics", ({override}) => {
         "python",
         "followed-devel",
     ]);
-    function mark_topic_as_read(topic) {
+    const mark_topic_as_read = (topic) => {
         topic_has_unreads.delete(topic);
-    }
+    };
     override(unread, "topic_has_any_unread", (_stream_id, topic) => topic_has_unreads.has(topic));
 
     override(user_topics, "is_topic_muted", (_stream_name, topic) => topic === "muted");

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -8,27 +8,19 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
 mock_esm("../src/message_store", {
-    get() {
-        return {
-            stream_id: 556,
-            topic: "general",
-        };
-    },
+    get: () => ({
+        stream_id: 556,
+        topic: "general",
+    }),
 });
 const user_topics = mock_esm("../src/user_topics", {
-    is_topic_muted() {
-        return false;
-    },
-    is_topic_followed() {
-        return false;
-    },
-    is_topic_unmuted_or_followed() {
-        return false;
-    },
+    is_topic_muted: () => false,
+    is_topic_followed: () => false,
+    is_topic_unmuted_or_followed: () => false,
 });
 const narrow_state = mock_esm("../src/narrow_state", {
-    topic() {},
-    stream_id() {},
+    topic: () => {},
+    stream_id: () => {},
 });
 
 const stream_data = zrequire("stream_data");
@@ -43,19 +35,19 @@ const general = {
 
 stream_data.add_sub(general);
 
-function get_list_info(zoom, search) {
+const get_list_info = (zoom, search) => {
     const stream_id = general.stream_id;
     const zoomed = zoom === undefined ? false : zoom;
     const search_term = search === undefined ? "" : search;
     return topic_list_data.get_list_info(stream_id, zoomed, search_term);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         stream_topic_history.reset();
         f(helpers);
     });
-}
+};
 
 test("get_list_info w/real stream_topic_history", ({override}) => {
     let list_info;
@@ -69,13 +61,13 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         num_possible_topics: 0,
     });
 
-    function add_topic_message(topic_name, message_id) {
+    const add_topic_message = (topic_name, message_id) => {
         stream_topic_history.add_message({
             stream_id: general.stream_id,
             topic_name,
             message_id,
         });
-    }
+    };
     for (const i of _.range(10)) {
         let topic_name;
         // All odd topics are resolved.
@@ -179,7 +171,7 @@ test("get_list_info unreads", ({override}) => {
         });
     }
 
-    function add_unreads(topic, count) {
+    const add_unreads = (topic, count) => {
         unread.process_loaded_messages(
             Array.from({length: count}, () => ({
                 id: (message_id += 1),
@@ -189,9 +181,9 @@ test("get_list_info unreads", ({override}) => {
                 unread: true,
             })),
         );
-    }
+    };
 
-    function add_unreads_with_mention(topic, count) {
+    const add_unreads_with_mention = (topic, count) => {
         unread.process_loaded_messages(
             Array.from({length: count}, () => ({
                 id: (message_id += 1),
@@ -203,7 +195,7 @@ test("get_list_info unreads", ({override}) => {
                 mentioned_me_directly: true,
             })),
         );
-    }
+    };
 
     /*
         We have 16 topics, but we only show up

--- a/web/tests/typeahead.test.js
+++ b/web/tests/typeahead.test.js
@@ -29,15 +29,15 @@ const emojis = [
     })),
 ];
 
-function emoji_matches(query) {
+const emoji_matches = (query) => {
     const matcher = typeahead.get_emoji_matcher(query);
     return emojis.filter((emoji) => matcher(emoji));
-}
+};
 
-function assert_emoji_matches(query, expected) {
+const assert_emoji_matches = (query, expected) => {
     const names = emoji_matches(query).map((emoji) => emoji.emoji_name);
     assert.deepEqual(names.sort(), expected);
-}
+};
 
 run_test("get_emoji_matcher: nonmatches", () => {
     assert_emoji_matches("notaemoji", []);
@@ -62,9 +62,9 @@ run_test("matches literal unicode emoji", () => {
 });
 
 run_test("get_emoji_matcher: spaces equivalent to underscores", () => {
-    function assert_equivalent(query) {
+    const assert_equivalent = (query) => {
         assert.deepEqual(emoji_matches(query), emoji_matches(query.replace(" ", "_")));
-    }
+    };
     assert_equivalent("da ");
     assert_equivalent("panda ");
     assert_equivalent("japanese post ");
@@ -170,9 +170,8 @@ run_test("triage: prioritise word boundary matches to arbitrary substring matche
     );
 });
 
-function sort_emojis(emojis, query) {
-    return typeahead.sort_emojis(emojis, query).map((emoji) => emoji.emoji_name);
-}
+const sort_emojis = (emojis, query) =>
+    typeahead.sort_emojis(emojis, query).map((emoji) => emoji.emoji_name);
 
 run_test("sort_emojis: th", () => {
     const emoji_list = [

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -25,20 +25,16 @@ const th = zrequire("typeahead_helper");
 
 let next_id = 0;
 
-function assertSameEmails(lst1, lst2) {
+const assertSameEmails = (lst1, lst2) => {
     assert.deepEqual(
         lst1.map((r) => r.user.email),
         lst2.map((r) => r.user.email),
     );
-}
+};
 
-function user_item(user) {
-    return {type: "user", user};
-}
+const user_item = (user) => ({type: "user", user});
 
-function broadcast_item(user) {
-    return {type: "broadcast", user};
-}
+const broadcast_item = (user) => ({type: "broadcast", user});
 
 const a_bot = {
     email: "a_bot@zulip.com",
@@ -124,7 +120,7 @@ stream_data.create_streams([dev_sub, linux_sub]);
 stream_data.add_sub(dev_sub);
 stream_data.add_sub(linux_sub);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         pm_conversations.clear_for_testing();
         recent_senders.clear_for_testing();
@@ -135,7 +131,7 @@ function test(label, f) {
 
         f(helpers);
     });
-}
+};
 
 test("sort_streams", ({override, override_rewire}) => {
     let test_streams = [
@@ -302,12 +298,11 @@ test("sort_streams", ({override, override_rewire}) => {
     assert.deepEqual(test_streams[5].name, "Mew"); // Unsubscribed and no match
 });
 
-function language_items(languages) {
-    return languages.map((language) => ({
+const language_items = (languages) =>
+    languages.map((language) => ({
         type: "syntax",
         language,
     }));
-}
 
 test("sort_languages", ({override_rewire}) => {
     override_rewire(pygments_data, "langs", {
@@ -358,7 +353,7 @@ test("sort_languages on actual data", () => {
     assert.deepEqual(test_langs, language_items(["js", "java"]));
 });
 
-function get_typeahead_result(query, current_stream_id, current_topic) {
+const get_typeahead_result = (query, current_stream_id, current_topic) => {
     const users = people.get_realm_users().map((user) => ({type: "user", user}));
     const result = th.sort_recipients({
         users,
@@ -367,7 +362,7 @@ function get_typeahead_result(query, current_stream_id, current_topic) {
         current_topic,
     });
     return result.map((person) => person.user.email);
-}
+};
 
 test("sort_recipients", () => {
     // Typeahead for recipientbox [query, "", undefined]
@@ -524,9 +519,9 @@ test("sort_recipients pm counts", () => {
     ]);
 
     /* istanbul ignore next */
-    function compare() {
+    const compare = () => {
         throw new Error("We do not expect to need a tiebreaker here.");
-    }
+    };
 
     // get some line coverage
     assert.equal(
@@ -736,9 +731,7 @@ test("test compare directly for direct message", () => {
 });
 
 test("highlight_with_escaping", () => {
-    function highlight(query, item) {
-        return th.make_query_highlighter(query)(item);
-    }
+    const highlight = (query, item) => th.make_query_highlighter(query)(item);
 
     let item = "Denmark";
     let query = "Den";

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -8,13 +8,13 @@ const {run_test} = require("./lib/test");
 const muted_users = zrequire("muted_users");
 const typing_data = zrequire("typing_data");
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         typing_data.clear_for_testing();
         muted_users.set_muted_users([]);
         f({override});
     });
-}
+};
 
 test("basics", () => {
     // The typing_data needs to be robust with lists of
@@ -124,49 +124,49 @@ test("timers", () => {
     const stub_topic = "typing notifications";
     const topic_typing_key = typing_data.get_topic_key(stub_stream_id, stub_topic);
 
-    function set_timeout(f, delay) {
+    const set_timeout = (f, delay) => {
         assert.equal(delay, stub_delay);
         events.f = f;
         events.timer_set = true;
         return stub_timer_id;
-    }
+    };
 
-    function clear_timeout(timer) {
+    const clear_timeout = (timer) => {
         assert.equal(timer, stub_timer_id);
         events.timer_cleared = true;
-    }
+    };
 
-    function reset_events() {
+    const reset_events = () => {
         events.f = undefined;
         events.timer_cleared = false;
         events.timer_set = false;
-    }
+    };
 
-    function kickstart() {
+    const kickstart = () => {
         reset_events();
         typing_data.kickstart_inbound_timer(
             typing_data.get_direct_message_conversation_key(stub_group),
             stub_delay,
             stub_f,
         );
-    }
+    };
 
-    function clear() {
+    const clear = () => {
         reset_events();
         typing_data.clear_inbound_timer(
             typing_data.get_direct_message_conversation_key(stub_group),
         );
-    }
+    };
 
-    function streams_kickstart() {
+    const streams_kickstart = () => {
         reset_events();
         typing_data.kickstart_inbound_timer(topic_typing_key, stub_delay, stub_f);
-    }
+    };
 
-    function streams_clear() {
+    const streams_clear = () => {
         reset_events();
         typing_data.clear_inbound_timer(topic_typing_key);
-    }
+    };
 
     set_global("setTimeout", set_timeout);
     set_global("clearTimeout", clear_timeout);

--- a/web/tests/typing_status.test.js
+++ b/web/tests/typing_status.test.js
@@ -15,16 +15,9 @@ const typing_status = zrequire("../shared/src/typing_status");
 const TYPING_STARTED_WAIT_PERIOD = 10000;
 const TYPING_STOPPED_WAIT_PERIOD = 5000;
 
-function make_time(secs) {
-    // make times semi-realistic
-    return 1000000 + 1000 * secs;
-}
+const make_time = (secs) => 1000000 + 1000 * secs;
 
-function returns_time(secs) {
-    return function () {
-        return make_time(secs);
-    };
-}
+const returns_time = (secs) => () => make_time(secs);
 
 run_test("basics", ({override, override_rewire}) => {
     assert.equal(typing_status.state, null);
@@ -36,37 +29,37 @@ run_test("basics", ({override, override_rewire}) => {
     // Start setting up more testing state.
     const events = {};
 
-    function set_timeout(f, delay) {
+    const set_timeout = (f, delay) => {
         assert.equal(delay, 5000);
         events.idle_callback = f;
         return "idle_timer_stub";
-    }
+    };
 
-    function clear_timeout() {
+    const clear_timeout = () => {
         events.timer_cleared = true;
-    }
+    };
 
     set_global("setTimeout", set_timeout);
     set_global("clearTimeout", clear_timeout);
 
-    function notify_server_start(recipient) {
+    const notify_server_start = (recipient) => {
         assert.deepStrictEqual(recipient, {message_type: "direct", ids: [1, 2]});
         events.started = true;
-    }
+    };
 
-    function notify_server_stop(recipient) {
+    const notify_server_stop = (recipient) => {
         assert.deepStrictEqual(recipient, {message_type: "direct", ids: [1, 2]});
         events.stopped = true;
-    }
+    };
 
-    function clear_events() {
+    const clear_events = () => {
         events.idle_callback = undefined;
         events.started = false;
         events.stopped = false;
         events.timer_cleared = false;
-    }
+    };
 
-    function call_handler(new_recipient) {
+    const call_handler = (new_recipient) => {
         clear_events();
         typing_status.update(
             worker,
@@ -74,7 +67,7 @@ run_test("basics", ({override, override_rewire}) => {
             TYPING_STARTED_WAIT_PERIOD,
             TYPING_STOPPED_WAIT_PERIOD,
         );
-    }
+    };
 
     worker = {
         get_current_time: returns_time(5),
@@ -329,37 +322,37 @@ run_test("stream_messages", ({override_rewire}) => {
     let worker = {};
     const events = {};
 
-    function set_timeout(f, delay) {
+    const set_timeout = (f, delay) => {
         assert.equal(delay, 5000);
         events.idle_callback = f;
         return "idle_timer_stub";
-    }
+    };
 
-    function clear_timeout() {
+    const clear_timeout = () => {
         events.timer_cleared = true;
-    }
+    };
 
     set_global("setTimeout", set_timeout);
     set_global("clearTimeout", clear_timeout);
 
-    function notify_server_start(recipient) {
+    const notify_server_start = (recipient) => {
         assert.deepStrictEqual(recipient, {message_type: "stream", stream_id: 3, topic: "test"});
         events.started = true;
-    }
+    };
 
-    function notify_server_stop(recipient) {
+    const notify_server_stop = (recipient) => {
         assert.deepStrictEqual(recipient, {message_type: "stream", stream_id: 3, topic: "test"});
         events.stopped = true;
-    }
+    };
 
-    function clear_events() {
+    const clear_events = () => {
         events.idle_callback = undefined;
         events.started = false;
         events.stopped = false;
         events.timer_cleared = false;
-    }
+    };
 
-    function call_handler(new_recipient) {
+    const call_handler = (new_recipient) => {
         clear_events();
         typing_status.update(
             worker,
@@ -367,7 +360,7 @@ run_test("stream_messages", ({override_rewire}) => {
             TYPING_STARTED_WAIT_PERIOD,
             TYPING_STOPPED_WAIT_PERIOD,
         );
-    }
+    };
 
     worker = {
         get_current_time: returns_time(5),

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -42,15 +42,15 @@ const social = {
 };
 stream_data.add_sub(social);
 
-function assert_zero_counts(counts) {
+const assert_zero_counts = (counts) => {
     assert.equal(counts.direct_message_count, 0);
     assert.equal(counts.home_unread_messages, 0);
     assert.equal(counts.mentioned_message_count, 0);
     assert.equal(counts.stream_count.size, 0);
     assert.equal(counts.pm_count.size, 0);
-}
+};
 
-function test_notifiable_count(home_unread_messages, expected_notifiable_count) {
+const test_notifiable_count = (home_unread_messages, expected_notifiable_count) => {
     user_settings.desktop_icon_count_display = 1;
     let notifiable_counts = unread.get_notifiable_count();
     assert.deepEqual(notifiable_counts, home_unread_messages);
@@ -63,15 +63,15 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
     user_settings.desktop_icon_count_display = 4;
     notifiable_counts = unread.get_notifiable_count();
     assert.deepEqual(notifiable_counts, 0);
-}
+};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         unread.declare_bankruptcy();
         user_topics.set_user_topics([]);
         f(helpers);
     });
-}
+};
 
 test("empty_counts_while_narrowed", () => {
     const counts = unread.get_counts();
@@ -615,10 +615,10 @@ test("mention updates", () => {
         topic: "hello",
     };
 
-    function test_counted(counted) {
+    const test_counted = (counted) => {
         unread.update_message_for_mention(message);
         assert.equal(unread.unread_mentions_counter.has(message.id), counted);
-    }
+    };
 
     test_counted(false);
 

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -39,12 +39,12 @@ const message_lists = mock_esm("../src/message_lists");
 message_lists.current = {
     id: "1",
 };
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (helpers) => {
         realm.max_file_upload_size_mib = 25;
         return f(helpers);
     });
-}
+};
 
 test("feature_check", ({override}) => {
     assert.ok(!upload.feature_check());
@@ -178,7 +178,7 @@ test("upload_files", async ({mock_template, override_rewire}) => {
     let uppy_add_file_called = false;
     let remove_file_called = false;
     const uppy = {
-        addFile(params) {
+        addFile: (params) => {
             uppy_add_file_called = true;
             assert.equal(params.source, "compose-file-input");
             assert.equal(params.name, "budapest.png");
@@ -186,7 +186,7 @@ test("upload_files", async ({mock_template, override_rewire}) => {
             assert.equal(params.data, files[0]);
             return "id_123";
         },
-        removeFile() {
+        removeFile: () => {
             remove_file_called = true;
         },
     };
@@ -309,7 +309,7 @@ test("uppy_config", () => {
     let uppy_set_meta_called = false;
     let uppy_used_xhrupload = false;
 
-    uppy_stub = function (config) {
+    uppy_stub = (config) => {
         uppy_stub_called = true;
         assert.equal(config.debug, false);
         assert.equal(config.autoProceed, true);
@@ -318,11 +318,11 @@ test("uppy_config", () => {
         assert.ok("exceedsSize" in config.locale.strings);
 
         return {
-            setMeta(params) {
+            setMeta: (params) => {
                 uppy_set_meta_called = true;
                 assert.equal(params.csrfmiddlewaretoken, "csrf_token");
             },
-            use(func, params) {
+            use: (func, params) => {
                 const func_name = func.name;
                 if (func_name === "XHRUpload") {
                     uppy_used_xhrupload = true;
@@ -337,7 +337,7 @@ test("uppy_config", () => {
                     assert.fail(`Missing tests for ${func_name}`);
                 }
             },
-            on() {},
+            on: () => {},
         };
     };
     upload.setup_upload(upload.compose_config);
@@ -374,7 +374,7 @@ test("file_drop", ({override, override_rewire}) => {
 
     let prevent_default_counter = 0;
     const drag_event = {
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
     };
@@ -389,10 +389,10 @@ test("file_drop", ({override, override_rewire}) => {
     let stop_propagation_counter = 0;
     const files = ["file1", "file2"];
     const drop_event = {
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
-        stopPropagation() {
+        stopPropagation: () => {
             stop_propagation_counter += 1;
         },
         originalEvent: {
@@ -429,7 +429,7 @@ test("copy_paste", ({override, override_rewire}) => {
                 items: [
                     {
                         kind: "file",
-                        getAsFile() {
+                        getAsFile: () => {
                             get_as_file_called = true;
                         },
                     },
@@ -440,7 +440,7 @@ test("copy_paste", ({override, override_rewire}) => {
                 ],
             },
         }),
-        preventDefault() {},
+        preventDefault: () => {},
     };
     let upload_files_called = false;
     override_rewire(upload, "upload_files", () => {
@@ -471,25 +471,23 @@ test("uppy_events", ({override_rewire, mock_template}) => {
     const callbacks = {};
     let state = {};
 
-    uppy_stub = function () {
-        return {
-            setMeta() {},
-            use() {},
-            on(event_name, callback) {
-                callbacks[event_name] = callback;
-            },
-            removeFile() {},
-            getState: () => ({
-                info: [
-                    {
-                        type: state.type,
-                        details: state.details,
-                        message: state.message,
-                    },
-                ],
-            }),
-        };
-    };
+    uppy_stub = () => ({
+        setMeta: () => {},
+        use: () => {},
+        on: (event_name, callback) => {
+            callbacks[event_name] = callback;
+        },
+        removeFile: () => {},
+        getState: () => ({
+            info: [
+                {
+                    type: state.type,
+                    details: state.details,
+                    message: state.message,
+                },
+            ],
+        }),
+    });
     upload.setup_upload(upload.compose_config);
     assert.equal(Object.keys(callbacks).length, 5);
 
@@ -605,21 +603,19 @@ test("uppy_events", ({override_rewire, mock_template}) => {
 });
 
 test("main_file_drop_compose_mode", ({override, override_rewire}) => {
-    uppy_stub = function () {
-        return {
-            setMeta() {},
-            use() {},
-            cancelAll() {},
-            on() {},
-            getFiles() {},
-            removeFile() {},
-        };
-    };
+    uppy_stub = () => ({
+        setMeta: () => {},
+        use: () => {},
+        cancelAll: () => {},
+        on: () => {},
+        getFiles: () => {},
+        removeFile: () => {},
+    });
     upload.initialize();
 
     let prevent_default_counter = 0;
     const drag_event = {
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
     };
@@ -637,7 +633,7 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
     const files = ["file1", "file2"];
     const drop_event = {
         target: "target",
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
         originalEvent: {
@@ -674,9 +670,7 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
     let compose_actions_start_called = false;
     let compose_actions_respond_to_message_called = false;
     override(message_lists, "current", {
-        selected_message() {
-            return msg;
-        },
+        selected_message: () => msg,
     });
     compose_actions.start = () => {
         compose_actions_start_called = true;
@@ -692,9 +686,7 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
     // Test drop on Recent Conversations view
     compose_actions_respond_to_message_called = false;
     override(message_lists, "current", {
-        selected_message() {
-            return undefined;
-        },
+        selected_message: () => undefined,
     });
     upload_files_called = false;
     drop_handler(drop_event);
@@ -704,23 +696,21 @@ test("main_file_drop_compose_mode", ({override, override_rewire}) => {
 });
 
 test("main_file_drop_edit_mode", ({override, override_rewire}) => {
-    uppy_stub = function () {
-        return {
-            setMeta() {},
-            use() {},
-            cancelAll() {},
-            on() {},
-            getFiles() {},
-            removeFile() {},
-        };
-    };
+    uppy_stub = () => ({
+        setMeta: () => {},
+        use: () => {},
+        cancelAll: () => {},
+        on: () => {},
+        getFiles: () => {},
+        removeFile: () => {},
+    });
 
     upload.setup_upload(upload.edit_config(40));
     upload.initialize();
     override(compose_state, "composing", () => false);
     let prevent_default_counter = 0;
     const drag_event = {
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
     };
@@ -738,7 +728,7 @@ test("main_file_drop_edit_mode", ({override, override_rewire}) => {
     const files = ["file1", "file2"];
     const drop_event = {
         target: "target",
-        preventDefault() {
+        preventDefault: () => {
             prevent_default_counter += 1;
         },
         originalEvent: {

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -11,44 +11,44 @@ const {current_user} = require("./lib/zpage_params");
 const message_live_update = mock_esm("../src/message_live_update");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
 const settings_account = mock_esm("../src/settings_account", {
-    maybe_update_deactivate_account_button() {},
-    update_email() {},
-    update_full_name() {},
-    update_account_settings_display() {},
+    maybe_update_deactivate_account_button: () => {},
+    update_email: () => {},
+    update_full_name: () => {},
+    update_account_settings_display: () => {},
 });
 const settings_users = mock_esm("../src/settings_users", {
-    update_user_data() {},
-    update_view_on_deactivate() {},
+    update_user_data: () => {},
+    update_view_on_deactivate: () => {},
 });
 mock_esm("../src/user_profile", {
-    update_profile_modal_ui() {},
-    update_user_custom_profile_fields() {},
+    update_profile_modal_ui: () => {},
+    update_user_custom_profile_fields: () => {},
 });
 const stream_events = mock_esm("../src/stream_events");
 
 mock_esm("../src/activity_ui", {
-    redraw() {},
+    redraw: () => {},
 });
 mock_esm("../src/compose_state", {
-    update_email() {},
+    update_email: () => {},
 });
 mock_esm("../src/pm_list", {
-    update_private_messages() {},
+    update_private_messages: () => {},
 });
 mock_esm("../src/settings_linkifiers", {
-    maybe_disable_widgets() {},
+    maybe_disable_widgets: () => {},
 });
 mock_esm("../src/settings_org", {
-    maybe_disable_widgets() {},
+    maybe_disable_widgets: () => {},
 });
 mock_esm("../src/settings_profile_fields", {
-    maybe_disable_widgets() {},
+    maybe_disable_widgets: () => {},
 });
 mock_esm("../src/settings_realm_user_settings_defaults", {
-    maybe_disable_widgets() {},
+    maybe_disable_widgets: () => {},
 });
 mock_esm("../src/settings_streams", {
-    maybe_disable_widgets() {},
+    maybe_disable_widgets: () => {},
 });
 
 current_user.is_admin = true;
@@ -65,11 +65,11 @@ const me = {
     role: settings_config.user_role_values.member.code,
 };
 
-function initialize() {
+const initialize = () => {
     people.init();
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
-}
+};
 
 initialize();
 

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -40,10 +40,10 @@ for (const group of groups) {
 }
 
 run_test("create_item", () => {
-    function test_create_item(group_name, current_items, expected_item) {
+    const test_create_item = (group_name, current_items, expected_item) => {
         const item = user_group_pill.create_item_from_group_name(group_name, current_items);
         assert.deepEqual(item, expected_item);
-    }
+    };
 
     test_create_item(" admins ", [], admins_pill);
     test_create_item("admins", [testers_pill], admins_pill);
@@ -74,11 +74,11 @@ run_test("get_group_ids", () => {
 run_test("append_user_group", () => {
     const items = [admins_pill];
     const widget = {
-        appendValidatedData(group) {
+        appendValidatedData: (group) => {
             assert.deepEqual(group, testers_pill);
             items.push(testers_pill);
         },
-        clear_text() {},
+        clear_text: () => {},
     };
 
     const group = {

--- a/web/tests/user_pill.test.js
+++ b/web/tests/user_pill.test.js
@@ -57,7 +57,7 @@ const inaccessible_user_item = {
 
 let pill_widget = {};
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         people.init();
         people.add_active_user(alice);
@@ -65,13 +65,13 @@ function test(label, f) {
         pill_widget = {};
         f({override});
     });
-}
+};
 
 test("create_item", () => {
-    function test_create_item(email, current_items, expected_item, pill_config) {
+    const test_create_item = (email, current_items, expected_item, pill_config) => {
         const item = user_pill.create_item_from_email(email, current_items, pill_config);
         assert.deepEqual(item, expected_item);
-    }
+    };
 
     realm.realm_is_zephyr_mirror_realm = true;
 
@@ -105,17 +105,17 @@ test("append", () => {
     let appended;
     let cleared;
 
-    function fake_append(opts) {
+    const fake_append = (opts) => {
         appended = true;
         assert.equal(opts.email, isaac.email);
         assert.equal(opts.display_value, isaac.full_name);
         assert.equal(opts.user_id, isaac.user_id);
         assert.equal(opts.img_src, isaac_item.img_src);
-    }
+    };
 
-    function fake_clear() {
+    const fake_clear = () => {
         cleared = true;
-    }
+    };
 
     pill_widget.appendValidatedData = fake_append;
     pill_widget.clear_text = fake_clear;

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -10,22 +10,22 @@ const {realm} = require("./lib/zpage_params");
 const fake_buddy_list = {
     scroll_container_selector: "#whatever",
     $users_matching_view_container: {
-        attr() {},
+        attr: () => {},
     },
     $other_users_container: {
-        attr() {},
+        attr: () => {},
     },
-    find_li() {},
-    first_key() {},
-    prev_key() {},
-    next_key() {},
+    find_li: () => {},
+    first_key: () => {},
+    prev_key: () => {},
+    next_key: () => {},
 };
 
 mock_esm("../src/buddy_list", {
     buddy_list: fake_buddy_list,
 });
 
-function mock_setTimeout() {
+const mock_setTimeout = () => {
     let set_timeout_function_called = false;
     set_global("setTimeout", (func) => {
         if (set_timeout_function_called) {
@@ -35,7 +35,7 @@ function mock_setTimeout() {
         set_timeout_function_called = true;
         func();
     });
-}
+};
 
 const popovers = mock_esm("../src/popovers");
 const presence = mock_esm("../src/presence");
@@ -72,7 +72,7 @@ const jill = {
 const all_user_ids = [alice.user_id, fred.user_id, jill.user_id, me.user_id];
 const ordered_user_ids = [me.user_id, alice.user_id, fred.user_id, jill.user_id];
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, (opts) => {
         people.init();
         people.add_active_user(alice);
@@ -84,17 +84,17 @@ function test(label, f) {
         activity_ui.set_cursor_and_filter();
         f(opts);
     });
-}
+};
 
-function set_input_val(val) {
+const set_input_val = (val) => {
     $("input.user-list-filter").val(val);
     $("input.user-list-filter").trigger("input");
-}
+};
 
-function stub_buddy_list_empty_list_message_lengths() {
+const stub_buddy_list_empty_list_message_lengths = () => {
     $("#buddy-list-users-matching-view .empty-list-message").length = 0;
     $("#buddy-list-other-users .empty-list-message").length = 0;
-}
+};
 
 test("clear_search", ({override}) => {
     override(presence, "get_status", () => "active");
@@ -182,7 +182,7 @@ test("filter_user_ids", ({override}) => {
     override(presence, "get_status", (user_id) => user_presence[user_id]);
     override(presence, "get_user_ids", () => all_user_ids);
 
-    function test_filter(search_text, expected_users) {
+    const test_filter = (search_text, expected_users) => {
         const expected_user_ids = expected_users.map((user) => user.user_id);
         $("input.user-list-filter").val(search_text);
         const filter_text = activity_ui.get_filter_text();
@@ -196,7 +196,7 @@ test("filter_user_ids", ({override}) => {
         });
 
         activity_ui.build_user_sidebar();
-    }
+    };
 
     // Sanity check data setup.
     assert.deepEqual(buddy_data.get_filtered_and_sorted_user_ids(), [

--- a/web/tests/user_status.test.js
+++ b/web/tests/user_status.test.js
@@ -33,7 +33,7 @@ const emoji_params = {
 
 emoji.initialize(emoji_params);
 
-function initialize() {
+const initialize = () => {
     const params = {
         user_status: {
             1: {status_text: "in a meeting"},
@@ -46,7 +46,7 @@ function initialize() {
         },
     };
     user_status.initialize(params);
-}
+};
 
 run_test("basics", () => {
     initialize();
@@ -143,7 +143,7 @@ run_test("server", () => {
 
     user_status.server_update_status({
         status_text: "out to lunch",
-        success() {
+        success: () => {
             called = true;
         },
     });

--- a/web/tests/user_topics.test.js
+++ b/web/tests/user_topics.test.js
@@ -41,12 +41,12 @@ stream_data.add_sub(devel);
 stream_data.add_sub(office);
 stream_data.add_sub(social);
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         user_topics.set_user_topics([]);
         f({override});
     });
-}
+};
 
 test("edge_cases", () => {
     // direct messages

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -17,9 +17,7 @@ run_test("CachedValue", () => {
     let x = 5;
 
     const cv = new util.CachedValue({
-        compute_value() {
-            return x * 2;
-        },
+        compute_value: () => x * 2,
     });
 
     assert.equal(cv.get(), 10);
@@ -38,9 +36,7 @@ run_test("extract_pm_recipients", () => {
 run_test("lower_bound", () => {
     const arr = [{x: 10}, {x: 20}, {x: 30}, {x: 40}, {x: 50}];
 
-    function compare(a, b) {
-        return a.x < b;
-    }
+    const compare = (a, b) => a.x < b;
 
     assert.equal(util.lower_bound(arr, 5, compare), 0);
     assert.equal(util.lower_bound(arr, 10, compare), 0);

--- a/web/tests/vdom.test.js
+++ b/web/tests/vdom.test.js
@@ -67,22 +67,20 @@ run_test("attribute updates", () => {
     let updated;
     let removed;
 
-    function find() {
-        return {
-            children: () => [],
+    const find = () => ({
+        children: () => [],
 
-            attr(k, v) {
-                assert.equal(k, "color");
-                assert.equal(v, "red");
-                updated = true;
-            },
+        attr: (k, v) => {
+            assert.equal(k, "color");
+            assert.equal(v, "red");
+            updated = true;
+        },
 
-            removeAttr(k) {
-                assert.equal(k, "id");
-                removed = true;
-            },
-        };
-    }
+        removeAttr: (k) => {
+            assert.equal(k, "id");
+            removed = true;
+        },
+    });
 
     const new_opts = {
         keyed_nodes: [],
@@ -101,7 +99,7 @@ run_test("attribute updates", () => {
     assert.ok(removed);
 });
 
-function make_child(i, name) {
+const make_child = (i, name) => {
     const render = () => "<li>" + name + "</li>";
 
     const eq = (other) => name === other.name;
@@ -112,18 +110,16 @@ function make_child(i, name) {
         name,
         eq,
     };
-}
+};
 
-function make_children(lst) {
-    return lst.map((i) => make_child(i, "foo" + i));
-}
+const make_children = (lst) => lst.map((i) => make_child(i, "foo" + i));
 
 run_test("children", () => {
     let rendered_html;
 
-    function replace_content(html) {
+    const replace_content = (html) => {
         rendered_html = html;
-    }
+    };
 
     const find = undefined;
 
@@ -184,10 +180,10 @@ run_test("partial updates", () => {
 
     find = () => ({
         children: () => ({
-            eq(i) {
+            eq: (i) => {
                 assert.equal(i, 0);
                 return {
-                    replaceWith($element) {
+                    replaceWith: ($element) => {
                         $patched = $element;
                     },
                 };

--- a/web/tests/watchdog.test.js
+++ b/web/tests/watchdog.test.js
@@ -12,10 +12,10 @@ let time = 0;
 let checker;
 MockDate.set(time);
 
-function advance_secs(secs) {
+const advance_secs = (secs) => {
     time += secs * 1000;
     MockDate.set(time);
-}
+};
 
 set_global("setInterval", (f, interval) => {
     checker = f;
@@ -32,9 +32,9 @@ run_test("basics", () => {
 
     let num_times_called_back = 0;
 
-    function callback() {
+    const callback = () => {
         num_times_called_back += 1;
-    }
+    };
 
     watchdog.on_unsuspend(callback);
 

--- a/web/tests/widgetize.test.js
+++ b/web/tests/widgetize.test.js
@@ -41,7 +41,7 @@ let is_event_handled;
 let is_widget_activated;
 
 const fake_poll_widget = {
-    activate(data) {
+    activate: (data) => {
         is_widget_activated = true;
         $widget_elem = data.$elem;
         assert.ok($widget_elem.hasClass("widget-content"));
@@ -64,7 +64,7 @@ const widgets = zrequire("widgets");
 
 widgets.initialize();
 
-function test(label, f) {
+const test = (label, f) => {
     run_test(label, ({override}) => {
         events = [...sample_events];
         $widget_elem = undefined;
@@ -74,7 +74,7 @@ function test(label, f) {
         widgetize.clear_for_testing();
         f({override});
     });
-}
+};
 
 test("activate", ({override}) => {
     // Both widgetize.activate and widgetize.handle_event are tested
@@ -91,7 +91,7 @@ test("activate", ({override}) => {
         message: {
             id: 2001,
         },
-        post_to_server(data) {
+        post_to_server: (data) => {
             assert.equal(data.msg_type, "widget");
             assert.equal(data.data, "test_data");
         },

--- a/web/tests/zblueslip.test.js
+++ b/web/tests/zblueslip.test.js
@@ -31,9 +31,9 @@ look at `people_errors.test.js` for actual usage of this module.
 
 run_test("basics", () => {
     // Let's create a sample piece of code to test:
-    function throw_an_error() {
+    const throw_an_error = () => {
         blueslip.error("world");
-    }
+    };
 
     // Since the error 'world' is not being expected, blueslip will
     // throw an error.
@@ -66,9 +66,9 @@ run_test("basics", () => {
     // warnings shouldn't stop the code execution, and thus, the
     // behaviour is slightly different.
 
-    function throw_a_warning() {
+    const throw_a_warning = () => {
         blueslip.warn("world");
-    }
+    };
 
     assert.throws(throw_a_warning);
     // Again, we do not expect this particular warning so blueslip.reset should complain.

--- a/web/tests/zjquery.test.js
+++ b/web/tests/zjquery.test.js
@@ -32,9 +32,9 @@ The code we are testing lives here:
 run_test("basics", () => {
     // Let's create a sample piece of code to test:
 
-    function show_my_form() {
+    const show_my_form = () => {
         $("#my-form").show();
-    }
+    };
 
     // Before we call show_my_form, we can assert that my-form is hidden:
     assert.ok(!$("#my-form").visible());
@@ -71,9 +71,9 @@ run_test("basics", () => {
 
 run_test("finding_related_objects", () => {
     // Let's say you have a function like the following:
-    function update_message_emoji(emoji_src) {
+    const update_message_emoji = (emoji_src) => {
         $("#my-message").find(".emoji").attr("src", emoji_src);
-    }
+    };
 
     // This would explode:
     // update_message_emoji('foo.png');
@@ -116,7 +116,7 @@ run_test("clicks", () => {
 
     const state = {};
 
-    function set_up_click_handlers() {
+    const set_up_click_handlers = () => {
         $("#widget1").on("click", () => {
             state.clicked = true;
         });
@@ -124,7 +124,7 @@ run_test("clicks", () => {
         $(".some-class").on("keydown", () => {
             state.keydown = true;
         });
-    }
+    };
 
     // Setting up the click handlers doesn't change state right away.
     set_up_click_handlers();
@@ -147,7 +147,7 @@ run_test("events", () => {
 
     let value;
 
-    function initialize_handler() {
+    const initialize_handler = () => {
         $("#my-parent").on("click", ".button-red", (e) => {
             value = "red"; // just a dummy side effect
             e.stopPropagation();
@@ -157,7 +157,7 @@ run_test("events", () => {
             value = "blue";
             e.stopPropagation();
         });
-    }
+    };
 
     // Calling initialize_handler() doesn't immediately do much of interest.
     initialize_handler();
@@ -169,7 +169,7 @@ run_test("events", () => {
 
     // Set up a stub event so that stopPropagation doesn't explode on us.
     const stub_event = {
-        stopPropagation() {},
+        stopPropagation: () => {},
     };
 
     // Now call the handler.

--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -9,7 +9,7 @@
   that the documented examples are all correct, runnable code.
 */
 
-const examples_handler = function () {
+const examples_handler = () => {
     const config = {
         username: process.env.ZULIP_USERNAME,
         apiKey: process.env.ZULIP_API_KEY,
@@ -32,7 +32,7 @@ const examples_handler = function () {
     const generate_validation_data = async (client, example) => {
         let count = 0;
         const console = {
-            log(result) {
+            log: (result) => {
                 response_data.push(make_result_object(example, result, count));
                 count += 1;
             },


### PR DESCRIPTION
As proposed in https://github.com/zulip/zulip/pull/30355#issuecomment-2155365926. A couple of problems would need to be solved if we want to pursue this:

- 369 `no-use-before-define` errors, because we currently exclude `function` from our `no-use-before-define` configuration (in JavaScript, `function` is [hoisted](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#function_hoisting) and `const` is not). See also #24865.
- Merge conflicts with, like, everything.
- Deleted comments: JamieMason/eslint-plugin-prefer-arrow-functions#24.