### PR TITLE
api-docs: Clean up of changes and changelog formatting.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -35,7 +35,7 @@ format used by the Zulip server that they are interacting with.
   now contains the superset of the true value that best approximates the actual
   permission setting.
 
-**Feature level 263**:
+**Feature level 263**
 
 * [`POST /users/me/presence`](/api/update-presence):
   A new `last_update_id` parameter can be given, instructing
@@ -58,7 +58,7 @@ format used by the Zulip server that they are interacting with.
   querying [`/users/me/presence`](/api/update-presence) to avoid
   re-fetching of already known data.
 
-**Feature level 262**:
+**Feature level 262**
 
 * [`GET /users/{user_id}/status`](/api/get-user-status): Added a new
   endpoint to fetch an individual user's currently set
@@ -78,13 +78,13 @@ format used by the Zulip server that they are interacting with.
   have permission to [subscribe other users to
   channels](/help/configure-who-can-invite-to-channels).
 
-**Feature level 260**:
+**Feature level 260**
 
 * [`PATCH /user_groups/{user_group_id}`](/api/update-user-group):
   Updating `can_mention_group` now uses a race-resistant format where
   the client sends the expected `old` value and desired `new` value.
 
-**Feature level 259**:
+**Feature level 259**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
   For the `onboarding_steps` event type, an array of onboarding steps
@@ -94,7 +94,7 @@ format used by the Zulip server that they are interacting with.
   support, as we expect that only official Zulip clients will interact with
   this data. Currently, no client other than the Zulip web app uses this.
 
-**Feature level 258**:
+**Feature level 258**
 
 * [`GET /user_groups`](/api/get-user-groups), [`POST
   /register`](/api/register-queue): `can_mention_group` field can now
@@ -105,7 +105,7 @@ format used by the Zulip server that they are interacting with.
   `can_mention_group` parameter can now either be an ID of a named
   user group or an object describing a set of users and groups.
 
-**Feature level 257**:
+**Feature level 257**
 
 * [`POST /register`](/api/register-queue),
   [`POST /server_settings`](/api/get-server-settings), `PATCH /realm`:
@@ -479,7 +479,7 @@ No changes; feature level used for Zulip 8.0 release.
 * [`POST /mobile_push/test_notification`](/api/test-notify): Added new endpoint
   to send a test push notification to a mobile device or devices.
 
-**Feature level 216**:
+**Feature level 216**
 
 * `PATCH /realm`, [`POST register`](/api/register-queue),
   [`GET /events`](/api/get-events): Added `enable_guest_user_indicator`
@@ -863,7 +863,7 @@ No changes; feature level used for Zulip 7.0 release.
   determine the user's preference on whether to mark messages as read or not when
   scrolling through their message feed.
 
-**Feature level 174**:
+**Feature level 174**
 
 * [`POST /typing`](/api/set-typing-status), [`POST /messages`](/api/send-message):
   Added `"direct"` as the preferred way to indicate a direct message for the
@@ -872,7 +872,7 @@ No changes; feature level used for Zulip 7.0 release.
   the modern convention with servers that support it, because support for
   `"private"` may eventually be removed.
 
-**Feature level 173**:
+**Feature level 173**
 
 * [`GET /scheduled_messages`](/api/get-scheduled-messages), [`DELETE
   /scheduled_messages/<int:scheduled_message_id>`](/api/delete-scheduled-message):
@@ -890,7 +890,7 @@ No changes; feature level used for Zulip 7.0 release.
   this endpoint now returns an error response
   (`"code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"`).
 
-**Feature level 171**:
+**Feature level 171**
 
 * [`POST /fetch_api_key`](/api/fetch-api-key),
   [`POST /dev_fetch_api_key`](/api/dev-fetch-api-key): The return values
@@ -2222,7 +2222,7 @@ No changes; feature level used for Zulip 3.0 release.
 * Added new `presence_enabled` user notification setting; previously
   [presence](/help/status-and-availability) was always enabled.
 
-**Feature level 2**:
+**Feature level 2**
 
 * [`POST /messages/{message_id}/reactions`](/api/add-reaction):
   The `reaction_type` parameter is optional; the server will guess the
@@ -2233,7 +2233,7 @@ No changes; feature level used for Zulip 3.0 release.
   `user_id` field.  The legacy `user` dictionary (which had
   inconsistent format between those two endpoints) is deprecated.
 
-**Feature level 1**:
+**Feature level 1**
 
 * [`PATCH /messages/{message_id}`](/api/update-message): Added the
   `stream_id` parameter to support moving messages between streams.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -666,7 +666,7 @@ paths:
                                     **Changes**: Removed `email_address` field from the dictionary
                                     in Zulip 8.0 (feature level 226).
 
-                                    **Changes**: Removed `role` field from the dictionary
+                                    Removed `role` field from the dictionary
                                     in Zulip 6.0 (feature level 133).
                                   items:
                                     $ref: "#/components/schemas/Subscriptions"
@@ -1068,7 +1068,7 @@ paths:
                                 `can_access_all_users_group` policy would receive a fake "Unknown
                                 user" event for such a user.
 
-                                **Changes**: Starting with Zulip 8.0 (feature level 228),
+                                Starting with Zulip 8.0 (feature level 228),
                                 this event is also sent when a guest user gains access to
                                 a user.
                               properties:
@@ -1115,12 +1115,12 @@ paths:
                               description: |
                                 Event sent to guest users when they lose access to a user.
 
-                                **Changes**: Prior to Zulip 8.0 (feature level 228), this event was deprecated.
+                                **Changes**: As of Zulip 8.0 (feature level 228), this event is no
+                                longer deprecated.
 
-                                **Changes**: Deprecated and no longer sent since Zulip 8.0 (feature level 222).
-
-                                Previously, this event was sent to all users in a Zulip organization when a
-                                user was deactivated.
+                                In Zulip 8.0 (feature level 222), this event was deprecated and no
+                                longer sent to clients. Prior to this feature level, it was sent to all
+                                users in a Zulip organization when a user was deactivated.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2158,7 +2158,7 @@ paths:
                                     registering their event queue will not receive this legacy
                                     event type.
 
-                                    **Changes**: Before Zulip 3.0 (feature level 1), the `muted_topics`
+                                    Before Zulip 3.0 (feature level 1), the `muted_topics`
                                     array objects were 2-item tuples and did not include the timestamp
                                     information for when the topic was muted.
                                   items:
@@ -3183,7 +3183,7 @@ paths:
                                             **Changes**: Before Zulip 9.0 (feature level 258), the
                                             `can_mention_group` field was always an integer.
 
-                                            **Changes**: Before Zulip 8.0 (feature level 198),
+                                            Before Zulip 8.0 (feature level 198),
                                             the `can_mention_group` setting
                                             was named `can_mention_group_id`.
 
@@ -9464,7 +9464,7 @@ paths:
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
 
-                          **Changes**: Removed `role` field from the dictionary
+                          Removed `role` field from the dictionary
                           in Zulip 6.0 (feature level 133).
                         items:
                           $ref: "#/components/schemas/Subscriptions"
@@ -11679,7 +11679,7 @@ paths:
                             that are sent to clients. Prior to this feature level, updating either
                             property only generated a subscription update event for
                             `"in_home_view"`. <br>
-                            **Changes**: Prior to Zulip 2.1.0, this feature was represented
+                            Prior to Zulip 2.1.0, this feature was represented
                             by the more confusingly named `"in_home_view"` (with the
                             opposite value: `in_home_view=!is_muted`); for
                             backwards-compatibility, modern Zulip still accepts that property.
@@ -13048,7 +13048,9 @@ paths:
                       incomplete user database. If true, then the `realm_users` array in the `register`
                       response will not include data for inaccessible users and clients of guest users will
                       not receive `realm_user op:add` events for newly created users that are not accessible
-                      to the current user. **Changes**: New in Zulip 8.0 (feature level 232). This
+                      to the current user.
+                      <br />
+                      **Changes**: New in Zulip 8.0 (feature level 232). This
                       capability is for backwards-compatibility.
 
                     [help-linkifiers]: /help/add-a-custom-linkifier
@@ -13393,7 +13395,7 @@ paths:
                           response if the `user_topic` object, which generalizes and replaces
                           this field, is not explicitly requested via `fetch_event_types`.
 
-                          **Changes**: Before Zulip 3.0 (feature level 1), the `muted_topics`
+                          Before Zulip 3.0 (feature level 1), the `muted_topics`
                           array objects were 2-item tuples and did not include the timestamp
                           information for when the topic was muted.
                         items:
@@ -13701,7 +13703,7 @@ paths:
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
 
-                          **Changes**: Removed `role` field from the dictionary
+                          Removed `role` field from the dictionary
                           in Zulip 6.0 (feature level 133).
                       unsubscribed:
                         type: array
@@ -13720,7 +13722,7 @@ paths:
                           **Changes**: Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
 
-                          **Changes**: Removed `role` field from the dictionary
+                          Removed `role` field from the dictionary
                           in Zulip 6.0 (feature level 133).
                       never_subscribed:
                         type: array
@@ -15336,9 +15338,11 @@ paths:
                           All users will receive a warning/reminder when using
                           mentions in large channels, even when permitted to do so.
 
-                          **Changes**: New in Zulip 4.0 (feature level 33). Moderators option added in
-                          Zulip 4.0 (feature level 62). Channel administrators option removed in
-                          Zulip 6.0 (feature level 133).
+                          **Changes**: In Zulip 6.0 (feature level 133), channel administrators option removed.
+
+                          In Zulip 4.0 (feature level 62), moderators option added.
+
+                          New in Zulip 4.0 (feature level 33).
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -17389,23 +17393,23 @@ paths:
         the handling of any invalid parameters present in a request
         (see feature level 78 change below).
 
-        The `/settings/display` and `/settings/notifications`
-        endpoints are now deprecated aliases for this endpoint for
-        backwards-compatibility, and will be removed once clients have
-        migrated to use this endpoint.
+        As of feature level 80, the `PATCH /settings/display` and
+        `PATCH /settings/notifications` endpoints are deprecated aliases
+        for this endpoint for backwards-compatibility, and will be removed
+        once clients have migrated to use this endpoint.
 
-        **Changes**: Prior to Zulip 5.0 (feature level 78),
-        the `/settings` endpoint indicated which parameters it had
-        processed by including in the response object `"key": value`
-        entries for values successfully changed by the request. That
-        was replaced by the more ergonomic
+        Prior to Zulip 5.0 (feature level 78), this endpoint indicated
+        which parameters it had processed by including in the response
+        object `"key": value` entries for values successfully changed by
+        the request. That was replaced by the more ergonomic
         [`ignored_parameters_unsupported`][ignored-parameters] array.
 
-        The `/settings/notifications` and `/settings/display` endpoints
-        also had this behavior before they became aliases of `/settings`
-        in Zulip 5.0 (see feature level 80 change above).
+        The `PATCH /settings/notifications` and `PATCH /settings/display`
+        endpoints also had this behavior of indicating processed parameters
+        before they became aliases of this endpoint in Zulip 5.0 (see
+        feature level 80 change above).
 
-        Before these changes, request parameters that were not supported
+        Before feature level 78, request parameters that were not supported
         (or were unchanged) were silently ignored.
 
         [ignored-parameters]: /api/rest-error-handling#ignored-parameters
@@ -19011,7 +19015,7 @@ paths:
                         **Changes**: Before Zulip 9.0 (feature level 258), the
                         `can_mention_group` setting could only be set to an integer.
 
-                        **Changes**: Before Zulip 8.0 (feature level 198),
+                        Before Zulip 8.0 (feature level 198),
                         the `can_mention_group` setting was named `can_mention_group_id`.
 
                         New in Zulip 8.0 (feature level 191). Previously, groups
@@ -19165,10 +19169,10 @@ paths:
                     **Changes**: In Zulip 9.0 (feature level 260), this was updated
                     to only accept an object with `old` and `new` fields.
 
-                    **Changes**: Before Zulip 9.0 (feature level 258), the
+                    Before Zulip 9.0 (feature level 258), the
                     `can_mention_group` field was always an integer.
 
-                    **Changes**: Before Zulip 8.0 (feature level 198),
+                    Before Zulip 8.0 (feature level 198),
                     the `can_mention_group` setting was named `can_mention_group_id`.
 
                     New in Zulip 8.0 (feature level 191). Previously, groups
@@ -19323,7 +19327,7 @@ paths:
                                     **Changes**: Before Zulip 9.0 (feature level 258), the
                                     `can_mention_group` field was always an integer.
 
-                                    **Changes**: Before Zulip 8.0 (feature level 198),
+                                    Before Zulip 8.0 (feature level 198),
                                     the `can_mention_group` setting was named `can_mention_group_id`.
 
                                     New in Zulip 8.0 (feature level 191). Previously, groups
@@ -20506,7 +20510,7 @@ components:
                 **Changes**: Before Zulip 9.0 (feature level 258), the
                 `can_mention_group` field was always an integer.
 
-                **Changes**: Before Zulip 8.0 (feature level 198),
+                Before Zulip 8.0 (feature level 198),
                 the `can_mention_group` setting was named `can_mention_group_id`.
 
                 New in Zulip 8.0 (feature level 191). Previously, groups


### PR DESCRIPTION
Updates:
- In the API changelog, removes colons in the feature level lines for consistency. The majority of these lines end without a colon.
- For changes notes in the API docs, we want to have only the most recent change entry to start with `**Changes**:`. Older entries should follow as separate paragraphs.
- Changes notes that I've done more editing on than removing extra **Changes** on are shown in screenshots below.

**Screenshots and screen captures:**

<details>
<summary>realm_user op: remove event</summary>

[Current documentation](https://zulip.com/api/get-events#realm_user-remove)
![image](https://github.com/zulip/zulip/assets/63245456/27f2f080-7895-439f-a6ee-00ce01a037d2)
</details>
<details>
<summary>user_list_incomplete in client_capabilities parameter</summary>

[Current documentation](https://zulip.com/api/register-queue#parameter-client_capabilities)
![Screenshot from 2024-06-12 12-55-47](https://github.com/zulip/zulip/assets/63245456/c2408443-ffac-4bad-b2bb-298e5dfb1a50)
</details>
<details>
<summary>realm_wildcard_mention_policy on register response</summary>

[Current documentation](https://zulip.com/api/register-queue) - find on page "realm_wildcard_mention_policy"
![Screenshot from 2024-06-12 12-58-47](https://github.com/zulip/zulip/assets/63245456/ed56cf01-f815-44f1-b9d0-734039f7654a)
</details>
<details>
<summary>Update settings changes notes in main endpoint description</summary>

[Current documentation](https://zulip.com/api/update-settings)
![Screenshot from 2024-06-12 13-01-19](https://github.com/zulip/zulip/assets/63245456/d34cda4d-8b80-488d-ae18-a8ecafa013a9)
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
