### PR TITLE
compose: Fix bug where compose box was sometimes not scrollable.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -123,6 +123,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
         bottom_whitespace_height - compose_non_textarea_height - 10,
     );
     $("#scroll-to-bottom-button-container").css("bottom", compose_height);
+    compose_ui.autosize_textarea($("#compose-textarea"));
 }
 
 export function resize_bottom_whitespace(): void {


### PR DESCRIPTION
Earlier, autosize wasn't updated for the compose box after resetting its `max-height`, so in cases where the older `max-height` was more than the height, and the current max-height was less than the height, the compose box would not be scrollable.

We now always update the autosize after resetting the max-height.

Fixes: [CZO issue thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/scrolling.20not.20working.20in.20compose.20box)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
