### PR TITLE
compose: Fix bug causing layout shift on expanding compose box.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -244,13 +244,10 @@
     margin: 0;
     height: 100%;
 
-    .messagebox-wrapper {
-        flex: 1;
-    }
-
     .messagebox {
         /* normally 5px 14px; pull in the right and bottom a bit */
         cursor: default;
+        flex: 1;
         padding: 0;
         background: none;
         box-shadow: none;

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -71,42 +71,40 @@
                             </div>
                         </div>
                     </div>
-                    <div class="messagebox-wrapper">
-                        <div class="messagebox">
-                            <div id="message-content-container">
-                                <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
-                                <div id="preview-message-area-container">
-                                    <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
-                                        <div class="markdown_preview_spinner"></div>
-                                        <div class="preview_content rendered_markdown"></div>
-                                    </div>
+                    <div class="messagebox">
+                        <div id="message-content-container">
+                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                            <div id="preview-message-area-container">
+                                <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
+                                    <div class="markdown_preview_spinner"></div>
+                                    <div class="preview_content rendered_markdown"></div>
                                 </div>
-                                <div class="composebox-buttons">
-                                    <button type="button" class="expand-composebox-button zulip-icon zulip-icon-expand-diagonal" aria-label="{{t 'Expand compose box' }}" data-tippy-content="{{t 'Expand compose box' }}"></button>
-                                    <button type="button" class="collapse-composebox-button zulip-icon zulip-icon-collapse-diagonal" aria-label="{{t 'Collapse compose box' }}" data-tippy-content="{{t 'Collapse compose box' }}"></button>
-                                </div>
-                                <div class="drag"></div>
                             </div>
+                            <div class="composebox-buttons">
+                                <button type="button" class="expand-composebox-button zulip-icon zulip-icon-expand-diagonal" aria-label="{{t 'Expand compose box' }}" data-tippy-content="{{t 'Expand compose box' }}"></button>
+                                <button type="button" class="collapse-composebox-button zulip-icon zulip-icon-collapse-diagonal" aria-label="{{t 'Collapse compose box' }}" data-tippy-content="{{t 'Collapse compose box' }}"></button>
+                            </div>
+                            <div class="drag"></div>
+                        </div>
 
-                            <div id="message-send-controls-container">
-                                <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts">
-                                    <span class="compose-drafts-text">{{t 'Drafts' }}</span><span class="compose-drafts-count-container">(<span class="compose-drafts-count"></span>)</span>
-                                </a>
-                                <span id="compose-limit-indicator" class="tippy-zulip-tooltip" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
-                                <div class="message-send-controls">
-                                    <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
-                                        <img class="loader" alt="" src="" />
-                                        <i class="zulip-icon zulip-icon-send"></i>
-                                    </button>
-                                    <button class="send-control-button send-related-action-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send options' }}">
-                                        <i class="zulip-icon zulip-icon-more-vertical"></i>
-                                    </button>
-                                </div>
+                        <div id="message-send-controls-container">
+                            <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts">
+                                <span class="compose-drafts-text">{{t 'Drafts' }}</span><span class="compose-drafts-count-container">(<span class="compose-drafts-count"></span>)</span>
+                            </a>
+                            <span id="compose-limit-indicator" class="tippy-zulip-tooltip" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
+                            <div class="message-send-controls">
+                                <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
+                                    <img class="loader" alt="" src="" />
+                                    <i class="zulip-icon zulip-icon-send"></i>
+                                </button>
+                                <button class="send-control-button send-related-action-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send options' }}">
+                                    <i class="zulip-icon zulip-icon-more-vertical"></i>
+                                </button>
                             </div>
+                        </div>
 
-                            <div id="message-formatting-controls-container">
-                                {{> compose_control_buttons }}
-                            </div>
+                        <div id="message-formatting-controls-container">
+                            {{> compose_control_buttons }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The messagebox-wrapper div is removed, and it's only style `flex: 1` is applied to the messagebox div. The `height: 100%` and `margin-top: 5px` styles on the messagebox div were earlier causing it to move 5px down, outside the messagebox-wrapper div, when the compose box was expanded.

Fixes: [CZO issue report thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/subtle.20layout.20shift.20when.20expanding.20compose.20box/near/1825379)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
