### PR TITLE
api-docs: Clean up descriptions of can_mention_group user group setting.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3176,19 +3176,24 @@ paths:
                                       allOf:
                                         - $ref: "#/components/schemas/GroupSettingValue"
                                         - description: |
-                                            Either the ID of a named user group that has permission
-                                            to mention the group, or an object describing the set of
-                                            users and groups who have permission mention the group.
+                                            A [group-setting value][setting-values] defining the set of users who
+                                            have permission to [mention this user group][mentions]. Only present
+                                            if this user group permission setting changed.
 
-                                            **Changes**: Before Zulip 9.0 (feature level 258), the
-                                            `can_mention_group` field was always an integer.
+                                            **Changes**: Before Zulip 9.0 (feature level 258), this setting was
+                                            always the integer form of a [group-setting value][setting-values].
 
-                                            Before Zulip 8.0 (feature level 198),
-                                            the `can_mention_group` setting
-                                            was named `can_mention_group_id`.
+                                            Before Zulip 8.0 (feature level 198), this setting was named
+                                            `can_mention_group_id`.
 
-                                            New in Zulip 8.0 (feature level 191). Previously, groups
-                                            could be mentioned if and only if they were not system groups.
+                                            New in Zulip 8.0 (feature level 191). Previously, groups could be
+                                            mentioned only if they were not [system groups][system-groups].
+
+                                            Will be one of the following:
+
+                                            [setting-values]: /api/group-setting-values
+                                            [system-groups]: /api/group-setting-values#system-groups
+                                            [mentions]: /help/mention-a-user-or-group
                               example:
                                 {
                                   "type": "user_group",
@@ -19006,20 +19011,24 @@ paths:
                 can_mention_group:
                   allOf:
                     - description: |
-                        A [group-setting value](/api/group-setting-values) defining the set
-                        of users who have permission to mention the new group.
+                        A [group-setting value][setting-values] defining the set of users who
+                        have permission to [mention this user group][mentions].
 
-                        This setting cannot be set to `"role:internet"` and
-                        `"role:owners"` system groups.
+                        This setting cannot be set to `"role:internet"` and `"role:owners"`
+                        [system groups][system-groups].
 
-                        **Changes**: Before Zulip 9.0 (feature level 258), the
-                        `can_mention_group` setting could only be set to an integer.
+                        Before Zulip 9.0 (feature level 258), this parameter could only be the
+                        integer form of a [group-setting value][setting-values].
 
-                        Before Zulip 8.0 (feature level 198),
-                        the `can_mention_group` setting was named `can_mention_group_id`.
+                        Before Zulip 8.0 (feature level 198), this parameter was named
+                        `can_mention_group_id`.
 
-                        New in Zulip 8.0 (feature level 191). Previously, groups
-                        could be mentioned if and only if they were not system groups.
+                        New in Zulip 8.0 (feature level 191). Previously, groups could be
+                        mentioned only if they were not [system groups][system-groups].
+
+                        [setting-values]: /api/group-setting-values
+                        [system-groups]: /api/group-setting-values#system-groups
+                        [mentions]: /help/mention-a-user-or-group
                     - $ref: "#/components/schemas/GroupSettingValue"
                   example: 11
               required:
@@ -19159,24 +19168,30 @@ paths:
                   example: The marketing team.
                 can_mention_group:
                   description: |
-                    The set of users who have permission to mention
-                    this group, expressed as an [update to a
-                    group-setting value](/api/group-setting-values#updating-group-setting-values).
+                    The set of users who have permission to [mention this group][mentions],
+                    expressed as an [update to a group-setting value][update-group-setting].
 
                     This setting cannot be set to `"role:internet"` and `"role:owners"`
-                    system groups.
+                    [system groups][system-groups].
 
-                    **Changes**: In Zulip 9.0 (feature level 260), this was updated
-                    to only accept an object with `old` and `new` fields.
+                    **Changes**: In Zulip 9.0 (feature level 260), this parameter was
+                    updated to only accept an object with the `old` and `new` fields
+                    described below. Prior to this feature level, this parameter could be
+                    either of the two forms of a [group-setting value][setting-values].
 
-                    Before Zulip 9.0 (feature level 258), the
-                    `can_mention_group` field was always an integer.
+                    Before Zulip 9.0 (feature level 258), this parameter could only be the
+                    integer form of a [group-setting value][setting-values].
 
-                    Before Zulip 8.0 (feature level 198),
-                    the `can_mention_group` setting was named `can_mention_group_id`.
+                    Before Zulip 8.0 (feature level 198), this parameter was named
+                    `can_mention_group_id`.
 
-                    New in Zulip 8.0 (feature level 191). Previously, groups
-                    could be mentioned if and only if they were not system groups.
+                    New in Zulip 8.0 (feature level 191). Previously, groups could be
+                    mentioned only if they were not [system groups][system-groups].
+
+                    [mentions]: /help/mention-a-user-or-group
+                    [update-group-setting]: /api/group-setting-values#updating-group-setting-values
+                    [system-groups]: /api/group-setting-values#system-groups
+                    [setting-values]: /api/group-setting-values
                   type: object
                   additionalProperties: false
                   properties:
@@ -19321,17 +19336,23 @@ paths:
                               allOf:
                                 - $ref: "#/components/schemas/GroupSettingValue"
                                 - description: |
-                                    A [group-setting value](/api/group-setting-values) defining the set
-                                    of users who have permission to mention the new group.
+                                    A [group-setting value][setting-values] defining the set of users who
+                                    have permission to [mention this user group][mentions].
 
-                                    **Changes**: Before Zulip 9.0 (feature level 258), the
-                                    `can_mention_group` field was always an integer.
+                                    **Changes**: Before Zulip 9.0 (feature level 258), this setting was
+                                    always the integer form of a [group-setting value][setting-values].
 
-                                    Before Zulip 8.0 (feature level 198),
-                                    the `can_mention_group` setting was named `can_mention_group_id`.
+                                    Before Zulip 8.0 (feature level 198), this setting was named
+                                    `can_mention_group_id`.
 
-                                    New in Zulip 8.0 (feature level 191). Previously, groups
-                                    could be mentioned if and only if they were not system groups.
+                                    New in Zulip 8.0 (feature level 191). Previously, groups could be
+                                    mentioned only if they were not [system groups][system-groups].
+
+                                    Will be one of the following:
+
+                                    [setting-values]: /api/group-setting-values
+                                    [system-groups]: /api/group-setting-values#system-groups
+                                    [mentions]: /help/mention-a-user-or-group
                         description: |
                           A list of `user_group` objects.
                     example:
@@ -20504,17 +20525,23 @@ components:
           allOf:
             - $ref: "#/components/schemas/GroupSettingValue"
             - description: |
-                A [group-setting value](/api/group-setting-values) defining the set
-                of users who have permission to mention the new group.
+                A [group-setting value][setting-values] defining the set of users who
+                have permission to [mention this user group][mentions].
 
-                **Changes**: Before Zulip 9.0 (feature level 258), the
-                `can_mention_group` field was always an integer.
+                **Changes**: Before Zulip 9.0 (feature level 258), this setting was
+                always the integer form of a [group-setting value][setting-values].
 
-                Before Zulip 8.0 (feature level 198),
-                the `can_mention_group` setting was named `can_mention_group_id`.
+                Before Zulip 8.0 (feature level 198), this setting was named
+                `can_mention_group_id`.
 
-                New in Zulip 8.0 (feature level 191). Previously, groups
-                could be mentioned if and only if they were not system groups.
+                New in Zulip 8.0 (feature level 191). Previously, groups could be
+                mentioned only if they were not [system groups][system-groups].
+
+                Will be one of the following:
+
+                [setting-values]: /api/group-setting-values
+                [system-groups]: /api/group-setting-values#system-groups
+                [mentions]: /help/mention-a-user-or-group
     GroupSettingValue:
       oneOf:
         - type: object
@@ -20532,6 +20559,8 @@ components:
               type: array
               items:
                 type: integer
+          description: |
+            An object with these fields:
         - type: integer
           description: |
             The ID of the [user group](/help/user-groups) with this permission.


### PR DESCRIPTION
Updates the various descriptions for `can_mention_group` user group setting in the API docs to be a bit clearer and more concise.

Also, adds more links to the [group-setting values](https://zulip.com/api/group-setting-values) article and to the help center article on [mentioning a user or user group](https://zulip.com/help/mention-a-user-or-group).

@sahil839 - Pinging you for a review to make sure that the text for these is still accurate.
@Vector73 - Pinging you for a review as you've been looking at this descriptions as well. Note this doesn't fix the issue with the endpoint parameters not rendering the `GroupSettingValue` schema properly.

---

**Screenshots and screen captures:**

<details>
<summary>Get user groups return value</summary>

[Current documentation](https://zulip.com/api/get-user-groups#response)
![Screenshot from 2024-06-12 17-50-00](https://github.com/zulip/zulip/assets/63245456/6a23c17c-7588-48a7-a3eb-df6e5faff681)
</details>
<details>
<summary>Create user group parameter</summary>

[Current documentation](https://zulip.com/api/create-user-group#parameter-can_mention_group)
![Screenshot from 2024-06-12 17-50-22](https://github.com/zulip/zulip/assets/63245456/4957b83e-7d51-4582-a046-1526d4eaba4c)
</details>
<details>
<summary>Update user group parameter</summary>

[Current documentation](https://zulip.com/api/update-user-group#parameter-can_mention_group)
![Screenshot from 2024-06-12 17-50-41](https://github.com/zulip/zulip/assets/63245456/2c43b030-3246-456d-8532-d61d2c55a6ba)
</details>
<details>
<summary>Register response - realm_user_groups object</summary>

[Current documentation](https://zulip.com/api/register-queue) - search in page "can_mention_group"
![Screenshot from 2024-06-12 17-51-02](https://github.com/zulip/zulip/assets/63245456/d6e0ac8e-eb30-4967-9183-9a2a79c9dc60)
</details>
<details>
<summary>Events user_group op: update</summary>

[Current documentation](https://zulip.com/api/get-events#user_group-update)
![Screenshot from 2024-06-12 17-51-23](https://github.com/zulip/zulip/assets/63245456/a64c45c4-0780-4a41-8205-69768b2cf4d6)
</details>
<details>
<summary>Events user_group op: add</summary>

[Current documentation](https://zulip.com/api/get-events#user_group-add)
![Screenshot from 2024-06-12 17-51-54](https://github.com/zulip/zulip/assets/63245456/296450cc-92b9-4458-b5a2-bcd043966b39)
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
