### PR TITLE
stream_edit: Fix user popover permanently displayed in stream settings.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -19,6 +19,7 @@ import * as dropdown_widget from "./dropdown_widget";
 import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
 import * as narrow_state from "./narrow_state";
+import * as popovers from "./popovers";
 import * as scroll_util from "./scroll_util";
 import * as settings_components from "./settings_components";
 import * as settings_config from "./settings_config";
@@ -244,6 +245,9 @@ function setup_dropdown(sub, slim_sub) {
 }
 
 export function show_settings_for(node) {
+    // Hide any tooltips or popovers before we rerender / change
+    // currently displayed stream settings.
+    popovers.hide_all();
     const stream_id = get_stream_id(node);
     const slim_sub = sub_store.get(stream_id);
     stream_data.clean_up_description(slim_sub);


### PR DESCRIPTION
If a user popover is open in stream settings, and user presses `down/up` arrow to view settings for a different stream, the user popover stay open.

Why we need to explicitly hide it?
We have click handlers to hide the popover and `data-reference-hidden` to hide the popover if the reference goes offscreen via scrolling.

In this case, those events don't fire, there is no reason for tippy to check if reference is visible and thus show / hide the popover.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Persistent.20user.20card.20popover.20in.20stream.20modal

Reproducer:
https://chat.zulip.org/user_uploads/2/6c/xnurQEaaNvd45VD6yO6UGcGM/Screencast-from-13-06-24-121001-AM-IST.webm