### PR TITLE
[fix:30044]:removed local time from personal user menu.

### DIFF
--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -19,7 +19,7 @@
                 {{#if user_time}}
                 <li role="none" class="text-item hidden-for-spectators popover-menu-list-item">
                     <i class="popover-menu-icon zulip-icon zulip-icon-clock" aria-hidden="true"></i>
-                    {{#tr}}{user_time} local time{{/tr}}
+                    
                 </li>
                 <li role="separator" class="popover-menu-separator"></li>
                 {{/if}}


### PR DESCRIPTION
<!-- removed word (local time_ from personal menu and time in number format.
previously there was local time displaying on user menu.-->

Fixes: <!-- https://github.com/zulip/zulip/issues/30044-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [ x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
