### PR TITLE
realm: Prefetch group settings only for "/register" response.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -94,6 +94,7 @@ from zerver.models.realms import (
     EditTopicPolicyEnum,
     get_corresponding_policy_value_for_group_setting,
     get_realm_domains,
+    get_realm_with_settings,
 )
 from zerver.models.streams import get_default_stream_groups
 from zerver.tornado.django_api import get_user_events, request_event_queue
@@ -1641,6 +1642,11 @@ def do_events_register(
         event_types_set = set(event_types)
     else:
         event_types_set = None
+
+    # Fetch the realm object again to prefetch all the
+    # group settings which support anonymous groups
+    # to avoid unnecessary DB queries.
+    realm = get_realm_with_settings(realm_id=realm.id)
 
     if user_profile is None:
         # TODO: Unify the two fetch_initial_state_data code paths.

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -122,7 +122,7 @@ def always_want(msg_type: str) -> bool:
 def fetch_initial_state_data(
     user_profile: Optional[UserProfile],
     *,
-    realm: Optional[Realm] = None,
+    realm: Realm,
     event_types: Optional[Iterable[str]] = None,
     queue_id: Optional[str] = "",
     client_gravatar: bool = False,
@@ -148,10 +148,6 @@ def fetch_initial_state_data(
     corresponding events for changes in the data structures and new
     code to apply_events (and add a test in test_events.py).
     """
-    if realm is None:
-        assert user_profile is not None
-        realm = user_profile.realm
-
     state: Dict[str, Any] = {"queue_id": queue_id}
 
     if event_types is None:
@@ -1705,6 +1701,7 @@ def do_events_register(
 
     ret = fetch_initial_state_data(
         user_profile,
+        realm=realm,
         event_types=event_types_set,
         queue_id=queue_id,
         client_gravatar=client_gravatar,

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -1074,6 +1074,19 @@ def get_realm_by_id(realm_id: int) -> Realm:
     return Realm.objects.get(id=realm_id)
 
 
+def get_realm_with_settings(realm_id: int) -> Realm:
+    # Prefetch all the settings that can be set to anonymous groups.
+    # This also prefetches can_access_all_users_group setting,
+    # even when it cannot be set to anonymous groups because
+    # the setting is used when fetching users in the realm.
+    return Realm.objects.select_related(
+        "can_access_all_users_group",
+        "can_access_all_users_group__named_user_group",
+        "can_create_public_channel_group",
+        "can_create_public_channel_group__named_user_group",
+    ).get(id=realm_id)
+
+
 def require_unique_names(realm: Optional[Realm]) -> bool:
     if realm is None:
         # realm is None when a new realm is being created.

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -882,8 +882,6 @@ def get_user_profile_by_id(user_profile_id: int) -> UserProfile:
         "realm",
         "realm__can_access_all_users_group",
         "realm__can_access_all_users_group__named_user_group",
-        "realm__can_create_public_channel_group",
-        "realm__can_create_public_channel_group__named_user_group",
         "bot_owner",
     ).get(id=user_profile_id)
 
@@ -905,8 +903,6 @@ def maybe_get_user_profile_by_api_key(api_key: str) -> Optional[UserProfile]:
             "realm",
             "realm__can_access_all_users_group",
             "realm__can_access_all_users_group__named_user_group",
-            "realm__can_create_public_channel_group",
-            "realm__can_create_public_channel_group__named_user_group",
             "bot_owner",
         ).get(api_key=api_key)
     except UserProfile.DoesNotExist:
@@ -936,8 +932,6 @@ def get_user_by_delivery_email(email: str, realm: "Realm") -> UserProfile:
         "realm",
         "realm__can_access_all_users_group",
         "realm__can_access_all_users_group__named_user_group",
-        "realm__can_create_public_channel_group",
-        "realm__can_create_public_channel_group__named_user_group",
         "bot_owner",
     ).get(delivery_email__iexact=email.strip(), realm=realm)
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1185,7 +1185,7 @@ class FetchQueriesTest(ZulipTestCase):
             muted_users=1,
             onboarding_steps=1,
             presence=1,
-            realm=1,
+            realm=3,
             realm_bot=1,
             realm_domains=1,
             realm_embedded_bots=0,
@@ -1216,6 +1216,11 @@ class FetchQueriesTest(ZulipTestCase):
         wanted_event_types = {item[0][0] for item in want_mock.call_args_list}
 
         self.assertEqual(wanted_event_types, set(expected_counts))
+
+        # Fetch realm again here so that the cached foreign key fields
+        # while testing the above case does not reduce the query count
+        # and we test the actual query count for each event type.
+        realm = get_realm_with_settings(realm_id=user.realm_id)
 
         for event_type in sorted(wanted_event_types):
             count = expected_counts[event_type]

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -329,6 +329,7 @@ class BaseAction(ZulipTestCase):
         # normal_state = do action then fetch at the end (the "normal" code path)
         hybrid_state = fetch_initial_state_data(
             self.user_profile,
+            realm=self.user_profile.realm,
             event_types=event_types,
             client_gravatar=client_gravatar,
             user_avatar_url_field_optional=user_avatar_url_field_optional,
@@ -397,6 +398,7 @@ class BaseAction(ZulipTestCase):
 
         normal_state = fetch_initial_state_data(
             self.user_profile,
+            realm=self.user_profile.realm,
             event_types=event_types,
             client_gravatar=client_gravatar,
             user_avatar_url_field_optional=user_avatar_url_field_optional,
@@ -2623,7 +2625,7 @@ class NormalActionsTest(BaseAction):
     def test_realm_update_org_type(self) -> None:
         realm = self.user_profile.realm
 
-        state_data = fetch_initial_state_data(self.user_profile)
+        state_data = fetch_initial_state_data(self.user_profile, realm=realm)
         self.assertEqual(state_data["realm_org_type"], Realm.ORG_TYPES["business"]["id"])
 
         with self.verify_action() as events:
@@ -2632,7 +2634,7 @@ class NormalActionsTest(BaseAction):
             )
         check_realm_update("events[0]", events[0], "org_type")
 
-        state_data = fetch_initial_state_data(self.user_profile)
+        state_data = fetch_initial_state_data(self.user_profile, realm=realm)
         self.assertEqual(state_data["realm_org_type"], Realm.ORG_TYPES["government"]["id"])
 
     def test_realm_update_plan_type(self) -> None:
@@ -2642,7 +2644,7 @@ class NormalActionsTest(BaseAction):
             realm, "can_access_all_users_group", members_group, acting_user=None
         )
 
-        state_data = fetch_initial_state_data(self.user_profile)
+        state_data = fetch_initial_state_data(self.user_profile, realm=realm)
         self.assertEqual(state_data["realm_plan_type"], Realm.PLAN_TYPE_SELF_HOSTED)
         self.assertEqual(state_data["zulip_plan_is_not_limited"], True)
 
@@ -2652,7 +2654,7 @@ class NormalActionsTest(BaseAction):
         check_realm_update_dict("events[1]", events[1])
         check_realm_update("events[2]", events[2], "plan_type")
 
-        state_data = fetch_initial_state_data(self.user_profile)
+        state_data = fetch_initial_state_data(self.user_profile, realm=realm)
         self.assertEqual(state_data["realm_plan_type"], Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(state_data["zulip_plan_is_not_limited"], False)
 
@@ -3201,7 +3203,7 @@ class NormalActionsTest(BaseAction):
         message = Message.objects.get(id=msg_id)
         with self.verify_action(state_change_expected=True):
             do_delete_messages(self.user_profile.realm, [message])
-        result = fetch_initial_state_data(user_profile)
+        result = fetch_initial_state_data(user_profile, realm=user_profile.realm)
         self.assertEqual(result["max_message_id"], -1)
 
     def test_do_delete_message_with_no_messages(self) -> None:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -259,7 +259,7 @@ class HomeTest(ZulipTestCase):
         self.client_post("/json/bots", bot_info)
 
         # Verify succeeds once logged-in
-        with self.assert_database_query_count(53):
+        with self.assert_database_query_count(55):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page(stream="Denmark")
                 self.check_rendered_logged_in_app(result)
@@ -564,7 +564,7 @@ class HomeTest(ZulipTestCase):
     def test_num_queries_for_realm_admin(self) -> None:
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
-        with self.assert_database_query_count(53):
+        with self.assert_database_query_count(55):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
@@ -595,7 +595,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(48):
+        with self.assert_database_query_count(50):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4767,7 +4767,7 @@ class SubscriptionAPITest(ZulipTestCase):
         realm = get_realm("zulip")
         streams_to_sub = ["multi_user_stream"]
         with self.capture_send_event_calls(expected_num_events=5) as events:
-            with self.assert_database_query_count(37):
+            with self.assert_database_query_count(38):
                 self.common_subscribe_to_streams(
                     self.test_user,
                     streams_to_sub,
@@ -5591,7 +5591,7 @@ class SubscriptionAPITest(ZulipTestCase):
         ]
 
         # Test creating a public stream when realm does not have a notification stream.
-        with self.assert_database_query_count(37):
+        with self.assert_database_query_count(38):
             self.common_subscribe_to_streams(
                 self.test_user,
                 [new_streams[0]],
@@ -5611,7 +5611,7 @@ class SubscriptionAPITest(ZulipTestCase):
         new_stream_announcements_stream = get_stream(self.streams[0], self.test_realm)
         self.test_realm.new_stream_announcements_stream_id = new_stream_announcements_stream.id
         self.test_realm.save()
-        with self.assert_database_query_count(48):
+        with self.assert_database_query_count(49):
             self.common_subscribe_to_streams(
                 self.test_user,
                 [new_streams[2]],


### PR DESCRIPTION
This PR updates code to prefetch realm group settings like "can_create_public_channel_group" only when computing settings for "/register" response in `fetch_initial_state_data` by refetching the realm object with `select_related` instead of fetching those settings in UserProfile query.

This change is done because we do not need to prefetch these settings for every UserProfile object and for most of the cases where these settings are actually accessed, we can afford extra query like when checking permission to create streams. But we cannot afford one query extra for each setting when computing these settings for "/register" response, so we re-fetch the realm object with select_related leading to only one extra query.

The query count changes in tests are -
- Query count increases by two when calling fetch_initial_state_data as one query is for refetching the Realm object and one query is for computing can_create_public_streams because Realm object from UserProfile does not have prefetched setting fields.

- Query count increases by one in test_subs where streams are created which is as expected due to the setting not being prefetched.

- There is also increase in query count for "realm" event type when checking query count for each event type in test_queries test in test_event_system.py. The query count changes from 1 to 4. Before this commit, 3 DB queries were actually needed for "realm" event type but the test mentioned 1 because, the related stream setting fields were already fetched when testing the case for all event types above it. So, when testing the query count for only "realm" event type the cached realm object was used and no extra queries were made for the stream settings.
Now since we refetch the realm in fetch_intial_state_data the correct query count is used in the test with 1 being added due to refetching the realm in this commit.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
