### PR TITLE
settings_modal: Present sidebar as gridded rows.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1303,7 +1303,15 @@ $option_title_width: 180px;
         }
 
         & li {
-            padding: 5px 0;
+            display: grid;
+            /* 3.5714em is 50px at 14px/1em -- the legacy height of these rows. */
+            grid-template:
+                "starting-anchor-element row-content ending-anchor-element" 3.5714em / 40px minmax(
+                    0,
+                    1fr
+                )
+                minmax(34px, auto);
+            align-items: center;
             outline: none;
             cursor: pointer;
             transition:
@@ -1320,50 +1328,33 @@ $option_title_width: 180px;
                 border-bottom: 1px solid transparent;
             }
 
-            .text,
-            .icon,
-            .locked {
-                display: inline-block;
-                vertical-align: top;
+            .icon {
+                font-size: 1.4em;
+                text-align: center;
+                color: hsl(0deg 0% 53%);
             }
 
             .text {
-                width: calc(100% - 90px);
-                padding: 10px 12px 10px 0;
-            }
-
-            .icon {
-                width: 18px;
-                height: 18px;
-                margin: 10px;
-                text-align: center;
-
-                font-size: 1.4em;
-                color: hsl(0deg 0% 53%);
-
-                background-size: cover;
-                background-repeat: no-repeat;
+                /* Hyphenate for internationalization */
+                hyphens: auto;
             }
 
             .zulip-icon-smart-toy {
                 font-size: 1.6em;
-                margin: 8px 11px 10px 9px;
             }
 
             .locked {
-                width: 18px;
-                height: 18px;
-                margin: 14px 8px 6px;
-
                 font-size: 1em;
+                text-align: center;
                 color: hsl(0deg 0% 62%);
-
-                background-size: cover;
-                background-repeat: no-repeat;
             }
         }
 
         .org-settings-list {
+            display: none;
+        }
+
+        .hide-org-settings {
             display: none;
         }
 
@@ -1658,10 +1649,6 @@ $option_title_width: 180px;
     position: relative;
     margin-top: 13px;
     display: inline-block;
-}
-
-.hide-org-settings {
-    display: none;
 }
 
 .collapse-settings-btn {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1306,7 +1306,9 @@ $option_title_width: 180px;
             padding: 5px 0;
             outline: none;
             cursor: pointer;
-            transition: all 0.2s ease;
+            transition:
+                background-color 0.2s ease,
+                border-bottom 0.2s ease;
             border-bottom: 1px solid hsl(0deg 0% 93%);
 
             &:last-of-type .text {


### PR DESCRIPTION
This PR replaces the old inline-block style layout of the settings modal sidebar with a gridded enhancement. This improves overall alignment in the area at legacy information density, and provides a more robust presentation of the sidebar for 16/140. It comes with numerous small improvements to horizontal and vertical alignment, including aligning the Tippy arrow with the lock icon (though a lingering likely z-index issue does clip the righthand side of that Tippy; that is not addressed in this PR).

One potentially controversial enhancement in this design is to hyphenate the sidebar entries for languages, such as German, that have long single-word names for certain settings. Multiword languages are allowed to open onto a second line, so it's arguably a better choice to hyphenate here, rather than force an ellipsis (which would hide important information even in multi-word languages).

CZO discussion on hyphenation

This fixes a part of #30359.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before | Legacy, after |
| --- | --- |
| ![org-settings-before](https://github.com/zulip/zulip/assets/170719/c341a16c-fc51-4086-9428-6255552cb2e8) | ![org-settings-after](https://github.com/zulip/zulip/assets/170719/6f565cc0-0d31-41ca-9992-4b259101707a) |
| ![org-settings-expanded-before](https://github.com/zulip/zulip/assets/170719/6b7bf81c-6e1e-4610-9db4-7b2278a5f24e) | ![org-settings-expanded-after](https://github.com/zulip/zulip/assets/170719/8472987b-31fa-448a-ab8d-ed70cf46f4fe) |
| ![personal-settings-before](https://github.com/zulip/zulip/assets/170719/23a7831d-0029-4184-9c7d-e60dea204c7e) | ![personal-settings-after](https://github.com/zulip/zulip/assets/170719/0cc5abf9-6808-4fb3-81c0-082358712b66) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![org-settings-before-16-140](https://github.com/zulip/zulip/assets/170719/c0d1ac34-9958-461e-b157-ed10ec6cb367) | ![org-settings-after-16-140](https://github.com/zulip/zulip/assets/170719/60c20f86-8902-42f3-bae5-b1c89ef8ddce) |
| ![org-settings-expanded-before-16-140](https://github.com/zulip/zulip/assets/170719/bb353b02-37aa-4a36-8bb5-c0a82582da3b) | ![org-settings-expanded-after-16-140](https://github.com/zulip/zulip/assets/170719/261c56e7-b5d6-4099-a280-448291df5b29) |
| ![personal-settings-before-16-140](https://github.com/zulip/zulip/assets/170719/8e09f3de-184f-4161-aaea-9c6c5b0e66d3) | ![personal-settings-after-16-140](https://github.com/zulip/zulip/assets/170719/f5148b54-059d-473d-9c5a-db63c0035b66) |

| 16/140 i18n, before | 16/140 i18n, after (note hyphens) |
| --- | --- |
| ![internationalization-16-140-before](https://github.com/zulip/zulip/assets/170719/7481c4ad-b4ec-4f46-990f-69602b248cf2) | ![internationalization-16-140-after](https://github.com/zulip/zulip/assets/170719/c38415c0-b158-4a2a-9f84-a70ae31bc99a) |

| Tippy arrow, before | Tippy arrow, after |
| --- | --- |
| ![lock-tippy-align-before](https://github.com/zulip/zulip/assets/170719/90e39674-f9b4-467f-b34d-8348babc7bd7) | ![lock-tippy-align-after](https://github.com/zulip/zulip/assets/170719/27f2fb1e-6d5d-43e0-a190-2a7ae39018c4) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


