### PR TITLE
help: Add page documenting the left sidebar.

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -97,6 +97,7 @@
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
 * [Combined feed](/help/combined-feed)
+* [Left sidebar](/help/left-sidebar)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -1,0 +1,36 @@
+# Left sidebar
+
+The left sidebar in the Zulip web and desktop apps helps you navigate your
+conversations. It has three main sections:
+
+- **Views** provide various ways to get an overview of your messages.
+- The **direct messages** section shows your [direct
+  message](/help/direct-messages) conversations.
+- The **channels** section shows the [channels](/help/introduction-to-channels)
+  you are subscribed to.
+
+You can adjust the left sidebar to focus on the information you need right now
+by:
+
+- Expanding or collapsing the **Views** section.
+- Expanding or collapsing the **Direct messages** section.
+- Showing all topics in a channel.
+- [Configuring unread message counters](/help/configure-unread-message-counters).
+- Hiding the left sidebar altogether.
+
+You can also customize how channels are organized within the **channels**
+section by:
+
+- [Pinning channels](/help/pin-a-channel) so that they appear in the top section.
+- [Changing channel colors](/help/change-the-color-of-a-channel).
+- [Configuring](/help/manage-inactive-channels) whether inactive channels are
+  sorted at the bottom.
+
+## Related articles
+* [Reading strategies](/help/reading-strategies)
+* [Configuring unread message counters](/help/configure-unread-message-counters)
+* [Inbox](/help/inbox)
+* [Recent conversations](/help/recent-conversations)
+* [Combined feed](/help/combined-feed)
+* [View your mentions](/help/view-your-mentions)
+* [Star a message](/help/star-a-message)


### PR DESCRIPTION
This is intended to be a mergeable starting point for this page. As follow-ups, we'll want to add documentation for:

- [ ] Expanding or collapsing the Views section.
- [ ] Expanding or collapsing the Direct messages section.
- [ ] Showing all topics in a channel.
- [ ] Hiding the left sidebar altogether.

<details>
<summary>
Screenshot
</summary>

![Screenshot 2024-06-12 at 11 03 49](https://github.com/zulip/zulip/assets/2090066/51f09b25-e4ec-4347-ae88-e86eeecc25d0)

</details>

[CZO discussion
](https://chat.zulip.org/#narrow/stream/101-design/topic/left.20sidebar.20toggle.20icon/near/1823029)