### PR TITLE
informational_overlays: Fix CSS for tables in info_overlay.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -380,6 +380,7 @@
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
+    --color-border-informational-overlays-table: hsl(0deg 0% 87%);
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
@@ -735,6 +736,7 @@
     /* Markdown color */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 100% / 20%);
+    --color-border-informational-overlays-table: hsl(0deg 0% 0% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -48,6 +48,20 @@
         }
     }
 
+    .overlay-body {
+        table {
+            border-color: var(--color-border-informational-overlays-table);
+        }
+
+        & tr th {
+            border-color: var(--color-border-informational-overlays-table);
+        }
+
+        & tr td {
+            border-color: var(--color-border-informational-overlays-table);
+        }
+    }
+
     & td.operator {
         font-size: 0.9em;
     }


### PR DESCRIPTION
The first regression detailed #30428 was because a table selector in `dark_theme.css` was deprecated. Specifically in this [commit](https://github.com/zulip/zulip/commit/dae4c28b5bf65de0945e76743ebaa47d2fcb1103). So, these tables basically don't have the correct formatting for their border-color.

This fix largely follows the approach used in the previous CSS refactor for other tables in #29859. Which is to add new CSS variables into `app_variables.css` specifically targeting these three tables in `keyboard_shortcuts.hbs`, `markdown_help.hbs`, and `search_operators.hbs`. Instead of targeting each table individually, the selector targets a wrapper div one level higher, using the `.informational-overlays .overlay-body` class. I think this is a nice level of abstraction because `.informational-overlays .overlay-body` doesn't have any rules yet and wraps around those three menus.

after I added the changes in PR, `git grep "overlay-body"` :
![image](https://github.com/zulip/zulip/assets/108744694/8e682856-d0b7-43a2-b578-ca7d1ee2739a)
_the other `.overlay-body` rule:_
![image](https://github.com/zulip/zulip/assets/108744694/860a2487-60ff-4e2a-901b-83ec4180e0b0)

This PR won't fix other similar regressions caused by #29859 though, We'll need separate PRs to address those issues specifically.
 
Fixes #30428.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>

**Screenshots and screen captures:**
</summary>

| Previous State | Regressed State|
|---|---|
|![image](https://github.com/zulip/zulip/assets/108744694/68b0bf0b-b167-407d-8a6a-fbf54ed2f83d)|![image](https://github.com/zulip/zulip/assets/108744694/89638b4e-ae9f-484d-a9c7-841b1423e6a1)|
|![image](https://github.com/zulip/zulip/assets/108744694/f0409e37-2a7f-4fc0-8155-adca7c211362)| ![image](https://github.com/zulip/zulip/assets/108744694/7dd7bd21-551e-4f06-950c-60b98896e7af) |
|![image](https://github.com/zulip/zulip/assets/108744694/c0264040-2a9d-4d96-b2ed-004de71cdbbd)| ![image](https://github.com/zulip/zulip/assets/108744694/64aa19c6-1310-4b9e-b2c3-273198e34f6d)|


_Fixed:_
| Dark Mode | Light Mode |
|---|---|
|![Screenshot from 2024-06-14 18-17-52](https://github.com/zulip/zulip/assets/108744694/cb003024-780a-47a5-8be9-2f0fc2663ab4)|![image](https://github.com/zulip/zulip/assets/108744694/b732fd59-a068-43f8-9a2c-3f3e35f7e703)|
|![image](https://github.com/zulip/zulip/assets/108744694/1325fd51-9515-4faa-b057-2b2e4f236aa5)|![image](https://github.com/zulip/zulip/assets/108744694/95a6a752-2f51-499e-a672-1dea1115d045)|
|![image](https://github.com/zulip/zulip/assets/108744694/f00a3cca-2aa2-47c7-b161-303d08d535b2)|![image](https://github.com/zulip/zulip/assets/108744694/323f1026-c0a4-42b9-be65-f36662ee6c26)|

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
