### PR TITLE
help: Fix left sidebar not bouncing on mac.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -132,9 +132,10 @@ html {
         z-index: 1;
         /* 100vh - navbar - paddingTop - paddingBottom - bottomNav */
         height: calc(100vh - 59px);
+        top: 59px;
 
         border-right: 1px solid hsl(219deg 10% 97%);
-        position: fixed;
+        position: sticky;
 
         background-color: hsl(153deg 32% 55%);
         color: hsl(0deg 0% 100%);
@@ -261,7 +262,6 @@ html {
     background-color: hsl(0deg 0% 100%);
     width: calc(100vw - 300px);
     height: calc(100% - 59px);
-    margin-left: 300px;
 
     & :target {
         scroll-margin-top: 59px;


### PR DESCRIPTION
Since left sidebar was in fixed position, mac's rubber-band scroll effect was not working on it while it was working for others making the bounce look weird.

Fixed by letting it bounce with the rest of the elements on the page.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/grey.20stripe.20in.20the.20help.20center

Tested /help and /api pages.