### PR TITLE
scroll: Set tabIndex to -1 for simplebar content wrapper.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prom-client": "^15.1.0",
     "regenerator-runtime": "^0.14.0",
     "shebang-loader": "^0.0.1",
-    "simplebar": "^6.2.0",
+    "simplebar": "^6.2.7",
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
     "source-code-pro": "^2.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       simplebar:
-        specifier: ^6.2.0
-        version: 6.2.6
+        specifier: ^6.2.7
+        version: 6.2.7
       sortablejs:
         specifier: ^1.9.0
         version: 1.15.2
@@ -6487,11 +6487,11 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  simplebar-core@1.2.5:
-    resolution: {integrity: sha512-33AVCYXS8yavWId0GbE4TG1cYELsYybpCKWHJYuWEY/j6nccgz6zQdJ7nCqOpIGo7HgPPbkSSSIlJhi43fHP6A==}
+  simplebar-core@1.2.6:
+    resolution: {integrity: sha512-H5NYU+O+uvqOH5VXw3+lgoc1vTI6jL8LOZJsw4xgRpV7uIPjRpmLPdz0TrouxwKHBhpVLzVIlyKhaRLelIThMw==}
 
-  simplebar@6.2.6:
-    resolution: {integrity: sha512-dN+MoK2JJY8u+3CokYm0GTAi1bo+aefyyY2fk3pZlwOZdLSNY9P0Ze6kb6e86VuXgFgbcX4z8SuM41RK1/zM+g==}
+  simplebar@6.2.7:
+    resolution: {integrity: sha512-IdD6HwZLz4f83lG0yN5r/3Mts4qR+pKAc9IjVdtJ96Ow6IqSA+jG2PlniQ710XUygal/mOA774IgAvcoirUP4g==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -14493,17 +14493,16 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
-  simplebar-core@1.2.5:
+  simplebar-core@1.2.6:
     dependencies:
       '@types/lodash-es': 4.17.12
-      can-use-dom: 0.1.0
       lodash: 4.17.21
       lodash-es: 4.17.21
 
-  simplebar@6.2.6:
+  simplebar@6.2.7:
     dependencies:
       can-use-dom: 0.1.0
-      simplebar-core: 1.2.5
+      simplebar-core: 1.2.6
 
   slash@3.0.0: {}
 

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 265
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (281, 0)  # bumped 2024-06-12 for adding firebase-admin
+PROVISION_VERSION = (281, 1)  # bumped 2024-06-16 for updating simplebar

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -685,8 +685,6 @@ export function complete_rerender(): void {
     // this, we scroll to top before restoring focus via revive_current_focus.
     $("html").scrollTop(0);
     setTimeout(() => {
-        // We don't want to focus on simplebar ever.
-        $("#inbox-list .simplebar-content-wrapper").attr("tabindex", "-1");
         revive_current_focus();
     }, 0);
 

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -94,7 +94,7 @@ function render_tabbed_sections() {
     });
 }
 
-new SimpleBar($(".sidebar")[0]);
+new SimpleBar($(".sidebar")[0], {tabIndex: -1});
 
 // Scroll to anchor link when clicked. Note that landing-page.js has a
 // similar function; this file and landing-page.js are never included

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -89,7 +89,9 @@ export function show_user_list(message_id: number): void {
                             $("#read_receipts_modal .read_receipts_list").html(
                                 render_read_receipts(context),
                             );
-                            new SimpleBar($("#read_receipts_modal .modal__content")[0]!);
+                            new SimpleBar($("#read_receipts_modal .modal__content")[0]!, {
+                                tabIndex: -1,
+                            });
                         }
                     },
                     error(xhr) {

--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -26,7 +26,7 @@ export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
     } else if ("simplebar" in element.dataset) {
         // The SimpleBar mutation observer hasn’t processed this element yet.
         // Create the SimpleBar early in case we need to add event listeners.
-        return $(new SimpleBar(element).getScrollElement()!);
+        return $(new SimpleBar(element, {tabIndex: -1}).getScrollElement()!);
     }
     return $element;
 }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -532,7 +532,6 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
                     break;
             }
             setTimeout(() => {
-                $(".modal__body .simplebar-content-wrapper").attr("tabindex", "-1");
                 $(".modal__container .ind-tab").attr("tabindex", "-1");
                 $(".modal__container .ind-tab.selected").attr("tabindex", "0");
             }, 0);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2264,10 +2264,6 @@ body:not(.hide-left-sidebar) {
 }
 
 .simplebar-content-wrapper {
-    /* `simplebar-content-wrapper` has `tabindex=0` set, which makes it focusable
-        but we don't want it to have an outline when focused anywhere in the app. */
-    outline: none;
-
     /* This prevents the popover from closing once the top/bottom is reached */
     overscroll-behavior: contain;
 }

--- a/web/templates/add_poll_modal.hbs
+++ b/web/templates/add_poll_modal.hbs
@@ -5,7 +5,7 @@
     </div>
     <label class="poll-label">{{t "Options"}}</label>
     <p>{{t "Anyone can add more options after the poll is posted."}}</p>
-    <ul class="poll-options-list" data-simplebar>
+    <ul class="poll-options-list" data-simplebar data-simplebar-tab-index="-1">
         {{> poll_modal_option }}
         {{> poll_modal_option }}
         {{> poll_modal_option }}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -44,7 +44,7 @@
         </div>
     </div>
     <div class="message_comp">
-        <div id="compose_banners" data-simplebar></div>
+        <div id="compose_banners" data-simplebar data-simplebar-tab-index="-1"></div>
         <div class="composition-area">
             <form id="send_message_form" action="/json/messages" method="post">
                 <div class="compose_table">
@@ -72,7 +72,7 @@
                         <div id="message-content-container">
                             <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
                             <div id="preview-message-area-container">
-                                <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
+                                <div class="scrolling_list preview_message_area" data-simplebar data-simplebar-tab-index="-1" id="preview_message_area" style="display:none;">
                                     <div class="markdown_preview_spinner"></div>
                                     <div class="preview_content rendered_markdown"></div>
                                 </div>

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -10,7 +10,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content" data-simplebar {{#if always_visible_scrollbar}}data-simplebar-auto-hide="false"{{/if}}>
+            <main class="modal__content" data-simplebar data-simplebar-tab-index="-1" {{#if always_visible_scrollbar}}data-simplebar-auto-hide="false"{{/if}}>
                 <div class="alert" id="dialog_error"></div>
                 {{{ html_body }}}
             </main>

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -2,7 +2,7 @@
     <div class="dropdown-list-search">
         <input class="dropdown-list-search-input filter_text_input{{#if hide_search_box}} hide{{/if}}" type="text" placeholder="{{t 'Filter' }}" autofocus/>
     </div>
-    <div class="dropdown-list-wrapper" data-simplebar>
+    <div class="dropdown-list-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <ul class="dropdown-list"></ul>
     </div>
     <div class="no-dropdown-items dropdown-list-item-common-styles">

--- a/web/templates/giphy_picker.hbs
+++ b/web/templates/giphy_picker.hbs
@@ -7,7 +7,7 @@
                 <i class="fa fa-remove" aria-hidden="true"></i>
             </button>
         </div>
-        <div class="giphy-scrolling-container" data-simplebar>
+        <div class="giphy-scrolling-container" data-simplebar data-simplebar-tab-index="-1">
             {{! We need a container we can replace
             without removing the simplebar wrappers.
             We replace the `giphy-content` when

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -1,6 +1,6 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
   aria-label="{{t 'Keyboard shortcuts' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
+    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
         <div>
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -161,7 +161,7 @@
         </a>
     </div>
     {{~!-- squash whitespace --~}}
-    <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar>
+    <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
         <div class="direct-messages-container zoom-out hidden-for-spectators">
             <div id="direct-messages-list"></div>
         </div>

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
   aria-label="{{t 'Message formatting' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
+    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
             <table class="table table-striped table-rounded table-bordered help-table">
                 <thead>

--- a/web/templates/popovers/change_visibility_policy_popover.hbs
+++ b/web/templates/popovers/change_visibility_policy_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu visibility-policy-popover" data-simplebar>
+<div class="popover-menu visibility-policy-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="popover-menu-list-item">
             <div role="group" class="recipient-bar-topic-visibility-switcher tab-picker tab-picker-vertical" aria-label="{{t 'Topic visibility' }}">

--- a/web/templates/popovers/emoji/emoji_popover.hbs
+++ b/web/templates/popovers/emoji/emoji_popover.hbs
@@ -9,9 +9,9 @@
                 <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
             {{/each}}
         </div>
-        <div class="emoji-popover-emoji-map" data-simplebar data-simplebar-auto-hide="false" data-message-id="{{message_id}}">
+        <div class="emoji-popover-emoji-map" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false" data-message-id="{{message_id}}">
         </div>
-        <div class="emoji-search-results-container" data-simplebar data-simplebar-auto-hide="false" data-message-id="{{message_id}}">
+        <div class="emoji-search-results-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false" data-message-id="{{message_id}}">
             <div class="emoji-popover-results-heading">{{t "Search results" }}</div>
             <div class="emoji-search-results"></div>
         </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="stream-actions-menu-popover" data-simplebar>
+<div class="popover-menu" id="stream-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
         <li role="none" class="popover-stream-header text-item popover-menu-inner-list-item">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="topic-actions-menu-popover" data-simplebar>
+<div class="popover-menu" id="topic-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="popover-topic-header text-item popover-menu-list-item">
             <span class="popover-topic-name">{{topic_name}}</span>

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="message-actions-menu-dropdown" data-simplebar>
+<div class="popover-menu" id="message-actions-menu-dropdown" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{!-- Group 1 --}}
         {{#if should_display_quote_and_reply}}

--- a/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="gear-menu-dropdown" aria-labelledby="settings-dropdown" data-simplebar>
+<div class="popover-menu" id="gear-menu-dropdown" aria-labelledby="settings-dropdown" data-simplebar data-simplebar-tab-index="-1">
     <div class="org-info-container">
         <div class="org-info org-name">{{realm_name}}</div>
         <div class="org-info org-url">{{realm_url}}</div>

--- a/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_help_menu_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="help-menu-dropdown" aria-labelledby="help-menu" data-simplebar>
+<div class="popover-menu" id="help-menu-dropdown" aria-labelledby="help-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" href="/help/" target="_blank" rel="noopener noreferrer" class="navigate-link-on-enter popover-menu-link">

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="personal-menu-dropdown" data-simplebar>
+<div class="popover-menu" id="personal-menu-dropdown" data-simplebar data-simplebar-tab-index="-1">
     <nav class="personal-menu-nav">
         <header class="personal-menu-header">
             <div class="avatar">

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -9,7 +9,7 @@
             </div>
         </div>
         <hr />
-        <ul class="nav nav-list member-list" data-simplebar data-simplebar-auto-hide="false">
+        <ul class="nav nav-list member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
             {{#each members}}
                 <li>
                     {{#if is_bot}}

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -13,7 +13,7 @@
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>
             </div>
-            <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar>
+            <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
                 <div id="buddy-list-users-matching-view-container">
                     <div class="buddy-list-subsection-header"></div>
                     <ul id="buddy-list-users-matching-view" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -1,5 +1,5 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search filters' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
+    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
         <div id="operators-instructions">
             <table class="table table-striped table-rounded table-bordered help-table">
                 <thead>

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -9,7 +9,7 @@
         </div>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -17,7 +17,7 @@
         </button>
         <span class="alert_word_status_text"></span>
     </div>
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="word">{{t "Word" }}</th>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -6,7 +6,7 @@
     </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -24,7 +24,7 @@
         <input type="text" class="search filter_text_input" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -32,7 +32,7 @@
           aria-label="{{t 'Filter exports' }}"/>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_exports_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="user">{{t "Requesting user" }}</th>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -12,7 +12,7 @@
         </div>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -14,7 +14,7 @@
         <input type="text" class="search filter_text_input" placeholder="{{t 'Filter emoji' }}"
           aria-label="{{t 'Filter emoji' }}"/>
     </div>
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_emoji_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -11,7 +11,7 @@
         <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invitations' }}" aria-label="{{t 'Filter invitations' }}"/>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="invitee">{{t "Invitee" }}</th>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -62,7 +62,7 @@
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
         </div>
 
-        <div class="progressive-table-wrapper" data-simplebar>
+        <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
             <table class="table table-striped wrapped-table admin_linkifiers_table">
                 <thead class="table-sticky-headers">
                     <th>{{t "Pattern" }}</th>

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Muted users"}}</h3>
         <input id="muted_users_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
     </div>
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="user_name">{{t "User" }}</th>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -67,7 +67,7 @@
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
         </div>
 
-        <div class="progressive-table-wrapper" data-simplebar>
+        <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
             <table class="table table-striped wrapped-table admin_playgrounds_table">
                 <thead class="table-sticky-headers">
                     <th class="active" data-sort="alphabetic" data-sort-prop="pygments_language">{{t "Language" }}</th>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -6,7 +6,7 @@
         <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
         {{/if}}
     </div>
-    <div class="admin-table-wrapper" data-simplebar>
+    <div class="admin-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped admin_profile_fields_table">
             <thead>
                 <tr>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -14,7 +14,7 @@
         {{> settings_save_discard_widget section_name="user-topics-settings" show_only_indicator=true }}
         <input id="user_topics_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"/>
     </div>
-    <div class="progressive-table-wrapper" data-simplebar>
+    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="stream">{{t "Channel" }}</th>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -9,7 +9,7 @@
     </div>
     <div class="sidebar-wrapper">
         <div class="center tab-container settings-sticky-bar"></div>
-        <div class="sidebar left" data-simplebar>
+        <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
             <div class="sidebar-list dark-grey small-text">
                 <ul class="normal-settings-list">
                     <li tabindex="0" data-section="profile">
@@ -147,7 +147,7 @@
                 <span class="exit-sign">&times;</span>
             </div>
         </div>
-        <div id="settings_content" data-simplebar data-simplebar-auto-hide="false">
+        <div id="settings_content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
             <div class="organization-box organization">
 
             </div>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -18,7 +18,7 @@
 </div>
 
 <div class="subscriber-list-box">
-    <div class="subscriber_list_container" data-simplebar>
+    <div class="subscriber_list_container" data-simplebar data-simplebar-tab-index="-1">
         <table class="subscriber-list table table-striped">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -1,7 +1,7 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'Channel creation' }}">
     <form id="stream_creation_form">
-        <div class="stream-creation-simplebar-container" data-simplebar>
+        <div class="stream-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
             <div class="alert stream_create_info"></div>
             <div id="stream_creating_indicator"></div>
             <div class="stream-creation-body">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -17,7 +17,7 @@
         </span>
     </div>
     <div class="subscriber-list-box">
-        <div class="subscriber_list_container" data-simplebar>
+        <div class="subscriber_list_container" data-simplebar data-simplebar-tab-index="-1">
             <div class="subscriber_list_loading_indicator"></div>
             <table id="stream_members_list" class="subscriber-list table table-striped">
                 <thead class="table-sticky-headers">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -50,7 +50,7 @@
                         </span>
                     </div>
                 </div>
-                <div class="streams-list" data-simplebar>
+                <div class="streams-list" data-simplebar data-simplebar-tab-index="-1">
                 </div>
             </div>
             <div class="right">
@@ -68,7 +68,7 @@
                     </span>
                     {{/if}}
                 </div>
-                <div id="stream_settings" class="settings" data-simplebar data-simplebar-auto-hide="false">
+                <div id="stream_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{!-- edit stream here --}}
                 </div>
                 {{> stream_creation_form }}

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -13,7 +13,7 @@
 </div>
 
 <div class="member-list-box">
-    <div class="member_list_container" data-simplebar>
+    <div class="member_list_container" data-simplebar data-simplebar-tab-index="-1">
         <table class="member-list table table-striped">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -1,7 +1,7 @@
 <div class="hide" id="user-group-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'User group creation' }}">
     <form id="user_group_creation_form">
-        <div class="user-group-creation-simplebar-container" data-simplebar>
+        <div class="user-group-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
             <div class="alert user_group_create_info"></div>
             <div id="user_group_creating_indicator"></div>
             <div class="user-group-creation-body">

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -16,7 +16,7 @@
         </span>
     </div>
     <div class="member-list-box">
-        <div class="member_list_container" data-simplebar>
+        <div class="member_list_container" data-simplebar data-simplebar-tab-index="-1">
             <div class="member_list_loading_indicator"></div>
             <table class="member-list table table-striped">
                 <thead class="table-sticky-headers">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -42,7 +42,7 @@
                         </span>
                     </div>
                 </div>
-                <div class="user-groups-list" data-simplebar>
+                <div class="user-groups-list" data-simplebar data-simplebar-tab-index="-1">
                 </div>
             </div>
             <div class="right">
@@ -60,7 +60,7 @@
                     </span>
                     {{/if}}
                 </div>
-                <div id="user_group_settings" class="settings" data-simplebar data-simplebar-auto-hide="false">
+                <div id="user_group_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{!-- edit user group here --}}
                 </div>
                 {{> user_group_creation_form }}

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -35,7 +35,7 @@
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </div>
             <div id="tab-toggle" class="center"></div>
-            <main class="modal__body" id="body" data-simplebar data-simplebar-auto-hide="false">
+            <main class="modal__body" id="body" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                 <div class="tab-data">
                     <div class="tabcontent active" id="profile-tab">
                         <div class="top">


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/30403.

Having tabIndex set to 0 led to keyboard focus being put on a scrollbar container, which led to users having to tab twice to skip a container. This commit also removes instances of tabIndex being set to -1 programatically for certain cases, since it is -1 by default now. This commit also removes `outline: none` for simplebar since that property is not needed anymore becuase the wrapper is not focusable anymore.

The option became configurable in https://github.com/Grsmto/simplebar/pull/695

The second commit is technically large, but I think all those changes belong together. Removing the previous hacks and css along with adding the property in the same commit made more sense to me. Reviewing it should be manage-able considering most of it just adding the tab-index property. Let me know if you think it should be split up

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
