### PR TITLE
compose: Prepare compose box for adjustable info density.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -127,9 +127,9 @@
     /*
     Compose-recipient box minimum height. Used in a flexbox context to
     allow elements like DM pills to stack without breaking out of their
-    flex item.
+    flex item. 2.1786em is 30.5px at 14px/1em.
     */
-    --compose-recipient-box-min-height: 30.5px;
+    --compose-recipient-box-min-height: 2.1786em;
 
     /*
     Width to be reserved for document scrollbar when scrolling is disabled.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -173,15 +173,16 @@
     Line height of the message buttons in compose box. Here it's necessary
     to control this value uniformly and precisely to avoid issues with
     layout shifts originating with non-Latin characters in this area.
+    1.429em is 20px at 14px em.
     */
-    --line-height-compose-buttons: 20px;
+    --line-height-compose-buttons: 1.429em;
 
     /*
     Maximum height of the subscribers list in stream settings so that
     it doesn't cause the container to have a second scrollbar.
     This value will be overridden when stream settings is opened.
     */
-    --stream-subscriber-list-max-height: 100%;
+    --stream-subscriber-list-max-height: 1.429em;
 
     /*
       Reusable dimensions and offsets.

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -414,8 +414,11 @@
     border: 1px solid;
     display: flex;
     align-items: center;
-    font-size: 15px;
-    line-height: 18px;
+    /* Banners should carry at least a minimum
+       legacy font-size of 15px, and a line-height
+       of 18px. 1.2em is 18px at 15px/1em. */
+    font-size: max(15px, var(--base-font-size-px));
+    line-height: max(18px, 1.2em);
 
     .main-view-banner-elements-wrapper {
         display: flex;
@@ -461,8 +464,8 @@
         margin-bottom: 4.5px;
         /* Buttons take a minimum height for
            when their text fits on a single
-           line. */
-        min-height: 32px;
+           line. 2.1333em is 32px at 15px/1em. */
+        min-height: 2.1333em;
         /* When we're larger than large mobile
            scales ($ml_min), flex the button to
            its max-content, i.e., all its text
@@ -512,8 +515,9 @@
         margin-bottom: 8px;
         /* Make as tall as two lines of banner message
            text, which have a line-height of 18px, but
-           no more. */
-        max-height: 36px;
+           no more. 2.4em is two 1.2em lines in the
+           banner area. */
+        max-height: 2.4em;
         /* Keep to the top of the box, but stretch
            taller based on how the box is flexing. */
         min-height: 0;
@@ -521,8 +525,10 @@
     }
 
     .main-view-banner-close-button {
-        font-size: 16px;
         text-decoration: none;
+        /* Set same top and bottom margin
+           as action buttons. */
+        margin: 8px 0;
         padding: 0 8px;
         /* Let the close button's box stretch,
            but no larger than the height of the
@@ -531,13 +537,22 @@
            padding, and height), which keeps
            the X vertically centered with it. */
         align-self: stretch;
-        max-height: 52px;
+        /* 2.4em is two 1.2em lines in the
+           banner area. */
+        max-height: 2.4em;
         /* Display as flexbox to better control
            the X icon's position. This creates
            an anonymous flexbox item out of the
            ::before content where the icon sits. */
         display: flex;
         align-items: center;
+
+        /* Set the font-size for the close button
+           on the ::before element, so that it doesn't
+           impact the em units above. */
+        &::before {
+            font-size: 16px;
+        }
     }
 
     .banner_content + .main-view-banner-close-button {
@@ -545,8 +560,9 @@
            height for the typical height of the box
            when it contains only banner message text.
            This will keep the action button aligned
-           with the first or only line of text. */
-        max-height: 34px;
+           with the first or only line of text.
+           2.2667 is 34px at 15px/1em; */
+        max-height: 2.2667em;
     }
 
     &.success {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -3,21 +3,32 @@
     display: flex;
     column-gap: 4px;
     flex-direction: row;
-    align-items: center;
+    /* With precisely controlled line-heights
+       in this area, stretch will both center
+       and maintain uniform heights between the
+       reply button and the new-message button. */
+    align-items: stretch;
 
     .new_message_button {
         .button.small {
-            font-size: 1em;
+            /* Keep the new message button sized to match
+               adjacent buttons. */
+            font-size: inherit;
+            line-height: var(--line-height-compose-buttons);
             padding: 3px 10px;
-            vertical-align: middle;
         }
 
         .compose_mobile_button {
-            & span {
-                font-size: 1.2em !important;
-                font-weight: 400;
-                line-height: var(--line-height-compose-buttons);
-            }
+            /* This is ugly, but necessary to use the
+               text + for the compose button. An icon
+               would likely be a better choice here.
+               1.2em is 16.8px at 14px em. */
+            font-size: 1.2em !important;
+            /* 1.2em is 16.8px at 14px em; this
+               maintains the 20px em-equivalent compose
+               line height, but at a 16.8px em. */
+            line-height: 1.19em !important;
+            font-weight: 400;
         }
     }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -761,7 +761,7 @@ textarea.new_message_textarea,
 
 #compose_recipient_box {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: stretch;
     flex: 1 1 0;
     border-radius: 3px;


### PR DESCRIPTION
This PR corrects for a number of issues that impact the compose box under user-selectable information density:

1. It sizes the collapsed compose buttons relatively for uniform sizing.
2. It converts to em units a critical height/min-height value in the recipient row.
3. It expresses compose-banner dimensions and layout relative to the base font-size in use.

Additionally, there is a small fix to prevent grid blowouts on the recipient box that was causing problems on screens narrower than ~400px.

Fixes all known info-density compose issues that aren't pill-related from #30359.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Small recipient box, before | Small recipient box, after |
| --- | --- |
| ![small-recipient-box-before](https://github.com/zulip/zulip/assets/170719/545bfc6c-2151-41d6-bddc-a31b3f650294) | ![small-recipient-box-after](https://github.com/zulip/zulip/assets/170719/154319c0-5862-4937-939c-55f9ec8156a7) |

| Banners, pills before | Banners, pills after (no change) | After, 16/140 |
| --- | --- | --- |
| ![small-dm-pills-before](https://github.com/zulip/zulip/assets/170719/8a79d1f8-9cf8-4e3d-9cc7-7ab9507c143a) | ![small-dm-pills-after](https://github.com/zulip/zulip/assets/170719/6209e665-0d09-4ef1-bedf-33a34c62e13f) | ![small-dm-pills-after-16-140](https://github.com/zulip/zulip/assets/170719/bc4a8c75-bd65-4f8e-bb4e-57848589f372) |
| ![compose-plus-banner-before](https://github.com/zulip/zulip/assets/170719/c4236f87-daa7-45ac-ad06-87de4f6ee5ab) | ![compose-plus-banner-after](https://github.com/zulip/zulip/assets/170719/3cbe585a-c1ba-4583-afb9-e51d20c23770) | ![compose-plus-banner-after-16-140](https://github.com/zulip/zulip/assets/170719/540d1630-4805-4ca9-87ac-461814d74c82) |

| Collapsed states, before | Collapsed states, after (subtle improvements in matching button heights) | After, 16/140 |
| --- | --- | --- |
| ![collapsed-compose-before](https://github.com/zulip/zulip/assets/170719/1532621f-44f5-4d23-a79f-67f6288f844b) | ![collapsed-compose-after](https://github.com/zulip/zulip/assets/170719/90254992-cb5d-48c6-86af-9a5f5ca75e81) | ![collapsed-compose-after-16-140](https://github.com/zulip/zulip/assets/170719/9c873621-5409-4207-b3d3-f809ee6fad52) |
| ![collapsed-dm-before](https://github.com/zulip/zulip/assets/170719/a36995a3-e149-41b1-a91c-8b78ccbb82a9) | ![collapsed-dm-after](https://github.com/zulip/zulip/assets/170719/dfc403c9-4b5b-4112-9d81-83564ff5934d) | ![collapsed-dm-after-16-140](https://github.com/zulip/zulip/assets/170719/56eaf381-2895-46fb-b762-bf6cb191c06c) |
| ![collapsed-narrow-comopse-before](https://github.com/zulip/zulip/assets/170719/ecd7e102-00ad-41dd-bc27-83121edef788) | ![collapsed-narrow-compose-after](https://github.com/zulip/zulip/assets/170719/565111c5-8150-4987-b5a3-a8193b2b75c9) | ![collapsed-narrow-compose-after-16-140](https://github.com/zulip/zulip/assets/170719/2f82de0b-b690-4d4d-8f24-e21b8b64da54) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>