### PR TITLE
left sidebar: Add Views label for spectators.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -130,6 +130,12 @@ export function handle_narrow_activated(filter: Filter): void {
 function toggle_condensed_navigation_area(): void {
     const $views_label_container = $("#views-label-container");
     const $views_label_icon = $("#toggle-top-left-navigation-area-icon");
+
+    if (page_params.is_spectator) {
+        // We don't support collapsing VIEWS for spectators, so exit early.
+        return;
+    }
+
     if ($views_label_container.hasClass("showing-expanded-navigation")) {
         // Toggle into the condensed state
         $views_label_container.addClass("showing-condensed-navigation");

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -219,6 +219,7 @@ export function initialize_left_sidebar(): void {
         is_recent_view_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code,
         hide_unread_counts: settings_data.should_mask_unread_count(false),
+        is_spectator: page_params.is_spectator,
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -812,6 +812,11 @@ li.top_left_scheduled_messages {
         }
     }
 
+    /* Remove the cursor: pointer property of Views label for the spectators. */
+    &.remove-pointer-for-spectator {
+        cursor: default;
+    }
+
     #toggle-top-left-navigation-area-icon {
         grid-area: starting-anchor-element;
     }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,7 +1,7 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
-        <div id="views-label-container" class="showing-expanded-navigation hidden-for-spectators">
-            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down views-tooltip-target" aria-hidden="true"></i>
+        <div id="views-label-container" class="showing-expanded-navigation {{#if is_spectator}}remove-pointer-for-spectator{{/if}}">
+            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
             {{~!-- squash whitespace --~}}
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">


### PR DESCRIPTION
This PR adds the Views label in the left side bar for the spectators without it being collapsible.

Fixes #30324 

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/142340063/890a9bd4-8c85-4be4-bd46-26e454157e85)


<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
