### PR TITLE
stripe: Use comma for collection method Literal values.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -914,7 +914,7 @@ class BillingSession(ABC):
             )
 
         if charge_automatically:
-            collection_method: Literal["charge_automatically" | "send_invoice"] = (
+            collection_method: Literal["charge_automatically", "send_invoice"] = (
                 "charge_automatically"
             )
         else:
@@ -3131,7 +3131,7 @@ class BillingSession(ABC):
                     )
 
                 if plan.charge_automatically:
-                    collection_method: Literal["charge_automatically" | "send_invoice"] = (
+                    collection_method: Literal["charge_automatically", "send_invoice"] = (
                         "charge_automatically"
                     )
                     days_until_due = None


### PR DESCRIPTION
Updates type annotation for stripe collection method:

```python
Literal["charge_automatically", "send_invoice"]
```

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
