### PR TITLE
Update README.md Issue#30214

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Come find us on the [development community chat](https://zulip.com/development-c
 - **Checking Zulip out**. The best way to see Zulip in action is to drop by the
   [Zulip community server](https://zulip.com/development-community/). We also
   recommend reading about Zulip's [unique
-  approach](https://zulip.com/why-zulip/) to organizing conversations.
+  approach](https://zulip.com/why-zulip/) to organizing conversations. We also
+  have a 1 minute long preview showcasing Zulip's interface and main features [here](https://www.kapwing.com/videos/66690b888a157e0fa0f9cfbd)
 
 - **Running a Zulip server**. Self-host Zulip directly on Ubuntu or Debian
   Linux, in [Docker](https://github.com/zulip/docker-zulip), or with prebuilt


### PR DESCRIPTION
I noticed that a ~1 min long video and/or a GIF of the site interface showing all the main features would be a great addition. It would give visitors a chance to see the front end and backend functionalities without having to go to the website itself. I had created an issue for this, but I was not able to get the help wanted label on my issue to help me create a pull request directly. I have changed the idea of creating a new tab to just pasting a video link under the "Checking Zulip Out" heading on the README. This seems relevant to the heading and a perfect place to put it.

Fixes: https://github.com/zulip/zulip/issues/30214

Link to Video Here: https://www.kapwing.com/videos/66690b888a157e0fa0f9cfbd
