### PR TITLE
puppeteer_tests: Update the instruction to view generated screenshots.

### DIFF
--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -143,9 +143,10 @@ or report and ask for help in chat.zulip.org""",
             print("", file=sys.stderr)
             print(
                 """
-See https://docs.github.com/en/rest/reference/actions#artifacts for information
-on how to view the generated screenshots, which are uploaded as Artifacts.
-Screenshots are extremely helpful for understanding puppeteer test failures.
+Screenshots generated on failure are extremely helpful for understanding
+puppeteer test failures, which are uploaded as artifacts. Use the
+artifact download URL available in the "Store Puppeteer artifacts" step
+below to download and view the generated screenshots.
             """,
                 file=sys.stderr,
             )


### PR DESCRIPTION
On puppeteer test failure, screenshots are generated which are helpful in debugging.

Earlier, the instruction to see those screenshot in github actions was not the easy way. It linked to a github doc which suggests to make API calls using artifact ID (which can be confusing to find) to download the artifact and extract it to see the screenshots.

Before:
> See https://docs.github.com/en/rest/reference/actions#artifacts for information
on how to view the generated screenshots, which are uploaded as Artifacts.
Screenshots are extremely helpful for understanding puppeteer test failures.


The easier way is to download the artifact directly using the download URL present in the "Store puppeteer artifacts" step of the job.

![image](https://github.com/zulip/zulip/assets/56781761/4ad36619-2042-4b62-adb0-241e79a7734a)




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
