### PR TITLE
[Fix: #30322] Update populate_db.py

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -334,8 +334,7 @@ class Command(ZulipBaseCommand):
                 string_id="zulip",
                 name="Zulip Dev",
                 emails_restricted_to_domains=False,
-                description="The Zulip development environment default organization."
-                "  It's great for testing!",
+                description="Welcome to Zulip",
                 invite_required=False,
                 plan_type=Realm.PLAN_TYPE_SELF_HOSTED,
                 org_type=Realm.ORG_TYPES["business"]["id"],


### PR DESCRIPTION
updated description to "Welcome to Zulip" by removing the organization description in the right sidebar



**Issue**: Remove the organization description from the right sidebar for logged-out users

**Initial description:** The Zulip development environment default organization." It's great for testing!

old code snippet:
![image](https://github.com/zulip/zulip/assets/135353498/b1915004-e01c-4d31-9d51-454f19bf70a3)

**Changed description:** 'Welcome to Zulip'

new code snippet:
![image](https://github.com/zulip/zulip/assets/135353498/d578f796-923c-4872-bf0e-1303718b3975)

No other description was found in the codebase related to this issue







