### PR TITLE
api-docs: Extract functions/templates for generating events documentation.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1413,6 +1413,35 @@ label.label-title {
     }
 }
 
+.api-events-table {
+    column-count: 3;
+    column-gap: 10px;
+    margin: 15px 0 0 10px;
+
+    .api-event-type,
+    .api-event-link {
+        line-height: 100%;
+        font-weight: 600;
+        margin-bottom: 7px;
+    }
+
+    .api-event-ops {
+        margin-left: 12px;
+    }
+}
+
+@media (width <= 1000px) {
+    .api-events-table {
+        column-count: 2;
+    }
+}
+
+@media (width <= 500px) {
+    .api-events-table {
+        column-count: 1;
+    }
+}
+
 .desktop-redirect-box {
     text-align: center;
 
@@ -1450,35 +1479,4 @@ label.label-title {
         color: hsl(0deg 0% 100%);
         text-decoration: underline;
     }
-}
-
-.events-table-link {
-    line-height: 100%;
-    font-weight: 600;
-}
-
-.events-table {
-    column-count: 3;
-    column-gap: 10px;
-    margin: 15px 0 0 10px !important;
-
-    & div {
-        margin-bottom: 7px !important;
-    }
-}
-
-@media (width <= 1000px) {
-    .events-table {
-        column-count: 2;
-    }
-}
-
-@media (width <= 500px) {
-    .events-table {
-        column-count: 1;
-    }
-}
-
-.events-table-ops {
-    margin-left: 12px !important;
 }

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -1401,6 +1401,18 @@ label.label-title {
     color: hsl(176deg 46.4% 41%);
 }
 
+.api-event-header {
+    .api-event-name {
+        color: hsl(14deg 75% 60%);
+        font-size: 1.1rem;
+
+        .api-event-op {
+            color: hsl(14deg 60% 60%);
+            font-size: 1rem;
+        }
+    }
+}
+
 .desktop-redirect-box {
     text-align: center;
 
@@ -1469,9 +1481,4 @@ label.label-title {
 
 .events-table-ops {
     margin-left: 12px !important;
-}
-
-.api-event-name {
-    color: hsl(14deg 75% 60%);
-    font-size: 1rem;
 }


### PR DESCRIPTION
Following up on updates in #30413, updates the CSS and `render_events` code for clarity.

**Notes**:
- Uses templates for parts of the events documentation where we're added HTML for CSS classes/styling as well as links.
- Creates two helper functions (`generate_event_strings` and `generate_events_table`) to clarify the logic / process of generating the documentation for each event and the events table.
- Uses nesting in CSS rules so that they are more specific and updates some of the class names to be clearer.

---

**Screenshots and screen captures:**

<details>
<summary>Events table and first few events</summary>

![Screenshot from 2024-06-14 13-00-37](https://github.com/zulip/zulip/assets/63245456/2c3aec3a-6e37-4c01-8b9f-b3b239144b68)
![Screenshot from 2024-06-14 13-01-02](https://github.com/zulip/zulip/assets/63245456/a3190ffc-b13e-4d29-bc98-f54c5b2f9955)
</details>
<details>
<summary>user_settings op: update event</summary>

[Current documentation](https://zulip.com/api/get-events#user_settings-update)
![Screenshot from 2024-06-14 13-01-24](https://github.com/zulip/zulip/assets/63245456/7f9b1d25-6477-4a48-b4e7-22f820c88dc5)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
