### PR TITLE
informational_overlay: Constrain to variablized width.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -193,6 +193,10 @@
     --subscriptions-overlay-display-type-height: 44px;
     /* .settings-sticky-footer */
     --subscriptions-overlay-sticky-footer-height: 60px;
+    /* Informational overlay */
+    /* Because zoom breaks at 525px perhaps due to rounding errors, we add a
+       trivial amount of width so the overlay doesn't break. */
+    --informational-overlay-max-width: 550px;
 
     /*
     Maximum height of the compose box when it is not in expanded state. This

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,8 +1,6 @@
 .informational-overlays {
     .overlay-content {
-        /* because zoom breaks at 525px perhaps due to rounding errors, so add a
-           trivial amount of width so it doesn't break. */
-        width: 550px;
+        width: var(--informational-overlay-max-width);
         margin: 0 auto;
         position: relative;
         top: calc((30vh - 50px) / 2);
@@ -119,6 +117,8 @@
     .informational-overlays {
         .overlay-content {
             width: calc(100% - 20px);
+            /* Constrain to same width as in larger viewports. */
+            max-width: var(--informational-overlay-max-width);
         }
 
         .tab-switcher {


### PR DESCRIPTION
This assumes the width of the informational overlay at the largest viewports to be the canonical reference. Future adjustments can be made gracefully care of a CSS variable.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/help.20modal.20.22snap.20back.22/near/1821161)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| ![informational-overlay-before](https://github.com/zulip/zulip/assets/170719/bdd294c5-5913-4f70-9060-c1d9a1445922) | ![informational-overlay-after](https://github.com/zulip/zulip/assets/170719/684647a0-3a50-4132-8aa7-8e565784570f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>