### PR TITLE
removed the local time from the personal menu #30054

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -128,7 +128,7 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
 
 async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): Promise<void> {
     const recipients = ["cordelia@zulip.com", "othello@zulip.com"];
-    const multiple_recipients_pm = "A huddle to check spaces";
+    const multiple_recipients_pm = "A direct message group to check spaces";
     await common.send_message(page, "private", {
         recipient: recipients.join(", "),
         outside_view: true,

--- a/web/src/direct_message_group_data.ts
+++ b/web/src/direct_message_group_data.ts
@@ -3,28 +3,30 @@ import _ from "lodash";
 import type {Message} from "./message_store";
 import * as people from "./people";
 
-const huddle_timestamps = new Map<string, number>();
+const direct_message_group_timestamps = new Map<string, number>();
 
 export function clear_for_testing(): void {
-    huddle_timestamps.clear();
+    direct_message_group_timestamps.clear();
 }
 
 export function process_loaded_messages(messages: Message[]): void {
     for (const message of messages) {
-        const huddle_string = people.huddle_string(message);
+        const direct_message_group = people.direct_message_group_string(message);
 
-        if (huddle_string) {
-            const old_timestamp = huddle_timestamps.get(huddle_string);
+        if (direct_message_group) {
+            const old_timestamp = direct_message_group_timestamps.get(direct_message_group);
 
             if (!old_timestamp || old_timestamp < message.timestamp) {
-                huddle_timestamps.set(huddle_string, message.timestamp);
+                direct_message_group_timestamps.set(direct_message_group, message.timestamp);
             }
         }
     }
 }
 
-export function get_huddles(): string[] {
-    let huddles = [...huddle_timestamps.keys()];
-    huddles = _.sortBy(huddles, (huddle) => huddle_timestamps.get(huddle));
-    return huddles.reverse();
+export function get_direct_message_groups(): string[] {
+    let direct_message_groups = [...direct_message_group_timestamps.keys()];
+    direct_message_groups = _.sortBy(direct_message_groups, (direct_message_group) =>
+        direct_message_group_timestamps.get(direct_message_group),
+    );
+    return direct_message_groups.reverse();
 }

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -727,7 +727,7 @@ export class Filter {
         return this.has_operator("search");
     }
 
-    is_non_huddle_pm(): boolean {
+    is_non_group_direct_message(): boolean {
         return this.has_operator("dm") && this.operands("dm")[0]!.split(",").length === 1;
     }
 

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -121,7 +121,7 @@ export function pm_with_url(reply_to: string): string {
     return "#narrow/dm/" + slug;
 }
 
-export function huddle_with_url(user_ids_string: string): string {
+export function direct_message_group_with_url(user_ids_string: string): string {
     // This method is convenient for callers
     // that have already converted emails to a comma-delimited
     // list of user_ids.  We should be careful to keep this

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -218,7 +218,7 @@ export class MessageListData {
     }
 
     messages_filtered_for_user_mutes(messages: Message[]): Message[] {
-        if (this.filter.is_non_huddle_pm()) {
+        if (this.filter.is_non_group_direct_message()) {
             // We are in a 1:1 direct message narrow, so do not do any filtering.
             return [...messages];
         }
@@ -229,7 +229,7 @@ export class MessageListData {
             }
             const recipients = util.extract_pm_recipients(message.to_user_ids);
             if (recipients.length > 1) {
-                // Huddle message
+                // Direct message group message
                 return true;
             }
 

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -270,7 +270,7 @@ function sort_numerically(user_ids: number[]): number[] {
     return user_ids;
 }
 
-export function huddle_string(message: Message): string | undefined {
+export function direct_message_group_string(message: Message): string | undefined {
     if (message.type !== "private") {
         return undefined;
     }
@@ -529,13 +529,13 @@ export function sorted_other_user_ids(user_ids: number[]): number[] {
     return user_ids;
 }
 
-export function concat_huddle(user_ids: number[], user_id: number): string {
+export function concat_direct_message_group(user_ids: number[], user_id: number): string {
     /*
         We assume user_ids and user_id have already
         been validated by the caller.
 
         The only logic we're encapsulating here is
-        how to encode huddles.
+        how to encode direct message group.
     */
     const sorted_ids = sort_numerically([...user_ids, user_id]);
     return sorted_ids.join(",");

--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -19,8 +19,8 @@ export function is_partner(user_id: number): boolean {
 }
 
 function filter_muted_pms(conversation: PMConversation): boolean {
-    // We hide muted users from the top left corner, as well as those huddles
-    // in which all participants are muted.
+    // We hide muted users from the top left corner, as well as those direct
+    // message groups in which all participants are muted.
     const recipients = people.split_to_ints(conversation.user_ids_string);
 
     if (recipients.every((id) => muted_users.is_user_muted(id))) {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -92,24 +92,31 @@ function format_as_suggestion(terms: NarrowTerm[]): Suggestion {
     };
 }
 
-function compare_by_huddle(huddle_emails: string[]): (person1: User, person2: User) => number {
-    const user_ids = huddle_emails.slice(0, -1).flatMap((person) => {
+function compare_by_direct_message_group(
+    direct_message_group_emails: string[],
+): (person1: User, person2: User) => number {
+    const user_ids = direct_message_group_emails.slice(0, -1).flatMap((person) => {
         const user = people.get_by_email(person);
         return user?.user_id ?? [];
     });
-    // Construct dict for all huddles, so we can look up each's recency
-    const huddles = direct_message_group_data.get_huddles();
-    const huddle_dict = new Map<string, number>();
-    for (const [i, huddle] of huddles.entries()) {
-        huddle_dict.set(huddle, i + 1);
+    // Construct dict for all direct message groups, so we can
+    // look up each's recency
+    const direct_message_groups = direct_message_group_data.get_direct_message_groups();
+    const direct_message_group_dict = new Map<string, number>();
+    for (const [i, direct_message_group] of direct_message_groups.entries()) {
+        direct_message_group_dict.set(direct_message_group, i + 1);
     }
 
     return function (person1: User, person2: User): number {
-        const huddle1 = people.concat_huddle(user_ids, person1.user_id);
-        const huddle2 = people.concat_huddle(user_ids, person2.user_id);
+        const direct_message_group1 = people.concat_direct_message_group(user_ids, person1.user_id);
+        const direct_message_group2 = people.concat_direct_message_group(user_ids, person2.user_id);
         // If not in the dict, assign an arbitrarily high index
-        const score1 = huddle_dict.get(huddle1) ?? huddles.length + 1;
-        const score2 = huddle_dict.get(huddle2) ?? huddles.length + 1;
+        const score1 =
+            direct_message_group_dict.get(direct_message_group1) ??
+            direct_message_groups.length + 1;
+        const score2 =
+            direct_message_group_dict.get(direct_message_group2) ??
+            direct_message_groups.length + 1;
         const diff = score1 - score2;
 
         if (diff !== 0) {
@@ -198,7 +205,7 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         return last_part === "" || person_matcher(person);
     });
 
-    persons.sort(compare_by_huddle(parts));
+    persons.sort(compare_by_direct_message_group(parts));
 
     // Take top 15 persons, since they're ordered by pm_recipient_count.
     persons = persons.slice(0, 15);

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -81,8 +81,8 @@ class UnreadDirectMessageCounter {
         }
     }
 
-    set_huddles(huddles: UnreadHuddleInfo[]): void {
-        for (const obj of huddles) {
+    set_direct_message_groups(direct_message_groups: UnreadDirectMessageGroupInfo[]): void {
+        for (const obj of direct_message_groups) {
             const user_ids_string = people.pm_lookup_key(obj.user_ids_string);
             this.set_message_ids(user_ids_string, obj.unread_message_ids);
         }
@@ -1072,7 +1072,7 @@ type UnreadDirectMessageInfo = {
     unread_message_ids: number[];
 };
 
-type UnreadHuddleInfo = {
+type UnreadDirectMessageGroupInfo = {
     user_ids_string: string;
     unread_message_ids: number[];
 };
@@ -1081,7 +1081,7 @@ type UnreadMessagesParams = {
     unread_msgs: {
         pms: UnreadDirectMessageInfo[];
         streams: UnreadStreamInfo[];
-        huddles: UnreadHuddleInfo[];
+        huddles: UnreadDirectMessageGroupInfo[];
         mentions: number[];
         count: number;
         old_unreads_missing: boolean;
@@ -1092,7 +1092,7 @@ export function initialize(params: UnreadMessagesParams): void {
     const unread_msgs = params.unread_msgs;
 
     old_unreads_missing = unread_msgs.old_unreads_missing;
-    unread_direct_message_counter.set_huddles(unread_msgs.huddles);
+    unread_direct_message_counter.set_direct_message_groups(unread_msgs.huddles);
     unread_direct_message_counter.set_pms(unread_msgs.pms);
     unread_topic_counter.set_streams(unread_msgs.streams);
     for (const message_id of unread_msgs.mentions) {

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -16,13 +16,6 @@
         </header>
         <section class="dropdown-menu-list-section personal-menu-actions" data-user-id="{{user_id}}">
             <ul role="menu" class="popover-menu-list">
-                {{#if user_time}}
-                <li role="none" class="text-item hidden-for-spectators popover-menu-list-item">
-                    <i class="popover-menu-icon zulip-icon zulip-icon-clock" aria-hidden="true"></i>
-                    {{#tr}}{user_time} local time{{/tr}}
-                </li>
-                <li role="separator" class="popover-menu-separator"></li>
-                {{/if}}
                 {{#if status_content_available}}
                 <li role="none" class="text-item popover-menu-list-item">
                     <span class="personal-menu-status-wrapper">

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -191,10 +191,10 @@ test("sort_users", () => {
 test("direct_message_group_data.process_loaded_messages", () => {
     // TODO: move this to a module for just testing `direct_message_group_data`
 
-    const huddle1 = "jill@zulip.com,norbert@zulip.com";
+    const direct_message_group1 = "jill@zulip.com,norbert@zulip.com";
     const timestamp1 = 1382479029; // older
 
-    const huddle2 = "alice@zulip.com,fred@zulip.com";
+    const direct_message_group2 = "alice@zulip.com,fred@zulip.com";
     const timestamp2 = 1382479033; // newer
 
     const old_timestamp = 1382479000;
@@ -227,9 +227,12 @@ test("direct_message_group_data.process_loaded_messages", () => {
 
     direct_message_group_data.process_loaded_messages(messages);
 
-    const user_ids_string1 = people.emails_strings_to_user_ids_string(huddle1);
-    const user_ids_string2 = people.emails_strings_to_user_ids_string(huddle2);
-    assert.deepEqual(direct_message_group_data.get_huddles(), [user_ids_string2, user_ids_string1]);
+    const user_ids_string1 = people.emails_strings_to_user_ids_string(direct_message_group1);
+    const user_ids_string2 = people.emails_strings_to_user_ids_string(direct_message_group2);
+    assert.deepEqual(direct_message_group_data.get_direct_message_groups(), [
+        user_ids_string2,
+        user_ids_string1,
+    ]);
 });
 
 test("presence_list_full_update", ({override, mock_template}) => {

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -288,7 +288,7 @@ test("basics", () => {
 
     terms = [{operator: "dm", operand: "joe@example.com"}];
     filter = new Filter(terms);
-    assert.ok(filter.is_non_huddle_pm());
+    assert.ok(filter.is_non_group_direct_message());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
@@ -303,7 +303,7 @@ test("basics", () => {
         {operator: "near", operand: 17},
     ];
     filter = new Filter(terms);
-    assert.ok(filter.is_non_huddle_pm());
+    assert.ok(filter.is_non_group_direct_message());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(!filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
@@ -315,7 +315,7 @@ test("basics", () => {
 
     terms = [{operator: "dm", operand: "joe@example.com,jack@example.com"}];
     filter = new Filter(terms);
-    assert.ok(!filter.is_non_huddle_pm());
+    assert.ok(!filter.is_non_group_direct_message());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(filter.can_mark_messages_read());
     assert.ok(filter.supports_collapsing_recipients());
@@ -332,7 +332,7 @@ test("basics", () => {
 
     terms = [{operator: "dm-including", operand: "joe@example.com"}];
     filter = new Filter(terms);
-    assert.ok(!filter.is_non_huddle_pm());
+    assert.ok(!filter.is_non_group_direct_message());
     assert.ok(filter.contains_only_private_messages());
     assert.ok(!filter.has_operator("search"));
     assert.ok(!filter.can_mark_messages_read());

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -178,7 +178,7 @@ run_test("urls", () => {
     let url = hash_util.pm_with_url(ray.email);
     assert.equal(url, "#narrow/dm/22-Raymond");
 
-    url = hash_util.huddle_with_url("22,23");
+    url = hash_util.direct_message_group_with_url("22,23");
     assert.equal(url, "#narrow/dm/22,23-group");
 
     url = hash_util.by_sender_url(ray.email);

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -805,23 +805,24 @@ test_people("emails_to_full_names_string", () => {
     );
 });
 
-test_people("concat_huddle", () => {
+test_people("concat_direct_message_group", () => {
     /*
         We assume that user_ids passed in
-        to concat_huddle have already been
-        validated, so we don't need actual
-        people for these tests to pass.
+        to concat_direct_message_group have
+        already been validated, so we don't
+        need actual people for these tests
+        to pass.
 
         That may change in the future.
     */
 
     const user_ids = [303, 301, 302];
 
-    assert.equal(people.concat_huddle(user_ids, 304), "301,302,303,304");
+    assert.equal(people.concat_direct_message_group(user_ids, 304), "301,302,303,304");
 
     // IMPORTANT: we always want to sort
-    // ids numerically to create huddle strings.
-    assert.equal(people.concat_huddle(user_ids, 99), "99,301,302,303");
+    // ids numerically to create direct message group strings.
+    assert.equal(people.concat_direct_message_group(user_ids, 99), "99,301,302,303");
 });
 
 test_people("message_methods", () => {
@@ -1360,11 +1361,11 @@ test_people("get_active_message_people", () => {
     assert.deepEqual(active_message_people, [steven, maria]);
 });
 
-test_people("huddle_string", () => {
-    assert.equal(people.huddle_string({type: "stream"}), undefined);
+test_people("direct_message_group_string", () => {
+    assert.equal(people.direct_message_group_string({type: "stream"}), undefined);
 
-    function huddle(user_ids) {
-        return people.huddle_string({
+    function direct_message_group(user_ids) {
+        return people.direct_message_group_string({
             type: "private",
             display_recipient: user_ids.map((id) => ({id})),
         });
@@ -1373,9 +1374,9 @@ test_people("huddle_string", () => {
     people.add_active_user(maria);
     people.add_active_user(bob);
 
-    assert.equal(huddle([]), undefined);
-    assert.equal(huddle([me.user_id, maria.user_id]), undefined);
-    assert.equal(huddle([me.user_id, maria.user_id, bob.user_id]), "203,302");
+    assert.equal(direct_message_group([]), undefined);
+    assert.equal(direct_message_group([me.user_id, maria.user_id]), undefined);
+    assert.equal(direct_message_group([me.user_id, maria.user_id, bob.user_id]), "203,302");
 });
 
 test_people("get_realm_active_human_users", () => {

--- a/web/tests/pm_conversations.test.js
+++ b/web/tests/pm_conversations.test.js
@@ -93,7 +93,7 @@ test("muted_users", () => {
 
     // We should now get back only those messages which are either-
     // 1:1 direct messages in which the other user hasn't been muted.
-    // Huddles where there's at least one non-muted participant.
+    // Direct message groups where there's at least one non-muted participant.
     assert.deepEqual(pmc.recent.get(), [
         {user_ids_string: "3", max_message_id: 99},
         {user_ids_string: "1,2,3", max_message_id: 97},


### PR DESCRIPTION
This pull request addresses the issue discussed in CZO where the local time is being displayed in the personal menu. As per the discussion, the local time feature is redundant in the personal menu and should be removed. Users can find the local time information in their user card if needed.

Removed local time display: The local time has been removed from the personal menu by modifying web/templates/personal_menu.hbs

Fixes: https://github.com/zulip/zulip/issues/30044

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before
![before](https://github.com/zulip/zulip/assets/119963915/2fac9962-5d89-43b9-9b53-735b8f119cee)

After 
![after](https://github.com/zulip/zulip/assets/119963915/549e2a17-834f-4b14-afdd-b0484f21bd5a)

Description: The only change made was removing the part where the user time was described in the personal menu file. No other parts of the file were altered as the goal was solely to remove the local time from the personal menu.

UI Change: This PR includes UI changes, as the local time display has been removed from the personal menu.

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.
- [x] Calls out remaining decisions and concerns.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
