### PR TITLE
navbar: Consolidate view, channel structures and styles.

### DIFF
--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -21,9 +21,6 @@
 
     .message-header-stream-settings-button,
     .navbar_title {
-        font-weight: 600;
-        /* 16px at 14px em */
-        font-size: 1.1429em;
         padding: 0 2px 0 6px;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -38,8 +35,6 @@
         align-items: baseline;
 
         .zulip-icon {
-            /* 14px at 16px em, inherited from .navbar_title */
-            font-size: 0.875em;
             /* Pull the icon out of baseline alignment,
                and center with stream name. */
             align-self: center;
@@ -74,14 +69,12 @@
                 margin: 0 5px;
             }
         }
-
-        .narrow_description {
-            /* 14px at 16px em, inherited from .navbar_title */
-            font-size: 0.875em;
-        }
     }
 
     .message-header-navbar-title {
+        font-weight: 600;
+        /* 16px at 14px em */
+        font-size: 1.1429em;
         /* Allow long navbar titles (e.g., stream names) to collapse. */
         flex: 0 1 auto;
         overflow: hidden;
@@ -89,38 +82,30 @@
     }
 
     .narrow_description {
-        /* the actual value of flex shrink does not matter, it is the
-           ratio of this value to other flex items that determines the
-           behavior while shrinking, here the other item has the .stream
-           class and a flex of 1, so the value here *is* the ratio, and
-           is chosen such that the narrow description shrinks to close
-           before the stream name must begin to shrink */
-        flex-shrink: 100;
+        /* Flexbox's baseline alignment is responsible for
+           matching the description's baseline to the title.
+           Here, normal just ensures a comfortable, i18n-friendly
+           line height for the description. */
+        line-height: normal;
         background: none;
-        /* 14px at 14px em */
-        font-size: 1em;
         color: inherit;
         font-weight: 400;
         padding-left: 10px;
         overflow: hidden;
         text-overflow: ellipsis;
+        /* The very last element in the navbar is the search icon, the second
+        last element is the narrow description (even if it is empty when a
+        channel contains no description). The flex-grow property ensures this
+        element takes up the entirety of the white space, while flex-shrink
+        accommodates narrower viewports. Setting flex-basis 0 enables an
+        ellipsis to be displayed, as the 0 takes the place of the max-content
+        default that would otherwise run titles under the search box. */
+        flex: 1 1 0;
+        margin: 0;
 
         .help_link_widget,
         .fa {
             margin: 0;
         }
-    }
-
-    /* The very last element in the navbar is the search icon, the second
-       last element is either the narrow description (for stream narrows) or
-       the "title" (for other narrows). The flex-grow property ensures these
-       elements take up the entirety of the white space, while flex-shrink
-       accommodates narrower viewports. Setting flex-basis 0 enables an
-       ellipsis to be displayed, as the 0 takes the place of the max-content
-       default that would otherwise run titles under the search box. */
-    .navbar_title,
-    .narrow_description {
-        flex: 1 1 0;
-        margin: 0;
     }
 }

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -27,4 +27,13 @@
 <span class="navbar_title">
     {{> navbar_icon_and_title }}
 </span>
+{{#if description}}
+    <span class="narrow_description rendered_markdown">{{description}}
+        {{#if link}}
+        <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+        </a>
+        {{/if}}
+    </span>
+{{/if}}
 {{/if}}

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -4,12 +4,3 @@
 <i class="fa fa-{{icon}}" aria-hidden="true"></i>
 {{/if}}
 <span class="message-header-navbar-title">{{title}}</span>
-{{#if description}}
-    <span class="narrow_description rendered_markdown">{{description}}
-        {{#if link}}
-        <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
-        {{/if}}
-    </span>
-{{/if}}


### PR DESCRIPTION
In addition to simplifying the code in this area, this has the effect of correcting vertical alignment of icons on views. There is also now the same amount of space between the view title and description as exists between channel titles and descriptions.

Note that the description portion has been moved from `navbar_icon_and_title.hbs` and into `message_view_header.hbs`. That is so that the `narrow_description` shares the same flexbox relationship between channels and views--though clearly there is room for additional cleanup and simplification here.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/icons.20sagging.20on.20.60main.60/near/1825971)

**Screenshots and screen captures:**

| View headers, before | View headers, after |
| --- | --- |
| ![view-header-before](https://github.com/zulip/zulip/assets/170719/8ca38788-2217-4f72-bbeb-44ff847deabf) | ![view-header-after](https://github.com/zulip/zulip/assets/170719/8d70ef3d-a6cc-4a30-a328-c14455b8929d) |
| ![view-header-narrow-before](https://github.com/zulip/zulip/assets/170719/81c60aa8-5355-47fb-a4f8-e2d21f104dc1) | ![view-header-narrow-after](https://github.com/zulip/zulip/assets/170719/bb7139f1-7083-466f-891d-c068191d29ff) |

| View headers, 16/140 before | View headers, 16/140 after |
| --- | --- |
| ![view-header-16-140-before](https://github.com/zulip/zulip/assets/170719/2b56189b-f703-486f-93e7-133dfe92d176) | ![view-header-16-140-after](https://github.com/zulip/zulip/assets/170719/b417747f-36af-4b76-8bcc-b48c64254fb7) |

| Stream headers, before | Stream headers, after (no change) |
| --- | --- |
| ![stream-header-before](https://github.com/zulip/zulip/assets/170719/08b9d4ef-4d9f-4f67-b273-69814d5f37c3) | ![stream-header-after](https://github.com/zulip/zulip/assets/170719/8ce98261-47e2-40ec-b277-89cf873f8559) |
| ![stream-header-narrow-before](https://github.com/zulip/zulip/assets/170719/42fa34d5-2c4a-4621-9216-b9d1d5cbfefe) | ![stream-header-narrow-after](https://github.com/zulip/zulip/assets/170719/fb4a1d49-a339-46f1-8633-fe46dc837b4c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>