### PR TITLE
 Show user pills in search typeahead dropdown even after user is selected

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -5,7 +5,7 @@ import render_user_pill from "../templates/user_pill.hbs";
 
 import * as common from "./common";
 import * as direct_message_group_data from "./direct_message_group_data";
-import {Filter} from "./filter";
+import {Filter, create_user_pill_context} from "./filter";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -16,7 +16,7 @@ import * as stream_topic_history from "./stream_topic_history";
 import * as stream_topic_history_util from "./stream_topic_history_util";
 import * as typeahead_helper from "./typeahead_helper";
 
-type UserPillItem = {
+export type UserPillItem = {
     id: number;
     display_value: Handlebars.SafeString;
     has_image: boolean;
@@ -40,18 +40,6 @@ export type Suggestion = {
           }[];
       }
 );
-
-function create_user_pill_context(user: User): UserPillItem {
-    const avatar_url = people.small_avatar_url_for_person(user);
-
-    return {
-        id: user.user_id,
-        display_value: new Handlebars.SafeString(user.full_name),
-        has_image: true,
-        img_src: avatar_url,
-        should_add_guest_user_indicator: people.should_add_guest_user_indicator(user.user_id),
-    };
-}
 
 export const max_num_of_search_results = 12;
 

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -14,6 +14,17 @@
         {{~!-- squash whitespace --~}}
         {{this.prefix_for_operator}} {{this.operand}}
         {{~!-- squash whitespace --~}}
+    {{else if (eq this.type "user_pill")}}
+        {{~!-- squash whitespace --~}}
+        {{this.operator}}
+        {{~#each this.users}}
+            {{#if this.valid_user}}
+                {{> user_pill}}
+            {{else}}
+                {{this.operand}}
+            {{/if}}
+        {{~/each~}}
+        {{~!-- squash whitespace --~}}
     {{else if (eq this.type "is_operator")}}
         {{#if (eq this.operand "mentioned")}}
             {{~!-- squash whitespace --~}}

--- a/web/templates/search_list_item.hbs
+++ b/web/templates/search_list_item.hbs
@@ -1,8 +1,10 @@
 <div class="search_list_item">
     <span>{{{ description_html }}}</span>
-    {{#if is_person}}
-    <span class="pill-container pill-container-btn">
-        {{> input_pill user_pill_context}}
-    </span>
+    {{#if is_people}}
+    {{#each users}}
+        <span class="pill-container pill-container-btn">
+            {{> input_pill user_pill_context}}
+        </span>
+    {{/each}}
     {{/if}}
 </div>

--- a/web/templates/user_pill.hbs
+++ b/web/templates/user_pill.hbs
@@ -1,0 +1,3 @@
+<span class="user-pill pill-container pill-container-btn">
+    {{> input_pill user_pill_context }}
+</span>

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -26,11 +26,13 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
     mock_template("search_list_item.hbs", true, (data, html) => {
         assert.equal(typeof data.description_html, "string");
-        if (data.is_person) {
-            assert.equal(typeof data.user_pill_context.id, "number");
-            assert.equal(typeof data.user_pill_context.display_value, "string");
-            assert.equal(typeof data.user_pill_context.has_image, "boolean");
-            assert.equal(typeof data.user_pill_context.img_src, "string");
+        if (data.is_people) {
+            for (const user of data.users) {
+                assert.equal(typeof user.user_pill_context.id, "number");
+                assert.equal(typeof user.user_pill_context.display_value, "string");
+                assert.equal(typeof user.user_pill_context.has_image, "boolean");
+                assert.equal(typeof user.user_pill_context.img_src, "string");
+            }
         }
         return html;
     });
@@ -90,45 +92,57 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                         "dm-including:zo",
                         {
                             description_html: "group direct messages including",
-                            is_person: true,
+                            is_people: true,
                             search_string: "dm-including:user7@zulipdev.com",
-                            user_pill_context: {
-                                display_value: "<strong>Zo</strong>e",
-                                has_image: true,
-                                id: 7,
-                                img_src:
-                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
-                            },
+                            users: [
+                                {
+                                    user_pill_context: {
+                                        display_value: "<strong>Zo</strong>e",
+                                        has_image: true,
+                                        id: 7,
+                                        img_src:
+                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                                    },
+                                },
+                            ],
                         },
                     ],
                     [
                         "dm:zo",
                         {
                             description_html: "direct messages with",
-                            is_person: true,
+                            is_people: true,
                             search_string: "dm:user7@zulipdev.com",
-                            user_pill_context: {
-                                display_value: "<strong>Zo</strong>e",
-                                has_image: true,
-                                id: 7,
-                                img_src:
-                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
-                            },
+                            users: [
+                                {
+                                    user_pill_context: {
+                                        display_value: "<strong>Zo</strong>e",
+                                        has_image: true,
+                                        id: 7,
+                                        img_src:
+                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                                    },
+                                },
+                            ],
                         },
                     ],
                     [
                         "sender:zo",
                         {
                             description_html: "sent by",
-                            is_person: true,
+                            is_people: true,
                             search_string: "sender:user7@zulipdev.com",
-                            user_pill_context: {
-                                display_value: "<strong>Zo</strong>e",
-                                has_image: true,
-                                id: 7,
-                                img_src:
-                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
-                            },
+                            users: [
+                                {
+                                    user_pill_context: {
+                                        display_value: "<strong>Zo</strong>e",
+                                        has_image: true,
+                                        id: 7,
+                                        img_src:
+                                            "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                                    },
+                                },
+                            ],
                         },
                     ],
                     [
@@ -152,13 +166,13 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             let expected_value = `<div class="search_list_item">\n    <span>Search for zo</span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[0]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n        <span class="pill-container pill-container-btn">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n        <span class="pill-container pill-container-btn">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n        <span class="pill-container pill-container-btn">\n            <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-label">\n        <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span></span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n        </span>\n</div>\n`;
             assert.equal(opts.highlighter_html(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -132,6 +132,7 @@ test("subset_suggestions", ({mock_template}) => {
 
 test("dm_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
+    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     let query = "is:dm";
     let suggestions = get_suggestions(query);
@@ -269,6 +270,7 @@ test("dm_suggestions", ({override, mock_template}) => {
 
 test("group_suggestions", ({mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
+    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     // Entering a comma in a "dm:" query should immediately
     // generate suggestions for the next person.
@@ -359,6 +361,8 @@ test("group_suggestions", ({mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
+    // Doesn't show ted@ because it's invalid in combination
+    // with a channel.
     query = "channel:Denmark has:link dm:bob@zulip.com,Smit";
     suggestions = get_suggestions(query);
     expected = [
@@ -366,6 +370,12 @@ test("group_suggestions", ({mock_template}) => {
         "channel:Denmark has:link",
         "channel:Denmark",
     ];
+    assert.deepEqual(suggestions.strings, expected);
+
+    // Invalid emails don't give suggestions
+    query = "has:link dm:invalid@zulip.com,Smit";
+    suggestions = get_suggestions(query);
+    expected = ["has:link dm:invalid@zulip.com,Smit", "has:link"];
     assert.deepEqual(suggestions.strings, expected);
 
     function message(user_ids, timestamp) {
@@ -533,6 +543,7 @@ test("has_suggestions", ({override, mock_template}) => {
 
 test("check_is_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
+    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
@@ -708,6 +719,7 @@ test("sent_by_me_suggestions", ({override, mock_template}) => {
 
 test("topic_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
+    mock_template("user_pill.hbs", true, (_data, html) => html);
     let suggestions;
     let expected;
 
@@ -872,6 +884,7 @@ test("channel_completion", ({override, mock_template}) => {
 
 test("people_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
+    mock_template("user_pill.hbs", true, (_data, html) => html);
 
     let query = "te";
 
@@ -949,68 +962,76 @@ test("people_suggestions", ({override, mock_template}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function is_person(q) {
-        return suggestions.lookup_table.get(q).is_person;
+        return suggestions.lookup_table.get(q).description_html.includes(`class="user-pill`);
     }
     assert.equal(is_person("dm:ted@zulip.com"), true);
     assert.equal(is_person("sender:ted@zulip.com"), true);
     assert.equal(is_person("dm-including:ted@zulip.com"), true);
 
     function has_image(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.has_image;
+        return suggestions.lookup_table.get(q).description_html.includes(`class="pill-image"`);
     }
     assert.equal(has_image("dm:bob@zulip.com"), true);
     assert.equal(has_image("sender:bob@zulip.com"), true);
     assert.equal(has_image("dm-including:bob@zulip.com"), true);
 
-    function describe(q) {
-        return suggestions.lookup_table.get(q).description_html;
+    function test_describe(q, description_html_start) {
+        assert.ok(
+            suggestions.lookup_table.get(q).description_html.startsWith(description_html_start),
+        );
     }
-    assert.equal(describe("dm:ted@zulip.com"), "Direct messages with");
-    assert.equal(describe("sender:ted@zulip.com"), "Sent by");
-    assert.equal(describe("dm-including:ted@zulip.com"), "Direct messages including");
+    test_describe("dm:ted@zulip.com", "Direct messages with");
+    test_describe("sender:ted@zulip.com", "Sent by");
+    test_describe("dm-including:ted@zulip.com", "Direct messages including");
 
     let expectedString = "<strong>Te</strong>d Smith";
 
-    function get_full_name(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.display_value.string;
+    function test_full_name(q, full_name_html) {
+        return suggestions.lookup_table.get(q).description_html.includes(full_name_html);
     }
-    assert.equal(get_full_name("sender:ted@zulip.com"), expectedString);
-    assert.equal(get_full_name("dm:ted@zulip.com"), expectedString);
-    assert.equal(get_full_name("dm-including:ted@zulip.com"), expectedString);
+    test_full_name("sender:ted@zulip.com", expectedString);
+    test_full_name("dm:ted@zulip.com", expectedString);
+    test_full_name("dm-including:ted@zulip.com", expectedString);
 
     expectedString = example_avatar_url + "?s=50";
 
-    function get_avatar_url(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.img_src;
+    function test_avatar_url(q, avatar_url) {
+        return suggestions.lookup_table.get(q).description_html.includes(avatar_url);
     }
-    assert.equal(get_avatar_url("dm:bob@zulip.com"), expectedString);
-    assert.equal(get_avatar_url("sender:bob@zulip.com"), expectedString);
-    assert.equal(get_avatar_url("dm-including:bob@zulip.com"), expectedString);
+    test_avatar_url("dm:bob@zulip.com", expectedString);
+    test_avatar_url("sender:bob@zulip.com", expectedString);
+    test_avatar_url("dm-including:bob@zulip.com", expectedString);
 
-    function get_should_add_guest_user_indicator(q) {
-        return suggestions.lookup_table.get(q).user_pill_context.should_add_guest_user_indicator;
+    const guest_html = "<i>(guest)</i>";
+    function test_guest_user_indicator(q, should_have_guest_indicator) {
+        const description_html = suggestions.lookup_table.get(q).description_html;
+        if (should_have_guest_indicator) {
+            assert.ok(description_html.includes(guest_html));
+        } else {
+            assert.ok(!description_html.includes(guest_html));
+        }
     }
 
     realm.realm_enable_guest_user_indicator = true;
     suggestions = get_suggestions(query);
 
-    assert.equal(get_should_add_guest_user_indicator("dm:bob@zulip.com"), false);
-    assert.equal(get_should_add_guest_user_indicator("sender:bob@zulip.com"), false);
-    assert.equal(get_should_add_guest_user_indicator("dm-including:bob@zulip.com"), false);
+    test_guest_user_indicator("dm:bob@zulip.com", false);
+    test_guest_user_indicator("sender:bob@zulip.com", false);
+    test_guest_user_indicator("dm-including:bob@zulip.com", false);
 
     bob.is_guest = true;
     suggestions = get_suggestions(query);
 
-    assert.equal(get_should_add_guest_user_indicator("dm:bob@zulip.com"), true);
-    assert.equal(get_should_add_guest_user_indicator("sender:bob@zulip.com"), true);
-    assert.equal(get_should_add_guest_user_indicator("dm-including:bob@zulip.com"), true);
+    test_guest_user_indicator("dm:bob@zulip.com", true);
+    test_guest_user_indicator("sender:bob@zulip.com", true);
+    test_guest_user_indicator("dm-including:bob@zulip.com", true);
 
     realm.realm_enable_guest_user_indicator = false;
     suggestions = get_suggestions(query);
 
-    assert.equal(get_should_add_guest_user_indicator("dm:bob@zulip.com"), false);
-    assert.equal(get_should_add_guest_user_indicator("sender:bob@zulip.com"), false);
-    assert.equal(get_should_add_guest_user_indicator("dm-including:bob@zulip.com"), false);
+    test_guest_user_indicator("dm:bob@zulip.com", false);
+    test_guest_user_indicator("sender:bob@zulip.com", false);
+    test_guest_user_indicator("dm-including:bob@zulip.com", false);
 
     suggestions = get_suggestions("Ted "); // note space
 


### PR DESCRIPTION
Fixes #23365. Still need to work on some puppeteer tests.

The first commit is pulled from https://github.com/zulip/zulip/pull/26803

<img width="633" alt="image" src="https://github.com/zulip/zulip/assets/5634097/2cea6bb9-69d6-442c-ba16-f4267dad95b4">

<img width="907" alt="image" src="https://github.com/zulip/zulip/assets/5634097/168263bf-c1fb-42df-b66e-f177450d7ced">
