### PR TITLE
navbar: Tweak Combined feed description for spectators.

### DIFF
--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -70,11 +70,19 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     // TODO: This ideally doesn't need a special case, we can just use
     // `filter.get_description` for it.
     if (filter === undefined || filter.is_in_home()) {
+        let description;
+        if (page_params.is_spectator) {
+            description = $t({
+                defaultMessage: "All your messages.",
+            });
+        } else {
+            description = $t({
+                defaultMessage: "All your messages except those in muted channels and topics.",
+            });
+        }
         return {
             title: $t({defaultMessage: "Combined feed"}),
-            description: $t({
-                defaultMessage: "All your messages except those in muted channels and topics.",
-            }),
+            description,
             zulip_icon: "all-messages",
             link: "/help/combined-feed",
         };


### PR DESCRIPTION
Since spectators cannot mute channels or topics, the combined feed description for spectators is tweaked to exclude that part.

Fixes #30321

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Screenshots</summary>

![image](https://github.com/zulip/zulip/assets/88523649/45ca3b0e-4244-48d5-baf9-2af5940657ec)


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
