### PR TITLE
user_profile: Fix live-update exception when viewing channels tab.

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -102,6 +102,10 @@ export function update_profile_modal_ui(user, new_data) {
     if (!(modals.any_active() && modals.active_modal() === "#user-profile-modal")) {
         return;
     }
+    if (original_values?.user_id === undefined) {
+        // This occurs if say, the "channel" tab is open.
+        return;
+    }
     const current_user_id = Number.parseInt(original_values.user_id, 10);
     if (current_user_id !== user.user_id) {
         return;


### PR DESCRIPTION
Sentry reporting discovered that if the user was viewing the channels tab for a bot when the bot's owner was changed (or various other live-updates), we'd throw an exception trying to access the original_values object for the manage-user/bot tab.

This code is fragile and messy, but probably a framework change is the most expedient path to fixing it.
