### PR TITLE
settings: Improve visibility of "Enter Sends Message" setting #29083.

### DIFF
--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -186,8 +186,6 @@ export function initialize() {
                     .attr("value");
                 selected_behaviour = selected_behaviour === "true"; // Convert to bool
                 user_settings.enter_sends = selected_behaviour;
-                $(`.enter_sends_${!selected_behaviour}`).hide();
-                $(`.enter_sends_${selected_behaviour}`).show();
 
                 // Refocus in the content box so you can continue typing or
                 // press Enter to send.

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -853,7 +853,6 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "enter_sends") {
                 user_settings.enter_sends = event.value;
-                break;
             }
             if (event.property === "presence_enabled") {
                 user_settings.presence_enabled = event.value;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -853,8 +853,6 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "enter_sends") {
                 user_settings.enter_sends = event.value;
-                $(`.enter_sends_${!user_settings.enter_sends}`).hide();
-                $(`.enter_sends_${user_settings.enter_sends}`).show();
                 break;
             }
             if (event.property === "presence_enabled") {

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -6,6 +6,7 @@ import render_settings_overlay from "../templates/settings_overlay.hbs";
 import render_settings_tab from "../templates/settings_tab.hbs";
 
 import * as browser_history from "./browser_history";
+import * as common from "./common";
 import * as flatpickr from "./flatpickr";
 import {$t} from "./i18n";
 import * as modals from "./modals";
@@ -147,6 +148,7 @@ export function build_page() {
 
     settings_bots.update_bot_settings_tip($("#personal-bot-settings-tip"), false);
     $(".settings-box").html(rendered_settings_tab);
+    common.adjust_mac_kbd_tags("#user_enter_sends_label kbd");
 }
 
 export function open_settings_overlay() {

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -628,7 +628,6 @@ export const realm_user_settings_defaults_labels = {
         defaultMessage: "Display availability to other users",
     }),
     realm_presence_enabled_parens_text: $t({defaultMessage: "invisible mode off"}),
-    realm_enter_sends: $t({defaultMessage: "Enter sends when composing a message"}),
     realm_send_read_receipts: $t({defaultMessage: "Allow other users to view read receipts"}),
     realm_send_private_typing_notifications: $t({
         defaultMessage: "Let recipients see when a user is typing direct messages",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -561,6 +561,9 @@ export const preferences_settings_labels = {
     ),
     fluid_layout_width: $t({defaultMessage: "Use full width on wide screens"}),
     high_contrast_mode: $t({defaultMessage: "High contrast mode"}),
+    enter_sends: new Handlebars.SafeString(
+        $t_html({defaultMessage: "<kbd>Enter</kbd> sends when composing a message"}),
+    ),
     receives_typing_notifications: $t({defaultMessage: "Show when other users are typing"}),
     starred_message_counts: $t({defaultMessage: "Show counts for starred messages"}),
     twenty_four_hour_time: $t({defaultMessage: "Time format"}),

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -50,6 +50,10 @@
         }
     }
 
+    & label.checkbox:has(.enter_sends) {
+        vertical-align: middle;
+    }
+
     & a.no-style {
         color: inherit;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -90,7 +90,8 @@
     }
 
     .enter_sends_choices,
-    #user_enter_sends_label {
+    #user_enter_sends_label,
+    #realm_enter_sends_label {
         & kbd {
             background-color: hsl(211deg 29% 14%);
             border-color: hsl(211deg 29% 14%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -89,15 +89,18 @@
         box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
     }
 
-    .enter_sends_choices {
-        color: hsl(236deg 33% 90%);
-
+    .enter_sends_choices,
+    #user_enter_sends_label {
         & kbd {
             background-color: hsl(211deg 29% 14%);
             border-color: hsl(211deg 29% 14%);
             text-shadow: none;
             color: hsl(236deg 33% 90%);
         }
+    }
+
+    .enter_sends_choices {
+        color: hsl(236deg 33% 90%);
 
         .enter_sends_minor {
             color: hsl(0deg 0% 80%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -518,6 +518,17 @@ input[type="checkbox"] {
     }
 }
 
+#user_enter_sends_label kbd {
+    /* 14px at 15px/1em */
+    font-size: 0.9333em;
+    font-style: normal;
+    font-weight: 500;
+    color: hsl(0deg 0% 40%);
+    position: relative;
+    bottom: 1px;
+    margin: 0 2px;
+}
+
 .edit-attachment-buttons {
     display: inline-block;
     vertical-align: middle;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -518,7 +518,8 @@ input[type="checkbox"] {
     }
 }
 
-#user_enter_sends_label kbd {
+#user_enter_sends_label kbd,
+#realm_enter_sends_label kbd {
     /* 14px at 15px/1em */
     font-size: 0.9333em;
     font-style: normal;

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -49,16 +49,4 @@
             </select>
         </div>
     </div>
-
-    <div class="other_settings settings-subsection-parent">
-        <div class="subsection-header inline-block">
-            <h3 class="inline-block">{{t "Other settings" }}</h3>
-            {{> settings_save_discard_widget section_name="other-setting" show_only_indicator=false }}
-        </div>
-        {{> settings_checkbox
-          setting_name="enter_sends"
-          is_checked=settings_object.enter_sends
-          label=settings_label.realm_enter_sends
-          prefix="realm_"}}
-    </div>
 </div>

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -29,6 +29,12 @@
     </div>
 
     {{> settings_checkbox
+      setting_name="enter_sends"
+      is_checked=settings_object.enter_sends
+      label=settings_label.enter_sends
+      prefix=prefix}}
+
+    {{> settings_checkbox
       setting_name="dense_mode"
       is_checked=settings_object.dense_mode
       label=settings_label.dense_mode


### PR DESCRIPTION
Addresses user research feedback by duplicating the "Enter Sends Message" setting in the Settings > Preferences menu, specifically within the General section, ensuring users can easily locate and configure this option.

This PR attempts to complete the original work done by #29111 completion candidate PR.

CZO: https://chat.zulip.org/#narrow/stream/6-frontend/topic/checkbox.20styling.2E

Fixes: https://github.com/zulip/zulip/issues/29083.
<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

SETTINGS/DEFAULT USER SETTINGS:

![image](https://github.com/user-attachments/assets/8dedb59b-7306-497b-92c2-5f05a6662e0a)
![image](https://github.com/user-attachments/assets/12cbd407-679e-4073-ba86-99f0e29d9b83)
SETTINGS/PREFERENCES:
![image](https://github.com/user-attachments/assets/ea5e4669-960a-44e5-a3c2-c3ce6221ee26)
![image](https://github.com/user-attachments/assets/2ce658ab-2fc1-495f-be8a-ee33388f41d9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
