### PR TITLE
redesign: Left sidebar popovers.

### DIFF
--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -10,6 +10,7 @@ import {parse_html} from "./ui_util";
 
 export function initialize(): void {
     popover_menus.register_popover_menu("#streams_inline_icon", {
+        theme: "popover-menu",
         onShow(instance) {
             const can_create_streams =
                 settings_data.user_can_create_private_streams() ||

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -89,6 +89,7 @@ export function initialize() {
 
     // Drafts popover
     popover_menus.register_popover_menu(".drafts-sidebar-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -218,6 +218,7 @@ export function initialize() {
     });
 
     popover_menus.register_popover_menu(".left-sidebar-navigation-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onShow(instance) {
             // Determine at show time whether there are scheduled messages,

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -44,6 +44,7 @@ function register_mark_all_read_handler(event) {
 export function initialize() {
     // Starred messages popover
     popover_menus.register_popover_menu(".starred-messages-sidebar-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -44,7 +44,6 @@ function register_mark_all_read_handler(event) {
 export function initialize() {
     // Starred messages popover
     popover_menus.register_popover_menu(".starred-messages-sidebar-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -89,7 +88,6 @@ export function initialize() {
 
     // Drafts popover
     popover_menus.register_popover_menu(".drafts-sidebar-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -116,7 +114,6 @@ export function initialize() {
 
     // Inbox popover
     popover_menus.register_popover_menu(".inbox-sidebar-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -151,7 +148,6 @@ export function initialize() {
 
     // Combined feed popover
     popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -185,7 +181,6 @@ export function initialize() {
 
     // Recent view popover
     popover_menus.register_popover_menu(".recent-view-sidebar-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -218,7 +213,6 @@ export function initialize() {
     });
 
     popover_menus.register_popover_menu(".left-sidebar-navigation-menu-icon", {
-        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onShow(instance) {
             // Determine at show time whether there are scheduled messages,

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -114,6 +114,7 @@ export function initialize() {
 
     // Inbox popover
     popover_menus.register_popover_menu(".inbox-sidebar-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -149,6 +149,7 @@ export function initialize() {
 
     // Combined feed popover
     popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -183,6 +183,7 @@ export function initialize() {
 
     // Recent view popover
     popover_menus.register_popover_menu(".recent-view-sidebar-menu-icon", {
+        theme: "popover-menu",
         ...popover_menus.left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -272,6 +272,7 @@ export const default_popover_props: Partial<tippy.Props> = {
 };
 
 export const left_sidebar_tippy_options = {
+    theme: "popover-menu",
     placement: "right",
     popperOptions: {
         modifiers: [

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -105,7 +105,6 @@ function build_stream_popover(opts) {
         // `onShow` is called after `hideOnClick`.
         // See https://github.com/atomiks/tippyjs/issues/230 for more details.
         delay: [100, 0],
-        theme: "popover-menu",
         ...left_sidebar_tippy_options,
         onCreate(instance) {
             stream_popover_instance = instance;

--- a/web/src/topic_popover.js
+++ b/web/src/topic_popover.js
@@ -21,7 +21,6 @@ export function initialize() {
     popover_menus.register_popover_menu(
         "#stream_filters .topic-sidebar-menu-icon, .inbox-row .inbox-topic-menu",
         {
-            theme: "popover-menu",
             ...popover_menus.left_sidebar_tippy_options,
             onShow(instance) {
                 popover_menus.popover_instances.topics_menu = instance;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -847,23 +847,8 @@ li.top_left_scheduled_messages {
 }
 
 .condensed-views-popover-menu {
-    .left-sidebar-popover-icon-label-count {
-        display: flex;
-        align-items: baseline;
-    }
-
-    .filter-icon {
-        align-self: center;
-        height: 15px;
-    }
-
-    .left-sidebar-navigation-label {
-        flex: 1 0 0;
-        margin-left: 3px;
-    }
-
     .unread_count {
-        margin-left: 6px;
+        margin: 1px 0 0 6px;
         border-color: var(--color-border-unread-counter-popover-menu);
     }
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1178,6 +1178,7 @@ ul {
         /* Keep menu items on a single line, unless forced to wrap
         by a max-width on the popover. */
         width: max-content;
+        flex: 1 0 0;
     }
 
     .text-item,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2331,7 +2331,6 @@ body:not(.hide-left-sidebar) {
     }
 }
 
-#unstar_all_messages,
 .emoji-popover-tab-item {
     .zulip-icon-star {
         position: relative;

--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -1,21 +1,23 @@
-<ul class="nav nav-list">
-    {{#if is_home_view}}
-    <li>
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" id="mark_all_messages_as_read">
-            <i class="fa fa-book" aria-hidden="true"></i>
-            {{t "Mark all messages as read" }}
-        </a>
-    </li>
-    {{/if}}
-    {{#unless is_home_view}}
-    <li>
-        <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
-            <i class="fa fa-home" aria-hidden="true"></i>
-            {{#tr}}
-                Make <b>combined feed</b> my home view
-            {{/tr}}
-        </a>
-    </li>
-    {{/unless}}
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        {{#if is_home_view}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+            </a>
+        </li>
+        {{else}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
+                <i class="popover-menu-icon fa fa-home" aria-hidden="true"></i>
+                <span class="popover-menu-label">
+                    {{#tr}}
+                        Make <b>combined feed</b> my home view
+                    {{/tr}}
+                </span>
+            </a>
+        </li>
+        {{/if}}
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -1,33 +1,26 @@
-{{! Contents of the condensed nav vdots popup }}
-<ul class="nav nav-list condensed-views-popover-menu">
-    <li class="condensed-views-popover-menu-reactions">
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" href="#narrow/has/reaction/sender/me" class="left-sidebar-popover-icon-label-count tippy-left-sidebar-tooltip" data-tooltip-template-id="my-reactions-tooltip-template">
-            <span class="filter-icon">
-                <i class="zulip-icon zulip-icon-smile" aria-hidden="true"></i>
-            </span>
-            <span class="left-sidebar-navigation-label">{{t 'Reactions' }}</span>
-        </a>
-    </li>
-    <li class="condensed-views-popover-menu-drafts">
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" href="#drafts" class="left-sidebar-popover-icon-label-count tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
-            <span class="filter-icon">
-                <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
-            </span>
-            <span class="left-sidebar-navigation-label">{{t 'Drafts' }}</span>
-            <span class="unread_count"></span>
-        </a>
-    </li>
-    {{#if has_scheduled_messages }}
-    <li class="condensed-views-popover-menu-scheduled-messages">
-        <a tabindex="0" href="#scheduled" class="left-sidebar-popover-icon-label-count">
-            <span class="filter-icon">
-                <i class="zulip-icon zulip-icon-scheduled-messages" aria-hidden="true"></i>
-            </span>
-            <span class="left-sidebar-navigation-label">{{t 'Scheduled messages' }}</span>
-            <span class="unread_count"></span>
-        </a>
-    </li>
-    {{/if}}
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list condensed-views-popover-menu">
+        <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-reactions">
+            <a href="#narrow/has/reaction/sender/me" role="menuitem" class="popover-menu-link tippy-left-sidebar-tooltip" data-tooltip-template-id="my-reactions-tooltip-template" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-smile" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Reactions' }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-drafts">
+            <a href="#drafts" role="menuitem" class="popover-menu-link tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Drafts' }}</span>
+                <span class="unread_count"></span>
+            </a>
+        </li>
+        {{#if has_scheduled_messages }}
+        <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-scheduled-messages">
+            <a href="#scheduled" role="menuitem" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-scheduled-messages" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t 'Scheduled messages' }}</span>
+                <span class="unread_count"></span>
+            </a>
+        </li>
+        {{/if}}
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
@@ -1,10 +1,10 @@
-{{! Contents of the "drafts sidebar" popup }}
-<ul class="nav nav-list">
-    <li>
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" id="delete_all_drafts_sidebar">
-            <i class="fa fa-trash-o" aria-hidden="true"></i>
-            {{t "Delete all drafts" }}
-        </a>
-    </li>
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="delete_all_drafts_sidebar" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Delete all drafts" }}</span>
+            </a>
+        </li>
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -1,21 +1,23 @@
-<ul class="nav nav-list">
-    {{#if is_home_view}}
-    <li>
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" id="mark_all_messages_as_read">
-            <i class="fa fa-book" aria-hidden="true"></i>
-            {{t "Mark all messages as read" }}
-        </a>
-    </li>
-    {{/if}}
-    {{#unless is_home_view}}
-    <li>
-        <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
-            <i class="fa fa-home" aria-hidden="true"></i>
-            {{#tr}}
-                Make <b>inbox</b> my home view
-            {{/tr}}
-        </a>
-    </li>
-    {{/unless}}
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        {{#if is_home_view}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+            </a>
+        </li>
+        {{else}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
+                <i class="popover-menu-icon fa fa-home" aria-hidden="true"></i>
+                <span class="popover-menu-label">
+                    {{#tr}}
+                        Make <b>inbox</b> my home view
+                    {{/tr}}
+                </span>
+            </a>
+        </li>
+        {{/if}}
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -13,7 +13,7 @@
                 <i class="popover-menu-icon fa fa-home" aria-hidden="true"></i>
                 <span class="popover-menu-label">
                     {{#tr}}
-                        Make <b>recent conversation</b> my home view
+                        Make <b>recent conversations</b> my home view
                     {{/tr}}
                 </span>
             </a>

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -1,21 +1,23 @@
-<ul class="nav nav-list">
-    {{#if is_home_view}}
-    <li>
-        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-        <a tabindex="0" id="mark_all_messages_as_read">
-            <i class="fa fa-book" aria-hidden="true"></i>
-            {{t "Mark all messages as read" }}
-        </a>
-    </li>
-    {{/if}}
-    {{#unless is_home_view}}
-    <li>
-        <a tabindex="0" class="set-home-view" data-view-code="{{view_code}}">
-            <i class="fa fa-home" aria-hidden="true"></i>
-            {{#tr}}
-                Make <b>recent conversation</b> my home view
-            {{/tr}}
-        </a>
-    </li>
-    {{/unless}}
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        {{#if is_home_view}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+            </a>
+        </li>
+        {{else}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
+                <i class="popover-menu-icon fa fa-home" aria-hidden="true"></i>
+                <span class="popover-menu-label">
+                    {{#tr}}
+                        Make <b>recent conversation</b> my home view
+                    {{/tr}}
+                </span>
+            </a>
+        </li>
+        {{/if}}
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
@@ -1,23 +1,23 @@
-{{! Contents of the "starred messages sidebar" popup }}
-<ul class="nav nav-list">
-    {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
-    {{#if show_unstar_all_button}}
-    <li>
-        <a tabindex="0" id="unstar_all_messages">
-            <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
-            {{t "Unstar all messages" }}
-        </a>
-    </li>
-    {{/if}}
-    <li>
-        <a tabindex="0" id="toggle_display_starred_msg_count">
-            {{#if starred_message_counts}}
-                <i class="fa fa-eye-slash" aria-hidden="true"></i>
-                {{t "Hide starred message count" }}
-            {{else}}
-                <i class="fa fa-eye" aria-hidden="true"></i>
-                {{t "Show starred message count" }}
-            {{/if}}
-        </a>
-    </li>
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        {{#if show_unstar_all_button}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="unstar_all_messages" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Unstar all messages" }}</span>
+            </a>
+        </li>
+        {{/if}}
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" id="toggle_display_starred_msg_count" class="popover-menu-link" tabindex="0">
+                {{#if starred_message_counts}}
+                <i class="popover-menu-icon zulip-icon zulip-icon-hide" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Hide starred message count" }}</span>
+                {{else}}
+                <i class="popover-menu-icon fa fa-eye" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Show starred message count" }}</span>
+                {{/if}}
+            </a>
+        </li>
+    </ul>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
@@ -1,12 +1,16 @@
-<ul class="nav nav-list">
-    <li>
-        <a href="#channels/notsubscribed" class="navigate_and_close_popover">
-            {{t "Browse channels" }}
-        </a>
-    </li>
-    <li>
-        <a href="#channels/new" class="navigate_and_close_popover">
-            {{t "Create a channel" }}
-        </a>
-    </li>
-</ul>
+<div class="popover-menu" data-simplebar>
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <a href="#channels/notsubscribed" role="menuitem" class="popover-menu-link navigate_and_close_popover" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-search" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Browse channels" }}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a href="#channels/new" role="menuitem" class="popover-menu-link navigate_and_close_popover" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Create a channel" }}</span>
+            </a>
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
As part of the popover menu redesign, this PR redesigns all the remaining left sidebar popovers using the new "popover-menu" tippy theme and improves accessibility by using appropriate ARIA attributes.

Fixes part of https://github.com/zulip/zulip/issues/28699.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
## Light Theme

| Desc | Before | After |
|--------|--------|--------|
| Inbox | ![Screenshot 2024-06-13 at 6 05 45 PM](https://github.com/zulip/zulip/assets/82862779/7e650a7f-6027-472a-b9a6-ebd759968965) | ![Screenshot 2024-06-13 at 4 49 16 PM](https://github.com/zulip/zulip/assets/82862779/5aa61daf-72e0-4fa7-9375-f7c865cdc12e) |
| Combined Feed | ![Screenshot 2024-06-13 at 5 59 29 PM](https://github.com/zulip/zulip/assets/82862779/7e0e1578-b415-4bf6-9db6-774bc97b4656) | ![Screenshot 2024-06-13 at 4 49 07 PM](https://github.com/zulip/zulip/assets/82862779/aa06c6a7-5969-4f42-bd83-6fdd0a7dc673) |
| Recents | ![Screenshot 2024-06-13 at 5 59 25 PM](https://github.com/zulip/zulip/assets/82862779/33b8b52f-946c-4e9c-8986-458cb85d519e) | ![Screenshot 2024-06-13 at 4 48 56 PM](https://github.com/zulip/zulip/assets/82862779/b7a9dc6f-2899-47ba-8c78-7a466b988bec) |
| Home View | ![Screenshot 2024-06-13 at 5 59 20 PM](https://github.com/zulip/zulip/assets/82862779/457dd55d-0d7e-4f6e-807b-9a9b115d5ade) | ![Screenshot 2024-06-13 at 4 48 27 PM](https://github.com/zulip/zulip/assets/82862779/a61f26ea-2c87-468e-adce-4f63c7be3a77) |
| Starred Messages | ![Screenshot 2024-06-13 at 5 59 34 PM](https://github.com/zulip/zulip/assets/82862779/8559d1b7-8aba-4c3c-b9e9-ea4a9b195d19) | ![Screenshot 2024-06-13 at 5 04 48 PM](https://github.com/zulip/zulip/assets/82862779/a03be678-3379-4125-9d21-62dc152b12f6) | 
| Drafts | ![Screenshot 2024-06-13 at 5 59 42 PM](https://github.com/zulip/zulip/assets/82862779/2e534992-97de-4ca3-b5d8-fd7b1e4258e3) | ![Screenshot 2024-06-13 at 5 04 41 PM](https://github.com/zulip/zulip/assets/82862779/2c790fba-0ec6-4541-9dde-3b7512ffa432) |
| Condensed View | ![Screenshot 2024-06-13 at 5 58 59 PM](https://github.com/zulip/zulip/assets/82862779/e768731f-eaef-47b8-9ad7-c862694a7bc0) | ![Screenshot 2024-06-13 at 5 19 27 PM](https://github.com/zulip/zulip/assets/82862779/ef7ed9c7-30e3-4d44-9038-15a2082893f5) |
| Stream Settings | ![Screenshot 2024-06-13 at 5 58 49 PM](https://github.com/zulip/zulip/assets/82862779/14713713-5879-40e6-9e46-38d0c72a1ec0) | ![Screenshot 2024-06-13 at 5 19 47 PM](https://github.com/zulip/zulip/assets/82862779/4ef57b59-39e4-4977-900d-783c0d423f49) |

## Dark Theme
| Desc | Before | After |
|--------|--------|--------|
| Inbox | ![Screenshot 2024-06-13 at 6 05 37 PM](https://github.com/zulip/zulip/assets/82862779/bb588551-7b7e-4317-b1d0-245498a50e3e) | ![Screenshot 2024-06-13 at 4 49 32 PM](https://github.com/zulip/zulip/assets/82862779/ef24f897-2ce3-4686-864d-12cc203876db) |
| Combined Feed | ![Screenshot 2024-06-13 at 6 00 44 PM](https://github.com/zulip/zulip/assets/82862779/ccc2968f-e60f-4860-b596-69ab55eec690) | ![Screenshot 2024-06-13 at 4 49 37 PM](https://github.com/zulip/zulip/assets/82862779/0b25a5e3-355f-497b-9fe6-bfdfe569e63a) |
| Recents | ![Screenshot 2024-06-13 at 6 00 41 PM](https://github.com/zulip/zulip/assets/82862779/58aa84f3-683a-4cc9-a417-58268926ef1f) | ![Screenshot 2024-06-13 at 4 49 57 PM](https://github.com/zulip/zulip/assets/82862779/2c9b8483-59bd-48bd-8fa5-a250ffa1da0e) |
| Home View | ![Screenshot 2024-06-13 at 6 00 38 PM](https://github.com/zulip/zulip/assets/82862779/ebca70e4-e6a0-49a8-b813-50df610e0efd) | ![Screenshot 2024-06-13 at 5 16 52 PM](https://github.com/zulip/zulip/assets/82862779/0c158085-03df-495e-b135-8038bcdc9bce) | 
| Starred Messages | ![Screenshot 2024-06-13 at 6 00 48 PM](https://github.com/zulip/zulip/assets/82862779/00a5e060-11e0-45ff-8035-91fc15f95802) | ![Screenshot 2024-06-13 at 5 04 56 PM](https://github.com/zulip/zulip/assets/82862779/8682ef35-989d-48fd-8aaf-917fa20253cf) | 
| Drafts | ![Screenshot 2024-06-13 at 6 00 54 PM](https://github.com/zulip/zulip/assets/82862779/bce9ceac-6163-43fd-8a7b-b4e6917145c2) | ![Screenshot 2024-06-13 at 5 05 00 PM](https://github.com/zulip/zulip/assets/82862779/d7f90d7d-e122-401f-b705-d80188fe5ba6) | 
| Condensed View | ![Screenshot 2024-06-13 at 5 58 24 PM](https://github.com/zulip/zulip/assets/82862779/2c3571ba-e0c7-4103-9d5c-a08e07551a8e) | ![Screenshot 2024-06-13 at 5 19 19 PM](https://github.com/zulip/zulip/assets/82862779/acfc60a1-05e7-4478-8aa7-6a5ca7b19e27) |
| Stream Settings | ![Screenshot 2024-06-13 at 6 00 34 PM](https://github.com/zulip/zulip/assets/82862779/2dc7276f-0d9c-4484-bf7c-f87024fd28bf) | ![Screenshot 2024-06-13 at 5 52 54 PM](https://github.com/zulip/zulip/assets/82862779/b40876b3-c3a8-4948-9dad-cc891bd4c9a7) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
