### PR TITLE
url_decoding: Add 'is_same_server_message_link' function.

### DIFF
--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const message_link_test_cases = require("../../zerver/tests/fixtures/message_link_test_cases");
+
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
@@ -88,39 +90,12 @@ run_test("get_current_nth_hash_section", () => {
 });
 
 run_test("test_is_same_server_message_link", () => {
-    const dm_message_link = "#narrow/dm/9,15-dm/near/43";
-    assert.equal(hash_parser.is_same_server_message_link(dm_message_link), true);
-
-    const group_message_link = "#narrow/dm/9,16,15-group/near/68";
-    assert.equal(hash_parser.is_same_server_message_link(group_message_link), true);
-
-    const stream_message_link = "#narrow/stream/8-design/topic/desktop/near/82";
-    assert.equal(hash_parser.is_same_server_message_link(stream_message_link), true);
-
-    const stream_link = "#narrow/stream/8-design";
-    assert.equal(hash_parser.is_same_server_message_link(stream_link), false);
-
-    const topic_link = "#narrow/stream/8-design/topic/desktop";
-    assert.equal(hash_parser.is_same_server_message_link(topic_link), false);
-
-    const dm_link = "#narrow/dm/15-John";
-    assert.equal(hash_parser.is_same_server_message_link(dm_link), false);
-
-    const search_link = "#narrow/search/database";
-    assert.equal(hash_parser.is_same_server_message_link(search_link), false);
-
-    const different_server_message_link =
-        "https://fakechat.zulip.org/#narrow/dm/8,1848,2369-group/near/1717378";
-    assert.equal(hash_parser.is_same_server_message_link(different_server_message_link), false);
-
-    const drafts_link = "#drafts";
-    assert.equal(hash_parser.is_same_server_message_link(drafts_link), false);
-
-    const empty_link = "#";
-    assert.equal(hash_parser.is_same_server_message_link(empty_link), false);
-
-    const non_zulip_link = "https://www.google.com";
-    assert.equal(hash_parser.is_same_server_message_link(non_zulip_link), false);
+    for (const message_link_test_case of message_link_test_cases) {
+        assert.equal(
+            hash_parser.is_same_server_message_link(message_link_test_case.message_link),
+            message_link_test_case.expected_output,
+        );
+    }
 });
 
 run_test("build_reload_url", () => {

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -54,6 +54,7 @@ from zerver.lib.remote_server import (
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
 from zerver.lib.tex import change_katex_to_raw_latex
 from zerver.lib.timestamp import datetime_to_timestamp
+from zerver.lib.url_decoding import is_same_server_message_link
 from zerver.lib.users import check_can_access_user
 from zerver.models import (
     AbstractPushDeviceToken,
@@ -921,20 +922,6 @@ def get_mobile_push_content(rendered_content: str) -> str:
             plain_text += sub_text
             plain_text += elem.tail or ""
         return plain_text
-
-    def is_same_server_message_link(hash: str) -> bool:
-        # A same server message link always has category `narrow`,
-        # section `stream` or `dm`, and ends with `/near/<message_id>`,
-        # where <message_id> is a sequence of digits.
-        match = re.match(r"#([^/]+)", hash)
-        if match is None or match.group(1) != "narrow":
-            return False
-
-        match = re.search(r"#narrow/([^/]+)", hash)
-        if match is None or not (match.group(1) == "stream" or match.group(1) == "dm"):
-            return False
-
-        return re.search(r"/near/\d+$", hash) is not None
 
     def is_user_said_paragraph(element: lxml.html.HtmlElement) -> bool:
         # The user said paragraph has these exact elements:

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -1,0 +1,26 @@
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+
+def is_same_server_message_link(url: str) -> bool:
+    split_result = urlsplit(url)
+    hostname = split_result.hostname
+    fragment = split_result.fragment
+
+    if hostname not in {None, settings.EXTERNAL_HOST_WITHOUT_PORT}:
+        return False
+
+    # A message link always has category `narrow`, section `stream`
+    # or `dm`, and ends with `/near/<message_id>`, where <message_id>
+    # is a sequence of digits. The URL fragment of a message link has
+    # at least 5 parts. e.g. '#narrow/dm/9,15-dm/near/43'
+    fragment_parts = fragment.split("/")
+    if len(fragment_parts) < 5:
+        return False
+
+    category = fragment_parts[0]
+    section = fragment_parts[1]
+    ends_with_near_message_id = fragment_parts[-2] == "near" and fragment_parts[-1].isdigit()
+
+    return category == "narrow" and section in {"stream", "dm"} and ends_with_near_message_id

--- a/zerver/tests/fixtures/message_link_test_cases.json
+++ b/zerver/tests/fixtures/message_link_test_cases.json
@@ -1,0 +1,57 @@
+[
+    {
+        "name": "dm_message_link",
+        "message_link": "#narrow/dm/9,15-dm/near/43",
+        "expected_output": true
+    },
+    {
+        "name": "group_message_link",
+        "message_link": "#narrow/dm/9,16,15-group/near/68",
+        "expected_output": true
+    },
+    {
+        "name": "stream_message_link",
+        "message_link": "#narrow/stream/8-design/topic/desktop/near/82",
+        "expected_output": true
+    },
+    {
+        "name": "stream_link",
+        "message_link": "#narrow/stream/8-design",
+        "expected_output": false
+    },
+    {
+        "name": "topic_link",
+        "message_link": "#narrow/stream/8-design/topic/desktop",
+        "expected_output": false
+    },
+    {
+        "name": "dm_link",
+        "message_link": "#narrow/dm/15-John",
+        "expected_output": false
+    },
+    {
+        "name": "search_link",
+        "message_link": "#narrow/search/database",
+        "expected_output": false
+    },
+    {
+        "name": "different_server_message_link",
+        "message_link": "https://fakechat.zulip.org/#narrow/dm/8,1848,2369-group/near/1717378",
+        "expected_output": false
+    },
+    {
+        "name": "drafts_link",
+        "message_link": "#drafts",
+        "expected_output": false
+    },
+    {
+        "name": "empty_link",
+        "message_link": "#",
+        "expected_output": false
+    },
+    {
+        "name": "non_zulip_link",
+        "message_link": "https://www.google.com",
+        "expected_output": false
+    }
+]

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -1,0 +1,13 @@
+import orjson
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.url_decoding import is_same_server_message_link
+
+
+class URLDecodeTest(ZulipTestCase):
+    def test_is_same_server_message_link(self) -> None:
+        tests = orjson.loads(self.fixture_data("message_link_test_cases.json"))
+        for test in tests:
+            self.assertEqual(
+                is_same_server_message_link(test["message_link"]), test["expected_output"]
+            )


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/30404#discussion_r1640557709

> I feel like it would be better for this to be an algorithm that uses urllib for parsing the full link into search operand/operator pairs, and then doing checks on those operators being exactly one of the specific formats for a said link.

> We don't currently do this in the server, but it might make sense to have a new function in a new file zerver/lib/url_decoding.py for this logic, with its own little test suite...


**operand/operator pairs**

I didn't actually use a data structure in  the PR to store operator-operand pair because I think we won't be benefiting much in that way because we still need to store the position at which the operator occurs instead of just verifying that certain operator and operator should exist...


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
