### PR TITLE
app_components: Fix CSS for tables in settings menu.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -799,7 +799,7 @@ div.overlay {
 }
 
 .table-bordered {
-    border: 1px solid hsl(0deg 0% 87%);
+    border: 1px solid var(--color-border-table-bordered);
     border-collapse: separate;
     border-left: 0;
     border-radius: 4px;
@@ -809,8 +809,8 @@ div.overlay {
 
     & th,
     td {
-        border-left: 1px solid hsl(0deg 0% 87%);
-        border-top: 1px solid hsl(0deg 0% 87%);
+        border-left: 1px solid var(--color-border-table-bordered);
+        border-top: 1px solid var(--color-border-table-bordered);
         padding: 4px 5px;
         text-align: left;
     }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -794,7 +794,7 @@ div.overlay {
     }
 
     & td {
-        border-top: 1px solid hsl(0deg 0% 87%);
+        border-top: 1px solid var(--color-border-table-striped);
     }
 }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -387,6 +387,7 @@
 
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 87%);
+    --color-border-table-bordered: hsl(0deg 0% 87%);
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
@@ -745,6 +746,7 @@
 
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 0% / 20%);
+    --color-border-table-bordered: hsl(0deg 0% 0% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -384,7 +384,6 @@
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
-    --color-border-informational-overlays-table: hsl(0deg 0% 87%);
 
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 87%);
@@ -743,7 +742,6 @@
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 100% / 20%);
-    --color-border-informational-overlays-table: hsl(0deg 0% 0% / 20%);
 
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 0% / 20%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -386,6 +386,9 @@
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
     --color-border-informational-overlays-table: hsl(0deg 0% 87%);
 
+    /* Settings table colors */
+    --color-border-table-striped: hsl(0deg 0% 87%);
+
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
     --color-markdown-code-background: hsl(0deg 0% 0% / 6%);
@@ -737,10 +740,13 @@
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
 
-    /* Markdown color */
+    /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 100% / 20%);
     --color-border-informational-overlays-table: hsl(0deg 0% 0% / 20%);
+
+    /* Settings table colors */
+    --color-border-table-striped: hsl(0deg 0% 0% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -747,6 +747,7 @@
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 0% / 20%);
     --color-border-table-bordered: hsl(0deg 0% 0% / 20%);
+    --color-background-notification-table-thead: hsl(0deg 0% 0% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -46,20 +46,6 @@
         }
     }
 
-    .overlay-body {
-        table {
-            border-color: var(--color-border-informational-overlays-table);
-        }
-
-        & tr th {
-            border-color: var(--color-border-informational-overlays-table);
-        }
-
-        & tr td {
-            border-color: var(--color-border-informational-overlays-table);
-        }
-    }
-
     & td.operator {
         font-size: 0.9em;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -633,6 +633,10 @@ input[type="checkbox"] {
 
 #user-notification-settings {
     .notification-table {
+        thead {
+            background-color: var(--color-background-notification-table-thead);
+        }
+
         & th,
         td {
             text-align: center;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
## Overview
The regression was because tables that used `.table-striped` CSS (`/app_components.css` starts at line 720) depended on the deprecated `dark_theme.css` rule at #29859 for its border-color value in dark theme. These tables are used primarily at the personal and organizational settings menu at /#settings. See full git grep:

`git grep ".table-striped"`:
<details>

![image](https://github.com/zulip/zulip/assets/108744694/e8520ba5-3a11-4ac3-84a9-6be4b1f794d8)
</details>


## Fix
The fix that I've included in this PR is to switch the border-color value for `.table-striped` for a new variable in `app_variable.css`. This approach is fairly in line with how it is done at #29859, where CSS variables are used more specifically for particular elements.

## Concern
Let me know whether this is at the right level of granularity that we want. For example, `.table-striped` is used in a wide range of menus, if we want more granularity, we could go one level deeper than ".table-striped" at the level of classes specific to each menu. For example, the Data Exports menu has the `.admin_exports_table` class, so we would probably assign the app_variables there instead of at `.table-striped` if we take with this approach.

If this is at the right level of granularity, I've also included an optional commit in this PR to reverse the previous fix (#30431) at infos_overlay and followed it up with a fix the info_overlay menus(keyboard_shortcuts, search_operators, markdown_help) by refactoring `.table-bordered` to use CSS variables for its border colors instead of `.overlay_body` to better align with the overall approach here.

Fixes: #30448 

## **Screenshots and screen captures:**

<details>
<summary>

#### Tables that used the `.table-striped` class
</summary>

`git grep ".table-striped"`:

![image](https://github.com/zulip/zulip/assets/108744694/e8520ba5-3a11-4ac3-84a9-6be4b1f794d8)

| Menu Location | Light Mode | Dark Mode |
|---|---|---|
| Alert Words menu | ![image](https://github.com/zulip/zulip/assets/108744694/4c64a2ce-3813-4979-a826-29e608b5d8f4) | ![image](https://github.com/zulip/zulip/assets/108744694/36b16f35-f4bb-4a4f-9aac-02a08b74aae5) |
| Uploaded Files menu | ![image](https://github.com/zulip/zulip/assets/108744694/367b82c6-aa13-4436-80b4-2097f6d7b161) | ![image](https://github.com/zulip/zulip/assets/108744694/e4bfb99b-aa86-4567-abfe-23c0c24fe8b8) |
| Bots List menu | ![image](https://github.com/zulip/zulip/assets/108744694/344941c0-d844-4966-8d1f-bf4d2dee2805) | ![image](https://github.com/zulip/zulip/assets/108744694/e2ac7559-ea70-4afc-9347-5a419138d4fc) |
| Data Exports menu | ![image](https://github.com/zulip/zulip/assets/108744694/24f07b87-684f-4681-b997-a3af415ec941) | ![image](https://github.com/zulip/zulip/assets/108744694/9b963013-3de4-4a8f-81be-2ed17536475c) |
| Deactivated Users menu | ![image](https://github.com/zulip/zulip/assets/108744694/09c06e0b-f829-4e2a-afee-96ea9acff1a9) | ![image](https://github.com/zulip/zulip/assets/108744694/caec00c2-6183-4ab0-a04d-8ae248866d77) |
| Default Channels menu | ![image](https://github.com/zulip/zulip/assets/108744694/a71a3cb5-2f66-4d4b-a04b-440426f5536b) | ![image](https://github.com/zulip/zulip/assets/108744694/4fd6ccb7-a962-40bb-9306-7df30741fac5) |
| Custom Emoji menu | ![image](https://github.com/zulip/zulip/assets/108744694/d2f5d5f5-1bc5-4cc8-be4a-20785d17fb18) | ![image](https://github.com/zulip/zulip/assets/108744694/db37ee6a-5cc3-4e64-bf01-7253b840c9e2) |
| Invitations menu | ![image](https://github.com/zulip/zulip/assets/108744694/64472226-2fd8-4ab6-9016-88819200d7dc) | ![image](https://github.com/zulip/zulip/assets/108744694/72d074c5-0483-4104-a76a-c6c23ee0149e) |
| Linkifiers menu | ![image](https://github.com/zulip/zulip/assets/108744694/c5406de9-388b-4630-ad0a-c5a725991c41) | ![image](https://github.com/zulip/zulip/assets/108744694/c5e54def-6fda-46c5-a826-21c9c5d9bbf4) |
| Muted Users menu | ![image](https://github.com/zulip/zulip/assets/108744694/a47076f2-30de-440d-8bfe-5c1b8feee767) | ![image](https://github.com/zulip/zulip/assets/108744694/b6a0b43a-dccc-4d6d-9289-213500d1eebb) |
| Code Playgrounds menu | ![image](https://github.com/zulip/zulip/assets/108744694/3de04de6-033e-4e88-b3e9-30112d5dd784) | ![image](https://github.com/zulip/zulip/assets/108744694/d8a9c0ba-9202-4779-a3e2-7f3325502245) |
| Custom Profile Fields | ![image](https://github.com/zulip/zulip/assets/108744694/e2155675-3338-4836-a867-8850cf6a427d) | ![image](https://github.com/zulip/zulip/assets/108744694/f53b5da9-5c33-4a42-ac6e-65d03de75b06) |
| Users menu | ![image](https://github.com/zulip/zulip/assets/108744694/12056888-0185-409f-b987-a0aa5cf0b161) | ![image](https://github.com/zulip/zulip/assets/108744694/26ffcd4a-505d-4ba0-963d-1e6cc7b3803e) |
| Topics menu | ![image](https://github.com/zulip/zulip/assets/108744694/669a6868-2cc7-42b2-9e74-8cb77d1b1d6e) | ![image](https://github.com/zulip/zulip/assets/108744694/fd557dbc-83d7-45d4-92d9-2baf101cbb7b) |
| Subscriber table at Channel Settings | ![image](https://github.com/zulip/zulip/assets/108744694/5767b242-9aa5-488a-956d-620dfe5beef1) | ![image](https://github.com/zulip/zulip/assets/108744694/7bd04336-dee3-45f8-82b7-e0607193ea3a) |
| Subscriber table at Create channel menu | ![image](https://github.com/zulip/zulip/assets/108744694/c1d21079-b88d-4b25-9154-50d79d12cc16) | ![image](https://github.com/zulip/zulip/assets/108744694/6efe9e5e-92ce-45ed-95d8-68ebf8353095) |
| Members table at User groups settings | ![image](https://github.com/zulip/zulip/assets/108744694/92607003-80ec-455f-a680-24f93bfe71b4) | ![image](https://github.com/zulip/zulip/assets/108744694/618b6862-60db-4f7b-853d-98bf8b92466f) |
| Members table at Create user group menu | ![image](https://github.com/zulip/zulip/assets/108744694/32a4386a-9b30-49da-bc69-4a1c20e17564) | ![image](https://github.com/zulip/zulip/assets/108744694/417af1f2-0590-4f17-acc5-c2c18a360eeb) |

</details>

<details>
<summary>

#### Tables that used the `.table-bordered` class
</summary>

`git grep ".table-bordered"`:

![image](https://github.com/zulip/zulip/assets/108744694/37b0fd32-02c3-4bc3-968b-f7765487441b)

`git grep "notification-table"`:

![image](https://github.com/zulip/zulip/assets/108744694/2c1d4440-223c-4acc-8a34-37036e34c1ef)

Notice that these are the same menus reported in #30428.
 
| Menu Location | Light Mode | Dark Mode |
|---|---|---|
| Keyboard Shortcuts menu | ![image](https://github.com/zulip/zulip/assets/108744694/6716b18a-b5f0-4a00-b94f-4d34ec34f417)|![image](https://github.com/zulip/zulip/assets/108744694/a419c511-2f53-4388-a357-2f73372e13f4)|
| Message Formatting menu | ![image](https://github.com/zulip/zulip/assets/108744694/e78de02c-8abd-4fb6-8285-7fb9a075aeaf) | ![image](https://github.com/zulip/zulip/assets/108744694/d3e525e1-f436-47a0-845d-f7596d94b566) |
| Search Filters menu | ![image](https://github.com/zulip/zulip/assets/108744694/090efffc-2a6f-4f33-abd4-cfe8d24ddd31) | ![image](https://github.com/zulip/zulip/assets/108744694/8de7f677-4217-47c7-9e01-184a8a679ca5) |
| Notification Menu | ![image](https://github.com/zulip/zulip/assets/108744694/30651b5f-c725-4157-93f9-1f4b2eee571c) | ![image](https://github.com/zulip/zulip/assets/108744694/83bf1334-b9e3-422e-926d-afaffed3c13b) |
</details>




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
